### PR TITLE
ci: align workflow secret/var refs with actual GitHub config

### DIFF
--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -10,7 +10,7 @@ env:
   HFS_PORT: 8088
   DOCKER_HOST: ${{ secrets.DOCKER_HOST }}
   DOCKER_HOST_IP: ${{ secrets.DOCKER_HOST_IP }}
-  HFS_S3_BUCKET: ${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}
+  HFS_S3_BUCKET: ${{ secrets.HFS_S3_BUCKET }}
   HFS_AUDIT_CLOUDWATCH_LOG_GROUP: ${{ vars.HFS_AUDIT_CLOUDWATCH_LOG_GROUP }}
 
 jobs:
@@ -335,8 +335,8 @@ jobs:
         if: matrix.backend == 's3-elasticsearch' || matrix.backend == 'cloudwatch'
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Install AWS CLI
         if: matrix.backend == 's3-elasticsearch' || matrix.backend == 'cloudwatch'
@@ -355,7 +355,7 @@ jobs:
       - name: Empty S3 prefix
         if: matrix.backend == 's3-elasticsearch'
         run: |
-          BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}"
+          BUCKET="${{ secrets.HFS_S3_BUCKET }}"
           PRIMARY_PREFIX="ci-audit/${{ github.run_id }}/${{ github.run_attempt }}/primary/"
           AUDIT_PREFIX="ci-audit/${{ github.run_id }}/${{ github.run_attempt }}/audit/"
           echo "PRIMARY_S3_PREFIX=$PRIMARY_PREFIX" >> $GITHUB_ENV
@@ -492,7 +492,7 @@ jobs:
             ./target/debug/hfs --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
           elif [ "${{ matrix.backend }}" = "s3-elasticsearch" ]; then
             HFS_STORAGE_BACKEND=s3-elasticsearch \
-            HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}" \
+            HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET }}" \
             HFS_S3_PREFIX="$PRIMARY_S3_PREFIX" \
             HFS_S3_VALIDATE_BUCKETS=false \
             HFS_ELASTICSEARCH_NODES="http://$DOCKER_HOST_IP:$ES_PORT" \
@@ -512,7 +512,7 @@ jobs:
             HFS_AUDIT_BACKEND=cloudwatch \
             HFS_AUDIT_CLOUDWATCH_LOG_GROUP="$CLOUDWATCH_LOG_GROUP" \
             HFS_AUDIT_CLOUDWATCH_LOG_STREAM="$CLOUDWATCH_LOG_STREAM" \
-            HFS_AUDIT_CLOUDWATCH_REGION="${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}" \
+            HFS_AUDIT_CLOUDWATCH_REGION="${{ vars.AWS_REGION || 'us-east-1' }}" \
             HFS_ENABLE_CORS=false \
             HFS_AUTH_ENABLED=true \
             HFS_AUTH_JWKS_URL="$AUTH_JWKS_URL" \
@@ -906,8 +906,8 @@ jobs:
         if: matrix.backend == 's3'
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Install AWS CLI
         if: matrix.backend == 's3'
@@ -926,7 +926,7 @@ jobs:
       - name: Prepare S3 prefixes
         if: matrix.backend == 's3'
         run: |
-          BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}"
+          BUCKET="${{ secrets.HFS_S3_BUCKET }}"
           PRIMARY_PREFIX="ci-audit-db/${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.mode }}/primary/"
           AUDIT_PREFIX="ci-audit-db/${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.mode }}/audit/"
           echo "PRIMARY_S3_PREFIX=$PRIMARY_PREFIX" >> $GITHUB_ENV
@@ -1012,7 +1012,7 @@ jobs:
           else
             if [ "${{ matrix.mode }}" = "dedicated" ]; then
               HFS_STORAGE_BACKEND=s3 \
-              HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}" \
+              HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET }}" \
               HFS_S3_PREFIX="$PRIMARY_S3_PREFIX" \
               HFS_S3_VALIDATE_BUCKETS=false \
               HFS_AUDIT_BACKEND=database \
@@ -1023,7 +1023,7 @@ jobs:
               ./target/debug/hfs --log-level info --port "$HFS_PORT_SMOKE" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
             else
               HFS_STORAGE_BACKEND=s3 \
-              HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}" \
+              HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET }}" \
               HFS_S3_PREFIX="$PRIMARY_S3_PREFIX" \
               HFS_S3_VALIDATE_BUCKETS=false \
               HFS_AUDIT_BACKEND=database \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1111,7 +1111,7 @@ jobs:
           DEPLOY_USER: ${{ matrix.server == 'fhirpath-server' && secrets.FHIRPATH_DEPLOY_USER || matrix.server == 'sof-server' && secrets.SOF_DEPLOY_USER || matrix.server == 'hts' && secrets.HTS_DEPLOY_USER || secrets.HFS_DEPLOY_USER }}
           DEPLOY_PORT: ${{ matrix.server == 'fhirpath-server' && secrets.FHIRPATH_DEPLOY_PORT || matrix.server == 'sof-server' && secrets.SOF_DEPLOY_PORT || matrix.server == 'hts' && secrets.HTS_DEPLOY_PORT || secrets.HFS_DEPLOY_PORT || 22 }}
           SERVER_NAME: ${{ matrix.server }}
-          HFS_PUBLIC_URL: ${{ secrets.HFS_BASE_URL }}
+          HFS_PUBLIC_URL: ${{ secrets.HFS_PUBLIC_URL }}
         run: |
           # Define SSH command with proper options (runner's own key is trusted by targets)
           SSH_CMD="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $DEPLOY_PORT $DEPLOY_USER@$DEPLOY_HOST"

--- a/.github/workflows/hts-benchmark.yml
+++ b/.github/workflows/hts-benchmark.yml
@@ -126,8 +126,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Install AWS CLI
         run: |

--- a/.github/workflows/inferno.yml
+++ b/.github/workflows/inferno.yml
@@ -13,7 +13,7 @@ env:
   DOCKER_HOST: ${{ secrets.DOCKER_HOST }}
   DOCKER_HOST_IP: ${{ secrets.DOCKER_HOST_IP }}
   # S3+Elasticsearch backend configuration (optional; s3-elasticsearch tests are skipped when not set)
-  HFS_S3_BUCKET: ${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}
+  HFS_S3_BUCKET: ${{ secrets.HFS_S3_BUCKET }}
 
 jobs:
   build:
@@ -258,8 +258,8 @@ jobs:
         if: matrix.backend == 's3-elasticsearch'
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Install AWS CLI
         if: matrix.backend == 's3-elasticsearch'
@@ -278,7 +278,7 @@ jobs:
       - name: Empty S3 prefix
         if: matrix.backend == 's3-elasticsearch'
         run: |
-          BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}"
+          BUCKET="${{ secrets.HFS_S3_BUCKET }}"
           PREFIX="ci/${{ matrix.suite_id }}/"
           echo "Emptying s3://$BUCKET/$PREFIX"
           aws s3 rm "s3://$BUCKET/$PREFIX" --recursive
@@ -309,7 +309,7 @@ jobs:
             ./target/debug/hfs --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
           elif [ "${{ matrix.backend }}" = "s3-elasticsearch" ]; then
             HFS_STORAGE_BACKEND=s3-elasticsearch \
-            HFS_S3_BUCKET=${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }} \
+            HFS_S3_BUCKET=${{ secrets.HFS_S3_BUCKET }} \
             HFS_S3_PREFIX=ci/${{ matrix.suite_id }}/ \
             HFS_S3_VALIDATE_BUCKETS=false \
             HFS_ELASTICSEARCH_NODES=http://$DOCKER_HOST_IP:$ES_PORT \

--- a/.github/workflows/subscriptions-smoke.yml
+++ b/.github/workflows/subscriptions-smoke.yml
@@ -17,7 +17,7 @@ env:
   HFS_PORT: 18088
   DOCKER_HOST: ${{ secrets.DOCKER_HOST }}
   DOCKER_HOST_IP: ${{ secrets.DOCKER_HOST_IP }}
-  HFS_S3_BUCKET: ${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}
+  HFS_S3_BUCKET: ${{ secrets.HFS_S3_BUCKET }}
 
 jobs:
   matrix-setup:
@@ -258,8 +258,8 @@ jobs:
         if: matrix.backend == 's3-elasticsearch'
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION || 'us-east-1' }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Install AWS CLI
         if: matrix.backend == 's3-elasticsearch'
@@ -350,7 +350,7 @@ jobs:
             HFS_BASE_URL="http://localhost:$HFS_PORT" \
             HFS_DEFAULT_FHIR_VERSION="${{ matrix.fhir_version }}" \
             HFS_STORAGE_BACKEND=s3-elasticsearch \
-            HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET || vars.HFS_S3_BUCKET }}" \
+            HFS_S3_BUCKET="${{ secrets.HFS_S3_BUCKET }}" \
             HFS_S3_PREFIX="ci/subscriptions-smoke/${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.build_key }}/${{ matrix.fhir_version }}/${{ matrix.backend }}/" \
             HFS_S3_VALIDATE_BUCKETS=false \
             HFS_ELASTICSEARCH_NODES="http://$DOCKER_HOST_IP:$ES_PORT" \


### PR DESCRIPTION
## Summary
- Collapse `secrets.X || vars.X` fallbacks to the single source that actually exists in GitHub config.
- `AWS_REGION` is a var; `AWS_ROLE_ARN` and `HFS_S3_BUCKET` are secrets.
- Rename stale `secrets.HFS_BASE_URL` → `secrets.HFS_PUBLIC_URL` in the deploy step (`ci.yml:1114`).

Skipped (intentionally left alone): `INFERNO_PORT` fallback in `inferno.yml`, and the `*_DEPLOY_PORT`/`HTS_DEPLOY_*` references in `ci.yml`.

## Test plan
- [ ] PR CI runs on the touched workflow files and passes.
- [ ] Next tag-triggered deploy of `hfs` resolves `HFS_PUBLIC_URL` correctly (now reads the right secret).
- [ ] AWS-using workflows (`audit-events`, `hts-benchmark`, `inferno`, `subscriptions-smoke`) still authenticate via OIDC.