### PR TITLE
test(ci): add external audit-event coverage workflow

### DIFF
--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -1,0 +1,470 @@
+name: HFS Audit Event External Coverage
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 1
+  CARGO_PROFILE_DEV_DEBUG: 0
+  HFS_PORT: 8088
+  DOCKER_HOST: ${{ secrets.DOCKER_HOST }}
+  DOCKER_HOST_IP: ${{ secrets.DOCKER_HOST_IP }}
+  HFS_S3_BUCKET: ${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}
+
+jobs:
+  build:
+    name: Build HFS
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Configure Rust to use LLD
+        run: |
+          mkdir -p ~/.cargo
+          rm -f ~/.cargo/config.toml
+          echo '[target.x86_64-unknown-linux-gnu]' >> ~/.cargo/config.toml
+          echo 'linker = "clang"' >> ~/.cargo/config.toml
+          echo 'rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,-zstack-size=8388608"]' >> ~/.cargo/config.toml
+
+      - name: Build HFS
+        run: cargo build -p helios-hfs --features R4,sqlite,elasticsearch,postgres,mongodb,s3
+
+      - name: Upload HFS binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: hfs-binary
+          path: target/debug/hfs
+          retention-days: 1
+
+  audit-test:
+    name: Audit External Test (${{ matrix.backend }})
+    needs: build
+    runs-on: [self-hosted, Linux]
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        backend: [sqlite, sqlite-elasticsearch, postgres, mongodb, s3-elasticsearch]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download HFS binary
+        uses: actions/download-artifact@v4
+        with:
+          name: hfs-binary
+          path: target/debug
+
+      - name: Make scripts executable
+        run: |
+          chmod +x target/debug/hfs
+          chmod +x crates/hfs/tests/audit/run_external_audit.sh
+          chmod +x crates/hfs/tests/audit/validate_report.py
+          chmod +x docker/keycloak/get-token.sh
+
+      - name: Determine runner IP
+        run: |
+          RUNNER_IP=$(hostname -I | awk '{print $1}')
+          if [ -n "${DOCKER_HOST_IP:-}" ]; then
+            EFFECTIVE_DOCKER_HOST_IP="$DOCKER_HOST_IP"
+          else
+            EFFECTIVE_DOCKER_HOST_IP="$RUNNER_IP"
+          fi
+
+          echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
+          echo "DOCKER_HOST_IP=$EFFECTIVE_DOCKER_HOST_IP" >> $GITHUB_ENV
+          echo "Runner IP: $RUNNER_IP"
+          echo "Docker host IP: $EFFECTIVE_DOCKER_HOST_IP"
+
+      - name: Validate backend configuration
+        run: |
+          if [ "${{ matrix.backend }}" = "s3-elasticsearch" ] && [ -z "$HFS_S3_BUCKET" ]; then
+            echo "::error::s3-elasticsearch backend requires HFS_S3_BUCKET to be configured"
+            exit 1
+          fi
+
+      - name: Start Elasticsearch
+        if: matrix.backend == 'sqlite-elasticsearch' || matrix.backend == 's3-elasticsearch'
+        run: |
+          ES_CONTAINER="es-audit-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+          docker run -d --name "$ES_CONTAINER" -p 0:9200 \
+            -e "discovery.type=single-node" \
+            -e "xpack.security.enabled=false" \
+            -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+            elasticsearch:8.15.0
+
+          echo "ES_CONTAINER=$ES_CONTAINER" >> $GITHUB_ENV
+
+          echo "Waiting for Elasticsearch to be ready..."
+          for i in {1..30}; do
+            ES_PORT=$(docker port "$ES_CONTAINER" 9200 2>/dev/null | head -1 | sed 's/.*://')
+            if [ -n "$ES_PORT" ]; then
+              if curl -sf "http://$DOCKER_HOST_IP:$ES_PORT/_cluster/health" > /dev/null 2>&1; then
+                echo "Elasticsearch is ready on port $ES_PORT"
+                echo "ES_PORT=$ES_PORT" >> $GITHUB_ENV
+                exit 0
+              fi
+            fi
+            echo "Attempt $i/30: Elasticsearch not ready yet..."
+            sleep 2
+          done
+
+          echo "Elasticsearch failed to start"
+          docker logs "$ES_CONTAINER"
+          exit 1
+
+      - name: Start PostgreSQL
+        if: matrix.backend == 'postgres'
+        run: |
+          PG_CONTAINER="pg-audit-${{ github.run_id }}-${{ github.run_attempt }}"
+          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker run -d --name "$PG_CONTAINER" -p 0:5432 \
+            -e POSTGRES_USER=helios \
+            -e POSTGRES_PASSWORD=helios \
+            -e POSTGRES_DB=helios \
+            postgres:16
+
+          echo "PG_CONTAINER=$PG_CONTAINER" >> $GITHUB_ENV
+
+          echo "Waiting for PostgreSQL to be ready..."
+          for i in {1..30}; do
+            if docker exec "$PG_CONTAINER" pg_isready -U helios > /dev/null 2>&1; then
+              PG_PORT=$(docker port "$PG_CONTAINER" 5432 | head -1 | sed 's/.*://')
+              if timeout 2 bash -c "cat < /dev/null > /dev/tcp/$DOCKER_HOST_IP/$PG_PORT" 2>/dev/null; then
+                echo "PostgreSQL is ready on port $PG_PORT"
+                echo "PG_PORT=$PG_PORT" >> $GITHUB_ENV
+                exit 0
+              fi
+            fi
+            echo "Attempt $i/30: PostgreSQL not ready yet..."
+            sleep 2
+          done
+
+          echo "PostgreSQL failed to start"
+          docker logs "$PG_CONTAINER"
+          exit 1
+
+      - name: Start MongoDB replica set
+        if: matrix.backend == 'mongodb'
+        run: |
+          MONGO_CONTAINER="mongo-audit-${{ github.run_id }}-${{ github.run_attempt }}"
+          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 --replSet rs0 --bind_ip_all
+
+          echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
+
+          READY=0
+          for i in {1..30}; do
+            if docker exec "$MONGO_CONTAINER" mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok' > /dev/null 2>&1; then
+              READY=1
+              break
+            fi
+            echo "Attempt $i/30: MongoDB not ready yet..."
+            sleep 2
+          done
+
+          if [ "$READY" -ne 1 ]; then
+            echo "MongoDB failed to start"
+            docker logs "$MONGO_CONTAINER"
+            exit 1
+          fi
+
+          docker exec "$MONGO_CONTAINER" mongosh --quiet --eval 'try { rs.status(); } catch (e) { rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "localhost:27017" }] }); }' > /dev/null 2>&1
+
+          echo "Waiting for MongoDB replica set primary..."
+          for i in {1..60}; do
+            PRIMARY_STATE=$(docker exec "$MONGO_CONTAINER" mongosh --quiet --eval 'try { rs.status().myState } catch (e) { 0 }' | tr -d '\r\n ')
+            if [ "$PRIMARY_STATE" = "1" ]; then
+              MONGO_PORT=$(docker port "$MONGO_CONTAINER" 27017 | head -1 | sed 's/.*://')
+              echo "MongoDB replica set is ready on port $MONGO_PORT"
+              echo "MONGO_PORT=$MONGO_PORT" >> $GITHUB_ENV
+              exit 0
+            fi
+            echo "Attempt $i/60: MongoDB replica set not primary yet..."
+            sleep 2
+          done
+
+          echo "MongoDB replica set failed to become primary"
+          docker logs "$MONGO_CONTAINER"
+          exit 1
+
+      - name: Configure AWS credentials
+        if: matrix.backend == 's3-elasticsearch'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
+
+      - name: Install AWS CLI
+        if: matrix.backend == 's3-elasticsearch'
+        run: |
+          if ! command -v aws &>/dev/null; then
+            if ! /tmp/aws-bin/aws --version &>/dev/null; then
+              curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+              unzip -qo /tmp/awscliv2.zip -d /tmp
+              /tmp/aws/install --install-dir /tmp/aws-cli --bin-dir /tmp/aws-bin --update
+              rm -rf /tmp/awscliv2.zip /tmp/aws
+            fi
+            echo "/tmp/aws-bin" >> $GITHUB_PATH
+          fi
+          aws --version 2>/dev/null || /tmp/aws-bin/aws --version
+
+      - name: Empty S3 prefix
+        if: matrix.backend == 's3-elasticsearch'
+        run: |
+          BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}"
+          PREFIX="ci-audit/${{ github.run_id }}/${{ github.run_attempt }}/"
+          echo "Emptying s3://$BUCKET/$PREFIX"
+          aws s3 rm "s3://$BUCKET/$PREFIX" --recursive
+          echo "Prefix emptied"
+
+      - name: Start ephemeral Keycloak
+        run: |
+          KC_CONTAINER="kc-audit-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          docker rm -f "$KC_CONTAINER" 2>/dev/null || true
+
+          docker create --name "$KC_CONTAINER" -p 0:8080 \
+            -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+            -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+            -e KC_HEALTH_ENABLED=true \
+            quay.io/keycloak/keycloak:26.1 start-dev --import-realm > /dev/null
+
+          docker cp docker/keycloak/realm.json "$KC_CONTAINER":/opt/keycloak/data/import/realm.json
+          docker start "$KC_CONTAINER" > /dev/null
+
+          echo "KC_CONTAINER=$KC_CONTAINER" >> $GITHUB_ENV
+
+      - name: Wait for Keycloak
+        run: |
+          echo "Waiting for Keycloak to be ready..."
+          for i in {1..60}; do
+            KEYCLOAK_PORT=$(docker port "$KC_CONTAINER" 8080 2>/dev/null | head -1 | sed 's/.*://')
+            if [ -n "$KEYCLOAK_PORT" ]; then
+              if curl -sf "http://$DOCKER_HOST_IP:$KEYCLOAK_PORT/realms/fhir" > /dev/null 2>&1; then
+                echo "Keycloak is ready on port $KEYCLOAK_PORT"
+                echo "KEYCLOAK_PORT=$KEYCLOAK_PORT" >> $GITHUB_ENV
+                exit 0
+              fi
+            fi
+            echo "Attempt $i/60: Keycloak not ready yet..."
+            sleep 2
+          done
+
+          echo "Keycloak failed to start"
+          docker logs "$KC_CONTAINER"
+          exit 1
+
+      - name: Mint auth tokens
+        run: |
+          FULL_TOKEN=$(KEYCLOAK_URL="http://$DOCKER_HOST_IP:$KEYCLOAK_PORT" ./docker/keycloak/get-token.sh)
+          READONLY_TOKEN=$(KEYCLOAK_URL="http://$DOCKER_HOST_IP:$KEYCLOAK_PORT" ./docker/keycloak/get-token.sh hfs-readonly-client)
+
+          {
+            echo "FULL_TOKEN<<EOF"
+            echo "$FULL_TOKEN"
+            echo "EOF"
+            echo "READONLY_TOKEN<<EOF"
+            echo "$READONLY_TOKEN"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Start HFS server
+        run: |
+          HFS_LOG="/tmp/hfs-audit-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}.log"
+          AUDIT_FILE="/tmp/hfs-audit-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}.ndjson"
+
+          echo "HFS_LOG=$HFS_LOG" >> $GITHUB_ENV
+          echo "AUDIT_FILE=$AUDIT_FILE" >> $GITHUB_ENV
+
+          AUTH_JWKS_URL="http://$DOCKER_HOST_IP:$KEYCLOAK_PORT/realms/fhir/protocol/openid-connect/certs"
+          AUTH_ISSUER="http://$DOCKER_HOST_IP:$KEYCLOAK_PORT/realms/fhir"
+          AUTH_TOKEN_ENDPOINT="http://$DOCKER_HOST_IP:$KEYCLOAK_PORT/realms/fhir/protocol/openid-connect/token"
+          AUTH_AUTHORIZE_ENDPOINT="http://$DOCKER_HOST_IP:$KEYCLOAK_PORT/realms/fhir/protocol/openid-connect/auth"
+
+          if [ "${{ matrix.backend }}" = "sqlite-elasticsearch" ]; then
+            HFS_STORAGE_BACKEND=sqlite-elasticsearch \
+            HFS_ELASTICSEARCH_NODES="http://$DOCKER_HOST_IP:$ES_PORT" \
+            HFS_AUDIT_BACKEND=file \
+            HFS_AUDIT_FILE_PATH="$AUDIT_FILE" \
+            HFS_AUTH_ENABLED=true \
+            HFS_AUTH_JWKS_URL="$AUTH_JWKS_URL" \
+            HFS_AUTH_ISSUER="$AUTH_ISSUER" \
+            HFS_SMART_TOKEN_ENDPOINT="$AUTH_TOKEN_ENDPOINT" \
+            HFS_SMART_AUTHORIZE_ENDPOINT="$AUTH_AUTHORIZE_ENDPOINT" \
+            HFS_SMART_JWKS_URL="$AUTH_JWKS_URL" \
+            ./target/debug/hfs --database-url :memory: --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          elif [ "${{ matrix.backend }}" = "postgres" ]; then
+            HFS_STORAGE_BACKEND=postgres \
+            HFS_PG_HOST="$DOCKER_HOST_IP" \
+            HFS_PG_PORT="$PG_PORT" \
+            HFS_PG_DBNAME=helios \
+            HFS_PG_USER=helios \
+            HFS_PG_PASSWORD=helios \
+            HFS_AUDIT_BACKEND=file \
+            HFS_AUDIT_FILE_PATH="$AUDIT_FILE" \
+            HFS_AUTH_ENABLED=true \
+            HFS_AUTH_JWKS_URL="$AUTH_JWKS_URL" \
+            HFS_AUTH_ISSUER="$AUTH_ISSUER" \
+            HFS_SMART_TOKEN_ENDPOINT="$AUTH_TOKEN_ENDPOINT" \
+            HFS_SMART_AUTHORIZE_ENDPOINT="$AUTH_AUTHORIZE_ENDPOINT" \
+            HFS_SMART_JWKS_URL="$AUTH_JWKS_URL" \
+            ./target/debug/hfs --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          elif [ "${{ matrix.backend }}" = "mongodb" ]; then
+            MONGO_HOST="${DOCKER_HOST_IP:-127.0.0.1}"
+            HFS_STORAGE_BACKEND=mongodb \
+            HFS_DATABASE_URL="mongodb://$MONGO_HOST:$MONGO_PORT/?replicaSet=rs0&directConnection=true" \
+            HFS_MONGODB_DATABASE="helios_audit_${{ github.run_id }}_${{ github.run_attempt }}" \
+            HFS_AUDIT_BACKEND=file \
+            HFS_AUDIT_FILE_PATH="$AUDIT_FILE" \
+            HFS_AUTH_ENABLED=true \
+            HFS_AUTH_JWKS_URL="$AUTH_JWKS_URL" \
+            HFS_AUTH_ISSUER="$AUTH_ISSUER" \
+            HFS_SMART_TOKEN_ENDPOINT="$AUTH_TOKEN_ENDPOINT" \
+            HFS_SMART_AUTHORIZE_ENDPOINT="$AUTH_AUTHORIZE_ENDPOINT" \
+            HFS_SMART_JWKS_URL="$AUTH_JWKS_URL" \
+            ./target/debug/hfs --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          elif [ "${{ matrix.backend }}" = "s3-elasticsearch" ]; then
+            HFS_STORAGE_BACKEND=s3-elasticsearch \
+            HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}" \
+            HFS_S3_PREFIX="ci-audit/${{ github.run_id }}/${{ github.run_attempt }}/" \
+            HFS_S3_VALIDATE_BUCKETS=false \
+            HFS_ELASTICSEARCH_NODES="http://$DOCKER_HOST_IP:$ES_PORT" \
+            HFS_AUDIT_BACKEND=file \
+            HFS_AUDIT_FILE_PATH="$AUDIT_FILE" \
+            HFS_AUTH_ENABLED=true \
+            HFS_AUTH_JWKS_URL="$AUTH_JWKS_URL" \
+            HFS_AUTH_ISSUER="$AUTH_ISSUER" \
+            HFS_SMART_TOKEN_ENDPOINT="$AUTH_TOKEN_ENDPOINT" \
+            HFS_SMART_AUTHORIZE_ENDPOINT="$AUTH_AUTHORIZE_ENDPOINT" \
+            HFS_SMART_JWKS_URL="$AUTH_JWKS_URL" \
+            ./target/debug/hfs --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          else
+            HFS_AUDIT_BACKEND=file \
+            HFS_AUDIT_FILE_PATH="$AUDIT_FILE" \
+            HFS_AUTH_ENABLED=true \
+            HFS_AUTH_JWKS_URL="$AUTH_JWKS_URL" \
+            HFS_AUTH_ISSUER="$AUTH_ISSUER" \
+            HFS_SMART_TOKEN_ENDPOINT="$AUTH_TOKEN_ENDPOINT" \
+            HFS_SMART_AUTHORIZE_ENDPOINT="$AUTH_AUTHORIZE_ENDPOINT" \
+            HFS_SMART_JWKS_URL="$AUTH_JWKS_URL" \
+            ./target/debug/hfs --database-url :memory: --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          fi
+
+          echo $! > /tmp/hfs-audit.pid
+          echo "HFS_PID=$(cat /tmp/hfs-audit.pid)" >> $GITHUB_ENV
+
+      - name: Wait for HFS to be ready
+        run: |
+          echo "Waiting for HFS to start..."
+          for i in {1..30}; do
+            if ! kill -0 $HFS_PID 2>/dev/null; then
+              echo "HFS process ($HFS_PID) exited"
+              cat "$HFS_LOG"
+              exit 1
+            fi
+            if curl -sf "http://localhost:$HFS_PORT/health" > /dev/null 2>&1; then
+              echo "HFS is ready"
+              exit 0
+            fi
+            echo "Attempt $i/30: HFS not ready yet..."
+            sleep 2
+          done
+
+          echo "HFS failed to start"
+          tail -50 "$HFS_LOG"
+          exit 1
+
+      - name: Run external interaction suite
+        run: |
+          mkdir -p audit-results
+
+          BASE_URL="http://localhost:$HFS_PORT" \
+          FULL_TOKEN="$FULL_TOKEN" \
+          READONLY_TOKEN="$READONLY_TOKEN" \
+          AUDIT_FILE="$AUDIT_FILE" \
+          RESULTS_DIR="audit-results" \
+          ./crates/hfs/tests/audit/run_external_audit.sh
+
+      - name: Stop HFS gracefully
+        if: always()
+        run: |
+          if [ -f /tmp/hfs-audit.pid ]; then
+            HFS_PID=$(cat /tmp/hfs-audit.pid)
+            kill -INT "$HFS_PID" 2>/dev/null || true
+            for _ in {1..50}; do
+              if kill -0 "$HFS_PID" 2>/dev/null; then
+                sleep 0.2
+              else
+                break
+              fi
+            done
+            kill -9 "$HFS_PID" 2>/dev/null || true
+          fi
+          sleep 1
+
+      - name: Validate audit coverage and generate report
+        run: |
+          cp "$AUDIT_FILE" audit-results/audit.ndjson || true
+          cp "$HFS_LOG" audit-results/hfs.log || true
+          docker logs "$KC_CONTAINER" > audit-results/keycloak.log 2>&1 || true
+
+          python3 ./crates/hfs/tests/audit/validate_report.py \
+            --audit-file "$AUDIT_FILE" \
+            --ranges-file audit-results/interaction_ranges.tsv \
+            --context-file audit-results/context.json \
+            --output-dir audit-results \
+            --strict-correlation
+
+      - name: Append report to workflow summary
+        if: always()
+        run: |
+          if [ -f audit-results/report.md ]; then
+            cat audit-results/report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "# HFS Audit Coverage Report" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No report generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-events-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit-results/
+          retention-days: 30
+
+      - name: Cleanup
+        if: always()
+        run: |
+          echo "Stopping HFS..."
+          if [ -f /tmp/hfs-audit.pid ]; then
+            kill $(cat /tmp/hfs-audit.pid) 2>/dev/null || true
+            rm -f /tmp/hfs-audit.pid
+          fi
+
+          echo "Stopping Keycloak..."
+          docker rm -f "${KC_CONTAINER:-none}" 2>/dev/null || true
+
+          echo "Stopping Elasticsearch..."
+          docker rm -f "${ES_CONTAINER:-none}" 2>/dev/null || true
+
+          echo "Stopping PostgreSQL..."
+          docker rm -f "${PG_CONTAINER:-none}" 2>/dev/null || true
+
+          echo "Stopping MongoDB..."
+          docker rm -f "${MONGO_CONTAINER:-none}" 2>/dev/null || true
+
+          echo "Cleanup complete"

--- a/crates/hfs/tests/audit/run_external_audit.sh
+++ b/crates/hfs/tests/audit/run_external_audit.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:?BASE_URL is required}"
+FULL_TOKEN="${FULL_TOKEN:?FULL_TOKEN is required}"
+READONLY_TOKEN="${READONLY_TOKEN:?READONLY_TOKEN is required}"
+AUDIT_FILE="${AUDIT_FILE:?AUDIT_FILE is required}"
+RESULTS_DIR="${RESULTS_DIR:-audit-results}"
+
+mkdir -p "$RESULTS_DIR/http" "$RESULTS_DIR/events" "$RESULTS_DIR/payloads"
+RANGES_FILE="$RESULTS_DIR/interaction_ranges.tsv"
+CONTEXT_FILE="$RESULTS_DIR/context.json"
+
+echo -e "name\tmethod\tpath\texpected_status\tactual_status\tstart_line\tend_line" > "$RANGES_FILE"
+
+line_count() {
+  if [ -f "$AUDIT_FILE" ]; then
+    wc -l < "$AUDIT_FILE" | tr -d ' '
+  else
+    echo "0"
+  fi
+}
+
+status_matches() {
+  local actual="$1"
+  local allowed_csv="$2"
+  IFS=',' read -r -a allowed <<< "$allowed_csv"
+  for code in "${allowed[@]}"; do
+    if [ "$actual" = "$code" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+capture_event_window() {
+  local start_line="$1"
+  local current
+  current="$(line_count)"
+
+  # Wait for at least one new event (audit logging is asynchronous)
+  for _ in $(seq 1 100); do
+    if [ "$current" -gt "$start_line" ]; then
+      break
+    fi
+    sleep 0.1
+    current="$(line_count)"
+  done
+
+  # If nothing new appeared, return early (validator will fail this interaction)
+  if [ "$current" -le "$start_line" ]; then
+    echo "$current"
+    return
+  fi
+
+  # Give the sink a short settle window to flush sibling events for the same request
+  local stable_loops=0
+  local prev="$current"
+  for _ in $(seq 1 40); do
+    sleep 0.1
+    current="$(line_count)"
+    if [ "$current" = "$prev" ]; then
+      stable_loops=$((stable_loops + 1))
+      if [ "$stable_loops" -ge 3 ]; then
+        break
+      fi
+    else
+      stable_loops=0
+      prev="$current"
+    fi
+  done
+
+  echo "$current"
+}
+
+run_call() {
+  local name="$1"
+  local method="$2"
+  local path="$3"
+  local expected_status="$4"
+  local token="$5"
+  local content_type="${6:-}"
+  local data_file="${7:-}"
+
+  local start_line end_line status
+  local body_file="$RESULTS_DIR/http/${name}.body"
+  local status_file="$RESULTS_DIR/http/${name}.status"
+
+  start_line="$(line_count)"
+
+  local -a curl_args
+  curl_args=(-sS -o "$body_file" -w "%{http_code}" -X "$method" "${BASE_URL}${path}")
+
+  if [ -n "$token" ]; then
+    curl_args+=(-H "Authorization: Bearer $token")
+  fi
+  if [ -n "$content_type" ]; then
+    curl_args+=(-H "Content-Type: $content_type")
+  fi
+  if [ -n "$data_file" ]; then
+    curl_args+=(--data-binary "@$data_file")
+  fi
+
+  status="$(curl "${curl_args[@]}")"
+  printf "%s\n" "$status" > "$status_file"
+
+  if ! status_matches "$status" "$expected_status"; then
+    echo "ERROR: $name expected HTTP $expected_status but got $status" >&2
+    echo "---- response body ($name) ----" >&2
+    cat "$body_file" >&2 || true
+    echo "---- end response body ----" >&2
+    exit 1
+  fi
+
+  end_line="$(capture_event_window "$start_line")"
+
+  if [ "$end_line" -gt "$start_line" ]; then
+    sed -n "$((start_line + 1)),$((end_line))p" "$AUDIT_FILE" > "$RESULTS_DIR/events/${name}.ndjson"
+  else
+    : > "$RESULTS_DIR/events/${name}.ndjson"
+  fi
+
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "$name" "$method" "$path" "$expected_status" "$status" "$start_line" "$end_line" >> "$RANGES_FILE"
+}
+
+# Give startup audit emission a chance to flush before first interaction windowing
+sleep 1
+
+RUN_TAG="audit-$(date +%s)"
+
+cat > "$RESULTS_DIR/payloads/create_patient.json" <<JSON
+{
+  "resourceType": "Patient",
+  "name": [{"family": "${RUN_TAG}", "given": ["External", "Audit"]}],
+  "active": true
+}
+JSON
+
+run_call "missing_token_search" "GET" "/Patient" "401" ""
+run_call "invalid_token_search" "GET" "/Patient" "401" "not.a.jwt"
+
+run_call "create_patient" "POST" "/Patient" "201" "$FULL_TOKEN" "application/fhir+json" "$RESULTS_DIR/payloads/create_patient.json"
+PATIENT_ID="$(jq -r '.id // empty' "$RESULTS_DIR/http/create_patient.body")"
+if [ -z "$PATIENT_ID" ]; then
+  echo "ERROR: create_patient response missing id" >&2
+  cat "$RESULTS_DIR/http/create_patient.body" >&2 || true
+  exit 1
+fi
+
+cat > "$RESULTS_DIR/payloads/create_observation.json" <<JSON
+{
+  "resourceType": "Observation",
+  "status": "final",
+  "code": {"text": "External Audit Observation"},
+  "subject": {"reference": "Patient/${PATIENT_ID}"}
+}
+JSON
+
+cat > "$RESULTS_DIR/payloads/update_patient.json" <<JSON
+{
+  "resourceType": "Patient",
+  "id": "${PATIENT_ID}",
+  "active": true,
+  "name": [{"family": "${RUN_TAG}", "given": ["Updated"]}]
+}
+JSON
+
+cat > "$RESULTS_DIR/payloads/patch_patient.json" <<JSON
+{
+  "active": false
+}
+JSON
+
+cat > "$RESULTS_DIR/payloads/search_post.form" <<FORM
+name=${RUN_TAG}
+FORM
+
+run_call "read_patient" "GET" "/Patient/${PATIENT_ID}" "200" "$FULL_TOKEN"
+run_call "head_patient" "HEAD" "/Patient/${PATIENT_ID}" "200" "$FULL_TOKEN"
+run_call "search_patient_get" "GET" "/Patient?family=${RUN_TAG}" "200" "$FULL_TOKEN"
+run_call "search_patient_post" "POST" "/Patient/_search" "200" "$FULL_TOKEN" "application/x-www-form-urlencoded" "$RESULTS_DIR/payloads/search_post.form"
+run_call "history_type" "GET" "/Patient/_history" "200" "$FULL_TOKEN"
+run_call "history_system" "GET" "/_history" "200" "$FULL_TOKEN"
+run_call "history_instance" "GET" "/Patient/${PATIENT_ID}/_history" "200" "$FULL_TOKEN"
+
+run_call "create_observation" "POST" "/Observation" "201" "$FULL_TOKEN" "application/fhir+json" "$RESULTS_DIR/payloads/create_observation.json"
+OBSERVATION_ID="$(jq -r '.id // empty' "$RESULTS_DIR/http/create_observation.body")"
+if [ -z "$OBSERVATION_ID" ]; then
+  echo "ERROR: create_observation response missing id" >&2
+  cat "$RESULTS_DIR/http/create_observation.body" >&2 || true
+  exit 1
+fi
+
+run_call "search_subject_query" "GET" "/Observation?subject=Patient/${PATIENT_ID}" "200" "$FULL_TOKEN"
+run_call "search_patient_query" "GET" "/Observation?patient=Patient/${PATIENT_ID}" "200" "$FULL_TOKEN"
+run_call "search_unresolved_query" "GET" "/Observation?code=1234-5" "200" "$FULL_TOKEN"
+
+run_call "update_patient_put" "PUT" "/Patient/${PATIENT_ID}" "200" "$FULL_TOKEN" "application/fhir+json" "$RESULTS_DIR/payloads/update_patient.json"
+run_call "patch_patient" "PATCH" "/Patient/${PATIENT_ID}" "200" "$FULL_TOKEN" "application/merge-patch+json" "$RESULTS_DIR/payloads/patch_patient.json"
+
+run_call "readonly_denied_create" "POST" "/Observation" "403" "$READONLY_TOKEN" "application/fhir+json" "$RESULTS_DIR/payloads/create_observation.json"
+run_call "options_execute" "OPTIONS" "/Patient" "405" "$FULL_TOKEN"
+
+cat > "$RESULTS_DIR/payloads/batch_bundle.json" <<JSON
+{
+  "resourceType": "Bundle",
+  "type": "batch",
+  "entry": [
+    {
+      "request": {"method": "GET", "url": "Patient/${PATIENT_ID}"}
+    },
+    {
+      "request": {"method": "POST", "url": "Observation"},
+      "resource": {
+        "resourceType": "Observation",
+        "status": "final",
+        "code": {"text": "Batch Observation"},
+        "subject": {"reference": "Patient/${PATIENT_ID}"}
+      }
+    }
+  ]
+}
+JSON
+
+cat > "$RESULTS_DIR/payloads/transaction_bundle.json" <<JSON
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {"method": "POST", "url": "Observation"},
+      "resource": {
+        "resourceType": "Observation",
+        "status": "final",
+        "code": {"text": "Transaction Observation"},
+        "subject": {"reference": "Patient/${PATIENT_ID}"}
+      }
+    },
+    {
+      "request": {"method": "GET", "url": "Patient/${PATIENT_ID}"}
+    }
+  ]
+}
+JSON
+
+run_call "batch_bundle" "POST" "/" "200" "$FULL_TOKEN" "application/fhir+json" "$RESULTS_DIR/payloads/batch_bundle.json"
+run_call "transaction_bundle" "POST" "/" "200" "$FULL_TOKEN" "application/fhir+json" "$RESULTS_DIR/payloads/transaction_bundle.json"
+
+run_call "delete_observation" "DELETE" "/Observation/${OBSERVATION_ID}" "204" "$FULL_TOKEN"
+run_call "delete_patient" "DELETE" "/Patient/${PATIENT_ID}" "204" "$FULL_TOKEN"
+
+# Persist context for the validator/report generator
+cat > "$CONTEXT_FILE" <<JSON
+{
+  "base_url": "${BASE_URL}",
+  "audit_file": "${AUDIT_FILE}",
+  "patient_id": "${PATIENT_ID}",
+  "observation_id": "${OBSERVATION_ID}",
+  "run_tag": "${RUN_TAG}",
+  "ranges_file": "${RANGES_FILE}"
+}
+JSON
+
+echo "Interaction suite completed: patient=${PATIENT_ID}, observation=${OBSERVATION_ID}"

--- a/crates/hfs/tests/audit/validate_report.py
+++ b/crates/hfs/tests/audit/validate_report.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+
+def load_ndjson(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    if not path.exists():
+        return events
+
+    for idx, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Invalid NDJSON at {path}:{idx}: {exc}") from exc
+        item["__line"] = idx
+        events.append(item)
+    return events
+
+
+def read_context(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def scalar(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, dict):
+        if "value" in value:
+            return scalar(value.get("value"))
+        for sub in value.values():
+            text = scalar(sub)
+            if text:
+                return text
+    return ""
+
+
+def type_code(event: dict[str, Any]) -> str:
+    return scalar((event.get("type") or {}).get("code"))
+
+
+def action(event: dict[str, Any]) -> str:
+    return scalar(event.get("action"))
+
+
+def outcome(event: dict[str, Any]) -> str:
+    return scalar(event.get("outcome"))
+
+
+def outcome_desc(event: dict[str, Any]) -> str:
+    return scalar(event.get("outcomeDesc"))
+
+
+def subtype_codes(event: dict[str, Any]) -> list[str]:
+    codes: list[str] = []
+    for sub in event.get("subtype") or []:
+        code = scalar(sub.get("code"))
+        if code:
+            codes.append(code)
+    return codes
+
+
+def extract_reference(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return scalar(value.get("reference"))
+    return ""
+
+
+def entity_refs(event: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+    for entity in event.get("entity") or []:
+        ref = extract_reference((entity.get("what") or {}).get("reference"))
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+def has_patient_ref(event: dict[str, Any], patient_ref: str | None = None) -> bool:
+    for ref in entity_refs(event):
+        if not ref.startswith("Patient/"):
+            continue
+        if patient_ref is None or ref == patient_ref:
+            return True
+    return False
+
+
+def detail_map(event: dict[str, Any]) -> dict[str, list[str]]:
+    details: dict[str, list[str]] = {}
+    for entity in event.get("entity") or []:
+        for detail in entity.get("detail") or []:
+            key = scalar(detail.get("type"))
+            if not key:
+                continue
+
+            value = ""
+            for typed_key in (
+                "valueString",
+                "valueCode",
+                "valueUri",
+                "valueBoolean",
+                "valueInteger",
+                "valueDecimal",
+                "valueDateTime",
+            ):
+                if typed_key in detail:
+                    value = scalar(detail.get(typed_key))
+                    break
+            if not value and "value" in detail:
+                value = scalar(detail.get("value"))
+
+            details.setdefault(key, []).append(value)
+    return details
+
+
+def find_example(events: list[dict[str, Any]], predicate: Callable[[dict[str, Any]], bool]) -> dict[str, Any] | None:
+    for event in events:
+        if predicate(event):
+            return event
+    return None
+
+
+def is_lifecycle_phase(event: dict[str, Any], phase: str) -> bool:
+    if type_code(event) != "lifecycle":
+        return False
+    values = detail_map(event).get("phase", [])
+    return phase in values
+
+
+def is_auth_missing_token(event: dict[str, Any]) -> bool:
+    return outcome(event) == "8" and "Missing Authorization header" in outcome_desc(event)
+
+
+def is_auth_invalid_token(event: dict[str, Any]) -> bool:
+    return outcome(event) == "8" and "Invalid token format" in outcome_desc(event)
+
+
+def is_auth_success(event: dict[str, Any]) -> bool:
+    if type_code(event) != "rest":
+        return False
+    if outcome(event) != "0":
+        return False
+    if action(event) != "E":
+        return False
+    if "execute" not in subtype_codes(event):
+        return False
+    desc = outcome_desc(event)
+    if desc:
+        return False
+    return True
+
+
+def is_authz_grant(event: dict[str, Any]) -> bool:
+    return outcome(event) == "0" and outcome_desc(event).startswith("Granted:")
+
+
+def is_authz_denial(event: dict[str, Any]) -> bool:
+    return outcome(event) == "8" and outcome_desc(event).startswith("Forbidden:")
+
+
+def has_subtype(event: dict[str, Any], code: str) -> bool:
+    return code in subtype_codes(event)
+
+
+def has_ref(event: dict[str, Any], ref: str) -> bool:
+    return ref in entity_refs(event)
+
+
+def read_ranges(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines:
+        return records
+    for row in lines[1:]:
+        if not row.strip():
+            continue
+        name, method, req_path, expected, actual, start, end = row.split("\t")
+        records.append(
+            {
+                "name": name,
+                "method": method,
+                "path": req_path,
+                "expected": expected,
+                "actual": actual,
+                "start_line": int(start),
+                "end_line": int(end),
+            }
+        )
+    return records
+
+
+def call_events(output_dir: Path, call_name: str) -> list[dict[str, Any]]:
+    return load_ndjson(output_dir / "events" / f"{call_name}.ndjson")
+
+
+def write_example(output_dir: Path, key: str, event: dict[str, Any] | None) -> str | None:
+    if event is None:
+        return None
+    examples_dir = output_dir / "examples"
+    examples_dir.mkdir(parents=True, exist_ok=True)
+    path = examples_dir / f"{key}.json"
+    clean = {k: v for k, v in event.items() if k != "__line"}
+    path.write_text(json.dumps(clean, indent=2, sort_keys=True), encoding="utf-8")
+    return str(path.relative_to(output_dir))
+
+
+def check(label: str, ok: bool, message: str, example: dict[str, Any] | None) -> dict[str, Any]:
+    return {
+        "key": label,
+        "status": "pass" if ok else "fail",
+        "message": message,
+        "example": example,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate HFS audit NDJSON coverage and generate a summary report")
+    parser.add_argument("--audit-file", required=True)
+    parser.add_argument("--ranges-file", required=True)
+    parser.add_argument("--context-file", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--strict-correlation", action="store_true")
+    args = parser.parse_args()
+
+    audit_file = Path(args.audit_file)
+    ranges_file = Path(args.ranges_file)
+    context_file = Path(args.context_file)
+    output_dir = Path(args.output_dir)
+
+    events = load_ndjson(audit_file)
+    context = read_context(context_file)
+    ranges = read_ranges(ranges_file)
+
+    patient_id = context.get("patient_id", "")
+    observation_id = context.get("observation_id", "")
+    patient_ref = f"Patient/{patient_id}" if patient_id else None
+    observation_ref = f"Observation/{observation_id}" if observation_id else None
+
+    checks: list[dict[str, Any]] = []
+
+    # Lifecycle
+    startup_example = find_example(events, lambda e: is_lifecycle_phase(e, "startup"))
+    shutdown_example = find_example(events, lambda e: is_lifecycle_phase(e, "shutdown"))
+    checks.append(check("lifecycle_startup", startup_example is not None, "Startup lifecycle audit event", startup_example))
+    checks.append(check("lifecycle_shutdown", shutdown_example is not None, "Shutdown lifecycle audit event", shutdown_example))
+
+    # Auth global categories
+    auth_missing_example = find_example(events, is_auth_missing_token)
+    auth_invalid_example = find_example(events, is_auth_invalid_token)
+    auth_success_example = find_example(events, is_auth_success)
+    authz_grant_example = find_example(events, is_authz_grant)
+    authz_denial_example = find_example(events, is_authz_denial)
+
+    checks.append(check("auth_missing_token", auth_missing_example is not None, "Authentication failure: missing token", auth_missing_example))
+    checks.append(check("auth_invalid_token", auth_invalid_example is not None, "Authentication failure: invalid token", auth_invalid_example))
+    checks.append(check("auth_success", auth_success_example is not None, "Authentication success", auth_success_example))
+    checks.append(check("authz_grant", authz_grant_example is not None, "Authorization grant", authz_grant_example))
+    checks.append(check("authz_denial", authz_denial_example is not None, "Authorization denial", authz_denial_example))
+
+    # Per-interaction checks from captured windows
+    interaction_specs: list[tuple[str, str, Callable[[list[dict[str, Any]]], dict[str, Any] | None]]] = [
+        (
+            "create_patient",
+            "POST /Patient -> Create",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "create") and action(e) == "C" and (patient_ref is None or has_ref(e, patient_ref))),
+        ),
+        (
+            "read_patient",
+            "GET /Patient/{id} -> Read",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "read") and action(e) == "R" and (patient_ref is None or has_ref(e, patient_ref))),
+        ),
+        (
+            "head_patient",
+            "HEAD /Patient/{id} -> Read",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "read") and action(e) == "R" and (patient_ref is None or has_ref(e, patient_ref))),
+        ),
+        (
+            "search_patient_get",
+            "GET /Patient -> Query",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "search") and action(e) == "E"),
+        ),
+        (
+            "search_patient_post",
+            "POST /Patient/_search -> Query",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "search") and action(e) == "E"),
+        ),
+        (
+            "history_type",
+            "GET /Patient/_history -> Query",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "search") and action(e) == "E"),
+        ),
+        (
+            "history_system",
+            "GET /_history -> Query",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "search") and action(e) == "E"),
+        ),
+        (
+            "history_instance",
+            "GET /Patient/{id}/_history -> Query",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "search") and action(e) == "E" and (patient_ref is None or has_ref(e, patient_ref))),
+        ),
+        (
+            "create_observation",
+            "POST /Observation -> Create",
+            lambda evs: find_example(
+                evs,
+                lambda e: has_subtype(e, "create")
+                and action(e) == "C"
+                and (observation_ref is None or has_ref(e, observation_ref))
+                and (patient_ref is None or has_patient_ref(e, patient_ref)),
+            ),
+        ),
+        (
+            "search_subject_query",
+            "GET /Observation?subject=... -> Query with patient search param",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "search") and has_patient_ref(e, patient_ref)),
+        ),
+        (
+            "search_patient_query",
+            "GET /Observation?patient=... -> Query with patient search param",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "search") and has_patient_ref(e, patient_ref)),
+        ),
+        (
+            "search_unresolved_query",
+            "GET /Observation?code=... -> Query without patient resolution",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "search") and not has_patient_ref(e, None)),
+        ),
+        (
+            "update_patient_put",
+            "PUT /Patient/{id} -> Update",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "update") and action(e) == "U" and (patient_ref is None or has_ref(e, patient_ref))),
+        ),
+        (
+            "patch_patient",
+            "PATCH /Patient/{id} -> Update",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "update") and action(e) == "U" and (patient_ref is None or has_ref(e, patient_ref))),
+        ),
+        (
+            "readonly_denied_create",
+            "Authorization denial on write attempt",
+            lambda evs: find_example(evs, is_authz_denial),
+        ),
+        (
+            "options_execute",
+            "Other method (OPTIONS) -> Execute",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "execute") and type_code(e) == "rest" and outcome(e) == "8"),
+        ),
+        (
+            "delete_observation",
+            "DELETE /Observation/{id} -> Delete",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "delete") and action(e) == "D" and (observation_ref is None or has_ref(e, observation_ref))),
+        ),
+        (
+            "delete_patient",
+            "DELETE /Patient/{id} -> Delete",
+            lambda evs: find_example(evs, lambda e: has_subtype(e, "delete") and action(e) == "D" and (patient_ref is None or has_ref(e, patient_ref))),
+        ),
+    ]
+
+    for call_name, label, matcher in interaction_specs:
+        evs = call_events(output_dir, call_name)
+        example = matcher(evs)
+        checks.append(check(f"interaction_{call_name}", example is not None, label, example))
+
+    # Batch/transaction per-entry and correlation checks
+    for call_name, bundle_type in (("batch_bundle", "batch"), ("transaction_bundle", "transaction")):
+        evs = call_events(output_dir, call_name)
+        entry_events = [
+            e
+            for e in evs
+            if type_code(e) == "rest" and any(code in {"read", "create", "update", "delete"} for code in subtype_codes(e))
+        ]
+        has_per_entry = len(entry_events) >= 2
+        checks.append(
+            check(
+                f"interaction_{call_name}_per_entry",
+                has_per_entry,
+                f"{bundle_type} bundle emits per-entry audit events",
+                entry_events[0] if entry_events else None,
+            )
+        )
+
+        if args.strict_correlation:
+            correlation_ok = True
+            failing_example: dict[str, Any] | None = None
+            for event in entry_events:
+                dmap = detail_map(event)
+                missing_keys = [k for k in ("bundle-id", "bundle-type", "entry-index") if k not in dmap]
+                if missing_keys:
+                    correlation_ok = False
+                    failing_example = event
+                    break
+                bundle_types = [v for v in dmap.get("bundle-type", []) if v]
+                if bundle_types and bundle_type not in bundle_types:
+                    correlation_ok = False
+                    failing_example = event
+                    break
+
+            checks.append(
+                check(
+                    f"interaction_{call_name}_correlation",
+                    correlation_ok and has_per_entry,
+                    f"{bundle_type} per-entry events include bundle-id/bundle-type/entry-index",
+                    (entry_events[0] if correlation_ok and entry_events else failing_example),
+                )
+            )
+
+    # Every recorded call should produce at least one audit event window
+    for rec in ranges:
+        produced = rec["end_line"] > rec["start_line"]
+        checks.append(
+            check(
+                f"window_{rec['name']}",
+                produced,
+                f"Captured audit window for {rec['method']} {rec['path']}",
+                call_events(output_dir, rec["name"])[0] if produced and call_events(output_dir, rec["name"]) else None,
+            )
+        )
+
+    # Emit examples and coverage artifact
+    coverage: dict[str, Any] = {
+        "audit_file": str(audit_file),
+        "total_events": len(events),
+        "strict_correlation": args.strict_correlation,
+        "checks": [],
+        "excluded": [
+            {
+                "operation": "bulk export",
+                "event_type": "export",
+                "reason": "Not externally routable from the current hfs binary; persistence-layer helper exists but is not wired to public REST operations",
+            },
+            {
+                "operation": "bulk submit/import",
+                "event_type": "import",
+                "reason": "Not externally routable from the current hfs binary; persistence-layer helper exists but is not wired to public REST operations",
+            },
+            {
+                "operation": "purge",
+                "event_type": "purge",
+                "reason": "Not externally routable from the current hfs binary; persistence-layer helper exists but is not wired to public REST operations",
+            },
+            {
+                "operation": "reindex",
+                "event_type": "reindex",
+                "reason": "Not externally routable from the current hfs binary; persistence-layer helper exists but is not wired to public REST operations",
+            },
+        ],
+    }
+
+    for item in checks:
+        example_rel = write_example(output_dir, item["key"], item["example"])
+        coverage["checks"].append(
+            {
+                "key": item["key"],
+                "status": item["status"],
+                "message": item["message"],
+                "example_file": example_rel,
+            }
+        )
+
+    (output_dir / "coverage.json").write_text(json.dumps(coverage, indent=2, sort_keys=True), encoding="utf-8")
+
+    failed = [c for c in coverage["checks"] if c["status"] == "fail"]
+    passed = [c for c in coverage["checks"] if c["status"] == "pass"]
+
+    lines: list[str] = []
+    lines.append("# HFS Audit Coverage Report")
+    lines.append("")
+    lines.append(f"- Total audit events parsed: **{len(events)}**")
+    lines.append(f"- Checks passed: **{len(passed)}**")
+    lines.append(f"- Checks failed: **{len(failed)}**")
+    lines.append(f"- Strict correlation mode: **{'on' if args.strict_correlation else 'off'}**")
+    lines.append("")
+
+    lines.append("## Coverage Checks")
+    lines.append("")
+    lines.append("| Check | Status | Detail | Example |")
+    lines.append("|---|---|---|---|")
+    for c in coverage["checks"]:
+        status_icon = "PASS" if c["status"] == "pass" else "FAIL"
+        example = c["example_file"] or "-"
+        lines.append(f"| `{c['key']}` | {status_icon} | {c['message']} | `{example}` |")
+
+    lines.append("")
+    lines.append("## Excluded Interactions")
+    lines.append("")
+    for excluded in coverage["excluded"]:
+        lines.append(
+            f"- `{excluded['operation']}` (`{excluded['event_type']}`): {excluded['reason']}"
+        )
+
+    if failed:
+        lines.append("")
+        lines.append("## Failures")
+        lines.append("")
+        for c in failed:
+            lines.append(f"- `{c['key']}`: {c['message']}")
+
+    (output_dir / "report.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"Wrote coverage report: {output_dir / 'report.md'}")
+    print(f"Wrote machine-readable coverage: {output_dir / 'coverage.json'}")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
This PR adds a new external audit validation workflow that verifies `hfs` emits `AuditEvent` records for all currently audit-enabled interactions documented in `crates/audit/README.md`.

The workflow:
- Builds `hfs` once, uploads the binary artifact, and reuses it across backend test jobs.
- Starts `hfs` in a CI environment patterned after `inferno.yml` (ephemeral infra + auth setup).
- Forces audit output to the file sink (`HFS_AUDIT_BACKEND=file`).
- Executes an exhaustive external HTTP interaction suite against a live `hfs` process.
- Validates emitted NDJSON audit events and generates a human-readable + machine-readable report.

## What’s Included

### 1) New GitHub Actions workflow
File: `.github/workflows/audit-events.yml`

- Trigger: `workflow_dispatch`
- Build job:
  - Installs Rust toolchain
  - Builds `helios-hfs`
  - Uploads `target/debug/hfs` as artifact
- Matrix audit job backends:
  - `sqlite`
  - `sqlite-elasticsearch`
  - `postgres`
  - `mongodb`
  - `s3-elasticsearch`
- Environment orchestration:
  - Brings up Keycloak for JWT auth
  - Starts backend-specific services (Elasticsearch/Postgres/Mongo/S3+ES as needed)
  - Starts `hfs` with audit file sink enabled
- Executes external interaction suite and validator
- Publishes report to `GITHUB_STEP_SUMMARY`
- Uploads full `audit-results/` artifacts for inspection

### 2) External interaction runner
File: `crates/hfs/tests/audit/run_external_audit.sh`

Runs a deterministic sequence of authenticated and unauthenticated FHIR requests, captures HTTP responses, and windows audit file lines per interaction so each call has isolated NDJSON evidence.

### 3) Coverage validator + report generator
File: `crates/hfs/tests/audit/validate_report.py`

- Parses full NDJSON audit output
- Checks coverage expectations
- Verifies batch/transaction per-entry correlation details in strict mode:
  - `bundle-id`
  - `bundle-type`
  - `entry-index`
- Writes:
  - `audit-results/report.md`
  - `audit-results/coverage.json`
  - `audit-results/examples/*.json` (example event per check)

## Coverage Map (README Interactions -> External Test)

| README interaction area | Validation in this PR |
|---|---|
| REST CRUD | `POST /Patient`, `GET /Patient/{id}`, `PUT/PATCH /Patient/{id}`, `DELETE /Observation/{id}`, `DELETE /Patient/{id}` |
| Query/Search/History | `GET /Patient?family=...`, `POST /Patient/_search`, `GET /Patient/_history`, `GET /_history`, `GET /Patient/{id}/_history`, `GET /Observation?...` |
| Execute / non-CRUD method | `OPTIONS /Patient` |
| Auth failures | Missing token, invalid token |
| Auth success + authz grant | Successful authorized requests |
| Authz denial | Read-only token attempting write (`POST /Observation` -> `403`) |
| Lifecycle | Startup and graceful shutdown events asserted |
| Batch/transaction correlation | `POST /` batch + transaction bundle; per-entry events and correlation keys asserted |

## Explicit Exclusions
The validator explicitly reports these as excluded because they are not externally routable via current `hfs` REST handlers:
- `export`
- `import`
- `purge`
- `reindex`

These functions exist at persistence-layer integration points but are not currently invoked by public REST operations.

## Artifacts Produced
For each backend job, uploaded artifact `audit-events-<backend>-<run_id>-<attempt>` includes:
- `audit.ndjson` (raw sink output)
- `interaction_ranges.tsv` (request -> audit line windows)
- `events/*.ndjson` (per-interaction windows)
- `examples/*.json` (sample event for each check)
- `coverage.json` (machine-readable pass/fail)
- `report.md` (human-readable summary)
- service logs (`hfs.log`, `keycloak.log`, HTTP response captures)

## Validation
Local sanity checks for new test assets:
- `bash -n crates/hfs/tests/audit/run_external_audit.sh`
- `python3 -m py_compile crates/hfs/tests/audit/validate_report.py`
- YAML parse check for `.github/workflows/audit-events.yml`

## Notes
- This PR is intentionally scoped to external audit workflow/testing only.
- It does not change audit event production logic; it validates and reports current behavior end-to-end.
