### PR TITLE
ci(hts): run HL7 Tx Ecosystem IG test bench against HTS

### DIFF
--- a/.github/workflows/tx-ecosystem.yml
+++ b/.github/workflows/tx-ecosystem.yml
@@ -1,0 +1,372 @@
+name: Tx Ecosystem IG conformance
+
+# Runs the HL7 FHIR Terminology Ecosystem IG test bench
+# (https://github.com/HL7/fhir-tx-ecosystem-ig) against a freshly built HTS
+# binary loaded with UTG + the tx-source corpora shipped in that repo.
+#
+# Informational only: the job never fails on test outcomes — pass/fail counts
+# are published to the step summary and failing-test JSONs are uploaded as an
+# artifact for offline triage.
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 2
+  CARGO_PROFILE_DEV_DEBUG: 0
+  HTS_PORT: 8096
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Fast feedback
+  # ─────────────────────────────────────────────────────────────────────────────
+  check:
+    name: Check helios-hts
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          clean: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: Configure Rust linker (Linux)
+        run: |
+          mkdir -p ~/.cargo
+          rm -f ~/.cargo/config.toml
+          printf '[target.x86_64-unknown-linux-gnu]\nlinker = "clang"\nrustflags = ["-C", "link-arg=-fuse-ld=lld"]\n' \
+            > ~/.cargo/config.toml
+
+      - name: cargo test (R4 — default)
+        run: cargo test -p helios-hts
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Release binaries (R4 and R5)
+  # ─────────────────────────────────────────────────────────────────────────────
+  build:
+    name: Build HTS binary (${{ matrix.label }})
+    runs-on: [self-hosted, Linux]
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: R4
+            cargo_features: "sqlite,R4"
+          - label: R5
+            cargo_features: "sqlite,R5"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          clean: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Configure Rust linker (Linux)
+        run: |
+          mkdir -p ~/.cargo
+          rm -f ~/.cargo/config.toml
+          printf '[target.x86_64-unknown-linux-gnu]\nlinker = "clang"\nrustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,-zstack-size=8388608"]\n' \
+            > ~/.cargo/config.toml
+
+      - name: cargo build --release (${{ matrix.label }})
+        run: |
+          cargo build --release -p helios-hts \
+            --no-default-features \
+            --features "${{ matrix.cargo_features }}"
+
+      - name: Upload HTS binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: hts-binary-${{ matrix.label }}
+          path: target/release/hts
+          retention-days: 1
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Run the HL7 Tx Ecosystem IG test bench (informational)
+  # ─────────────────────────────────────────────────────────────────────────────
+  tx-ecosystem-test:
+    name: Tx Ecosystem tests — FHIR ${{ matrix.label }}
+    runs-on: [self-hosted, Linux]
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: R4
+            utg_url: https://build.fhir.org/ig/HL7/UTG/hl7.terminology.r4.tgz
+          - label: R5
+            utg_url: https://build.fhir.org/ig/HL7/UTG/hl7.terminology.r5.tgz
+
+    steps:
+      - name: Install OS dependencies (jq, zip)
+        run: |
+          command -v jq  >/dev/null 2>&1 || sudo apt-get install -y jq
+          command -v zip >/dev/null 2>&1 || sudo apt-get install -y zip
+
+      - name: Install Java 21 (for validator_cli.jar)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Download HTS binary (${{ matrix.label }})
+        uses: actions/download-artifact@v8
+        with:
+          name: hts-binary-${{ matrix.label }}
+          path: .
+
+      - name: Make binary executable
+        run: chmod +x ./hts
+
+      - name: Checkout HL7/fhir-tx-ecosystem-ig
+        uses: actions/checkout@v5
+        with:
+          repository: HL7/fhir-tx-ecosystem-ig
+          path: tx-ecosystem-ig
+          clean: false
+
+      - name: Download FHIR validator_cli.jar (latest)
+        run: |
+          curl -fsSL --max-time 300 \
+            https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar \
+            -o validator.jar
+          ls -lh validator.jar
+
+      - name: Download UTG terminology package (${{ matrix.label }})
+        run: |
+          echo "Downloading ${{ matrix.utg_url }}"
+          curl -fsSL --max-time 300 "${{ matrix.utg_url }}" -o utg.tgz
+          ls -lh utg.tgz
+
+      - name: Create data directory
+        run: mkdir -p ./data
+
+      # ── Imports ────────────────────────────────────────────────────────────
+      # Each import is best-effort. Exit 0 = clean, exit 2 = success with
+      # non-fatal warnings (accept both). Exit 1 is logged but does NOT abort
+      # the job — the test bench run will still happen against whatever data
+      # loaded successfully, and the step summary will flag what's missing.
+      - name: Import UTG terminology
+        run: |
+          set +e
+          ./hts import ./utg.tgz \
+            --database-url "./data/hts-${{ matrix.label }}.db" \
+            --batch-size 500 \
+            --verbose
+          CODE=$?
+          echo "UTG_IMPORT_EXIT=$CODE" >> "$GITHUB_ENV"
+          echo "UTG import exit code: $CODE"
+
+      - name: Zip SNOMED RF2 subset (loose .txt files → .zip)
+        run: |
+          set -euo pipefail
+          (cd tx-ecosystem-ig/tx-source/snomed && zip -qr ../snomed-subset-rf2.zip .)
+          ls -lh tx-ecosystem-ig/tx-source/snomed-subset-rf2.zip
+
+      - name: Import SNOMED subset
+        run: |
+          set +e
+          ./hts import tx-ecosystem-ig/tx-source/snomed-subset-rf2.zip \
+            --format snomed-rf2 \
+            --database-url "./data/hts-${{ matrix.label }}.db" \
+            --batch-size 500 \
+            --verbose
+          CODE=$?
+          echo "SNOMED_IMPORT_EXIT=$CODE" >> "$GITHUB_ENV"
+          echo "SNOMED import exit code: $CODE"
+
+      - name: Zip LOINC subset
+        run: |
+          set -euo pipefail
+          (cd tx-ecosystem-ig/tx-source/loinc && zip -qr ../loinc-subset.zip .)
+          ls -lh tx-ecosystem-ig/tx-source/loinc-subset.zip
+
+      - name: Import LOINC subset
+        run: |
+          set +e
+          ./hts import tx-ecosystem-ig/tx-source/loinc-subset.zip \
+            --format loinc \
+            --database-url "./data/hts-${{ matrix.label }}.db" \
+            --batch-size 500 \
+            --verbose
+          CODE=$?
+          echo "LOINC_IMPORT_EXIT=$CODE" >> "$GITHUB_ENV"
+          echo "LOINC import exit code: $CODE"
+
+      - name: Import RxNorm subset
+        run: |
+          set +e
+          ./hts import tx-ecosystem-ig/tx-source/rxnorm/ \
+            --format rxnorm \
+            --database-url "./data/hts-${{ matrix.label }}.db" \
+            --batch-size 500 \
+            --verbose
+          CODE=$?
+          echo "RXNORM_IMPORT_EXIT=$CODE" >> "$GITHUB_ENV"
+          echo "RxNorm import exit code: $CODE"
+
+      - name: Import NDC subset
+        run: |
+          set +e
+          # NDC importer reads a product.txt file directly.
+          NDC_FILE=$(find tx-ecosystem-ig/tx-source/ndc -maxdepth 2 -name product.txt 2>/dev/null | head -1)
+          if [ -z "$NDC_FILE" ]; then
+            echo "No product.txt found under tx-source/ndc — skipping NDC import"
+            echo "NDC_IMPORT_EXIT=skip" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          ./hts import "$NDC_FILE" \
+            --format ndc \
+            --database-url "./data/hts-${{ matrix.label }}.db" \
+            --batch-size 500 \
+            --verbose
+          CODE=$?
+          echo "NDC_IMPORT_EXIT=$CODE" >> "$GITHUB_ENV"
+          echo "NDC import exit code: $CODE"
+
+      # ── Run the server ─────────────────────────────────────────────────────
+      - name: Kill any leftover process on port ${{ env.HTS_PORT }}
+        run: fuser -k "${{ env.HTS_PORT }}/tcp" 2>/dev/null || true
+
+      - name: Start HTS server (${{ matrix.label }})
+        run: |
+          HTS_SERVER_PORT="${{ env.HTS_PORT }}" \
+          HTS_DATABASE_URL="./data/hts-${{ matrix.label }}.db" \
+          HTS_LOG_LEVEL="warn" \
+            ./hts serve > "/tmp/hts-${{ matrix.label }}.log" 2>&1 &
+
+          echo "HTS_PID=$!" >> "$GITHUB_ENV"
+          echo "Started HTS server (PID=$!)"
+
+          for i in $(seq 1 30); do
+            if curl -sf "http://localhost:${{ env.HTS_PORT }}/health" > /dev/null 2>&1; then
+              echo "Server ready after $((i * 2)) seconds"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "ERROR: server did not start within 60 s"
+              echo "--- server log ---"
+              cat "/tmp/hts-${{ matrix.label }}.log" || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+      # ── Run the IG test bench ──────────────────────────────────────────────
+      - name: Run txtests (${{ matrix.label }})
+        run: |
+          set +e
+          mkdir -p tx-test-output
+          java -jar validator.jar -txtests \
+            -source ./tx-ecosystem-ig \
+            -tx "http://localhost:${{ env.HTS_PORT }}" \
+            -output ./tx-test-output \
+            2>&1 | tee "/tmp/txtests-${{ matrix.label }}.log"
+          # Informational — capture exit code but don't fail the job.
+          echo "TXTESTS_EXIT=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
+
+      - name: Summarize results
+        if: always()
+        run: |
+          set +e
+          LABEL="${{ matrix.label }}"
+          LOG="/tmp/txtests-${LABEL}.log"
+
+          # The validator writes one JSON file per failing test to -output.
+          FAILED=$(find tx-test-output -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+
+          # Total tests: grep the validator's own summary line from its log
+          # (format varies across validator releases — we tolerate missing).
+          TOTAL_LINE=$(grep -E '(tests? (run|executed)|txtests?.+complete)' "$LOG" 2>/dev/null | tail -1 || true)
+          TOTAL=$(printf '%s' "$TOTAL_LINE" | grep -oE '[0-9]+' | head -1)
+          if [ -z "$TOTAL" ]; then TOTAL="unknown"; fi
+
+          PASSED="unknown"
+          PASS_RATE="unknown"
+          if [ "$TOTAL" != "unknown" ] && [ "$TOTAL" -gt 0 ] 2>/dev/null; then
+            PASSED=$((TOTAL - FAILED))
+            PASS_RATE=$(awk -v p="$PASSED" -v t="$TOTAL" 'BEGIN{ printf "%.1f%%", (p*100)/t }')
+          fi
+
+          {
+            echo "## Tx Ecosystem IG — FHIR ${LABEL}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Total tests | ${TOTAL} |"
+            echo "| Failed      | ${FAILED} |"
+            echo "| Passed      | ${PASSED} |"
+            echo "| Pass rate   | ${PASS_RATE} |"
+            echo "| Validator exit | ${TXTESTS_EXIT:-?} |"
+            echo ""
+            echo "### Import status"
+            echo ""
+            echo "| Corpus | Exit code |"
+            echo "|---|---|"
+            echo "| UTG    | ${UTG_IMPORT_EXIT:-?} |"
+            echo "| SNOMED | ${SNOMED_IMPORT_EXIT:-?} |"
+            echo "| LOINC  | ${LOINC_IMPORT_EXIT:-?} |"
+            echo "| RxNorm | ${RXNORM_IMPORT_EXIT:-?} |"
+            echo "| NDC    | ${NDC_IMPORT_EXIT:-?} |"
+            echo ""
+            echo "> Informational run. 0 = success, 2 = success-with-warnings, 1 = fatal, skip = not attempted."
+            echo "> Failing-test JSON diffs are published as the \`tx-test-output-${LABEL}\` artifact."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "=== Tx Ecosystem IG — FHIR ${LABEL} ==="
+          echo "Total=${TOTAL} Failed=${FAILED} Passed=${PASSED} PassRate=${PASS_RATE}"
+
+      - name: Upload failing-test JSON diffs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tx-test-output-${{ matrix.label }}
+          path: tx-test-output
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload txtests log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: txtests-log-${{ matrix.label }}
+          path: /tmp/txtests-${{ matrix.label }}.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Dump server log on failure
+        if: failure()
+        run: cat "/tmp/hts-${{ matrix.label }}.log" 2>/dev/null || echo "(no server log found)"
+
+      - name: Stop HTS server
+        if: always()
+        run: |
+          if [ -n "${HTS_PID:-}" ]; then
+            kill "$HTS_PID" 2>/dev/null || true
+            wait "$HTS_PID" 2>/dev/null || true
+          fi
+
+      - name: Clean up working files
+        if: always()
+        run: |
+          rm -f \
+            "./data/hts-${{ matrix.label }}.db" \
+            "./utg.tgz" \
+            "./validator.jar" \
+            "./hts" \
+            "/tmp/hts-${{ matrix.label }}.log" \
+            "/tmp/txtests-${{ matrix.label }}.log" \
+            "tx-ecosystem-ig/tx-source/snomed-subset-rf2.zip" \
+            "tx-ecosystem-ig/tx-source/loinc-subset.zip"
+          rm -rf ./tx-test-output ./tx-ecosystem-ig


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/tx-ecosystem.yml` — a `workflow_dispatch`-only pipeline that exercises the [HL7 FHIR Tx Ecosystem IG](https://github.com/HL7/fhir-tx-ecosystem-ig) conformance suite against a freshly built HTS binary.
- Matrix covers **R4 + R5**: builds `hts` with the matching cargo feature set, imports UTG plus the SNOMED / LOINC / RxNorm / NDC subsets shipped in `tx-source/`, starts the server, and runs `java -jar validator_cli.jar -txtests -tx http://localhost:8096 ...`.
- **Informational only** — the job does not fail on test outcomes. Pass/fail counts and per-import exit codes go to `$GITHUB_STEP_SUMMARY`; failing-test JSON diffs and the validator log upload as artifacts (7-day retention).
- Reuses the self-hosted runner pattern, linker config, UTG download, port-freeing, health-poll, and cleanup structure from the existing `hts.yml`.

## Test plan

- [ ] Trigger the workflow manually from the Actions tab (`Tx Ecosystem IG conformance` → `Run workflow`).
- [ ] `check` and `build` jobs (both matrix entries) complete green.
- [ ] `tx-ecosystem-test` jobs publish a summary table with Total / Failed / Passed / Pass rate, plus import-status rows for UTG / SNOMED / LOINC / RxNorm / NDC.
- [ ] Artifact `tx-test-output-R4` (and `-R5`) downloads with failing-test JSONs for offline triage.
- [ ] Inspect artifacts to confirm the validator is actually hitting HTS (not hanging on startup or import failures).

## Notes / follow-ups

- **Unpinned validator JAR** — currently downloads `validator_cli.jar` from the `latest` GitHub release. If upstream releases break us, pin to a specific tag.
- **SNOMED snapshot vs full** — repo ships `sct2_*_Snapshot_INT_*.txt`; our RF2 importer's auto-detection looks for `concept_full`/`description_full`. We bypass auto-detect with `--format snomed-rf2`, but the importer itself may still need tweaks for snapshot-only data. Fix forward once we see the first run's output.
- **NDC / LOINC paths** — best-effort: import exit codes captured but non-fatal. Tests referencing unavailable content will fail, which is fine for an informational run.
- **`messages-hts.json`** — not authored yet. Many "error text mismatch" failures expected until we write one and pass it via `-externals`.
- **Gating** — once pass rate stabilizes, promote from `workflow_dispatch` to `pull_request` + `schedule` and add a threshold check.

Plan document: `/Users/slm/.claude/plans/hidden-cooking-fairy.md` (local).