### PR TITLE
fix(persistence): use & delimiter for _cursor in pagination links

### DIFF
--- a/crates/persistence/src/core/search.rs
+++ b/crates/persistence/src/core/search.rs
@@ -94,9 +94,16 @@ impl SearchResult {
             bundle = bundle.with_total(total);
         }
 
-        // Add next link if there's more data
+        // Add next link if there's more data. The self_link already contains
+        // the request's query string (potentially including a `_cursor` param
+        // from the previous page), so we strip any existing `_cursor=` and
+        // append the new one with the correct delimiter.
         if let Some(ref cursor) = self.resources.page_info.next_cursor {
-            bundle = bundle.with_next_link(format!("{}?_cursor={}", self_link, cursor));
+            bundle = bundle.with_next_link(replace_cursor_param(self_link, cursor));
+        }
+
+        if let Some(ref cursor) = self.resources.page_info.previous_cursor {
+            bundle = bundle.with_previous_link(replace_cursor_param(self_link, cursor));
         }
 
         // Add matching resources
@@ -119,6 +126,40 @@ impl SearchResult {
 
         bundle
     }
+}
+
+/// Returns `url` with any existing `_cursor=…` query parameter replaced by the
+/// supplied opaque `cursor` value. Used to build pagination links from the
+/// request's self URL.
+///
+/// Cursors are base64-url-safe so they don't need percent-encoding; the only
+/// surgery required is splitting on the first `?`, dropping any pre-existing
+/// `_cursor` pair, and re-joining with `&`. This is what makes the difference
+/// between
+///
+/// ```text
+/// .../Patient?_count=3&_elements=id?_cursor=…   // wrong: literal `?` mid-query
+/// ```
+///
+/// and the spec-compliant
+///
+/// ```text
+/// .../Patient?_count=3&_elements=id&_cursor=…
+/// ```
+fn replace_cursor_param(url: &str, cursor: &str) -> String {
+    let (base, query) = match url.find('?') {
+        Some(pos) => (&url[..pos], &url[pos + 1..]),
+        None => (url, ""),
+    };
+
+    let mut parts: Vec<String> = query
+        .split('&')
+        .filter(|p| !p.is_empty() && !p.starts_with("_cursor="))
+        .map(str::to_string)
+        .collect();
+    parts.push(format!("_cursor={}", cursor));
+
+    format!("{}?{}", base, parts.join("&"))
 }
 
 /// Basic search provider for single resource type queries.
@@ -475,5 +516,82 @@ mod tests {
 
         assert_eq!(bundle.total, Some(1));
         assert_eq!(bundle.entry.len(), 1);
+    }
+
+    /// Self-link has no query: cursor is appended with `?` (issue #69 bug 1).
+    #[test]
+    fn test_replace_cursor_param_no_query() {
+        let url = replace_cursor_param("http://example.com/fhir/Patient", "abc");
+        assert_eq!(url, "http://example.com/fhir/Patient?_cursor=abc");
+    }
+
+    /// Self-link already has params: cursor is joined with `&`, not `?`. This is
+    /// the core regression — see issue #69. A literal `?` mid-query made
+    /// `urljoin` percent-encode the cursor delimiter, breaking pagination.
+    #[test]
+    fn test_replace_cursor_param_with_existing_params() {
+        let url = replace_cursor_param(
+            "http://example.com/fhir/Patient?_count=3&_elements=id",
+            "abc",
+        );
+        assert_eq!(
+            url,
+            "http://example.com/fhir/Patient?_count=3&_elements=id&_cursor=abc"
+        );
+    }
+
+    /// When the self-link already carries the previous page's cursor (because
+    /// the request URL is reused as the self link), the old cursor is dropped
+    /// before the new one is appended — otherwise pages accumulate stale
+    /// cursors and the next link grows unbounded.
+    #[test]
+    fn test_replace_cursor_param_replaces_existing_cursor() {
+        let url = replace_cursor_param(
+            "http://example.com/fhir/Patient?_count=3&_cursor=old&_elements=id",
+            "new",
+        );
+        assert!(url.starts_with("http://example.com/fhir/Patient?"));
+        assert!(url.contains("_count=3"));
+        assert!(url.contains("_elements=id"));
+        assert!(url.contains("_cursor=new"));
+        assert!(!url.contains("_cursor=old"));
+        assert_eq!(url.matches("_cursor=").count(), 1);
+    }
+
+    /// `to_bundle` should produce a `next` link whose URL contains exactly one
+    /// `_cursor` and uses `&` between query params.
+    #[test]
+    fn test_to_bundle_next_link_format() {
+        let page = Page::new(
+            Vec::<StoredResource>::new(),
+            PageInfo {
+                next_cursor: Some("CURSOR_VALUE".to_string()),
+                previous_cursor: None,
+                total: None,
+                has_next: true,
+                has_previous: false,
+            },
+        );
+        let result = SearchResult::new(page);
+
+        let bundle = result.to_bundle(
+            "http://example.com/fhir",
+            "http://example.com/fhir/Patient?_count=3&_elements=id",
+        );
+
+        let next = bundle
+            .link
+            .iter()
+            .find(|l| l.relation == "next")
+            .expect("next link present");
+        assert_eq!(
+            next.url,
+            "http://example.com/fhir/Patient?_count=3&_elements=id&_cursor=CURSOR_VALUE"
+        );
+        assert_eq!(
+            next.url.matches('?').count(),
+            1,
+            "exactly one '?' delimiter"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #69 — search pagination is unusable for any client that follows `Bundle.link[rel=next]`.

**Root cause** (one line in `crates/persistence/src/core/search.rs`): the next-link builder always concatenated `?_cursor=…` to the request's self URL, even when the URL already had a query string. Result: `…/Patient?_count=3&_elements=id?_cursor=…`. A spec-compliant client (`urllib.parse.urljoin` + percent-encoding) then sends `_elements=id%3F_cursor%3D…`, the server treats it as one big `_elements` value, the cursor never reaches the backend, and search restarts from page 1 every request. All three symptoms reported in the issue (malformed URL, unbounded URL growth, duplicates / non-termination) collapse to this single bug.

- Added `replace_cursor_param`: strips any existing `_cursor=` from the query, appends the new cursor with `&` if a query is already present, `?` otherwise.
- Routed both the `next` **and** `previous` links through it. The previous-link path was previously dead — backends populate `previous_cursor` but nothing built a link from it.
- Self link and other params are preserved verbatim, so `_count`, `_elements`, etc. now correctly thread through pagination.

## Test plan

- [x] 4 new unit tests in `core::search::tests` covering: no query, with query, replacing existing cursor, end-to-end via `to_bundle`
- [x] `cargo test -p helios-persistence --features R4 --lib` — 600 passed
- [x] `cargo test -p helios-rest --features R4 --lib` — 182 passed
- [x] `cargo clippy -p helios-persistence --features R4,postgres,elasticsearch --all-targets` with CI flags — clean
- [x] `cargo fmt --all`
- [ ] Manual repro from the issue against a built binary (recommend re-running the reporter's Python script before merging)