### PR TITLE
ci(subscriptions): add external smoke workflow for rest-hook and websocket

### DIFF
--- a/.github/workflows/subscriptions-smoke.yml
+++ b/.github/workflows/subscriptions-smoke.yml
@@ -1,0 +1,398 @@
+name: HFS Subscriptions External Smoke
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 1
+  CARGO_PROFILE_DEV_DEBUG: 0
+  HFS_PORT: 18088
+  DOCKER_HOST: ${{ secrets.DOCKER_HOST }}
+  DOCKER_HOST_IP: ${{ secrets.DOCKER_HOST_IP }}
+  HFS_S3_BUCKET: ${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}
+
+jobs:
+  build:
+    name: Build HFS (subscriptions)
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Configure Rust to use LLD
+        run: |
+          mkdir -p ~/.cargo
+          rm -f ~/.cargo/config.toml
+          echo '[target.x86_64-unknown-linux-gnu]' >> ~/.cargo/config.toml
+          echo 'linker = "clang"' >> ~/.cargo/config.toml
+          echo 'rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,-zstack-size=8388608"]' >> ~/.cargo/config.toml
+
+      - name: Build HFS binary with subscriptions
+        run: cargo build -p helios-hfs --features R4,subscriptions,sqlite,elasticsearch,postgres,mongodb,s3
+
+      - name: Upload HFS binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: hfs-subscriptions-binary
+          path: target/debug/hfs
+          retention-days: 1
+
+  subscriptions-smoke:
+    name: Subscriptions Smoke (${{ matrix.backend }})
+    needs: build
+    runs-on: [self-hosted, Linux]
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        backend: [sqlite, sqlite-elasticsearch, postgres, mongodb, s3-elasticsearch]
+    env:
+      RESULTS_DIR: subscriptions-smoke-results/${{ matrix.backend }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download HFS binary
+        uses: actions/download-artifact@v4
+        with:
+          name: hfs-subscriptions-binary
+          path: target/debug
+
+      - name: Make executables available
+        run: |
+          chmod +x target/debug/hfs
+          chmod +x crates/hfs/tests/subscriptions/run_external_subscriptions_smoke.sh
+
+      - name: Determine runner and Docker host IP
+        run: |
+          RUNNER_IP=$(hostname -I | awk '{print $1}')
+          if [ -n "${DOCKER_HOST_IP:-}" ]; then
+            EFFECTIVE_DOCKER_HOST_IP="$DOCKER_HOST_IP"
+          else
+            EFFECTIVE_DOCKER_HOST_IP="$RUNNER_IP"
+          fi
+          echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
+          echo "DOCKER_HOST_IP=$EFFECTIVE_DOCKER_HOST_IP" >> $GITHUB_ENV
+          echo "Runner IP: $RUNNER_IP"
+          echo "Docker host IP: $EFFECTIVE_DOCKER_HOST_IP"
+
+      - name: Validate backend configuration
+        run: |
+          if [ "${{ matrix.backend }}" = "s3-elasticsearch" ] && [ -z "$HFS_S3_BUCKET" ]; then
+            echo "::error::s3-elasticsearch backend requires HFS_S3_BUCKET to be configured"
+            exit 1
+          fi
+
+      - name: Start Elasticsearch
+        if: matrix.backend == 'sqlite-elasticsearch' || matrix.backend == 's3-elasticsearch'
+        run: |
+          ES_CONTAINER="es-subscriptions-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+          docker run -d --name "$ES_CONTAINER" -p 0:9200 \
+            -e "discovery.type=single-node" \
+            -e "xpack.security.enabled=false" \
+            -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+            elasticsearch:8.15.0
+
+          echo "ES_CONTAINER=$ES_CONTAINER" >> $GITHUB_ENV
+
+          echo "Waiting for Elasticsearch to be ready..."
+          for i in {1..30}; do
+            ES_PORT=$(docker port "$ES_CONTAINER" 9200 2>/dev/null | head -1 | sed 's/.*://')
+            if [ -n "$ES_PORT" ]; then
+              if curl -sf "http://$DOCKER_HOST_IP:$ES_PORT/_cluster/health" > /dev/null 2>&1; then
+                echo "Elasticsearch is ready on port $ES_PORT"
+                echo "ES_PORT=$ES_PORT" >> $GITHUB_ENV
+                exit 0
+              fi
+            fi
+            echo "Attempt $i/30: Elasticsearch not ready yet..."
+            sleep 2
+          done
+
+          echo "Elasticsearch failed to start"
+          docker logs "$ES_CONTAINER"
+          exit 1
+
+      - name: Start PostgreSQL
+        if: matrix.backend == 'postgres'
+        run: |
+          PG_CONTAINER="pg-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}"
+          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker run -d --name "$PG_CONTAINER" -p 0:5432 \
+            -e POSTGRES_USER=helios \
+            -e POSTGRES_PASSWORD=helios \
+            -e POSTGRES_DB=helios \
+            postgres:16
+
+          echo "PG_CONTAINER=$PG_CONTAINER" >> $GITHUB_ENV
+
+          echo "Waiting for PostgreSQL to be ready..."
+          for i in {1..30}; do
+            if docker exec "$PG_CONTAINER" pg_isready -U helios > /dev/null 2>&1; then
+              PG_PORT=$(docker port "$PG_CONTAINER" 5432 | head -1 | sed 's/.*://')
+              if timeout 2 bash -c "cat < /dev/null > /dev/tcp/$DOCKER_HOST_IP/$PG_PORT" 2>/dev/null; then
+                echo "PostgreSQL is ready on port $PG_PORT"
+                echo "PG_PORT=$PG_PORT" >> $GITHUB_ENV
+                exit 0
+              fi
+            fi
+            echo "Attempt $i/30: PostgreSQL not ready yet..."
+            sleep 2
+          done
+
+          echo "PostgreSQL failed to start"
+          docker logs "$PG_CONTAINER"
+          exit 1
+
+      - name: Start MongoDB replica set
+        if: matrix.backend == 'mongodb'
+        run: |
+          MONGO_CONTAINER="mongo-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}"
+          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 --replSet rs0 --bind_ip_all
+
+          echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
+
+          READY=0
+          for i in {1..30}; do
+            if docker exec "$MONGO_CONTAINER" mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok' > /dev/null 2>&1; then
+              READY=1
+              break
+            fi
+            echo "Attempt $i/30: MongoDB not ready yet..."
+            sleep 2
+          done
+
+          if [ "$READY" -ne 1 ]; then
+            echo "MongoDB failed to start"
+            docker logs "$MONGO_CONTAINER"
+            exit 1
+          fi
+
+          docker exec "$MONGO_CONTAINER" mongosh --quiet --eval 'try { rs.status(); } catch (e) { rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "localhost:27017" }] }); }' > /dev/null 2>&1
+
+          echo "Waiting for MongoDB replica set primary..."
+          for i in {1..60}; do
+            PRIMARY_STATE=$(docker exec "$MONGO_CONTAINER" mongosh --quiet --eval 'try { rs.status().myState } catch (e) { 0 }' | tr -d '\r\n ')
+            if [ "$PRIMARY_STATE" = "1" ]; then
+              MONGO_PORT=$(docker port "$MONGO_CONTAINER" 27017 | head -1 | sed 's/.*://')
+              echo "MongoDB replica set is ready on port $MONGO_PORT"
+              echo "MONGO_PORT=$MONGO_PORT" >> $GITHUB_ENV
+              exit 0
+            fi
+            echo "Attempt $i/60: MongoDB replica set not primary yet..."
+            sleep 2
+          done
+
+          echo "MongoDB replica set failed to become primary"
+          docker logs "$MONGO_CONTAINER"
+          exit 1
+
+      - name: Configure AWS credentials
+        if: matrix.backend == 's3-elasticsearch'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
+
+      - name: Install AWS CLI
+        if: matrix.backend == 's3-elasticsearch'
+        run: |
+          if ! command -v aws &>/dev/null; then
+            if ! /tmp/aws-bin/aws --version &>/dev/null; then
+              curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+              unzip -qo /tmp/awscliv2.zip -d /tmp
+              /tmp/aws/install --install-dir /tmp/aws-cli --bin-dir /tmp/aws-bin --update
+              rm -rf /tmp/awscliv2.zip /tmp/aws
+            fi
+            echo "/tmp/aws-bin" >> $GITHUB_PATH
+          fi
+          aws --version 2>/dev/null || /tmp/aws-bin/aws --version
+
+      - name: Install websocat
+        run: |
+          if command -v websocat >/dev/null 2>&1; then
+            echo "WEBSOCAT_BIN=$(command -v websocat)" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          ARCH="$(uname -m)"
+          case "$ARCH" in
+            x86_64)
+              ASSET="websocat.x86_64-unknown-linux-musl"
+              ;;
+            aarch64|arm64)
+              ASSET="websocat.aarch64-unknown-linux-musl"
+              ;;
+            *)
+              echo "::error::Unsupported architecture for websocat install: $ARCH"
+              exit 1
+              ;;
+          esac
+
+          WEBSOCAT_PATH="/tmp/websocat"
+          curl -fsSL "https://github.com/vi/websocat/releases/download/v1.13.0/${ASSET}" -o "$WEBSOCAT_PATH"
+          chmod +x "$WEBSOCAT_PATH"
+          echo "WEBSOCAT_BIN=$WEBSOCAT_PATH" >> $GITHUB_ENV
+          "$WEBSOCAT_PATH" --version
+
+      - name: Start HFS server
+        run: |
+          case "${{ matrix.backend }}" in
+            sqlite) HFS_PORT=18088 ;;
+            sqlite-elasticsearch) HFS_PORT=18089 ;;
+            postgres) HFS_PORT=18090 ;;
+            mongodb) HFS_PORT=18091 ;;
+            s3-elasticsearch) HFS_PORT=18092 ;;
+            *) HFS_PORT=18088 ;;
+          esac
+          mkdir -p "$RESULTS_DIR"
+
+          HFS_LOG="$RESULTS_DIR/hfs.log"
+          echo "HFS_PORT=$HFS_PORT" >> $GITHUB_ENV
+          echo "RESULTS_DIR=$RESULTS_DIR" >> $GITHUB_ENV
+          echo "HFS_LOG=$HFS_LOG" >> $GITHUB_ENV
+
+          if [ "${{ matrix.backend }}" = "sqlite-elasticsearch" ]; then
+            HFS_SUBSCRIPTIONS_ENABLED=true \
+            HFS_BASE_URL="http://localhost:$HFS_PORT" \
+            HFS_STORAGE_BACKEND=sqlite-elasticsearch \
+            HFS_ELASTICSEARCH_NODES="http://$DOCKER_HOST_IP:$ES_PORT" \
+            ./target/debug/hfs --database-url :memory: --log-level info --port "$HFS_PORT" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          elif [ "${{ matrix.backend }}" = "postgres" ]; then
+            HFS_SUBSCRIPTIONS_ENABLED=true \
+            HFS_BASE_URL="http://localhost:$HFS_PORT" \
+            HFS_STORAGE_BACKEND=postgres \
+            HFS_PG_HOST="$DOCKER_HOST_IP" \
+            HFS_PG_PORT="$PG_PORT" \
+            HFS_PG_DBNAME=helios \
+            HFS_PG_USER=helios \
+            HFS_PG_PASSWORD=helios \
+            ./target/debug/hfs --log-level info --port "$HFS_PORT" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          elif [ "${{ matrix.backend }}" = "mongodb" ]; then
+            HFS_SUBSCRIPTIONS_ENABLED=true \
+            HFS_BASE_URL="http://localhost:$HFS_PORT" \
+            HFS_STORAGE_BACKEND=mongodb \
+            HFS_DATABASE_URL="mongodb://$DOCKER_HOST_IP:$MONGO_PORT/?replicaSet=rs0&directConnection=true" \
+            HFS_MONGODB_DATABASE="helios_subscriptions_smoke_${{ github.run_id }}_${{ github.run_attempt }}" \
+            ./target/debug/hfs --log-level info --port "$HFS_PORT" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          elif [ "${{ matrix.backend }}" = "s3-elasticsearch" ]; then
+            HFS_SUBSCRIPTIONS_ENABLED=true \
+            HFS_BASE_URL="http://localhost:$HFS_PORT" \
+            HFS_STORAGE_BACKEND=s3-elasticsearch \
+            HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}" \
+            HFS_S3_PREFIX="ci/subscriptions-smoke/${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.backend }}/" \
+            HFS_S3_VALIDATE_BUCKETS=false \
+            HFS_ELASTICSEARCH_NODES="http://$DOCKER_HOST_IP:$ES_PORT" \
+            ./target/debug/hfs --log-level info --port "$HFS_PORT" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          else
+            HFS_SUBSCRIPTIONS_ENABLED=true \
+            HFS_BASE_URL="http://localhost:$HFS_PORT" \
+            ./target/debug/hfs --database-url :memory: --log-level info --port "$HFS_PORT" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          fi
+
+          echo $! > /tmp/hfs-subscriptions-smoke.pid
+          echo "HFS_PID=$(cat /tmp/hfs-subscriptions-smoke.pid)" >> $GITHUB_ENV
+
+      - name: Wait for HFS to be ready
+        run: |
+          echo "Waiting for HFS to start..."
+          for i in {1..30}; do
+            if ! kill -0 "$HFS_PID" 2>/dev/null; then
+              echo "HFS process ($HFS_PID) exited"
+              cat "$HFS_LOG"
+              exit 1
+            fi
+            if curl -sf "http://localhost:$HFS_PORT/health" > /dev/null 2>&1; then
+              echo "HFS is ready"
+              exit 0
+            fi
+            echo "Attempt $i/30: HFS not ready yet..."
+            sleep 2
+          done
+
+          echo "HFS failed to start"
+          tail -50 "$HFS_LOG"
+          exit 1
+
+      - name: Run subscriptions smoke checks
+        run: |
+          BASE_URL="http://localhost:$HFS_PORT" \
+          RESULTS_DIR="$RESULTS_DIR" \
+          WEBSOCAT_BIN="$WEBSOCAT_BIN" \
+          ./crates/hfs/tests/subscriptions/run_external_subscriptions_smoke.sh
+
+      - name: Stop HFS gracefully
+        if: always()
+        run: |
+          if [ -f /tmp/hfs-subscriptions-smoke.pid ]; then
+            HFS_PID=$(cat /tmp/hfs-subscriptions-smoke.pid)
+            kill -INT "$HFS_PID" 2>/dev/null || true
+            for _ in {1..50}; do
+              if kill -0 "$HFS_PID" 2>/dev/null; then
+                sleep 0.2
+              else
+                break
+              fi
+            done
+            kill -9 "$HFS_PID" 2>/dev/null || true
+          fi
+          rm -f /tmp/hfs-subscriptions-smoke.pid
+
+      - name: Collect backend container logs
+        if: always()
+        run: |
+          RESULTS_DIR="${RESULTS_DIR:-subscriptions-smoke-results/${{ matrix.backend }}}"
+          mkdir -p "$RESULTS_DIR/backend-logs"
+          if [ -n "${ES_CONTAINER:-}" ]; then
+            docker logs "$ES_CONTAINER" > "$RESULTS_DIR/backend-logs/elasticsearch.log" 2>&1 || true
+          fi
+          if [ -n "${PG_CONTAINER:-}" ]; then
+            docker logs "$PG_CONTAINER" > "$RESULTS_DIR/backend-logs/postgres.log" 2>&1 || true
+          fi
+          if [ -n "${MONGO_CONTAINER:-}" ]; then
+            docker logs "$MONGO_CONTAINER" > "$RESULTS_DIR/backend-logs/mongodb.log" 2>&1 || true
+          fi
+
+      - name: Append smoke report to summary
+        if: always()
+        run: |
+          RESULTS_DIR="${RESULTS_DIR:-subscriptions-smoke-results/${{ matrix.backend }}}"
+          if [ -f "$RESULTS_DIR/summary.md" ]; then
+            cat "$RESULTS_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Subscriptions Smoke (${{ matrix.backend }})" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No summary produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload subscriptions smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: subscriptions-smoke-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: subscriptions-smoke-results/${{ matrix.backend }}/
+          retention-days: 30
+
+      - name: Cleanup containers
+        if: always()
+        run: |
+          if [ -n "${ES_CONTAINER:-}" ]; then
+            docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+          fi
+          if [ -n "${PG_CONTAINER:-}" ]; then
+            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          fi
+          if [ -n "${MONGO_CONTAINER:-}" ]; then
+            docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          fi

--- a/crates/hfs/tests/subscriptions/run_external_subscriptions_smoke.sh
+++ b/crates/hfs/tests/subscriptions/run_external_subscriptions_smoke.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+RESULTS_DIR="${RESULTS_DIR:-subscriptions-smoke-results}"
+WEBSOCAT_BIN="${WEBSOCAT_BIN:-websocat}"
+TOPIC_URL="${TOPIC_URL:-http://example.org/topic/encounter-start-smoke}"
+
+HTTP_DIR="$RESULTS_DIR/http"
+REST_DIR="$RESULTS_DIR/rest-hook"
+WS_DIR="$RESULTS_DIR/ws"
+SUMMARY_FILE="$RESULTS_DIR/summary.md"
+FHIR_CT="application/fhir+json"
+
+mkdir -p "$HTTP_DIR" "$REST_DIR" "$WS_DIR"
+
+log() {
+  echo "[subscriptions-smoke] $*"
+}
+
+fail() {
+  local msg="$1"
+  echo "[subscriptions-smoke] ERROR: $msg" >&2
+  echo "- FAIL: $msg" >> "$SUMMARY_FILE"
+  exit 1
+}
+
+pass() {
+  local msg="$1"
+  echo "- PASS: $msg" >> "$SUMMARY_FILE"
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fail "required command not found: $cmd"
+  fi
+}
+
+expect_created() {
+  local status="$1"
+  local operation="$2"
+  local response_file="$3"
+  if [ "$status" != "200" ] && [ "$status" != "201" ]; then
+    echo "---- $operation response ----" >&2
+    cat "$response_file" >&2 || true
+    echo "----------------------------" >&2
+    fail "$operation returned unexpected HTTP status: $status"
+  fi
+}
+
+expect_ok() {
+  local status="$1"
+  local operation="$2"
+  local response_file="$3"
+  if [ "$status" != "200" ]; then
+    echo "---- $operation response ----" >&2
+    cat "$response_file" >&2 || true
+    echo "----------------------------" >&2
+    fail "$operation returned unexpected HTTP status: $status"
+  fi
+}
+
+wait_for_value_count() {
+  local file="$1"
+  local jq_expr="$2"
+  local expected_min="$3"
+  local timeout_secs="$4"
+  local label="$5"
+  local count=""
+
+  for _ in $(seq 1 "$timeout_secs"); do
+    count="$( (jq -r "$jq_expr" "$file" 2>/dev/null || true) | sed '/^$/d' | wc -l | tr -d ' ' )"
+    if [ "${count:-0}" -ge "$expected_min" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "timed out waiting for $label in $file"
+}
+
+wait_for_health() {
+  local url="$1"
+  local timeout_secs="$2"
+  for _ in $(seq 1 "$timeout_secs"); do
+    if curl -sf "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+WEBHOOK_PID=""
+WS_PID=""
+cleanup() {
+  if [ -n "${WS_PID:-}" ]; then
+    kill "$WS_PID" 2>/dev/null || true
+    wait "$WS_PID" 2>/dev/null || true
+  fi
+  if [ -n "${WEBHOOK_PID:-}" ]; then
+    kill "$WEBHOOK_PID" 2>/dev/null || true
+    wait "$WEBHOOK_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+cat > "$SUMMARY_FILE" <<EOF
+## Subscriptions Smoke Test
+
+- Base URL: \`$BASE_URL\`
+- Topic URL: \`$TOPIC_URL\`
+
+EOF
+
+require_cmd curl
+require_cmd jq
+require_cmd python3
+
+if ! command -v "$WEBSOCAT_BIN" >/dev/null 2>&1 && [ ! -x "$WEBSOCAT_BIN" ]; then
+  fail "websocket client not found: $WEBSOCAT_BIN"
+fi
+
+log "Starting local webhook capture service"
+WEBHOOK_CAPTURE_DIR="$REST_DIR/capture"
+WEBHOOK_LOG="$REST_DIR/webhook_capture.log"
+mkdir -p "$WEBHOOK_CAPTURE_DIR"
+
+webhook_started=0
+for _ in $(seq 1 10); do
+  WEBHOOK_PORT="$((20000 + (RANDOM % 15000)))"
+  python3 ./crates/hfs/tests/subscriptions/webhook_capture.py \
+    --host 127.0.0.1 \
+    --port "$WEBHOOK_PORT" \
+    --out-dir "$WEBHOOK_CAPTURE_DIR" > "$WEBHOOK_LOG" 2>&1 &
+  WEBHOOK_PID="$!"
+
+  if wait_for_health "http://127.0.0.1:$WEBHOOK_PORT/health" 3; then
+    webhook_started=1
+    break
+  fi
+  kill "$WEBHOOK_PID" 2>/dev/null || true
+  wait "$WEBHOOK_PID" 2>/dev/null || true
+  WEBHOOK_PID=""
+done
+
+if [ "$webhook_started" -ne 1 ]; then
+  fail "unable to start webhook capture service"
+fi
+pass "webhook capture started on port $WEBHOOK_PORT"
+
+TOPIC_ID="topic-smoke-1"
+REST_SUB_ID="sub-rest-smoke-1"
+WS_SUB_ID="sub-ws-smoke-1"
+REST_ENCOUNTER_ID="enc-rest-smoke-1"
+WS_ENCOUNTER_ID="enc-ws-smoke-1"
+
+cat > "$HTTP_DIR/topic.request.json" <<EOF
+{
+  "resourceType": "SubscriptionTopic",
+  "id": "$TOPIC_ID",
+  "url": "$TOPIC_URL",
+  "status": "active",
+  "resourceTrigger": [{
+    "resource": "Encounter",
+    "supportedInteraction": ["create"]
+  }]
+}
+EOF
+
+TOPIC_STATUS="$(curl -sS -o "$HTTP_DIR/topic.response.json" -w "%{http_code}" \
+  -X POST "$BASE_URL/SubscriptionTopic" \
+  -H "Content-Type: $FHIR_CT" \
+  --data-binary @"$HTTP_DIR/topic.request.json")"
+expect_created "$TOPIC_STATUS" "create SubscriptionTopic" "$HTTP_DIR/topic.response.json"
+pass "created SubscriptionTopic"
+
+cat > "$HTTP_DIR/rest-subscription.request.json" <<EOF
+{
+  "resourceType": "Subscription",
+  "id": "$REST_SUB_ID",
+  "status": "requested",
+  "criteria": "$TOPIC_URL",
+  "channel": {
+    "type": "rest-hook",
+    "endpoint": "http://127.0.0.1:$WEBHOOK_PORT/webhook",
+    "payload": "application/fhir+json"
+  }
+}
+EOF
+
+REST_SUB_STATUS="$(curl -sS -o "$HTTP_DIR/rest-subscription.response.json" -w "%{http_code}" \
+  -X POST "$BASE_URL/Subscription" \
+  -H "Content-Type: $FHIR_CT" \
+  --data-binary @"$HTTP_DIR/rest-subscription.request.json")"
+expect_created "$REST_SUB_STATUS" "create rest-hook Subscription" "$HTTP_DIR/rest-subscription.response.json"
+
+REST_CAPTURE_FILE="$WEBHOOK_CAPTURE_DIR/bodies.ndjson"
+wait_for_value_count "$REST_CAPTURE_FILE" \
+  '.entry[0].resource.parameter[]? | select(.name=="type" and .valueCode=="handshake") | .valueCode' \
+  1 30 "rest-hook handshake notification"
+
+cat > "$HTTP_DIR/rest-encounter.request.json" <<EOF
+{
+  "resourceType": "Encounter",
+  "id": "$REST_ENCOUNTER_ID",
+  "status": "in-progress"
+}
+EOF
+
+REST_ENCOUNTER_STATUS="$(curl -sS -o "$HTTP_DIR/rest-encounter.response.json" -w "%{http_code}" \
+  -X POST "$BASE_URL/Encounter" \
+  -H "Content-Type: $FHIR_CT" \
+  --data-binary @"$HTTP_DIR/rest-encounter.request.json")"
+expect_created "$REST_ENCOUNTER_STATUS" "create Encounter for rest-hook smoke" "$HTTP_DIR/rest-encounter.response.json"
+
+wait_for_value_count "$REST_CAPTURE_FILE" \
+  '.entry[0].resource.parameter[]? | select(.name=="type" and .valueCode=="event-notification") | .valueCode' \
+  1 30 "rest-hook event-notification"
+
+jq -c 'select((.entry[0].resource.parameter[]? | select(.name=="type") | .valueCode)=="handshake")' \
+  "$REST_CAPTURE_FILE" | head -n 1 > "$REST_DIR/handshake.json"
+jq -c 'select((.entry[0].resource.parameter[]? | select(.name=="type") | .valueCode)=="event-notification")' \
+  "$REST_CAPTURE_FILE" | head -n 1 > "$REST_DIR/event-notification.json"
+
+[ -s "$REST_DIR/handshake.json" ] || fail "missing captured rest-hook handshake bundle"
+[ -s "$REST_DIR/event-notification.json" ] || fail "missing captured rest-hook event bundle"
+
+jq -e '.resourceType=="Bundle" and .type=="history"' "$REST_DIR/handshake.json" >/dev/null \
+  || fail "rest-hook handshake bundle shape mismatch"
+jq -e '[.entry[0].resource.parameter[]? | select(.name=="type") | .valueCode][0]=="handshake"' \
+  "$REST_DIR/handshake.json" >/dev/null || fail "rest-hook handshake type missing"
+jq -e --arg focus "Encounter/$REST_ENCOUNTER_ID" \
+  '.resourceType=="Bundle"
+   and .type=="history"
+   and ([.entry[0].resource.parameter[]? | select(.name=="type") | .valueCode][0]=="event-notification")
+   and any(.entry[]?; (.request.url // "") == $focus)' \
+  "$REST_DIR/event-notification.json" >/dev/null || fail "rest-hook event bundle missing expected focus"
+
+pass "rest-hook smoke assertions passed (handshake + event-notification)"
+
+cat > "$HTTP_DIR/ws-subscription.request.json" <<EOF
+{
+  "resourceType": "Subscription",
+  "id": "$WS_SUB_ID",
+  "status": "requested",
+  "criteria": "$TOPIC_URL",
+  "channel": {
+    "type": "websocket",
+    "payload": "application/fhir+json"
+  }
+}
+EOF
+
+WS_SUB_STATUS="$(curl -sS -o "$HTTP_DIR/ws-subscription.response.json" -w "%{http_code}" \
+  -X POST "$BASE_URL/Subscription" \
+  -H "Content-Type: $FHIR_CT" \
+  --data-binary @"$HTTP_DIR/ws-subscription.request.json")"
+expect_created "$WS_SUB_STATUS" "create websocket Subscription" "$HTTP_DIR/ws-subscription.response.json"
+
+WS_TOKEN_STATUS="$(curl -sS -o "$WS_DIR/token.response.json" -w "%{http_code}" \
+  "$BASE_URL/Subscription/$WS_SUB_ID/\$get-ws-binding-token")"
+expect_ok "$WS_TOKEN_STATUS" "get websocket binding token" "$WS_DIR/token.response.json"
+
+TOKEN="$(jq -r '.parameter[]? | select(.name=="token") | .valueString // empty' "$WS_DIR/token.response.json")"
+WS_URL="$(jq -r '.parameter[]? | select(.name=="websocket-url") | .valueUrl // empty' "$WS_DIR/token.response.json")"
+EXPIRATION="$(jq -r '.parameter[]? | select(.name=="expiration") | .valueDateTime // empty' "$WS_DIR/token.response.json")"
+
+[ -n "$TOKEN" ] || fail "token missing from \$get-ws-binding-token response"
+[ -n "$WS_URL" ] || fail "websocket-url missing from \$get-ws-binding-token response"
+[ -n "$EXPIRATION" ] || fail "expiration missing from \$get-ws-binding-token response"
+pass "websocket binding token response includes token, expiration, and websocket-url"
+
+WS_FRAMES="$WS_DIR/frames.ndjson"
+: > "$WS_FRAMES"
+
+log "Connecting websocket client"
+timeout 45s "$WEBSOCAT_BIN" "${WS_URL}?token=${TOKEN}" > "$WS_FRAMES" 2> "$WS_DIR/websocat.stderr" &
+WS_PID="$!"
+
+wait_for_value_count "$WS_FRAMES" \
+  '.entry[0].resource.parameter[]? | select(.name=="type" and .valueCode=="handshake") | .valueCode' \
+  1 30 "websocket handshake frame"
+
+cat > "$HTTP_DIR/ws-encounter.request.json" <<EOF
+{
+  "resourceType": "Encounter",
+  "id": "$WS_ENCOUNTER_ID",
+  "status": "in-progress"
+}
+EOF
+
+WS_ENCOUNTER_STATUS="$(curl -sS -o "$HTTP_DIR/ws-encounter.response.json" -w "%{http_code}" \
+  -X POST "$BASE_URL/Encounter" \
+  -H "Content-Type: $FHIR_CT" \
+  --data-binary @"$HTTP_DIR/ws-encounter.request.json")"
+expect_created "$WS_ENCOUNTER_STATUS" "create Encounter for websocket smoke" "$HTTP_DIR/ws-encounter.response.json"
+
+wait_for_value_count "$WS_FRAMES" \
+  '.entry[0].resource.parameter[]? | select(.name=="type" and .valueCode=="event-notification") | .valueCode' \
+  1 30 "websocket event-notification frame"
+
+jq -c 'select((.entry[0].resource.parameter[]? | select(.name=="type") | .valueCode)=="handshake")' \
+  "$WS_FRAMES" | head -n 1 > "$WS_DIR/handshake.json"
+jq -c 'select((.entry[0].resource.parameter[]? | select(.name=="type") | .valueCode)=="event-notification")' \
+  "$WS_FRAMES" | head -n 1 > "$WS_DIR/event-notification.json"
+
+[ -s "$WS_DIR/handshake.json" ] || fail "missing websocket handshake frame"
+[ -s "$WS_DIR/event-notification.json" ] || fail "missing websocket event-notification frame"
+
+jq -e '.resourceType=="Bundle" and .type=="history"' "$WS_DIR/handshake.json" >/dev/null \
+  || fail "websocket handshake bundle shape mismatch"
+jq -e '[.entry[0].resource.parameter[]? | select(.name=="type") | .valueCode][0]=="handshake"' \
+  "$WS_DIR/handshake.json" >/dev/null || fail "websocket handshake type missing"
+jq -e --arg focus "Encounter/$WS_ENCOUNTER_ID" \
+  '.resourceType=="Bundle"
+   and .type=="history"
+   and ([.entry[0].resource.parameter[]? | select(.name=="type") | .valueCode][0]=="event-notification")
+   and any(.entry[]?; (.request.url // "") == $focus)' \
+  "$WS_DIR/event-notification.json" >/dev/null || fail "websocket event bundle missing expected focus"
+
+pass "websocket smoke assertions passed (token + bind + handshake + event-notification)"
+
+if [ -n "${WS_PID:-}" ]; then
+  kill "$WS_PID" 2>/dev/null || true
+  wait "$WS_PID" 2>/dev/null || true
+  WS_PID=""
+fi
+
+REST_TOTAL="$(wc -l < "$REST_CAPTURE_FILE" 2>/dev/null | tr -d ' ')"
+WS_TOTAL="$(wc -l < "$WS_FRAMES" 2>/dev/null | tr -d ' ')"
+
+cat >> "$SUMMARY_FILE" <<EOF
+
+- Rest-hook notifications captured: $REST_TOTAL
+- WebSocket frames captured: $WS_TOTAL
+
+All subscriptions smoke checks completed successfully.
+EOF
+
+log "Subscriptions smoke test completed successfully"

--- a/crates/hfs/tests/subscriptions/webhook_capture.py
+++ b/crates/hfs/tests/subscriptions/webhook_capture.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Minimal webhook capture server for subscriptions smoke tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class CaptureState:
+    def __init__(self, out_dir: Path) -> None:
+        self.out_dir = out_dir
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self._counter = 0
+        self._lock = threading.Lock()
+
+        self.requests_path = self.out_dir / "requests.ndjson"
+        self.bodies_path = self.out_dir / "bodies.ndjson"
+
+    def next_index(self) -> int:
+        with self._lock:
+            self._counter += 1
+            return self._counter
+
+    def append_json_line(self, path: Path, payload: dict) -> None:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, separators=(",", ":")))
+            handle.write("\n")
+
+
+class WebhookCaptureHandler(BaseHTTPRequestHandler):
+    state: CaptureState
+
+    def log_message(self, fmt: str, *args) -> None:
+        # Keep CI logs focused; detailed request payloads are persisted to files.
+        return
+
+    def do_GET(self) -> None:
+        if self.path != "/health":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"status":"ok"}')
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body_raw = self.rfile.read(content_length)
+        body_text = body_raw.decode("utf-8", errors="replace")
+
+        try:
+            parsed_body = json.loads(body_text)
+        except json.JSONDecodeError:
+            parsed_body = {"_raw_body": body_text}
+
+        index = self.state.next_index()
+        body_file = self.state.out_dir / f"request-{index:04d}.json"
+        with body_file.open("w", encoding="utf-8") as handle:
+            json.dump(parsed_body, handle, separators=(",", ":"))
+            handle.write("\n")
+
+        metadata = {
+            "index": index,
+            "timestamp": utc_now_iso(),
+            "method": "POST",
+            "path": self.path,
+            "headers": {k: v for k, v in self.headers.items()},
+            "body_file": body_file.name,
+        }
+        self.state.append_json_line(self.state.requests_path, metadata)
+        self.state.append_json_line(self.state.bodies_path, parsed_body)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok":true}')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Webhook capture server")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host")
+    parser.add_argument("--port", type=int, required=True, help="Bind port")
+    parser.add_argument("--out-dir", required=True, help="Capture output directory")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    out_dir = Path(args.out_dir).resolve()
+    state = CaptureState(out_dir)
+
+    WebhookCaptureHandler.state = state
+    server = ThreadingHTTPServer((args.host, args.port), WebhookCaptureHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add manual subscriptions external smoke workflow modeled after inferno/audit style
- run rest-hook and websocket end-to-end checks against live HFS
- collect logs/artifacts for each backend matrix run

## Includes
- .github/workflows/subscriptions-smoke.yml
- crates/hfs/tests/subscriptions/run_external_subscriptions_smoke.sh
- crates/hfs/tests/subscriptions/webhook_capture.py

## Notes
- this PR is scoped only to the subscriptions smoke workflow and helper scripts