### PR TITLE
style(rest): alphabetize axum imports to satisfy cargo fmt

### DIFF
--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -158,7 +158,7 @@ pub use tenant::{ResolvedTenant, TenantResolver, TenantSource};
 
 use std::sync::Arc;
 
-use axum::{extract::DefaultBodyLimit, Router};
+use axum::{Router, extract::DefaultBodyLimit};
 use helios_persistence::core::{
     BundleProvider, ConditionalStorage, InstanceHistoryProvider, ResourceStorage, SearchProvider,
 };


### PR DESCRIPTION
## Summary
- Follow-up to #68: rustfmt expects `Router` before `extract::DefaultBodyLimit` in the `axum` use-group.
- Unblocks the `Linting` CI check on `main`.

## Test plan
- [x] `cargo fmt --all -- --check` passes locally