### PR TITLE
feat(persistence/mongodb): implement IncludeProvider and RevincludeProvider

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -360,8 +360,8 @@ The matrix below shows which FHIR operations each backend supports. This reflect
 | **Advanced Search**                                                         |
 | [Chained Parameters](https://build.fhir.org/search.html#chaining)           | ✓      | ◐          | ○       | ✗         | ○     | ✗             | ✗   |
 | [Reverse Chaining (\_has)](https://build.fhir.org/search.html#has)          | ✓      | ◐          | ○       | ✗         | ○     | ✗             | ✗   |
-| [\_include](https://build.fhir.org/search.html#include)                     | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
-| [\_revinclude](https://build.fhir.org/search.html#revinclude)               | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
+| [\_include](https://build.fhir.org/search.html#include)                     | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
+| [\_revinclude](https://build.fhir.org/search.html#revinclude)               | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | **[Pagination](https://build.fhir.org/http.html#paging)**                   |
 | Offset                                                                      | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | Cursor (keyset)                                                             | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
@@ -535,6 +535,7 @@ MongoDB provides document-centric primary storage with full FHIR capabilities in
 - Versioning and history providers (`vread`, instance/type/system history)
 - Transaction bundles with urn:uuid reference resolution (requires replica set)
 - Native search (string, token, reference, date, number, URI parameters)
+- `_include` and `_revinclude` resolution
 - Conditional create, update, and delete operations
 - Cursor and offset pagination with multi-field sorting
 - Shared-schema multitenancy with strict tenant filtering

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -14,13 +14,15 @@ use serde_json::Value;
 
 use crate::core::{
     ConditionalCreateResult, ConditionalDeleteResult, ConditionalPatchResult, ConditionalStorage,
-    ConditionalUpdateResult, PatchFormat, ResourceStorage, SearchProvider, SearchResult,
+    ConditionalUpdateResult, IncludeProvider, PatchFormat, ResourceStorage, RevincludeProvider,
+    SearchProvider, SearchResult,
 };
 use crate::error::{BackendError, SearchError, StorageError, StorageResult};
 use crate::tenant::TenantContext;
 use crate::types::{
-    CursorDirection, CursorValue, Page, PageCursor, PageInfo, SearchModifier, SearchParamType,
-    SearchParameter, SearchPrefix, SearchQuery, SearchValue, StoredResource,
+    CursorDirection, CursorValue, IncludeDirective, IncludeType, Page, PageCursor, PageInfo,
+    SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
+    StoredResource,
 };
 
 use super::MongoBackend;
@@ -214,9 +216,38 @@ impl SearchProvider for MongoBackend {
             has_previous,
         };
 
+        let page = Page::new(resources, page_info);
+        let mut included: Vec<StoredResource> = Vec::new();
+
+        if !query.includes.is_empty() {
+            let forward: Vec<IncludeDirective> = query
+                .includes
+                .iter()
+                .filter(|i| i.include_type == IncludeType::Include)
+                .cloned()
+                .collect();
+            if !forward.is_empty() {
+                let resolved = self.resolve_includes(tenant, &page.items, &forward).await?;
+                Self::merge_unique(&mut included, resolved);
+            }
+
+            let reverse: Vec<IncludeDirective> = query
+                .includes
+                .iter()
+                .filter(|i| i.include_type == IncludeType::Revinclude)
+                .cloned()
+                .collect();
+            if !reverse.is_empty() {
+                let resolved = self
+                    .resolve_revincludes(tenant, &page.items, &reverse)
+                    .await?;
+                Self::merge_unique(&mut included, resolved);
+            }
+        }
+
         Ok(SearchResult {
-            resources: Page::new(resources, page_info),
-            included: Vec::new(),
+            resources: page,
+            included,
             total,
         })
     }
@@ -360,12 +391,6 @@ impl MongoBackend {
 
         if !query.reverse_chains.is_empty() {
             return Err(StorageError::Search(SearchError::ReverseChainNotSupported));
-        }
-
-        if !query.includes.is_empty() {
-            return Err(StorageError::Search(SearchError::IncludeNotSupported {
-                operation: "_include/_revinclude".to_string(),
-            }));
         }
 
         for param in &query.parameters {
@@ -1038,5 +1063,242 @@ impl MongoBackend {
         }
 
         None
+    }
+
+    fn merge_unique(target: &mut Vec<StoredResource>, additions: Vec<StoredResource>) {
+        let mut seen: HashSet<String> = target
+            .iter()
+            .map(|r| format!("{}/{}", r.resource_type(), r.id()))
+            .collect();
+        for resource in additions {
+            let key = format!("{}/{}", resource.resource_type(), resource.id());
+            if seen.insert(key) {
+                target.push(resource);
+            }
+        }
+    }
+
+    fn extract_references(content: &Value, search_param: &str) -> Vec<String> {
+        let mut refs = Vec::new();
+        if let Some(value) = content.get(search_param) {
+            Self::collect_references_from_value(value, &mut refs);
+        }
+        refs
+    }
+
+    fn collect_references_from_value(value: &Value, refs: &mut Vec<String>) {
+        match value {
+            Value::Object(obj) => {
+                if let Some(Value::String(reference)) = obj.get("reference") {
+                    refs.push(reference.clone());
+                }
+                for v in obj.values() {
+                    Self::collect_references_from_value(v, refs);
+                }
+            }
+            Value::Array(arr) => {
+                for item in arr {
+                    Self::collect_references_from_value(item, refs);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn parse_reference(reference: &str) -> Option<(String, String)> {
+        let trimmed = reference
+            .strip_prefix("http://")
+            .or_else(|| reference.strip_prefix("https://"))
+            .unwrap_or(reference);
+
+        let mut segments: Vec<&str> = trimmed.split('/').filter(|s| !s.is_empty()).collect();
+        if segments.len() < 2 {
+            return None;
+        }
+
+        let id = segments.pop()?.to_string();
+        let resource_type = segments.pop()?.to_string();
+
+        if !resource_type
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_uppercase())
+        {
+            return None;
+        }
+
+        Some((resource_type, id))
+    }
+
+    async fn fetch_resource_by_type_id(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        id: &str,
+    ) -> StorageResult<Option<StoredResource>> {
+        let db = self.get_database().await?;
+        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+        let tenant_id = tenant.tenant_id().as_str();
+
+        let doc = resources
+            .find_one(doc! {
+                "tenant_id": tenant_id,
+                "resource_type": resource_type,
+                "id": id,
+                "is_deleted": false,
+            })
+            .await
+            .map_err(|e| internal_error(format!("Failed to fetch included resource: {}", e)))?;
+
+        match doc {
+            Some(doc) => Ok(Some(self.document_to_stored_resource(
+                tenant,
+                resource_type,
+                doc,
+            )?)),
+            None => Ok(None),
+        }
+    }
+}
+
+#[async_trait]
+impl IncludeProvider for MongoBackend {
+    async fn resolve_includes(
+        &self,
+        tenant: &TenantContext,
+        resources: &[StoredResource],
+        includes: &[IncludeDirective],
+    ) -> StorageResult<Vec<StoredResource>> {
+        if resources.is_empty() || includes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut included = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+
+        for include in includes {
+            for resource in resources {
+                if resource.resource_type() != include.source_type {
+                    continue;
+                }
+
+                let refs = Self::extract_references(resource.content(), &include.search_param);
+                for reference in refs {
+                    let Some((ref_type, ref_id)) = Self::parse_reference(&reference) else {
+                        continue;
+                    };
+
+                    if let Some(target) = include.target_type.as_ref() {
+                        if ref_type != *target {
+                            continue;
+                        }
+                    }
+
+                    let key = format!("{}/{}", ref_type, ref_id);
+                    if !seen.insert(key) {
+                        continue;
+                    }
+
+                    if let Some(stored) = self
+                        .fetch_resource_by_type_id(tenant, &ref_type, &ref_id)
+                        .await?
+                    {
+                        included.push(stored);
+                    }
+                }
+            }
+        }
+
+        Ok(included)
+    }
+}
+
+#[async_trait]
+impl RevincludeProvider for MongoBackend {
+    async fn resolve_revincludes(
+        &self,
+        tenant: &TenantContext,
+        resources: &[StoredResource],
+        revincludes: &[IncludeDirective],
+    ) -> StorageResult<Vec<StoredResource>> {
+        if resources.is_empty() || revincludes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let db = self.get_database().await?;
+        let tenant_id = tenant.tenant_id().as_str();
+        let search_index = db.collection::<Document>(MongoBackend::SEARCH_INDEX_COLLECTION);
+        let resources_collection = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+
+        let mut included = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+
+        for revinclude in revincludes {
+            if revinclude.source_type.is_empty() {
+                continue;
+            }
+
+            let mut reference_values: Vec<String> = Vec::with_capacity(resources.len() * 2);
+            for resource in resources {
+                reference_values.push(format!("{}/{}", resource.resource_type(), resource.id()));
+                reference_values.push(resource.id().to_string());
+            }
+            reference_values.sort();
+            reference_values.dedup();
+
+            if reference_values.is_empty() {
+                continue;
+            }
+
+            let bson_values: Vec<Bson> = reference_values.into_iter().map(Bson::String).collect();
+            let index_filter = doc! {
+                "tenant_id": tenant_id,
+                "resource_type": &revinclude.source_type,
+                "param_name": &revinclude.search_param,
+                "value_reference": { "$in": Bson::Array(bson_values) },
+            };
+
+            let matching_ids: Vec<String> = search_index
+                .distinct("resource_id", index_filter)
+                .await
+                .map_err(|e| {
+                    internal_error(format!(
+                        "Failed to query search_index for revinclude: {}",
+                        e
+                    ))
+                })?
+                .into_iter()
+                .filter_map(|value| value.as_str().map(ToString::to_string))
+                .collect();
+
+            if matching_ids.is_empty() {
+                continue;
+            }
+
+            let id_bson: Vec<Bson> = matching_ids.into_iter().map(Bson::String).collect();
+            let resource_filter = doc! {
+                "tenant_id": tenant_id,
+                "resource_type": &revinclude.source_type,
+                "is_deleted": false,
+                "id": { "$in": Bson::Array(id_bson) },
+            };
+
+            let docs =
+                collect_documents(resources_collection.find(resource_filter).await.map_err(
+                    |e| internal_error(format!("Failed to fetch revinclude resources: {}", e)),
+                )?)
+                .await?;
+
+            for doc in docs {
+                let stored =
+                    self.document_to_stored_resource(tenant, &revinclude.source_type, doc)?;
+                let key = format!("{}/{}", stored.resource_type(), stored.id());
+                if seen.insert(key) {
+                    included.push(stored);
+                }
+            }
+        }
+
+        Ok(included)
     }
 }

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -1917,7 +1917,7 @@ async fn mongodb_integration_resolve_include_and_revinclude() {
         iterate: false,
     };
     let included = backend
-        .resolve_includes(&tenant, &[observation.clone()], &[forward])
+        .resolve_includes(&tenant, std::slice::from_ref(&observation), &[forward])
         .await
         .expect("forward include resolution must succeed");
     assert_eq!(included.len(), 1, "exactly one Patient should be included");
@@ -1932,7 +1932,11 @@ async fn mongodb_integration_resolve_include_and_revinclude() {
         iterate: false,
     };
     let revincluded = backend
-        .resolve_revincludes(&tenant, &[patient.clone()], &[reverse.clone()])
+        .resolve_revincludes(
+            &tenant,
+            std::slice::from_ref(&patient),
+            std::slice::from_ref(&reverse),
+        )
         .await
         .expect("revinclude resolution must succeed");
     assert_eq!(

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -13,8 +13,9 @@ use helios_persistence::backends::mongodb::{MongoBackend, MongoBackendConfig};
 use helios_persistence::core::{
     Backend, BackendCapability, BackendKind, BundleEntry, BundleMethod, BundleProvider,
     BundleResult, ConditionalCreateResult, ConditionalDeleteResult, ConditionalStorage,
-    ConditionalUpdateResult, HistoryParams, InstanceHistoryProvider, PatchFormat, ResourceStorage,
-    SearchProvider, SystemHistoryProvider, TypeHistoryProvider, VersionedStorage,
+    ConditionalUpdateResult, HistoryParams, IncludeProvider, InstanceHistoryProvider, PatchFormat,
+    ResourceStorage, RevincludeProvider, SearchProvider, SystemHistoryProvider,
+    TypeHistoryProvider, VersionedStorage,
 };
 use helios_persistence::error::{
     BackendError, ConcurrencyError, ResourceError, StorageError, TransactionError,
@@ -22,7 +23,8 @@ use helios_persistence::error::{
 use helios_persistence::search::SearchParameterStatus;
 use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
 use helios_persistence::types::{
-    SearchParamType, SearchParameter, SearchQuery, SearchValue, SortDirective,
+    IncludeDirective, IncludeType, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+    SortDirective,
 };
 use mongodb::Client;
 use mongodb::bson::{Document, doc};
@@ -1846,5 +1848,119 @@ async fn mongodb_integration_search_parameter_registry_updates_when_offloaded() 
             .get_param("Patient", "mongo-offloaded-code")
             .is_none(),
         "Deleted SearchParameter should unregister when offloaded"
+    );
+}
+
+#[tokio::test]
+async fn mongodb_integration_resolve_include_and_revinclude() {
+    let Some(connection_string) = test_mongo_url() else {
+        eprintln!(
+            "Skipping mongodb_integration_resolve_include_and_revinclude (set HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    // Point at the workspace-root spec file so that the registry knows about
+    // Observation.subject — without it, no reference index entries get written
+    // and revinclude resolution would have nothing to match.
+    let workspace_data_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("data");
+    let config = MongoBackendConfig {
+        connection_string,
+        database_name: build_test_database_name("includes"),
+        data_dir: Some(workspace_data_dir),
+        ..Default::default()
+    };
+    let backend = MongoBackend::new(config)
+        .expect("failed to create MongoBackend for include/revinclude test");
+    backend
+        .initialize()
+        .await
+        .expect("failed to initialize MongoDB schema for include/revinclude test");
+
+    let tenant = create_tenant("tenant-includes");
+
+    let patient = backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "name": [{"family": "Includer"}],
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let observation = backend
+        .create(
+            &tenant,
+            "Observation",
+            json!({
+                "resourceType": "Observation",
+                "status": "final",
+                "subject": {"reference": format!("Patient/{}", patient.id())},
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let forward = IncludeDirective {
+        include_type: IncludeType::Include,
+        source_type: "Observation".to_string(),
+        search_param: "subject".to_string(),
+        target_type: Some("Patient".to_string()),
+        iterate: false,
+    };
+    let included = backend
+        .resolve_includes(&tenant, &[observation.clone()], &[forward])
+        .await
+        .expect("forward include resolution must succeed");
+    assert_eq!(included.len(), 1, "exactly one Patient should be included");
+    assert_eq!(included[0].resource_type(), "Patient");
+    assert_eq!(included[0].id(), patient.id());
+
+    let reverse = IncludeDirective {
+        include_type: IncludeType::Revinclude,
+        source_type: "Observation".to_string(),
+        search_param: "subject".to_string(),
+        target_type: None,
+        iterate: false,
+    };
+    let revincluded = backend
+        .resolve_revincludes(&tenant, &[patient.clone()], &[reverse.clone()])
+        .await
+        .expect("revinclude resolution must succeed");
+    assert_eq!(
+        revincluded.len(),
+        1,
+        "exactly one Observation should be revincluded"
+    );
+    assert_eq!(revincluded[0].resource_type(), "Observation");
+    assert_eq!(revincluded[0].id(), observation.id());
+
+    let query = SearchQuery::new("Patient").with_include(reverse);
+    let result = backend
+        .search(&tenant, &query)
+        .await
+        .expect("search with _revinclude must not be rejected");
+    assert!(
+        result
+            .resources
+            .items
+            .iter()
+            .any(|r| r.resource_type() == "Patient" && r.id() == patient.id()),
+        "primary results should still contain the Patient"
+    );
+    assert!(
+        result
+            .included
+            .iter()
+            .any(|r| r.resource_type() == "Observation" && r.id() == observation.id()),
+        "search() should populate `included` from revinclude resolution"
     );
 }


### PR DESCRIPTION
## Summary
- `MongoBackend` now resolves `_include` and `_revinclude` instead of rejecting them with `SearchError::IncludeNotSupported`. Forward includes walk primary results for the named reference search param and read targets from the `resources` collection; reverse includes query the existing `search_index` collection on `(resource_type, param_name, value_reference)` and load source documents.
- `SearchProvider::search` wires both kinds of resolution into `SearchResult.included`, mirroring `ElasticsearchBackend`.
- Added integration test `mongodb_integration_resolve_include_and_revinclude` that exercises both directions plus the `search()` integration. The test points `data_dir` at the workspace `data/` so the registry knows about `Observation.subject` (without it, no reference index entries are written).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p helios-persistence --features mongodb,R4 --all-targets -- -D warnings <CI -A flags>` — clean
- [x] `cargo test -p helios-persistence --features mongodb,R4 --test mongodb_tests` against a real MongoDB — new test passes; the 4 pre-existing failures (`conditional_create_exists`, `conditional_create_multiple_matches`, `conditional_update_delete_and_no_match`, `search_token_string_and_offset_pagination`) are unrelated and reproduce on `main` because `create_backend()` leaves `data_dir=None` so spec params don't load.