### PR TITLE
feat(auth): SMART on FHIR authentication, authorization, and IdP integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1614,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,6 +1643,15 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -2268,6 +2311,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "expect-json"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,6 +2764,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "helios-auth"
+version = "0.1.47"
+dependencies = [
+ "async-trait",
+ "bitflags 2.11.0",
+ "chrono",
+ "jsonwebtoken",
+ "moka",
+ "redis",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "helios-cds-hooks"
 version = "0.1.47"
 dependencies = [
@@ -2807,6 +2889,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "helios-auth",
  "helios-fhir",
  "helios-persistence",
  "helios-rest",
@@ -2874,6 +2957,7 @@ dependencies = [
  "axum-test",
  "chrono",
  "clap",
+ "helios-auth",
  "helios-fhir",
  "helios-persistence",
  "helios-serde",
@@ -3201,6 +3285,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3624,6 +3709,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3919,10 +4019,13 @@ version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
 dependencies = [
+ "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
+ "event-listener",
+ "futures-util",
  "parking_lot",
  "portable-atomic",
  "smallvec",
@@ -4340,6 +4443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4466,6 +4575,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -5116,6 +5235,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.27.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "backon",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itertools 0.13.0",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5260,6 +5405,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5811,6 +5957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5867,6 +6019,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default-members = [
 	"crates/rest",
 	"crates/sof",
 	"crates/cds-hooks",
+	"crates/auth",
 ]
 resolver = "2"
 

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "helios-auth"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Authentication and authorization for the Helios FHIR Server"
+
+[features]
+default = []
+redis = ["dep:redis"]
+
+[dependencies]
+# JWT validation
+jsonwebtoken = "9"
+
+# HTTP client for JWKS endpoint
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# In-memory caching (JTI + JWKS)
+moka = { version = "0.12", features = ["future"] }
+
+# Redis (optional, for distributed JTI cache and JWKS coordination)
+redis = { version = "0.27", features = ["tokio-comp", "connection-manager"], optional = true }
+
+# SMART scope permissions
+bitflags = "2"
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Async runtime
+tokio = { version = "1", features = ["time", "sync", "rt", "macros"] }
+async-trait = "0.1"
+
+# Time
+chrono.workspace = true
+
+# Logging
+tracing = "0.1"
+
+# Error handling
+thiserror = "2"

--- a/crates/auth/README.md
+++ b/crates/auth/README.md
@@ -1,0 +1,288 @@
+# helios-auth
+
+Authentication and authorization for the Helios FHIR Server.
+
+## Overview
+
+This crate provides [SMART Backend Services](https://hl7.org/fhir/smart-app-launch/backend-services.html) authentication via JWT/JWKS validation and SMART v2 scope-based authorization. It is designed around a key architectural principle: **HFS does not act as an authorization server.** Token issuance and client registration remain external (Keycloak, Okta, Auth0, Entra ID, etc.). This crate performs local token validation only.
+
+- **JWKS-Based JWT Validation**: Fetches and caches public keys from IdP JWKS endpoints
+- **SMART v2 Scope Parsing**: Parses `system/Patient.rs`, `system/*.cruds` scope syntax
+- **Scope-Based Authorization**: Maps FHIR operations to SMART permissions (CRUDS)
+- **JTI Replay Prevention**: In-memory and Redis-backed caches for JWT ID tracking
+- **Multi-Instance Coordination**: Redis leader election for JWKS refresh across scaled deployments
+- **SMART Discovery**: Builds `/.well-known/smart-configuration` documents
+- **Pluggable Audit**: Trait-based audit event sink (noop default, extensible)
+
+## Quick Start
+
+```rust
+use std::sync::Arc;
+use helios_auth::{
+    AuthConfig, JwksBearerAuthProvider, JwksCache,
+    InMemoryJtiCache, AuthProvider,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = AuthConfig {
+        enabled: true,
+        jwks_url: Some("https://idp.example.com/.well-known/jwks.json".to_string()),
+        expected_issuer: Some("https://idp.example.com".to_string()),
+        expected_audience: Some("https://fhir.example.com".to_string()),
+        ..AuthConfig::default()
+    };
+
+    // Create caches
+    let jwks_cache = Arc::new(JwksCache::new(
+        config.jwks_url.as_ref().unwrap(),
+        config.jwks_min_refresh_interval,
+    ));
+    jwks_cache.initial_fetch().await?;
+
+    let jti_cache = Arc::new(InMemoryJtiCache::new());
+
+    // Create provider
+    let provider = JwksBearerAuthProvider::new(jwks_cache, jti_cache, &config);
+
+    // Validate a token
+    match provider.authenticate("Bearer eyJhbGciOi...").await {
+        Ok(principal) => println!("Authenticated: {}", principal.subject()),
+        Err(e) => println!("Auth failed: {}", e),
+    }
+
+    Ok(())
+}
+```
+
+## How Authentication Works
+
+The authentication flow follows the [SMART Backend Services](https://hl7.org/fhir/smart-app-launch/backend-services.html) protocol:
+
+1. **Client registers** with an external authorization server (Keycloak, Okta, etc.)
+2. **Client obtains a token** from the authorization server using its private key
+3. **Client sends request** to HFS with `Authorization: Bearer <token>`
+4. **HFS validates the token locally**:
+   - Decodes the JWT header to extract `kid` and `alg`
+   - Rejects tokens using algorithms not in the allowed list
+   - Fetches the public key from the cached JWKS keyset (refreshes on unknown `kid`)
+   - Validates signature, expiration, issuer, and audience claims
+   - Checks the `jti` claim against the replay prevention cache
+   - Parses SMART v2 scopes from the `scope` or `scp` claim
+   - Extracts the tenant ID from the configured claim
+5. **HFS enforces authorization** by checking scopes against the requested FHIR operation
+
+## SMART v2 Scopes
+
+Scopes follow the SMART v2 syntax: `context/resourceType.permissions`
+
+| Scope | Meaning |
+|-------|---------|
+| `system/Patient.rs` | Read and search Patient resources |
+| `system/*.cruds` | Full CRUD + search on all resource types |
+| `system/Observation.r` | Read-only access to Observation |
+| `system/Condition.crud` | Create, read, update, delete Condition (no search) |
+| `user/Patient.rs` | User-level read/search on Patient |
+
+Permission characters: `c` = create, `r` = read, `u` = update, `d` = delete, `s` = search.
+
+### Operation-to-Permission Mapping
+
+| HTTP Request | FHIR Operation | Required Permission |
+|-------------|---------------|-------------------|
+| `GET /Patient/123` | read | `r` |
+| `GET /Patient?name=Smith` | search | `s` |
+| `POST /Patient` | create | `c` |
+| `PUT /Patient/123` | update | `u` |
+| `PATCH /Patient/123` | update | `u` |
+| `DELETE /Patient/123` | delete | `d` |
+| `GET /Patient/_history` | history | `r` |
+
+## Configuration
+
+All configuration is via environment variables. Auth is a runtime toggle — no feature flags needed to enable it.
+
+### Core Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HFS_AUTH_ENABLED` | `false` | Master switch for authentication |
+| `HFS_AUTH_JWKS_URL` | *(required)* | JWKS endpoint URL |
+| `HFS_AUTH_ISSUER` | *(none)* | Expected JWT `iss` claim |
+| `HFS_AUTH_AUDIENCE` | *(none)* | Expected JWT `aud` claim (**recommended for production** — prevents accepting tokens intended for other services) |
+| `HFS_AUTH_TENANT_CLAIM` | `tenant_id` | JWT claim name for tenant ID |
+| `HFS_AUTH_ALGORITHMS` | `RS256,RS384,ES256,ES384` | Allowed signing algorithms |
+
+### Caching and Replay Prevention
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HFS_AUTH_JTI_BACKEND` | `memory` | JTI cache backend (`memory` or `redis`) |
+| `HFS_AUTH_REDIS_URL` | *(none)* | Redis URL (required for `redis` backend) |
+| `HFS_AUTH_JWKS_MIN_REFRESH_INTERVAL` | `10` | Min seconds between JWKS refreshes |
+
+### SMART Discovery Endpoint
+
+These populate the `GET /.well-known/smart-configuration` response:
+
+| Variable | Description |
+|----------|-------------|
+| `HFS_SMART_TOKEN_ENDPOINT` | Token endpoint URL |
+| `HFS_SMART_AUTHORIZE_ENDPOINT` | Authorization endpoint URL |
+| `HFS_SMART_JWKS_URL` | JWKS URL (for discovery doc; falls back to `HFS_AUTH_JWKS_URL`) |
+| `HFS_SMART_INTROSPECTION_ENDPOINT` | Token introspection endpoint |
+| `HFS_SMART_MANAGEMENT_ENDPOINT` | Token management endpoint |
+| `HFS_SMART_REGISTRATION_ENDPOINT` | Dynamic client registration endpoint |
+| `HFS_SMART_REVOCATION_ENDPOINT` | Token revocation endpoint |
+
+## Running with Authentication
+
+```bash
+# Enable auth with Keycloak
+HFS_AUTH_ENABLED=true \
+  HFS_AUTH_JWKS_URL=http://keycloak:8080/realms/fhir/protocol/openid-connect/certs \
+  HFS_AUTH_ISSUER=http://keycloak:8080/realms/fhir \
+  HFS_AUTH_AUDIENCE=https://fhir.example.com \
+  HFS_SMART_TOKEN_ENDPOINT=http://keycloak:8080/realms/fhir/protocol/openid-connect/token \
+  cargo run --bin hfs
+
+# Verify SMART discovery
+curl http://localhost:8080/.well-known/smart-configuration
+
+# Unauthenticated request (expect 401)
+curl -v http://localhost:8080/Patient
+
+# Authenticated request
+curl -H "Authorization: Bearer <token>" http://localhost:8080/Patient/123
+```
+
+### Exempt Paths
+
+These endpoints are always accessible without a token:
+
+- `/health`, `/_liveness`, `/_readiness`
+- `/metadata`
+- `/.well-known/smart-configuration`
+- `/$versions`
+
+## Identity Provider Integration
+
+### Keycloak
+
+```bash
+HFS_AUTH_JWKS_URL=http://keycloak:8080/realms/{realm}/protocol/openid-connect/certs
+HFS_AUTH_ISSUER=http://keycloak:8080/realms/{realm}
+# Scope claim: "scope" (space-delimited string)
+```
+
+### Okta
+
+```bash
+HFS_AUTH_JWKS_URL=https://{domain}/oauth2/{auth-server}/v1/keys
+HFS_AUTH_ISSUER=https://{domain}/oauth2/{auth-server}
+# Scope claim: "scp" (JSON array) — both formats are auto-detected
+```
+
+### Auth0
+
+```bash
+HFS_AUTH_JWKS_URL=https://{domain}/.well-known/jwks.json
+HFS_AUTH_ISSUER=https://{domain}/
+HFS_AUTH_AUDIENCE=https://fhir.example.com
+```
+
+### Microsoft Entra ID
+
+```bash
+HFS_AUTH_JWKS_URL=https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys
+HFS_AUTH_ISSUER=https://login.microsoftonline.com/{tenant}/v2.0
+# Permissions are typically in the "roles" claim
+```
+
+## Tenant Resolution
+
+When authentication is enabled, the tenant ID is derived **exclusively** from the JWT claim configured by `HFS_AUTH_TENANT_CLAIM` (default: `tenant_id`). The `X-Tenant-ID` header and URL-based tenant routing are ignored for authenticated requests — this prevents tenant impersonation.
+
+If the token does not contain the tenant claim, the server falls back to the standard tenant resolution (header, URL path, or default).
+
+## Multi-Instance Deployments
+
+For HFS deployments with multiple instances behind a load balancer:
+
+```bash
+# Use Redis for JTI replay prevention (shared across instances)
+HFS_AUTH_JTI_BACKEND=redis
+HFS_AUTH_REDIS_URL=redis://redis:6379
+
+# Build with Redis support
+cargo build -p helios-hfs --features redis
+```
+
+The Redis backend also coordinates JWKS refresh across instances using leader election, so only one instance fetches from the IdP's JWKS endpoint at a time.
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| `redis` | Enables Redis-backed JTI cache and JWKS refresh coordination |
+
+## Testing
+
+```bash
+# Run all auth tests
+cargo test -p helios-auth
+
+# Run specific test module
+cargo test -p helios-auth scope
+cargo test -p helios-auth policy
+cargo test -p helios-auth jti
+```
+
+## Architecture
+
+```
+src/
+├── lib.rs              # Crate entry, re-exports
+├── config.rs           # AuthConfig (env var parsing)
+├── error.rs            # AuthError enum, FhirOperation
+├── principal.rs        # Principal (authenticated identity)
+├── audit.rs            # AuditEventSink trait + NoopAuditEventSink
+├── discovery.rs        # SmartConfiguration builder
+├── scope/
+│   ├── mod.rs          # ScopeSet (collection of parsed scopes)
+│   ├── smart_v2.rs     # SmartScope parser (context/type.perms)
+│   └── permissions.rs  # SmartPermissions bitflags (CRUDS)
+├── provider/
+│   ├── mod.rs          # AuthProvider trait
+│   └── jwks_bearer.rs  # JwksBearerAuthProvider (JWT validation)
+├── jwks/
+│   ├── mod.rs          # Module exports
+│   ├── fetcher.rs      # HTTP JWKS fetcher with Cache-Control parsing
+│   ├── cache.rs        # JwksCache (background refresh, rate limiting)
+│   └── coordinator.rs  # Redis leader election (feature = "redis")
+├── jti/
+│   ├── mod.rs          # JtiCache trait
+│   ├── memory.rs       # InMemoryJtiCache (moka)
+│   └── redis.rs        # RedisJtiCache (feature = "redis")
+└── policy/
+    └── mod.rs          # SmartScopePolicy (operation → permission check)
+```
+
+### Key Types
+
+| Type | Description |
+|------|-------------|
+| `Principal` | Authenticated identity from a validated JWT (subject, issuer, scopes, tenant) |
+| `ScopeSet` | Parsed collection of SMART v2 scopes with permission checking |
+| `SmartPermissions` | Bitflags for CRUDS permissions |
+| `AuthProvider` | Trait for token validation (currently: JWKS Bearer) |
+| `JwksCache` | JWKS key cache with Cache-Control awareness and background refresh |
+| `JtiCache` | Trait for JWT ID replay prevention (in-memory or Redis) |
+| `SmartScopePolicy` | Checks principal scopes against FHIR operations |
+| `AuditEventSink` | Trait for recording auth events (noop default) |
+| `AuthConfig` | Configuration from environment variables |
+| `SmartConfiguration` | SMART discovery document builder |
+
+## License
+
+MIT

--- a/crates/auth/README.md
+++ b/crates/auth/README.md
@@ -169,27 +169,296 @@ These endpoints are always accessible without a token:
 
 ### Keycloak
 
+#### Docker Quickstart
+
+A pre-configured Keycloak 26 instance with a `fhir` realm, two test clients, and SMART client scopes is provided in `docker/keycloak/`.
+
 ```bash
-HFS_AUTH_JWKS_URL=http://keycloak:8080/realms/{realm}/protocol/openid-connect/certs
-HFS_AUTH_ISSUER=http://keycloak:8080/realms/{realm}
-# Scope claim: "scope" (space-delimited string)
+# Start Keycloak (port 8180 to avoid conflict with HFS on 8080)
+docker compose -f docker/keycloak/docker-compose.yml up -d
+
+# Wait for health check to pass (~30-40s on first run)
+docker compose -f docker/keycloak/docker-compose.yml ps
+
+# Verify the realm is available
+curl -s http://localhost:8180/realms/fhir | python3 -m json.tool | grep issuer
 ```
+
+#### Pre-configured Test Clients
+
+| Client ID | Secret | Default Scopes | Use case |
+|-----------|--------|----------------|----------|
+| `hfs-backend-client` | `hfs-backend-secret` | `system/*.cruds` | Full access testing |
+| `hfs-readonly-client` | `hfs-readonly-secret` | `system/Patient.rs` | Restricted access testing |
+
+#### Run HFS Against Keycloak
+
+```bash
+HFS_AUTH_ENABLED=true \
+  HFS_AUTH_JWKS_URL=http://localhost:8180/realms/fhir/protocol/openid-connect/certs \
+  HFS_AUTH_ISSUER=http://localhost:8180/realms/fhir \
+  HFS_SMART_TOKEN_ENDPOINT=http://localhost:8180/realms/fhir/protocol/openid-connect/token \
+  HFS_SMART_AUTHORIZE_ENDPOINT=http://localhost:8180/realms/fhir/protocol/openid-connect/auth \
+  HFS_SMART_JWKS_URL=http://localhost:8180/realms/fhir/protocol/openid-connect/certs \
+  cargo run --bin hfs
+```
+
+Verify SMART discovery is populated:
+```bash
+curl -s http://localhost:8080/.well-known/smart-configuration | python3 -m json.tool
+```
+
+#### Get a Token
+
+Use the provided helper script:
+```bash
+# Full-access token (system/*.cruds) — prints token to stdout
+export TOKEN=$(./docker/keycloak/get-token.sh)
+
+# Read-only token (system/Patient.rs)
+export READONLY_TOKEN=$(./docker/keycloak/get-token.sh hfs-readonly-client)
+```
+
+Or call Keycloak directly:
+```bash
+export TOKEN=$(curl -s -X POST \
+  http://localhost:8180/realms/fhir/protocol/openid-connect/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  --data-urlencode "client_id=hfs-backend-client" \
+  --data-urlencode "client_secret=hfs-backend-secret" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+```
+
+Inspect the token claims (no library needed):
+```bash
+echo $TOKEN | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool
+```
+
+#### End-to-End Test
+
+```bash
+# Unauthenticated request → 401
+curl -sv http://localhost:8080/Patient 2>&1 | grep "< HTTP"
+
+# Authenticated request → 200 (or 404 if no data)
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8080/Patient | python3 -m json.tool
+
+# Create a patient (requires 'c' permission — works with hfs-backend-client)
+curl -s -X POST http://localhost:8080/Patient \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{"resourceType":"Patient","name":[{"family":"Smith","given":["John"]}]}' \
+  | python3 -m json.tool
+
+# Attempt write with read-only token → 403
+READONLY_TOKEN=$(./docker/keycloak/get-token.sh hfs-readonly-client)
+curl -sv -X POST http://localhost:8080/Patient \
+  -H "Authorization: Bearer $READONLY_TOKEN" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{"resourceType":"Patient"}' 2>&1 | grep "< HTTP"
+```
+
+#### Manual Realm Setup (Existing Keycloak)
+
+If you have an existing Keycloak instance, configure it via the Admin Console or CLI:
+
+1. **Create a realm** named `fhir` (or use an existing one).
+
+2. **Create client scopes** for each SMART scope you need:
+   - Admin Console → Client Scopes → Create → Name: `system/*.cruds` → Protocol: `openid-connect`
+   - Set `Include in token scope` = `On` under Settings
+   - Repeat for `system/Patient.rs`, `system/Observation.r`, etc.
+
+3. **Create a client**:
+   - Admin Console → Clients → Create
+   - Client ID: `hfs-backend-client`
+   - Client authentication: `On`
+   - Standard flow: `Off`, Service accounts roles: `On`
+   - Save → Credentials tab → note the client secret
+
+4. **Assign scopes to the client**:
+   - Client → Client Scopes tab → Add client scope → select your SMART scopes → Add as Default
+
+5. **HFS environment variables**:
+
+```bash
+HFS_AUTH_JWKS_URL=https://{keycloak-host}/realms/{realm}/protocol/openid-connect/certs
+HFS_AUTH_ISSUER=https://{keycloak-host}/realms/{realm}
+# Scope claim: "scope" (space-delimited string) — no additional config needed
+```
+
+#### Keycloak Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 401 on all requests | Wrong issuer | Confirm `HFS_AUTH_ISSUER` matches the `iss` in your decoded token exactly |
+| 401 — signature validation failed | JWKS not yet cached | HFS fetches JWKS on first request; retry after ~5s or check `HFS_AUTH_JWKS_URL` is reachable |
+| 403 on valid token | Scope not in token | Check `scope` claim in decoded token; ensure client scopes are assigned as *Default* not *Optional* |
+| Token has no `scope` claim | Mapper missing | In Keycloak Admin → Client Scopes → verify `include.in.token.scope` is `true` for each scope |
+| Realm import didn't apply | File not found | Check the volume mount path; Keycloak imports from `/opt/keycloak/data/import/` |
+
+---
 
 ### Okta
 
+Okta uses a custom Authorization Server for client credentials. A free developer account is available at [developer.okta.com](https://developer.okta.com).
+
+#### Okta Setup (one-time)
+
+1. **Create a Custom Authorization Server**
+   - Admin Console → Security → API → Add Authorization Server
+   - Name: `FHIR`, Audience: `https://fhir.example.com` (or your FHIR base URL)
+   - Note the **Issuer URI** shown on the server's Settings tab
+
+2. **Add SMART scopes to the Authorization Server**
+   - Scopes tab → Add Scope for each scope you need:
+     - Name: `system/*.cruds`, Description: Full SMART access, Default scope: off
+     - Name: `system/Patient.rs`, Description: Read/search Patient
+     - Name: `system/Observation.r`, Description: Read Observation
+   - Leave Metadata published: on
+
+3. **Create a Machine-to-Machine application**
+   - Applications → Create App Integration → API Services (machine-to-machine)
+   - Note the **Client ID** and **Client Secret** from the app's General tab
+
+4. **Assign scopes to the application**
+   - App → Okta API Scopes tab — this is for Okta management APIs, not your custom server
+   - Instead: go to Security → API → your Authorization Server → Access Policies
+   - Add a Policy → Add Rule → Grant type: Client Credentials, Client: your app, Scopes: the SMART scopes you created
+
+#### Run HFS Against Okta
+
+Replace `{domain}` with your Okta domain (e.g. `dev-12345678.okta.com`) and `{auth-server-id}` with the ID from the authorization server URL (e.g. `aus1abc2defGHIJK`):
+
 ```bash
-HFS_AUTH_JWKS_URL=https://{domain}/oauth2/{auth-server}/v1/keys
-HFS_AUTH_ISSUER=https://{domain}/oauth2/{auth-server}
-# Scope claim: "scp" (JSON array) — both formats are auto-detected
+HFS_AUTH_ENABLED=true \
+  HFS_AUTH_JWKS_URL=https://{domain}/oauth2/{auth-server-id}/v1/keys \
+  HFS_AUTH_ISSUER=https://{domain}/oauth2/{auth-server-id} \
+  HFS_AUTH_AUDIENCE=https://fhir.example.com \
+  HFS_SMART_TOKEN_ENDPOINT=https://{domain}/oauth2/{auth-server-id}/v1/token \
+  cargo run --bin hfs
 ```
+
+#### Get a Token
+
+```bash
+export TOKEN=$(curl -s -X POST \
+  https://{domain}/oauth2/{auth-server-id}/v1/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "{client_id}:{client_secret}" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "scope=system/*.cruds" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+```
+
+Or use the helper script (set env vars first):
+
+```bash
+OKTA_DOMAIN=dev-12345678.okta.com \
+  OKTA_AUTH_SERVER_ID=aus1abc2defGHIJK \
+  OKTA_CLIENT_ID=0oa... \
+  OKTA_CLIENT_SECRET=... \
+  ./docker/okta/get-token.sh
+```
+
+Decode the token to confirm the `scp` claim contains your SMART scopes and test:
+```bash
+echo $TOKEN | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool | grep -E "scp|iss|aud"
+curl -H "Authorization: Bearer <token>" http://localhost:8080/Patient/123
+```
+
+#### Okta Scope Claim Notes
+
+Okta issues scopes as `scp` (a JSON array), not `scope` (a string). HFS auto-detects both formats — no extra configuration is needed.
+
+#### Okta Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 401 — issuer mismatch | Wrong auth server ID | The `iss` in the token must exactly match `HFS_AUTH_ISSUER`; check with the decode one-liner above |
+| 401 — audience mismatch | `HFS_AUTH_AUDIENCE` set wrong | The `aud` claim in Okta tokens is the Authorization Server's audience value (set in step 1) |
+| 403 — scope not granted | Access Policy missing | Verify the Access Policy rule explicitly lists your client and the SMART scopes |
+| Empty `scp` in token | Scopes not requested | Include `scope=system/*.cruds` in the token request; Okta only grants requested scopes |
 
 ### Auth0
 
+A free developer account is available at [auth0.com](https://auth0.com).
+
+#### Auth0 Setup (one-time)
+
+1. **Register an API** (this is Auth0's term for the resource server HFS represents)
+   - Dashboard → Applications → APIs → Create API
+   - Name: `FHIR Server`, Identifier: `https://fhir.example.com` (this becomes the `aud` claim)
+   - Signing Algorithm: `RS256`
+   - Save — Auth0 automatically creates a test M2M application for the API
+
+2. **Add SMART scope permissions to the API**
+   - Dashboard → Applications → APIs → your API → Permissions tab
+   - Add each scope you need:
+     - `system/*.cruds` — Full SMART access
+     - `system/Patient.rs` — Read and search Patient
+     - `system/Observation.r` — Read-only Observation
+
+3. **Create a Machine-to-Machine application** (or use the auto-created test app)
+   - Dashboard → Applications → Applications → Create Application
+   - Choose **Machine to Machine Applications**
+   - Select your FHIR API from the dropdown and authorize it
+   - Select the scopes this client may request, then Authorize
+
+4. **Note your credentials**
+   - Application → Settings tab: copy **Domain**, **Client ID**, **Client Secret**
+
+#### Run HFS Against Auth0
+
 ```bash
-HFS_AUTH_JWKS_URL=https://{domain}/.well-known/jwks.json
-HFS_AUTH_ISSUER=https://{domain}/
-HFS_AUTH_AUDIENCE=https://fhir.example.com
+HFS_AUTH_ENABLED=true \
+  HFS_AUTH_JWKS_URL=https://{domain}/.well-known/jwks.json \
+  HFS_AUTH_ISSUER=https://{domain}/ \
+  HFS_AUTH_AUDIENCE=https://fhir.example.com \
+  HFS_SMART_TOKEN_ENDPOINT=https://{domain}/oauth/token \
+  cargo run --bin hfs
 ```
+
+#### Get a Token
+
+```bash
+export TOKEN=$(AUTH0_DOMAIN=... AUTH0_CLIENT_ID=... AUTH0_CLIENT_SECRET=... \
+  ./docker/auth0/get-token.sh)
+```
+
+Or call Auth0 directly:
+```bash
+export TOKEN=$(curl -s -X POST \
+  https://{domain}/oauth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  --data-urlencode "client_id={client_id}" \
+  --data-urlencode "client_secret={client_secret}" \
+  --data-urlencode "audience=https://fhir.example.com" \
+  --data-urlencode "scope=system/*.cruds" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+```
+
+Decode the token to confirm claims and test:
+```bash
+echo $TOKEN | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool | grep -E "scope|iss|aud"
+curl -H "Authorization: Bearer <token>" http://localhost:8080/Patient/123
+```
+
+#### Auth0 Scope Claim Notes
+
+Auth0 tokens include granted scopes in the `scope` claim as a space-delimited string. Scopes only appear in the token if they were both defined as API permissions *and* requested in the token request.
+
+#### Auth0 Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 401 — issuer mismatch | Trailing slash | Auth0 issuer is `https://{domain}/` — the trailing slash is required |
+| 401 — audience mismatch | Wrong identifier | `HFS_AUTH_AUDIENCE` must exactly match the API Identifier set in step 1 |
+| 403 — scope not in token | Scope not authorized | Ensure the scope is added as an API Permission *and* the M2M app is authorized for it |
+| Empty `scope` in token | Scope not requested | Include `scope=system/*.cruds` in the token request body |
+
 
 ### Microsoft Entra ID
 
@@ -198,6 +467,8 @@ HFS_AUTH_JWKS_URL=https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys
 HFS_AUTH_ISSUER=https://login.microsoftonline.com/{tenant}/v2.0
 # Permissions are typically in the "roles" claim
 ```
+
+**Setup summary:** Register an application, define App Roles with SMART scope names, grant the client application the roles, and use the client credentials flow. Entra tokens include granted permissions in the `roles` array rather than `scope`.
 
 ## Tenant Resolution
 

--- a/crates/auth/src/audit.rs
+++ b/crates/auth/src/audit.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+
+use crate::error::AuthError;
+use crate::principal::Principal;
+
+/// Trait for recording authentication and authorization events.
+///
+/// Implementations can log to structured tracing, persist FHIR AuditEvent
+/// resources, or forward to external systems. The default `NoopAuditEventSink`
+/// discards all events.
+#[async_trait]
+pub trait AuditEventSink: Send + Sync + 'static {
+    /// Called after a token is successfully validated.
+    async fn record_auth_success(&self, principal: &Principal, path: &str, method: &str);
+
+    /// Called when authentication fails (invalid/missing token).
+    async fn record_auth_failure(&self, error: &AuthError, path: &str, method: &str);
+
+    /// Called when an authenticated principal is denied access by policy.
+    async fn record_authz_denial(
+        &self,
+        principal: &Principal,
+        resource_type: &str,
+        operation: &str,
+    );
+}
+
+/// No-op audit sink that discards all events.
+///
+/// This is the default implementation used until a real audit
+/// backend is configured.
+pub struct NoopAuditEventSink;
+
+#[async_trait]
+impl AuditEventSink for NoopAuditEventSink {
+    async fn record_auth_success(&self, _principal: &Principal, _path: &str, _method: &str) {}
+
+    async fn record_auth_failure(&self, _error: &AuthError, _path: &str, _method: &str) {}
+
+    async fn record_authz_denial(
+        &self,
+        _principal: &Principal,
+        _resource_type: &str,
+        _operation: &str,
+    ) {
+    }
+}

--- a/crates/auth/src/config.rs
+++ b/crates/auth/src/config.rs
@@ -1,0 +1,122 @@
+use std::env;
+
+/// Configuration for the authentication and authorization subsystem.
+#[derive(Debug, Clone)]
+pub struct AuthConfig {
+    /// Master switch — when false, all auth is bypassed.
+    pub enabled: bool,
+    /// JWKS endpoint URL. Required when `enabled` is true.
+    pub jwks_url: Option<String>,
+    /// Expected JWT issuer (`iss` claim). Validated if set.
+    pub expected_issuer: Option<String>,
+    /// Expected JWT audience (`aud` claim). Validated if set.
+    ///
+    /// **Recommended for production.** Without audience validation, any valid
+    /// token from the same issuer is accepted — even tokens intended for a
+    /// different service. Set `HFS_AUTH_AUDIENCE` to restrict accepted tokens
+    /// to those explicitly issued for this server.
+    pub expected_audience: Option<String>,
+    /// JWT claim name used to extract the tenant ID.
+    pub tenant_claim: String,
+    /// Comma-separated list of allowed JWT signing algorithms.
+    pub allowed_algorithms: Vec<String>,
+    /// JTI cache backend: `"memory"` or `"redis"`.
+    pub jti_backend: String,
+    /// Redis connection URL (required when `jti_backend` is `"redis"`).
+    pub redis_url: Option<String>,
+    /// Minimum interval (seconds) between JWKS refreshes.
+    pub jwks_min_refresh_interval: u64,
+
+    // SMART discovery endpoint fields
+    /// Token endpoint URL for `/.well-known/smart-configuration`.
+    pub smart_token_endpoint: Option<String>,
+    /// Authorization endpoint URL.
+    pub smart_authorize_endpoint: Option<String>,
+    /// JWKS URL for the discovery document (may differ from `jwks_url`).
+    pub smart_jwks_url: Option<String>,
+    /// Introspection endpoint URL.
+    pub smart_introspection_endpoint: Option<String>,
+    /// Management endpoint URL.
+    pub smart_management_endpoint: Option<String>,
+    /// Registration endpoint URL.
+    pub smart_registration_endpoint: Option<String>,
+    /// Revocation endpoint URL.
+    pub smart_revocation_endpoint: Option<String>,
+}
+
+impl AuthConfig {
+    /// Load configuration from environment variables.
+    pub fn from_env() -> Self {
+        Self {
+            enabled: env::var("HFS_AUTH_ENABLED")
+                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+                .unwrap_or(false),
+            jwks_url: env::var("HFS_AUTH_JWKS_URL").ok(),
+            expected_issuer: env::var("HFS_AUTH_ISSUER").ok(),
+            expected_audience: env::var("HFS_AUTH_AUDIENCE").ok(),
+            tenant_claim: env::var("HFS_AUTH_TENANT_CLAIM")
+                .unwrap_or_else(|_| "tenant_id".to_string()),
+            allowed_algorithms: env::var("HFS_AUTH_ALGORITHMS")
+                .unwrap_or_else(|_| "RS256,RS384,ES256,ES384".to_string())
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .collect(),
+            jti_backend: env::var("HFS_AUTH_JTI_BACKEND").unwrap_or_else(|_| "memory".to_string()),
+            redis_url: env::var("HFS_AUTH_REDIS_URL").ok(),
+            jwks_min_refresh_interval: env::var("HFS_AUTH_JWKS_MIN_REFRESH_INTERVAL")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(10),
+            smart_token_endpoint: env::var("HFS_SMART_TOKEN_ENDPOINT").ok(),
+            smart_authorize_endpoint: env::var("HFS_SMART_AUTHORIZE_ENDPOINT").ok(),
+            smart_jwks_url: env::var("HFS_SMART_JWKS_URL").ok(),
+            smart_introspection_endpoint: env::var("HFS_SMART_INTROSPECTION_ENDPOINT").ok(),
+            smart_management_endpoint: env::var("HFS_SMART_MANAGEMENT_ENDPOINT").ok(),
+            smart_registration_endpoint: env::var("HFS_SMART_REGISTRATION_ENDPOINT").ok(),
+            smart_revocation_endpoint: env::var("HFS_SMART_REVOCATION_ENDPOINT").ok(),
+        }
+    }
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            jwks_url: None,
+            expected_issuer: None,
+            expected_audience: None,
+            tenant_claim: "tenant_id".to_string(),
+            allowed_algorithms: vec![
+                "RS256".to_string(),
+                "RS384".to_string(),
+                "ES256".to_string(),
+                "ES384".to_string(),
+            ],
+            jti_backend: "memory".to_string(),
+            redis_url: None,
+            jwks_min_refresh_interval: 10,
+            smart_token_endpoint: None,
+            smart_authorize_endpoint: None,
+            smart_jwks_url: None,
+            smart_introspection_endpoint: None,
+            smart_management_endpoint: None,
+            smart_registration_endpoint: None,
+            smart_revocation_endpoint: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = AuthConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.tenant_claim, "tenant_id");
+        assert_eq!(config.jti_backend, "memory");
+        assert_eq!(config.jwks_min_refresh_interval, 10);
+        assert_eq!(config.allowed_algorithms.len(), 4);
+    }
+}

--- a/crates/auth/src/discovery.rs
+++ b/crates/auth/src/discovery.rs
@@ -1,0 +1,118 @@
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::config::AuthConfig;
+
+/// SMART on FHIR configuration document served at
+/// `/.well-known/smart-configuration`.
+#[derive(Debug, Serialize)]
+pub struct SmartConfiguration {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwks_uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub introspection_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub management_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registration_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revocation_endpoint: Option<String>,
+    pub scopes_supported: Vec<String>,
+    pub response_types_supported: Vec<String>,
+    pub grant_types_supported: Vec<String>,
+    pub token_endpoint_auth_methods_supported: Vec<String>,
+    pub capabilities: Vec<String>,
+}
+
+impl SmartConfiguration {
+    /// Build the SMART configuration document from `AuthConfig`.
+    pub fn from_config(config: &AuthConfig) -> Self {
+        Self {
+            issuer: config.expected_issuer.clone(),
+            jwks_uri: config
+                .smart_jwks_url
+                .clone()
+                .or_else(|| config.jwks_url.clone()),
+            authorization_endpoint: config.smart_authorize_endpoint.clone(),
+            token_endpoint: config.smart_token_endpoint.clone(),
+            introspection_endpoint: config.smart_introspection_endpoint.clone(),
+            management_endpoint: config.smart_management_endpoint.clone(),
+            registration_endpoint: config.smart_registration_endpoint.clone(),
+            revocation_endpoint: config.smart_revocation_endpoint.clone(),
+            scopes_supported: vec![
+                "system/*.cruds".to_string(),
+                "system/*.rs".to_string(),
+                "system/*.r".to_string(),
+            ],
+            response_types_supported: vec!["token".to_string()],
+            grant_types_supported: vec!["client_credentials".to_string()],
+            token_endpoint_auth_methods_supported: vec!["private_key_jwt".to_string()],
+            capabilities: vec![
+                "permission-v2".to_string(),
+                "client-confidential-asymmetric".to_string(),
+            ],
+        }
+    }
+
+    /// Serialize to a JSON `Value`.
+    pub fn to_json(&self) -> Value {
+        serde_json::to_value(self).expect("SmartConfiguration serialization cannot fail")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_smart_config_from_default() {
+        let config = AuthConfig::default();
+        let smart = SmartConfiguration::from_config(&config);
+
+        assert!(smart.issuer.is_none());
+        assert!(smart.token_endpoint.is_none());
+        assert!(smart.capabilities.contains(&"permission-v2".to_string()));
+    }
+
+    #[test]
+    fn test_smart_config_with_values() {
+        let config = AuthConfig {
+            expected_issuer: Some("https://idp.example.com".to_string()),
+            smart_token_endpoint: Some("https://idp.example.com/token".to_string()),
+            smart_jwks_url: Some("https://idp.example.com/.well-known/jwks.json".to_string()),
+            ..AuthConfig::default()
+        };
+        let smart = SmartConfiguration::from_config(&config);
+
+        assert_eq!(smart.issuer.as_deref(), Some("https://idp.example.com"));
+        assert_eq!(
+            smart.token_endpoint.as_deref(),
+            Some("https://idp.example.com/token")
+        );
+        assert_eq!(
+            smart.jwks_uri.as_deref(),
+            Some("https://idp.example.com/.well-known/jwks.json")
+        );
+    }
+
+    #[test]
+    fn test_smart_config_json_serialization() {
+        let config = AuthConfig {
+            expected_issuer: Some("https://idp.example.com".to_string()),
+            ..AuthConfig::default()
+        };
+        let smart = SmartConfiguration::from_config(&config);
+        let json = smart.to_json();
+
+        assert!(json["capabilities"].is_array());
+        assert!(json["scopes_supported"].is_array());
+        // Fields that are None should be omitted
+        assert!(json.get("authorization_endpoint").is_none());
+    }
+}

--- a/crates/auth/src/error.rs
+++ b/crates/auth/src/error.rs
@@ -1,0 +1,90 @@
+use std::fmt;
+
+/// Errors that can occur during authentication and authorization.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    /// No Authorization header present.
+    #[error("Missing Authorization header")]
+    MissingToken,
+
+    /// Authorization header is malformed.
+    #[error("Invalid token format: {0}")]
+    InvalidTokenFormat(String),
+
+    /// Token has expired.
+    #[error("Token expired")]
+    TokenExpired,
+
+    /// Token signature is invalid.
+    #[error("Invalid signature")]
+    InvalidSignature,
+
+    /// JWT algorithm is not in the allowed list.
+    #[error("Unsupported algorithm: {alg}")]
+    UnsupportedAlgorithm {
+        /// The algorithm that was rejected.
+        alg: String,
+    },
+
+    /// Key ID from JWT header not found in JWKS.
+    #[error("Unknown key ID: {kid}")]
+    UnknownKid {
+        /// The key ID that was not found.
+        kid: String,
+    },
+
+    /// Token with this JTI has already been used.
+    #[error("JTI replay detected: {jti}")]
+    ReplayDetected {
+        /// The replayed JWT ID.
+        jti: String,
+    },
+
+    /// Authenticated principal lacks required scopes.
+    #[error("Forbidden: insufficient scope for {operation} on {resource_type}")]
+    Forbidden {
+        /// The FHIR resource type.
+        resource_type: String,
+        /// The operation that was attempted.
+        operation: String,
+    },
+
+    /// Failed to fetch JWKS from the endpoint.
+    #[error("JWKS fetch error: {0}")]
+    JwksFetchError(String),
+
+    /// General token validation error.
+    #[error("Token validation error: {0}")]
+    ValidationError(String),
+
+    /// Internal error in the auth subsystem.
+    #[error("Internal auth error: {0}")]
+    InternalError(String),
+}
+
+/// The kind of FHIR operation being performed, used for scope checking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FhirOperation {
+    /// Read a resource by ID.
+    Read,
+    /// Search for resources.
+    Search,
+    /// Create a new resource.
+    Create,
+    /// Update an existing resource.
+    Update,
+    /// Delete a resource.
+    Delete,
+}
+
+impl fmt::Display for FhirOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FhirOperation::Read => write!(f, "read"),
+            FhirOperation::Search => write!(f, "search"),
+            FhirOperation::Create => write!(f, "create"),
+            FhirOperation::Update => write!(f, "update"),
+            FhirOperation::Delete => write!(f, "delete"),
+        }
+    }
+}

--- a/crates/auth/src/jti/memory.rs
+++ b/crates/auth/src/jti/memory.rs
@@ -1,0 +1,94 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use moka::future::Cache;
+
+use super::JtiCache;
+use crate::error::AuthError;
+
+/// In-memory JTI cache backed by moka.
+///
+/// Uses moka's time-to-live (TTL) to automatically evict entries
+/// after tokens expire, preventing unbounded growth.
+pub struct InMemoryJtiCache {
+    cache: Cache<String, ()>,
+}
+
+impl InMemoryJtiCache {
+    /// Create a new in-memory JTI cache.
+    ///
+    /// Entries are evicted after 1 hour (covers typical token lifetimes).
+    /// Max capacity prevents unbounded growth.
+    pub fn new() -> Self {
+        let cache = Cache::builder()
+            .max_capacity(100_000)
+            .time_to_live(Duration::from_secs(3600))
+            .build();
+        Self { cache }
+    }
+}
+
+impl Default for InMemoryJtiCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl JtiCache for InMemoryJtiCache {
+    async fn check_and_store(
+        &self,
+        jti: &str,
+        _expires_at: DateTime<Utc>,
+    ) -> Result<bool, AuthError> {
+        // Check if already present
+        if self.cache.get(jti).await.is_some() {
+            return Ok(true); // replay
+        }
+
+        // Store the JTI (TTL is set at cache level)
+        self.cache.insert(jti.to_string(), ()).await;
+
+        Ok(false) // not a replay
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration as ChronoDuration;
+
+    #[tokio::test]
+    async fn test_new_jti_not_replay() {
+        let cache = InMemoryJtiCache::new();
+        let expires = Utc::now() + ChronoDuration::hours(1);
+
+        let replay = cache.check_and_store("jti-1", expires).await.unwrap();
+        assert!(!replay);
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_jti_is_replay() {
+        let cache = InMemoryJtiCache::new();
+        let expires = Utc::now() + ChronoDuration::hours(1);
+
+        let first = cache.check_and_store("jti-2", expires).await.unwrap();
+        assert!(!first);
+
+        let second = cache.check_and_store("jti-2", expires).await.unwrap();
+        assert!(second);
+    }
+
+    #[tokio::test]
+    async fn test_different_jtis_independent() {
+        let cache = InMemoryJtiCache::new();
+        let expires = Utc::now() + ChronoDuration::hours(1);
+
+        let a = cache.check_and_store("jti-a", expires).await.unwrap();
+        assert!(!a);
+
+        let b = cache.check_and_store("jti-b", expires).await.unwrap();
+        assert!(!b);
+    }
+}

--- a/crates/auth/src/jti/mod.rs
+++ b/crates/auth/src/jti/mod.rs
@@ -1,0 +1,25 @@
+pub mod memory;
+#[cfg(feature = "redis")]
+pub mod redis;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::error::AuthError;
+
+/// Trait for JWT ID (jti) replay prevention.
+///
+/// Implementations store seen JTI values with TTLs matching
+/// the token's expiration time.
+#[async_trait]
+pub trait JtiCache: Send + Sync + 'static {
+    /// Check if a JTI has been seen before, and store it if not.
+    ///
+    /// Returns `true` if the JTI was already seen (replay detected).
+    /// Returns `false` if the JTI is new (stored successfully).
+    async fn check_and_store(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, AuthError>;
+}

--- a/crates/auth/src/jti/redis.rs
+++ b/crates/auth/src/jti/redis.rs
@@ -1,0 +1,65 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use redis::AsyncCommands;
+
+use super::JtiCache;
+use crate::error::AuthError;
+
+/// Redis-backed JTI cache for distributed deployments.
+///
+/// Uses `SET NX EX` for atomic check-and-store with TTL.
+pub struct RedisJtiCache {
+    client: redis::Client,
+}
+
+impl RedisJtiCache {
+    /// Create a new Redis JTI cache.
+    pub fn new(redis_url: &str) -> Result<Self, AuthError> {
+        let client = redis::Client::open(redis_url)
+            .map_err(|e| AuthError::InternalError(format!("Redis connection error: {}", e)))?;
+        Ok(Self { client })
+    }
+
+    fn key(jti: &str) -> String {
+        format!("hfs:jti:{}", jti)
+    }
+}
+
+#[async_trait]
+impl JtiCache for RedisJtiCache {
+    async fn check_and_store(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, AuthError> {
+        let mut conn = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| AuthError::InternalError(format!("Redis connection error: {}", e)))?;
+
+        let now = Utc::now();
+        let ttl_secs = if expires_at > now {
+            (expires_at - now).num_seconds().max(1) as u64
+        } else {
+            60 // expired tokens get a brief TTL
+        };
+
+        let key = Self::key(jti);
+
+        // SET key value NX EX ttl — returns true if the key was set (new),
+        // false if it already existed (replay).
+        let was_set: bool = redis::cmd("SET")
+            .arg(&key)
+            .arg("1")
+            .arg("NX")
+            .arg("EX")
+            .arg(ttl_secs)
+            .query_async(&mut conn)
+            .await
+            .map(|v: Option<String>| v.is_some())
+            .map_err(|e| AuthError::InternalError(format!("Redis SET error: {}", e)))?;
+
+        Ok(!was_set) // true = replay (key already existed)
+    }
+}

--- a/crates/auth/src/jti/redis.rs
+++ b/crates/auth/src/jti/redis.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use redis::AsyncCommands;
 
 use super::JtiCache;
 use crate::error::AuthError;

--- a/crates/auth/src/jwks/cache.rs
+++ b/crates/auth/src/jwks/cache.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use jsonwebtoken::DecodingKey;
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
+
+use super::fetcher::JwksFetcher;
+use crate::error::AuthError;
+
+/// Default cache TTL when no Cache-Control header is present.
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(3600);
+
+/// Caches JWKS keys with Cache-Control awareness and background refresh.
+pub struct JwksCache {
+    keys: Arc<RwLock<HashMap<String, DecodingKey>>>,
+    jwks_url: String,
+    fetcher: JwksFetcher,
+    expires_at: Arc<RwLock<Instant>>,
+    last_refresh: Arc<RwLock<Instant>>,
+    min_refresh_interval: Duration,
+}
+
+impl JwksCache {
+    /// Create a new JWKS cache.
+    ///
+    /// Does not fetch keys — call `initial_fetch()` before use.
+    pub fn new(jwks_url: &str, min_refresh_interval_secs: u64) -> Self {
+        Self {
+            keys: Arc::new(RwLock::new(HashMap::new())),
+            jwks_url: jwks_url.to_string(),
+            fetcher: JwksFetcher::new(),
+            expires_at: Arc::new(RwLock::new(Instant::now())),
+            last_refresh: Arc::new(RwLock::new(
+                Instant::now() - Duration::from_secs(min_refresh_interval_secs + 1),
+            )),
+            min_refresh_interval: Duration::from_secs(min_refresh_interval_secs),
+        }
+    }
+
+    /// Perform the initial JWKS fetch. Must be called before serving requests.
+    ///
+    /// Also spawns a background task to refresh keys before expiry.
+    pub async fn initial_fetch(&self) -> Result<(), AuthError> {
+        info!(url = %self.jwks_url, "Performing initial JWKS fetch");
+        self.refresh().await?;
+        self.spawn_background_refresh();
+        Ok(())
+    }
+
+    /// Get the decoding key for a given key ID.
+    ///
+    /// If the `kid` is not found, triggers a rate-limited refresh and retries.
+    pub async fn get_key(&self, kid: &str) -> Result<DecodingKey, AuthError> {
+        // Try cached keys first
+        {
+            let keys = self.keys.read().await;
+            if let Some(key) = keys.get(kid) {
+                return Ok(key.clone());
+            }
+        }
+
+        // Unknown kid — try refreshing (rate-limited)
+        debug!(kid, "Key not found in cache, attempting refresh");
+        self.try_refresh().await?;
+
+        // Retry after refresh
+        let keys = self.keys.read().await;
+        keys.get(kid).cloned().ok_or_else(|| AuthError::UnknownKid {
+            kid: kid.to_string(),
+        })
+    }
+
+    /// Attempt a refresh, respecting the rate limit.
+    async fn try_refresh(&self) -> Result<(), AuthError> {
+        let now = Instant::now();
+        {
+            let last = self.last_refresh.read().await;
+            if now.duration_since(*last) < self.min_refresh_interval {
+                debug!("JWKS refresh rate-limited, skipping");
+                return Ok(());
+            }
+        }
+        self.refresh().await
+    }
+
+    /// Fetch keys from the JWKS endpoint and update the cache.
+    async fn refresh(&self) -> Result<(), AuthError> {
+        let response = self.fetcher.fetch(&self.jwks_url).await?;
+
+        let ttl = response.max_age.unwrap_or(DEFAULT_CACHE_TTL);
+
+        {
+            let mut keys = self.keys.write().await;
+            *keys = response.keys;
+        }
+        {
+            let mut expires = self.expires_at.write().await;
+            *expires = Instant::now() + ttl;
+        }
+        {
+            let mut last = self.last_refresh.write().await;
+            *last = Instant::now();
+        }
+
+        info!(ttl_secs = ttl.as_secs(), "JWKS cache refreshed");
+        Ok(())
+    }
+
+    /// Spawn a background task that refreshes keys before they expire.
+    fn spawn_background_refresh(&self) {
+        let keys = Arc::clone(&self.keys);
+        let expires_at = Arc::clone(&self.expires_at);
+        let last_refresh = Arc::clone(&self.last_refresh);
+        let url = self.jwks_url.clone();
+        let fetcher = self.fetcher.clone();
+        let min_interval = self.min_refresh_interval;
+
+        tokio::spawn(async move {
+            loop {
+                // Sleep until shortly before expiry
+                let sleep_duration = {
+                    let expires = expires_at.read().await;
+                    let now = Instant::now();
+                    if *expires > now {
+                        let remaining = *expires - now;
+                        // Refresh at 75% of TTL to avoid edge cases
+                        remaining.mul_f64(0.75)
+                    } else {
+                        min_interval
+                    }
+                };
+
+                tokio::time::sleep(sleep_duration).await;
+
+                debug!(url = %url, "Background JWKS refresh triggered");
+                match fetcher.fetch(&url).await {
+                    Ok(response) => {
+                        let ttl = response.max_age.unwrap_or(DEFAULT_CACHE_TTL);
+                        {
+                            let mut k = keys.write().await;
+                            *k = response.keys;
+                        }
+                        {
+                            let mut e = expires_at.write().await;
+                            *e = Instant::now() + ttl;
+                        }
+                        {
+                            let mut l = last_refresh.write().await;
+                            *l = Instant::now();
+                        }
+                        info!(ttl_secs = ttl.as_secs(), "Background JWKS refresh complete");
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "Background JWKS refresh failed, will retry");
+                    }
+                }
+            }
+        });
+    }
+}

--- a/crates/auth/src/jwks/coordinator.rs
+++ b/crates/auth/src/jwks/coordinator.rs
@@ -1,0 +1,95 @@
+use redis::AsyncCommands;
+use std::time::Duration;
+use tracing::{debug, info, warn};
+
+use crate::error::AuthError;
+
+/// Redis-based coordinator for JWKS refresh across multiple HFS instances.
+///
+/// Uses a Redis lock to ensure only one instance performs the JWKS fetch
+/// at a time, preventing thundering herd on the IdP's JWKS endpoint.
+pub struct JwksCoordinator {
+    client: redis::Client,
+    lock_key: String,
+    lock_ttl: Duration,
+}
+
+impl JwksCoordinator {
+    /// Create a new coordinator.
+    ///
+    /// * `redis_url` — Redis connection string
+    /// * `lock_ttl` — How long the refresh lock is held (default: 30s)
+    pub fn new(redis_url: &str, lock_ttl: Duration) -> Result<Self, AuthError> {
+        let client = redis::Client::open(redis_url)
+            .map_err(|e| AuthError::InternalError(format!("Redis connection error: {}", e)))?;
+        Ok(Self {
+            client,
+            lock_key: "hfs:jwks:refresh_lock".to_string(),
+            lock_ttl,
+        })
+    }
+
+    /// Try to acquire the refresh lock.
+    ///
+    /// Returns `true` if this instance is the leader and should perform the refresh.
+    pub async fn try_acquire_lock(&self) -> Result<bool, AuthError> {
+        let mut conn = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| AuthError::InternalError(format!("Redis connection error: {}", e)))?;
+
+        let acquired: bool = redis::cmd("SET")
+            .arg(&self.lock_key)
+            .arg("1")
+            .arg("NX")
+            .arg("EX")
+            .arg(self.lock_ttl.as_secs())
+            .query_async(&mut conn)
+            .await
+            .map(|v: Option<String>| v.is_some())
+            .map_err(|e| AuthError::InternalError(format!("Redis SET error: {}", e)))?;
+
+        if acquired {
+            debug!("Acquired JWKS refresh lock");
+        } else {
+            debug!("Another instance holds the JWKS refresh lock");
+        }
+
+        Ok(acquired)
+    }
+
+    /// Store serialized JWKS keys in Redis for other instances to read.
+    pub async fn store_keys(&self, keys_json: &str) -> Result<(), AuthError> {
+        let mut conn = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| AuthError::InternalError(format!("Redis connection error: {}", e)))?;
+
+        // Store keys with a TTL longer than the lock to allow non-leaders to read
+        let _: () = conn
+            .set_ex("hfs:jwks:keys", keys_json, self.lock_ttl.as_secs() * 4)
+            .await
+            .map_err(|e| AuthError::InternalError(format!("Redis SET error: {}", e)))?;
+
+        info!("Stored JWKS keys in Redis");
+        Ok(())
+    }
+
+    /// Read cached JWKS keys from Redis (for non-leader instances).
+    pub async fn load_keys(&self) -> Result<Option<String>, AuthError> {
+        let mut conn = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| AuthError::InternalError(format!("Redis connection error: {}", e)))?;
+
+        let keys: Option<String> = conn
+            .get("hfs:jwks:keys")
+            .await
+            .map_err(|e| AuthError::InternalError(format!("Redis GET error: {}", e)))?;
+
+        Ok(keys)
+    }
+}

--- a/crates/auth/src/jwks/coordinator.rs
+++ b/crates/auth/src/jwks/coordinator.rs
@@ -1,6 +1,6 @@
 use redis::AsyncCommands;
 use std::time::Duration;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::error::AuthError;
 

--- a/crates/auth/src/jwks/fetcher.rs
+++ b/crates/auth/src/jwks/fetcher.rs
@@ -1,0 +1,191 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use jsonwebtoken::DecodingKey;
+use serde::Deserialize;
+use tracing::{debug, warn};
+
+use crate::error::AuthError;
+
+/// Response from a JWKS endpoint.
+pub struct JwksResponse {
+    /// Decoding keys indexed by key ID (`kid`).
+    pub keys: HashMap<String, DecodingKey>,
+    /// Cache duration parsed from HTTP `Cache-Control: max-age=N`.
+    pub max_age: Option<Duration>,
+}
+
+/// A single JWK from a JWKS endpoint.
+#[derive(Debug, Deserialize)]
+struct Jwk {
+    kid: Option<String>,
+    kty: String,
+    #[serde(rename = "use")]
+    key_use: Option<String>,
+    #[allow(dead_code)]
+    alg: Option<String>,
+    // RSA fields
+    n: Option<String>,
+    e: Option<String>,
+    // EC fields
+    crv: Option<String>,
+    x: Option<String>,
+    y: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JwksDocument {
+    keys: Vec<Jwk>,
+}
+
+/// Fetches and parses JWKS documents from HTTP endpoints.
+#[derive(Clone)]
+pub struct JwksFetcher {
+    client: reqwest::Client,
+}
+
+impl JwksFetcher {
+    /// Create a new JWKS fetcher with a shared HTTP client.
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .expect("Failed to build HTTP client");
+        Self { client }
+    }
+
+    /// Fetch and parse a JWKS document from the given URL.
+    pub async fn fetch(&self, url: &str) -> Result<JwksResponse, AuthError> {
+        debug!(url, "Fetching JWKS");
+
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| AuthError::JwksFetchError(format!("HTTP request failed: {}", e)))?;
+
+        if !response.status().is_success() {
+            return Err(AuthError::JwksFetchError(format!(
+                "JWKS endpoint returned status {}",
+                response.status()
+            )));
+        }
+
+        // Parse Cache-Control max-age
+        let max_age = response
+            .headers()
+            .get("cache-control")
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_max_age);
+
+        let doc: JwksDocument = response
+            .json()
+            .await
+            .map_err(|e| AuthError::JwksFetchError(format!("Failed to parse JWKS JSON: {}", e)))?;
+
+        let mut keys = HashMap::new();
+        for jwk in doc.keys {
+            // Only include signing keys (use=sig or unspecified)
+            if let Some(ref key_use) = jwk.key_use {
+                if key_use != "sig" {
+                    continue;
+                }
+            }
+
+            let kid = match jwk.kid {
+                Some(ref kid) => kid.clone(),
+                None => {
+                    warn!("Skipping JWK without kid");
+                    continue;
+                }
+            };
+
+            match build_decoding_key(&jwk) {
+                Ok(key) => {
+                    debug!(kid = %kid, kty = %jwk.kty, "Loaded JWK");
+                    keys.insert(kid, key);
+                }
+                Err(e) => {
+                    warn!(kid = %kid, error = %e, "Failed to parse JWK, skipping");
+                }
+            }
+        }
+
+        debug!(key_count = keys.len(), "JWKS fetch complete");
+        Ok(JwksResponse { keys, max_age })
+    }
+}
+
+impl Default for JwksFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn build_decoding_key(jwk: &Jwk) -> Result<DecodingKey, AuthError> {
+    match jwk.kty.as_str() {
+        "RSA" => {
+            let n = jwk
+                .n
+                .as_ref()
+                .ok_or_else(|| AuthError::JwksFetchError("RSA JWK missing 'n'".to_string()))?;
+            let e = jwk
+                .e
+                .as_ref()
+                .ok_or_else(|| AuthError::JwksFetchError("RSA JWK missing 'e'".to_string()))?;
+            DecodingKey::from_rsa_components(n, e)
+                .map_err(|e| AuthError::JwksFetchError(format!("Invalid RSA key: {}", e)))
+        }
+        "EC" => {
+            let x = jwk
+                .x
+                .as_ref()
+                .ok_or_else(|| AuthError::JwksFetchError("EC JWK missing 'x'".to_string()))?;
+            let y = jwk
+                .y
+                .as_ref()
+                .ok_or_else(|| AuthError::JwksFetchError("EC JWK missing 'y'".to_string()))?;
+            let crv = jwk.crv.as_deref().unwrap_or("P-256");
+            DecodingKey::from_ec_components(x, y).map_err(|e| {
+                AuthError::JwksFetchError(format!("Invalid EC key (crv={}): {}", crv, e))
+            })
+        }
+        other => Err(AuthError::JwksFetchError(format!(
+            "Unsupported key type: {}",
+            other
+        ))),
+    }
+}
+
+/// Parse `max-age=N` from a Cache-Control header value.
+fn parse_max_age(cache_control: &str) -> Option<Duration> {
+    for directive in cache_control.split(',') {
+        let directive = directive.trim();
+        if let Some(val) = directive.strip_prefix("max-age=") {
+            if let Ok(secs) = val.trim().parse::<u64>() {
+                return Some(Duration::from_secs(secs));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_max_age() {
+        assert_eq!(
+            parse_max_age("max-age=3600"),
+            Some(Duration::from_secs(3600))
+        );
+        assert_eq!(
+            parse_max_age("public, max-age=86400, must-revalidate"),
+            Some(Duration::from_secs(86400))
+        );
+        assert_eq!(parse_max_age("no-cache"), None);
+        assert_eq!(parse_max_age(""), None);
+    }
+}

--- a/crates/auth/src/jwks/mod.rs
+++ b/crates/auth/src/jwks/mod.rs
@@ -1,0 +1,7 @@
+pub mod cache;
+#[cfg(feature = "redis")]
+pub mod coordinator;
+pub mod fetcher;
+
+pub use cache::JwksCache;
+pub use fetcher::JwksFetcher;

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -1,0 +1,47 @@
+//! # helios-auth — Authentication and Authorization for the Helios FHIR Server
+//!
+//! This crate provides SMART Backend Services authentication via JWT/JWKS
+//! validation, SMART v2 scope-based authorization, and supporting infrastructure
+//! (JTI replay prevention, JWKS key caching, audit event sinks).
+//!
+//! ## Architecture
+//!
+//! HFS does **not** act as an authorization server. Token issuance and client
+//! registration remain external (Keycloak, Okta, Auth0, Entra ID, etc.).
+//! This crate performs local JWT validation: signature verification, claim
+//! checks (issuer, audience, expiry), and JTI replay prevention.
+//!
+//! ## Key Types
+//!
+//! - [`Principal`] — Authenticated identity extracted from a validated JWT
+//! - [`ScopeSet`] — Parsed SMART v2 scopes with permission checking
+//! - [`AuthProvider`] — Trait for token validation implementations
+//! - [`JwksBearerAuthProvider`] — JWKS-based JWT validation
+//! - [`SmartScopePolicy`] — Scope-based authorization checks
+//! - [`AuthConfig`] — Configuration from environment variables
+
+pub mod audit;
+pub mod config;
+pub mod discovery;
+pub mod error;
+pub mod jti;
+pub mod jwks;
+pub mod policy;
+pub mod principal;
+pub mod provider;
+pub mod scope;
+
+// Re-export commonly used types
+pub use audit::{AuditEventSink, NoopAuditEventSink};
+pub use config::AuthConfig;
+pub use discovery::SmartConfiguration;
+pub use error::{AuthError, FhirOperation};
+pub use jti::{JtiCache, memory::InMemoryJtiCache};
+pub use jwks::JwksCache;
+pub use policy::SmartScopePolicy;
+pub use principal::Principal;
+pub use provider::{AuthProvider, jwks_bearer::JwksBearerAuthProvider};
+pub use scope::{ScopeSet, SmartPermissions};
+
+#[cfg(feature = "redis")]
+pub use jti::redis::RedisJtiCache;

--- a/crates/auth/src/policy/mod.rs
+++ b/crates/auth/src/policy/mod.rs
@@ -1,0 +1,106 @@
+use crate::error::{AuthError, FhirOperation};
+use crate::principal::Principal;
+use crate::scope::SmartPermissions;
+
+/// Checks whether a Principal's SMART scopes authorize a FHIR operation.
+pub struct SmartScopePolicy;
+
+impl SmartScopePolicy {
+    /// Check if the principal is authorized to perform the given operation
+    /// on the given resource type.
+    ///
+    /// Returns `Ok(())` if authorized, or `Err(AuthError::Forbidden)` if not.
+    pub fn check(
+        principal: &Principal,
+        resource_type: &str,
+        operation: FhirOperation,
+    ) -> Result<(), AuthError> {
+        let permission = Self::operation_to_permission(operation);
+
+        if principal.scopes.is_permitted(resource_type, permission) {
+            Ok(())
+        } else {
+            Err(AuthError::Forbidden {
+                resource_type: resource_type.to_string(),
+                operation: operation.to_string(),
+            })
+        }
+    }
+
+    /// Map a FHIR operation to the corresponding SMART permission bit.
+    fn operation_to_permission(operation: FhirOperation) -> SmartPermissions {
+        match operation {
+            FhirOperation::Read => SmartPermissions::READ,
+            FhirOperation::Search => SmartPermissions::SEARCH,
+            FhirOperation::Create => SmartPermissions::CREATE,
+            FhirOperation::Update => SmartPermissions::UPDATE,
+            FhirOperation::Delete => SmartPermissions::DELETE,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scope::ScopeSet;
+    use chrono::Utc;
+
+    fn make_principal(scope_str: &str) -> Principal {
+        Principal {
+            subject: "test-client".to_string(),
+            issuer: "https://idp.example.com".to_string(),
+            tenant_id: Some("tenant-1".to_string()),
+            scopes: ScopeSet::parse(scope_str),
+            jti: None,
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            custom_claims: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn test_read_permitted() {
+        let principal = make_principal("system/Patient.rs");
+        assert!(SmartScopePolicy::check(&principal, "Patient", FhirOperation::Read).is_ok());
+    }
+
+    #[test]
+    fn test_search_permitted() {
+        let principal = make_principal("system/Patient.rs");
+        assert!(SmartScopePolicy::check(&principal, "Patient", FhirOperation::Search).is_ok());
+    }
+
+    #[test]
+    fn test_create_denied() {
+        let principal = make_principal("system/Patient.rs");
+        assert!(SmartScopePolicy::check(&principal, "Patient", FhirOperation::Create).is_err());
+    }
+
+    #[test]
+    fn test_wrong_resource_type() {
+        let principal = make_principal("system/Patient.rs");
+        assert!(SmartScopePolicy::check(&principal, "Observation", FhirOperation::Read).is_err());
+    }
+
+    #[test]
+    fn test_wildcard_full_access() {
+        let principal = make_principal("system/*.cruds");
+        assert!(SmartScopePolicy::check(&principal, "Patient", FhirOperation::Create).is_ok());
+        assert!(SmartScopePolicy::check(&principal, "Observation", FhirOperation::Delete).is_ok());
+        assert!(SmartScopePolicy::check(&principal, "Condition", FhirOperation::Search).is_ok());
+    }
+
+    #[test]
+    fn test_multiple_scopes() {
+        let principal = make_principal("system/Patient.rs system/Observation.crud");
+        assert!(SmartScopePolicy::check(&principal, "Patient", FhirOperation::Read).is_ok());
+        assert!(SmartScopePolicy::check(&principal, "Patient", FhirOperation::Create).is_err());
+        assert!(SmartScopePolicy::check(&principal, "Observation", FhirOperation::Create).is_ok());
+        assert!(SmartScopePolicy::check(&principal, "Observation", FhirOperation::Search).is_err());
+    }
+
+    #[test]
+    fn test_empty_scopes_deny_all() {
+        let principal = make_principal("");
+        assert!(SmartScopePolicy::check(&principal, "Patient", FhirOperation::Read).is_err());
+    }
+}

--- a/crates/auth/src/principal.rs
+++ b/crates/auth/src/principal.rs
@@ -1,0 +1,42 @@
+use chrono::{DateTime, Utc};
+
+use crate::scope::ScopeSet;
+
+/// Represents an authenticated identity extracted from a validated JWT.
+///
+/// Injected into Axum request extensions by the auth middleware after
+/// successful token validation.
+#[derive(Debug, Clone)]
+pub struct Principal {
+    /// The `sub` (subject) claim from the JWT.
+    pub subject: String,
+    /// The `iss` (issuer) claim from the JWT.
+    pub issuer: String,
+    /// The tenant ID extracted from the configured JWT claim.
+    pub tenant_id: Option<String>,
+    /// Parsed SMART v2 scopes granted to this principal.
+    pub scopes: ScopeSet,
+    /// The `jti` (JWT ID) claim, used for replay prevention.
+    pub jti: Option<String>,
+    /// Token expiration time.
+    pub expires_at: DateTime<Utc>,
+    /// Additional claims from the JWT not captured in other fields.
+    pub custom_claims: serde_json::Map<String, serde_json::Value>,
+}
+
+impl Principal {
+    /// Returns the client/subject identifier.
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// Returns the token issuer.
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    /// Returns the tenant ID if present in the token.
+    pub fn tenant_id(&self) -> Option<&str> {
+        self.tenant_id.as_deref()
+    }
+}

--- a/crates/auth/src/provider/jwks_bearer.rs
+++ b/crates/auth/src/provider/jwks_bearer.rs
@@ -1,0 +1,219 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use jsonwebtoken::{Algorithm, Validation, decode, decode_header};
+use tracing::{debug, warn};
+
+use super::AuthProvider;
+use crate::config::AuthConfig;
+use crate::error::AuthError;
+use crate::jti::JtiCache;
+use crate::jwks::JwksCache;
+use crate::principal::Principal;
+use crate::scope::ScopeSet;
+
+/// Authentication provider that validates Bearer tokens as JWTs
+/// using keys from a JWKS endpoint.
+pub struct JwksBearerAuthProvider {
+    jwks_cache: Arc<JwksCache>,
+    jti_cache: Arc<dyn JtiCache>,
+    expected_audience: Option<String>,
+    expected_issuer: Option<String>,
+    tenant_claim: String,
+    allowed_algorithms: Vec<Algorithm>,
+}
+
+impl JwksBearerAuthProvider {
+    /// Create a new JWKS Bearer auth provider.
+    pub fn new(
+        jwks_cache: Arc<JwksCache>,
+        jti_cache: Arc<dyn JtiCache>,
+        config: &AuthConfig,
+    ) -> Self {
+        let allowed_algorithms = config
+            .allowed_algorithms
+            .iter()
+            .filter_map(|alg| parse_algorithm(alg))
+            .collect();
+
+        Self {
+            jwks_cache,
+            jti_cache,
+            expected_audience: config.expected_audience.clone(),
+            expected_issuer: config.expected_issuer.clone(),
+            tenant_claim: config.tenant_claim.clone(),
+            allowed_algorithms,
+        }
+    }
+}
+
+#[async_trait]
+impl AuthProvider for JwksBearerAuthProvider {
+    async fn authenticate(&self, authorization_header: &str) -> Result<Principal, AuthError> {
+        // 1. Strip "Bearer " prefix
+        let token = authorization_header
+            .strip_prefix("Bearer ")
+            .ok_or_else(|| {
+                AuthError::InvalidTokenFormat(
+                    "Authorization header must start with 'Bearer '".to_string(),
+                )
+            })?;
+
+        if token.is_empty() {
+            return Err(AuthError::InvalidTokenFormat("Empty token".to_string()));
+        }
+
+        // 2. Decode JWT header to get kid and alg
+        let header = decode_header(token).map_err(|e| {
+            AuthError::InvalidTokenFormat(format!("Failed to decode JWT header: {}", e))
+        })?;
+
+        let alg = header.alg;
+
+        // 3. Check algorithm is allowed
+        if !self.allowed_algorithms.contains(&alg) {
+            return Err(AuthError::UnsupportedAlgorithm {
+                alg: format!("{:?}", alg),
+            });
+        }
+
+        // 4. Look up key by kid
+        let kid = header
+            .kid
+            .ok_or_else(|| AuthError::InvalidTokenFormat("JWT header missing 'kid'".to_string()))?;
+
+        let decoding_key = self.jwks_cache.get_key(&kid).await?;
+
+        // 5. Build validation
+        let mut validation = Validation::new(alg);
+
+        if let Some(ref aud) = self.expected_audience {
+            validation.set_audience(&[aud]);
+        } else {
+            validation.validate_aud = false;
+        }
+
+        if let Some(ref iss) = self.expected_issuer {
+            validation.set_issuer(&[iss]);
+        }
+
+        validation.validate_exp = true;
+
+        // 6. Decode and validate
+        let token_data =
+            decode::<serde_json::Value>(token, &decoding_key, &validation).map_err(|e| match e
+                .kind()
+            {
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature => AuthError::TokenExpired,
+                jsonwebtoken::errors::ErrorKind::InvalidSignature => AuthError::InvalidSignature,
+                jsonwebtoken::errors::ErrorKind::InvalidAudience => {
+                    AuthError::ValidationError("Invalid audience".to_string())
+                }
+                jsonwebtoken::errors::ErrorKind::InvalidIssuer => {
+                    AuthError::ValidationError("Invalid issuer".to_string())
+                }
+                _ => AuthError::ValidationError(format!("Token validation failed: {}", e)),
+            })?;
+
+        let claims = token_data.claims;
+
+        // 7. Extract standard claims
+        let subject = claims
+            .get("sub")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let issuer = claims
+            .get("iss")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let jti = claims.get("jti").and_then(|v| v.as_str()).map(String::from);
+
+        let exp = claims
+            .get("exp")
+            .and_then(|v| v.as_i64())
+            .ok_or_else(|| AuthError::ValidationError("Missing 'exp' claim".to_string()))?;
+
+        let expires_at = chrono::DateTime::from_timestamp(exp, 0)
+            .ok_or_else(|| AuthError::ValidationError("Invalid 'exp' timestamp".to_string()))?;
+
+        // 8. JTI replay check
+        if let Some(ref jti_value) = jti {
+            let is_replay = self
+                .jti_cache
+                .check_and_store(jti_value, expires_at)
+                .await?;
+            if is_replay {
+                warn!(jti = %jti_value, sub = %subject, "JTI replay detected");
+                return Err(AuthError::ReplayDetected {
+                    jti: jti_value.clone(),
+                });
+            }
+        }
+
+        // 9. Parse scopes — handle both string ("scope") and array ("scp") formats
+        let scopes = if let Some(scope_str) = claims.get("scope").and_then(|v| v.as_str()) {
+            ScopeSet::parse(scope_str)
+        } else if let Some(scp_array) = claims.get("scp").and_then(|v| v.as_array()) {
+            let scope_strings: Vec<String> = scp_array
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            ScopeSet::parse_array(&scope_strings)
+        } else {
+            debug!(sub = %subject, "No scope or scp claim found in token");
+            ScopeSet::empty()
+        };
+
+        // 10. Extract tenant from configured claim
+        let tenant_id = claims
+            .get(&self.tenant_claim)
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        // 11. Build custom claims map (excluding standard claims)
+        let custom_claims = if let serde_json::Value::Object(map) = claims {
+            let standard = [
+                "sub", "iss", "exp", "iat", "nbf", "aud", "jti", "scope", "scp",
+            ];
+            map.into_iter()
+                .filter(|(k, _)| !standard.contains(&k.as_str()) && k != &self.tenant_claim)
+                .collect()
+        } else {
+            serde_json::Map::new()
+        };
+
+        debug!(sub = %subject, iss = %issuer, "Token validated successfully");
+
+        Ok(Principal {
+            subject,
+            issuer,
+            tenant_id,
+            scopes,
+            jti,
+            expires_at,
+            custom_claims,
+        })
+    }
+
+    fn name(&self) -> &str {
+        "jwks-bearer"
+    }
+}
+
+fn parse_algorithm(alg: &str) -> Option<Algorithm> {
+    match alg {
+        "RS256" => Some(Algorithm::RS256),
+        "RS384" => Some(Algorithm::RS384),
+        "RS512" => Some(Algorithm::RS512),
+        "ES256" => Some(Algorithm::ES256),
+        "ES384" => Some(Algorithm::ES384),
+        _ => {
+            warn!(algorithm = alg, "Unknown JWT algorithm, ignoring");
+            None
+        }
+    }
+}

--- a/crates/auth/src/provider/mod.rs
+++ b/crates/auth/src/provider/mod.rs
@@ -1,0 +1,20 @@
+pub mod jwks_bearer;
+
+use async_trait::async_trait;
+
+use crate::error::AuthError;
+use crate::principal::Principal;
+
+/// Trait for authenticating incoming requests.
+///
+/// The auth middleware calls `authenticate()` with the raw `Authorization`
+/// header value. Implementations validate the token and return a `Principal`
+/// on success.
+#[async_trait]
+pub trait AuthProvider: Send + Sync + 'static {
+    /// Authenticate from the Authorization header value (e.g., "Bearer <token>").
+    async fn authenticate(&self, authorization_header: &str) -> Result<Principal, AuthError>;
+
+    /// Returns the provider name for logging/diagnostics.
+    fn name(&self) -> &str;
+}

--- a/crates/auth/src/scope/mod.rs
+++ b/crates/auth/src/scope/mod.rs
@@ -1,0 +1,105 @@
+pub mod permissions;
+pub mod smart_v2;
+
+pub use permissions::SmartPermissions;
+pub use smart_v2::{ResourceTypeSpec, ScopeContext, SmartScope};
+
+/// A set of parsed SMART v2 scopes from a JWT token.
+#[derive(Debug, Clone, Default)]
+pub struct ScopeSet {
+    scopes: Vec<SmartScope>,
+}
+
+impl ScopeSet {
+    /// Create an empty scope set.
+    pub fn empty() -> Self {
+        Self { scopes: Vec::new() }
+    }
+
+    /// Parse a space-delimited scope string (from JWT `scope` claim).
+    ///
+    /// Non-SMART scopes (e.g., `openid`, `profile`) are silently ignored.
+    pub fn parse(scope_str: &str) -> Self {
+        let scopes = scope_str
+            .split_whitespace()
+            .filter_map(SmartScope::parse)
+            .collect();
+        Self { scopes }
+    }
+
+    /// Parse from an array of scope strings (from JWT `scp` claim, e.g., Okta).
+    pub fn parse_array(scope_strs: &[String]) -> Self {
+        let scopes = scope_strs
+            .iter()
+            .filter_map(|s| SmartScope::parse(s))
+            .collect();
+        Self { scopes }
+    }
+
+    /// Check if any scope grants the given permission on the given resource type.
+    pub fn is_permitted(&self, resource_type: &str, permission: SmartPermissions) -> bool {
+        self.scopes
+            .iter()
+            .any(|scope| scope.permits(resource_type, permission))
+    }
+
+    /// Returns the parsed scopes.
+    pub fn scopes(&self) -> &[SmartScope] {
+        &self.scopes
+    }
+
+    /// Returns true if no SMART scopes were parsed.
+    pub fn is_empty(&self) -> bool {
+        self.scopes.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_space_delimited() {
+        let set = ScopeSet::parse("system/Patient.rs system/Observation.r openid profile");
+        assert_eq!(set.scopes().len(), 2);
+        assert!(set.is_permitted("Patient", SmartPermissions::READ));
+        assert!(set.is_permitted("Patient", SmartPermissions::SEARCH));
+        assert!(set.is_permitted("Observation", SmartPermissions::READ));
+        assert!(!set.is_permitted("Observation", SmartPermissions::SEARCH));
+    }
+
+    #[test]
+    fn test_parse_array() {
+        let scopes = vec![
+            "system/Patient.rs".to_string(),
+            "system/*.crud".to_string(),
+            "openid".to_string(),
+        ];
+        let set = ScopeSet::parse_array(&scopes);
+        assert_eq!(set.scopes().len(), 2);
+        assert!(set.is_permitted("Patient", SmartPermissions::READ));
+        // Wildcard scope grants CRUD on everything
+        assert!(set.is_permitted("Condition", SmartPermissions::CREATE));
+    }
+
+    #[test]
+    fn test_empty_scope() {
+        let set = ScopeSet::parse("");
+        assert!(set.is_empty());
+        assert!(!set.is_permitted("Patient", SmartPermissions::READ));
+    }
+
+    #[test]
+    fn test_wildcard_scope() {
+        let set = ScopeSet::parse("system/*.cruds");
+        assert!(set.is_permitted("Patient", SmartPermissions::CREATE));
+        assert!(set.is_permitted("Observation", SmartPermissions::DELETE));
+        assert!(set.is_permitted("Condition", SmartPermissions::SEARCH));
+    }
+
+    #[test]
+    fn test_non_smart_scopes_ignored() {
+        let set = ScopeSet::parse("openid profile email launch/patient");
+        assert!(set.is_empty());
+    }
+}

--- a/crates/auth/src/scope/permissions.rs
+++ b/crates/auth/src/scope/permissions.rs
@@ -1,0 +1,127 @@
+use bitflags::bitflags;
+use std::fmt;
+
+bitflags! {
+    /// Permission bits for SMART on FHIR v2 scopes.
+    ///
+    /// Each bit corresponds to one of the CRUDS operations:
+    /// - `c` = Create
+    /// - `r` = Read
+    /// - `u` = Update
+    /// - `d` = Delete
+    /// - `s` = Search
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct SmartPermissions: u8 {
+        /// Permission to create resources.
+        const CREATE = 0b0000_0001;
+        /// Permission to read resources by ID.
+        const READ   = 0b0000_0010;
+        /// Permission to update resources.
+        const UPDATE = 0b0000_0100;
+        /// Permission to delete resources.
+        const DELETE = 0b0000_1000;
+        /// Permission to search for resources.
+        const SEARCH = 0b0001_0000;
+    }
+}
+
+impl SmartPermissions {
+    /// Parse a permission string from SMART v2 scope syntax.
+    ///
+    /// Each character maps to a permission: c, r, u, d, s.
+    /// Returns `None` if any character is unrecognized.
+    pub fn from_permission_str(s: &str) -> Option<Self> {
+        let mut perms = SmartPermissions::empty();
+        for ch in s.chars() {
+            match ch {
+                'c' => perms |= SmartPermissions::CREATE,
+                'r' => perms |= SmartPermissions::READ,
+                'u' => perms |= SmartPermissions::UPDATE,
+                'd' => perms |= SmartPermissions::DELETE,
+                's' => perms |= SmartPermissions::SEARCH,
+                _ => return None,
+            }
+        }
+        if perms.is_empty() { None } else { Some(perms) }
+    }
+}
+
+impl fmt::Display for SmartPermissions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.contains(SmartPermissions::CREATE) {
+            write!(f, "c")?;
+        }
+        if self.contains(SmartPermissions::READ) {
+            write!(f, "r")?;
+        }
+        if self.contains(SmartPermissions::UPDATE) {
+            write!(f, "u")?;
+        }
+        if self.contains(SmartPermissions::DELETE) {
+            write!(f, "d")?;
+        }
+        if self.contains(SmartPermissions::SEARCH) {
+            write!(f, "s")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_single_permissions() {
+        assert_eq!(
+            SmartPermissions::from_permission_str("r"),
+            Some(SmartPermissions::READ)
+        );
+        assert_eq!(
+            SmartPermissions::from_permission_str("c"),
+            Some(SmartPermissions::CREATE)
+        );
+        assert_eq!(
+            SmartPermissions::from_permission_str("s"),
+            Some(SmartPermissions::SEARCH)
+        );
+    }
+
+    #[test]
+    fn test_parse_combined_permissions() {
+        assert_eq!(
+            SmartPermissions::from_permission_str("rs"),
+            Some(SmartPermissions::READ | SmartPermissions::SEARCH)
+        );
+        assert_eq!(
+            SmartPermissions::from_permission_str("cruds"),
+            Some(
+                SmartPermissions::CREATE
+                    | SmartPermissions::READ
+                    | SmartPermissions::UPDATE
+                    | SmartPermissions::DELETE
+                    | SmartPermissions::SEARCH
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_permission() {
+        assert_eq!(SmartPermissions::from_permission_str("x"), None);
+        assert_eq!(SmartPermissions::from_permission_str("rz"), None);
+        assert_eq!(SmartPermissions::from_permission_str(""), None);
+    }
+
+    #[test]
+    fn test_display() {
+        let perms = SmartPermissions::READ | SmartPermissions::SEARCH;
+        assert_eq!(format!("{}", perms), "rs");
+
+        let all = SmartPermissions::CREATE
+            | SmartPermissions::READ
+            | SmartPermissions::UPDATE
+            | SmartPermissions::DELETE
+            | SmartPermissions::SEARCH;
+        assert_eq!(format!("{}", all), "cruds");
+    }
+}

--- a/crates/auth/src/scope/smart_v2.rs
+++ b/crates/auth/src/scope/smart_v2.rs
@@ -1,0 +1,203 @@
+use super::permissions::SmartPermissions;
+use std::fmt;
+
+/// The access context of a SMART scope.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ScopeContext {
+    /// System-level access (backend services, no user context).
+    System,
+    /// User-level access (scoped to the authenticated user).
+    User,
+    /// Patient-level access (scoped to a specific patient).
+    Patient,
+}
+
+impl fmt::Display for ScopeContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScopeContext::System => write!(f, "system"),
+            ScopeContext::User => write!(f, "user"),
+            ScopeContext::Patient => write!(f, "patient"),
+        }
+    }
+}
+
+/// The resource type specifier in a SMART scope.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ResourceTypeSpec {
+    /// A specific FHIR resource type (e.g., "Patient").
+    Specific(String),
+    /// Wildcard — applies to all resource types.
+    Wildcard,
+}
+
+impl fmt::Display for ResourceTypeSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ResourceTypeSpec::Specific(t) => write!(f, "{}", t),
+            ResourceTypeSpec::Wildcard => write!(f, "*"),
+        }
+    }
+}
+
+/// A single parsed SMART v2 scope.
+///
+/// Follows the format: `context/resourceType.permissions`
+///
+/// Examples:
+/// - `system/Patient.rs` — system-level read+search on Patient
+/// - `system/*.cruds` — system-level full CRUD+search on all types
+/// - `user/Observation.r` — user-level read on Observation
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SmartScope {
+    /// The access context.
+    pub context: ScopeContext,
+    /// The resource type or wildcard.
+    pub resource_type: ResourceTypeSpec,
+    /// The granted permissions.
+    pub permissions: SmartPermissions,
+}
+
+impl SmartScope {
+    /// Parse a single SMART v2 scope string.
+    ///
+    /// Expected format: `context/resourceType.permissions`
+    /// Returns `None` if the string is malformed.
+    pub fn parse(scope_str: &str) -> Option<Self> {
+        // Split into context and rest: "system/Patient.rs"
+        let (context_str, rest) = scope_str.split_once('/')?;
+
+        let context = match context_str {
+            "system" => ScopeContext::System,
+            "user" => ScopeContext::User,
+            "patient" => ScopeContext::Patient,
+            _ => return None,
+        };
+
+        // Split rest into resource type and permissions: "Patient.rs"
+        let (resource_str, perm_str) = rest.split_once('.')?;
+
+        if resource_str.is_empty() || perm_str.is_empty() {
+            return None;
+        }
+
+        let resource_type = if resource_str == "*" {
+            ResourceTypeSpec::Wildcard
+        } else {
+            ResourceTypeSpec::Specific(resource_str.to_string())
+        };
+
+        let permissions = SmartPermissions::from_permission_str(perm_str)?;
+
+        Some(SmartScope {
+            context,
+            resource_type,
+            permissions,
+        })
+    }
+
+    /// Check if this scope grants the given permission on the given resource type.
+    pub fn permits(&self, resource_type: &str, permission: SmartPermissions) -> bool {
+        let type_matches = match &self.resource_type {
+            ResourceTypeSpec::Wildcard => true,
+            ResourceTypeSpec::Specific(t) => t == resource_type,
+        };
+
+        type_matches && self.permissions.contains(permission)
+    }
+}
+
+impl fmt::Display for SmartScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}/{}.{}",
+            self.context, self.resource_type, self.permissions
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_system_patient_rs() {
+        let scope = SmartScope::parse("system/Patient.rs").unwrap();
+        assert_eq!(scope.context, ScopeContext::System);
+        assert_eq!(
+            scope.resource_type,
+            ResourceTypeSpec::Specific("Patient".to_string())
+        );
+        assert_eq!(
+            scope.permissions,
+            SmartPermissions::READ | SmartPermissions::SEARCH
+        );
+    }
+
+    #[test]
+    fn test_parse_wildcard_cruds() {
+        let scope = SmartScope::parse("system/*.cruds").unwrap();
+        assert_eq!(scope.context, ScopeContext::System);
+        assert_eq!(scope.resource_type, ResourceTypeSpec::Wildcard);
+        assert!(scope.permissions.contains(SmartPermissions::CREATE));
+        assert!(scope.permissions.contains(SmartPermissions::READ));
+        assert!(scope.permissions.contains(SmartPermissions::UPDATE));
+        assert!(scope.permissions.contains(SmartPermissions::DELETE));
+        assert!(scope.permissions.contains(SmartPermissions::SEARCH));
+    }
+
+    #[test]
+    fn test_parse_user_context() {
+        let scope = SmartScope::parse("user/Observation.r").unwrap();
+        assert_eq!(scope.context, ScopeContext::User);
+        assert_eq!(
+            scope.resource_type,
+            ResourceTypeSpec::Specific("Observation".to_string())
+        );
+        assert_eq!(scope.permissions, SmartPermissions::READ);
+    }
+
+    #[test]
+    fn test_parse_patient_context() {
+        let scope = SmartScope::parse("patient/MedicationRequest.crud").unwrap();
+        assert_eq!(scope.context, ScopeContext::Patient);
+    }
+
+    #[test]
+    fn test_parse_invalid_scopes() {
+        assert!(SmartScope::parse("").is_none());
+        assert!(SmartScope::parse("system").is_none());
+        assert!(SmartScope::parse("system/").is_none());
+        assert!(SmartScope::parse("system/Patient").is_none());
+        assert!(SmartScope::parse("system/.rs").is_none());
+        assert!(SmartScope::parse("system/Patient.").is_none());
+        assert!(SmartScope::parse("system/Patient.xyz").is_none());
+        assert!(SmartScope::parse("unknown/Patient.rs").is_none());
+        assert!(SmartScope::parse("foo/bar/baz").is_none());
+    }
+
+    #[test]
+    fn test_permits() {
+        let scope = SmartScope::parse("system/Patient.rs").unwrap();
+        assert!(scope.permits("Patient", SmartPermissions::READ));
+        assert!(scope.permits("Patient", SmartPermissions::SEARCH));
+        assert!(!scope.permits("Patient", SmartPermissions::CREATE));
+        assert!(!scope.permits("Observation", SmartPermissions::READ));
+    }
+
+    #[test]
+    fn test_permits_wildcard() {
+        let scope = SmartScope::parse("system/*.rs").unwrap();
+        assert!(scope.permits("Patient", SmartPermissions::READ));
+        assert!(scope.permits("Observation", SmartPermissions::SEARCH));
+        assert!(!scope.permits("Patient", SmartPermissions::DELETE));
+    }
+
+    #[test]
+    fn test_display_roundtrip() {
+        let original = "system/Patient.rs";
+        let scope = SmartScope::parse(original).unwrap();
+        assert_eq!(format!("{}", scope), original);
+    }
+}

--- a/crates/hfs/Cargo.toml
+++ b/crates/hfs/Cargo.toml
@@ -33,6 +33,9 @@ mongodb = ["helios-rest/mongodb"]
 elasticsearch = ["helios-rest/elasticsearch"]
 s3 = ["helios-rest/s3"]
 
+# Auth backends
+redis = ["helios-rest/redis", "helios-auth/redis"]
+
 [build-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }
 
@@ -40,6 +43,7 @@ reqwest = { version = "0.12", features = ["blocking"] }
 helios-fhir = { path = "../fhir", version = "0.1.47" }
 helios-rest = { path = "../rest", version = "0.1.47", default-features = false }
 helios-persistence = { path = "../persistence", version = "0.1.47", default-features = false }
+helios-auth = { path = "../auth", version = "0.1.47" }
 
 # Web framework
 axum = "0.8"

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -18,8 +18,15 @@
 //! Set `HFS_STORAGE_BACKEND` to `sqlite`, `sqlite-elasticsearch`, `postgres`,
 //! `postgres-elasticsearch`, `mongodb`, `mongodb-elasticsearch`, `s3`, or `s3-elasticsearch`.
 
+use std::sync::Arc;
+
 use clap::Parser;
-use helios_rest::{ServerConfig, StorageBackendMode, create_app_with_config, init_logging};
+use helios_auth::{
+    AuthConfig, InMemoryJtiCache, JtiCache, JwksBearerAuthProvider, JwksCache, NoopAuditEventSink,
+};
+use helios_rest::{
+    AuthMiddlewareState, ServerConfig, StorageBackendMode, create_app_with_auth, init_logging,
+};
 use tracing::info;
 
 #[cfg(feature = "sqlite")]
@@ -52,7 +59,11 @@ fn create_sqlite_backend(config: &ServerConfig) -> anyhow::Result<SqliteBackend>
 
 /// Starts the server with MongoDB backend.
 #[cfg(feature = "mongodb")]
-async fn start_mongodb(config: ServerConfig) -> anyhow::Result<()> {
+async fn start_mongodb(
+    config: ServerConfig,
+    auth_config: AuthConfig,
+    auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     let backend = if let Some(ref url) = config.database_url {
         if url.starts_with("mongodb://") || url.starts_with("mongodb+srv://") {
             info!(url = %url, "Initializing MongoDB backend from connection string");
@@ -70,13 +81,17 @@ async fn start_mongodb(config: ServerConfig) -> anyhow::Result<()> {
 
     backend.init_schema().await?;
 
-    let app = create_app_with_config(backend, config.clone());
+    let app = create_app_with_auth(backend, config.clone(), auth_config, auth_state);
     serve(app, &config).await
 }
 
 /// Fallback when mongodb feature is not enabled.
 #[cfg(not(feature = "mongodb"))]
-async fn start_mongodb(_config: ServerConfig) -> anyhow::Result<()> {
+async fn start_mongodb(
+    _config: ServerConfig,
+    _auth_config: AuthConfig,
+    _auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     anyhow::bail!(
         "The mongodb backend requires the 'mongodb' feature. \
          Build with: cargo build -p helios-hfs --features mongodb"
@@ -90,6 +105,76 @@ async fn serve(app: axum::Router, config: &ServerConfig) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     axum::serve(listener, app).await?;
     Ok(())
+}
+
+/// Initializes the authentication subsystem from environment configuration.
+///
+/// Returns the auth config and optional middleware state. If auth is disabled,
+/// returns `(config, None)`.
+async fn init_auth() -> anyhow::Result<(AuthConfig, Option<Arc<AuthMiddlewareState>>)> {
+    let auth_config = AuthConfig::from_env();
+
+    if !auth_config.enabled {
+        info!("Authentication is DISABLED");
+        return Ok((auth_config, None));
+    }
+
+    let jwks_url = auth_config.jwks_url.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("HFS_AUTH_JWKS_URL is required when HFS_AUTH_ENABLED=true")
+    })?;
+
+    // Require issuer validation to prevent cross-service token reuse
+    if auth_config.expected_issuer.is_none() {
+        anyhow::bail!("HFS_AUTH_ISSUER is required when HFS_AUTH_ENABLED=true");
+    }
+
+    // Create JTI cache
+    let jti_cache: Arc<dyn JtiCache> = match auth_config.jti_backend.as_str() {
+        #[cfg(feature = "redis")]
+        "redis" => {
+            let redis_url = auth_config.redis_url.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("HFS_AUTH_REDIS_URL is required when HFS_AUTH_JTI_BACKEND=redis")
+            })?;
+            info!(redis_url = %redis_url, "Using Redis JTI cache");
+            Arc::new(helios_auth::RedisJtiCache::new(redis_url)?)
+        }
+        #[cfg(not(feature = "redis"))]
+        "redis" => {
+            anyhow::bail!(
+                "Redis JTI backend requires the 'redis' feature. \
+                 Build with: cargo build -p helios-hfs --features redis"
+            );
+        }
+        _ => {
+            info!("Using in-memory JTI cache");
+            Arc::new(InMemoryJtiCache::new())
+        }
+    };
+
+    // Create JWKS cache
+    let jwks_cache = Arc::new(JwksCache::new(
+        jwks_url,
+        auth_config.jwks_min_refresh_interval,
+    ));
+    jwks_cache.initial_fetch().await?;
+
+    // Create auth provider
+    let provider = JwksBearerAuthProvider::new(jwks_cache, jti_cache, &auth_config);
+
+    info!(
+        jwks_url = %jwks_url,
+        issuer = ?auth_config.expected_issuer,
+        audience = ?auth_config.expected_audience,
+        "Authentication ENABLED"
+    );
+
+    let auth_state = Arc::new(AuthMiddlewareState {
+        provider: Arc::new(provider),
+        config: Arc::new(auth_config.clone()),
+        audit_sink: Arc::new(NoopAuditEventSink),
+    });
+
+    Ok((auth_config, Some(auth_state)))
 }
 
 #[tokio::main]
@@ -108,38 +193,42 @@ async fn main() -> anyhow::Result<()> {
         .storage_backend_mode()
         .map_err(|e| anyhow::anyhow!("Invalid storage backend configuration: {}", e))?;
 
+    // Initialize authentication
+    let (auth_config, auth_state) = init_auth().await?;
+
     info!(
         port = config.port,
         host = %config.host,
         fhir_version = ?config.default_fhir_version,
         storage_backend = %backend_mode,
+        auth_enabled = auth_config.enabled,
         "Starting Helios FHIR Server"
     );
 
     match backend_mode {
         StorageBackendMode::Sqlite => {
-            start_sqlite(config).await?;
+            start_sqlite(config, auth_config, auth_state).await?;
         }
         StorageBackendMode::SqliteElasticsearch => {
-            start_sqlite_elasticsearch(config).await?;
+            start_sqlite_elasticsearch(config, auth_config, auth_state).await?;
         }
         StorageBackendMode::Postgres => {
-            start_postgres(config).await?;
+            start_postgres(config, auth_config, auth_state).await?;
         }
         StorageBackendMode::PostgresElasticsearch => {
-            start_postgres_elasticsearch(config).await?;
+            start_postgres_elasticsearch(config, auth_config, auth_state).await?;
         }
         StorageBackendMode::MongoDB => {
-            start_mongodb(config).await?;
+            start_mongodb(config, auth_config, auth_state).await?;
         }
         StorageBackendMode::MongoDBElasticsearch => {
-            start_mongodb_elasticsearch(config).await?;
+            start_mongodb_elasticsearch(config, auth_config, auth_state).await?;
         }
         StorageBackendMode::S3 => {
-            start_s3(config).await?;
+            start_s3(config, auth_config, auth_state).await?;
         }
         StorageBackendMode::S3Elasticsearch => {
-            start_s3_elasticsearch(config).await?;
+            start_s3_elasticsearch(config, auth_config, auth_state).await?;
         }
     }
 
@@ -148,15 +237,23 @@ async fn main() -> anyhow::Result<()> {
 
 /// Starts the server with SQLite-only backend.
 #[cfg(feature = "sqlite")]
-async fn start_sqlite(config: ServerConfig) -> anyhow::Result<()> {
+async fn start_sqlite(
+    config: ServerConfig,
+    auth_config: AuthConfig,
+    auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     let backend = create_sqlite_backend(&config)?;
-    let app = create_app_with_config(backend, config.clone());
+    let app = create_app_with_auth(backend, config.clone(), auth_config, auth_state);
     serve(app, &config).await
 }
 
 /// Fallback when sqlite feature is not enabled.
 #[cfg(not(feature = "sqlite"))]
-async fn start_sqlite(_config: ServerConfig) -> anyhow::Result<()> {
+async fn start_sqlite(
+    _config: ServerConfig,
+    _auth_config: AuthConfig,
+    _auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     anyhow::bail!(
         "The sqlite backend requires the 'sqlite' feature. \
          Build with: cargo build -p helios-hfs --features sqlite"
@@ -165,7 +262,11 @@ async fn start_sqlite(_config: ServerConfig) -> anyhow::Result<()> {
 
 /// Starts the server with SQLite + Elasticsearch composite backend.
 #[cfg(all(feature = "sqlite", feature = "elasticsearch"))]
-async fn start_sqlite_elasticsearch(config: ServerConfig) -> anyhow::Result<()> {
+async fn start_sqlite_elasticsearch(
+    config: ServerConfig,
+    auth_config: AuthConfig,
+    auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -262,13 +363,17 @@ async fn start_sqlite_elasticsearch(config: ServerConfig) -> anyhow::Result<()> 
 
     info!("Composite storage initialized: SQLite (primary) + Elasticsearch (search)");
 
-    let app = create_app_with_config(composite, config.clone());
+    let app = create_app_with_auth(composite, config.clone(), auth_config, auth_state);
     serve(app, &config).await
 }
 
 /// Fallback when elasticsearch feature is not enabled.
 #[cfg(not(all(feature = "sqlite", feature = "elasticsearch")))]
-async fn start_sqlite_elasticsearch(_config: ServerConfig) -> anyhow::Result<()> {
+async fn start_sqlite_elasticsearch(
+    _config: ServerConfig,
+    _auth_config: AuthConfig,
+    _auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     anyhow::bail!(
         "The sqlite-elasticsearch backend requires the 'elasticsearch' feature. \
          Build with: cargo build -p helios-hfs --features sqlite,elasticsearch"
@@ -277,7 +382,11 @@ async fn start_sqlite_elasticsearch(_config: ServerConfig) -> anyhow::Result<()>
 
 /// Starts the server with PostgreSQL backend.
 #[cfg(feature = "postgres")]
-async fn start_postgres(config: ServerConfig) -> anyhow::Result<()> {
+async fn start_postgres(
+    config: ServerConfig,
+    auth_config: AuthConfig,
+    auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     use helios_persistence::backends::postgres::PostgresBackend;
 
     let backend = if let Some(ref url) = config.database_url {
@@ -295,13 +404,17 @@ async fn start_postgres(config: ServerConfig) -> anyhow::Result<()> {
 
     backend.init_schema().await?;
 
-    let app = create_app_with_config(backend, config.clone());
+    let app = create_app_with_auth(backend, config.clone(), auth_config, auth_state);
     serve(app, &config).await
 }
 
 /// Fallback when postgres feature is not enabled.
 #[cfg(not(feature = "postgres"))]
-async fn start_postgres(_config: ServerConfig) -> anyhow::Result<()> {
+async fn start_postgres(
+    _config: ServerConfig,
+    _auth_config: AuthConfig,
+    _auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     anyhow::bail!(
         "The postgres backend requires the 'postgres' feature. \
          Build with: cargo build -p helios-hfs --features postgres"
@@ -310,7 +423,11 @@ async fn start_postgres(_config: ServerConfig) -> anyhow::Result<()> {
 
 /// Starts the server with PostgreSQL + Elasticsearch composite backend.
 #[cfg(all(feature = "postgres", feature = "elasticsearch"))]
-async fn start_postgres_elasticsearch(config: ServerConfig) -> anyhow::Result<()> {
+async fn start_postgres_elasticsearch(
+    config: ServerConfig,
+    auth_config: AuthConfig,
+    auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -424,13 +541,17 @@ async fn start_postgres_elasticsearch(config: ServerConfig) -> anyhow::Result<()
 
     info!("Composite storage initialized: PostgreSQL (primary) + Elasticsearch (search)");
 
-    let app = create_app_with_config(composite, config.clone());
+    let app = create_app_with_auth(composite, config.clone(), auth_config, auth_state);
     serve(app, &config).await
 }
 
 /// Fallback when postgres+elasticsearch features are not both enabled.
 #[cfg(not(all(feature = "postgres", feature = "elasticsearch")))]
-async fn start_postgres_elasticsearch(_config: ServerConfig) -> anyhow::Result<()> {
+async fn start_postgres_elasticsearch(
+    _config: ServerConfig,
+    _auth_config: AuthConfig,
+    _auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     anyhow::bail!(
         "The postgres-elasticsearch backend requires both 'postgres' and 'elasticsearch' features. \
          Build with: cargo build -p helios-hfs --features postgres,elasticsearch"
@@ -439,7 +560,11 @@ async fn start_postgres_elasticsearch(_config: ServerConfig) -> anyhow::Result<(
 
 /// Starts the server with MongoDB + Elasticsearch composite backend.
 #[cfg(all(feature = "mongodb", feature = "elasticsearch"))]
-async fn start_mongodb_elasticsearch(config: ServerConfig) -> anyhow::Result<()> {
+async fn start_mongodb_elasticsearch(
+    config: ServerConfig,
+    auth_config: AuthConfig,
+    auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -553,13 +678,17 @@ async fn start_mongodb_elasticsearch(config: ServerConfig) -> anyhow::Result<()>
 
     info!("Composite storage initialized: MongoDB (primary) + Elasticsearch (search)");
 
-    let app = create_app_with_config(composite, config.clone());
+    let app = create_app_with_auth(composite, config.clone(), auth_config, auth_state);
     serve(app, &config).await
 }
 
 /// Fallback when mongodb+elasticsearch features are not both enabled.
 #[cfg(not(all(feature = "mongodb", feature = "elasticsearch")))]
-async fn start_mongodb_elasticsearch(_config: ServerConfig) -> anyhow::Result<()> {
+async fn start_mongodb_elasticsearch(
+    _config: ServerConfig,
+    _auth_config: AuthConfig,
+    _auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     anyhow::bail!(
         "The mongodb-elasticsearch backend requires both 'mongodb' and 'elasticsearch' features. \
          Build with: cargo build -p helios-hfs --features mongodb,elasticsearch"
@@ -568,7 +697,11 @@ async fn start_mongodb_elasticsearch(_config: ServerConfig) -> anyhow::Result<()
 
 /// Starts the server with AWS S3 backend.
 #[cfg(feature = "s3")]
-async fn start_s3(config: ServerConfig) -> anyhow::Result<()> {
+async fn start_s3(
+    config: ServerConfig,
+    auth_config: AuthConfig,
+    auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     use helios_persistence::backends::s3::{S3Backend, S3BackendConfig, S3TenancyMode};
 
     let bucket = std::env::var("HFS_S3_BUCKET").unwrap_or_else(|_| "hfs".to_string());
@@ -605,13 +738,17 @@ async fn start_s3(config: ServerConfig) -> anyhow::Result<()> {
         )
     })?;
 
-    let app = create_app_with_config(backend, config.clone());
+    let app = create_app_with_auth(backend, config.clone(), auth_config, auth_state);
     serve(app, &config).await
 }
 
 /// Fallback when s3 feature is not enabled.
 #[cfg(not(feature = "s3"))]
-async fn start_s3(_config: ServerConfig) -> anyhow::Result<()> {
+async fn start_s3(
+    _config: ServerConfig,
+    _auth_config: AuthConfig,
+    _auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     anyhow::bail!(
         "The s3 backend requires the 's3' feature. \
          Build with: cargo build -p helios-hfs --features s3"
@@ -647,7 +784,11 @@ fn build_search_registry(
 
 /// Starts the server with S3 + Elasticsearch composite backend.
 #[cfg(all(feature = "s3", feature = "elasticsearch"))]
-async fn start_s3_elasticsearch(config: ServerConfig) -> anyhow::Result<()> {
+async fn start_s3_elasticsearch(
+    config: ServerConfig,
+    auth_config: AuthConfig,
+    auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -767,13 +908,17 @@ async fn start_s3_elasticsearch(config: ServerConfig) -> anyhow::Result<()> {
 
     info!("Composite storage initialized: S3 (primary) + Elasticsearch (search)");
 
-    let app = create_app_with_config(composite, config.clone());
+    let app = create_app_with_auth(composite, config.clone(), auth_config, auth_state);
     serve(app, &config).await
 }
 
 /// Fallback when s3+elasticsearch features are not both enabled.
 #[cfg(not(all(feature = "s3", feature = "elasticsearch")))]
-async fn start_s3_elasticsearch(_config: ServerConfig) -> anyhow::Result<()> {
+async fn start_s3_elasticsearch(
+    _config: ServerConfig,
+    _auth_config: AuthConfig,
+    _auth_state: Option<Arc<AuthMiddlewareState>>,
+) -> anyhow::Result<()> {
     anyhow::bail!(
         "The s3-elasticsearch backend requires both 's3' and 'elasticsearch' features. \
          Build with: cargo build -p helios-hfs --features s3,elasticsearch"

--- a/crates/rest/Cargo.toml
+++ b/crates/rest/Cargo.toml
@@ -30,11 +30,15 @@ mongodb = ["helios-persistence/mongodb"]
 elasticsearch = ["helios-persistence/elasticsearch"]
 s3 = ["helios-persistence/s3"]
 
+# Auth feature (pass through to helios-auth)
+redis = ["helios-auth/redis"]
+
 [dependencies]
 # Core dependencies
 helios-fhir = { path = "../fhir", version = "0.1.47" }
 helios-persistence = { path = "../persistence", version = "0.1.47", default-features = false }
 helios-serde = { path = "../serde", version = "0.1.47", default-features = false, optional = true }
+helios-auth = { path = "../auth", version = "0.1.47" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/rest/src/error.rs
+++ b/crates/rest/src/error.rs
@@ -105,6 +105,12 @@ pub enum RestError {
         message: String,
     },
 
+    /// Unauthorized — missing or invalid authentication (HTTP 401).
+    Unauthorized {
+        /// Error message.
+        message: String,
+    },
+
     /// Access denied (HTTP 403).
     Forbidden {
         /// Error message.
@@ -188,6 +194,9 @@ impl fmt::Display for RestError {
             RestError::UnprocessableEntity { message } => {
                 write!(f, "Unprocessable entity: {}", message)
             }
+            RestError::Unauthorized { message } => {
+                write!(f, "Unauthorized: {}", message)
+            }
             RestError::Forbidden { message } => {
                 write!(f, "Forbidden: {}", message)
             }
@@ -267,6 +276,18 @@ impl IntoResponse for RestError {
                 "processing",
                 message.clone(),
             ),
+            RestError::Unauthorized { message } => {
+                let operation_outcome = create_operation_outcome("error", "login", message);
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    [(
+                        axum::http::header::WWW_AUTHENTICATE,
+                        axum::http::HeaderValue::from_static("Bearer"),
+                    )],
+                    Json(operation_outcome),
+                )
+                    .into_response();
+            }
             RestError::Forbidden { message } => {
                 (StatusCode::FORBIDDEN, "forbidden", message.clone())
             }
@@ -344,6 +365,25 @@ pub fn create_operation_outcome_multi(issues: Vec<(String, String, String)>) -> 
         "resourceType": "OperationOutcome",
         "issue": issues
     })
+}
+
+// Implement conversion from AuthError
+
+impl From<helios_auth::AuthError> for RestError {
+    fn from(err: helios_auth::AuthError) -> Self {
+        match err {
+            helios_auth::AuthError::Forbidden {
+                resource_type,
+                operation,
+            } => RestError::Forbidden {
+                message: format!("Insufficient scope for {} on {}", operation, resource_type),
+            },
+            helios_auth::AuthError::InternalError(msg) => RestError::InternalError { message: msg },
+            other => RestError::Unauthorized {
+                message: other.to_string(),
+            },
+        }
+    }
 }
 
 // Implement conversions from storage errors

--- a/crates/rest/src/extractors/tenant.rs
+++ b/crates/rest/src/extractors/tenant.rs
@@ -138,6 +138,35 @@ where
     ) -> Result<Self, Self::Rejection> {
         let config = state.config();
 
+        // If auth is enabled and a Principal with a tenant_id is present,
+        // use the JWT tenant authoritatively. When strict validation is enabled,
+        // verify that the JWT tenant matches any header/URL tenant to prevent
+        // confusion between URL context and actual data access.
+        if let Some(principal) = parts.extensions.get::<helios_auth::Principal>() {
+            if let Some(jwt_tenant) = principal.tenant_id() {
+                if config.multitenancy.strict_validation {
+                    let resolver = TenantResolver::new(&config.multitenancy);
+                    let resolved =
+                        resolver.resolve(parts, &config.multitenancy, &config.default_tenant);
+                    // If a non-default source provided a tenant, it must match the JWT
+                    if !resolved.is_default() && resolved.tenant_id_str() != jwt_tenant {
+                        return Err((
+                            StatusCode::BAD_REQUEST,
+                            format!(
+                                "Tenant mismatch: JWT tenant '{}' does not match request tenant '{}'",
+                                jwt_tenant,
+                                resolved.tenant_id_str()
+                            ),
+                        ));
+                    }
+                }
+                return Ok(TenantExtractor::new(
+                    jwt_tenant,
+                    crate::tenant::TenantSource::JwtClaim,
+                ));
+            }
+        }
+
         // Create resolver based on configuration
         let resolver = TenantResolver::new(&config.multitenancy);
 

--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -186,10 +186,11 @@ where
                 // Enforce per-entry scope authorization for transactions.
                 // Transactions are atomic so any denied entry rejects the whole bundle.
                 if let Some(principal) = principal {
-                    let (resource_type, _) =
-                        parse_request_url(&bundle_entry.url).map_err(|e| RestError::BadRequest {
+                    let (resource_type, _) = parse_request_url(&bundle_entry.url).map_err(|e| {
+                        RestError::BadRequest {
                             message: format!("Entry {}: {}", index, e),
-                        })?;
+                        }
+                    })?;
                     let operation = bundle_method_to_fhir_operation(&bundle_entry.method);
                     SmartScopePolicy::check(principal, &resource_type, operation).map_err(
                         |_| RestError::Forbidden {

--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -5,10 +5,11 @@
 
 use axum::{
     Json,
-    extract::State,
+    extract::{Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use helios_auth::{FhirOperation, Principal, SmartScopePolicy};
 use helios_fhir::FhirVersion;
 use helios_persistence::core::{
     BundleEntry, BundleEntryResult, BundleMethod, BundleProvider, ResourceStorage,
@@ -48,11 +49,23 @@ pub async fn batch_handler<S>(
     State(state): State<AppState<S>>,
     tenant: TenantExtractor,
     prefer: PreferHeader,
-    Json(bundle): Json<Value>,
+    request: Request,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + BundleProvider + Send + Sync,
 {
+    // Extract the Principal from request extensions (set by auth middleware).
+    // If present, per-entry scope checks will be enforced.
+    let principal = request.extensions().get::<Principal>().cloned();
+
+    // Parse the body as JSON
+    let bundle: Value = serde_json::from_slice(
+        &axum::body::to_bytes(request.into_body(), state.config().max_body_size)
+            .await
+            .map_err(|_| RestError::BadRequest {
+                message: "Failed to read request body".to_string(),
+            })?,
+    )?;
     // Validate it's a Bundle
     let resource_type = bundle
         .get("resourceType")
@@ -77,8 +90,10 @@ where
             })?;
 
     match bundle_type {
-        "batch" => process_batch(&state, tenant, &prefer, &bundle).await,
-        "transaction" => process_transaction(&state, tenant, &prefer, &bundle).await,
+        "batch" => process_batch(&state, tenant, &prefer, &bundle, principal.as_ref()).await,
+        "transaction" => {
+            process_transaction(&state, tenant, &prefer, &bundle, principal.as_ref()).await
+        }
         _ => Err(RestError::BadRequest {
             message: format!(
                 "Bundle type must be 'batch' or 'transaction', got '{}'",
@@ -94,6 +109,7 @@ async fn process_batch<S>(
     tenant: TenantExtractor,
     prefer: &PreferHeader,
     bundle: &Value,
+    principal: Option<&Principal>,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + Send + Sync,
@@ -113,7 +129,7 @@ where
     let mut response_entries = Vec::with_capacity(entries.len());
 
     for (index, entry) in entries.iter().enumerate() {
-        let result = process_batch_entry(state, &tenant, entry, index).await;
+        let result = process_batch_entry(state, &tenant, entry, index, principal).await;
         response_entries.push(bundle_entry_result_to_json(&result, base_url, prefer));
     }
 
@@ -144,6 +160,7 @@ async fn process_transaction<S>(
     tenant: TenantExtractor,
     prefer: &PreferHeader,
     bundle: &Value,
+    principal: Option<&Principal>,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + BundleProvider + Send + Sync,
@@ -166,6 +183,23 @@ where
     for (index, entry) in json_entries.iter().enumerate() {
         match parse_bundle_entry(entry) {
             Ok((bundle_entry, full_url)) => {
+                // Enforce per-entry scope authorization for transactions.
+                // Transactions are atomic so any denied entry rejects the whole bundle.
+                if let Some(principal) = principal {
+                    let (resource_type, _) =
+                        parse_request_url(&bundle_entry.url).map_err(|e| RestError::BadRequest {
+                            message: format!("Entry {}: {}", index, e),
+                        })?;
+                    let operation = bundle_method_to_fhir_operation(&bundle_entry.method);
+                    SmartScopePolicy::check(principal, &resource_type, operation).map_err(
+                        |_| RestError::Forbidden {
+                            message: format!(
+                                "Insufficient scope for {} on {} (transaction entry {})",
+                                operation, resource_type, index
+                            ),
+                        },
+                    )?;
+                }
                 indexed_entries.push((index, bundle_entry, full_url));
             }
             Err(e) => {
@@ -238,6 +272,7 @@ async fn process_batch_entry<S>(
     tenant: &TenantExtractor,
     entry: &Value,
     index: usize,
+    principal: Option<&Principal>,
 ) -> BundleEntryResult
 where
     S: ResourceStorage + Send + Sync,
@@ -259,6 +294,26 @@ where
             return create_error_result(400, &e);
         }
     };
+
+    // Enforce per-entry scope authorization
+    if let Some(principal) = principal {
+        let operation = match method {
+            "GET" => FhirOperation::Read,
+            "POST" => FhirOperation::Create,
+            "PUT" | "PATCH" => FhirOperation::Update,
+            "DELETE" => FhirOperation::Delete,
+            _ => FhirOperation::Read, // will be caught by unsupported method below
+        };
+        if SmartScopePolicy::check(principal, &resource_type, operation).is_err() {
+            return create_error_result(
+                403,
+                &format!(
+                    "Insufficient scope for {} on {} (batch entry {})",
+                    operation, resource_type, index
+                ),
+            );
+        }
+    }
 
     match method {
         "GET" => {
@@ -456,6 +511,16 @@ fn parse_bundle_entry(entry: &Value) -> Result<(BundleEntry, Option<String>), St
         },
         full_url,
     ))
+}
+
+/// Maps a [`BundleMethod`] to a [`FhirOperation`] for scope checking.
+fn bundle_method_to_fhir_operation(method: &BundleMethod) -> FhirOperation {
+    match method {
+        BundleMethod::Get => FhirOperation::Read,
+        BundleMethod::Post => FhirOperation::Create,
+        BundleMethod::Put | BundleMethod::Patch => FhirOperation::Update,
+        BundleMethod::Delete => FhirOperation::Delete,
+    }
 }
 
 /// Returns a processing order for bundle methods per FHIR spec.

--- a/crates/rest/src/handlers/mod.rs
+++ b/crates/rest/src/handlers/mod.rs
@@ -25,6 +25,7 @@ pub mod history;
 pub mod patch;
 pub mod read;
 pub mod search;
+pub mod smart_discovery;
 pub mod update;
 pub mod versions;
 pub mod vread;

--- a/crates/rest/src/handlers/smart_discovery.rs
+++ b/crates/rest/src/handlers/smart_discovery.rs
@@ -1,0 +1,23 @@
+//! SMART on FHIR discovery endpoint.
+//!
+//! Serves the `/.well-known/smart-configuration` document.
+
+use axum::{Json, extract::State, response::IntoResponse};
+use helios_auth::SmartConfiguration;
+use helios_persistence::core::ResourceStorage;
+
+use crate::state::AppState;
+
+/// Handler for `GET /.well-known/smart-configuration`.
+///
+/// Returns a SMART configuration document built from the server's
+/// auth configuration. If auth is not configured, returns a minimal
+/// document.
+pub async fn smart_configuration_handler<S>(State(state): State<AppState<S>>) -> impl IntoResponse
+where
+    S: ResourceStorage + Send + Sync,
+{
+    let config = state.auth_config();
+    let smart = SmartConfiguration::from_config(config);
+    Json(smart.to_json())
+}

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -152,6 +152,7 @@ pub mod tenant;
 // Re-export commonly used types
 pub use config::{MultitenancyConfig, ServerConfig, StorageBackendMode, TenantRoutingMode};
 pub use error::{RestError, RestResult};
+pub use middleware::auth::AuthMiddlewareState;
 pub use state::AppState;
 pub use tenant::{ResolvedTenant, TenantResolver, TenantSource};
 
@@ -236,16 +237,62 @@ where
         + Sync
         + 'static,
 {
+    create_app_with_auth(storage, config, helios_auth::AuthConfig::default(), None)
+}
+
+/// Creates the Axum application with custom configuration and optional authentication.
+///
+/// When `auth_state` is `Some`, authentication and authorization middleware
+/// are added to the middleware stack.
+pub fn create_app_with_auth<S>(
+    storage: S,
+    config: ServerConfig,
+    auth_config: helios_auth::AuthConfig,
+    auth_state: Option<Arc<middleware::auth::AuthMiddlewareState>>,
+) -> Router
+where
+    S: ResourceStorage
+        + ConditionalStorage
+        + SearchProvider
+        + InstanceHistoryProvider
+        + BundleProvider
+        + Send
+        + Sync
+        + 'static,
+{
     info!(
         "Creating REST API server with backend: {}",
         storage.backend_name()
     );
+    if auth_state.is_some() {
+        info!("Authentication is ENABLED");
+    }
 
     // Create application state
-    let state = AppState::new(Arc::new(storage), config.clone());
+    let state = AppState::with_auth(
+        Arc::new(storage),
+        config.clone(),
+        auth_config,
+        auth_state.clone(),
+    );
 
     // Build the router with all FHIR routes
     let router = routing::fhir_routes::create_routes(state);
+
+    // Apply auth middleware if enabled (outermost = runs first)
+    let router = if let Some(ref auth) = auth_state {
+        router
+            .layer(axum::middleware::from_fn_with_state(
+                auth.clone(),
+                middleware::auth::authz_middleware,
+            ))
+            .layer(axum::middleware::from_fn_with_state(
+                auth.clone(),
+                middleware::auth::auth_middleware,
+            ))
+    } else {
+        router
+    };
 
     // Build middleware stack
     let service_builder = ServiceBuilder::new()

--- a/crates/rest/src/middleware/auth.rs
+++ b/crates/rest/src/middleware/auth.rs
@@ -1,0 +1,376 @@
+//! Authentication and authorization middleware.
+//!
+//! Two middleware layers work together:
+//!
+//! 1. [`auth_middleware`] — Validates Bearer tokens and injects [`Principal`]
+//!    into request extensions. Returns 401 for invalid/missing tokens.
+//!
+//! 2. [`authz_middleware`] — Checks the [`Principal`]'s SMART scopes against
+//!    the requested FHIR operation. Returns 403 for insufficient scopes.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Request, State},
+    http::{StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use helios_auth::{
+    AuditEventSink, AuthConfig, AuthError, AuthProvider, FhirOperation, Principal, SmartScopePolicy,
+};
+use tracing::{debug, warn};
+
+/// Shared state for the auth middleware layers.
+pub struct AuthMiddlewareState {
+    /// The token validation provider.
+    pub provider: Arc<dyn AuthProvider>,
+    /// Auth configuration.
+    pub config: Arc<AuthConfig>,
+    /// Audit event sink.
+    pub audit_sink: Arc<dyn AuditEventSink>,
+}
+
+/// Paths that are exempt from authentication.
+const EXEMPT_PATHS: &[&str] = &[
+    "/metadata",
+    "/health",
+    "/_liveness",
+    "/_readiness",
+    "/.well-known/smart-configuration",
+    "/$versions",
+];
+
+/// Check if a request path is exempt from authentication.
+///
+/// Only exact matches are allowed to prevent path traversal bypasses
+/// (e.g., `/Patient/metadata` must NOT be treated as exempt).
+fn is_exempt_path(path: &str) -> bool {
+    let path = path.trim_end_matches('/');
+    EXEMPT_PATHS.contains(&path)
+}
+
+/// Authentication middleware.
+///
+/// Validates the `Authorization: Bearer <token>` header using the configured
+/// [`AuthProvider`]. On success, inserts a [`Principal`] into request extensions.
+/// On failure, returns a 401 Unauthorized response with an OperationOutcome.
+///
+/// Exempt paths (health, metadata, SMART discovery) bypass authentication.
+pub async fn auth_middleware(
+    State(auth_state): State<Arc<AuthMiddlewareState>>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let path = request.uri().path().to_string();
+    let method = request.method().to_string();
+
+    // Skip auth for exempt paths
+    if is_exempt_path(&path) {
+        debug!(path = %path, "Exempt path, skipping authentication");
+        return next.run(request).await;
+    }
+
+    // Extract Authorization header
+    let auth_header = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok());
+
+    let auth_header = match auth_header {
+        Some(h) => h.to_string(),
+        None => {
+            auth_state
+                .audit_sink
+                .record_auth_failure(&AuthError::MissingToken, &path, &method)
+                .await;
+            return unauthorized_response("Missing Authorization header");
+        }
+    };
+
+    // Validate token
+    match auth_state.provider.authenticate(&auth_header).await {
+        Ok(principal) => {
+            debug!(
+                sub = %principal.subject(),
+                iss = %principal.issuer(),
+                "Authentication successful"
+            );
+            auth_state
+                .audit_sink
+                .record_auth_success(&principal, &path, &method)
+                .await;
+            request.extensions_mut().insert(principal);
+            next.run(request).await
+        }
+        Err(err) => {
+            warn!(error = %err, path = %path, "Authentication failed");
+            auth_state
+                .audit_sink
+                .record_auth_failure(&err, &path, &method)
+                .await;
+            unauthorized_response(&err.to_string())
+        }
+    }
+}
+
+/// Authorization middleware.
+///
+/// Checks the [`Principal`]'s SMART scopes against the requested FHIR operation
+/// and resource type. Returns 403 Forbidden if the principal lacks sufficient scopes.
+///
+/// If no [`Principal`] is present in extensions (exempt path or auth disabled),
+/// the request passes through.
+pub async fn authz_middleware(
+    State(auth_state): State<Arc<AuthMiddlewareState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    // If no principal, pass through (exempt path or auth disabled)
+    let principal = match request.extensions().get::<Principal>() {
+        Some(p) => p.clone(),
+        None => return next.run(request).await,
+    };
+
+    let path = request.uri().path().to_string();
+    let method = request.method().clone();
+
+    // Determine the FHIR operation and resource type from the path
+    if let Some((resource_type, operation)) = extract_operation(&path, method.as_str()) {
+        match SmartScopePolicy::check(&principal, &resource_type, operation) {
+            Ok(()) => {
+                debug!(
+                    sub = %principal.subject(),
+                    resource_type = %resource_type,
+                    operation = %operation,
+                    "Authorization granted"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    sub = %principal.subject(),
+                    resource_type = %resource_type,
+                    operation = %operation,
+                    "Authorization denied"
+                );
+                auth_state
+                    .audit_sink
+                    .record_authz_denial(&principal, &resource_type, &operation.to_string())
+                    .await;
+                return forbidden_response(&err.to_string());
+            }
+        }
+    }
+
+    next.run(request).await
+}
+
+/// Extract the FHIR resource type and operation from a request path and method.
+///
+/// Returns `None` for system-level operations (batch, history) where
+/// per-resource-type authorization doesn't apply.
+fn extract_operation(path: &str, method: &str) -> Option<(String, FhirOperation)> {
+    // Split path segments, filtering empty
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    if segments.is_empty() {
+        // POST / (batch/transaction) — authorization deferred to batch handler
+        return None;
+    }
+
+    // System-level paths
+    let first = segments[0];
+    if first.starts_with('_') || first.starts_with('$') || first == "metadata" || first == "health"
+    {
+        return None;
+    }
+
+    // The first segment is the resource type (or tenant — handled by prefix stripping)
+    let resource_type = first.to_string();
+
+    // Detect compartment search: GET /{compartment_type}/{id}/{target_type}
+    // The third segment is the actual resource type being accessed, so the
+    // authorization check must be against the target type, not the compartment.
+    if segments.len() == 3
+        && matches!(method, "GET" | "HEAD")
+        && !segments[2].starts_with('_')
+        && !segments[2].starts_with('$')
+    {
+        let target_type = segments[2].to_string();
+        return Some((target_type, FhirOperation::Search));
+    }
+
+    // Determine operation from method and path structure
+    let operation = match method {
+        "GET" | "HEAD" => {
+            if segments.len() == 1 {
+                // GET /Patient → search
+                FhirOperation::Search
+            } else if segments.len() >= 2 && segments.get(1).is_some_and(|s| s.starts_with('_')) {
+                // GET /Patient/_history → read (history)
+                FhirOperation::Read
+            } else {
+                // GET /Patient/123 → read
+                FhirOperation::Read
+            }
+        }
+        "POST" => {
+            if segments.len() >= 2 && segments.get(1) == Some(&"_search") {
+                FhirOperation::Search
+            } else {
+                // POST /Patient → create
+                FhirOperation::Create
+            }
+        }
+        "PUT" => FhirOperation::Update,
+        "PATCH" => FhirOperation::Update,
+        "DELETE" => FhirOperation::Delete,
+        _ => return None,
+    };
+
+    Some((resource_type, operation))
+}
+
+fn unauthorized_response(message: &str) -> Response {
+    let body = serde_json::json!({
+        "resourceType": "OperationOutcome",
+        "issue": [{
+            "severity": "error",
+            "code": "login",
+            "details": { "text": message }
+        }]
+    });
+
+    (
+        StatusCode::UNAUTHORIZED,
+        [(
+            header::WWW_AUTHENTICATE,
+            axum::http::HeaderValue::from_static("Bearer"),
+        )],
+        Json(body),
+    )
+        .into_response()
+}
+
+fn forbidden_response(message: &str) -> Response {
+    let body = serde_json::json!({
+        "resourceType": "OperationOutcome",
+        "issue": [{
+            "severity": "error",
+            "code": "forbidden",
+            "details": { "text": message }
+        }]
+    });
+
+    (StatusCode::FORBIDDEN, Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exempt_paths() {
+        assert!(is_exempt_path("/metadata"));
+        assert!(is_exempt_path("/health"));
+        assert!(is_exempt_path("/_liveness"));
+        assert!(is_exempt_path("/_readiness"));
+        assert!(is_exempt_path("/.well-known/smart-configuration"));
+        assert!(is_exempt_path("/$versions"));
+
+        assert!(!is_exempt_path("/Patient"));
+        assert!(!is_exempt_path("/Patient/123"));
+        assert!(!is_exempt_path("/"));
+
+        // Path traversal attempts must NOT be exempt
+        assert!(!is_exempt_path("/Patient/metadata"));
+        assert!(!is_exempt_path("/Observation/health"));
+        assert!(!is_exempt_path("/Device/_liveness"));
+        assert!(!is_exempt_path("/Patient/_readiness"));
+        assert!(!is_exempt_path("/Patient/.well-known/smart-configuration"));
+        assert!(!is_exempt_path("/tenant/metadata"));
+        assert!(!is_exempt_path("/tenant/$versions"));
+    }
+
+    #[test]
+    fn test_extract_operation_search() {
+        let (rt, op) = extract_operation("/Patient", "GET").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Search);
+    }
+
+    #[test]
+    fn test_extract_operation_read() {
+        let (rt, op) = extract_operation("/Patient/123", "GET").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Read);
+    }
+
+    #[test]
+    fn test_extract_operation_create() {
+        let (rt, op) = extract_operation("/Patient", "POST").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Create);
+    }
+
+    #[test]
+    fn test_extract_operation_update() {
+        let (rt, op) = extract_operation("/Patient/123", "PUT").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Update);
+    }
+
+    #[test]
+    fn test_extract_operation_delete() {
+        let (rt, op) = extract_operation("/Patient/123", "DELETE").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Delete);
+    }
+
+    #[test]
+    fn test_extract_operation_search_post() {
+        let (rt, op) = extract_operation("/Patient/_search", "POST").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Search);
+    }
+
+    #[test]
+    fn test_extract_operation_batch() {
+        assert!(extract_operation("/", "POST").is_none());
+    }
+
+    #[test]
+    fn test_extract_operation_system_history() {
+        assert!(extract_operation("/_history", "GET").is_none());
+    }
+
+    #[test]
+    fn test_extract_operation_metadata() {
+        assert!(extract_operation("/metadata", "GET").is_none());
+    }
+
+    #[test]
+    fn test_extract_operation_compartment_search() {
+        // GET /Patient/123/Observation → authz must check Observation (target), not Patient
+        let (rt, op) = extract_operation("/Patient/123/Observation", "GET").unwrap();
+        assert_eq!(rt, "Observation");
+        assert_eq!(op, FhirOperation::Search);
+    }
+
+    #[test]
+    fn test_extract_operation_compartment_search_different_types() {
+        let (rt, op) = extract_operation("/Encounter/456/Procedure", "GET").unwrap();
+        assert_eq!(rt, "Procedure");
+        assert_eq!(op, FhirOperation::Search);
+    }
+
+    #[test]
+    fn test_extract_operation_instance_history_not_compartment() {
+        // GET /Patient/123/_history has 3 segments but third starts with '_'
+        // so it should NOT be treated as compartment search
+        let (rt, op) = extract_operation("/Patient/123/_history", "GET").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Read);
+    }
+}

--- a/crates/rest/src/middleware/mod.rs
+++ b/crates/rest/src/middleware/mod.rs
@@ -8,6 +8,7 @@
 //! - [`conditional`] - Conditional request headers (If-Match, etc.)
 //! - [`prefer`] - Prefer header handling
 
+pub mod auth;
 pub mod conditional;
 pub mod content_type;
 pub mod prefer;

--- a/crates/rest/src/routing/fhir_routes.rs
+++ b/crates/rest/src/routing/fhir_routes.rs
@@ -192,6 +192,10 @@ where
         .route("/health", get(handlers::health_handler::<S>))
         .route("/_liveness", get(handlers::health::liveness_handler))
         .route("/_readiness", get(handlers::health::readiness_handler::<S>))
+        .route(
+            "/.well-known/smart-configuration",
+            get(handlers::smart_discovery::smart_configuration_handler::<S>),
+        )
         .route("/_history", get(handlers::history_system_handler::<S>))
         .route("/", post(handlers::batch_handler::<S>))
         // Type-level routes

--- a/crates/rest/src/state.rs
+++ b/crates/rest/src/state.rs
@@ -6,9 +6,11 @@
 
 use std::sync::Arc;
 
+use helios_auth::AuthConfig;
 use helios_persistence::core::ResourceStorage;
 
 use crate::config::ServerConfig;
+use crate::middleware::auth::AuthMiddlewareState;
 
 /// Shared application state for the REST API.
 ///
@@ -36,6 +38,12 @@ pub struct AppState<S> {
 
     /// Server configuration.
     config: Arc<ServerConfig>,
+
+    /// Authentication configuration (always present, may be disabled).
+    auth_config: Arc<AuthConfig>,
+
+    /// Auth middleware state (present only when auth is enabled).
+    auth: Option<Arc<AuthMiddlewareState>>,
 }
 
 // Manually implement Clone since S is wrapped in Arc and doesn't need to be Clone
@@ -44,6 +52,8 @@ impl<S> Clone for AppState<S> {
         Self {
             storage: Arc::clone(&self.storage),
             config: Arc::clone(&self.config),
+            auth_config: Arc::clone(&self.auth_config),
+            auth: self.auth.clone(),
         }
     }
 }
@@ -59,6 +69,23 @@ impl<S: ResourceStorage> AppState<S> {
         Self {
             storage,
             config: Arc::new(config),
+            auth_config: Arc::new(AuthConfig::default()),
+            auth: None,
+        }
+    }
+
+    /// Creates a new AppState with auth configuration.
+    pub fn with_auth(
+        storage: Arc<S>,
+        config: ServerConfig,
+        auth_config: AuthConfig,
+        auth_state: Option<Arc<AuthMiddlewareState>>,
+    ) -> Self {
+        Self {
+            storage,
+            config: Arc::new(config),
+            auth_config: Arc::new(auth_config),
+            auth: auth_state,
         }
     }
 
@@ -110,6 +137,21 @@ impl<S: ResourceStorage> AppState<S> {
     /// Returns whether deleted resources should return 410 Gone.
     pub fn return_gone(&self) -> bool {
         self.config.return_gone
+    }
+
+    /// Returns the auth configuration.
+    pub fn auth_config(&self) -> &AuthConfig {
+        &self.auth_config
+    }
+
+    /// Returns the auth middleware state if auth is enabled.
+    pub fn auth_state(&self) -> Option<&Arc<AuthMiddlewareState>> {
+        self.auth.as_ref()
+    }
+
+    /// Returns whether authentication is enabled.
+    pub fn auth_enabled(&self) -> bool {
+        self.auth.is_some()
     }
 }
 

--- a/crates/rest/src/tenant/resolver.rs
+++ b/crates/rest/src/tenant/resolver.rs
@@ -133,18 +133,21 @@ impl TenantSourceExtractor for HeaderTenantExtractor {
     }
 }
 
-/// Extracts tenant from JWT token claim.
+/// Extracts tenant from a validated JWT's [`Principal`] in request extensions.
 ///
-/// This is a stub implementation for future JWT-based tenant resolution.
+/// The auth middleware inserts a [`Principal`] into request extensions after
+/// successful token validation. This extractor reads the tenant ID from
+/// the principal's configured claim.
 #[derive(Debug, Default)]
 pub struct JwtTenantExtractor;
 
 impl TenantSourceExtractor for JwtTenantExtractor {
-    fn extract(&self, _parts: &Parts, _config: &MultitenancyConfig) -> Option<TenantId> {
-        // TODO: Implement JWT-based tenant extraction
-        // This will read the Authorization header, verify the JWT,
-        // and extract the tenant claim specified in config.jwt_tenant_claim
-        None
+    fn extract(&self, parts: &Parts, _config: &MultitenancyConfig) -> Option<TenantId> {
+        parts
+            .extensions
+            .get::<helios_auth::Principal>()
+            .and_then(|p| p.tenant_id())
+            .map(TenantId::new)
     }
 
     fn source_type(&self) -> TenantSource {

--- a/docker/auth0/get-token.sh
+++ b/docker/auth0/get-token.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Obtain a SMART Backend Services token from Auth0 using the client credentials flow.
+#
+# Required environment variables:
+#   AUTH0_DOMAIN         e.g. dev-abc123.us.auth0.com
+#   AUTH0_CLIENT_ID      Client ID from Application → Settings
+#   AUTH0_CLIENT_SECRET  Client Secret from Application → Settings
+#
+# Optional:
+#   AUTH0_AUDIENCE       API Identifier (default: https://fhir.example.com)
+#   AUTH0_SCOPE          Space-separated SMART scopes (default: system/*.cruds)
+#
+# Usage:
+#   export TOKEN=$(AUTH0_DOMAIN=... AUTH0_CLIENT_ID=... AUTH0_CLIENT_SECRET=... ./get-token.sh)
+
+set -euo pipefail
+
+: "${AUTH0_DOMAIN:?AUTH0_DOMAIN is required (e.g. dev-abc123.us.auth0.com)}"
+: "${AUTH0_CLIENT_ID:?AUTH0_CLIENT_ID is required}"
+: "${AUTH0_CLIENT_SECRET:?AUTH0_CLIENT_SECRET is required}"
+
+AUDIENCE="${AUTH0_AUDIENCE:-https://fhir.example.com}"
+SCOPE="${AUTH0_SCOPE:-system/*.cruds}"
+TOKEN_ENDPOINT="https://${AUTH0_DOMAIN}/oauth/token"
+
+echo "Requesting token from ${TOKEN_ENDPOINT}" >&2
+echo "Audience: ${AUDIENCE}" >&2
+echo "Scope: ${SCOPE}" >&2
+
+RESPONSE=$(curl -sf -X POST "${TOKEN_ENDPOINT}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  --data-urlencode "client_id=${AUTH0_CLIENT_ID}" \
+  --data-urlencode "client_secret=${AUTH0_CLIENT_SECRET}" \
+  --data-urlencode "audience=${AUDIENCE}" \
+  --data-urlencode "scope=${SCOPE}")
+
+ACCESS_TOKEN=$(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+echo "Token obtained (expires in $(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('expires_in','?'))") seconds)" >&2
+echo "Scopes granted: $(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('scope','(none)'))") " >&2
+echo "" >&2
+echo "To decode claims:" >&2
+echo "  echo \"\$TOKEN\" | cut -d. -f2 | base64 -d | python3 -m json.tool" >&2
+echo "" >&2
+
+echo "${ACCESS_TOKEN}"

--- a/docker/keycloak/docker-compose.yml
+++ b/docker/keycloak/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.1
+    command: start-dev --import-realm
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "8180:8080"
+    volumes:
+      - ./realm.json:/opt/keycloak/data/import/realm.json:ro
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sf http://localhost:9000/health/ready | grep -q UP || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 40s

--- a/docker/keycloak/get-token.sh
+++ b/docker/keycloak/get-token.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Obtain a SMART Backend Services token from the local Keycloak dev instance.
+#
+# Usage:
+#   ./get-token.sh                     # full-access client (system/*.cruds)
+#   ./get-token.sh hfs-readonly-client # read-only client (system/Patient.rs)
+#
+# The access_token is printed to stdout; all other output goes to stderr.
+# Example: export TOKEN=$(./get-token.sh)
+
+set -euo pipefail
+
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://localhost:8180}"
+REALM="${REALM:-fhir}"
+CLIENT_ID="${1:-hfs-backend-client}"
+
+case "${CLIENT_ID}" in
+  hfs-backend-client)  CLIENT_SECRET="${CLIENT_SECRET:-hfs-backend-secret}" ;;
+  hfs-readonly-client) CLIENT_SECRET="${CLIENT_SECRET:-hfs-readonly-secret}" ;;
+  *)                   CLIENT_SECRET="${CLIENT_SECRET:?CLIENT_SECRET must be set for custom client IDs}" ;;
+esac
+
+TOKEN_ENDPOINT="${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/token"
+
+echo "Requesting token from ${TOKEN_ENDPOINT} (client: ${CLIENT_ID})" >&2
+
+RESPONSE=$(curl -sf -X POST "${TOKEN_ENDPOINT}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  --data-urlencode "client_id=${CLIENT_ID}" \
+  --data-urlencode "client_secret=${CLIENT_SECRET}")
+
+ACCESS_TOKEN=$(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+echo "Token obtained (expires in $(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('expires_in','?'))") seconds)" >&2
+echo "Scopes: $(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('scope','(none)'))") " >&2
+echo "" >&2
+echo "To decode claims:" >&2
+echo "  echo \"\$TOKEN\" | cut -d. -f2 | base64 -d | python3 -m json.tool" >&2
+echo "" >&2
+
+# Print the raw token to stdout so callers can do: export TOKEN=\$(./get-token.sh)
+echo "${ACCESS_TOKEN}"

--- a/docker/keycloak/realm.json
+++ b/docker/keycloak/realm.json
@@ -1,0 +1,80 @@
+{
+  "id": "fhir",
+  "realm": "fhir",
+  "displayName": "FHIR Realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "bruteForceProtected": false,
+  "accessTokenLifespan": 300,
+  "clientScopes": [
+    {
+      "name": "system/*.cruds",
+      "description": "Full system-level SMART access on all resource types",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      }
+    },
+    {
+      "name": "system/Patient.rs",
+      "description": "Read and search Patient resources",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      }
+    },
+    {
+      "name": "system/Observation.r",
+      "description": "Read-only access to Observation resources",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      }
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "hfs-backend-client",
+      "name": "HFS Backend Service (full access)",
+      "description": "Service account client for SMART Backend Services — full CRUD+search access",
+      "enabled": true,
+      "publicClient": false,
+      "bearerOnly": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "hfs-backend-secret",
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "authorizationServicesEnabled": false,
+      "protocol": "openid-connect",
+      "defaultClientScopes": ["system/*.cruds"],
+      "optionalClientScopes": ["system/Patient.rs", "system/Observation.r"]
+    },
+    {
+      "clientId": "hfs-readonly-client",
+      "name": "HFS Read-only Client",
+      "description": "Service account client limited to reading Patient resources",
+      "enabled": true,
+      "publicClient": false,
+      "bearerOnly": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "hfs-readonly-secret",
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "authorizationServicesEnabled": false,
+      "protocol": "openid-connect",
+      "defaultClientScopes": ["system/Patient.rs"],
+      "optionalClientScopes": ["system/Observation.r"]
+    }
+  ]
+}

--- a/docker/okta/get-token.sh
+++ b/docker/okta/get-token.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Obtain a SMART Backend Services token from Okta using the client credentials flow.
+#
+# Required environment variables:
+#   OKTA_DOMAIN          e.g. dev-12345678.okta.com
+#   OKTA_AUTH_SERVER_ID  e.g. aus1abc2defGHIJK  (from Security → API → Authorization Servers)
+#   OKTA_CLIENT_ID       Client ID of your API Services app
+#   OKTA_CLIENT_SECRET   Client secret of your API Services app
+#
+# Optional:
+#   OKTA_SCOPE           Space-separated SMART scopes (default: system/*.cruds)
+#
+# Usage:
+#   export TOKEN=$(OKTA_DOMAIN=... OKTA_AUTH_SERVER_ID=... OKTA_CLIENT_ID=... OKTA_CLIENT_SECRET=... ./get-token.sh)
+
+set -euo pipefail
+
+: "${OKTA_DOMAIN:?OKTA_DOMAIN is required (e.g. dev-12345678.okta.com)}"
+: "${OKTA_AUTH_SERVER_ID:?OKTA_AUTH_SERVER_ID is required (e.g. aus1abc2defGHIJK)}"
+: "${OKTA_CLIENT_ID:?OKTA_CLIENT_ID is required}"
+: "${OKTA_CLIENT_SECRET:?OKTA_CLIENT_SECRET is required}"
+
+SCOPE="${OKTA_SCOPE:-system/*.cruds}"
+TOKEN_ENDPOINT="https://${OKTA_DOMAIN}/oauth2/${OKTA_AUTH_SERVER_ID}/v1/token"
+
+echo "Requesting token from ${TOKEN_ENDPOINT}" >&2
+echo "Scope: ${SCOPE}" >&2
+
+RESPONSE=$(curl -sf -X POST "${TOKEN_ENDPOINT}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "${OKTA_CLIENT_ID}:${OKTA_CLIENT_SECRET}" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "scope=${SCOPE}")
+
+ACCESS_TOKEN=$(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+echo "Token obtained (expires in $(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('expires_in','?'))") seconds)" >&2
+echo "Scopes granted: $(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('scope','(none)'))") " >&2
+echo "" >&2
+echo "To decode claims:" >&2
+echo "  echo \"\$TOKEN\" | cut -d. -f2 | base64 -d | python3 -m json.tool" >&2
+echo "" >&2
+
+echo "${ACCESS_TOKEN}"


### PR DESCRIPTION
## Summary

- Adds `helios-auth` crate implementing SMART Backend Services authentication via JWT/JWKS validation and SMART v2 scope-based authorization
- Integrates auth and authz middleware into `helios-rest` (401/403 enforcement, exempt paths, operation→permission mapping)
- Recommends audience validation for production deployments
- Adds step-by-step IdP integration guides for Keycloak, Okta, and Auth0 with troubleshooting tables
- Adds `docker/keycloak/` with a Keycloak 26 compose file, pre-configured `fhir` realm (two SMART service-account clients, three client scopes), and token helper scripts for Keycloak, Okta, and Auth0

## Test plan

- [ ] Start Keycloak: `docker compose -f docker/keycloak/docker-compose.yml up -d`
- [ ] Run HFS with auth enabled pointing at Keycloak (see `crates/auth/README.md`)
- [ ] Verify `GET /metadata` and `/.well-known/smart-configuration` are accessible without a token
- [ ] Verify `GET /Patient` returns 401 without a token
- [ ] Obtain a full-access token: `export TOKEN=$(./docker/keycloak/get-token.sh)`
- [ ] Verify `GET /Patient` returns 200 with the token
- [ ] Obtain a read-only token and verify `POST /Patient` returns 403
- [ ] Run auth unit tests: `cargo test -p helios-auth`
- [ ] Run middleware tests: `cargo test -p helios-rest middleware::auth`