### PR TITLE
fix(rest): honor HFS_MAX_BODY_SIZE on the REST router

### DIFF
--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -158,7 +158,7 @@ pub use tenant::{ResolvedTenant, TenantResolver, TenantSource};
 
 use std::sync::Arc;
 
-use axum::Router;
+use axum::{extract::DefaultBodyLimit, Router};
 use helios_persistence::core::{
     BundleProvider, ConditionalStorage, InstanceHistoryProvider, ResourceStorage, SearchProvider,
 };
@@ -358,6 +358,15 @@ where
     } else {
         router
     };
+
+    // Raise the body-size limit from axum's 2 MiB default to the configured
+    // ceiling. Without this, `HFS_MAX_BODY_SIZE` / `--max-body-size` has no
+    // effect on the REST router: individual batch/transaction handlers read
+    // their body via `axum::body::to_bytes(..., config.max_body_size)`, but
+    // axum's `DefaultBodyLimit` extractor runs first and rejects any request
+    // > 2 MiB with 413 "length limit exceeded" before the handler is called.
+    // Mirrors the pattern already used in `crates/sof/src/server.rs`.
+    let router = router.layer(DefaultBodyLimit::max(config.max_body_size));
 
     // Apply remaining middleware
     router.layer(service_builder)


### PR DESCRIPTION
## Summary

Add `DefaultBodyLimit::max(config.max_body_size)` to the REST router so the configured body-size ceiling actually takes effect. Without this, `HFS_MAX_BODY_SIZE` (and the equivalent `--max-body-size` CLI flag) has no effect on the FHIR REST server — request bodies over 2 MiB are rejected with `413 length limit exceeded` by axum's default extractor before any handler runs.

## Repro

```bash
# Start HFS with a 100 MiB body cap explicitly configured.
docker run --rm -p 8080:8080 \
  -e HFS_MAX_BODY_SIZE=104857600 \
  ghcr.io/heliossoftware/hfs:latest

# POST a 5 MiB Synthea transaction bundle.
curl -v -X POST -H 'Content-Type: application/fhir+json' \
  --data-binary @synthea-5mb-bundle.json \
  http://localhost:8080/
# => HTTP/1.1 413 Payload Too Large
#    body: "Failed to buffer the request body: length limit exceeded"
```

With this patch, the same request returns `200 OK` with the expected transaction-response bundle.

## Why the current code doesn't work

- `crates/rest/src/config.rs` binds `--max-body-size` / `HFS_MAX_BODY_SIZE` to `config.max_body_size` (default `10485760` = 10 MiB).
- `crates/rest/src/handlers/batch.rs` honors the config: `axum::body::to_bytes(request.into_body(), state.config().max_body_size)`.
- **But** `crates/rest/src/lib.rs` doesn't install a `DefaultBodyLimit` tower layer on the router, so axum's default limit (2 MiB) applies and rejects the request before the handler can read it.

`crates/sof/src/server.rs` already does this correctly for the SOF server (line 299 on current `main`). This PR brings the FHIR REST server in line with the same pattern.

## Impact

Observed during a multi-server FHIR load test using Synthea transaction bundles (median ~2-4 MiB, chronic patients up to ~70 MiB). Pre-patch: ~50% of bundles rejected at the 2 MiB boundary regardless of `HFS_MAX_BODY_SIZE`. Post-patch: bundles up to `config.max_body_size` land cleanly.

## Test plan

- [ ] `cargo check -p helios-rest --all-features`
- [ ] `cargo test -p helios-rest` (existing REST crate tests)
- [ ] Manual repro above (5 MiB Synthea bundle POST)

## Notes

- The change is a one-for-one mirror of the existing SOF pattern (`crates/sof/src/server.rs:299`), so the failure mode surface should match.
- Applies the layer *after* CORS/auth/audit and *before* the final `service_builder` — same ordering as SOF.
- Default value in config (`10485760` = 10 MiB) is unchanged; only the enforcement path is fixed.

Happy to adjust the layer placement, comment wording, or add a unit test if you'd prefer a different style.