### PR TITLE
feat(subscriptions): implement FHIR topic-based Subscriptions — Phase 1   (rest-hook + core infrastructure)

### DIFF
--- a/.github/workflows/subscriptions-channels.yml
+++ b/.github/workflows/subscriptions-channels.yml
@@ -1,0 +1,45 @@
+name: Subscriptions Channel Integration
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+    paths:
+      - "crates/subscriptions/**"
+      - ".github/workflows/subscriptions-channels.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/subscriptions/**"
+      - ".github/workflows/subscriptions-channels.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 2
+  CARGO_PROFILE_DEV_DEBUG: 0
+
+jobs:
+  rest-hook-integration:
+    name: Rest-Hook Channel Integration
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Configure Rust linker (Linux)
+        run: |
+          mkdir -p ~/.cargo
+          rm -f ~/.cargo/config.toml
+          echo '[target.x86_64-unknown-linux-gnu]' >> ~/.cargo/config.toml
+          echo 'linker = "clang"' >> ~/.cargo/config.toml
+          echo 'rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,-zstack-size=8388608"]' >> ~/.cargo/config.toml
+
+      - name: Run subscriptions rest-hook integration test
+        run: cargo test -p helios-subscriptions --test rest_hook_integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "astral-tokio-tar"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,6 +1988,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2770,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2929,6 +2959,7 @@ name = "helios-hfs"
 version = "0.1.47"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "clap",
  "helios-audit",
@@ -2936,9 +2967,11 @@ dependencies = [
  "helios-fhir",
  "helios-persistence",
  "helios-rest",
+ "helios-subscriptions",
  "openssl",
  "parking_lot",
  "reqwest",
+ "serde_json",
  "tokio",
  "tracing",
 ]
@@ -3006,6 +3039,7 @@ dependencies = [
  "helios-fhir",
  "helios-persistence",
  "helios-serde",
+ "helios-subscriptions",
  "http 1.4.0",
  "json-patch",
  "jsonpath-rust",
@@ -3087,6 +3121,25 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "zip 2.4.2",
+]
+
+[[package]]
+name = "helios-subscriptions"
+version = "0.1.47"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "helios-fhir",
+ "helios-persistence",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -7625,6 +7678,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool 0.12.3",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default-members = [
 	"crates/cds-hooks",
 	"crates/auth",
 	"crates/audit",
+	"crates/subscriptions",
 ]
 resolver = "2"
 

--- a/crates/hfs/Cargo.toml
+++ b/crates/hfs/Cargo.toml
@@ -36,6 +36,9 @@ s3 = ["helios-rest/s3"]
 # Auth backends
 redis = ["helios-rest/redis", "helios-auth/redis"]
 
+# Subscriptions
+subscriptions = ["helios-rest/subscriptions", "dep:helios-subscriptions"]
+
 # Cloud audit backends
 cloudwatch = ["helios-audit/cloudwatch"]
 
@@ -48,6 +51,7 @@ helios-rest = { path = "../rest", version = "0.1.47", default-features = false }
 helios-persistence = { path = "../persistence", version = "0.1.47", default-features = false, features = ["audit"] }
 helios-auth = { path = "../auth", version = "0.1.47" }
 helios-audit = { path = "../audit", version = "0.1.47" }
+helios-subscriptions = { path = "../subscriptions", version = "0.1.47", optional = true }
 
 # Web framework
 axum = "0.8"

--- a/crates/rest/Cargo.toml
+++ b/crates/rest/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["web-programming", "database"]
 [features]
 default = ["R4", "sqlite"]
 
-# FHIR version features (pass through to helios-fhir, helios-persistence, and helios-serde)
-R4 = ["helios-fhir/R4", "helios-persistence/R4", "helios-serde?/R4"]
-R4B = ["helios-fhir/R4B", "helios-persistence/R4B", "helios-serde?/R4B"]
-R5 = ["helios-fhir/R5", "helios-persistence/R5", "helios-serde?/R5"]
-R6 = ["helios-fhir/R6", "helios-persistence/R6", "helios-serde?/R6"]
+# FHIR version features (pass through to helios-fhir, helios-persistence, helios-serde, helios-subscriptions)
+R4 = ["helios-fhir/R4", "helios-persistence/R4", "helios-serde?/R4", "helios-subscriptions?/R4"]
+R4B = ["helios-fhir/R4B", "helios-persistence/R4B", "helios-serde?/R4B", "helios-subscriptions?/R4B"]
+R5 = ["helios-fhir/R5", "helios-persistence/R5", "helios-serde?/R5", "helios-subscriptions?/R5"]
+R6 = ["helios-fhir/R6", "helios-persistence/R6", "helios-serde?/R6", "helios-subscriptions?/R6"]
 
 # Serialization format features
 xml = ["helios-fhir/xml", "dep:helios-serde", "helios-serde?/xml"]
@@ -33,6 +33,9 @@ s3 = ["helios-persistence/s3"]
 # Auth feature (pass through to helios-auth)
 redis = ["helios-auth/redis"]
 
+# Subscriptions
+subscriptions = ["dep:helios-subscriptions"]
+
 [dependencies]
 # Core dependencies
 helios-fhir = { path = "../fhir", version = "0.1.47" }
@@ -40,6 +43,7 @@ helios-persistence = { path = "../persistence", version = "0.1.47", default-feat
 helios-serde = { path = "../serde", version = "0.1.47", default-features = false, optional = true }
 helios-auth = { path = "../auth", version = "0.1.47" }
 helios-audit = { path = "../audit", version = "0.1.47" }
+helios-subscriptions = { path = "../subscriptions", version = "0.1.47", optional = true }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/rest/src/handlers/create.rs
+++ b/crates/rest/src/handlers/create.rs
@@ -201,6 +201,18 @@ where
         "Resource created"
     );
 
+    // Emit subscription event
+    #[cfg(feature = "subscriptions")]
+    if let Some(engine) = state.subscription_engine() {
+        super::subscription_event::emit_subscription_event(
+            engine,
+            tenant.context(),
+            &stored,
+            fhir_version,
+            helios_subscriptions::ResourceEventType::Create,
+        );
+    }
+
     build_create_response(
         StatusCode::CREATED,
         &stored,

--- a/crates/rest/src/handlers/delete.rs
+++ b/crates/rest/src/handlers/delete.rs
@@ -70,6 +70,18 @@ where
         "Resource deleted"
     );
 
+    // Emit subscription event
+    #[cfg(feature = "subscriptions")]
+    if let Some(engine) = state.subscription_engine() {
+        super::subscription_event::emit_delete_event(
+            engine,
+            tenant.context(),
+            &resource_type,
+            &id,
+            helios_fhir::FhirVersion::default(),
+        );
+    }
+
     // Return 204 No Content (or 200 with OperationOutcome)
     Ok(StatusCode::NO_CONTENT.into_response())
 }

--- a/crates/rest/src/handlers/mod.rs
+++ b/crates/rest/src/handlers/mod.rs
@@ -26,6 +26,10 @@ pub mod patch;
 pub mod read;
 pub mod search;
 pub mod smart_discovery;
+#[cfg(feature = "subscriptions")]
+pub mod subscription_event;
+#[cfg(feature = "subscriptions")]
+pub mod subscriptions;
 pub mod update;
 pub mod versions;
 pub mod vread;

--- a/crates/rest/src/handlers/patch.rs
+++ b/crates/rest/src/handlers/patch.rs
@@ -132,6 +132,18 @@ where
         "Resource patched"
     );
 
+    // Emit subscription event
+    #[cfg(feature = "subscriptions")]
+    if let Some(engine) = state.subscription_engine() {
+        super::subscription_event::emit_subscription_event(
+            engine,
+            tenant.context(),
+            &stored,
+            stored.fhir_version(),
+            helios_subscriptions::ResourceEventType::Update,
+        );
+    }
+
     build_patch_response(&stored, headers, &prefer).map(|mut response| {
         response
             .extensions_mut()

--- a/crates/rest/src/handlers/subscription_event.rs
+++ b/crates/rest/src/handlers/subscription_event.rs
@@ -1,0 +1,86 @@
+//! Subscription event emission helper.
+//!
+//! Constructs a `ResourceEvent` from handler context and spawns the
+//! subscription engine's event handler asynchronously, mirroring the
+//! fire-and-forget pattern used by the audit middleware.
+
+use std::sync::Arc;
+
+use helios_fhir::FhirVersion;
+use helios_persistence::tenant::TenantContext;
+use helios_persistence::types::StoredResource;
+use helios_subscriptions::{ResourceEvent, ResourceEventType, SubscriptionEngine};
+use tracing::debug;
+
+/// Emits a subscription event for a successful resource write.
+///
+/// This function constructs a `ResourceEvent` from the handler context and
+/// spawns the subscription engine's `on_resource_event` asynchronously.
+/// It is a no-op if the subscription engine is not configured.
+pub fn emit_subscription_event(
+    engine: &Arc<SubscriptionEngine>,
+    tenant: &TenantContext,
+    stored: &StoredResource,
+    fhir_version: FhirVersion,
+    event_type: ResourceEventType,
+) {
+    let event = ResourceEvent {
+        tenant_id: tenant.tenant_id().clone(),
+        fhir_version,
+        resource_type: stored.resource_type().to_string(),
+        resource_id: stored.id().to_string(),
+        version_id: stored.version_id().to_string(),
+        event_type,
+        resource: Some(stored.content().clone()),
+        previous_resource: None,
+        timestamp: chrono::Utc::now(),
+    };
+
+    let engine = Arc::clone(engine);
+
+    debug!(
+        resource_type = %event.resource_type,
+        resource_id = %event.resource_id,
+        event_type = %event.event_type,
+        "Emitting subscription event"
+    );
+
+    tokio::spawn(async move {
+        engine.on_resource_event(event).await;
+    });
+}
+
+/// Emits a subscription event for a resource delete.
+///
+/// Delete events carry the resource type and ID but no resource content.
+pub fn emit_delete_event(
+    engine: &Arc<SubscriptionEngine>,
+    tenant: &TenantContext,
+    resource_type: &str,
+    resource_id: &str,
+    fhir_version: FhirVersion,
+) {
+    let event = ResourceEvent {
+        tenant_id: tenant.tenant_id().clone(),
+        fhir_version,
+        resource_type: resource_type.to_string(),
+        resource_id: resource_id.to_string(),
+        version_id: String::new(),
+        event_type: ResourceEventType::Delete,
+        resource: None,
+        previous_resource: None,
+        timestamp: chrono::Utc::now(),
+    };
+
+    let engine = Arc::clone(engine);
+
+    debug!(
+        resource_type = %event.resource_type,
+        resource_id = %event.resource_id,
+        "Emitting subscription delete event"
+    );
+
+    tokio::spawn(async move {
+        engine.on_resource_event(event).await;
+    });
+}

--- a/crates/rest/src/handlers/subscriptions.rs
+++ b/crates/rest/src/handlers/subscriptions.rs
@@ -1,0 +1,160 @@
+//! Subscription operation handlers ($status, $events).
+//!
+//! Implements custom FHIR operations for subscription management:
+//! - `GET /Subscription/{id}/$status` — returns the current `SubscriptionStatus`
+//! - `GET /Subscription/{id}/$events` — returns recent events (R5/R6 only)
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use helios_persistence::core::ResourceStorage;
+use serde_json::json;
+
+use crate::error::{RestError, RestResult};
+use crate::extractors::TenantExtractor;
+use crate::state::AppState;
+
+/// Handler for the `$status` operation on Subscription resources.
+///
+/// Returns a `SubscriptionStatus` (R5/R6) or `Parameters` (R4/R4B backport)
+/// resource reflecting the subscription's current runtime state.
+///
+/// # HTTP Request
+///
+/// `GET [base]/Subscription/{id}/$status`
+pub async fn subscription_status_handler<S>(
+    State(state): State<AppState<S>>,
+    Path((_resource_type, id)): Path<(String, String)>,
+    tenant: TenantExtractor,
+) -> RestResult<Response>
+where
+    S: ResourceStorage + Send + Sync,
+{
+    let engine = state
+        .subscription_engine()
+        .ok_or(RestError::NotImplemented {
+            feature: "Subscriptions".to_string(),
+        })?;
+
+    let sub = engine
+        .manager()
+        .get_subscription(tenant.tenant_id(), &id)
+        .ok_or(RestError::NotFound {
+            resource_type: "Subscription".to_string(),
+            id: id.clone(),
+        })?;
+
+    let status_resource = build_subscription_status(&sub, &id, state.base_url());
+
+    Ok((StatusCode::OK, Json(status_resource)).into_response())
+}
+
+/// Handler for the `$events` operation on Subscription resources.
+///
+/// Returns recent events for the subscription. This is a simplified
+/// implementation that returns the current event count.
+///
+/// # HTTP Request
+///
+/// `GET [base]/Subscription/{id}/$events`
+pub async fn subscription_events_handler<S>(
+    State(state): State<AppState<S>>,
+    Path((_resource_type, id)): Path<(String, String)>,
+    tenant: TenantExtractor,
+) -> RestResult<Response>
+where
+    S: ResourceStorage + Send + Sync,
+{
+    let engine = state
+        .subscription_engine()
+        .ok_or(RestError::NotImplemented {
+            feature: "Subscriptions".to_string(),
+        })?;
+
+    let sub = engine
+        .manager()
+        .get_subscription(tenant.tenant_id(), &id)
+        .ok_or(RestError::NotFound {
+            resource_type: "Subscription".to_string(),
+            id: id.clone(),
+        })?;
+
+    // Return a Bundle with a SubscriptionStatus indicating query-status
+    let bundle = json!({
+        "resourceType": "Bundle",
+        "type": "history",
+        "entry": [{
+            "resource": {
+                "resourceType": "SubscriptionStatus",
+                "status": sub.status.as_fhir_str(),
+                "type": "query-status",
+                "eventsSinceSubscriptionStart": sub.events_since_start.to_string(),
+                "subscription": {
+                    "reference": format!("Subscription/{}", id)
+                },
+                "topic": sub.topic_url
+            }
+        }]
+    });
+
+    Ok((StatusCode::OK, Json(bundle)).into_response())
+}
+
+/// Builds a SubscriptionStatus resource for the $status response.
+fn build_subscription_status(
+    sub: &helios_subscriptions::manager::ActiveSubscription,
+    id: &str,
+    base_url: &str,
+) -> serde_json::Value {
+    if uses_backport_ig(sub.fhir_version) {
+        // R4/R4B backport: return Parameters resource
+        json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {
+                    "name": "subscription",
+                    "valueReference": {
+                        "reference": format!("{}/Subscription/{}", base_url, id)
+                    }
+                },
+                {
+                    "name": "topic",
+                    "valueCanonical": sub.topic_url
+                },
+                {
+                    "name": "status",
+                    "valueCode": sub.status.as_fhir_str()
+                },
+                {
+                    "name": "type",
+                    "valueCode": "query-status"
+                },
+                {
+                    "name": "events-since-subscription-start",
+                    "valueString": sub.events_since_start.to_string()
+                }
+            ]
+        })
+    } else {
+        // R5/R6 native: return SubscriptionStatus resource
+        json!({
+            "resourceType": "SubscriptionStatus",
+            "status": sub.status.as_fhir_str(),
+            "type": "query-status",
+            "eventsSinceSubscriptionStart": sub.events_since_start.to_string(),
+            "subscription": {
+                "reference": format!("Subscription/{}", id)
+            },
+            "topic": sub.topic_url
+        })
+    }
+}
+
+/// Returns true for FHIR versions that use the Subscriptions R5 Backport IG
+/// (R4 and R4B), false for versions with native subscription support (R5, R6).
+fn uses_backport_ig(version: helios_fhir::FhirVersion) -> bool {
+    matches!(version.as_str(), "R4" | "R4B")
+}

--- a/crates/rest/src/handlers/update.rs
+++ b/crates/rest/src/handlers/update.rs
@@ -184,6 +184,23 @@ where
         "Resource updated"
     );
 
+    // Emit subscription event
+    #[cfg(feature = "subscriptions")]
+    if let Some(engine) = state.subscription_engine() {
+        let event_type = if created {
+            helios_subscriptions::ResourceEventType::Create
+        } else {
+            helios_subscriptions::ResourceEventType::Update
+        };
+        super::subscription_event::emit_subscription_event(
+            engine,
+            tenant.context(),
+            &stored,
+            fhir_version,
+            event_type,
+        );
+    }
+
     build_update_response(
         status,
         &stored,

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -298,6 +298,23 @@ where
         app_audit_source_observer,
     );
 
+    // Inject subscription engine if enabled
+    #[cfg(feature = "subscriptions")]
+    let state = {
+        let subscriptions_enabled = std::env::var("HFS_SUBSCRIPTIONS_ENABLED")
+            .map(|v| !matches!(v.trim().to_ascii_lowercase().as_str(), "false" | "0"))
+            .unwrap_or(false);
+        if subscriptions_enabled {
+            let sub_config = helios_subscriptions::SubscriptionConfig::default();
+            let engine =
+                helios_subscriptions::SubscriptionEngine::new(sub_config, config.base_url.clone());
+            info!("Subscriptions engine ENABLED");
+            state.with_subscription_engine(Arc::new(engine))
+        } else {
+            state
+        }
+    };
+
     // Build the router with all FHIR routes
     let router = routing::fhir_routes::create_routes(state);
 

--- a/crates/rest/src/routing/fhir_routes.rs
+++ b/crates/rest/src/routing/fhir_routes.rs
@@ -185,7 +185,7 @@ where
         + Sync
         + 'static,
 {
-    Router::new()
+    let router = Router::new()
         // System-level routes
         .route("/metadata", get(handlers::capabilities_handler::<S>))
         .route("/$versions", get(handlers::versions_handler::<S>))
@@ -249,12 +249,25 @@ where
         .route(
             "/{resource_type}/{id}/_history/{version_id}",
             delete(handlers::delete_version_handler::<S>),
-        )
-        // Compartment search: GET [base]/[compartment-type]/[id]/[target-type]?params
+        );
+
+    // Subscription operations (feature-gated, before compartment search)
+    #[cfg(feature = "subscriptions")]
+    let router = router
         .route(
-            "/{compartment_type}/{compartment_id}/{target_type}",
-            get(handlers::compartment_search_handler::<S>),
+            "/{resource_type}/{id}/$status",
+            get(handlers::subscriptions::subscription_status_handler::<S>),
         )
+        .route(
+            "/{resource_type}/{id}/$events",
+            get(handlers::subscriptions::subscription_events_handler::<S>),
+        );
+
+    // Compartment search: GET [base]/[compartment-type]/[id]/[target-type]?params
+    router.route(
+        "/{compartment_type}/{compartment_id}/{target_type}",
+        get(handlers::compartment_search_handler::<S>),
+    )
 }
 
 /// Creates a minimal set of routes for testing.

--- a/crates/rest/src/state.rs
+++ b/crates/rest/src/state.rs
@@ -51,6 +51,10 @@ pub struct AppState<S> {
 
     /// Audit source observer reference used when emitting handler-level events.
     audit_source_observer: String,
+
+    /// Optional subscription engine for FHIR topic-based subscriptions.
+    #[cfg(feature = "subscriptions")]
+    subscription_engine: Option<Arc<helios_subscriptions::SubscriptionEngine>>,
 }
 
 // Manually implement Clone since S is wrapped in Arc and doesn't need to be Clone
@@ -63,6 +67,8 @@ impl<S> Clone for AppState<S> {
             auth: self.auth.clone(),
             audit_sink: self.audit_sink.clone(),
             audit_source_observer: self.audit_source_observer.clone(),
+            #[cfg(feature = "subscriptions")]
+            subscription_engine: self.subscription_engine.clone(),
         }
     }
 }
@@ -82,6 +88,8 @@ impl<S: ResourceStorage> AppState<S> {
             auth: None,
             audit_sink: None,
             audit_source_observer: "Device/hfs".to_string(),
+            #[cfg(feature = "subscriptions")]
+            subscription_engine: None,
         }
     }
 
@@ -111,7 +119,19 @@ impl<S: ResourceStorage> AppState<S> {
             auth: auth_state,
             audit_sink,
             audit_source_observer: audit_source_observer.into(),
+            #[cfg(feature = "subscriptions")]
+            subscription_engine: None,
         }
+    }
+
+    /// Sets the subscription engine on this AppState.
+    #[cfg(feature = "subscriptions")]
+    pub fn with_subscription_engine(
+        mut self,
+        engine: Arc<helios_subscriptions::SubscriptionEngine>,
+    ) -> Self {
+        self.subscription_engine = Some(engine);
+        self
     }
 
     /// Returns a reference to the storage backend.
@@ -187,6 +207,12 @@ impl<S: ResourceStorage> AppState<S> {
     /// Returns the configured audit source observer reference.
     pub fn audit_source_observer(&self) -> &str {
         &self.audit_source_observer
+    }
+
+    /// Returns the subscription engine, if configured.
+    #[cfg(feature = "subscriptions")]
+    pub fn subscription_engine(&self) -> Option<&Arc<helios_subscriptions::SubscriptionEngine>> {
+        self.subscription_engine.as_ref()
     }
 }
 

--- a/crates/subscriptions/Cargo.toml
+++ b/crates/subscriptions/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "helios-subscriptions"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "FHIR topic-based Subscriptions engine for HFS"
+
+[features]
+default = ["R4"]
+R4 = ["helios-fhir/R4"]
+R4B = ["helios-fhir/R4B"]
+R5 = ["helios-fhir/R5"]
+R6 = ["helios-fhir/R6"]
+
+[dependencies]
+# FHIR models
+helios-fhir = { path = "../fhir" }
+
+# Persistence (for TenantContext, StoredResource, etc.)
+helios-persistence = { path = "../persistence", default-features = false }
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Async runtime
+tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
+async-trait = "0.1"
+
+# Time
+chrono.workspace = true
+
+# Logging
+tracing = "0.1"
+
+# Error handling
+thiserror = "2"
+
+# UUID generation
+uuid = { version = "1", features = ["v4"] }
+
+# HTTP client (rest-hook channel)
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# Concurrent data structures
+dashmap = "6"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/crates/subscriptions/README.md
+++ b/crates/subscriptions/README.md
@@ -6,7 +6,7 @@ R4 and R4B use the [Subscriptions R5 Backport IG](https://build.fhir.org/ig/HL7/
 
 ## Overview
 
-This crate implements topic-based subscriptions as an asynchronous pipeline that fires after every resource write. It decomposes into five concerns:
+This crate implements topic-based subscriptions as an asynchronous pipeline that fires after every resource create, update, or delete. These are the three interaction types defined by the FHIR [`SubscriptionTopic.resourceTrigger.supportedInteraction`](https://hl7.org/fhir/subscriptiontopic.html) value set. It decomposes into five concerns:
 
 1. **Topic Registry** — stores `SubscriptionTopic` definitions and evaluates resource triggers
 2. **Subscription Manager** — tracks active `Subscription` resources and their runtime state
@@ -14,7 +14,7 @@ This crate implements topic-based subscriptions as an asynchronous pipeline that
 4. **Notification Builder** — constructs version-specific notification bundles (R4 Parameters-based backport, R5/R6 native `SubscriptionStatus`)
 5. **Channel Dispatcher** — delivers notifications via pluggable channel implementations
 
-The [`SubscriptionEngine`] orchestrates all five concerns and is the main entry point, invoked via `tokio::spawn` after each resource write — mirroring the fire-and-forget pattern used by the audit middleware.
+The `SubscriptionEngine` orchestrates all five concerns and is the main entry point, invoked via `tokio::spawn` after each resource create, update, patch, or delete — mirroring the fire-and-forget pattern used by the audit middleware.
 
 ## Features
 
@@ -246,10 +246,103 @@ FHIR version support via Cargo feature flags:
 helios-subscriptions = { version = "0.1", features = ["R4"] }
 ```
 
+## Design Considerations
+
+### Performance: `tokio::spawn` per event
+
+The current design spawns one Tokio task per resource write. Each task runs the full evaluate → build → dispatch pipeline.
+
+**Where this works well:**
+
+- Task creation is cheap — a dozen allocations, no syscall. Thousands per second is not a problem for Tokio's scheduler.
+- In-memory evaluation is fast — topic matching and filter checks on `DashMap` are microseconds.
+- Low-volume servers handling tens of writes per second are well-served by this model.
+
+**Where it breaks down:**
+
+- **Unbounded concurrency on HTTP dispatch.** If an endpoint is slow or down, tasks accumulate — each holding memory for the request, the notification bundle, and sleeping during retry backoff. A burst of 1,000 writes to a subscription with a failing endpoint spawns 1,000 tasks, each retrying up to 10 times.
+- **No ordering guarantees.** Tokio tasks are scheduled cooperatively — event 2 can be dispatched before event 1. The engine assigns monotonic `eventNumber`s, but HTTP POSTs can arrive out of order at the receiver.
+- **Retry holds tasks alive.** A single dispatch with max retries and a 60s backoff cap can keep a task alive for ~2 minutes (1+2+4+8+16+32+60+60+60+60s), holding its full context in memory the entire time.
+- **No event coalescing.** If a resource is updated 5 times in rapid succession, 5 separate tasks run the full pipeline. No deduplication or batching.
+- **Fan-out is sequential.** If 50 subscriptions match an event, `dispatch_with_retry` runs sequentially for each within a single task. One slow endpoint blocks all subsequent dispatches in that task.
+
+### Alternative dispatch approaches (future phases)
+
+| Approach | Description | Trade-off |
+|----------|-------------|-----------|
+| **Semaphore on spawn** | Add a `tokio::sync::Semaphore` to cap concurrent outbound HTTP calls (e.g., 32). Minimal change. | Prevents unbounded fan-out but doesn't solve ordering or retry memory. |
+| **Bounded channel + worker pool** | Replace `tokio::spawn` with `tokio::sync::mpsc`. N worker tasks pull events from the channel. Backpressure is built in. | Standard production pattern. Solves backpressure and enables graceful shutdown. Recommended next step. |
+| **Per-subscription queues** | One queue per `(tenant, subscription_id)`. Events to the same subscription are strictly ordered; a slow endpoint only blocks its own queue. | "Actor per subscription" model. Good for ordering guarantees, heavier to implement. |
+| **Deferred retry queue** | Failed deliveries go to a separate retry queue with a scheduled wake-up, freeing the worker immediately. | Pairs well with the channel + worker pool approach. Eliminates long-lived sleeping tasks. |
+
+### Clustering
+
+The current architecture is **single-instance only**. The `InMemoryTopicRegistry` and `SubscriptionManager` are process-local `DashMap`s with no shared state between instances.
+
+In a clustered deployment behind a load balancer:
+
+```
+                    Load Balancer
+                   /             \
+              Instance A         Instance B
+              ┌──────────┐      ┌──────────┐
+              │ Topics: 1│      │ Topics: 0│
+              │ Subs:   3│      │ Subs:   0│
+              └──────────┘      └──────────┘
+
+POST /SubscriptionTopic → routed to A → only A has the topic
+POST /Subscription      → routed to A → only A tracks it
+POST /Encounter         → routed to B → B has no topics → no notification fires
+```
+
+Additional problems in a multi-instance deployment:
+
+- **Duplicate notifications.** If events are somehow visible to multiple instances, each fires independently — the subscriber receives the same notification N times.
+- **Split event counters.** `eventNumber` and `events_since_subscription_start` are per-instance counters. Instance A says event #5, Instance B says event #3 — the subscriber sees non-monotonic, duplicated sequence numbers.
+- **Split failure tracking.** Instance A records 2 consecutive failures, Instance B records 1. Neither reaches the `error_threshold` of 3, so the subscription never transitions to `error` even though the endpoint has failed 3 times total.
+- **Handshake races.** Two instances could both try to activate the same subscription simultaneously, sending duplicate handshake notifications.
+
+**Common production approaches:**
+
+| Approach | Description |
+|----------|-------------|
+| **Leader election** | One instance is elected (via distributed lock / lease) as the subscription processor. Others publish events to a shared queue (Postgres NOTIFY/LISTEN, Redis streams, Kafka). Simple, avoids duplication, but the leader is a bottleneck / SPOF. |
+| **Subscription partitioning** | Subscriptions are hash-partitioned across instances (`subscription_id % N`). Each instance only dispatches for its assigned subscriptions. Rebalances on scale-up/down. |
+| **Shared DB state / outbox pattern** | Topics, subscriptions, event counters, and failure counts live in the database. Events are written as outbox rows in the same transaction as the resource write. A single consumer dispatches from the outbox. |
+| **DB change streams** | The engine subscribes to the database's change feed (Postgres logical replication, MongoDB change streams) rather than hooking into REST handlers. Any write — including batch/transaction — triggers evaluation. |
+
+### Kafka-Based Event Bus (Future Phase)
+
+A Kafka-backed architecture addresses most of the single-instance and performance limitations simultaneously. In this model, REST handlers publish a lightweight `ResourceEvent` to a Kafka topic instead of spawning a local task, and a separate consumer group evaluates and dispatches notifications:
+
+```
+  HFS Instance A ──┐                          ┌── Subscription Worker 1
+  HFS Instance B ──┼── Kafka topic ──────────►├── Subscription Worker 2
+  HFS Instance C ──┘   (resource-events)       └── Subscription Worker 3
+                        partitioned by               (consumer group)
+                        resource type + id
+```
+
+**Why Kafka is a good fit for FHIR Subscriptions:**
+
+- **Decouples write path from notification path.** Handlers publish an event and return immediately — no HTTP dispatch, no retry loops, no spawned tasks. Write latency is unaffected regardless of how many subscriptions exist or how slow their endpoints are.
+- **Ordering guarantees.** Kafka partitions preserve strict ordering within a partition. Partitioning by `(resource_type, resource_id)` ensures that all events for a given resource are processed in order, so subscribers see monotonically increasing `eventNumber`s.
+- **Scalable consumer group.** Multiple subscription workers share the load via Kafka's consumer group protocol. Adding workers increases throughput without code changes. Kafka handles rebalancing automatically on scale-up/down.
+- **Durable retry without sleeping tasks.** Failed deliveries can be published to a retry topic (or dead-letter topic) with a delay, rather than holding a task alive with `tokio::time::sleep`. The worker is freed immediately to process the next event.
+- **Cluster-safe by design.** All HFS instances publish to the same topic. The consumer group ensures each event is processed exactly once — no duplicate notifications, no split counters, no handshake races.
+- **Batch/transaction gap closes naturally.** Any code path that writes a resource (including batch and transaction handlers) just needs to publish an event to Kafka. The subscription evaluation happens downstream, so there is no need to wire `emit_subscription_event` into every handler individually.
+- **Replay and debugging.** Kafka retains events for a configurable period. Operators can replay events to re-evaluate subscriptions after a bug fix, or inspect the event stream to diagnose why a notification was or wasn't sent.
+- **Backpressure is built in.** If workers fall behind, Kafka buffers events durably on disk. Consumer lag is observable via standard Kafka metrics, giving operators clear visibility into subscription processing health.
+
+**Trade-offs:** Kafka adds operational complexity (broker cluster, ZooKeeper/KRaft, topic configuration, monitoring). For single-node or small deployments the in-memory engine remains simpler and sufficient. Kafka is most justified when HFS is deployed as a clustered service handling high write volumes or when notification reliability is critical.
+
+**AWS alternative:** [Amazon MSK](https://aws.amazon.com/msk/) (Managed Streaming for Apache Kafka) provides a fully managed Kafka-compatible service, eliminating broker and ZooKeeper/KRaft operational overhead. For deployments that don't need Kafka's full feature set, [Amazon SQS](https://aws.amazon.com/sqs/) with FIFO queues offers a simpler alternative — FIFO queues provide exactly-once processing and strict ordering within a message group (analogous to a Kafka partition), which maps well to partitioning by `(resource_type, resource_id)`. SQS FIFO requires no cluster management and scales automatically, making it a pragmatic choice for AWS-native deployments where Kafka's replay and retention capabilities are not required.
+
 ## Current Limitations
 
 - FHIRPath filter criteria are not evaluated — Phase 1 uses direct JSON field matching only
 - Heartbeat delivery is not yet implemented — the `heartbeat_period` field is stored but no background task fires heartbeats
 - Batch and transaction bundle entries do not emit subscription events — only direct CRUD handlers (create, update, delete, patch) do
-- The engine is in-memory only; subscriptions and topics are not reloaded from storage on restart
+- [`eventTrigger`](https://hl7.org/fhir/subscriptiontopic.html) is not supported — only `resourceTrigger` (create, update, delete) is implemented
+- The engine is in-memory only and single-instance — subscriptions and topics are not shared across cluster nodes or reloaded from storage on restart (see [Clustering](#clustering) above)
 - Only the `rest-hook` channel is implemented; WebSocket, email, and FHIR messaging are planned for subsequent phases

--- a/crates/subscriptions/README.md
+++ b/crates/subscriptions/README.md
@@ -1,0 +1,255 @@
+# helios-subscriptions
+
+FHIR topic-based Subscriptions engine for the Helios FHIR Server, implementing the [FHIR Subscriptions Framework](https://build.fhir.org/subscriptions.html) across R4, R4B, R5, and R6.
+
+R4 and R4B use the [Subscriptions R5 Backport IG](https://build.fhir.org/ig/HL7/fhir-subscription-backport-ig/); R5 and R6 use the native Subscriptions Framework.
+
+## Overview
+
+This crate implements topic-based subscriptions as an asynchronous pipeline that fires after every resource write. It decomposes into five concerns:
+
+1. **Topic Registry** — stores `SubscriptionTopic` definitions and evaluates resource triggers
+2. **Subscription Manager** — tracks active `Subscription` resources and their runtime state
+3. **Event Evaluator** — matches write events against active subscriptions using topic triggers and filter criteria
+4. **Notification Builder** — constructs version-specific notification bundles (R4 Parameters-based backport, R5/R6 native `SubscriptionStatus`)
+5. **Channel Dispatcher** — delivers notifications via pluggable channel implementations
+
+The [`SubscriptionEngine`] orchestrates all five concerns and is the main entry point, invoked via `tokio::spawn` after each resource write — mirroring the fire-and-forget pattern used by the audit middleware.
+
+## Features
+
+- **Version-aware parsing**: R4 reads the backport extension set (`backport-topic-canonical`, `backport-payload-content`, `backport-channel-type`, `backport-filter-criteria`); R5/R6 read native `topic`, `channelType`, `filterBy` fields
+- **Status state machine**: `Requested → Active → Error → Off` with validated transitions; subscriptions activate only after a successful handshake
+- **Exponential backoff retry**: configurable initial delay, max delay, backoff factor, and max attempts before transitioning to `error` or `off`
+- **Tenant isolation**: all in-memory maps are keyed by `(tenant_id, subscription_id)` — subscriptions in different tenants never interact
+- **TLS enforcement**: `full-resource` payload subscriptions over non-HTTPS endpoints are rejected at dispatch time
+- **Pluggable channels**: `ChannelDispatcher` trait allows new channel types (WebSocket, email, FHIR messaging) to be added without touching the engine
+
+## Channel Support
+
+| Channel | Status | Notes |
+|---------|--------|-------|
+| `rest-hook` | Implemented | HTTP POST with custom headers, TLS enforcement for full-resource payloads |
+| `websocket` | Planned (Phase 2) | Binding token flow, per-subscription client registry |
+| `email` | Planned (Phase 3) | SMTP via `lettre` |
+| `fhir-messaging` | Planned (Phase 4) | Notification wrapped in a FHIR message Bundle |
+
+## Architecture
+
+```
+ResourceEvent
+     │
+     ▼
+SubscriptionEngine.on_resource_event()
+     │
+     ├─ resource_type == "Subscription"   → SubscriptionManager.register() / deregister()
+     ├─ resource_type == "SubscriptionTopic" → InMemoryTopicRegistry.add_topic()
+     │
+     └─ otherwise:
+           │
+           ▼
+       EventEvaluator.evaluate()
+           │  finds matching topics + subscriptions + applies filter criteria
+           ▼
+       NotificationBundleBuilder.build()
+           │  R4: Bundle(history) + Parameters-based SubscriptionStatus
+           │  R4B/R5/R6: Bundle + native SubscriptionStatus
+           ▼
+       ChannelDispatcher.dispatch()
+           │  rest-hook: HTTP POST with retry
+           ▼
+       handle_delivery_failure() on exhaustion
+           │  consecutive_failures >= error_threshold → Error
+           │  consecutive_failures >= off_threshold   → Off
+```
+
+## Notification Bundle Format
+
+### R4 (Backport IG)
+
+```json
+{
+  "resourceType": "Bundle",
+  "type": "history",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "parameter": [
+          { "name": "subscription", "valueReference": { "reference": "Subscription/sub-1" } },
+          { "name": "topic", "valueCanonical": "http://example.org/topic/encounter-start" },
+          { "name": "status", "valueCode": "active" },
+          { "name": "type", "valueCode": "event-notification" },
+          { "name": "events-since-subscription-start", "valueString": "3" },
+          {
+            "name": "notification-event",
+            "part": [
+              { "name": "event-number", "valueString": "3" },
+              { "name": "timestamp", "valueInstant": "2026-04-09T12:00:00Z" },
+              { "name": "focus", "valueReference": { "reference": "Encounter/enc-99" } }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### R5/R6 (Native)
+
+```json
+{
+  "resourceType": "Bundle",
+  "type": "subscription-notification",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "SubscriptionStatus",
+        "status": "active",
+        "type": "event-notification",
+        "eventsSinceSubscriptionStart": "3",
+        "subscription": { "reference": "Subscription/sub-1" },
+        "topic": "http://example.org/topic/encounter-start",
+        "notificationEvent": [
+          {
+            "eventNumber": "3",
+            "timestamp": "2026-04-09T12:00:00Z",
+            "focus": { "reference": "Encounter/enc-99" }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Filter Matching
+
+Filters use the R4 backport string format `ResourceType?parameter=value` (parsed by `parse_filter_string`) or the native R5 `filterBy` array. The evaluator supports:
+
+| Filter parameter | Resolved from |
+|-----------------|---------------|
+| `code` | `CodeableConcept.coding[].code` tokens |
+| `category` | `CodeableConcept.coding[].code` tokens |
+| `patient` / `subject` | `subject.reference` or `patient.reference` |
+| `identifier` | `identifier[].value` |
+| *(other)* | Direct JSON field lookup by name |
+
+Comparators supported: `eq` (default), `in`. FHIRPath evaluation is not used in Phase 1 — filters operate on the raw resource JSON.
+
+## Configuration
+
+`SubscriptionConfig` is constructed programmatically or from environment variables when running inside HFS:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HFS_SUBSCRIPTIONS_ENABLED` | `false` | Enable the subscription engine |
+| `HFS_SUBSCRIPTION_MAX_RETRIES` | `10` | Max delivery attempts before marking error |
+| `HFS_SUBSCRIPTION_RETRY_INITIAL_DELAY` | `1s` | Initial delay for exponential backoff |
+| `HFS_SUBSCRIPTION_RETRY_MAX_DELAY` | `60s` | Maximum delay cap for backoff |
+| `HFS_SUBSCRIPTION_HEARTBEAT_INTERVAL` | `30s` | How often to check for due heartbeats |
+| `HFS_SUBSCRIPTION_ERROR_THRESHOLD` | `3` | Consecutive failures before `error` status |
+| `HFS_SUBSCRIPTION_OFF_THRESHOLD` | `10` | Consecutive failures before `off` status |
+
+## Enabling in HFS
+
+The subscription engine is an optional feature in `helios-rest` and `helios-hfs`:
+
+```bash
+# Build with subscriptions support
+cargo build --bin hfs --features subscriptions
+
+# Enable at runtime
+HFS_SUBSCRIPTIONS_ENABLED=true cargo run --bin hfs --features subscriptions
+```
+
+When enabled, the engine auto-initializes with default configuration and begins processing events after the first resource write.
+
+## Integration
+
+The engine integrates into `helios-rest` via the `AppState::with_subscription_engine()` builder. After each successful write, handlers call `emit_subscription_event()` which spawns an async task:
+
+```rust,ignore
+// In create handler (simplified)
+if let Some(engine) = state.subscription_engine() {
+    emit_subscription_event(engine, tenant.context(), &stored, fhir_version, ResourceEventType::Create);
+}
+```
+
+The spawned task calls `engine.on_resource_event(event).await`, which runs the full evaluation → notification → dispatch pipeline without blocking the HTTP response.
+
+### Registering a Topic
+
+POST a `SubscriptionTopic` resource (R5/R6) or a `Basic` resource with the backport profile (R4) to your HFS instance. The engine picks it up automatically on the next write:
+
+```bash
+curl -X POST http://localhost:8080/SubscriptionTopic \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "SubscriptionTopic",
+    "url": "http://example.org/topic/encounter-start",
+    "status": "active",
+    "resourceTrigger": [{
+      "resource": "Encounter",
+      "supportedInteraction": ["create", "update"]
+    }],
+    "canFilterBy": [{
+      "resource": "Encounter",
+      "filterParameter": "patient"
+    }]
+  }'
+```
+
+### Creating a Subscription
+
+```bash
+curl -X POST http://localhost:8080/Subscription \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Subscription",
+    "status": "requested",
+    "topic": "http://example.org/topic/encounter-start",
+    "channelType": { "code": "rest-hook" },
+    "endpoint": "https://your-server.example.com/webhook",
+    "content": "id-only",
+    "filterBy": [{
+      "filterParameter": "patient",
+      "value": "Patient/123"
+    }]
+  }'
+```
+
+The server will immediately send a handshake notification to the endpoint. On a successful 2xx response the subscription transitions to `active`.
+
+### Checking Subscription Status
+
+```bash
+GET /Subscription/{id}/$status
+```
+
+Returns a `Parameters` resource (R4) or `SubscriptionStatus` resource (R5/R6) with the current runtime status and event count.
+
+## Features
+
+FHIR version support via Cargo feature flags:
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `R4` | Yes | FHIR R4 with Subscriptions R5 Backport IG |
+| `R4B` | No | FHIR R4B with Subscriptions R5 Backport IG |
+| `R5` | No | FHIR R5 with native Subscriptions Framework |
+| `R6` | No | FHIR R6 with native Subscriptions Framework |
+
+```toml
+[dependencies]
+helios-subscriptions = { version = "0.1", features = ["R4"] }
+```
+
+## Current Limitations
+
+- FHIRPath filter criteria are not evaluated — Phase 1 uses direct JSON field matching only
+- Heartbeat delivery is not yet implemented — the `heartbeat_period` field is stored but no background task fires heartbeats
+- Batch and transaction bundle entries do not emit subscription events — only direct CRUD handlers (create, update, delete, patch) do
+- The engine is in-memory only; subscriptions and topics are not reloaded from storage on restart
+- Only the `rest-hook` channel is implemented; WebSocket, email, and FHIR messaging are planned for subsequent phases

--- a/crates/subscriptions/src/channels/mod.rs
+++ b/crates/subscriptions/src/channels/mod.rs
@@ -1,0 +1,40 @@
+//! Channel dispatchers.
+//!
+//! Delivers notification bundles to subscriber endpoints via the configured
+//! channel type (rest-hook, WebSocket, email, FHIR messaging).
+
+pub mod rest_hook;
+
+use async_trait::async_trait;
+
+use crate::error::SubscriptionError;
+use crate::manager::ActiveSubscription;
+
+/// The result of attempting to deliver a notification.
+#[derive(Debug)]
+pub enum DispatchResult {
+    /// The endpoint accepted the notification.
+    Success,
+    /// The delivery failed with a retryable error (e.g., 5xx, timeout).
+    RetryableError(String),
+    /// The delivery failed with a permanent error (e.g., 4xx).
+    PermanentError(String),
+}
+
+/// Trait for channel-specific notification delivery.
+#[async_trait]
+pub trait ChannelDispatcher: Send + Sync {
+    /// Deliver a notification bundle to the subscriber's endpoint.
+    async fn dispatch(
+        &self,
+        subscription: &ActiveSubscription,
+        notification_bundle: &serde_json::Value,
+    ) -> Result<DispatchResult, SubscriptionError>;
+
+    /// Perform the handshake sequence for a newly activated subscription.
+    async fn handshake(
+        &self,
+        subscription: &ActiveSubscription,
+        handshake_bundle: &serde_json::Value,
+    ) -> Result<DispatchResult, SubscriptionError>;
+}

--- a/crates/subscriptions/src/channels/rest_hook.rs
+++ b/crates/subscriptions/src/channels/rest_hook.rs
@@ -1,0 +1,336 @@
+//! REST-hook channel dispatcher.
+//!
+//! Delivers notification bundles via HTTP POST to the subscriber's endpoint.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+use crate::channels::{ChannelDispatcher, DispatchResult};
+use crate::error::SubscriptionError;
+use crate::manager::{ActiveSubscription, PayloadContent};
+
+/// REST-hook channel implementation.
+///
+/// Uses an HTTP client to POST notification bundles to subscriber endpoints.
+/// Supports custom headers and TLS enforcement for full-resource payloads.
+pub struct RestHookChannel {
+    client: Client,
+}
+
+impl RestHookChannel {
+    /// Creates a new REST-hook channel with default HTTP client settings.
+    pub fn new() -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+
+        Self { client }
+    }
+
+    /// Creates a new REST-hook channel with a custom HTTP client.
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Sends a notification bundle to the given endpoint.
+    async fn send(
+        &self,
+        subscription: &ActiveSubscription,
+        bundle: &serde_json::Value,
+    ) -> Result<DispatchResult, SubscriptionError> {
+        let endpoint = subscription.channel.endpoint.as_deref().ok_or_else(|| {
+            SubscriptionError::InvalidEndpoint {
+                message: "rest-hook channel requires an endpoint".to_string(),
+            }
+        })?;
+
+        // Enforce TLS for full-resource payloads.
+        if subscription.channel.payload_content == PayloadContent::FullResource
+            && !endpoint.starts_with("https://")
+        {
+            return Ok(DispatchResult::PermanentError(
+                "full-resource payload requires HTTPS endpoint".to_string(),
+            ));
+        }
+
+        let mut request = self
+            .client
+            .post(endpoint)
+            .header("Content-Type", "application/fhir+json")
+            .json(bundle);
+
+        // Add custom headers from the subscription.
+        for header in &subscription.channel.headers {
+            if let Some((name, value)) = header.split_once(':') {
+                let name = name.trim();
+                let value = value.trim();
+                request = request.header(name, value);
+            }
+        }
+
+        debug!(
+            subscription_id = %subscription.id,
+            endpoint,
+            "Dispatching rest-hook notification"
+        );
+
+        match request.send().await {
+            Ok(response) => {
+                let status = response.status().as_u16();
+                if response.status().is_success() {
+                    debug!(
+                        subscription_id = %subscription.id,
+                        status,
+                        "Notification delivered successfully"
+                    );
+                    Ok(DispatchResult::Success)
+                } else if response.status().is_client_error() {
+                    warn!(
+                        subscription_id = %subscription.id,
+                        status,
+                        "Notification delivery failed (client error)"
+                    );
+                    Ok(DispatchResult::PermanentError(format!("HTTP {status}")))
+                } else {
+                    warn!(
+                        subscription_id = %subscription.id,
+                        status,
+                        "Notification delivery failed (server error)"
+                    );
+                    Ok(DispatchResult::RetryableError(format!("HTTP {status}")))
+                }
+            }
+            Err(e) => {
+                if e.is_timeout() {
+                    warn!(
+                        subscription_id = %subscription.id,
+                        "Notification delivery timed out"
+                    );
+                    Ok(DispatchResult::RetryableError("timeout".to_string()))
+                } else if e.is_connect() {
+                    warn!(
+                        subscription_id = %subscription.id,
+                        error = %e,
+                        "Connection failed"
+                    );
+                    Ok(DispatchResult::RetryableError(format!(
+                        "connection error: {e}"
+                    )))
+                } else {
+                    warn!(
+                        subscription_id = %subscription.id,
+                        error = %e,
+                        "Notification delivery failed"
+                    );
+                    Ok(DispatchResult::RetryableError(e.to_string()))
+                }
+            }
+        }
+    }
+}
+
+impl Default for RestHookChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ChannelDispatcher for RestHookChannel {
+    async fn dispatch(
+        &self,
+        subscription: &ActiveSubscription,
+        notification_bundle: &serde_json::Value,
+    ) -> Result<DispatchResult, SubscriptionError> {
+        self.send(subscription, notification_bundle).await
+    }
+
+    async fn handshake(
+        &self,
+        subscription: &ActiveSubscription,
+        handshake_bundle: &serde_json::Value,
+    ) -> Result<DispatchResult, SubscriptionError> {
+        self.send(subscription, handshake_bundle).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manager::{ChannelConfig, ChannelType, PayloadContent, SubscriptionStatusCode};
+    use helios_fhir::FhirVersion;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_subscription(endpoint: &str, payload: PayloadContent) -> ActiveSubscription {
+        ActiveSubscription {
+            id: "sub-1".to_string(),
+            topic_url: "http://example.org/topic/test".to_string(),
+            status: SubscriptionStatusCode::Active,
+            channel: ChannelConfig {
+                channel_type: ChannelType::RestHook,
+                endpoint: Some(endpoint.to_string()),
+                payload_mime_type: Some("application/fhir+json".to_string()),
+                payload_content: payload,
+                headers: vec!["Authorization: Bearer test-token".to_string()],
+                heartbeat_period: None,
+                timeout: None,
+                max_count: None,
+            },
+            filters: vec![],
+            fhir_version: FhirVersion::default(),
+            events_since_start: 0,
+            consecutive_failures: 0,
+            tenant_id: "test".to_string(),
+        }
+    }
+
+    fn test_bundle() -> serde_json::Value {
+        json!({"resourceType": "Bundle", "type": "history", "entry": []})
+    }
+
+    #[tokio::test]
+    async fn test_successful_delivery() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webhook"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let channel = RestHookChannel::new();
+        let sub = test_subscription(&format!("{}/webhook", server.uri()), PayloadContent::IdOnly);
+        let result = channel.dispatch(&sub, &test_bundle()).await.unwrap();
+
+        assert!(matches!(result, DispatchResult::Success));
+    }
+
+    #[tokio::test]
+    async fn test_server_error_retryable() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webhook"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let channel = RestHookChannel::new();
+        let sub = test_subscription(&format!("{}/webhook", server.uri()), PayloadContent::IdOnly);
+        let result = channel.dispatch(&sub, &test_bundle()).await.unwrap();
+
+        assert!(matches!(result, DispatchResult::RetryableError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_client_error_permanent() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webhook"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let channel = RestHookChannel::new();
+        let sub = test_subscription(&format!("{}/webhook", server.uri()), PayloadContent::IdOnly);
+        let result = channel.dispatch(&sub, &test_bundle()).await.unwrap();
+
+        assert!(matches!(result, DispatchResult::PermanentError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_custom_headers_sent() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webhook"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer test-token",
+            ))
+            .and(wiremock::matchers::header(
+                "Content-Type",
+                "application/fhir+json",
+            ))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let channel = RestHookChannel::new();
+        let sub = test_subscription(&format!("{}/webhook", server.uri()), PayloadContent::IdOnly);
+        let result = channel.dispatch(&sub, &test_bundle()).await.unwrap();
+
+        assert!(matches!(result, DispatchResult::Success));
+    }
+
+    #[tokio::test]
+    async fn test_tls_enforcement_for_full_resource() {
+        let channel = RestHookChannel::new();
+        let sub = test_subscription(
+            "http://insecure.example.com/webhook",
+            PayloadContent::FullResource,
+        );
+        let result = channel.dispatch(&sub, &test_bundle()).await.unwrap();
+
+        assert!(matches!(result, DispatchResult::PermanentError(_)));
+        if let DispatchResult::PermanentError(msg) = result {
+            assert!(msg.contains("HTTPS"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tls_not_required_for_id_only() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webhook"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let channel = RestHookChannel::new();
+        // MockServer uses HTTP, which is fine for id-only.
+        let sub = test_subscription(&format!("{}/webhook", server.uri()), PayloadContent::IdOnly);
+        let result = channel.dispatch(&sub, &test_bundle()).await.unwrap();
+
+        assert!(matches!(result, DispatchResult::Success));
+    }
+
+    #[tokio::test]
+    async fn test_handshake_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webhook"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let channel = RestHookChannel::new();
+        let sub = test_subscription(&format!("{}/webhook", server.uri()), PayloadContent::IdOnly);
+        let bundle = test_bundle();
+        let result = channel.handshake(&sub, &bundle).await.unwrap();
+
+        assert!(matches!(result, DispatchResult::Success));
+    }
+
+    #[tokio::test]
+    async fn test_connection_error() {
+        let channel = RestHookChannel::new();
+        // Use a port that nothing is listening on.
+        let sub = test_subscription("http://127.0.0.1:1/webhook", PayloadContent::IdOnly);
+        let result = channel.dispatch(&sub, &test_bundle()).await.unwrap();
+
+        assert!(matches!(result, DispatchResult::RetryableError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_missing_endpoint() {
+        let channel = RestHookChannel::new();
+        let mut sub = test_subscription("http://example.com/webhook", PayloadContent::IdOnly);
+        sub.channel.endpoint = None;
+
+        let result = channel.dispatch(&sub, &test_bundle()).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/subscriptions/src/config.rs
+++ b/crates/subscriptions/src/config.rs
@@ -1,0 +1,46 @@
+//! Subscription engine configuration.
+
+use std::time::Duration;
+
+/// Configuration for the subscription engine.
+#[derive(Debug, Clone)]
+pub struct SubscriptionConfig {
+    /// Maximum number of retry attempts for failed deliveries.
+    pub max_retries: u32,
+
+    /// Initial delay before the first retry.
+    pub retry_initial_delay: Duration,
+
+    /// Maximum delay between retries.
+    pub retry_max_delay: Duration,
+
+    /// Backoff multiplier for exponential backoff.
+    pub retry_backoff_factor: f64,
+
+    /// How often to check for heartbeats that are due.
+    pub heartbeat_check_interval: Duration,
+
+    /// Number of consecutive failures before transitioning to `error` status.
+    pub error_threshold: u32,
+
+    /// Number of consecutive failures before transitioning to `off` status.
+    pub off_threshold: u32,
+
+    /// Supported channel types.
+    pub supported_channel_types: Vec<String>,
+}
+
+impl Default for SubscriptionConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 10,
+            retry_initial_delay: Duration::from_secs(1),
+            retry_max_delay: Duration::from_secs(60),
+            retry_backoff_factor: 2.0,
+            heartbeat_check_interval: Duration::from_secs(30),
+            error_threshold: 3,
+            off_threshold: 10,
+            supported_channel_types: vec!["rest-hook".to_string()],
+        }
+    }
+}

--- a/crates/subscriptions/src/engine/mod.rs
+++ b/crates/subscriptions/src/engine/mod.rs
@@ -1,0 +1,727 @@
+//! Subscription engine — the orchestrator.
+//!
+//! Ties together topic registry, subscription manager, event evaluator,
+//! notification builder, and channel dispatchers. Invoked asynchronously
+//! after each resource write.
+
+pub mod retry;
+
+use std::sync::Arc;
+
+use tracing::{debug, error, info, warn};
+
+use crate::channels::rest_hook::RestHookChannel;
+use crate::channels::{ChannelDispatcher, DispatchResult};
+use crate::config::SubscriptionConfig;
+use crate::evaluator::EventEvaluator;
+use crate::event::{ResourceEvent, ResourceEventType};
+use crate::manager::{
+    ActiveSubscription, ChannelType, SubscriptionManager, SubscriptionStatusCode,
+};
+use crate::notification::{self, NotificationEventData};
+use crate::topics::InMemoryTopicRegistry;
+
+/// The subscription engine orchestrates the entire subscription pipeline.
+///
+/// It is designed to be invoked asynchronously after resource writes
+/// (fire-and-forget via `tokio::spawn`), mirroring the audit middleware pattern.
+pub struct SubscriptionEngine {
+    topic_registry: Arc<InMemoryTopicRegistry>,
+    manager: Arc<SubscriptionManager>,
+    evaluator: EventEvaluator,
+    rest_hook_channel: Arc<RestHookChannel>,
+    config: SubscriptionConfig,
+    base_url: String,
+}
+
+impl SubscriptionEngine {
+    /// Creates a new subscription engine.
+    pub fn new(config: SubscriptionConfig, base_url: String) -> Self {
+        let topic_registry = Arc::new(InMemoryTopicRegistry::new());
+        let manager = Arc::new(SubscriptionManager::new(
+            Arc::clone(&topic_registry),
+            config.supported_channel_types.clone(),
+        ));
+        let evaluator = EventEvaluator::new(Arc::clone(&topic_registry), Arc::clone(&manager));
+        let rest_hook_channel = Arc::new(RestHookChannel::new());
+
+        Self {
+            topic_registry,
+            manager,
+            evaluator,
+            rest_hook_channel,
+            config,
+            base_url,
+        }
+    }
+
+    /// Returns a reference to the topic registry.
+    pub fn topic_registry(&self) -> &Arc<InMemoryTopicRegistry> {
+        &self.topic_registry
+    }
+
+    /// Returns a reference to the subscription manager.
+    pub fn manager(&self) -> &Arc<SubscriptionManager> {
+        &self.manager
+    }
+
+    /// Called after a resource write has been committed.
+    ///
+    /// This method:
+    /// 1. Handles subscription/topic lifecycle events (if the written resource
+    ///    is a Subscription or SubscriptionTopic).
+    /// 2. Evaluates the event against all active subscriptions.
+    /// 3. Builds and dispatches notifications.
+    pub async fn on_resource_event(&self, event: ResourceEvent) {
+        // Handle subscription lifecycle events.
+        match event.resource_type.as_str() {
+            "Subscription" => {
+                self.handle_subscription_event(&event).await;
+                return;
+            }
+            "SubscriptionTopic" => {
+                self.handle_topic_event(&event).await;
+                return;
+            }
+            _ => {}
+        }
+
+        // Evaluate which subscriptions match this event.
+        let matches = self.evaluator.evaluate(&event);
+        if matches.is_empty() {
+            return;
+        }
+
+        debug!(
+            resource_type = %event.resource_type,
+            resource_id = %event.resource_id,
+            matched_subscriptions = matches.len(),
+            "Event matched subscriptions"
+        );
+
+        // Build and dispatch notifications for each match.
+        for eval_match in matches {
+            let subscription = &eval_match.subscription;
+
+            // Increment event counter.
+            let event_number = self
+                .manager
+                .increment_event_count(&subscription.tenant_id, &subscription.id)
+                .unwrap_or(0);
+
+            let event_data = NotificationEventData {
+                event_number,
+                timestamp: event.timestamp,
+                focus_reference: format!("{}/{}", event.resource_type, event.resource_id),
+            };
+
+            // Build notification bundle.
+            let bundle = match notification::build_event_notification(
+                subscription,
+                event_data,
+                event.resource.as_ref(),
+                &self.base_url,
+            ) {
+                Ok(b) => b,
+                Err(e) => {
+                    error!(
+                        subscription_id = %subscription.id,
+                        error = %e,
+                        "Failed to build notification"
+                    );
+                    continue;
+                }
+            };
+
+            // Dispatch with retry.
+            self.dispatch_with_retry(subscription, &bundle).await;
+        }
+    }
+
+    /// Handle a Subscription resource event (create/update/delete).
+    async fn handle_subscription_event(&self, event: &ResourceEvent) {
+        let tenant_id = event.tenant_id.to_string();
+        let subscription_id = &event.resource_id;
+
+        match event.event_type {
+            ResourceEventType::Delete => {
+                self.manager.deregister(&tenant_id, subscription_id);
+            }
+            ResourceEventType::Create | ResourceEventType::Update => {
+                if let Some(resource) = &event.resource {
+                    // Register (or re-register) the subscription.
+                    match self.manager.register(
+                        &tenant_id,
+                        subscription_id,
+                        resource,
+                        event.fhir_version,
+                    ) {
+                        Ok(sub) => {
+                            // If status is requested, perform handshake and activate.
+                            if sub.status == SubscriptionStatusCode::Requested {
+                                self.activate_subscription(&sub).await;
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                subscription_id,
+                                error = %e,
+                                "Failed to register subscription"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handle a SubscriptionTopic resource event.
+    async fn handle_topic_event(&self, event: &ResourceEvent) {
+        match event.event_type {
+            ResourceEventType::Delete => {
+                // Remove topic by canonical URL (we'd need to look it up).
+                // For now, we can't easily remove without knowing the canonical URL.
+                // This will be handled via a full registry refresh.
+                info!(
+                    resource_id = %event.resource_id,
+                    "SubscriptionTopic deleted"
+                );
+            }
+            ResourceEventType::Create | ResourceEventType::Update => {
+                if let Some(resource) = &event.resource {
+                    match InMemoryTopicRegistry::parse_topic_resource(resource) {
+                        Ok(topic) => {
+                            info!(
+                                topic_url = %topic.canonical_url,
+                                "Registered SubscriptionTopic"
+                            );
+                            self.topic_registry.add_topic(topic);
+                        }
+                        Err(e) => {
+                            warn!(
+                                resource_id = %event.resource_id,
+                                error = %e,
+                                "Failed to parse SubscriptionTopic"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Activate a subscription by performing the handshake.
+    async fn activate_subscription(&self, subscription: &ActiveSubscription) {
+        let tenant_id = &subscription.tenant_id;
+        let sub_id = &subscription.id;
+
+        // Build handshake notification.
+        let handshake_bundle = match notification::build_handshake(subscription, &self.base_url) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(subscription_id = sub_id, error = %e, "Failed to build handshake");
+                let _ =
+                    self.manager
+                        .update_status(tenant_id, sub_id, SubscriptionStatusCode::Error);
+                return;
+            }
+        };
+
+        // Perform handshake.
+        let result = match subscription.channel.channel_type {
+            ChannelType::RestHook => {
+                self.rest_hook_channel
+                    .handshake(subscription, &handshake_bundle)
+                    .await
+            }
+            _ => {
+                warn!(
+                    subscription_id = sub_id,
+                    channel_type = subscription.channel.channel_type.as_fhir_str(),
+                    "Handshake not supported for channel type"
+                );
+                return;
+            }
+        };
+
+        match result {
+            Ok(DispatchResult::Success) => {
+                info!(
+                    subscription_id = sub_id,
+                    "Handshake successful, activating subscription"
+                );
+                let _ =
+                    self.manager
+                        .update_status(tenant_id, sub_id, SubscriptionStatusCode::Active);
+            }
+            Ok(DispatchResult::RetryableError(msg)) | Ok(DispatchResult::PermanentError(msg)) => {
+                warn!(subscription_id = sub_id, error = %msg, "Handshake failed");
+                let _ =
+                    self.manager
+                        .update_status(tenant_id, sub_id, SubscriptionStatusCode::Error);
+            }
+            Err(e) => {
+                warn!(subscription_id = sub_id, error = %e, "Handshake error");
+                let _ =
+                    self.manager
+                        .update_status(tenant_id, sub_id, SubscriptionStatusCode::Error);
+            }
+        }
+    }
+
+    /// Dispatch a notification with retry logic.
+    async fn dispatch_with_retry(
+        &self,
+        subscription: &ActiveSubscription,
+        bundle: &serde_json::Value,
+    ) {
+        let tenant_id = &subscription.tenant_id;
+        let sub_id = &subscription.id;
+
+        let dispatcher: &dyn ChannelDispatcher = match subscription.channel.channel_type {
+            ChannelType::RestHook => self.rest_hook_channel.as_ref(),
+            _ => {
+                warn!(
+                    subscription_id = sub_id,
+                    channel = subscription.channel.channel_type.as_fhir_str(),
+                    "No dispatcher for channel type"
+                );
+                return;
+            }
+        };
+
+        let mut attempt: u32 = 0;
+        loop {
+            match dispatcher.dispatch(subscription, bundle).await {
+                Ok(DispatchResult::Success) => {
+                    self.manager.reset_failures(tenant_id, sub_id);
+                    return;
+                }
+                Ok(DispatchResult::PermanentError(msg)) => {
+                    warn!(
+                        subscription_id = sub_id,
+                        error = %msg,
+                        "Permanent delivery error"
+                    );
+                    self.handle_delivery_failure(tenant_id, sub_id);
+                    return;
+                }
+                Ok(DispatchResult::RetryableError(msg)) => {
+                    attempt += 1;
+                    if !retry::should_retry(&self.config, attempt) {
+                        warn!(
+                            subscription_id = sub_id,
+                            attempts = attempt,
+                            error = %msg,
+                            "Max retries exhausted"
+                        );
+                        self.handle_delivery_failure(tenant_id, sub_id);
+                        return;
+                    }
+
+                    let delay = retry::calculate_delay(&self.config, attempt);
+                    debug!(
+                        subscription_id = sub_id,
+                        attempt,
+                        delay_ms = delay.as_millis() as u64,
+                        "Retrying delivery"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+                Err(e) => {
+                    error!(
+                        subscription_id = sub_id,
+                        error = %e,
+                        "Dispatch error"
+                    );
+                    self.handle_delivery_failure(tenant_id, sub_id);
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Handle a delivery failure: increment failure count and potentially
+    /// transition status to error or off.
+    fn handle_delivery_failure(&self, tenant_id: &str, subscription_id: &str) {
+        if let Some(failure_count) = self.manager.record_failure(tenant_id, subscription_id) {
+            if failure_count >= self.config.off_threshold {
+                warn!(
+                    subscription_id,
+                    failures = failure_count,
+                    "Turning off subscription after repeated failures"
+                );
+                let _ = self.manager.update_status(
+                    tenant_id,
+                    subscription_id,
+                    SubscriptionStatusCode::Off,
+                );
+            } else if failure_count >= self.config.error_threshold {
+                let _ = self.manager.update_status(
+                    tenant_id,
+                    subscription_id,
+                    SubscriptionStatusCode::Error,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::ResourceEventType;
+    use crate::topics::{ResourceTrigger, TopicDefinition};
+    use chrono::Utc;
+    use helios_fhir::FhirVersion;
+    use helios_persistence::tenant::TenantId;
+    use serde_json::json;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn make_engine(base_url: &str) -> SubscriptionEngine {
+        let config = SubscriptionConfig {
+            max_retries: 2,
+            error_threshold: 2,
+            off_threshold: 4,
+            ..Default::default()
+        };
+        SubscriptionEngine::new(config, base_url.to_string())
+    }
+
+    fn encounter_topic() -> TopicDefinition {
+        TopicDefinition {
+            canonical_url: "http://example.org/topic/encounter-start".to_string(),
+            title: Some("Encounter Start".to_string()),
+            resource_triggers: vec![ResourceTrigger {
+                resource_type: "Encounter".to_string(),
+                interactions: vec![ResourceEventType::Create],
+                fhirpath_criteria: None,
+            }],
+            can_filter_by: vec![],
+            notification_shape: vec![],
+        }
+    }
+
+    fn encounter_event() -> ResourceEvent {
+        ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "Encounter".to_string(),
+            resource_id: "enc-1".to_string(),
+            version_id: "1".to_string(),
+            event_type: ResourceEventType::Create,
+            resource: Some(json!({
+                "resourceType": "Encounter",
+                "id": "enc-1",
+                "status": "in-progress"
+            })),
+            previous_resource: None,
+            timestamp: Utc::now(),
+        }
+    }
+
+    fn topic_event() -> ResourceEvent {
+        ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "SubscriptionTopic".to_string(),
+            resource_id: "topic-1".to_string(),
+            version_id: "1".to_string(),
+            event_type: ResourceEventType::Create,
+            resource: Some(json!({
+                "resourceType": "SubscriptionTopic",
+                "id": "topic-1",
+                "url": "http://example.org/topic/encounter-start",
+                "resourceTrigger": [{
+                    "resource": "Encounter",
+                    "supportedInteraction": ["create"]
+                }]
+            })),
+            previous_resource: None,
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_topic_event_registers_topic() {
+        let engine = make_engine("http://localhost:8080");
+
+        assert!(engine.topic_registry().list_topics().is_empty());
+
+        engine.on_resource_event(topic_event()).await;
+
+        let topics = engine.topic_registry().list_topics();
+        assert_eq!(topics.len(), 1);
+        assert!(topics.contains(&"http://example.org/topic/encounter-start".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_subscription_event_registers_subscription() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let engine = make_engine("http://localhost:8080");
+        engine.topic_registry().add_topic(encounter_topic());
+
+        // Create a subscription event.
+        let sub_resource = crate::manager::tests::build_subscription_json(
+            "http://example.org/topic/encounter-start",
+            "rest-hook",
+            Some(&format!("{}/webhook", server.uri())),
+        );
+
+        let event = ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "Subscription".to_string(),
+            resource_id: "sub-1".to_string(),
+            version_id: "1".to_string(),
+            event_type: ResourceEventType::Create,
+            resource: Some(sub_resource),
+            previous_resource: None,
+            timestamp: Utc::now(),
+        };
+
+        engine.on_resource_event(event).await;
+
+        // Subscription should be registered.
+        let sub = engine.manager().get_subscription("t1", "sub-1");
+        assert!(sub.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_full_pipeline_event_to_dispatch() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(2) // handshake + event notification
+            .mount(&server)
+            .await;
+
+        let engine = make_engine("http://localhost:8080");
+        engine.topic_registry().add_topic(encounter_topic());
+
+        // Register and activate a subscription.
+        let sub_resource = crate::manager::tests::build_subscription_json(
+            "http://example.org/topic/encounter-start",
+            "rest-hook",
+            Some(&format!("{}/webhook", server.uri())),
+        );
+
+        let sub_event = ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "Subscription".to_string(),
+            resource_id: "sub-1".to_string(),
+            version_id: "1".to_string(),
+            event_type: ResourceEventType::Create,
+            resource: Some(sub_resource),
+            previous_resource: None,
+            timestamp: Utc::now(),
+        };
+
+        engine.on_resource_event(sub_event).await;
+
+        // Fire a matching event.
+        engine.on_resource_event(encounter_event()).await;
+
+        // Verify the mock received the requests.
+        // (wiremock's expect(2) will panic on drop if not satisfied)
+    }
+
+    #[tokio::test]
+    async fn test_no_dispatch_when_no_matching_subscriptions() {
+        let engine = make_engine("http://localhost:8080");
+        engine.topic_registry().add_topic(encounter_topic());
+
+        // Fire an event with no subscriptions registered.
+        engine.on_resource_event(encounter_event()).await;
+        // Should complete without error.
+    }
+
+    #[tokio::test]
+    async fn test_no_dispatch_for_non_matching_resource_type() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1) // Only the handshake
+            .mount(&server)
+            .await;
+
+        let engine = make_engine("http://localhost:8080");
+        engine.topic_registry().add_topic(encounter_topic());
+
+        // Register subscription for Encounter topic.
+        let sub_resource = crate::manager::tests::build_subscription_json(
+            "http://example.org/topic/encounter-start",
+            "rest-hook",
+            Some(&format!("{}/webhook", server.uri())),
+        );
+
+        let sub_event = ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "Subscription".to_string(),
+            resource_id: "sub-1".to_string(),
+            version_id: "1".to_string(),
+            event_type: ResourceEventType::Create,
+            resource: Some(sub_resource),
+            previous_resource: None,
+            timestamp: Utc::now(),
+        };
+
+        engine.on_resource_event(sub_event).await;
+
+        // Fire a Patient event (doesn't match Encounter topic).
+        let patient_event = ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "Patient".to_string(),
+            resource_id: "pat-1".to_string(),
+            version_id: "1".to_string(),
+            event_type: ResourceEventType::Create,
+            resource: Some(json!({"resourceType": "Patient", "id": "pat-1"})),
+            previous_resource: None,
+            timestamp: Utc::now(),
+        };
+
+        engine.on_resource_event(patient_event).await;
+        // Only 1 mock call (handshake), not 2.
+    }
+
+    #[tokio::test]
+    async fn test_delivery_failure_updates_status() {
+        let server = MockServer::start().await;
+
+        // First request (handshake) succeeds, subsequent fail.
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let config = SubscriptionConfig {
+            max_retries: 1,
+            error_threshold: 1,
+            off_threshold: 3,
+            ..Default::default()
+        };
+        let engine = SubscriptionEngine::new(config, "http://localhost:8080".to_string());
+        engine.topic_registry().add_topic(encounter_topic());
+
+        // Register subscription.
+        let sub_resource = crate::manager::tests::build_subscription_json(
+            "http://example.org/topic/encounter-start",
+            "rest-hook",
+            Some(&format!("{}/webhook", server.uri())),
+        );
+
+        let sub_event = ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "Subscription".to_string(),
+            resource_id: "sub-1".to_string(),
+            version_id: "1".to_string(),
+            event_type: ResourceEventType::Create,
+            resource: Some(sub_resource),
+            previous_resource: None,
+            timestamp: Utc::now(),
+        };
+
+        engine.on_resource_event(sub_event).await;
+
+        // Fire a matching event (will fail delivery).
+        engine.on_resource_event(encounter_event()).await;
+
+        // Check subscription status changed to error.
+        let sub = engine.manager().get_subscription("t1", "sub-1").unwrap();
+        assert_eq!(sub.status, SubscriptionStatusCode::Error);
+    }
+
+    #[tokio::test]
+    async fn test_subscription_delete_event() {
+        let engine = make_engine("http://localhost:8080");
+        engine.topic_registry().add_topic(encounter_topic());
+
+        // Register directly.
+        let resource = crate::manager::tests::default_subscription_json();
+        engine
+            .manager()
+            .register("t1", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+
+        assert!(engine.manager().get_subscription("t1", "sub-1").is_some());
+
+        // Delete event.
+        let delete_event = ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "Subscription".to_string(),
+            resource_id: "sub-1".to_string(),
+            version_id: "2".to_string(),
+            event_type: ResourceEventType::Delete,
+            resource: None,
+            previous_resource: None,
+            timestamp: Utc::now(),
+        };
+
+        engine.on_resource_event(delete_event).await;
+
+        assert!(engine.manager().get_subscription("t1", "sub-1").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_tenant_isolation() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(2) // 1 handshake + 1 event notification (only tenant-a)
+            .mount(&server)
+            .await;
+
+        let engine = make_engine("http://localhost:8080");
+        engine.topic_registry().add_topic(encounter_topic());
+
+        // Register subscription for tenant-a.
+        let sub_resource = crate::manager::tests::build_subscription_json(
+            "http://example.org/topic/encounter-start",
+            "rest-hook",
+            Some(&format!("{}/webhook", server.uri())),
+        );
+
+        let sub_event_a = ResourceEvent {
+            tenant_id: TenantId::new("tenant-a"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "Subscription".to_string(),
+            resource_id: "sub-a".to_string(),
+            version_id: "1".to_string(),
+            event_type: ResourceEventType::Create,
+            resource: Some(sub_resource),
+            previous_resource: None,
+            timestamp: Utc::now(),
+        };
+
+        engine.on_resource_event(sub_event_a).await;
+
+        // Fire event from tenant-a (should match).
+        let mut event_a = encounter_event();
+        event_a.tenant_id = TenantId::new("tenant-a");
+        engine.on_resource_event(event_a).await;
+
+        // Fire event from tenant-b (should NOT match).
+        let mut event_b = encounter_event();
+        event_b.tenant_id = TenantId::new("tenant-b");
+        engine.on_resource_event(event_b).await;
+
+        // wiremock expects exactly 2 calls (handshake + 1 notification).
+    }
+}

--- a/crates/subscriptions/src/engine/retry.rs
+++ b/crates/subscriptions/src/engine/retry.rs
@@ -1,0 +1,63 @@
+//! Retry logic with exponential backoff.
+
+use std::time::Duration;
+
+use crate::config::SubscriptionConfig;
+
+/// Calculates the delay before the next retry attempt using exponential backoff.
+///
+/// delay = min(initial_delay * backoff_factor^attempt, max_delay)
+pub fn calculate_delay(config: &SubscriptionConfig, attempt: u32) -> Duration {
+    let delay_secs =
+        config.retry_initial_delay.as_secs_f64() * config.retry_backoff_factor.powi(attempt as i32);
+
+    let capped = delay_secs.min(config.retry_max_delay.as_secs_f64());
+
+    Duration::from_secs_f64(capped)
+}
+
+/// Returns whether another retry should be attempted.
+pub fn should_retry(config: &SubscriptionConfig, attempt: u32) -> bool {
+    attempt < config.max_retries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> SubscriptionConfig {
+        SubscriptionConfig {
+            max_retries: 5,
+            retry_initial_delay: Duration::from_secs(1),
+            retry_max_delay: Duration::from_secs(60),
+            retry_backoff_factor: 2.0,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_calculate_delay_exponential() {
+        let config = test_config();
+        assert_eq!(calculate_delay(&config, 0), Duration::from_secs(1)); // 1 * 2^0 = 1
+        assert_eq!(calculate_delay(&config, 1), Duration::from_secs(2)); // 1 * 2^1 = 2
+        assert_eq!(calculate_delay(&config, 2), Duration::from_secs(4)); // 1 * 2^2 = 4
+        assert_eq!(calculate_delay(&config, 3), Duration::from_secs(8)); // 1 * 2^3 = 8
+        assert_eq!(calculate_delay(&config, 4), Duration::from_secs(16)); // 1 * 2^4 = 16
+    }
+
+    #[test]
+    fn test_calculate_delay_capped() {
+        let config = test_config();
+        // 1 * 2^10 = 1024, but max is 60.
+        assert_eq!(calculate_delay(&config, 10), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_should_retry() {
+        let config = test_config();
+        assert!(should_retry(&config, 0));
+        assert!(should_retry(&config, 4));
+        assert!(!should_retry(&config, 5));
+        assert!(!should_retry(&config, 10));
+    }
+}

--- a/crates/subscriptions/src/error.rs
+++ b/crates/subscriptions/src/error.rs
@@ -1,0 +1,49 @@
+//! Subscription error types.
+
+use thiserror::Error;
+
+/// Errors that can occur during subscription operations.
+#[derive(Debug, Error)]
+pub enum SubscriptionError {
+    /// The referenced SubscriptionTopic was not found.
+    #[error("subscription topic not found: {url}")]
+    TopicNotFound { url: String },
+
+    /// A filter parameter is invalid or not supported by the topic.
+    #[error("invalid filter: {message}")]
+    InvalidFilter { message: String },
+
+    /// The requested channel type is not supported.
+    #[error("unsupported channel type: {channel_type}")]
+    UnsupportedChannel { channel_type: String },
+
+    /// The channel endpoint is invalid or missing.
+    #[error("invalid channel endpoint: {message}")]
+    InvalidEndpoint { message: String },
+
+    /// Notification delivery failed.
+    #[error("delivery failed: {message}")]
+    DeliveryFailed { message: String },
+
+    /// An invalid subscription status transition was attempted.
+    #[error("invalid status transition from {from} to {to}")]
+    InvalidStatusTransition { from: String, to: String },
+
+    /// The subscription resource is malformed.
+    #[error("invalid subscription resource: {message}")]
+    InvalidSubscription { message: String },
+
+    /// An error occurred in the persistence layer.
+    #[error("storage error: {0}")]
+    Storage(String),
+
+    /// An internal error occurred.
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl From<helios_persistence::error::StorageError> for SubscriptionError {
+    fn from(e: helios_persistence::error::StorageError) -> Self {
+        Self::Storage(e.to_string())
+    }
+}

--- a/crates/subscriptions/src/evaluator/filter_match.rs
+++ b/crates/subscriptions/src/evaluator/filter_match.rs
@@ -1,0 +1,435 @@
+//! Filter matching logic.
+//!
+//! Evaluates subscription filter criteria against resource JSON content.
+//! Uses simple JSON path traversal for Phase 1 (not FHIRPath).
+
+use crate::manager::SubscriptionFilter;
+
+/// Checks whether a resource matches all of a subscription's filters.
+///
+/// Returns `true` if:
+/// - The filter list is empty (match all).
+/// - Every filter matches the resource content.
+pub fn matches_filters(
+    resource: &serde_json::Value,
+    resource_type: &str,
+    filters: &[SubscriptionFilter],
+) -> bool {
+    filters
+        .iter()
+        .all(|filter| matches_single_filter(resource, resource_type, filter))
+}
+
+/// Evaluates a single filter against a resource.
+fn matches_single_filter(
+    resource: &serde_json::Value,
+    resource_type: &str,
+    filter: &SubscriptionFilter,
+) -> bool {
+    // If the filter specifies a resource type, it must match.
+    if let Some(ref filter_rt) = filter.resource_type {
+        if filter_rt != resource_type {
+            return false;
+        }
+    }
+
+    // Look up the field in the resource.
+    let field_value = resolve_field(resource, &filter.filter_parameter);
+
+    match field_value {
+        None => {
+            // Field not present — only matches "ne" comparator.
+            filter.comparator == "ne"
+        }
+        Some(value) => match filter.comparator.as_str() {
+            "eq" => value_matches_eq(&value, &filter.value),
+            "ne" => !value_matches_eq(&value, &filter.value),
+            "in" => value_matches_in(&value, &filter.value),
+            "not-in" => !value_matches_in(&value, &filter.value),
+            // For unsupported comparators, default to not matching.
+            _ => false,
+        },
+    }
+}
+
+/// Resolves a field path in a resource JSON.
+///
+/// Supports simple dot-free FHIR search parameter names by mapping common
+/// search parameters to their JSON paths. For example, "patient" maps to
+/// "subject.reference" for some resource types.
+fn resolve_field<'a>(resource: &'a serde_json::Value, param_name: &str) -> Option<FieldValue<'a>> {
+    // Try known search parameter mappings first (these extract structured
+    // types like CodeableConcept, Reference, and Identifier into token strings).
+    match param_name {
+        "patient" => {
+            if let Some(v) = try_resolve_reference(resource, &["subject", "patient"]) {
+                return Some(v);
+            }
+        }
+        "code" => {
+            if let Some(v) = resolve_codeable_concept(resource, "code") {
+                return Some(v);
+            }
+        }
+        "category" => {
+            if let Some(v) = resolve_codeable_concept(resource, "category") {
+                return Some(v);
+            }
+        }
+        "identifier" => {
+            if let Some(v) = resolve_identifier(resource, "identifier") {
+                return Some(v);
+            }
+        }
+        _ => {}
+    }
+
+    // Fall back to direct field lookup for simple fields (e.g., "status").
+    if let Some(val) = resource.get(param_name) {
+        return Some(FieldValue::from_json(val));
+    }
+
+    None
+}
+
+/// Try to resolve a reference field from multiple possible paths.
+fn try_resolve_reference<'a>(
+    resource: &'a serde_json::Value,
+    field_names: &[&str],
+) -> Option<FieldValue<'a>> {
+    for name in field_names {
+        if let Some(obj) = resource.get(name) {
+            if let Some(reference) = obj.get("reference").and_then(|v| v.as_str()) {
+                return Some(FieldValue::String(reference));
+            }
+        }
+    }
+    None
+}
+
+/// Resolve a CodeableConcept field to a set of system|code tokens.
+fn resolve_codeable_concept<'a>(
+    resource: &'a serde_json::Value,
+    field_name: &str,
+) -> Option<FieldValue<'a>> {
+    let cc = resource.get(field_name)?;
+
+    // Could be a single CodeableConcept or an array of them.
+    let concepts = if cc.is_array() {
+        cc.as_array().unwrap().iter().collect::<Vec<_>>()
+    } else {
+        vec![cc]
+    };
+
+    let mut tokens = Vec::new();
+    for concept in concepts {
+        if let Some(codings) = concept.get("coding").and_then(|v| v.as_array()) {
+            for coding in codings {
+                let system = coding.get("system").and_then(|v| v.as_str()).unwrap_or("");
+                let code = coding.get("code").and_then(|v| v.as_str()).unwrap_or("");
+                tokens.push(format!("{system}|{code}"));
+                // Also match just the code.
+                if !code.is_empty() {
+                    tokens.push(code.to_string());
+                }
+            }
+        }
+    }
+
+    if tokens.is_empty() {
+        None
+    } else {
+        Some(FieldValue::Tokens(tokens))
+    }
+}
+
+/// Resolve an Identifier field.
+fn resolve_identifier<'a>(
+    resource: &'a serde_json::Value,
+    field_name: &str,
+) -> Option<FieldValue<'a>> {
+    let identifiers = resource.get(field_name)?.as_array()?;
+    let mut tokens = Vec::new();
+    for id in identifiers {
+        let system = id.get("system").and_then(|v| v.as_str()).unwrap_or("");
+        let value = id.get("value").and_then(|v| v.as_str()).unwrap_or("");
+        tokens.push(format!("{system}|{value}"));
+        if !value.is_empty() {
+            tokens.push(value.to_string());
+        }
+    }
+
+    if tokens.is_empty() {
+        None
+    } else {
+        Some(FieldValue::Tokens(tokens))
+    }
+}
+
+/// A resolved field value from a resource.
+#[derive(Debug)]
+enum FieldValue<'a> {
+    /// A simple string value.
+    String(&'a str),
+    /// A set of token values (from CodeableConcept, Identifier, etc.).
+    Tokens(Vec<String>),
+    /// A raw JSON value.
+    Json(&'a serde_json::Value),
+}
+
+impl<'a> FieldValue<'a> {
+    fn from_json(val: &'a serde_json::Value) -> Self {
+        if let Some(s) = val.as_str() {
+            FieldValue::String(s)
+        } else {
+            FieldValue::Json(val)
+        }
+    }
+}
+
+/// Check equality between a field value and a filter value string.
+fn value_matches_eq(field: &FieldValue<'_>, filter_value: &str) -> bool {
+    match field {
+        FieldValue::String(s) => *s == filter_value,
+        FieldValue::Tokens(tokens) => tokens.iter().any(|t| t == filter_value),
+        FieldValue::Json(val) => {
+            // Try numeric, boolean, or string comparison.
+            if let Some(s) = val.as_str() {
+                s == filter_value
+            } else if let Some(b) = val.as_bool() {
+                filter_value == if b { "true" } else { "false" }
+            } else if let Some(n) = val.as_f64() {
+                filter_value
+                    .parse::<f64>()
+                    .is_ok_and(|fv| (n - fv).abs() < f64::EPSILON)
+            } else {
+                false
+            }
+        }
+    }
+}
+
+/// Check if a field value matches any value in a comma-separated "in" list.
+fn value_matches_in(field: &FieldValue<'_>, filter_value: &str) -> bool {
+    let in_values: Vec<&str> = filter_value.split(',').collect();
+    in_values.iter().any(|v| value_matches_eq(field, v.trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_empty_filters_match_all() {
+        let resource = json!({"resourceType": "Patient", "id": "123"});
+        assert!(matches_filters(&resource, "Patient", &[]));
+    }
+
+    #[test]
+    fn test_direct_field_eq_match() {
+        let resource = json!({"resourceType": "Encounter", "status": "in-progress"});
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "status".to_string(),
+            comparator: "eq".to_string(),
+            value: "in-progress".to_string(),
+        }];
+        assert!(matches_filters(&resource, "Encounter", &filters));
+    }
+
+    #[test]
+    fn test_direct_field_eq_no_match() {
+        let resource = json!({"resourceType": "Encounter", "status": "finished"});
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "status".to_string(),
+            comparator: "eq".to_string(),
+            value: "in-progress".to_string(),
+        }];
+        assert!(!matches_filters(&resource, "Encounter", &filters));
+    }
+
+    #[test]
+    fn test_resource_type_filter_mismatch() {
+        let resource = json!({"resourceType": "Patient", "status": "active"});
+        let filters = vec![SubscriptionFilter {
+            resource_type: Some("Encounter".to_string()),
+            filter_parameter: "status".to_string(),
+            comparator: "eq".to_string(),
+            value: "active".to_string(),
+        }];
+        // Filter resource type is Encounter, but resource is Patient.
+        assert!(!matches_filters(&resource, "Patient", &filters));
+    }
+
+    #[test]
+    fn test_code_filter_with_codeable_concept() {
+        let resource = json!({
+            "resourceType": "Observation",
+            "code": {
+                "coding": [{
+                    "system": "http://loinc.org",
+                    "code": "1234-5"
+                }]
+            }
+        });
+
+        // Match by system|code.
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "code".to_string(),
+            comparator: "eq".to_string(),
+            value: "http://loinc.org|1234-5".to_string(),
+        }];
+        assert!(matches_filters(&resource, "Observation", &filters));
+
+        // Match by code only.
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "code".to_string(),
+            comparator: "eq".to_string(),
+            value: "1234-5".to_string(),
+        }];
+        assert!(matches_filters(&resource, "Observation", &filters));
+    }
+
+    #[test]
+    fn test_code_filter_no_match() {
+        let resource = json!({
+            "resourceType": "Observation",
+            "code": {
+                "coding": [{
+                    "system": "http://loinc.org",
+                    "code": "1234-5"
+                }]
+            }
+        });
+
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "code".to_string(),
+            comparator: "eq".to_string(),
+            value: "http://loinc.org|9999-9".to_string(),
+        }];
+        assert!(!matches_filters(&resource, "Observation", &filters));
+    }
+
+    #[test]
+    fn test_patient_reference_filter() {
+        let resource = json!({
+            "resourceType": "Encounter",
+            "subject": {
+                "reference": "Patient/123"
+            }
+        });
+
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "patient".to_string(),
+            comparator: "eq".to_string(),
+            value: "Patient/123".to_string(),
+        }];
+        assert!(matches_filters(&resource, "Encounter", &filters));
+    }
+
+    #[test]
+    fn test_identifier_filter() {
+        let resource = json!({
+            "resourceType": "Patient",
+            "identifier": [{
+                "system": "http://example.org/mrn",
+                "value": "MRN-001"
+            }]
+        });
+
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "identifier".to_string(),
+            comparator: "eq".to_string(),
+            value: "http://example.org/mrn|MRN-001".to_string(),
+        }];
+        assert!(matches_filters(&resource, "Patient", &filters));
+    }
+
+    #[test]
+    fn test_ne_comparator() {
+        let resource = json!({"resourceType": "Encounter", "status": "finished"});
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "status".to_string(),
+            comparator: "ne".to_string(),
+            value: "in-progress".to_string(),
+        }];
+        assert!(matches_filters(&resource, "Encounter", &filters));
+    }
+
+    #[test]
+    fn test_in_comparator() {
+        let resource = json!({"resourceType": "Encounter", "status": "in-progress"});
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "status".to_string(),
+            comparator: "in".to_string(),
+            value: "planned,in-progress,completed".to_string(),
+        }];
+        assert!(matches_filters(&resource, "Encounter", &filters));
+    }
+
+    #[test]
+    fn test_multiple_filters_all_must_match() {
+        let resource = json!({
+            "resourceType": "Observation",
+            "status": "final",
+            "code": {
+                "coding": [{"system": "http://loinc.org", "code": "1234-5"}]
+            }
+        });
+
+        let filters = vec![
+            SubscriptionFilter {
+                resource_type: None,
+                filter_parameter: "status".to_string(),
+                comparator: "eq".to_string(),
+                value: "final".to_string(),
+            },
+            SubscriptionFilter {
+                resource_type: None,
+                filter_parameter: "code".to_string(),
+                comparator: "eq".to_string(),
+                value: "1234-5".to_string(),
+            },
+        ];
+        assert!(matches_filters(&resource, "Observation", &filters));
+
+        // Change one filter to not match.
+        let filters = vec![
+            SubscriptionFilter {
+                resource_type: None,
+                filter_parameter: "status".to_string(),
+                comparator: "eq".to_string(),
+                value: "preliminary".to_string(),
+            },
+            SubscriptionFilter {
+                resource_type: None,
+                filter_parameter: "code".to_string(),
+                comparator: "eq".to_string(),
+                value: "1234-5".to_string(),
+            },
+        ];
+        assert!(!matches_filters(&resource, "Observation", &filters));
+    }
+
+    #[test]
+    fn test_missing_field_ne_matches() {
+        let resource = json!({"resourceType": "Encounter"});
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "status".to_string(),
+            comparator: "ne".to_string(),
+            value: "finished".to_string(),
+        }];
+        // Missing field with "ne" comparator should match.
+        assert!(matches_filters(&resource, "Encounter", &filters));
+    }
+}

--- a/crates/subscriptions/src/evaluator/mod.rs
+++ b/crates/subscriptions/src/evaluator/mod.rs
@@ -1,0 +1,281 @@
+//! Event evaluator.
+//!
+//! Matches resource write events against active subscriptions by evaluating
+//! topic triggers and subscription filter criteria.
+
+pub mod filter_match;
+
+use std::sync::Arc;
+
+use crate::event::ResourceEvent;
+use crate::manager::{ActiveSubscription, SubscriptionManager};
+use crate::topics::{InMemoryTopicRegistry, TopicMatch};
+
+/// Evaluates which subscriptions should receive notifications for a resource event.
+pub struct EventEvaluator {
+    topic_registry: Arc<InMemoryTopicRegistry>,
+    subscription_manager: Arc<SubscriptionManager>,
+}
+
+/// A subscription that matched an event, along with topic information.
+#[derive(Debug)]
+pub struct EvaluationMatch {
+    pub subscription: ActiveSubscription,
+    pub topic_match: TopicMatch,
+}
+
+impl EventEvaluator {
+    pub fn new(
+        topic_registry: Arc<InMemoryTopicRegistry>,
+        subscription_manager: Arc<SubscriptionManager>,
+    ) -> Self {
+        Self {
+            topic_registry,
+            subscription_manager,
+        }
+    }
+
+    /// Evaluates a resource event and returns all matching subscriptions.
+    ///
+    /// The flow is:
+    /// 1. Find all topics whose triggers match the event's resource type + interaction.
+    /// 2. For each matching topic, find all active subscriptions.
+    /// 3. For each subscription, evaluate filter criteria against the resource.
+    /// 4. Return subscriptions that pass all filters.
+    pub fn evaluate(&self, event: &ResourceEvent) -> Vec<EvaluationMatch> {
+        let topic_matches = self
+            .topic_registry
+            .matching_topics(&event.resource_type, event.event_type);
+
+        let mut results = Vec::new();
+
+        for topic_match in topic_matches {
+            let subscriptions = self
+                .subscription_manager
+                .active_subscriptions_for_topic(event.tenant_id.as_ref(), &topic_match.topic_url);
+
+            for sub in subscriptions {
+                // Evaluate filter criteria against the resource.
+                let resource_matches = match &event.resource {
+                    Some(resource) => {
+                        filter_match::matches_filters(resource, &event.resource_type, &sub.filters)
+                    }
+                    None => {
+                        // Delete events with no resource content: match if no filters.
+                        sub.filters.is_empty()
+                    }
+                };
+
+                if resource_matches {
+                    results.push(EvaluationMatch {
+                        subscription: sub,
+                        topic_match: topic_match.clone(),
+                    });
+                }
+            }
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::ResourceEventType;
+    use crate::manager::SubscriptionStatusCode;
+    use crate::manager::filters::SubscriptionFilter;
+    use crate::topics::{FilterDefinition, ResourceTrigger, TopicDefinition};
+    use chrono::Utc;
+    use helios_fhir::FhirVersion;
+    use helios_persistence::tenant::TenantId;
+    use serde_json::json;
+
+    fn setup() -> (Arc<InMemoryTopicRegistry>, Arc<SubscriptionManager>) {
+        let registry = Arc::new(InMemoryTopicRegistry::new());
+        registry.add_topic(TopicDefinition {
+            canonical_url: "http://example.org/topic/encounter-start".to_string(),
+            title: Some("Encounter Start".to_string()),
+            resource_triggers: vec![ResourceTrigger {
+                resource_type: "Encounter".to_string(),
+                interactions: vec![ResourceEventType::Create],
+                fhirpath_criteria: None,
+            }],
+            can_filter_by: vec![FilterDefinition {
+                resource_type: Some("Encounter".to_string()),
+                filter_parameter: "patient".to_string(),
+                comparators: vec!["eq".to_string()],
+                modifiers: vec![],
+            }],
+            notification_shape: vec![],
+        });
+
+        let manager = Arc::new(SubscriptionManager::new(
+            Arc::clone(&registry),
+            vec!["rest-hook".to_string()],
+        ));
+
+        (registry, manager)
+    }
+
+    fn register_active_subscription(
+        manager: &SubscriptionManager,
+        tenant: &str,
+        id: &str,
+        _filters: Vec<SubscriptionFilter>,
+    ) {
+        let resource = crate::manager::tests::default_subscription_json();
+        manager
+            .register(tenant, id, &resource, FhirVersion::default())
+            .unwrap();
+        manager
+            .update_status(tenant, id, SubscriptionStatusCode::Active)
+            .unwrap();
+    }
+
+    fn make_event(resource_type: &str, event_type: ResourceEventType) -> ResourceEvent {
+        ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: resource_type.to_string(),
+            resource_id: "123".to_string(),
+            version_id: "1".to_string(),
+            event_type,
+            resource: Some(json!({
+                "resourceType": resource_type,
+                "id": "123",
+                "status": "in-progress",
+                "subject": { "reference": "Patient/456" }
+            })),
+            previous_resource: None,
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_match_by_resource_type() {
+        let (registry, manager) = setup();
+        register_active_subscription(&manager, "t1", "sub-1", vec![]);
+
+        let evaluator = EventEvaluator::new(registry, manager);
+        let event = make_event("Encounter", ResourceEventType::Create);
+
+        let matches = evaluator.evaluate(&event);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].subscription.id, "sub-1");
+        assert_eq!(
+            matches[0].topic_match.topic_url,
+            "http://example.org/topic/encounter-start"
+        );
+    }
+
+    #[test]
+    fn test_no_match_wrong_resource_type() {
+        let (registry, manager) = setup();
+        register_active_subscription(&manager, "t1", "sub-1", vec![]);
+
+        let evaluator = EventEvaluator::new(registry, manager);
+        let event = make_event("Patient", ResourceEventType::Create);
+
+        let matches = evaluator.evaluate(&event);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_no_match_wrong_interaction() {
+        let (registry, manager) = setup();
+        register_active_subscription(&manager, "t1", "sub-1", vec![]);
+
+        let evaluator = EventEvaluator::new(registry, manager);
+        // Topic only triggers on Create, not Update.
+        let event = make_event("Encounter", ResourceEventType::Update);
+
+        let matches = evaluator.evaluate(&event);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_no_match_inactive_subscription() {
+        let (registry, manager) = setup();
+        // Register but don't activate.
+        let resource = crate::manager::tests::default_subscription_json();
+        manager
+            .register("t1", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+        // Status is "requested", not "active".
+
+        let evaluator = EventEvaluator::new(registry, manager);
+        let event = make_event("Encounter", ResourceEventType::Create);
+
+        let matches = evaluator.evaluate(&event);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_subscriptions_same_topic() {
+        let (registry, manager) = setup();
+        register_active_subscription(&manager, "t1", "sub-1", vec![]);
+        register_active_subscription(&manager, "t1", "sub-2", vec![]);
+
+        let evaluator = EventEvaluator::new(registry, manager);
+        let event = make_event("Encounter", ResourceEventType::Create);
+
+        let matches = evaluator.evaluate(&event);
+        assert_eq!(matches.len(), 2);
+    }
+
+    #[test]
+    fn test_tenant_isolation_in_evaluator() {
+        let (registry, manager) = setup();
+        register_active_subscription(&manager, "tenant-a", "sub-1", vec![]);
+        register_active_subscription(&manager, "tenant-b", "sub-2", vec![]);
+
+        let evaluator = EventEvaluator::new(registry, manager);
+
+        // Event from tenant-a should only match tenant-a subscriptions.
+        let mut event = make_event("Encounter", ResourceEventType::Create);
+        event.tenant_id = TenantId::new("tenant-a");
+
+        let matches = evaluator.evaluate(&event);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].subscription.id, "sub-1");
+    }
+
+    #[test]
+    fn test_delete_event_no_resource() {
+        let (registry, manager) = setup();
+
+        // Add a topic that triggers on delete.
+        registry.add_topic(TopicDefinition {
+            canonical_url: "http://example.org/topic/encounter-delete".to_string(),
+            title: None,
+            resource_triggers: vec![ResourceTrigger {
+                resource_type: "Encounter".to_string(),
+                interactions: vec![ResourceEventType::Delete],
+                fhirpath_criteria: None,
+            }],
+            can_filter_by: vec![],
+            notification_shape: vec![],
+        });
+
+        register_active_subscription(&manager, "t1", "sub-1", vec![]);
+
+        let evaluator = EventEvaluator::new(registry, manager);
+
+        let event = ResourceEvent {
+            tenant_id: TenantId::new("t1"),
+            fhir_version: FhirVersion::default(),
+            resource_type: "Encounter".to_string(),
+            resource_id: "123".to_string(),
+            version_id: "2".to_string(),
+            event_type: ResourceEventType::Delete,
+            resource: None,
+            previous_resource: None,
+            timestamp: Utc::now(),
+        };
+
+        // encounter-start only triggers on Create, not Delete, so no match.
+        let matches = evaluator.evaluate(&event);
+        assert!(matches.is_empty());
+    }
+}

--- a/crates/subscriptions/src/event.rs
+++ b/crates/subscriptions/src/event.rs
@@ -1,0 +1,71 @@
+//! Resource event types emitted after write operations.
+
+use chrono::{DateTime, Utc};
+use helios_fhir::FhirVersion;
+use helios_persistence::tenant::TenantId;
+
+/// An event emitted after a resource write operation (create, update, or delete).
+///
+/// This is the input to the subscription engine's evaluation pipeline.
+#[derive(Debug, Clone)]
+pub struct ResourceEvent {
+    /// The tenant that owns the resource.
+    pub tenant_id: TenantId,
+
+    /// The FHIR version of the resource.
+    pub fhir_version: FhirVersion,
+
+    /// The resource type (e.g., "Patient", "Observation").
+    pub resource_type: String,
+
+    /// The resource ID.
+    pub resource_id: String,
+
+    /// The version ID after the write operation.
+    pub version_id: String,
+
+    /// The type of interaction that produced this event.
+    pub event_type: ResourceEventType,
+
+    /// The resource content after the interaction (`None` for delete).
+    pub resource: Option<serde_json::Value>,
+
+    /// The resource content before the interaction (`None` for create).
+    pub previous_resource: Option<serde_json::Value>,
+
+    /// When the event occurred.
+    pub timestamp: DateTime<Utc>,
+}
+
+/// The type of interaction that produced a resource event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceEventType {
+    /// A new resource was created.
+    Create,
+    /// An existing resource was updated (including patch).
+    Update,
+    /// A resource was deleted.
+    Delete,
+}
+
+impl std::fmt::Display for ResourceEventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Create => write!(f, "create"),
+            Self::Update => write!(f, "update"),
+            Self::Delete => write!(f, "delete"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_type_display() {
+        assert_eq!(ResourceEventType::Create.to_string(), "create");
+        assert_eq!(ResourceEventType::Update.to_string(), "update");
+        assert_eq!(ResourceEventType::Delete.to_string(), "delete");
+    }
+}

--- a/crates/subscriptions/src/lib.rs
+++ b/crates/subscriptions/src/lib.rs
@@ -1,0 +1,35 @@
+//! FHIR topic-based Subscriptions engine for HFS.
+//!
+//! This crate implements the [FHIR Subscriptions Framework](https://build.fhir.org/subscriptions.html)
+//! for the Helios FHIR Server. It supports topic-based subscriptions across all
+//! FHIR versions (R4, R4B, R5, R6), with R4/R4B using the
+//! [Subscriptions R5 Backport IG](https://build.fhir.org/ig/HL7/fhir-subscription-backport-ig/).
+//!
+//! # Architecture
+//!
+//! The subscription system decomposes into five primary concerns:
+//!
+//! - **Topic Registry** — stores `SubscriptionTopic` definitions and evaluates triggers
+//! - **Subscription Manager** — CRUD lifecycle and status tracking for `Subscription` resources
+//! - **Event Evaluator** — matches resource write events against active subscriptions
+//! - **Notification Builder** — constructs version-specific notification bundles
+//! - **Channel Dispatcher** — delivers notifications via rest-hook, WebSocket, etc.
+//!
+//! The [`SubscriptionEngine`] orchestrates all five concerns and is the main
+//! entry point, invoked asynchronously after each resource write.
+
+pub mod channels;
+pub mod config;
+pub mod engine;
+pub mod error;
+pub mod evaluator;
+pub mod event;
+pub mod manager;
+pub mod notification;
+pub mod topics;
+
+// Re-export key types for convenience.
+pub use config::SubscriptionConfig;
+pub use engine::SubscriptionEngine;
+pub use error::SubscriptionError;
+pub use event::{ResourceEvent, ResourceEventType};

--- a/crates/subscriptions/src/manager/filters.rs
+++ b/crates/subscriptions/src/manager/filters.rs
@@ -1,0 +1,271 @@
+//! Subscription filter parsing and validation.
+
+use crate::error::SubscriptionError;
+use crate::topics::FilterDefinition;
+
+/// A parsed subscription filter criterion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubscriptionFilter {
+    /// The resource type (e.g., "Observation").
+    pub resource_type: Option<String>,
+
+    /// The filter parameter name (e.g., "code").
+    pub filter_parameter: String,
+
+    /// The comparator (e.g., "eq", "in").
+    pub comparator: String,
+
+    /// The filter value (e.g., "http://loinc.org|1234-5").
+    pub value: String,
+}
+
+/// Parses a filter criteria string in backport IG format.
+///
+/// The format is: `[ResourceType?]param=value` or `[ResourceType?]param=comparator:value`.
+///
+/// Examples:
+/// - `Observation?code=http://loinc.org|1234-5`
+/// - `Encounter?patient=Patient/123`
+/// - `code=http://loinc.org|1234-5` (no resource type prefix)
+pub fn parse_filter_string(filter: &str) -> Result<SubscriptionFilter, SubscriptionError> {
+    let (resource_type, param_str) = if let Some(idx) = filter.find('?') {
+        (Some(filter[..idx].to_string()), &filter[idx + 1..])
+    } else {
+        (None, filter)
+    };
+
+    let (param_name, value_str) =
+        param_str
+            .split_once('=')
+            .ok_or_else(|| SubscriptionError::InvalidFilter {
+                message: format!("filter missing '=' separator: {filter}"),
+            })?;
+
+    if param_name.is_empty() {
+        return Err(SubscriptionError::InvalidFilter {
+            message: "filter parameter name is empty".to_string(),
+        });
+    }
+
+    if value_str.is_empty() {
+        return Err(SubscriptionError::InvalidFilter {
+            message: format!("filter value is empty for parameter '{param_name}'"),
+        });
+    }
+
+    // Check for comparator prefix (e.g., "gt:5" or "ne:finished").
+    let (comparator, value) = if let Some((comp, val)) = value_str.split_once(':') {
+        // Only treat as comparator if it's a known FHIR comparator.
+        if is_known_comparator(comp) {
+            (comp.to_string(), val.to_string())
+        } else {
+            // Not a comparator — the colon is part of the value (e.g., system|code).
+            ("eq".to_string(), value_str.to_string())
+        }
+    } else {
+        ("eq".to_string(), value_str.to_string())
+    };
+
+    Ok(SubscriptionFilter {
+        resource_type,
+        filter_parameter: param_name.to_string(),
+        comparator,
+        value,
+    })
+}
+
+fn is_known_comparator(s: &str) -> bool {
+    matches!(
+        s,
+        "eq" | "ne" | "gt" | "lt" | "ge" | "le" | "sa" | "eb" | "in" | "not-in"
+    )
+}
+
+/// Validates a list of subscription filters against a topic's `canFilterBy` definitions.
+///
+/// Returns `Ok(())` if all filters are valid, or an error describing the first invalid filter.
+pub fn validate_filters(
+    filters: &[SubscriptionFilter],
+    can_filter_by: &[FilterDefinition],
+) -> Result<(), SubscriptionError> {
+    for filter in filters {
+        let matching_def = can_filter_by.iter().find(|def| {
+            // Match filter parameter name.
+            def.filter_parameter == filter.filter_parameter
+                // If the topic filter has a resource type constraint, it must match.
+                && def
+                    .resource_type
+                    .as_ref()
+                    .is_none_or(|rt| filter.resource_type.as_ref().is_none_or(|frt| frt == rt))
+        });
+
+        match matching_def {
+            None => {
+                return Err(SubscriptionError::InvalidFilter {
+                    message: format!(
+                        "filter parameter '{}' is not supported by the topic",
+                        filter.filter_parameter
+                    ),
+                });
+            }
+            Some(def) => {
+                // If the topic defines allowed comparators, check the filter uses one.
+                if !def.comparators.is_empty() && !def.comparators.contains(&filter.comparator) {
+                    return Err(SubscriptionError::InvalidFilter {
+                        message: format!(
+                            "comparator '{}' not supported for filter parameter '{}' (supported: {:?})",
+                            filter.comparator, filter.filter_parameter, def.comparators
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_filter_with_resource_type() {
+        let filter = parse_filter_string("Observation?code=http://loinc.org|1234-5").unwrap();
+        assert_eq!(filter.resource_type.as_deref(), Some("Observation"));
+        assert_eq!(filter.filter_parameter, "code");
+        assert_eq!(filter.comparator, "eq");
+        assert_eq!(filter.value, "http://loinc.org|1234-5");
+    }
+
+    #[test]
+    fn test_parse_filter_without_resource_type() {
+        let filter = parse_filter_string("code=http://loinc.org|1234-5").unwrap();
+        assert!(filter.resource_type.is_none());
+        assert_eq!(filter.filter_parameter, "code");
+        assert_eq!(filter.value, "http://loinc.org|1234-5");
+    }
+
+    #[test]
+    fn test_parse_filter_with_comparator() {
+        let filter = parse_filter_string("Observation?value-quantity=gt:5").unwrap();
+        assert_eq!(filter.comparator, "gt");
+        assert_eq!(filter.value, "5");
+    }
+
+    #[test]
+    fn test_parse_filter_colon_in_value_not_comparator() {
+        // "http://loinc.org|1234-5" contains a colon but "http" is not a comparator.
+        let filter = parse_filter_string("code=http://loinc.org|1234-5").unwrap();
+        assert_eq!(filter.comparator, "eq");
+        assert_eq!(filter.value, "http://loinc.org|1234-5");
+    }
+
+    #[test]
+    fn test_parse_filter_reference() {
+        let filter = parse_filter_string("Encounter?patient=Patient/123").unwrap();
+        assert_eq!(filter.filter_parameter, "patient");
+        assert_eq!(filter.value, "Patient/123");
+    }
+
+    #[test]
+    fn test_parse_filter_missing_equals() {
+        let result = parse_filter_string("Observation?code");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_filter_empty_param() {
+        let result = parse_filter_string("=value");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_filter_empty_value() {
+        let result = parse_filter_string("code=");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_filters_success() {
+        let filters = vec![SubscriptionFilter {
+            resource_type: Some("Observation".to_string()),
+            filter_parameter: "code".to_string(),
+            comparator: "eq".to_string(),
+            value: "http://loinc.org|1234-5".to_string(),
+        }];
+
+        let can_filter_by = vec![FilterDefinition {
+            resource_type: Some("Observation".to_string()),
+            filter_parameter: "code".to_string(),
+            comparators: vec!["eq".to_string(), "in".to_string()],
+            modifiers: vec![],
+        }];
+
+        assert!(validate_filters(&filters, &can_filter_by).is_ok());
+    }
+
+    #[test]
+    fn test_validate_filters_unknown_parameter() {
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "unknown-param".to_string(),
+            comparator: "eq".to_string(),
+            value: "value".to_string(),
+        }];
+
+        let can_filter_by = vec![FilterDefinition {
+            resource_type: Some("Observation".to_string()),
+            filter_parameter: "code".to_string(),
+            comparators: vec!["eq".to_string()],
+            modifiers: vec![],
+        }];
+
+        let result = validate_filters(&filters, &can_filter_by);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_filters_unsupported_comparator() {
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "code".to_string(),
+            comparator: "gt".to_string(),
+            value: "value".to_string(),
+        }];
+
+        let can_filter_by = vec![FilterDefinition {
+            resource_type: Some("Observation".to_string()),
+            filter_parameter: "code".to_string(),
+            comparators: vec!["eq".to_string()],
+            modifiers: vec![],
+        }];
+
+        let result = validate_filters(&filters, &can_filter_by);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_filters_empty_comparators_allows_any() {
+        let filters = vec![SubscriptionFilter {
+            resource_type: None,
+            filter_parameter: "code".to_string(),
+            comparator: "gt".to_string(),
+            value: "value".to_string(),
+        }];
+
+        let can_filter_by = vec![FilterDefinition {
+            resource_type: None,
+            filter_parameter: "code".to_string(),
+            comparators: vec![], // No restriction.
+            modifiers: vec![],
+        }];
+
+        assert!(validate_filters(&filters, &can_filter_by).is_ok());
+    }
+
+    #[test]
+    fn test_validate_empty_filters_always_valid() {
+        assert!(validate_filters(&[], &[]).is_ok());
+    }
+}

--- a/crates/subscriptions/src/manager/mod.rs
+++ b/crates/subscriptions/src/manager/mod.rs
@@ -1,0 +1,1102 @@
+//! Subscription manager.
+//!
+//! Manages the lifecycle of `Subscription` resources: CRUD, status tracking,
+//! filter validation, and in-memory indexing of active subscriptions.
+
+pub mod filters;
+pub mod status;
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use helios_fhir::FhirVersion;
+use tracing::{debug, warn};
+
+use crate::error::SubscriptionError;
+use crate::topics::InMemoryTopicRegistry;
+
+pub use filters::SubscriptionFilter;
+pub use status::SubscriptionStatusCode;
+
+/// Payload content level requested by the subscriber.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PayloadContent {
+    /// No resource content in the notification.
+    Empty,
+    /// Resource references only (fullUrl + request, no resource body).
+    IdOnly,
+    /// Full resource content included.
+    FullResource,
+}
+
+impl PayloadContent {
+    /// Parse from a FHIR string value.
+    pub fn from_fhir_str(s: &str) -> Option<Self> {
+        match s {
+            "empty" => Some(Self::Empty),
+            "id-only" => Some(Self::IdOnly),
+            "full-resource" => Some(Self::FullResource),
+            _ => None,
+        }
+    }
+
+    /// Returns the FHIR string representation.
+    pub fn as_fhir_str(&self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::IdOnly => "id-only",
+            Self::FullResource => "full-resource",
+        }
+    }
+}
+
+/// Channel type for a subscription.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ChannelType {
+    RestHook,
+    Websocket,
+    Email,
+    Message,
+    Custom(String),
+}
+
+impl ChannelType {
+    /// Parse from a FHIR channel type string.
+    pub fn from_fhir_str(s: &str) -> Self {
+        match s {
+            "rest-hook" => Self::RestHook,
+            "websocket" => Self::Websocket,
+            "email" => Self::Email,
+            "message" => Self::Message,
+            other => Self::Custom(other.to_string()),
+        }
+    }
+
+    /// Returns the FHIR string representation.
+    pub fn as_fhir_str(&self) -> &str {
+        match self {
+            Self::RestHook => "rest-hook",
+            Self::Websocket => "websocket",
+            Self::Email => "email",
+            Self::Message => "message",
+            Self::Custom(s) => s,
+        }
+    }
+}
+
+/// Channel configuration for a subscription.
+#[derive(Debug, Clone)]
+pub struct ChannelConfig {
+    pub channel_type: ChannelType,
+    pub endpoint: Option<String>,
+    pub payload_mime_type: Option<String>,
+    pub payload_content: PayloadContent,
+    pub headers: Vec<String>,
+    pub heartbeat_period: Option<u32>,
+    pub timeout: Option<u32>,
+    pub max_count: Option<u32>,
+}
+
+/// An active subscription tracked by the manager.
+///
+/// This is a version-agnostic in-memory representation of the essential fields
+/// needed for event evaluation and notification delivery.
+#[derive(Debug, Clone)]
+pub struct ActiveSubscription {
+    /// The subscription resource ID.
+    pub id: String,
+
+    /// The canonical URL of the SubscriptionTopic.
+    pub topic_url: String,
+
+    /// Current status.
+    pub status: SubscriptionStatusCode,
+
+    /// Channel configuration.
+    pub channel: ChannelConfig,
+
+    /// Parsed filter criteria.
+    pub filters: Vec<SubscriptionFilter>,
+
+    /// The FHIR version of the subscription resource.
+    pub fhir_version: FhirVersion,
+
+    /// Monotonically increasing event counter.
+    pub events_since_start: u64,
+
+    /// Consecutive delivery failure count (for error/off transitions).
+    pub consecutive_failures: u32,
+
+    /// Tenant ID that owns this subscription.
+    pub tenant_id: String,
+}
+
+/// Manages the lifecycle and in-memory indexing of active subscriptions.
+pub struct SubscriptionManager {
+    /// Active subscriptions keyed by (tenant_id, subscription_id).
+    subscriptions: DashMap<(String, String), ActiveSubscription>,
+
+    /// Topic registry for validation.
+    topic_registry: Arc<InMemoryTopicRegistry>,
+
+    /// Supported channel types.
+    supported_channels: Vec<String>,
+}
+
+impl SubscriptionManager {
+    /// Creates a new subscription manager.
+    pub fn new(
+        topic_registry: Arc<InMemoryTopicRegistry>,
+        supported_channels: Vec<String>,
+    ) -> Self {
+        Self {
+            subscriptions: DashMap::new(),
+            topic_registry,
+            supported_channels,
+        }
+    }
+
+    /// Registers a subscription from a FHIR Subscription resource JSON.
+    ///
+    /// Validates the topic URL, channel type, and filter criteria.
+    /// On success, the subscription is stored in the in-memory index.
+    pub fn register(
+        &self,
+        tenant_id: &str,
+        subscription_id: &str,
+        resource: &serde_json::Value,
+        fhir_version: FhirVersion,
+    ) -> Result<ActiveSubscription, SubscriptionError> {
+        // Parse the subscription resource.
+        let topic_url = extract_topic_url(resource, fhir_version)?;
+        let channel = extract_channel_config(resource, fhir_version)?;
+        let filter_strings = extract_filter_criteria(resource, fhir_version);
+
+        // Validate topic exists.
+        let topic = self.topic_registry.get_topic(&topic_url).ok_or_else(|| {
+            SubscriptionError::TopicNotFound {
+                url: topic_url.clone(),
+            }
+        })?;
+
+        // Validate channel type is supported.
+        if !self
+            .supported_channels
+            .contains(&channel.channel_type.as_fhir_str().to_string())
+        {
+            return Err(SubscriptionError::UnsupportedChannel {
+                channel_type: channel.channel_type.as_fhir_str().to_string(),
+            });
+        }
+
+        // Validate rest-hook endpoint is present.
+        if channel.channel_type == ChannelType::RestHook && channel.endpoint.is_none() {
+            return Err(SubscriptionError::InvalidEndpoint {
+                message: "rest-hook channel requires an endpoint".to_string(),
+            });
+        }
+
+        // Parse and validate filters.
+        let mut parsed_filters = Vec::new();
+        for filter_str in &filter_strings {
+            let filter = filters::parse_filter_string(filter_str)?;
+            parsed_filters.push(filter);
+        }
+        filters::validate_filters(&parsed_filters, &topic.can_filter_by)?;
+
+        let status = resource
+            .get("status")
+            .and_then(|v| v.as_str())
+            .and_then(SubscriptionStatusCode::from_fhir_str)
+            .unwrap_or(SubscriptionStatusCode::Requested);
+
+        let subscription = ActiveSubscription {
+            id: subscription_id.to_string(),
+            topic_url,
+            status,
+            channel,
+            filters: parsed_filters,
+            fhir_version,
+            events_since_start: 0,
+            consecutive_failures: 0,
+            tenant_id: tenant_id.to_string(),
+        };
+
+        debug!(
+            tenant = tenant_id,
+            subscription_id,
+            topic = %subscription.topic_url,
+            "Registered subscription"
+        );
+
+        let key = (tenant_id.to_string(), subscription_id.to_string());
+        self.subscriptions.insert(key, subscription.clone());
+
+        Ok(subscription)
+    }
+
+    /// Removes a subscription from the in-memory index.
+    pub fn deregister(&self, tenant_id: &str, subscription_id: &str) -> bool {
+        let key = (tenant_id.to_string(), subscription_id.to_string());
+        let removed = self.subscriptions.remove(&key).is_some();
+        if removed {
+            debug!(
+                tenant = tenant_id,
+                subscription_id, "Deregistered subscription"
+            );
+        }
+        removed
+    }
+
+    /// Returns all active subscriptions for a given topic URL within a tenant.
+    pub fn active_subscriptions_for_topic(
+        &self,
+        tenant_id: &str,
+        topic_url: &str,
+    ) -> Vec<ActiveSubscription> {
+        self.subscriptions
+            .iter()
+            .filter(|entry| {
+                let sub = entry.value();
+                sub.tenant_id == tenant_id
+                    && sub.topic_url == topic_url
+                    && sub.status == SubscriptionStatusCode::Active
+            })
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+
+    /// Gets the current status of a subscription.
+    pub fn get_subscription(
+        &self,
+        tenant_id: &str,
+        subscription_id: &str,
+    ) -> Option<ActiveSubscription> {
+        let key = (tenant_id.to_string(), subscription_id.to_string());
+        self.subscriptions.get(&key).map(|entry| entry.clone())
+    }
+
+    /// Updates the status of a subscription.
+    pub fn update_status(
+        &self,
+        tenant_id: &str,
+        subscription_id: &str,
+        new_status: SubscriptionStatusCode,
+    ) -> Result<SubscriptionStatusCode, SubscriptionError> {
+        let key = (tenant_id.to_string(), subscription_id.to_string());
+        let mut entry = self.subscriptions.get_mut(&key).ok_or_else(|| {
+            SubscriptionError::Internal(format!("subscription not found: {subscription_id}"))
+        })?;
+
+        let old_status = entry.status;
+        if !old_status.can_transition_to(new_status) {
+            return Err(SubscriptionError::InvalidStatusTransition {
+                from: old_status.to_string(),
+                to: new_status.to_string(),
+            });
+        }
+
+        entry.status = new_status;
+        debug!(
+            tenant = tenant_id,
+            subscription_id,
+            from = %old_status,
+            to = %new_status,
+            "Status transition"
+        );
+
+        Ok(old_status)
+    }
+
+    /// Increments the event counter and returns the new value.
+    pub fn increment_event_count(&self, tenant_id: &str, subscription_id: &str) -> Option<u64> {
+        let key = (tenant_id.to_string(), subscription_id.to_string());
+        let mut entry = self.subscriptions.get_mut(&key)?;
+        entry.events_since_start += 1;
+        Some(entry.events_since_start)
+    }
+
+    /// Records a delivery failure and returns the new consecutive failure count.
+    pub fn record_failure(&self, tenant_id: &str, subscription_id: &str) -> Option<u32> {
+        let key = (tenant_id.to_string(), subscription_id.to_string());
+        let mut entry = self.subscriptions.get_mut(&key)?;
+        entry.consecutive_failures += 1;
+        let count = entry.consecutive_failures;
+        warn!(
+            tenant = tenant_id,
+            subscription_id,
+            consecutive_failures = count,
+            "Delivery failure recorded"
+        );
+        Some(count)
+    }
+
+    /// Resets the consecutive failure counter after a successful delivery.
+    pub fn reset_failures(&self, tenant_id: &str, subscription_id: &str) {
+        let key = (tenant_id.to_string(), subscription_id.to_string());
+        if let Some(mut entry) = self.subscriptions.get_mut(&key) {
+            entry.consecutive_failures = 0;
+        }
+    }
+
+    /// Returns all subscriptions (for heartbeat checking, initialization, etc.).
+    pub fn all_subscriptions(&self) -> Vec<ActiveSubscription> {
+        self.subscriptions
+            .iter()
+            .map(|e| e.value().clone())
+            .collect()
+    }
+}
+
+// --- Version-aware field extraction ---
+
+/// Extract the topic canonical URL from a Subscription resource.
+fn extract_topic_url(
+    resource: &serde_json::Value,
+    fhir_version: FhirVersion,
+) -> Result<String, SubscriptionError> {
+    match fhir_version {
+        // R4: topic URL is in the `criteria` field (backport IG convention)
+        // or in the `backport-topic-canonical` extension.
+        #[cfg(feature = "R4")]
+        FhirVersion::R4 => {
+            // First try backport extension.
+            if let Some(url) = find_extension_value_url(
+                resource,
+                "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-topic-canonical",
+            ) {
+                return Ok(url);
+            }
+            // Fall back to criteria field.
+            resource
+                .get("criteria")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .ok_or_else(|| SubscriptionError::InvalidSubscription {
+                    message: "R4 Subscription missing topic URL (criteria or backport-topic-canonical extension)".to_string(),
+                })
+        }
+
+        // R4B+: topic URL is in the `topic` field (canonical reference).
+        #[allow(unreachable_patterns)]
+        _ => resource
+            .get("topic")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| SubscriptionError::InvalidSubscription {
+                message: "Subscription missing 'topic' field".to_string(),
+            }),
+    }
+}
+
+/// Extract channel configuration from a Subscription resource.
+fn extract_channel_config(
+    resource: &serde_json::Value,
+    fhir_version: FhirVersion,
+) -> Result<ChannelConfig, SubscriptionError> {
+    match fhir_version {
+        // R4: channel is a nested object with type, endpoint, payload, header.
+        #[cfg(feature = "R4")]
+        FhirVersion::R4 => {
+            let channel =
+                resource
+                    .get("channel")
+                    .ok_or_else(|| SubscriptionError::InvalidSubscription {
+                        message: "R4 Subscription missing 'channel' field".to_string(),
+                    })?;
+
+            let channel_type_str = channel
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("rest-hook");
+
+            let endpoint = channel
+                .get("endpoint")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+
+            let payload_mime_type = channel
+                .get("payload")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+
+            let headers = channel
+                .get("header")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            // Payload content from backport extension.
+            let payload_content = find_extension_value_code(
+                resource,
+                "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-payload-content",
+            )
+            .and_then(|s| PayloadContent::from_fhir_str(&s))
+            .unwrap_or(PayloadContent::IdOnly);
+
+            let heartbeat_period = find_extension_value_unsigned_int(
+                resource,
+                "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-heartbeat-period",
+            );
+
+            let timeout = find_extension_value_unsigned_int(
+                resource,
+                "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-timeout",
+            );
+
+            let max_count = find_extension_value_unsigned_int(
+                resource,
+                "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-max-count",
+            );
+
+            Ok(ChannelConfig {
+                channel_type: ChannelType::from_fhir_str(channel_type_str),
+                endpoint,
+                payload_mime_type,
+                payload_content,
+                headers,
+                heartbeat_period,
+                timeout,
+                max_count,
+            })
+        }
+
+        // R4B+: channel type is `channelType` coding, endpoint, content, etc.
+        #[allow(unreachable_patterns)]
+        _ => {
+            let channel_type_str = resource
+                .get("channelType")
+                .and_then(|v| v.get("code"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("rest-hook");
+
+            let endpoint = resource
+                .get("endpoint")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+
+            let payload_content = resource
+                .get("content")
+                .and_then(|v| v.as_str())
+                .and_then(PayloadContent::from_fhir_str)
+                .unwrap_or(PayloadContent::IdOnly);
+
+            let payload_mime_type = resource
+                .get("contentType")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+
+            let heartbeat_period = resource
+                .get("heartbeatPeriod")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+
+            let timeout = resource
+                .get("timeout")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+
+            let max_count = resource
+                .get("maxCount")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+
+            let headers = resource
+                .get("parameter")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|p| {
+                            let name = p.get("name")?.as_str()?;
+                            let value = p.get("value")?.as_str()?;
+                            Some(format!("{name}: {value}"))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            Ok(ChannelConfig {
+                channel_type: ChannelType::from_fhir_str(channel_type_str),
+                endpoint,
+                payload_mime_type,
+                payload_content,
+                headers,
+                heartbeat_period,
+                timeout,
+                max_count,
+            })
+        }
+    }
+}
+
+/// Extract filter criteria strings from a Subscription resource.
+fn extract_filter_criteria(resource: &serde_json::Value, fhir_version: FhirVersion) -> Vec<String> {
+    match fhir_version {
+        // R4: filter criteria from backport extension.
+        #[cfg(feature = "R4")]
+        FhirVersion::R4 => find_all_extension_values_string(
+            resource,
+            "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-filter-criteria",
+        ),
+
+        // R4B+: filterBy array with resourceType, filterParameter, comparator, value.
+        #[allow(unreachable_patterns)]
+        _ => {
+            let filter_by = match resource.get("filterBy").and_then(|v| v.as_array()) {
+                Some(arr) => arr,
+                None => return Vec::new(),
+            };
+
+            filter_by
+                .iter()
+                .filter_map(|f| {
+                    let param = f.get("filterParameter")?.as_str()?;
+                    let value = f.get("value")?.as_str()?;
+                    let resource_type = f.get("resourceType").and_then(|v| v.as_str());
+
+                    let filter_str = if let Some(rt) = resource_type {
+                        format!("{rt}?{param}={value}")
+                    } else {
+                        format!("{param}={value}")
+                    };
+
+                    Some(filter_str)
+                })
+                .collect()
+        }
+    }
+}
+
+// --- Extension helpers for R4 backport ---
+
+/// Find a single extension with the given URL and return its `valueUrl`.
+fn find_extension_value_url(resource: &serde_json::Value, url: &str) -> Option<String> {
+    resource
+        .get("extension")?
+        .as_array()?
+        .iter()
+        .find(|ext| ext.get("url").and_then(|v| v.as_str()) == Some(url))
+        .and_then(|ext| ext.get("valueUrl").or_else(|| ext.get("valueCanonical")))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+/// Find a single extension with the given URL and return its `valueCode`.
+fn find_extension_value_code(resource: &serde_json::Value, url: &str) -> Option<String> {
+    resource
+        .get("extension")?
+        .as_array()?
+        .iter()
+        .find(|ext| ext.get("url").and_then(|v| v.as_str()) == Some(url))
+        .and_then(|ext| ext.get("valueCode"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+/// Find a single extension with the given URL and return its `valueUnsignedInt`.
+fn find_extension_value_unsigned_int(resource: &serde_json::Value, url: &str) -> Option<u32> {
+    resource
+        .get("extension")?
+        .as_array()?
+        .iter()
+        .find(|ext| ext.get("url").and_then(|v| v.as_str()) == Some(url))
+        .and_then(|ext| ext.get("valueUnsignedInt"))
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+}
+
+/// Find all extensions with the given URL and return their `valueString` values.
+fn find_all_extension_values_string(resource: &serde_json::Value, url: &str) -> Vec<String> {
+    resource
+        .get("extension")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|ext| ext.get("url").and_then(|v| v.as_str()) == Some(url))
+                .filter_map(|ext| {
+                    ext.get("valueString")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::event::ResourceEventType;
+    use crate::topics::{FilterDefinition, ResourceTrigger, TopicDefinition};
+    use serde_json::json;
+
+    fn create_test_registry() -> Arc<InMemoryTopicRegistry> {
+        let registry = Arc::new(InMemoryTopicRegistry::new());
+        registry.add_topic(TopicDefinition {
+            canonical_url: "http://example.org/topic/encounter-start".to_string(),
+            title: Some("Encounter Start".to_string()),
+            resource_triggers: vec![ResourceTrigger {
+                resource_type: "Encounter".to_string(),
+                interactions: vec![ResourceEventType::Create],
+                fhirpath_criteria: None,
+            }],
+            can_filter_by: vec![FilterDefinition {
+                resource_type: Some("Encounter".to_string()),
+                filter_parameter: "patient".to_string(),
+                comparators: vec!["eq".to_string()],
+                modifiers: vec![],
+            }],
+            notification_shape: vec![],
+        });
+        registry
+    }
+
+    /// Returns a subscription JSON compatible with the default FHIR version.
+    /// R4 uses criteria + channel object; R4B+ uses topic + channelType.
+    pub(crate) fn default_subscription_json() -> serde_json::Value {
+        #[cfg(feature = "R4")]
+        {
+            json!({
+                "resourceType": "Subscription",
+                "id": "sub-1",
+                "status": "requested",
+                "criteria": "http://example.org/topic/encounter-start",
+                "channel": {
+                    "type": "rest-hook",
+                    "endpoint": "https://example.com/webhook",
+                    "payload": "application/fhir+json"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-topic-canonical",
+                        "valueCanonical": "http://example.org/topic/encounter-start"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-payload-content",
+                        "valueCode": "id-only"
+                    }
+                ]
+            })
+        }
+        #[cfg(not(feature = "R4"))]
+        {
+            json!({
+                "resourceType": "Subscription",
+                "id": "sub-1",
+                "status": "requested",
+                "topic": "http://example.org/topic/encounter-start",
+                "channelType": {
+                    "system": "http://terminology.hl7.org/CodeSystem/subscription-channel-type",
+                    "code": "rest-hook"
+                },
+                "endpoint": "https://example.com/webhook",
+                "content": "id-only",
+                "contentType": "application/fhir+json"
+            })
+        }
+    }
+
+    #[cfg(feature = "R4")]
+    fn r4_subscription_json() -> serde_json::Value {
+        json!({
+            "resourceType": "Subscription",
+            "id": "sub-r4-1",
+            "status": "requested",
+            "criteria": "http://example.org/topic/encounter-start",
+            "channel": {
+                "type": "rest-hook",
+                "endpoint": "https://example.com/webhook",
+                "payload": "application/fhir+json",
+                "header": ["Authorization: Bearer token123"]
+            },
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-topic-canonical",
+                    "valueCanonical": "http://example.org/topic/encounter-start"
+                },
+                {
+                    "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-payload-content",
+                    "valueCode": "id-only"
+                },
+                {
+                    "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-heartbeat-period",
+                    "valueUnsignedInt": 60
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn test_register_r5_subscription() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = default_subscription_json();
+        let sub = manager
+            .register("tenant-1", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+
+        assert_eq!(sub.id, "sub-1");
+        assert_eq!(sub.topic_url, "http://example.org/topic/encounter-start");
+        assert_eq!(sub.channel.channel_type, ChannelType::RestHook);
+        assert_eq!(
+            sub.channel.endpoint.as_deref(),
+            Some("https://example.com/webhook")
+        );
+        assert_eq!(sub.channel.payload_content, PayloadContent::IdOnly);
+        assert_eq!(sub.status, SubscriptionStatusCode::Requested);
+        assert_eq!(sub.events_since_start, 0);
+    }
+
+    #[cfg(feature = "R4")]
+    #[test]
+    fn test_register_r4_subscription_with_backport_extensions() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = r4_subscription_json();
+        let sub = manager
+            .register("tenant-1", "sub-r4-1", &resource, FhirVersion::R4)
+            .unwrap();
+
+        assert_eq!(sub.topic_url, "http://example.org/topic/encounter-start");
+        assert_eq!(sub.channel.channel_type, ChannelType::RestHook);
+        assert_eq!(sub.channel.payload_content, PayloadContent::IdOnly);
+        assert_eq!(sub.channel.heartbeat_period, Some(60));
+        assert_eq!(sub.channel.headers.len(), 1);
+        assert!(sub.channel.headers[0].contains("Authorization"));
+    }
+
+    /// Build a version-appropriate subscription JSON with custom topic/channel.
+    pub(crate) fn build_subscription_json(
+        topic_url: &str,
+        channel_type: &str,
+        endpoint: Option<&str>,
+    ) -> serde_json::Value {
+        #[cfg(feature = "R4")]
+        {
+            let mut sub = json!({
+                "resourceType": "Subscription",
+                "status": "requested",
+                "criteria": topic_url,
+                "channel": {
+                    "type": channel_type
+                },
+                "extension": [{
+                    "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-topic-canonical",
+                    "valueCanonical": topic_url
+                }]
+            });
+            if let Some(ep) = endpoint {
+                sub["channel"]["endpoint"] = json!(ep);
+            }
+            sub
+        }
+        #[cfg(not(feature = "R4"))]
+        {
+            let mut sub = json!({
+                "resourceType": "Subscription",
+                "status": "requested",
+                "topic": topic_url,
+                "channelType": { "code": channel_type }
+            });
+            if let Some(ep) = endpoint {
+                sub["endpoint"] = json!(ep);
+            }
+            sub
+        }
+    }
+
+    #[test]
+    fn test_register_invalid_topic() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = build_subscription_json(
+            "http://nonexistent.org/topic/missing",
+            "rest-hook",
+            Some("https://example.com/webhook"),
+        );
+
+        let result = manager.register("t1", "s1", &resource, FhirVersion::default());
+        assert!(matches!(
+            result,
+            Err(SubscriptionError::TopicNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn test_register_unsupported_channel() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = build_subscription_json(
+            "http://example.org/topic/encounter-start",
+            "email",
+            Some("mailto:test@example.com"),
+        );
+
+        let result = manager.register("t1", "s1", &resource, FhirVersion::default());
+        assert!(matches!(
+            result,
+            Err(SubscriptionError::UnsupportedChannel { .. })
+        ));
+    }
+
+    #[test]
+    fn test_register_rest_hook_missing_endpoint() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = build_subscription_json(
+            "http://example.org/topic/encounter-start",
+            "rest-hook",
+            None, // No endpoint.
+        );
+
+        let result = manager.register("t1", "s1", &resource, FhirVersion::default());
+        assert!(matches!(
+            result,
+            Err(SubscriptionError::InvalidEndpoint { .. })
+        ));
+    }
+
+    #[test]
+    fn test_deregister() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = default_subscription_json();
+        manager
+            .register("t1", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+
+        assert!(manager.deregister("t1", "sub-1"));
+        assert!(manager.get_subscription("t1", "sub-1").is_none());
+
+        // Deregistering again returns false.
+        assert!(!manager.deregister("t1", "sub-1"));
+    }
+
+    #[test]
+    fn test_active_subscriptions_for_topic() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = default_subscription_json();
+        manager
+            .register("t1", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+
+        // Subscription is in "requested" status, should not appear in active list.
+        let active = manager
+            .active_subscriptions_for_topic("t1", "http://example.org/topic/encounter-start");
+        assert!(active.is_empty());
+
+        // Transition to active.
+        manager
+            .update_status("t1", "sub-1", SubscriptionStatusCode::Active)
+            .unwrap();
+
+        let active = manager
+            .active_subscriptions_for_topic("t1", "http://example.org/topic/encounter-start");
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, "sub-1");
+    }
+
+    #[test]
+    fn test_status_transitions() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = default_subscription_json();
+        manager
+            .register("t1", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+
+        // Requested -> Active (valid).
+        let old = manager
+            .update_status("t1", "sub-1", SubscriptionStatusCode::Active)
+            .unwrap();
+        assert_eq!(old, SubscriptionStatusCode::Requested);
+
+        // Active -> Error (valid).
+        manager
+            .update_status("t1", "sub-1", SubscriptionStatusCode::Error)
+            .unwrap();
+
+        // Error -> Active (valid, recovery).
+        manager
+            .update_status("t1", "sub-1", SubscriptionStatusCode::Active)
+            .unwrap();
+
+        // Active -> Requested (invalid).
+        let result = manager.update_status("t1", "sub-1", SubscriptionStatusCode::Requested);
+        assert!(matches!(
+            result,
+            Err(SubscriptionError::InvalidStatusTransition { .. })
+        ));
+    }
+
+    #[test]
+    fn test_increment_event_count() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = default_subscription_json();
+        manager
+            .register("t1", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+
+        assert_eq!(manager.increment_event_count("t1", "sub-1"), Some(1));
+        assert_eq!(manager.increment_event_count("t1", "sub-1"), Some(2));
+        assert_eq!(manager.increment_event_count("t1", "sub-1"), Some(3));
+
+        // Nonexistent subscription.
+        assert!(manager.increment_event_count("t1", "nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_record_and_reset_failures() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = default_subscription_json();
+        manager
+            .register("t1", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+
+        assert_eq!(manager.record_failure("t1", "sub-1"), Some(1));
+        assert_eq!(manager.record_failure("t1", "sub-1"), Some(2));
+
+        manager.reset_failures("t1", "sub-1");
+        let sub = manager.get_subscription("t1", "sub-1").unwrap();
+        assert_eq!(sub.consecutive_failures, 0);
+    }
+
+    #[test]
+    fn test_tenant_isolation() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        let resource = default_subscription_json();
+        manager
+            .register("tenant-a", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+        manager
+            .register("tenant-b", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+
+        // Each tenant sees their own subscription.
+        assert!(manager.get_subscription("tenant-a", "sub-1").is_some());
+        assert!(manager.get_subscription("tenant-b", "sub-1").is_some());
+
+        // Deregistering in one tenant doesn't affect the other.
+        manager.deregister("tenant-a", "sub-1");
+        assert!(manager.get_subscription("tenant-a", "sub-1").is_none());
+        assert!(manager.get_subscription("tenant-b", "sub-1").is_some());
+    }
+
+    #[test]
+    fn test_register_with_filter_by() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        #[cfg(feature = "R4")]
+        let resource = json!({
+            "resourceType": "Subscription",
+            "status": "requested",
+            "criteria": "http://example.org/topic/encounter-start",
+            "channel": {
+                "type": "rest-hook",
+                "endpoint": "https://example.com/webhook"
+            },
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-topic-canonical",
+                    "valueCanonical": "http://example.org/topic/encounter-start"
+                },
+                {
+                    "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-payload-content",
+                    "valueCode": "full-resource"
+                },
+                {
+                    "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-filter-criteria",
+                    "valueString": "Encounter?patient=Patient/123"
+                }
+            ]
+        });
+        #[cfg(not(feature = "R4"))]
+        let resource = json!({
+            "resourceType": "Subscription",
+            "status": "requested",
+            "topic": "http://example.org/topic/encounter-start",
+            "channelType": { "code": "rest-hook" },
+            "endpoint": "https://example.com/webhook",
+            "content": "full-resource",
+            "filterBy": [{
+                "resourceType": "Encounter",
+                "filterParameter": "patient",
+                "value": "Patient/123"
+            }]
+        });
+
+        let sub = manager
+            .register("t1", "sub-1", &resource, FhirVersion::default())
+            .unwrap();
+
+        assert_eq!(sub.filters.len(), 1);
+        assert_eq!(sub.filters[0].filter_parameter, "patient");
+        assert_eq!(sub.filters[0].value, "Patient/123");
+        assert_eq!(sub.channel.payload_content, PayloadContent::FullResource);
+    }
+
+    #[test]
+    fn test_register_with_invalid_filter() {
+        let registry = create_test_registry();
+        let manager = SubscriptionManager::new(registry, vec!["rest-hook".to_string()]);
+
+        #[cfg(feature = "R4")]
+        let resource = json!({
+            "resourceType": "Subscription",
+            "status": "requested",
+            "criteria": "http://example.org/topic/encounter-start",
+            "channel": {
+                "type": "rest-hook",
+                "endpoint": "https://example.com/webhook"
+            },
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-topic-canonical",
+                    "valueCanonical": "http://example.org/topic/encounter-start"
+                },
+                {
+                    "url": "http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-filter-criteria",
+                    "valueString": "unknown-param=some-value"
+                }
+            ]
+        });
+        #[cfg(not(feature = "R4"))]
+        let resource = json!({
+            "resourceType": "Subscription",
+            "status": "requested",
+            "topic": "http://example.org/topic/encounter-start",
+            "channelType": { "code": "rest-hook" },
+            "endpoint": "https://example.com/webhook",
+            "filterBy": [{
+                "filterParameter": "unknown-param",
+                "value": "some-value"
+            }]
+        });
+
+        let result = manager.register("t1", "sub-1", &resource, FhirVersion::default());
+        assert!(matches!(
+            result,
+            Err(SubscriptionError::InvalidFilter { .. })
+        ));
+    }
+}

--- a/crates/subscriptions/src/manager/status.rs
+++ b/crates/subscriptions/src/manager/status.rs
@@ -1,0 +1,131 @@
+//! Subscription status state machine.
+
+use std::fmt;
+
+/// The possible states of a subscription.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SubscriptionStatusCode {
+    /// The client has requested the subscription, and the server has not yet
+    /// set it to be active.
+    Requested,
+    /// The subscription is active and notifications will be sent.
+    Active,
+    /// The server has an error executing the notification or detecting status changes.
+    Error,
+    /// The subscription has been turned off by the server or client.
+    Off,
+}
+
+impl SubscriptionStatusCode {
+    /// Returns whether a transition from `self` to `target` is valid.
+    pub fn can_transition_to(self, target: Self) -> bool {
+        matches!(
+            (self, target),
+            // Requested can become Active (handshake succeeded) or Error or Off.
+            (Self::Requested, Self::Active)
+                | (Self::Requested, Self::Error)
+                | (Self::Requested, Self::Off)
+                // Active can become Error (delivery failure) or Off (client/server deactivates).
+                | (Self::Active, Self::Error)
+                | (Self::Active, Self::Off)
+                // Error can recover to Active (after successful retry) or be turned off.
+                | (Self::Error, Self::Active)
+                | (Self::Error, Self::Off)
+        )
+    }
+
+    /// Parses a status string from a FHIR Subscription resource.
+    pub fn from_fhir_str(s: &str) -> Option<Self> {
+        match s {
+            "requested" => Some(Self::Requested),
+            "active" => Some(Self::Active),
+            "error" => Some(Self::Error),
+            "off" => Some(Self::Off),
+            _ => None,
+        }
+    }
+
+    /// Returns the FHIR string representation.
+    pub fn as_fhir_str(&self) -> &'static str {
+        match self {
+            Self::Requested => "requested",
+            Self::Active => "active",
+            Self::Error => "error",
+            Self::Off => "off",
+        }
+    }
+}
+
+impl fmt::Display for SubscriptionStatusCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_fhir_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_transitions() {
+        use SubscriptionStatusCode::*;
+
+        // From Requested
+        assert!(Requested.can_transition_to(Active));
+        assert!(Requested.can_transition_to(Error));
+        assert!(Requested.can_transition_to(Off));
+
+        // From Active
+        assert!(Active.can_transition_to(Error));
+        assert!(Active.can_transition_to(Off));
+
+        // From Error
+        assert!(Error.can_transition_to(Active));
+        assert!(Error.can_transition_to(Off));
+    }
+
+    #[test]
+    fn test_invalid_transitions() {
+        use SubscriptionStatusCode::*;
+
+        // Cannot go backward.
+        assert!(!Active.can_transition_to(Requested));
+        assert!(!Error.can_transition_to(Requested));
+        assert!(!Off.can_transition_to(Requested));
+
+        // Off is terminal (cannot transition anywhere).
+        assert!(!Off.can_transition_to(Active));
+        assert!(!Off.can_transition_to(Error));
+        assert!(!Off.can_transition_to(Off));
+
+        // Cannot stay in same state.
+        assert!(!Requested.can_transition_to(Requested));
+        assert!(!Active.can_transition_to(Active));
+    }
+
+    #[test]
+    fn test_fhir_str_roundtrip() {
+        for status in [
+            SubscriptionStatusCode::Requested,
+            SubscriptionStatusCode::Active,
+            SubscriptionStatusCode::Error,
+            SubscriptionStatusCode::Off,
+        ] {
+            let s = status.as_fhir_str();
+            let parsed = SubscriptionStatusCode::from_fhir_str(s).unwrap();
+            assert_eq!(parsed, status);
+        }
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(SubscriptionStatusCode::Active.to_string(), "active");
+        assert_eq!(SubscriptionStatusCode::Error.to_string(), "error");
+    }
+
+    #[test]
+    fn test_from_fhir_str_invalid() {
+        assert!(SubscriptionStatusCode::from_fhir_str("invalid").is_none());
+        assert!(SubscriptionStatusCode::from_fhir_str("").is_none());
+    }
+}

--- a/crates/subscriptions/src/notification/builder.rs
+++ b/crates/subscriptions/src/notification/builder.rs
@@ -1,0 +1,263 @@
+//! Notification bundle builder.
+//!
+//! Shared logic for constructing notification bundles across FHIR versions.
+
+use chrono::Utc;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::error::SubscriptionError;
+use crate::manager::{ActiveSubscription, PayloadContent};
+use crate::notification::{NotificationEventData, NotificationType};
+
+/// Builds notification bundles for a subscription.
+pub struct NotificationBundleBuilder<'a> {
+    subscription: &'a ActiveSubscription,
+    notification_type: NotificationType,
+    base_url: &'a str,
+}
+
+impl<'a> NotificationBundleBuilder<'a> {
+    pub fn new(
+        subscription: &'a ActiveSubscription,
+        notification_type: NotificationType,
+        base_url: &'a str,
+    ) -> Self {
+        Self {
+            subscription,
+            notification_type,
+            base_url,
+        }
+    }
+
+    /// Build an R4 backport notification bundle.
+    ///
+    /// - Bundle type: `history`
+    /// - First entry: `Parameters` resource (backport SubscriptionStatus)
+    #[cfg(feature = "R4")]
+    pub fn build_r4(
+        &self,
+        events: &[NotificationEventData],
+        resources: &[serde_json::Value],
+    ) -> Result<serde_json::Value, SubscriptionError> {
+        let mut entries = Vec::new();
+
+        // Build the SubscriptionStatus as a Parameters resource.
+        let status_parameters = self.build_r4_status_parameters(events);
+        entries.push(json!({
+            "fullUrl": format!("urn:uuid:{}", Uuid::new_v4()),
+            "resource": status_parameters,
+            "request": {
+                "method": "GET",
+                "url": format!("Subscription/{}/$status", self.subscription.id)
+            },
+            "response": {
+                "status": "200"
+            }
+        }));
+
+        // Add payload entries.
+        self.add_payload_entries(&mut entries, events, resources);
+
+        Ok(json!({
+            "resourceType": "Bundle",
+            "id": Uuid::new_v4().to_string(),
+            "type": "history",
+            "timestamp": Utc::now().to_rfc3339(),
+            "entry": entries
+        }))
+    }
+
+    /// Build an R4 backport SubscriptionStatus as a Parameters resource.
+    #[cfg(feature = "R4")]
+    fn build_r4_status_parameters(&self, events: &[NotificationEventData]) -> serde_json::Value {
+        let mut parameters = vec![
+            json!({
+                "name": "subscription",
+                "valueReference": {
+                    "reference": format!("Subscription/{}", self.subscription.id)
+                }
+            }),
+            json!({
+                "name": "topic",
+                "valueCanonical": self.subscription.topic_url
+            }),
+            json!({
+                "name": "status",
+                "valueCode": self.subscription.status.as_fhir_str()
+            }),
+            json!({
+                "name": "type",
+                "valueCode": self.notification_type.as_fhir_str()
+            }),
+            json!({
+                "name": "events-since-subscription-start",
+                "valueString": self.subscription.events_since_start.to_string()
+            }),
+        ];
+
+        // Add notification-event parts for event notifications.
+        for event in events {
+            let event_parts = vec![
+                json!({
+                    "name": "event-number",
+                    "valueString": event.event_number.to_string()
+                }),
+                json!({
+                    "name": "timestamp",
+                    "valueInstant": event.timestamp.to_rfc3339()
+                }),
+                json!({
+                    "name": "focus",
+                    "valueReference": {
+                        "reference": &event.focus_reference
+                    }
+                }),
+            ];
+
+            parameters.push(json!({
+                "name": "notification-event",
+                "part": event_parts
+            }));
+        }
+
+        json!({
+            "resourceType": "Parameters",
+            "parameter": parameters
+        })
+    }
+
+    /// Build a native notification bundle (R4B, R5, R6).
+    ///
+    /// - R4B: Bundle type `history`
+    /// - R5/R6: Bundle type `subscription-notification`
+    /// - First entry: native `SubscriptionStatus` resource
+    pub fn build_native(
+        &self,
+        events: &[NotificationEventData],
+        resources: &[serde_json::Value],
+    ) -> Result<serde_json::Value, SubscriptionError> {
+        let mut entries = Vec::new();
+
+        // Build the native SubscriptionStatus resource.
+        let status = self.build_native_status(events);
+        entries.push(json!({
+            "fullUrl": format!("urn:uuid:{}", Uuid::new_v4()),
+            "resource": status,
+            "request": {
+                "method": "GET",
+                "url": format!("Subscription/{}/$status", self.subscription.id)
+            },
+            "response": {
+                "status": "200"
+            }
+        }));
+
+        // Add payload entries.
+        self.add_payload_entries(&mut entries, events, resources);
+
+        let bundle_type = self.bundle_type();
+
+        Ok(json!({
+            "resourceType": "Bundle",
+            "id": Uuid::new_v4().to_string(),
+            "type": bundle_type,
+            "timestamp": Utc::now().to_rfc3339(),
+            "entry": entries
+        }))
+    }
+
+    /// Build a native SubscriptionStatus resource.
+    fn build_native_status(&self, events: &[NotificationEventData]) -> serde_json::Value {
+        let mut notification_events = Vec::new();
+        for event in events {
+            notification_events.push(json!({
+                "eventNumber": event.event_number.to_string(),
+                "timestamp": event.timestamp.to_rfc3339(),
+                "focus": {
+                    "reference": &event.focus_reference
+                }
+            }));
+        }
+
+        let mut status = json!({
+            "resourceType": "SubscriptionStatus",
+            "status": self.subscription.status.as_fhir_str(),
+            "type": self.notification_type.as_fhir_str(),
+            "eventsSinceSubscriptionStart": self.subscription.events_since_start.to_string(),
+            "subscription": {
+                "reference": format!("Subscription/{}", self.subscription.id)
+            },
+            "topic": self.subscription.topic_url
+        });
+
+        if !notification_events.is_empty() {
+            status["notificationEvent"] = json!(notification_events);
+        }
+
+        status
+    }
+
+    /// Add payload entries based on the subscription's payload content level.
+    fn add_payload_entries(
+        &self,
+        entries: &mut Vec<serde_json::Value>,
+        events: &[NotificationEventData],
+        resources: &[serde_json::Value],
+    ) {
+        match self.subscription.channel.payload_content {
+            PayloadContent::Empty => {
+                // No additional entries.
+            }
+            PayloadContent::IdOnly => {
+                for event in events {
+                    entries.push(json!({
+                        "fullUrl": format!("{}/{}", self.base_url, event.focus_reference),
+                        "request": {
+                            "method": "GET",
+                            "url": &event.focus_reference
+                        },
+                        "response": {
+                            "status": "200"
+                        }
+                    }));
+                }
+            }
+            PayloadContent::FullResource => {
+                for (i, event) in events.iter().enumerate() {
+                    let mut entry = json!({
+                        "fullUrl": format!("{}/{}", self.base_url, event.focus_reference),
+                        "request": {
+                            "method": "GET",
+                            "url": &event.focus_reference
+                        },
+                        "response": {
+                            "status": "200"
+                        }
+                    });
+
+                    if let Some(resource) = resources.get(i) {
+                        entry["resource"] = resource.clone();
+                    }
+
+                    entries.push(entry);
+                }
+            }
+        }
+    }
+
+    /// Returns the Bundle type based on FHIR version.
+    fn bundle_type(&self) -> &'static str {
+        match self.subscription.fhir_version {
+            #[cfg(feature = "R4")]
+            helios_fhir::FhirVersion::R4 => "history",
+
+            #[cfg(feature = "R4B")]
+            helios_fhir::FhirVersion::R4B => "history",
+
+            // R5, R6 use the new bundle type.
+            #[allow(unreachable_patterns)]
+            _ => "subscription-notification",
+        }
+    }
+}

--- a/crates/subscriptions/src/notification/mod.rs
+++ b/crates/subscriptions/src/notification/mod.rs
@@ -1,0 +1,269 @@
+//! Notification builder.
+//!
+//! Constructs FHIR notification bundles for subscription events. This is the
+//! primary point of version-specific divergence:
+//!
+//! - **R4**: Bundle(type=history) with SubscriptionStatus as Parameters (backport IG)
+//! - **R4B**: Bundle(type=history) with native SubscriptionStatus
+//! - **R5**: Bundle(type=subscription-notification) with native SubscriptionStatus
+//! - **R6**: Follows R5 model with refinements
+
+mod builder;
+
+use chrono::{DateTime, Utc};
+use helios_fhir::FhirVersion;
+
+use crate::error::SubscriptionError;
+use crate::manager::ActiveSubscription;
+
+pub use builder::NotificationBundleBuilder;
+
+/// The type of notification being sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationType {
+    /// Initial connection verification.
+    Handshake,
+    /// Periodic keep-alive.
+    Heartbeat,
+    /// A resource event matched the subscription.
+    EventNotification,
+}
+
+impl NotificationType {
+    pub fn as_fhir_str(&self) -> &'static str {
+        match self {
+            Self::Handshake => "handshake",
+            Self::Heartbeat => "heartbeat",
+            Self::EventNotification => "event-notification",
+        }
+    }
+}
+
+/// Metadata about a notification event.
+#[derive(Debug, Clone)]
+pub struct NotificationEventData {
+    /// Monotonically increasing event number.
+    pub event_number: u64,
+    /// When the event occurred.
+    pub timestamp: DateTime<Utc>,
+    /// Reference to the focus resource (e.g., "Encounter/123").
+    pub focus_reference: String,
+}
+
+/// Builds a notification bundle for a subscription.
+///
+/// Dispatches to the appropriate version-specific builder based on the
+/// subscription's FHIR version.
+pub fn build_notification(
+    subscription: &ActiveSubscription,
+    notification_type: NotificationType,
+    events: &[NotificationEventData],
+    resources: &[serde_json::Value],
+    base_url: &str,
+) -> Result<serde_json::Value, SubscriptionError> {
+    let builder = NotificationBundleBuilder::new(subscription, notification_type, base_url);
+
+    match subscription.fhir_version {
+        #[cfg(feature = "R4")]
+        FhirVersion::R4 => builder.build_r4(events, resources),
+
+        // R4B, R5, R6 all use native SubscriptionStatus with minor differences.
+        #[allow(unreachable_patterns)]
+        _ => builder.build_native(events, resources),
+    }
+}
+
+/// Builds a handshake notification for a newly activated subscription.
+pub fn build_handshake(
+    subscription: &ActiveSubscription,
+    base_url: &str,
+) -> Result<serde_json::Value, SubscriptionError> {
+    build_notification(
+        subscription,
+        NotificationType::Handshake,
+        &[],
+        &[],
+        base_url,
+    )
+}
+
+/// Builds a heartbeat notification.
+pub fn build_heartbeat(
+    subscription: &ActiveSubscription,
+    base_url: &str,
+) -> Result<serde_json::Value, SubscriptionError> {
+    build_notification(
+        subscription,
+        NotificationType::Heartbeat,
+        &[],
+        &[],
+        base_url,
+    )
+}
+
+/// Builds an event notification for a matched resource event.
+pub fn build_event_notification(
+    subscription: &ActiveSubscription,
+    event_data: NotificationEventData,
+    resource: Option<&serde_json::Value>,
+    base_url: &str,
+) -> Result<serde_json::Value, SubscriptionError> {
+    let events = vec![event_data];
+    let resources: Vec<serde_json::Value> = match resource {
+        Some(r) => vec![r.clone()],
+        None => vec![],
+    };
+    build_notification(
+        subscription,
+        NotificationType::EventNotification,
+        &events,
+        &resources,
+        base_url,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manager::{ChannelConfig, ChannelType, PayloadContent, SubscriptionStatusCode};
+    use chrono::Utc;
+    use serde_json::json;
+
+    fn test_subscription(payload: PayloadContent) -> ActiveSubscription {
+        ActiveSubscription {
+            id: "sub-1".to_string(),
+            topic_url: "http://example.org/topic/encounter-start".to_string(),
+            status: SubscriptionStatusCode::Active,
+            channel: ChannelConfig {
+                channel_type: ChannelType::RestHook,
+                endpoint: Some("https://example.com/webhook".to_string()),
+                payload_mime_type: Some("application/fhir+json".to_string()),
+                payload_content: payload,
+                headers: vec![],
+                heartbeat_period: None,
+                timeout: None,
+                max_count: None,
+            },
+            filters: vec![],
+            fhir_version: FhirVersion::default(),
+            events_since_start: 5,
+            consecutive_failures: 0,
+            tenant_id: "test-tenant".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_handshake_notification() {
+        let sub = test_subscription(PayloadContent::IdOnly);
+        let bundle = build_handshake(&sub, "http://localhost:8080").unwrap();
+
+        assert_eq!(bundle["resourceType"], "Bundle");
+        // Should have exactly one entry (the status).
+        let entries = bundle["entry"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn test_heartbeat_notification() {
+        let sub = test_subscription(PayloadContent::Empty);
+        let bundle = build_heartbeat(&sub, "http://localhost:8080").unwrap();
+
+        assert_eq!(bundle["resourceType"], "Bundle");
+        let entries = bundle["entry"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn test_event_notification_empty_payload() {
+        let sub = test_subscription(PayloadContent::Empty);
+        let event = NotificationEventData {
+            event_number: 6,
+            timestamp: Utc::now(),
+            focus_reference: "Encounter/123".to_string(),
+        };
+
+        let bundle = build_event_notification(&sub, event, None, "http://localhost:8080").unwrap();
+
+        let entries = bundle["entry"].as_array().unwrap();
+        // Only the status entry, no resource entries for empty payload.
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn test_event_notification_id_only_payload() {
+        let sub = test_subscription(PayloadContent::IdOnly);
+        let event = NotificationEventData {
+            event_number: 6,
+            timestamp: Utc::now(),
+            focus_reference: "Encounter/123".to_string(),
+        };
+
+        let resource = json!({"resourceType": "Encounter", "id": "123"});
+        let bundle =
+            build_event_notification(&sub, event, Some(&resource), "http://localhost:8080")
+                .unwrap();
+
+        let entries = bundle["entry"].as_array().unwrap();
+        // Status entry + id-only entry.
+        assert_eq!(entries.len(), 2);
+
+        // The id-only entry should have fullUrl and request but no resource.
+        let id_entry = &entries[1];
+        assert!(id_entry.get("fullUrl").is_some());
+        assert!(id_entry.get("request").is_some());
+        assert!(id_entry.get("resource").is_none());
+    }
+
+    #[test]
+    fn test_event_notification_full_resource_payload() {
+        let sub = test_subscription(PayloadContent::FullResource);
+        let event = NotificationEventData {
+            event_number: 6,
+            timestamp: Utc::now(),
+            focus_reference: "Encounter/123".to_string(),
+        };
+
+        let resource = json!({"resourceType": "Encounter", "id": "123", "status": "in-progress"});
+        let bundle =
+            build_event_notification(&sub, event, Some(&resource), "http://localhost:8080")
+                .unwrap();
+
+        let entries = bundle["entry"].as_array().unwrap();
+        // Status entry + full resource entry.
+        assert_eq!(entries.len(), 2);
+
+        // The full resource entry should contain the resource.
+        let resource_entry = &entries[1];
+        assert!(resource_entry.get("fullUrl").is_some());
+        assert!(resource_entry.get("resource").is_some());
+        assert_eq!(resource_entry["resource"]["id"], "123");
+    }
+
+    #[cfg(feature = "R4")]
+    #[test]
+    fn test_r4_notification_uses_parameters() {
+        let mut sub = test_subscription(PayloadContent::IdOnly);
+        sub.fhir_version = FhirVersion::R4;
+
+        let bundle = build_handshake(&sub, "http://localhost:8080").unwrap();
+
+        // R4: Bundle type is "history".
+        assert_eq!(bundle["type"], "history");
+
+        // First entry should be a Parameters resource.
+        let status_entry = &bundle["entry"].as_array().unwrap()[0];
+        let status_resource = &status_entry["resource"];
+        assert_eq!(status_resource["resourceType"], "Parameters");
+    }
+
+    #[test]
+    fn test_native_notification_bundle_type() {
+        let sub = test_subscription(PayloadContent::IdOnly);
+        let bundle = build_handshake(&sub, "http://localhost:8080").unwrap();
+
+        // For the default version (R4 with backport), type is "history".
+        // For R5+, type would be "subscription-notification".
+        #[cfg(feature = "R4")]
+        assert_eq!(bundle["type"], "history");
+    }
+}

--- a/crates/subscriptions/src/topics/mod.rs
+++ b/crates/subscriptions/src/topics/mod.rs
@@ -1,0 +1,568 @@
+//! Subscription topic registry.
+//!
+//! Manages `SubscriptionTopic` definitions and evaluates whether resource events
+//! match a topic's triggers.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use crate::error::SubscriptionError;
+use crate::event::ResourceEventType;
+
+/// A version-agnostic representation of a `SubscriptionTopic`.
+#[derive(Debug, Clone)]
+pub struct TopicDefinition {
+    /// The canonical URL of the topic (e.g., `http://example.org/topic/encounter-start`).
+    pub canonical_url: String,
+
+    /// Human-readable title.
+    pub title: Option<String>,
+
+    /// Resource triggers that define when this topic fires.
+    pub resource_triggers: Vec<ResourceTrigger>,
+
+    /// Filters that subscribers can use to narrow which events they receive.
+    pub can_filter_by: Vec<FilterDefinition>,
+
+    /// Notification shape: which resource types may appear in notifications.
+    pub notification_shape: Vec<NotificationShape>,
+}
+
+/// A trigger condition defined by a topic.
+#[derive(Debug, Clone)]
+pub struct ResourceTrigger {
+    /// The resource type this trigger monitors (e.g., "Encounter", "Observation").
+    pub resource_type: String,
+
+    /// Which interaction types trigger this (create, update, delete).
+    pub interactions: Vec<ResourceEventType>,
+
+    /// Optional FHIRPath expression for additional trigger criteria.
+    pub fhirpath_criteria: Option<String>,
+}
+
+/// Defines a filter parameter that subscribers can use.
+#[derive(Debug, Clone)]
+pub struct FilterDefinition {
+    /// The resource type this filter applies to.
+    pub resource_type: Option<String>,
+
+    /// The filter parameter name (often a FHIR search parameter name).
+    pub filter_parameter: String,
+
+    /// Supported comparators (e.g., "eq", "in", "gt").
+    pub comparators: Vec<String>,
+
+    /// Supported modifiers (e.g., "missing", "exact").
+    pub modifiers: Vec<String>,
+}
+
+/// Defines the shape of notifications for a topic.
+#[derive(Debug, Clone)]
+pub struct NotificationShape {
+    /// The resource type included in notifications.
+    pub resource_type: String,
+
+    /// Include references to follow.
+    pub include: Vec<String>,
+}
+
+/// Describes a topic whose trigger matched a resource event.
+#[derive(Debug, Clone)]
+pub struct TopicMatch {
+    /// Canonical URL of the matching topic.
+    pub topic_url: String,
+
+    /// The focus resource type that triggered the match.
+    pub focus_resource_type: String,
+}
+
+/// Registry for subscription topics.
+///
+/// Stores topic definitions and evaluates which topics match a given
+/// resource event.
+pub struct InMemoryTopicRegistry {
+    /// Topics keyed by canonical URL.
+    topics: RwLock<HashMap<String, TopicDefinition>>,
+}
+
+impl InMemoryTopicRegistry {
+    /// Creates an empty topic registry.
+    pub fn new() -> Self {
+        Self {
+            topics: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Registers a topic definition.
+    pub fn add_topic(&self, topic: TopicDefinition) {
+        let mut topics = self.topics.write().unwrap();
+        topics.insert(topic.canonical_url.clone(), topic);
+    }
+
+    /// Removes a topic by canonical URL.
+    pub fn remove_topic(&self, canonical_url: &str) -> bool {
+        let mut topics = self.topics.write().unwrap();
+        topics.remove(canonical_url).is_some()
+    }
+
+    /// Returns all registered topic canonical URLs.
+    pub fn list_topics(&self) -> Vec<String> {
+        let topics = self.topics.read().unwrap();
+        topics.keys().cloned().collect()
+    }
+
+    /// Returns a topic definition by canonical URL.
+    pub fn get_topic(&self, canonical_url: &str) -> Option<TopicDefinition> {
+        let topics = self.topics.read().unwrap();
+        topics.get(canonical_url).cloned()
+    }
+
+    /// Evaluates which topics match a resource event.
+    ///
+    /// Checks all registered topics' resource triggers against the event's
+    /// resource type and interaction type.
+    pub fn matching_topics(
+        &self,
+        resource_type: &str,
+        event_type: ResourceEventType,
+    ) -> Vec<TopicMatch> {
+        let topics = self.topics.read().unwrap();
+        let mut matches = Vec::new();
+
+        for topic in topics.values() {
+            for trigger in &topic.resource_triggers {
+                if trigger.resource_type == resource_type
+                    && trigger.interactions.contains(&event_type)
+                {
+                    matches.push(TopicMatch {
+                        topic_url: topic.canonical_url.clone(),
+                        focus_resource_type: trigger.resource_type.clone(),
+                    });
+                    // Only match once per topic even if multiple triggers match.
+                    break;
+                }
+            }
+        }
+
+        matches
+    }
+
+    /// Parses a `SubscriptionTopic` FHIR resource (JSON) into a [`TopicDefinition`].
+    ///
+    /// Works for R4B, R5, and R6 native `SubscriptionTopic` resources.
+    pub fn parse_topic_resource(
+        resource: &serde_json::Value,
+    ) -> Result<TopicDefinition, SubscriptionError> {
+        let canonical_url = resource
+            .get("url")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| SubscriptionError::InvalidSubscription {
+                message: "SubscriptionTopic missing 'url' field".to_string(),
+            })?
+            .to_string();
+
+        let title = resource
+            .get("title")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let resource_triggers = parse_resource_triggers(resource)?;
+        let can_filter_by = parse_can_filter_by(resource);
+        let notification_shape = parse_notification_shape(resource);
+
+        Ok(TopicDefinition {
+            canonical_url,
+            title,
+            resource_triggers,
+            can_filter_by,
+            notification_shape,
+        })
+    }
+}
+
+impl Default for InMemoryTopicRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Parse `resourceTrigger` array from a SubscriptionTopic JSON resource.
+fn parse_resource_triggers(
+    resource: &serde_json::Value,
+) -> Result<Vec<ResourceTrigger>, SubscriptionError> {
+    let triggers = match resource.get("resourceTrigger").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut result = Vec::new();
+    for trigger in triggers {
+        let resource_type = trigger
+            .get("resource")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| SubscriptionError::InvalidSubscription {
+                message: "resourceTrigger missing 'resource' field".to_string(),
+            })?
+            .to_string();
+
+        let interactions = parse_interactions(trigger);
+
+        let fhirpath_criteria = trigger
+            .get("fhirPathCriteria")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        result.push(ResourceTrigger {
+            resource_type,
+            interactions,
+            fhirpath_criteria,
+        });
+    }
+
+    Ok(result)
+}
+
+/// Parse `supportedInteraction` array from a trigger definition.
+fn parse_interactions(trigger: &serde_json::Value) -> Vec<ResourceEventType> {
+    let interactions = match trigger
+        .get("supportedInteraction")
+        .and_then(|v| v.as_array())
+    {
+        Some(arr) => arr,
+        None => {
+            // Default to all interactions if not specified.
+            return vec![
+                ResourceEventType::Create,
+                ResourceEventType::Update,
+                ResourceEventType::Delete,
+            ];
+        }
+    };
+
+    interactions
+        .iter()
+        .filter_map(|v| match v.as_str()? {
+            "create" => Some(ResourceEventType::Create),
+            "update" => Some(ResourceEventType::Update),
+            "delete" => Some(ResourceEventType::Delete),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Parse `canFilterBy` array from a SubscriptionTopic JSON resource.
+fn parse_can_filter_by(resource: &serde_json::Value) -> Vec<FilterDefinition> {
+    let filters = match resource.get("canFilterBy").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+
+    filters
+        .iter()
+        .filter_map(|f| {
+            let filter_parameter = f.get("filterParameter")?.as_str()?.to_string();
+            let resource_type = f.get("resource").and_then(|v| v.as_str()).map(String::from);
+
+            let comparators = f
+                .get("comparator")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let modifiers = f
+                .get("modifier")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            Some(FilterDefinition {
+                resource_type,
+                filter_parameter,
+                comparators,
+                modifiers,
+            })
+        })
+        .collect()
+}
+
+/// Parse `notificationShape` array from a SubscriptionTopic JSON resource.
+fn parse_notification_shape(resource: &serde_json::Value) -> Vec<NotificationShape> {
+    let shapes = match resource.get("notificationShape").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+
+    shapes
+        .iter()
+        .filter_map(|s| {
+            let resource_type = s.get("resource")?.as_str()?.to_string();
+            let include = s
+                .get("include")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            Some(NotificationShape {
+                resource_type,
+                include,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_encounter_topic() -> TopicDefinition {
+        TopicDefinition {
+            canonical_url: "http://example.org/topic/encounter-start".to_string(),
+            title: Some("Encounter Start".to_string()),
+            resource_triggers: vec![ResourceTrigger {
+                resource_type: "Encounter".to_string(),
+                interactions: vec![ResourceEventType::Create],
+                fhirpath_criteria: None,
+            }],
+            can_filter_by: vec![FilterDefinition {
+                resource_type: Some("Encounter".to_string()),
+                filter_parameter: "patient".to_string(),
+                comparators: vec!["eq".to_string()],
+                modifiers: vec![],
+            }],
+            notification_shape: vec![NotificationShape {
+                resource_type: "Encounter".to_string(),
+                include: vec!["Encounter:patient".to_string()],
+            }],
+        }
+    }
+
+    fn sample_observation_topic() -> TopicDefinition {
+        TopicDefinition {
+            canonical_url: "http://example.org/topic/new-lab-result".to_string(),
+            title: Some("New Lab Result".to_string()),
+            resource_triggers: vec![ResourceTrigger {
+                resource_type: "Observation".to_string(),
+                interactions: vec![ResourceEventType::Create, ResourceEventType::Update],
+                fhirpath_criteria: None,
+            }],
+            can_filter_by: vec![FilterDefinition {
+                resource_type: Some("Observation".to_string()),
+                filter_parameter: "code".to_string(),
+                comparators: vec!["eq".to_string(), "in".to_string()],
+                modifiers: vec![],
+            }],
+            notification_shape: vec![],
+        }
+    }
+
+    #[test]
+    fn test_add_and_list_topics() {
+        let registry = InMemoryTopicRegistry::new();
+        assert!(registry.list_topics().is_empty());
+
+        registry.add_topic(sample_encounter_topic());
+        let topics = registry.list_topics();
+        assert_eq!(topics.len(), 1);
+        assert!(topics.contains(&"http://example.org/topic/encounter-start".to_string()));
+    }
+
+    #[test]
+    fn test_get_topic() {
+        let registry = InMemoryTopicRegistry::new();
+        registry.add_topic(sample_encounter_topic());
+
+        let topic = registry
+            .get_topic("http://example.org/topic/encounter-start")
+            .unwrap();
+        assert_eq!(topic.title.unwrap(), "Encounter Start");
+        assert_eq!(topic.resource_triggers.len(), 1);
+
+        assert!(
+            registry
+                .get_topic("http://example.org/nonexistent")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_remove_topic() {
+        let registry = InMemoryTopicRegistry::new();
+        registry.add_topic(sample_encounter_topic());
+
+        assert!(registry.remove_topic("http://example.org/topic/encounter-start"));
+        assert!(registry.list_topics().is_empty());
+
+        assert!(!registry.remove_topic("http://example.org/nonexistent"));
+    }
+
+    #[test]
+    fn test_matching_topics_by_resource_type_and_interaction() {
+        let registry = InMemoryTopicRegistry::new();
+        registry.add_topic(sample_encounter_topic());
+        registry.add_topic(sample_observation_topic());
+
+        // Encounter create should match encounter topic.
+        let matches = registry.matching_topics("Encounter", ResourceEventType::Create);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0].topic_url,
+            "http://example.org/topic/encounter-start"
+        );
+        assert_eq!(matches[0].focus_resource_type, "Encounter");
+
+        // Observation create should match observation topic.
+        let matches = registry.matching_topics("Observation", ResourceEventType::Create);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0].topic_url,
+            "http://example.org/topic/new-lab-result"
+        );
+
+        // Observation update should also match.
+        let matches = registry.matching_topics("Observation", ResourceEventType::Update);
+        assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn test_no_match_for_wrong_resource_type() {
+        let registry = InMemoryTopicRegistry::new();
+        registry.add_topic(sample_encounter_topic());
+
+        let matches = registry.matching_topics("Patient", ResourceEventType::Create);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_no_match_for_wrong_interaction() {
+        let registry = InMemoryTopicRegistry::new();
+        registry.add_topic(sample_encounter_topic());
+
+        // Encounter topic only triggers on create, not update or delete.
+        let matches = registry.matching_topics("Encounter", ResourceEventType::Update);
+        assert!(matches.is_empty());
+
+        let matches = registry.matching_topics("Encounter", ResourceEventType::Delete);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_topics_matching_same_event() {
+        let registry = InMemoryTopicRegistry::new();
+
+        // Add two topics that both trigger on Observation create.
+        registry.add_topic(sample_observation_topic());
+        registry.add_topic(TopicDefinition {
+            canonical_url: "http://example.org/topic/vital-signs".to_string(),
+            title: Some("Vital Signs".to_string()),
+            resource_triggers: vec![ResourceTrigger {
+                resource_type: "Observation".to_string(),
+                interactions: vec![ResourceEventType::Create],
+                fhirpath_criteria: None,
+            }],
+            can_filter_by: vec![],
+            notification_shape: vec![],
+        });
+
+        let matches = registry.matching_topics("Observation", ResourceEventType::Create);
+        assert_eq!(matches.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_topic_resource() {
+        let topic_json = json!({
+            "resourceType": "SubscriptionTopic",
+            "url": "http://example.org/topic/patient-admit",
+            "title": "Patient Admission",
+            "resourceTrigger": [{
+                "resource": "Encounter",
+                "supportedInteraction": ["create", "update"],
+                "fhirPathCriteria": "(%previous.empty() | (%previous.status != 'in-progress')) and (%current.status = 'in-progress')"
+            }],
+            "canFilterBy": [{
+                "resource": "Encounter",
+                "filterParameter": "patient",
+                "comparator": ["eq"]
+            }],
+            "notificationShape": [{
+                "resource": "Encounter",
+                "include": ["Encounter:patient", "Encounter:location"]
+            }]
+        });
+
+        let topic = InMemoryTopicRegistry::parse_topic_resource(&topic_json).unwrap();
+        assert_eq!(
+            topic.canonical_url,
+            "http://example.org/topic/patient-admit"
+        );
+        assert_eq!(topic.title.unwrap(), "Patient Admission");
+
+        assert_eq!(topic.resource_triggers.len(), 1);
+        let trigger = &topic.resource_triggers[0];
+        assert_eq!(trigger.resource_type, "Encounter");
+        assert_eq!(trigger.interactions.len(), 2);
+        assert!(trigger.interactions.contains(&ResourceEventType::Create));
+        assert!(trigger.interactions.contains(&ResourceEventType::Update));
+        assert!(trigger.fhirpath_criteria.is_some());
+
+        assert_eq!(topic.can_filter_by.len(), 1);
+        assert_eq!(topic.can_filter_by[0].filter_parameter, "patient");
+
+        assert_eq!(topic.notification_shape.len(), 1);
+        assert_eq!(topic.notification_shape[0].include.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_topic_resource_missing_url() {
+        let topic_json = json!({
+            "resourceType": "SubscriptionTopic",
+            "title": "No URL"
+        });
+
+        let result = InMemoryTopicRegistry::parse_topic_resource(&topic_json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_topic_resource_minimal() {
+        let topic_json = json!({
+            "resourceType": "SubscriptionTopic",
+            "url": "http://example.org/topic/minimal"
+        });
+
+        let topic = InMemoryTopicRegistry::parse_topic_resource(&topic_json).unwrap();
+        assert_eq!(topic.canonical_url, "http://example.org/topic/minimal");
+        assert!(topic.resource_triggers.is_empty());
+        assert!(topic.can_filter_by.is_empty());
+        assert!(topic.notification_shape.is_empty());
+    }
+
+    #[test]
+    fn test_parse_topic_default_interactions() {
+        // When supportedInteraction is not specified, all interactions should be assumed.
+        let topic_json = json!({
+            "resourceType": "SubscriptionTopic",
+            "url": "http://example.org/topic/all-interactions",
+            "resourceTrigger": [{
+                "resource": "Patient"
+            }]
+        });
+
+        let topic = InMemoryTopicRegistry::parse_topic_resource(&topic_json).unwrap();
+        let trigger = &topic.resource_triggers[0];
+        assert_eq!(trigger.interactions.len(), 3);
+    }
+}

--- a/crates/subscriptions/tests/rest_hook_integration.rs
+++ b/crates/subscriptions/tests/rest_hook_integration.rs
@@ -1,0 +1,236 @@
+use chrono::Utc;
+use helios_fhir::FhirVersion;
+use helios_persistence::tenant::TenantId;
+use helios_subscriptions::manager::SubscriptionStatusCode;
+use helios_subscriptions::{
+    ResourceEvent, ResourceEventType, SubscriptionConfig, SubscriptionEngine, SubscriptionError,
+};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+const TENANT_ID: &str = "tenant-a";
+const TOPIC_URL: &str = "http://example.org/topic/encounter-start";
+
+fn topic_resource() -> Value {
+    json!({
+        "resourceType": "SubscriptionTopic",
+        "id": "topic-1",
+        "url": TOPIC_URL,
+        "status": "active",
+        "resourceTrigger": [{
+            "resource": "Encounter",
+            "supportedInteraction": ["create"]
+        }]
+    })
+}
+
+fn rest_hook_subscription_resource(endpoint: &str) -> Value {
+    json!({
+        "resourceType": "Subscription",
+        "id": "sub-rest-hook",
+        "status": "requested",
+        "criteria": TOPIC_URL,
+        "channel": {
+            "type": "rest-hook",
+            "endpoint": endpoint,
+            "payload": "application/fhir+json",
+            "header": ["Authorization: Bearer integration-token"]
+        }
+    })
+}
+
+fn message_channel_subscription_resource(endpoint: &str) -> Value {
+    json!({
+        "resourceType": "Subscription",
+        "id": "sub-message",
+        "status": "requested",
+        "criteria": TOPIC_URL,
+        "channel": {
+            "type": "message",
+            "endpoint": endpoint
+        }
+    })
+}
+
+fn topic_create_event() -> ResourceEvent {
+    ResourceEvent {
+        tenant_id: TenantId::new(TENANT_ID),
+        fhir_version: FhirVersion::default(),
+        resource_type: "SubscriptionTopic".to_string(),
+        resource_id: "topic-1".to_string(),
+        version_id: "1".to_string(),
+        event_type: ResourceEventType::Create,
+        resource: Some(topic_resource()),
+        previous_resource: None,
+        timestamp: Utc::now(),
+    }
+}
+
+fn subscription_create_event(subscription_resource: Value) -> ResourceEvent {
+    ResourceEvent {
+        tenant_id: TenantId::new(TENANT_ID),
+        fhir_version: FhirVersion::default(),
+        resource_type: "Subscription".to_string(),
+        resource_id: "sub-rest-hook".to_string(),
+        version_id: "1".to_string(),
+        event_type: ResourceEventType::Create,
+        resource: Some(subscription_resource),
+        previous_resource: None,
+        timestamp: Utc::now(),
+    }
+}
+
+fn encounter_create_event() -> ResourceEvent {
+    ResourceEvent {
+        tenant_id: TenantId::new(TENANT_ID),
+        fhir_version: FhirVersion::default(),
+        resource_type: "Encounter".to_string(),
+        resource_id: "enc-1".to_string(),
+        version_id: "1".to_string(),
+        event_type: ResourceEventType::Create,
+        resource: Some(json!({
+            "resourceType": "Encounter",
+            "id": "enc-1",
+            "status": "in-progress"
+        })),
+        previous_resource: None,
+        timestamp: Utc::now(),
+    }
+}
+
+fn header_value<'a>(request: &'a Request, name: &str) -> Option<&'a str> {
+    request
+        .headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+}
+
+fn notification_type_from_backport_bundle(bundle: &Value) -> Option<&str> {
+    let status_resource = bundle.get("entry")?.get(0)?.get("resource")?;
+    if status_resource.get("resourceType")?.as_str()? != "Parameters" {
+        return None;
+    }
+
+    status_resource
+        .get("parameter")?
+        .as_array()?
+        .iter()
+        .find_map(|parameter| {
+            let name = parameter.get("name")?.as_str()?;
+            if name == "type" {
+                parameter.get("valueCode")?.as_str()
+            } else {
+                None
+            }
+        })
+}
+
+#[tokio::test]
+async fn rest_hook_handshake_and_event_notifications_follow_backport_flow() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/webhook"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let config = SubscriptionConfig {
+        max_retries: 1,
+        ..Default::default()
+    };
+    let engine = SubscriptionEngine::new(config, "http://localhost:8080".to_string());
+
+    engine.on_resource_event(topic_create_event()).await;
+
+    let endpoint = format!("{}/webhook", server.uri());
+    engine
+        .on_resource_event(subscription_create_event(rest_hook_subscription_resource(
+            &endpoint,
+        )))
+        .await;
+
+    let registered = engine
+        .manager()
+        .get_subscription(TENANT_ID, "sub-rest-hook")
+        .expect("subscription should be registered");
+    assert_eq!(registered.status, SubscriptionStatusCode::Active);
+
+    engine.on_resource_event(encounter_create_event()).await;
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("should retrieve requests from mock server");
+    assert_eq!(requests.len(), 2, "expected handshake + event notification");
+
+    let mut observed_types = Vec::new();
+    for request in &requests {
+        assert_eq!(request.method.as_str(), "POST");
+        assert_eq!(request.url.path(), "/webhook");
+        assert_eq!(
+            header_value(request, "content-type"),
+            Some("application/fhir+json")
+        );
+        assert_eq!(
+            header_value(request, "authorization"),
+            Some("Bearer integration-token")
+        );
+
+        let body: Value =
+            serde_json::from_slice(&request.body).expect("request body should be JSON");
+        assert_eq!(body["resourceType"], "Bundle");
+        assert_eq!(body["type"], "history");
+
+        let notification_type = notification_type_from_backport_bundle(&body)
+            .expect("backport bundle should include a Parameters.type value");
+        observed_types.push(notification_type.to_string());
+
+        if notification_type == "event-notification" {
+            let entries = body["entry"]
+                .as_array()
+                .expect("bundle entry should be an array");
+            assert_eq!(
+                entries.len(),
+                2,
+                "id-only payload should include focus entry"
+            );
+            assert_eq!(entries[1]["request"]["url"], "Encounter/enc-1");
+        }
+    }
+
+    observed_types.sort();
+    assert_eq!(
+        observed_types,
+        vec!["event-notification".to_string(), "handshake".to_string()]
+    );
+
+    let updated = engine
+        .manager()
+        .get_subscription(TENANT_ID, "sub-rest-hook")
+        .expect("subscription should still be available");
+    assert_eq!(updated.events_since_start, 1);
+}
+
+#[tokio::test]
+async fn message_channel_is_rejected_when_only_rest_hook_is_supported() {
+    let engine = SubscriptionEngine::new(
+        SubscriptionConfig::default(),
+        "http://localhost:8080".to_string(),
+    );
+    engine.on_resource_event(topic_create_event()).await;
+
+    let resource = message_channel_subscription_resource("https://example.org/fhir");
+    let result =
+        engine
+            .manager()
+            .register(TENANT_ID, "sub-message", &resource, FhirVersion::default());
+
+    assert!(
+        matches!(
+            result,
+            Err(SubscriptionError::UnsupportedChannel { channel_type }) if channel_type == "message"
+        ),
+        "expected unsupported message channel error"
+    );
+}


### PR DESCRIPTION
## Summary

  Implements Phase 1 of the FHIR topic-based Subscriptions Framework as
  described in [Discussion
  #59](https://github.com/HeliosSoftware/hfs/discussions/59).

  This introduces a new `helios-subscriptions` crate and integrates it into the
  REST layer as an optional feature. The engine fires asynchronously after every
  resource write (fire-and-forget via `tokio::spawn`), mirroring the existing
  audit middleware pattern.

  R4 and R4B use the [Subscriptions R5 Backport
  IG](https://build.fhir.org/ig/HL7/fhir-subscription-backport-ig/);
  R5 and R6 use the native Subscriptions Framework.

  ---

  ## What's in this PR

  ### New crate: `helios-subscriptions`

  The engine decomposes into five concerns:

  **Topic Registry** (`src/topics/`)
  - `InMemoryTopicRegistry` backed by `RwLock<HashMap>` for concurrent read
  access
  - Parses `SubscriptionTopic` JSON (R5/R6 native) and `Basic` resources with
  backport extensions (R4)
  - Matches resource write events against topics by resource type and
  interaction type

  **Subscription Manager** (`src/manager/`)
  - `SubscriptionManager` backed by `DashMap<(tenant_id, subscription_id),
  ActiveSubscription>` for lock-free concurrent access
  - `SubscriptionStatusCode` state machine: `Requested → Active → Error → Off`
  with validated transitions
  - Version-aware JSON parsing: R4 reads the backport extension set
  (`backport-topic-canonical`, `backport-payload-content`,
  `backport-channel-type`, `backport-filter-criteria`); R5/R6 read native
  `topic`, `channelType`, `filterBy` fields

  **Event Evaluator** (`src/evaluator/`)
  - Matches `ResourceEvent` against active subscriptions via topic triggers and
  subscription filter criteria
  - Filter matching supports `code`, `category`, `patient`/`subject`,
  `identifier`, and direct field lookup
  - All maps are keyed by `(tenant_id, ...)` — subscriptions in different
  tenants never interact

  **Notification Builder** (`src/notification/`)
  - R4: `Bundle(type=history)` with `SubscriptionStatus` as a `Parameters`
  resource (backport IG profile)
  - R4B/R5/R6: `Bundle` with native `SubscriptionStatus` resource; R5/R6 use
  `type=subscription-notification`
  - Three payload content levels: `empty`, `id-only`, `full-resource`

  **Channel Dispatcher** (`src/channels/`)
  - `ChannelDispatcher` trait with `dispatch()` and `handshake()` methods
  - `DispatchResult` enum: `Success`, `RetryableError`, `PermanentError` —
  drives retry and status transition decisions

  **rest-hook channel** (`src/channels/rest_hook.rs`)
  - HTTP POST via `reqwest` with connection pooling
  - Custom header forwarding from subscription definition
  - TLS enforcement: `full-resource` payload rejected over non-HTTPS endpoints
  - Error classification: 2xx → Success, 4xx → PermanentError,
  5xx/timeout/connect → RetryableError

  **Subscription Engine** (`src/engine/`)
  - Orchestrates all five concerns; single entry point: `on_resource_event()`
  - Subscription lifecycle: `Subscription` writes trigger
  `register()`/`deregister()`; status `requested` triggers immediate handshake
  - Topic lifecycle: `SubscriptionTopic` writes refresh the topic registry
  - Exponential backoff retry with configurable initial delay, max delay, and
  backoff factor
  - Failure escalation: `consecutive_failures >= error_threshold` → `Error`; `>=
   off_threshold` → `Off`

  ### REST layer integration (`helios-rest`, feature: `subscriptions`)

  - `AppState` gains a feature-gated `subscription_engine:
  Option<Arc<SubscriptionEngine>>` field with `with_subscription_engine()`
  builder
  - `emit_subscription_event()` / `emit_delete_event()` helpers: construct
  `ResourceEvent` from handler context and spawn `engine.on_resource_event()`
  asynchronously
  - Event emission added to `create`, `update`, `delete`, and `patch` handlers
  - New routes: `GET /Subscription/{id}/$status` and `GET
  /Subscription/{id}/$events`
  - Engine auto-initializes from `HFS_SUBSCRIPTIONS_ENABLED=true` inside
  `create_app_with_auth()`

  ### `helios-hfs`

  - New `subscriptions` feature flag: `subscriptions =
  ["helios-rest/subscriptions", "dep:helios-subscriptions"]`

  ---

  ## Test Coverage

  89 unit tests across all five concerns:

  | Module | Tests |
  |--------|-------|
  | Topic Registry | 12 |
  | Subscription Manager (status, filters, parsing) | 22 |
  | Event Evaluator + filter matching | 18 |
  | Notification Builder (R4 + native) | 7 |
  | REST-hook channel (via wiremock) | 9 |
  | Subscription Engine (pipeline, retry, tenant isolation) | 7 |
  | Retry logic | 3 |
  | Event types | 1 |

  Plus a `rest_hook_integration` test that runs the full engine pipeline
  end-to-end against a live `wiremock` server: topic registration → subscription
   registration → handshake → resource write → notification delivery.

  ---

  ## Enabling

  ```bash
  # Build
  cargo build --bin hfs --features subscriptions

  # Run
  HFS_SUBSCRIPTIONS_ENABLED=true cargo run --bin hfs --features subscriptions

  ---
  Out of scope / follow-up phases

  - Phase 2: WebSocket channel ($get-ws-binding-token, /$ws upgrade endpoint)
  - Phase 3: Email channel (lettre + SMTP config)
  - Phase 4: FHIR Messaging channel (notification wrapped in
  Bundle(type=message))
  - Heartbeat delivery (field is stored; background task not yet implemented)
  - Subscription state persistence across restarts (currently in-memory only)
  - Batch/transaction entry-level subscription events
  - FHIRPath filter evaluation (Phase 1 uses direct JSON field matching)
  - capabilities.rs advertisement of $status operation and supported topics