### PR TITLE
chore(ci): add subscriptions channel integration workflow

### DIFF
--- a/.github/workflows/subscriptions-channels.yml
+++ b/.github/workflows/subscriptions-channels.yml
@@ -1,0 +1,45 @@
+name: Subscriptions Channel Integration
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+    paths:
+      - "crates/subscriptions/**"
+      - ".github/workflows/subscriptions-channels.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/subscriptions/**"
+      - ".github/workflows/subscriptions-channels.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 2
+  CARGO_PROFILE_DEV_DEBUG: 0
+
+jobs:
+  rest-hook-integration:
+    name: Rest-Hook Channel Integration
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Configure Rust linker (Linux)
+        run: |
+          mkdir -p ~/.cargo
+          rm -f ~/.cargo/config.toml
+          echo '[target.x86_64-unknown-linux-gnu]' >> ~/.cargo/config.toml
+          echo 'linker = "clang"' >> ~/.cargo/config.toml
+          echo 'rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,-zstack-size=8388608"]' >> ~/.cargo/config.toml
+
+      - name: Run subscriptions rest-hook integration test
+        run: cargo test -p helios-subscriptions --test rest_hook_integration


### PR DESCRIPTION
## Summary

  This PR adds a dedicated GitHub Actions workflow to run subscription channel integration coverage for
  the subscriptions crate.

  ## What changed

  - Added .github/workflows/subscriptions-channels.yml
  - New workflow runs the rest-hook channel integration test target:
      - cargo test -p helios-subscriptions --test rest_hook_integration
  - Triggered on:
      - workflow_dispatch
      - push to main/develop when crates/subscriptions/** or this workflow file changes
      - pull_request to main with the same path filters

  ## Validation

  - Local verification command:
      - cargo test -p helios-subscriptions --test rest_hook_integration
  - Workflow is Linux self-hosted and uses the repo’s standard Rust toolchain/linker setup