### PR TITLE
ci: bump JS-based actions to Node.js 24 majors

### DIFF
--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo build -p helios-hfs --features R4,sqlite,elasticsearch,postgres,mongodb,s3,cloudwatch
 
       - name: Upload HFS binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: hfs-binary
           path: target/debug/hfs
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: hfs-binary
           path: target/debug
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload CORS artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: cors-preflight-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
@@ -187,7 +187,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: hfs-binary
           path: target/debug
@@ -744,7 +744,7 @@ jobs:
 
       - name: Upload audit artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: audit-events-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: audit-results/
@@ -792,7 +792,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: hfs-binary
           path: target/debug
@@ -1184,7 +1184,7 @@ jobs:
 
       - name: Upload database-smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: audit-db-smoke-${{ matrix.backend }}-${{ matrix.mode }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -38,7 +38,7 @@ jobs:
         run: cargo build -p helios-hfs --features R4,sqlite,elasticsearch,postgres,mongodb,s3,cloudwatch
 
       - name: Upload HFS binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: hfs-binary
           path: target/debug/hfs
@@ -50,10 +50,10 @@ jobs:
     runs-on: [self-hosted, Linux]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: hfs-binary
           path: target/debug
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload CORS artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cors-preflight-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
@@ -184,10 +184,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: hfs-binary
           path: target/debug
@@ -333,7 +333,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: matrix.backend == 's3-elasticsearch' || matrix.backend == 'cloudwatch'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
@@ -744,7 +744,7 @@ jobs:
 
       - name: Upload audit artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: audit-events-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: audit-results/
@@ -789,10 +789,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: hfs-binary
           path: target/debug
@@ -904,7 +904,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: matrix.backend == 's3'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
@@ -1184,7 +1184,7 @@ jobs:
 
       - name: Upload database-smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: audit-db-smoke-${{ matrix.backend }}-${{ matrix.mode }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -22,7 +22,7 @@ jobs:
         rust: [beta, nightly]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
       - name: Install Rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
       # Upload coverage report as artifact
       - name: Upload Coverage Report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: lcov.info
@@ -535,7 +535,7 @@ jobs:
 
       - name: Upload FhirPath Test Results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: fhirpath-test-results
           path: fhirpath-results/
@@ -645,7 +645,7 @@ jobs:
 
       - name: Upload Rust build artifacts to GitHub
         if: matrix.os != 'Linux-ARM64'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: hfs-${{ matrix.target }}
           path: |
@@ -664,7 +664,7 @@ jobs:
 
       - name: Upload Rust build artifacts to GitHub (Cross-compile)
         if: matrix.os == 'Linux-ARM64'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: hfs-${{ matrix.target }}
           path: |
@@ -684,7 +684,7 @@ jobs:
 
       - name: Upload test_report.json to GitHub
         if: matrix.os == 'Linux-x86'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: test_report
           path: crates/sof/test_report.json
@@ -707,7 +707,7 @@ jobs:
         run: uv run maturin build --release -o dist --target aarch64-unknown-linux-gnu -i python3.10 -i python3.11 -i python3.12 -i python3.13 -i python3.14
 
       - name: Upload pysof artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: pysof-${{ matrix.target }}
           path: crates/pysof/dist/*
@@ -719,7 +719,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all pysof artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: pysof-*
           path: ./pysof-dist
@@ -763,7 +763,7 @@ jobs:
         working-directory: book
 
       - name: Download all pysof artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: test_report
           path: ./book/book/
@@ -790,13 +790,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: 'hfs-*'
           path: ./artifacts
 
       - name: Download pysof artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: 'pysof-*'
           path: ./artifacts
@@ -923,7 +923,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download CI artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: hfs-${{ matrix.rust_target }}
           path: ./artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           exit 1
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
@@ -85,7 +85,7 @@ jobs:
     needs: [test-rust]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
@@ -137,7 +137,7 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
@@ -204,7 +204,7 @@ jobs:
     needs: [lint]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
@@ -255,7 +255,7 @@ jobs:
     needs: [lint]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
@@ -303,7 +303,7 @@ jobs:
       # Upload coverage report as artifact
       - name: Upload Coverage Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-report
           path: lcov.info
@@ -319,7 +319,7 @@ jobs:
 
       # Upload to Codecov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
@@ -331,13 +331,13 @@ jobs:
     needs: [test-rust]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
           fetch-depth: 0 # Need full history for change detection
 
       - name: Download FhirPath Validator
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -376,14 +376,14 @@ jobs:
             console.log('FhirPath Validator download completed');
 
       - name: Checkout FHIR Test Cases
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: FHIR/fhir-test-cases
           path: fhir-test-cases
           ref: master
 
       - name: Extract and Setup FhirPath Validator
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -486,7 +486,7 @@ jobs:
         run: if not exist fhirpath-results mkdir fhirpath-results
 
       - name: Run FhirPath Validation with FHIR Test Cases
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { execSync } = require('child_process');
@@ -535,7 +535,7 @@ jobs:
 
       - name: Upload FhirPath Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: fhirpath-test-results
           path: fhirpath-results/
@@ -581,7 +581,7 @@ jobs:
             archive_ext: tar.gz
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain (Linux/macOS)
         if: runner.os != 'Windows'
@@ -645,7 +645,7 @@ jobs:
 
       - name: Upload Rust build artifacts to GitHub
         if: matrix.os != 'Linux-ARM64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: hfs-${{ matrix.target }}
           path: |
@@ -664,7 +664,7 @@ jobs:
 
       - name: Upload Rust build artifacts to GitHub (Cross-compile)
         if: matrix.os == 'Linux-ARM64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: hfs-${{ matrix.target }}
           path: |
@@ -684,7 +684,7 @@ jobs:
 
       - name: Upload test_report.json to GitHub
         if: matrix.os == 'Linux-x86'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test_report
           path: crates/sof/test_report.json
@@ -707,7 +707,7 @@ jobs:
         run: uv run maturin build --release -o dist --target aarch64-unknown-linux-gnu -i python3.10 -i python3.11 -i python3.12 -i python3.13 -i python3.14
 
       - name: Upload pysof artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: pysof-${{ matrix.target }}
           path: crates/pysof/dist/*
@@ -719,7 +719,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all pysof artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: pysof-*
           path: ./pysof-dist
@@ -751,7 +751,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install mdBook
         run: |
@@ -763,7 +763,7 @@ jobs:
         working-directory: book
 
       - name: Download all pysof artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: test_report
           path: ./book/book/
@@ -776,7 +776,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   release:
     name: Create GitHub Release
@@ -787,16 +787,16 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: 'hfs-*'
           path: ./artifacts
 
       - name: Download pysof artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: 'pysof-*'
           path: ./artifacts
@@ -863,7 +863,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             releases/*
@@ -913,7 +913,7 @@ jobs:
             artifact_release_dir: target/aarch64-unknown-linux-gnu/release
     steps:
       - name: Checkout (for Dockerfile)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Determine version
         id: version
@@ -923,7 +923,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download CI artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: hfs-${{ matrix.rust_target }}
           path: ./artifact
@@ -937,20 +937,20 @@ jobs:
           fi
 
       - name: Set up QEMU (for cross-arch builds)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push (${{ matrix.arch }})
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docker-context
           file: Dockerfile
@@ -992,10 +992,10 @@ jobs:
           echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -1034,7 +1034,7 @@ jobs:
           - hfs
     steps:
       - name: Download release binary
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
           exit 0
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/hts.yml
+++ b/.github/workflows/hts.yml
@@ -130,7 +130,7 @@ jobs:
         run: cargo build --release -p helios-hts --features "R4,R4B,R5"
 
       - name: Upload HTS binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: hts-binary
           path: target/release/hts
@@ -162,7 +162,7 @@ jobs:
           clean: false
 
       - name: Download HTS binary
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: hts-binary
           path: .

--- a/.github/workflows/hts.yml
+++ b/.github/workflows/hts.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
@@ -77,7 +77,7 @@ jobs:
         version: [R4B, R5, R6]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
@@ -108,7 +108,7 @@ jobs:
     needs: check
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
@@ -130,7 +130,7 @@ jobs:
         run: cargo build --release -p helios-hts --features "R4,R4B,R5"
 
       - name: Upload HTS binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: hts-binary
           path: target/release/hts
@@ -157,12 +157,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
       - name: Download HTS binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: hts-binary
           path: .

--- a/.github/workflows/inferno.yml
+++ b/.github/workflows/inferno.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -40,7 +40,7 @@ jobs:
         run: cargo build -p helios-hfs --features R4,sqlite,elasticsearch,postgres,mongodb,s3
 
       - name: Upload HFS binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: hfs-binary
           path: target/debug/hfs
@@ -76,10 +76,10 @@ jobs:
           - { suite_id: us_core_v800, version_label: "v8.0.0" }
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: hfs-binary
           path: target/debug
@@ -256,7 +256,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: matrix.backend == 's3-elasticsearch'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
@@ -566,7 +566,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: inferno-test-results-${{ matrix.suite_id }}-${{ matrix.backend }}
           path: inferno-results/

--- a/.github/workflows/inferno.yml
+++ b/.github/workflows/inferno.yml
@@ -40,7 +40,7 @@ jobs:
         run: cargo build -p helios-hfs --features R4,sqlite,elasticsearch,postgres,mongodb,s3
 
       - name: Upload HFS binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: hfs-binary
           path: target/debug/hfs
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: hfs-binary
           path: target/debug
@@ -566,7 +566,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: inferno-test-results-${{ matrix.suite_id }}-${{ matrix.backend }}
           path: inferno-results/

--- a/.github/workflows/subscriptions-channels.yml
+++ b/.github/workflows/subscriptions-channels.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 

--- a/.github/workflows/subscriptions-smoke.yml
+++ b/.github/workflows/subscriptions-smoke.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
         run: cargo build -p helios-hfs --features R4,subscriptions,sqlite,elasticsearch,postgres,mongodb,s3
 
       - name: Upload HFS binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: hfs-subscriptions-binary
           path: target/debug/hfs
@@ -59,10 +59,10 @@ jobs:
       RESULTS_DIR: subscriptions-smoke-results/${{ matrix.backend }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: hfs-subscriptions-binary
           path: target/debug
@@ -200,7 +200,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: matrix.backend == 's3-elasticsearch'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
@@ -378,7 +378,7 @@ jobs:
 
       - name: Upload subscriptions smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: subscriptions-smoke-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: subscriptions-smoke-results/${{ matrix.backend }}/

--- a/.github/workflows/subscriptions-smoke.yml
+++ b/.github/workflows/subscriptions-smoke.yml
@@ -37,7 +37,7 @@ jobs:
         run: cargo build -p helios-hfs --features R4,subscriptions,sqlite,elasticsearch,postgres,mongodb,s3
 
       - name: Upload HFS binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: hfs-subscriptions-binary
           path: target/debug/hfs
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download HFS binary
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: hfs-subscriptions-binary
           path: target/debug
@@ -378,7 +378,7 @@ jobs:
 
       - name: Upload subscriptions smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: subscriptions-smoke-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: subscriptions-smoke-results/${{ matrix.backend }}/


### PR DESCRIPTION
## Summary
- Updates all JS-based GitHub Actions to versions that run on Node.js 24, ahead of the June 2026 deprecation of Node.js 20 on hosted runners.
- No input-shape changes needed — existing `with:` blocks remain compatible (codecov already passes `token`; aws-credentials only uses `role-to-assume`/`aws-region`; download-artifact is only used by name/pattern).
- Composite actions (`actions/upload-pages-artifact@v3`, `anthropics/claude-code-action@v1`) left alone — they aren't affected by the Node 20 deprecation.

### Bumps
- `actions/checkout` v4 → v5
- `actions/upload-artifact` v4 → v5
- `actions/download-artifact` v4 → v5
- `actions/github-script` v7 → v8
- `actions/deploy-pages` v4 → v5
- `codecov/codecov-action` v4 → v6
- `softprops/action-gh-release` v2 → v3
- `aws-actions/configure-aws-credentials` v4 → v6
- `docker/{setup-qemu,setup-buildx,login}-action` v3 → v4
- `docker/build-push-action` v6 → v7

## Test plan
- [ ] CI runs green on this PR (exercises checkout, upload/download-artifact, github-script, codecov, docker build/push paths).
- [ ] `inferno.yml` / `subscriptions-smoke.yml` / `audit-events.yml` exercise `configure-aws-credentials@v6` against the S3 backend.
- [ ] Release workflow (tag push) exercises `softprops/action-gh-release@v3` and `actions/deploy-pages@v5` — not triggered by this PR; verify on next release.