### PR TITLE
fix(persistence): make testcontainers watchdog feature non-Windows only

### DIFF
--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -104,9 +104,16 @@ tokio = { version = "1", features = ["full", "test-util"] }
 tokio-test = "0.4"
 tempfile = "3"
 criterion = { version = "0.5", features = ["async_tokio"] }
-testcontainers = { version = "0.27", features = ["watchdog"] }
 testcontainers-modules = { version = "0.15", features = ["postgres", "elastic_search", "minio"] }
 paste = "1.0"
+
+# `watchdog` pulls in `signal_hook::iterator`/`SIGQUIT`, which only compile on Unix.
+# Windows test runs don't need SIGTERM cleanup, so drop the feature there.
+[target.'cfg(not(windows))'.dev-dependencies]
+testcontainers = { version = "0.27", features = ["watchdog"] }
+
+[target.'cfg(windows)'.dev-dependencies]
+testcontainers = { version = "0.27" }
 
 # Configuration advisor binary
 [[bin]]


### PR DESCRIPTION
## Summary
- The Windows clippy CI job has been failing on `main` since #75 enabled the `watchdog` feature on `testcontainers = \"0.27\"`. That feature pulls in `signal_hook::consts::SIGQUIT` and `signal_hook::iterator`, which are gated to non-Windows in the `signal-hook` crate, so checking `crates/persistence` on Windows fails with `E0432: unresolved imports`.
- Move the watchdog-enabled `testcontainers` entry under `[target.'cfg(not(windows))'.dev-dependencies]` and add a plain `testcontainers = \"0.27\"` for Windows. Cleanup on Actions cancellations (SIGTERM) is the watchdog's reason for existing, so dropping the feature on Windows preserves Linux/macOS behavior without breaking the Windows build.
- No `Cargo.lock` changes — the same crate version is selected on all targets.

## Test plan
- [x] `cargo check -p helios-persistence --features mongodb,R4 --tests` (macOS)
- [ ] CI Linting (Windows) goes green
- [ ] CI Test Rust (Linux/macOS) stays green