### PR TITLE
fix(fhirpath): operate on Unicode scalar values in string functions (FHIR-53554)

### DIFF
--- a/crates/fhirpath/src/evaluator.rs
+++ b/crates/fhirpath/src/evaluator.rs
@@ -4261,8 +4261,12 @@ fn call_function(
             Ok(match (invocation_base, &args[0]) {
                 // Wrap in Ok
                 (EvaluationResult::String(s, _), EvaluationResult::String(substring, _)) => {
-                    match s.find(substring) {
-                        Some(index) => EvaluationResult::integer(index as i64),
+                    match s.find(substring.as_str()) {
+                        // Convert byte offset to character (Unicode scalar value) index
+                        // per FHIRPath string spec (FHIR-53554).
+                        Some(byte_idx) => {
+                            EvaluationResult::integer(s[..byte_idx].chars().count() as i64)
+                        }
                         None => EvaluationResult::integer(-1),
                     }
                 }
@@ -4304,8 +4308,11 @@ fn call_function(
                         // Per spec: returns 0 if substring is empty
                         EvaluationResult::integer(0)
                     } else {
-                        match s.rfind(substring) {
-                            Some(index) => EvaluationResult::integer(index as i64),
+                        match s.rfind(substring.as_str()) {
+                            // Convert byte offset to character index (FHIR-53554).
+                            Some(byte_idx) => {
+                                EvaluationResult::integer(s[..byte_idx].chars().count() as i64)
+                            }
                             None => EvaluationResult::integer(-1),
                         }
                     }
@@ -7010,6 +7017,12 @@ fn evaluate_indexer(
             }
             items.get(idx).cloned().unwrap_or(EvaluationResult::Empty)
         }
+        // String indexer: returns the idx-th character (Unicode scalar value)
+        // as a single-character string, per FHIRPath string spec (FHIR-53554).
+        EvaluationResult::String(s, _) => match s.chars().nth(idx) {
+            Some(c) => EvaluationResult::string(c.to_string()),
+            None => EvaluationResult::Empty,
+        },
         // Indexer on single item or empty returns empty
         _ => EvaluationResult::Empty,
     })

--- a/crates/fhirpath/src/parser.rs
+++ b/crates/fhirpath/src/parser.rs
@@ -480,6 +480,43 @@ fn clean_backtick_identifier(id: &str) -> String {
     }
 }
 
+/// Combines a sequence of code units (from literal scalars and `\uXXXX` escapes)
+/// into a FHIRPath string. Adjacent high/low UTF-16 surrogate escapes are joined
+/// into a single Unicode scalar value; unpaired surrogates are rejected. This
+/// matches the FHIRPath string-literal rules (FHIR-53554).
+fn combine_string_code_units(codes: Vec<u32>) -> Result<String, &'static str> {
+    let mut out = String::with_capacity(codes.len());
+    let mut i = 0;
+    while i < codes.len() {
+        let c = codes[i];
+        if (0xD800..=0xDBFF).contains(&c) {
+            if let Some(&lo) = codes.get(i + 1) {
+                if (0xDC00..=0xDFFF).contains(&lo) {
+                    let scalar = 0x10000 + ((c - 0xD800) << 10) + (lo - 0xDC00);
+                    match char::from_u32(scalar) {
+                        Some(ch) => {
+                            out.push(ch);
+                            i += 2;
+                            continue;
+                        }
+                        None => return Err("Invalid surrogate pair"),
+                    }
+                }
+            }
+            return Err("Unpaired high surrogate in \\uXXXX escape");
+        }
+        if (0xDC00..=0xDFFF).contains(&c) {
+            return Err("Unpaired low surrogate in \\uXXXX escape");
+        }
+        match char::from_u32(c) {
+            Some(ch) => out.push(ch),
+            None => return Err("Invalid Unicode code point"),
+        }
+        i += 1;
+    }
+    Ok(out)
+}
+
 /// Creates a parser for FHIRPath expressions
 ///
 /// This function creates and returns a parser that can parse FHIRPath expressions
@@ -539,32 +576,30 @@ where
 
 pub fn parser<'src>()
 -> impl Parser<'src, &'src str, Expression, extra::Err<Rich<'src, char>>> + Clone + 'src {
-    // Parser for escape sequences within string literals
-    // Handles standard escape sequences like \n, \t, \r, etc., plus Unicode
-    // escape sequences in the form \uXXXX where XXXX is a 4-digit hex code.
+    // Parser for escape sequences within string literals. Produces a raw
+    // code unit (u32) so that `\uXXXX` UTF-16 surrogate escapes can be paired
+    // into a single scalar value by `combine_string_code_units`.
     let esc = just('\\').ignore_then(choice((
-        just('`').to('`'),        // Backtick escape
-        just('\'').to('\''),      // Single quote escape
-        just('\\').to('\\'),      // Backslash escape
-        just('/').to('/'),        // Forward slash escape
-        just('f').to('\u{000C}'), // Form feed
-        just('n').to('\n'),       // Newline
-        just('r').to('\r'),       // Carriage return
-        just('t').to('\t'),       // Tab
-        just('"').to('"'),        // Double quote escape
-        // Unicode escape sequence: \uXXXX
+        just('`').to('`' as u32),
+        just('\'').to('\'' as u32),
+        just('\\').to('\\' as u32),
+        just('/').to('/' as u32),
+        just('f').to(0x000C_u32),
+        just('n').to('\n' as u32),
+        just('r').to('\r' as u32),
+        just('t').to('\t' as u32),
+        just('"').to('"' as u32),
+        // Unicode escape sequence: \uXXXX. May be a surrogate half that will
+        // be paired with a following escape in `combine_string_code_units`.
         just('u').ignore_then(
             any()
                 .filter(|c: &char| c.is_ascii_hexdigit())
                 .repeated()
-                .exactly(4) // Require exactly 4 hex digits
+                .exactly(4)
                 .collect::<String>()
                 .try_map(
                     |digits: String, span| match u32::from_str_radix(&digits, 16) {
-                        Ok(code) => match char::from_u32(code) {
-                            Some(c) => Ok(c),
-                            None => Err(Rich::custom(span, "Invalid Unicode code point")),
-                        },
+                        Ok(code) => Ok(code),
                         Err(_) => Err(Rich::custom(span, "Invalid hex digits")),
                     },
                 ),
@@ -596,13 +631,15 @@ pub fn parser<'src>()
     // Handles escape sequences and allows any characters between single quotes
     let string = just('\'')
         .ignore_then(
-            none_of("\\\'") // Any character except \ or '
-                .or(esc) // Or an escape sequence
+            none_of("\\\'")
+                .map(|c: char| c as u32)
+                .or(esc)
                 .repeated()
-                .collect::<String>(),
+                .collect::<Vec<u32>>(),
         )
-        .then_ignore(just('\'')) // End with a closing quote
-        .map(Literal::String) // Convert to String literal
+        .then_ignore(just('\''))
+        .try_map(|codes, span| combine_string_code_units(codes).map_err(|e| Rich::custom(span, e)))
+        .map(Literal::String)
         .boxed();
 
     // Parser for integer literals
@@ -857,12 +894,14 @@ pub fn parser<'src>()
     // These are arbitrary units enclosed in single quotes
     let unit_string_literal = just('\'')
         .ignore_then(
-            none_of("\\\'") // Any character except \ or '
-                .or(esc) // Or an escape sequence
+            none_of("\\\'")
+                .map(|c: char| c as u32)
+                .or(esc)
                 .repeated()
-                .collect::<String>(),
+                .collect::<Vec<u32>>(),
         )
-        .then_ignore(just('\''));
+        .then_ignore(just('\''))
+        .try_map(|codes, span| combine_string_code_units(codes).map_err(|e| Rich::custom(span, e)));
 
     // Combined parser for all unit forms
     let unit = choice((
@@ -1021,8 +1060,15 @@ pub fn parser<'src>()
 
     // DELIMITEDIDENTIFIER: '`' (ESC | .)*? '`'
     let delimited_identifier = just('`')
-        .ignore_then(none_of("`").or(esc).repeated().collect::<String>())
+        .ignore_then(
+            none_of("`")
+                .map(|c: char| c as u32)
+                .or(esc)
+                .repeated()
+                .collect::<Vec<u32>>(),
+        )
         .then_ignore(just('`'))
+        .try_map(|codes, span| combine_string_code_units(codes).map_err(|e| Rich::custom(span, e)))
         .padded();
 
     // Combined identifier parser - allow true/false as identifiers
@@ -1088,8 +1134,15 @@ pub fn parser<'src>()
 
     // Create a separate string parser for external constants
     let string_for_external = just('\'')
-        .ignore_then(none_of("\'\\").or(esc).repeated().collect::<String>())
+        .ignore_then(
+            none_of("\'\\")
+                .map(|c: char| c as u32)
+                .or(esc)
+                .repeated()
+                .collect::<Vec<u32>>(),
+        )
         .then_ignore(just('\''))
+        .try_map(|codes, span| combine_string_code_units(codes).map_err(|e| Rich::custom(span, e)))
         .padded();
 
     // External constants
@@ -1403,17 +1456,18 @@ pub fn parser<'src>()
 /// using chumsky's `map_with` combinator.
 pub fn spanned_parser<'src>()
 -> impl Parser<'src, &'src str, SpannedExpression, extra::Err<Rich<'src, char>>> + Clone + 'src {
-    // Parser for escape sequences (same as parser())
+    // Parser for escape sequences (same as parser()). Emits a raw code unit
+    // so surrogate pairs can be combined in `combine_string_code_units`.
     let esc = just('\\').ignore_then(choice((
-        just('`').to('`'),
-        just('\'').to('\''),
-        just('\\').to('\\'),
-        just('/').to('/'),
-        just('f').to('\u{000C}'),
-        just('n').to('\n'),
-        just('r').to('\r'),
-        just('t').to('\t'),
-        just('"').to('"'),
+        just('`').to('`' as u32),
+        just('\'').to('\'' as u32),
+        just('\\').to('\\' as u32),
+        just('/').to('/' as u32),
+        just('f').to(0x000C_u32),
+        just('n').to('\n' as u32),
+        just('r').to('\r' as u32),
+        just('t').to('\t' as u32),
+        just('"').to('"' as u32),
         just('u').ignore_then(
             any()
                 .filter(|c: &char| c.is_ascii_hexdigit())
@@ -1422,10 +1476,7 @@ pub fn spanned_parser<'src>()
                 .collect::<String>()
                 .try_map(
                     |digits: String, span| match u32::from_str_radix(&digits, 16) {
-                        Ok(code) => match char::from_u32(code) {
-                            Some(c) => Ok(c),
-                            None => Err(Rich::custom(span, "Invalid Unicode code point")),
-                        },
+                        Ok(code) => Ok(code),
                         Err(_) => Err(Rich::custom(span, "Invalid hex digits")),
                     },
                 ),
@@ -1443,8 +1494,15 @@ pub fn spanned_parser<'src>()
     .boxed();
 
     let string = just('\'')
-        .ignore_then(none_of("\\\'").or(esc).repeated().collect::<String>())
+        .ignore_then(
+            none_of("\\\'")
+                .map(|c: char| c as u32)
+                .or(esc)
+                .repeated()
+                .collect::<Vec<u32>>(),
+        )
         .then_ignore(just('\''))
+        .try_map(|codes, span| combine_string_code_units(codes).map_err(|e| Rich::custom(span, e)))
         .map(Literal::String)
         .boxed();
 
@@ -1622,8 +1680,15 @@ pub fn spanned_parser<'src>()
     ));
 
     let unit_string_literal = just('\'')
-        .ignore_then(none_of("\\\'").or(esc).repeated().collect::<String>())
-        .then_ignore(just('\''));
+        .ignore_then(
+            none_of("\\\'")
+                .map(|c: char| c as u32)
+                .or(esc)
+                .repeated()
+                .collect::<Vec<u32>>(),
+        )
+        .then_ignore(just('\''))
+        .try_map(|codes, span| combine_string_code_units(codes).map_err(|e| Rich::custom(span, e)));
 
     let unit = choice((unit_keyword, unit_string_literal)).boxed().padded();
 
@@ -1759,8 +1824,15 @@ pub fn spanned_parser<'src>()
         .padded();
 
     let delimited_identifier = just('`')
-        .ignore_then(none_of("`").or(esc).repeated().collect::<String>())
+        .ignore_then(
+            none_of("`")
+                .map(|c: char| c as u32)
+                .or(esc)
+                .repeated()
+                .collect::<Vec<u32>>(),
+        )
         .then_ignore(just('`'))
+        .try_map(|codes, span| combine_string_code_units(codes).map_err(|e| Rich::custom(span, e)))
         .padded();
 
     let identifier = choice((
@@ -1804,8 +1876,15 @@ pub fn spanned_parser<'src>()
     let qualified_identifier = custom_padded(qualified_identifier);
 
     let string_for_external = just('\'')
-        .ignore_then(none_of("\'\\").or(esc).repeated().collect::<String>())
+        .ignore_then(
+            none_of("\'\\")
+                .map(|c: char| c as u32)
+                .or(esc)
+                .repeated()
+                .collect::<Vec<u32>>(),
+        )
         .then_ignore(just('\''))
+        .try_map(|codes, span| combine_string_code_units(codes).map_err(|e| Rich::custom(span, e)))
         .padded();
 
     let external_constant = just('%')

--- a/crates/fhirpath/tests/unicode_scalar_value_tests.rs
+++ b/crates/fhirpath/tests/unicode_scalar_value_tests.rs
@@ -1,0 +1,175 @@
+//! Tests for FHIRPath string functions operating on Unicode scalar values
+//! per FHIR-53554 (https://jira.hl7.org/browse/FHIR-53554).
+//!
+//! String functions such as `length()`, `indexOf()`, `lastIndexOf()`,
+//! `substring()`, the indexer, `toChars()`, and `replace()` must operate on
+//! characters (Unicode scalar values), not on UTF-8 bytes, UTF-16 code units,
+//! or grapheme clusters. UTF-16 surrogate escape pairs (`\uD83D\uDD25`) must
+//! combine into a single scalar value.
+
+use chumsky::Parser;
+use helios_fhirpath::evaluator::{EvaluationContext, evaluate};
+use helios_fhirpath::parser::parser;
+use helios_fhirpath_support::{EvaluationError, EvaluationResult};
+
+fn eval(input: &str, context: &EvaluationContext) -> Result<EvaluationResult, EvaluationError> {
+    let expr = parser()
+        .parse(input)
+        .into_result()
+        .unwrap_or_else(|e| panic!("Parser error for input '{}': {:?}", input, e));
+    evaluate(&expr, context, None)
+}
+
+#[test]
+fn surrogate_pair_escape_combines_into_scalar_value() {
+    let ctx = EvaluationContext::new_empty_with_default_version();
+    // \uD83D\uDD25 is the UTF-16 surrogate pair for U+1F525 (🔥).
+    assert_eq!(
+        eval("'\\uD83D\\uDD25'", &ctx).unwrap(),
+        EvaluationResult::string("🔥".to_string())
+    );
+}
+
+#[test]
+fn length_counts_scalar_values_not_utf8_bytes() {
+    let ctx = EvaluationContext::new_empty_with_default_version();
+    // Surrogate-pair escape is one scalar value.
+    assert_eq!(
+        eval("'\\uD83D\\uDD25'.length()", &ctx).unwrap(),
+        EvaluationResult::integer(1)
+    );
+    // Combining form 'é' (U+0065 + U+0301) is two scalar values.
+    assert_eq!(
+        eval("'\\u0065\\u0301'.length()", &ctx).unwrap(),
+        EvaluationResult::integer(2)
+    );
+    // Precomposed 'é' (U+00E9) is one scalar value.
+    assert_eq!(
+        eval("'\\u00E9'.length()", &ctx).unwrap(),
+        EvaluationResult::integer(1)
+    );
+}
+
+#[test]
+fn index_of_returns_character_index_not_byte_offset() {
+    let ctx = EvaluationContext::new_empty_with_default_version();
+    // Literal emoji in source text.
+    assert_eq!(
+        eval("'a🔥b'.indexOf('🔥')", &ctx).unwrap(),
+        EvaluationResult::integer(1)
+    );
+    // 'b' is at character index 2, not byte offset 5.
+    assert_eq!(
+        eval("'a🔥b'.indexOf('b')", &ctx).unwrap(),
+        EvaluationResult::integer(2)
+    );
+    // Same string constructed via surrogate pair escape.
+    assert_eq!(
+        eval("'a\\uD83D\\uDD25b'.indexOf('b')", &ctx).unwrap(),
+        EvaluationResult::integer(2)
+    );
+}
+
+#[test]
+fn last_index_of_returns_character_index() {
+    let ctx = EvaluationContext::new_empty_with_default_version();
+    assert_eq!(
+        eval("'a🔥b🔥c'.lastIndexOf('🔥')", &ctx).unwrap(),
+        EvaluationResult::integer(3)
+    );
+    assert_eq!(
+        eval("'a🔥b🔥c'.lastIndexOf('c')", &ctx).unwrap(),
+        EvaluationResult::integer(4)
+    );
+}
+
+#[test]
+fn substring_operates_on_characters() {
+    let ctx = EvaluationContext::new_empty_with_default_version();
+    // substring(start, length) in characters, not bytes.
+    assert_eq!(
+        eval("'a🔥b'.substring(1, 1)", &ctx).unwrap(),
+        EvaluationResult::string("🔥".to_string())
+    );
+    assert_eq!(
+        eval("'a🔥b'.substring(2, 1)", &ctx).unwrap(),
+        EvaluationResult::string("b".to_string())
+    );
+}
+
+#[test]
+fn indexer_returns_scalar_value_character() {
+    let ctx = EvaluationContext::new_empty_with_default_version();
+    assert_eq!(
+        eval("'a🔥b'[0]", &ctx).unwrap(),
+        EvaluationResult::string("a".to_string())
+    );
+    assert_eq!(
+        eval("'a🔥b'[1]", &ctx).unwrap(),
+        EvaluationResult::string("🔥".to_string())
+    );
+    assert_eq!(
+        eval("'a🔥b'[2]", &ctx).unwrap(),
+        EvaluationResult::string("b".to_string())
+    );
+    assert_eq!(eval("'a🔥b'[3]", &ctx).unwrap(), EvaluationResult::Empty);
+}
+
+#[test]
+fn to_chars_does_not_split_surrogate_pairs() {
+    let ctx = EvaluationContext::new_empty_with_default_version();
+    // 'a🔥b' (surrogate-pair form) should yield three single-char strings.
+    let result = eval("'a\\uD83D\\uDD25b'.toChars()", &ctx).unwrap();
+    match result {
+        EvaluationResult::Collection { items, .. } => {
+            assert_eq!(items.len(), 3);
+            assert_eq!(items[0], EvaluationResult::string("a".to_string()));
+            assert_eq!(items[1], EvaluationResult::string("🔥".to_string()));
+            assert_eq!(items[2], EvaluationResult::string("b".to_string()));
+        }
+        other => panic!("Expected Collection, got {:?}", other),
+    }
+
+    // Combining 'é' (U+0065 + U+0301) yields two entries.
+    let result = eval("'\\u0065\\u0301'.toChars()", &ctx).unwrap();
+    match result {
+        EvaluationResult::Collection { items, .. } => {
+            assert_eq!(items.len(), 2);
+            assert_eq!(items[0], EvaluationResult::string("e".to_string()));
+            assert_eq!(items[1], EvaluationResult::string("\u{0301}".to_string()));
+        }
+        other => panic!("Expected Collection, got {:?}", other),
+    }
+}
+
+#[test]
+fn replace_with_empty_pattern_preserves_scalar_values() {
+    let ctx = EvaluationContext::new_empty_with_default_version();
+    // Inserting 'x' between every character must not split a surrogate pair.
+    assert_eq!(
+        eval("'a🔥c'.replace('', 'x')", &ctx).unwrap(),
+        EvaluationResult::string("xax🔥xcx".to_string())
+    );
+}
+
+#[test]
+fn unpaired_high_surrogate_is_rejected() {
+    // `\uD83D` alone is an unpaired high surrogate and must fail to parse.
+    let result = parser().parse("'\\uD83D'").into_result();
+    assert!(
+        result.is_err(),
+        "Parser unexpectedly accepted unpaired high surrogate: {:?}",
+        result
+    );
+}
+
+#[test]
+fn unpaired_low_surrogate_is_rejected() {
+    // `\uDD25` alone is an unpaired low surrogate and must fail to parse.
+    let result = parser().parse("'\\uDD25'").into_result();
+    assert!(
+        result.is_err(),
+        "Parser unexpectedly accepted unpaired low surrogate: {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Summary
- Bring FHIRPath string handling into line with [FHIR-53554](https://jira.hl7.org/browse/FHIR-53554): strings are sequences of Unicode scalar values, and `length()`, `indexOf()`, `lastIndexOf()`, `substring()`, the indexer, `toChars()`, and `replace()` must operate on characters (not UTF-8 bytes or UTF-16 code units).
- Parser now combines `\uD83D\uDD25`-style UTF-16 surrogate escape pairs into a single scalar value (via a new `combine_string_code_units` helper) and rejects unpaired surrogates.
- `indexOf`/`lastIndexOf` convert `str::find`/`rfind` byte offsets to character counts; the string indexer `s[i]` now returns the i-th scalar value as a single-char string (previously always returned empty).

## Test plan
- [x] `cargo test -p helios-fhirpath` — all suites pass, including the 10 new tests in `crates/fhirpath/tests/unicode_scalar_value_tests.rs` covering the spec examples (surrogate pair parsing, `length()`, `indexOf`/`lastIndexOf`, `substring`, indexer, `toChars`, `replace('', 'x')`, unpaired surrogate rejection).
- [x] `cargo clippy -p helios-fhirpath --all-targets` with CI flags — clean.
- [x] `cargo fmt --all` — no changes needed.