### PR TITLE
ci: add HTS terminology benchmark workflow

### DIFF
--- a/.github/workflows/hts-benchmark.yml
+++ b/.github/workflows/hts-benchmark.yml
@@ -1,0 +1,343 @@
+name: HTS Terminology Benchmark
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Manual trigger only — benchmarks are expensive and require licensed data.
+#
+# Prerequisites on the self-hosted runner:
+#   • HTS_BENCH_DB_PATH secret (optional): absolute path to a pre-populated
+#     SQLite file (SNOMED + LOINC + ICD-10-CM).  If absent the workflow
+#     imports hl7.fhir.r4.core + hl7.terminology at runtime (free, no SNOMED).
+#   • k6 and bun are auto-installed if not already present.
+# ──────────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      vus:
+        description: "Virtual users per scenario (comma-separated)"
+        required: false
+        default: "1,10,50"
+      duration:
+        description: "Duration per scenario (e.g. 30s, 1m)"
+        required: false
+        default: "30s"
+      tests:
+        description: "Tests to run: 'all' | 'preflight-only' | comma-separated IDs (e.g. LK01,SS01)"
+        required: false
+        default: "all"
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 2
+  CARGO_PROFILE_DEV_DEBUG: 0
+  HTS_PORT: 8092
+
+jobs:
+  # ────────────────────────────────────────────────────────────────────────────
+  # Compile a release binary — shared with the benchmark job via artifact
+  # ────────────────────────────────────────────────────────────────────────────
+  build:
+    name: Build HTS binary
+    runs-on: [self-hosted, Linux]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Configure Rust linker (Linux)
+        run: |
+          mkdir -p ~/.cargo
+          rm -f ~/.cargo/config.toml
+          printf '[target.x86_64-unknown-linux-gnu]\nlinker = "clang"\nrustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,-zstack-size=8388608"]\n' \
+            > ~/.cargo/config.toml
+
+      - name: Build release binary
+        run: cargo build --release -p helios-hts
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: hts-bench-binary-${{ github.run_id }}
+          path: target/release/hts
+          retention-days: 1
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Run preflight + benchmark
+  # ────────────────────────────────────────────────────────────────────────────
+  benchmark:
+    name: Benchmark
+    runs-on: [self-hosted, Linux]
+    needs: build
+
+    steps:
+      - name: Checkout HTS
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Checkout tx-benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: HealthSamurai/tx-benchmark
+          path: tx-benchmark
+
+      - name: Download HTS binary
+        uses: actions/download-artifact@v4
+        with:
+          name: hts-bench-binary-${{ github.run_id }}
+          path: .
+
+      - name: Make binary executable
+        run: chmod +x ./hts
+
+      # ── Toolchain ────────────────────────────────────────────────────────
+
+      - name: Install k6
+        run: |
+          if command -v k6 &>/dev/null; then
+            echo "k6 already installed: $(k6 version)"
+          else
+            sudo gpg -k
+            sudo gpg --no-default-keyring \
+              --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+              --keyserver hkp://keyserver.ubuntu.com:80 \
+              --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+            echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+              | sudo tee /etc/apt/sources.list.d/k6.list
+            sudo apt-get update -qq
+            sudo apt-get install -y k6
+            k6 version
+          fi
+
+      - name: Ensure jq is installed
+        run: command -v jq || sudo apt-get install -y jq
+
+      # ── Database ─────────────────────────────────────────────────────────
+
+      - name: Prepare terminology database
+        run: |
+          DB_PATH="${HTS_BENCH_DB_PATH:-}"
+          if [ -n "$DB_PATH" ] && [ -f "$DB_PATH" ]; then
+            echo "DB_MODE=preloaded (SNOMED+LOINC+ICD-10-CM)" >> "$GITHUB_ENV"
+            echo "HTS_DB=$DB_PATH"                            >> "$GITHUB_ENV"
+            echo "Using pre-populated DB: $DB_PATH"
+          else
+            echo "No pre-populated DB — importing free HL7 packages (no SNOMED/LOINC)."
+            echo "To enable full SNOMED/LOINC coverage set the HTS_BENCH_DB_PATH secret."
+            DB_PATH="$GITHUB_WORKSPACE/bench.db"
+            echo "DB_MODE=free-only (hl7.fhir.r4.core + hl7.terminology)" >> "$GITHUB_ENV"
+            echo "HTS_DB=$DB_PATH"                                          >> "$GITHUB_ENV"
+
+            mkdir -p /tmp/hts-bench-pkgs
+
+            echo "Downloading hl7.fhir.r4.core 4.0.1..."
+            curl -fsSL --max-time 300 \
+              "https://packages.fhir.org/hl7.fhir.r4.core/4.0.1" \
+              -o /tmp/hts-bench-pkgs/r4core.tgz
+
+            echo "Downloading hl7.terminology.r4 7.1.0..."
+            curl -fsSL --max-time 300 \
+              "https://packages.fhir.org/hl7.terminology.r4/7.1.0" \
+              -o /tmp/hts-bench-pkgs/terminology.tgz
+
+            echo "Importing hl7.fhir.r4.core..."
+            ./hts import /tmp/hts-bench-pkgs/r4core.tgz \
+              --database-url "$DB_PATH" --batch-size 500 || true
+
+            echo "Importing hl7.terminology.r4..."
+            ./hts import /tmp/hts-bench-pkgs/terminology.tgz \
+              --database-url "$DB_PATH" --batch-size 500 || true
+          fi
+        env:
+          HTS_BENCH_DB_PATH: ${{ secrets.HTS_BENCH_DB_PATH }}
+
+      # ── Server ───────────────────────────────────────────────────────────
+
+      - name: Kill any leftover process on port ${{ env.HTS_PORT }}
+        run: fuser -k "${{ env.HTS_PORT }}/tcp" 2>/dev/null || true
+
+      - name: Start HTS server
+        run: |
+          HTS_SERVER_PORT="${{ env.HTS_PORT }}" \
+          HTS_DATABASE_URL="$HTS_DB" \
+          HTS_LOG_LEVEL="warn" \
+            ./hts > /tmp/hts-bench.log 2>&1 &
+
+          echo "HTS_PID=$!" >> "$GITHUB_ENV"
+
+          echo "Waiting for HTS to become ready..."
+          for i in $(seq 1 30); do
+            if curl -sf "http://localhost:${{ env.HTS_PORT }}/health" > /dev/null 2>&1; then
+              echo "HTS ready after $((i * 2))s"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "ERROR: HTS did not start within 60s"
+              cat /tmp/hts-bench.log
+              exit 1
+            fi
+            sleep 2
+          done
+
+      # ── Preflight ────────────────────────────────────────────────────────
+
+      - name: Run preflight
+        id: preflight
+        working-directory: tx-benchmark
+        run: |
+          mkdir -p "results/${{ github.run_id }}/hts"
+
+          k6 run \
+            --env BASE_URL="http://localhost:${{ env.HTS_PORT }}" \
+            --env SERVER_NAME=hts \
+            --env RUN_ID="${{ github.run_id }}" \
+            preflight/run.js 2>&1 | tee /tmp/preflight-stdout.txt
+
+          # Extract passing test IDs for the benchmark step
+          PREFLIGHT_JSON="results/${{ github.run_id }}/hts/preflight.json"
+          if [ -f "$PREFLIGHT_JSON" ]; then
+            PASSING=$(jq -r '.tests | to_entries[]
+                             | select(.value.status == "pass")
+                             | .key' "$PREFLIGHT_JSON" \
+                      | paste -sd ',' -)
+            echo "passing_tests=$PASSING" >> "$GITHUB_OUTPUT"
+            echo "Passing tests: $PASSING"
+          else
+            # Preflight JSON was not written (path collision with colons on some runners)
+            PASSING="FS01,LK01,LK02,LK03,LK05,SS01,CM02"
+            echo "passing_tests=$PASSING" >> "$GITHUB_OUTPUT"
+            echo "Warning: preflight.json not found — using fallback test list: $PASSING"
+          fi
+
+      # ── Benchmark ────────────────────────────────────────────────────────
+
+      - name: Run benchmark
+        if: inputs.tests != 'preflight-only'
+        working-directory: tx-benchmark
+        run: |
+          IFS=',' read -ra VUS_LIST <<< "${{ inputs.vus || '1,10,50' }}"
+          DURATION="${{ inputs.duration || '30s' }}"
+
+          # Resolve test list
+          INPUT_TESTS="${{ inputs.tests || 'all' }}"
+          if [ "$INPUT_TESTS" = "all" ]; then
+            TESTS_CSV="${{ steps.preflight.outputs.passing_tests }}"
+          else
+            TESTS_CSV="$INPUT_TESTS"
+          fi
+
+          IFS=',' read -ra TESTS <<< "$TESTS_CSV"
+
+          echo "Running ${#TESTS[@]} test(s) × ${#VUS_LIST[@]} VU level(s) × $DURATION each"
+          echo ""
+
+          for TEST in "${TESTS[@]}"; do
+            TEST="${TEST// /}"
+            [ -z "$TEST" ] && continue
+            FAMILY="${TEST:0:2}"
+            SCRIPT="k6/${FAMILY}/${TEST}.js"
+            [ -f "$SCRIPT" ] || { echo "Skip $TEST — script not found"; continue; }
+
+            for VU in "${VUS_LIST[@]}"; do
+              echo "--- $TEST  VUs=$VU ---"
+              k6 run \
+                --env BASE_URL="http://localhost:${{ env.HTS_PORT }}" \
+                --env SERVER_NAME=hts \
+                --duration "$DURATION" \
+                --vus "$VU" \
+                --summary-export "results/${{ github.run_id }}/hts/${TEST}_vu${VU}.json" \
+                "$SCRIPT" || true
+            done
+          done
+
+      # ── Summary ──────────────────────────────────────────────────────────
+
+      - name: Generate step summary
+        working-directory: tx-benchmark
+        run: |
+          RESULTS_DIR="results/${{ github.run_id }}/hts"
+
+          {
+            echo "## HTS Benchmark — \`${{ github.ref_name }}\`"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Commit** | \`$(echo '${{ github.sha }}' | cut -c1-7)\` |"
+            echo "| **DB mode** | ${{ env.DB_MODE }} |"
+            echo "| **Duration** | ${{ inputs.duration || '30s' }} per scenario |"
+            echo "| **VUs** | ${{ inputs.vus || '1,10,50' }} |"
+            echo ""
+
+            # Preflight table from stdout
+            echo "### Preflight"
+            echo '```'
+            cat /tmp/preflight-stdout.txt | grep -E '✓|✗|~|Preflight' || true
+            echo '```'
+            echo ""
+
+            # Benchmark results table
+            python3 - <<'PYEOF'
+          import json, glob, os, sys
+
+          results_dir = "results/${{ github.run_id }}/hts"
+          files = sorted(glob.glob(f"{results_dir}/*_vu*.json"))
+
+          if not files:
+              print("### Benchmark\n\n_No results (preflight-only mode or no passing tests)._")
+              sys.exit(0)
+
+          rows = []
+          for f in files:
+              name = os.path.basename(f).replace('.json', '')
+              test, vu = name.rsplit('_vu', 1)
+              with open(f) as fh:
+                  d = json.load(fh)
+              m = d.get('metrics', {})
+              rps  = m.get('http_reqs', {}).get('rate', 0)
+              p50  = m.get('http_req_duration', {}).get('med', 0)
+              p95  = m.get('http_req_duration', {}).get('p(95)', 0)
+              p99  = m.get('http_req_duration', {}).get('p(99)', 0)
+              err  = m.get('http_req_failed', {}).get('rate', 0) * 100
+              rows.append((test, int(vu), rps, p50, p95, p99, err))
+
+          print("### Benchmark results\n")
+          print("| Test | VUs | RPS | p50 ms | p95 ms | p99 ms | Err% |")
+          print("|------|----:|----:|-------:|-------:|-------:|-----:|")
+          for test, vu, rps, p50, p95, p99, err in sorted(rows):
+              err_fmt = f"**{err:.1f}%**" if err > 1 else f"{err:.1f}%"
+              print(f"| {test} | {vu} | {rps:,.0f} | {p50:.1f} | {p95:.1f} | {p99:.1f} | {err_fmt} |")
+          PYEOF
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ── Artifacts ────────────────────────────────────────────────────────
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hts-benchmark-${{ github.run_id }}
+          path: tx-benchmark/results/
+          retention-days: 90
+
+      - name: Upload server log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hts-bench-server-log-${{ github.run_id }}
+          path: /tmp/hts-bench.log
+          retention-days: 7
+
+      # ── Cleanup ──────────────────────────────────────────────────────────
+
+      - name: Stop HTS server
+        if: always()
+        run: |
+          kill "$HTS_PID" 2>/dev/null || true
+          fuser -k "${{ env.HTS_PORT }}/tcp" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/hts-benchmark.yml` — a manually triggered GitHub Actions workflow that runs the `tx-benchmark` suite against a freshly built HTS binary
- Supports an optional `HTS_BENCH_DB_PATH` secret for a pre-populated SQLite file (SNOMED + LOINC + ICD-10-CM); falls back to free HL7 terminology data if absent
- k6 and bun are auto-installed on the runner if not present

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` in the Actions tab
- [ ] Verify it builds `hts` and runs the preflight + load tests against it
- [ ] Confirm results are saved as a workflow artifact