### PR TITLE
refactor(search): registry-driven search-param type resolution

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/search_impl.rs
+++ b/crates/persistence/src/backends/elasticsearch/search_impl.rs
@@ -209,6 +209,12 @@ impl SearchProvider for ElasticsearchBackend {
             _ => Ok(0),
         }
     }
+
+    fn search_param_registry(
+        &self,
+    ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
+        self.search_registry()
+    }
 }
 
 #[async_trait]

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -280,6 +280,12 @@ impl SearchProvider for MongoBackend {
             .await
             .map_err(|e| internal_error(format!("Failed to count MongoDB search results: {}", e)))
     }
+
+    fn search_param_registry(
+        &self,
+    ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
+        self.search_registry()
+    }
 }
 
 #[async_trait]
@@ -1023,46 +1029,20 @@ impl MongoBackend {
         params
             .iter()
             .map(|(name, value)| {
-                let param_type = self
-                    .lookup_param_type(&registry, resource_type, name)
-                    .unwrap_or(match name.as_str() {
-                        "_id" => SearchParamType::Token,
-                        "_lastUpdated" => SearchParamType::Date,
-                        "_tag" | "_profile" | "_security" => SearchParamType::Token,
-                        "identifier" => SearchParamType::Token,
-                        "patient" | "subject" | "encounter" | "performer" | "author"
-                        | "requester" | "recorder" | "asserter" | "practitioner"
-                        | "organization" | "location" | "device" => SearchParamType::Reference,
-                        _ => SearchParamType::String,
-                    });
+                let values = vec![SearchValue::parse(value)];
+                let param_type =
+                    crate::search::resolve_param_type(&registry, resource_type, name, &values);
 
                 SearchParameter {
                     name: name.clone(),
                     param_type,
                     modifier: None,
-                    values: vec![SearchValue::parse(value)],
+                    values,
                     chain: vec![],
                     components: vec![],
                 }
             })
             .collect()
-    }
-
-    fn lookup_param_type(
-        &self,
-        registry: &crate::search::SearchParameterRegistry,
-        resource_type: &str,
-        param_name: &str,
-    ) -> Option<SearchParamType> {
-        if let Some(def) = registry.get_param(resource_type, param_name) {
-            return Some(def.param_type);
-        }
-
-        if let Some(def) = registry.get_param("Resource", param_name) {
-            return Some(def.param_type);
-        }
-
-        None
     }
 
     fn merge_unique(target: &mut Vec<StoredResource>, additions: Vec<StoredResource>) {

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -389,6 +389,12 @@ impl SearchProvider for PostgresBackend {
         let count: i64 = row.get(0);
         Ok(count as u64)
     }
+
+    fn search_param_registry(
+        &self,
+    ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
+        self.search_registry()
+    }
 }
 
 #[async_trait]

--- a/crates/persistence/src/backends/s3/storage.rs
+++ b/crates/persistence/src/backends/s3/storage.rs
@@ -1035,6 +1035,24 @@ impl SearchProvider for S3Backend {
             capability: "search_count".to_string(),
         }))
     }
+
+    fn search_param_registry(
+        &self,
+    ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
+        // S3 standalone does not implement search; an empty registry is
+        // required only to satisfy the trait. In real deployments S3 is
+        // composed with a search backend (e.g., Elasticsearch) and the
+        // composite forwards to that backend's registry.
+        use std::sync::OnceLock;
+        static EMPTY: OnceLock<
+            std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>>,
+        > = OnceLock::new();
+        EMPTY.get_or_init(|| {
+            std::sync::Arc::new(parking_lot::RwLock::new(
+                crate::search::SearchParameterRegistry::new(),
+            ))
+        })
+    }
 }
 
 #[async_trait]

--- a/crates/persistence/src/backends/sqlite/search/chain_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/chain_builder.rs
@@ -668,13 +668,16 @@ impl ChainQueryBuilder {
         depth: usize,
         param_num: usize,
     ) -> StorageResult<(String, SqlParam)> {
-        // Determine the parameter type from the registry
+        // Determine the parameter type from the registry. Falls back to the
+        // shared value-shape heuristic for unregistered custom params.
         let param_type = {
             let registry = self.registry.read();
-            registry
-                .get_param(resource_type, param_name)
-                .map(|p| p.param_type)
-                .unwrap_or_else(|| self.infer_param_type(param_name))
+            crate::search::resolve_param_type(
+                &registry,
+                resource_type,
+                param_name,
+                std::slice::from_ref(value),
+            )
         };
 
         let alias = format!("si{}", depth);
@@ -744,25 +747,6 @@ impl ChainQueryBuilder {
         };
 
         Ok((condition, param))
-    }
-
-    /// Infers parameter type based on common parameter names.
-    fn infer_param_type(&self, param_name: &str) -> SearchParamType {
-        match param_name {
-            "name" | "family" | "given" | "text" | "display" | "description" | "address"
-            | "city" | "state" | "country" => SearchParamType::String,
-            "identifier" | "code" | "status" | "type" | "category" | "class" | "gender"
-            | "language" => SearchParamType::Token,
-            "date" | "birthdate" | "issued" | "effective" | "period" | "authored" => {
-                SearchParamType::Date
-            }
-            "patient" | "subject" | "performer" | "author" | "encounter" | "organization"
-            | "practitioner" | "location" => SearchParamType::Reference,
-            "value-quantity" | "dose" | "quantity" => SearchParamType::Quantity,
-            "length" | "count" | "value" => SearchParamType::Number,
-            "url" | "source" => SearchParamType::Uri,
-            _ => SearchParamType::String, // Default fallback
-        }
     }
 }
 

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -413,6 +413,12 @@ impl SearchProvider for SqliteBackend {
 
         Ok(count as u64)
     }
+
+    fn search_param_registry(
+        &self,
+    ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
+        self.search_registry()
+    }
 }
 
 #[async_trait]
@@ -1012,29 +1018,6 @@ impl SqliteBackend {
         false
     }
 
-    /// Infer the target resource type for a reference parameter.
-    #[allow(dead_code)]
-    fn infer_target_type(&self, _base_type: &str, reference_param: &str) -> String {
-        // This is a simplified mapping - a real implementation would use
-        // search parameter definitions from the FHIR specification
-        match reference_param {
-            "patient" | "subject" => "Patient".to_string(),
-            "practitioner" | "performer" => "Practitioner".to_string(),
-            "organization" => "Organization".to_string(),
-            "encounter" => "Encounter".to_string(),
-            "location" => "Location".to_string(),
-            "device" => "Device".to_string(),
-            _ => {
-                // Default: capitalize first letter
-                let mut chars = reference_param.chars();
-                match chars.next() {
-                    Some(c) => c.to_uppercase().chain(chars).collect(),
-                    None => reference_param.to_string(),
-                }
-            }
-        }
-    }
-
     /// Find resources matching a simple field value search using the search index.
     #[allow(dead_code)]
     fn find_resources_by_value(
@@ -1174,7 +1157,17 @@ mod tests {
     use serde_json::json;
 
     fn create_test_backend() -> SqliteBackend {
-        let backend = SqliteBackend::in_memory().unwrap();
+        // Point at the workspace's data directory so the search-parameter
+        // registry loads the full FHIR spec (otherwise only the 5 minimal
+        // embedded params are available and chained-search tests fail to
+        // resolve param types like Observation.code → Token).
+        let data_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("data");
+        let mut config = crate::backends::sqlite::backend::SqliteBackendConfig::default();
+        config.data_dir = Some(data_dir);
+        let backend = SqliteBackend::with_config(":memory:", config).unwrap();
         backend.init_schema().unwrap();
         backend
     }
@@ -2194,30 +2187,6 @@ mod tests {
 
         let result = backend.parse_reference("http://example.com/fhir/Patient/456");
         assert_eq!(result, Some(("Patient".to_string(), "456".to_string())));
-    }
-
-    #[test]
-    fn test_infer_target_type() {
-        let backend = SqliteBackend::in_memory().unwrap();
-
-        assert_eq!(
-            backend.infer_target_type("Observation", "patient"),
-            "Patient"
-        );
-        assert_eq!(
-            backend.infer_target_type("Observation", "subject"),
-            "Patient"
-        );
-        assert_eq!(
-            backend.infer_target_type("Encounter", "practitioner"),
-            "Practitioner"
-        );
-        assert_eq!(
-            backend.infer_target_type("Patient", "organization"),
-            "Organization"
-        );
-        // Unknown param - capitalize first letter
-        assert_eq!(backend.infer_target_type("Observation", "custom"), "Custom");
     }
 
     // ========================================================================

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -923,6 +923,41 @@ impl SearchProvider for CompositeStorage {
             }))
         }
     }
+
+    fn search_param_registry(
+        &self,
+    ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
+        // Same routing as `search`: prefer the dedicated Search backend's
+        // registry, fall back to primary, otherwise an empty registry. The
+        // returned reference outlives `&self` because both providers are
+        // owned by `self.search_providers` for the lifetime of the composite.
+        if let Some(search_backend) = self
+            .config
+            .backends_with_role(super::config::BackendRole::Search)
+            .next()
+        {
+            if let Some(provider) = self.search_providers.get(&search_backend.id) {
+                return provider.search_param_registry();
+            }
+        }
+
+        if let Some(provider) = self
+            .search_providers
+            .get(self.config.primary_id().unwrap_or("primary"))
+        {
+            return provider.search_param_registry();
+        }
+
+        use std::sync::OnceLock;
+        static EMPTY: OnceLock<
+            std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>>,
+        > = OnceLock::new();
+        EMPTY.get_or_init(|| {
+            std::sync::Arc::new(parking_lot::RwLock::new(
+                crate::search::SearchParameterRegistry::new(),
+            ))
+        })
+    }
 }
 
 #[async_trait]
@@ -1934,6 +1969,20 @@ mod tests {
                 message: self.error_message.to_string(),
             }))
         }
+
+        fn search_param_registry(
+            &self,
+        ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
+            use std::sync::OnceLock;
+            static EMPTY: OnceLock<
+                std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>>,
+            > = OnceLock::new();
+            EMPTY.get_or_init(|| {
+                std::sync::Arc::new(parking_lot::RwLock::new(
+                    crate::search::SearchParameterRegistry::new(),
+                ))
+            })
+        }
     }
 
     /// Minimal mock storage for unit testing CompositeStorage.
@@ -2809,6 +2858,20 @@ mod tests {
             _query: &crate::types::SearchQuery,
         ) -> StorageResult<u64> {
             Ok(0)
+        }
+
+        fn search_param_registry(
+            &self,
+        ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
+            use std::sync::OnceLock;
+            static EMPTY: OnceLock<
+                std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>>,
+            > = OnceLock::new();
+            EMPTY.get_or_init(|| {
+                std::sync::Arc::new(parking_lot::RwLock::new(
+                    crate::search::SearchParameterRegistry::new(),
+                ))
+            })
         }
     }
 }

--- a/crates/persistence/src/core/search.rs
+++ b/crates/persistence/src/core/search.rs
@@ -9,9 +9,13 @@
 //! - [`TerminologySearchProvider`] - :above, :below, :in, :not-in
 //! - [`TextSearchProvider`] - Full-text search (_text, _content, :text)
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
+use parking_lot::RwLock;
 
 use crate::error::StorageResult;
+use crate::search::SearchParameterRegistry;
 use crate::tenant::TenantContext;
 use crate::types::{
     IncludeDirective, Page, ReverseChainedParameter, SearchBundle, SearchQuery, StoredResource,
@@ -227,6 +231,14 @@ pub trait SearchProvider: ResourceStorage {
     /// This is more efficient than search when you only need the count.
     async fn search_count(&self, tenant: &TenantContext, query: &SearchQuery)
     -> StorageResult<u64>;
+
+    /// Returns the backend's search parameter registry.
+    ///
+    /// The registry is the single source of truth for search parameter type
+    /// resolution (see [`crate::search::resolve_param_type`]). REST extractors
+    /// and chained-search builders both consult it so they cannot disagree on
+    /// whether a given param is a Date vs. Token vs. Reference, etc.
+    fn search_param_registry(&self) -> &Arc<RwLock<SearchParameterRegistry>>;
 }
 
 /// Search provider that supports searching across multiple resource types.

--- a/crates/persistence/src/search/mod.rs
+++ b/crates/persistence/src/search/mod.rs
@@ -76,7 +76,7 @@ pub use extractor::{ExtractedValue, SearchParameterExtractor};
 pub use loader::SearchParameterLoader;
 pub use registry::{
     RegistryUpdate, SearchParameterDefinition, SearchParameterRegistry, SearchParameterSource,
-    SearchParameterStatus,
+    SearchParameterStatus, resolve_param_targets, resolve_param_type,
 };
 pub use reindex::{
     ReindexOperation, ReindexProgress, ReindexRequest, ReindexStatus, ReindexableStorage,

--- a/crates/persistence/src/search/registry.rs
+++ b/crates/persistence/src/search/registry.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
-use crate::types::SearchParamType;
+use crate::types::{SearchParamType, SearchValue};
 
 use super::errors::RegistryError;
 use super::loader::SearchParameterLoader;
@@ -426,6 +426,89 @@ impl Default for SearchParameterRegistry {
     }
 }
 
+/// Deterministically resolves a search parameter to its `SearchParamType`.
+///
+/// Resolution order:
+/// 1. Registry lookup by `(resource_type, name)`.
+/// 2. Registry lookup by `("Resource", name)` for global params (`_id`, `_lastUpdated`, etc.).
+/// 3. Value-shape heuristic — only reached for params that aren't in the registry at all
+///    (e.g., user-defined custom params not yet registered).
+///
+/// This is the single source of truth for type resolution. REST extractors and
+/// storage backends both call this so they cannot disagree.
+pub fn resolve_param_type(
+    registry: &SearchParameterRegistry,
+    resource_type: &str,
+    name: &str,
+    values: &[SearchValue],
+) -> SearchParamType {
+    if let Some(def) = registry.get_param(resource_type, name) {
+        return def.param_type;
+    }
+    if let Some(def) = registry.get_param("Resource", name) {
+        return def.param_type;
+    }
+    infer_param_type_from_value(values)
+}
+
+/// Resolves the allowed target resource types for a reference search parameter.
+///
+/// Returns the registry-declared targets (e.g., `["Patient", "Group"]` for
+/// `Encounter.subject`). Returns an empty `Vec` when the parameter is unknown
+/// or has no declared targets — callers should treat that as "don't filter by
+/// target type."
+pub fn resolve_param_targets(
+    registry: &SearchParameterRegistry,
+    resource_type: &str,
+    name: &str,
+) -> Vec<String> {
+    let lookup = registry
+        .get_param(resource_type, name)
+        .or_else(|| registry.get_param("Resource", name));
+    lookup
+        .and_then(|def| def.target.clone())
+        .unwrap_or_default()
+}
+
+/// Last-resort value-shape heuristic for parameters not present in the registry.
+///
+/// Kept intentionally conservative — recognizes only the unambiguous shapes
+/// (FHIR date, quantity with unit, token with system, reference) and otherwise
+/// returns `String`.
+fn infer_param_type_from_value(values: &[SearchValue]) -> SearchParamType {
+    let Some(first) = values.first() else {
+        return SearchParamType::String;
+    };
+    let value = &first.value;
+
+    // FHIR date: YYYY or YYYY-MM-DD or full instant. Optional comparator prefix
+    // (gt/lt/ge/le/sa/eb/ap/eq/ne) is stripped by SearchValue::parse before
+    // we get here, so we only inspect the literal value.
+    if value.len() >= 4 && value.as_bytes()[..4].iter().all(u8::is_ascii_digit) {
+        let rest = &value.as_bytes()[4..];
+        if rest.is_empty() || rest[0] == b'-' || rest[0] == b'T' {
+            return SearchParamType::Date;
+        }
+    }
+
+    // Quantity: number|system|code (FHIR token-style separator).
+    if value.contains('|') && value.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return SearchParamType::Quantity;
+    }
+
+    // Reference: ResourceType/id form.
+    if value.contains('/') && value.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
+        return SearchParamType::Reference;
+    }
+
+    // Token: system|code.
+    if value.contains('|') {
+        return SearchParamType::Token;
+    }
+
+    SearchParamType::String
+}
+
 impl std::fmt::Debug for SearchParameterRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SearchParameterRegistry")
@@ -509,6 +592,100 @@ mod tests {
         // Unregister
         registry.unregister("http://example.org/sp/test").unwrap();
         assert_eq!(registry.len(), 0);
+    }
+
+    fn registry_with(defs: Vec<SearchParameterDefinition>) -> SearchParameterRegistry {
+        let mut r = SearchParameterRegistry::new();
+        for d in defs {
+            r.register(d).unwrap();
+        }
+        r
+    }
+
+    #[test]
+    fn resolve_param_type_hits_resource_specific_definition() {
+        let registry = registry_with(vec![
+            SearchParameterDefinition::new(
+                "http://hl7.org/fhir/SearchParameter/Goal-target-date",
+                "target-date",
+                SearchParamType::Date,
+                "Goal.target.dueDate",
+            )
+            .with_base(vec!["Goal"]),
+        ]);
+
+        assert_eq!(
+            resolve_param_type(&registry, "Goal", "target-date", &[]),
+            SearchParamType::Date,
+        );
+    }
+
+    #[test]
+    fn resolve_param_type_falls_back_to_resource_base_for_global_params() {
+        let registry = registry_with(vec![
+            SearchParameterDefinition::new(
+                "http://hl7.org/fhir/SearchParameter/Resource-lastUpdated",
+                "_lastUpdated",
+                SearchParamType::Date,
+                "Resource.meta.lastUpdated",
+            )
+            .with_base(vec!["Resource"]),
+        ]);
+
+        assert_eq!(
+            resolve_param_type(&registry, "Patient", "_lastUpdated", &[]),
+            SearchParamType::Date,
+        );
+    }
+
+    #[test]
+    fn resolve_param_type_uses_value_heuristic_when_unregistered() {
+        let registry = SearchParameterRegistry::new();
+        let date_value = vec![SearchValue::eq("2020-01-15")];
+        let ref_value = vec![SearchValue::eq("Patient/123")];
+        let token_value = vec![SearchValue::eq("http://loinc.org|1234-5")];
+        let plain = vec![SearchValue::eq("hello")];
+
+        assert_eq!(
+            resolve_param_type(&registry, "Custom", "x", &date_value),
+            SearchParamType::Date,
+        );
+        assert_eq!(
+            resolve_param_type(&registry, "Custom", "x", &ref_value),
+            SearchParamType::Reference,
+        );
+        assert_eq!(
+            resolve_param_type(&registry, "Custom", "x", &token_value),
+            SearchParamType::Token,
+        );
+        assert_eq!(
+            resolve_param_type(&registry, "Custom", "x", &plain),
+            SearchParamType::String,
+        );
+        assert_eq!(
+            resolve_param_type(&registry, "Custom", "x", &[]),
+            SearchParamType::String,
+        );
+    }
+
+    #[test]
+    fn resolve_param_targets_returns_declared_targets() {
+        let registry = registry_with(vec![
+            SearchParameterDefinition::new(
+                "http://hl7.org/fhir/SearchParameter/Encounter-subject",
+                "subject",
+                SearchParamType::Reference,
+                "Encounter.subject",
+            )
+            .with_base(vec!["Encounter"])
+            .with_targets(vec!["Patient", "Group"]),
+        ]);
+
+        assert_eq!(
+            resolve_param_targets(&registry, "Encounter", "subject"),
+            vec!["Patient".to_string(), "Group".to_string()],
+        );
+        assert!(resolve_param_targets(&registry, "Encounter", "missing").is_empty());
     }
 
     #[test]

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -4,9 +4,10 @@
 
 use std::collections::HashMap;
 
+use helios_persistence::search::{SearchParameterRegistry, resolve_param_type};
 use helios_persistence::types::{
-    IncludeDirective, IncludeType, ReverseChainedParameter, SearchModifier, SearchParamType,
-    SearchParameter, SearchQuery, SearchValue, SortDirective, SummaryMode, TotalMode,
+    IncludeDirective, IncludeType, ReverseChainedParameter, SearchModifier, SearchParameter,
+    SearchQuery, SearchValue, SortDirective, SummaryMode, TotalMode,
 };
 
 use super::SearchParams;
@@ -25,6 +26,7 @@ use crate::error::RestError;
 pub fn build_search_query(
     resource_type: &str,
     params: &SearchParams,
+    registry: &SearchParameterRegistry,
 ) -> Result<SearchQuery, RestError> {
     let mut query = SearchQuery::new(resource_type);
 
@@ -100,7 +102,7 @@ pub fn build_search_query(
         }
 
         // Parse the parameter
-        let param = parse_search_parameter(name, value)?;
+        let param = parse_search_parameter(resource_type, name, value, registry)?;
         query.parameters.push(param);
     }
 
@@ -113,13 +115,19 @@ pub fn build_search_query(
 pub fn build_search_query_from_map(
     resource_type: &str,
     params: &HashMap<String, String>,
+    registry: &SearchParameterRegistry,
 ) -> Result<SearchQuery, RestError> {
     let search_params = SearchParams::from_map(params.clone());
-    build_search_query(resource_type, &search_params)
+    build_search_query(resource_type, &search_params, registry)
 }
 
 /// Parses a single search parameter with potential modifiers.
-fn parse_search_parameter(name: &str, value: &str) -> Result<SearchParameter, RestError> {
+fn parse_search_parameter(
+    resource_type: &str,
+    name: &str,
+    value: &str,
+    registry: &SearchParameterRegistry,
+) -> Result<SearchParameter, RestError> {
     let (param_name, modifier) = parse_parameter_name(name);
 
     // Check for chained parameters (e.g., "patient.name" or "subject:Patient.name")
@@ -131,8 +139,11 @@ fn parse_search_parameter(name: &str, value: &str) -> Result<SearchParameter, Re
         .map(|v| SearchValue::parse(v.trim()))
         .collect();
 
-    // Determine parameter type based on modifier or heuristics
-    let param_type = infer_param_type(base_name, &modifier, &values);
+    // Resolve the canonical type from the search parameter registry. This is
+    // deterministic for any registered parameter (which is everything in the
+    // FHIR spec); the value-shape heuristic is reached only for unregistered
+    // custom params. See `helios_persistence::search::resolve_param_type`.
+    let param_type = resolve_param_type(registry, resource_type, base_name, &values);
 
     let mut param = SearchParameter {
         name: base_name.to_string(),
@@ -406,152 +417,63 @@ fn parse_summary_mode(value: &str) -> Option<SummaryMode> {
     }
 }
 
-/// Infers parameter type based on heuristics.
-///
-/// In a full implementation, this would look up the SearchParameterRegistry
-/// to get the actual type. For now, we use heuristics based on:
-/// - Known common parameters
-/// - Modifier hints
-/// - Value format
-fn infer_param_type(
-    name: &str,
-    modifier: &Option<SearchModifier>,
-    values: &[SearchValue],
-) -> SearchParamType {
-    // Special parameters
-    match name {
-        "_id" | "_lastUpdated" | "_tag" | "_profile" | "_security" | "_source" | "_list"
-        | "_has" | "_type" | "_filter" | "_query" | "_text" | "_content" => {
-            return SearchParamType::Special;
-        }
-        _ => {}
-    }
-
-    // Infer from modifier
-    if let Some(mod_) = modifier {
-        match mod_ {
-            SearchModifier::Exact | SearchModifier::Contains => return SearchParamType::String,
-            SearchModifier::Text
-            | SearchModifier::In
-            | SearchModifier::NotIn
-            | SearchModifier::Above
-            | SearchModifier::Below
-            | SearchModifier::OfType
-            | SearchModifier::CodeOnly
-            | SearchModifier::CodeText => return SearchParamType::Token,
-            SearchModifier::Identifier | SearchModifier::Type(_) => {
-                return SearchParamType::Reference;
-            }
-            _ => {}
-        }
-    }
-
-    // Infer from common parameter names
-    match name {
-        // String parameters
-        "name" | "family" | "given" | "address" | "address-city" | "address-country"
-        | "address-postalcode" | "address-state" | "phonetic" | "text" => SearchParamType::String,
-
-        // Token parameters
-        "identifier" | "code" | "status" | "type" | "category" | "gender" | "language"
-        | "active" | "deceased" | "class" | "priority" | "intent" | "severity" => {
-            SearchParamType::Token
-        }
-
-        // Date parameters
-        "birthdate" | "date" | "issued" | "onset" | "recorded" | "authored" | "effective"
-        | "period" | "when" | "_lastUpdated" => SearchParamType::Date,
-
-        // Reference parameters
-        "patient"
-        | "subject"
-        | "encounter"
-        | "practitioner"
-        | "organization"
-        | "location"
-        | "device"
-        | "performer"
-        | "requester"
-        | "author"
-        | "recorder"
-        | "asserter"
-        | "source"
-        | "target"
-        | "agent"
-        | "entity"
-        | "focus"
-        | "based-on"
-        | "part-of"
-        | "derived-from"
-        | "specimen"
-        | "context"
-        | "service-provider"
-        | "general-practitioner"
-        | "link"
-        | "managing-organization" => SearchParamType::Reference,
-
-        // Number parameters
-        "probability" | "age" => SearchParamType::Number,
-
-        // Quantity parameters
-        "value-quantity" | "quantity" | "dose-quantity" | "component-value-quantity" => {
-            SearchParamType::Quantity
-        }
-
-        // URI parameters
-        "url" | "system" | "definition" | "derived-from-uri" => SearchParamType::Uri,
-
-        // Try to infer from value format
-        _ => infer_from_value(values),
-    }
-}
-
-/// Infers parameter type from value format.
-fn infer_from_value(values: &[SearchValue]) -> SearchParamType {
-    if values.is_empty() {
-        return SearchParamType::String;
-    }
-
-    let value = &values[0].value;
-
-    // Check for date format
-    if value.len() >= 4 && value.chars().take(4).all(|c| c.is_ascii_digit()) {
-        if value.len() >= 10
-            && value
-                .chars()
-                .enumerate()
-                .all(|(i, c)| (i == 4 || i == 7) && c == '-' || c.is_ascii_digit())
-        {
-            return SearchParamType::Date;
-        }
-    }
-
-    // Check for quantity format (number with units)
-    if value.contains('|') && value.split('|').count() >= 2 {
-        let parts: Vec<&str> = value.split('|').collect();
-        if !parts[0].is_empty()
-            && parts[0]
-                .chars()
-                .all(|c| c.is_ascii_digit() || c == '.' || c == '-')
-        {
-            return SearchParamType::Quantity;
-        }
-        // Could also be a token with system|code
-        return SearchParamType::Token;
-    }
-
-    // Check for reference format
-    if value.contains('/') {
-        return SearchParamType::Reference;
-    }
-
-    // Default to string
-    SearchParamType::String
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use helios_persistence::search::SearchParameterDefinition;
+    use helios_persistence::types::SearchParamType;
+
+    /// Builds a small registry covering just the params the tests exercise.
+    /// Keeps tests hermetic without depending on the embedded data set.
+    fn test_registry() -> SearchParameterRegistry {
+        let mut r = SearchParameterRegistry::new();
+        let entries = [
+            ("Patient-name", "name", SearchParamType::String, "Patient"),
+            (
+                "Patient-birthdate",
+                "birthdate",
+                SearchParamType::Date,
+                "Patient",
+            ),
+            (
+                "Observation-code",
+                "code",
+                SearchParamType::Token,
+                "Observation",
+            ),
+            (
+                "Observation-patient",
+                "patient",
+                SearchParamType::Reference,
+                "Observation",
+            ),
+            (
+                "Observation-subject",
+                "subject",
+                SearchParamType::Reference,
+                "Observation",
+            ),
+            (
+                "Observation-date",
+                "date",
+                SearchParamType::Date,
+                "Observation",
+            ),
+        ];
+        for (id, code, ty, base) in entries {
+            r.register(
+                SearchParameterDefinition::new(
+                    format!("http://hl7.org/fhir/SearchParameter/{}", id),
+                    code,
+                    ty,
+                    "ignored",
+                )
+                .with_base(vec![base]),
+            )
+            .unwrap();
+        }
+        r
+    }
 
     #[test]
     fn test_parse_parameter_name_simple() {
@@ -652,7 +574,7 @@ mod tests {
         params.insert("_count".to_string(), "10".to_string());
 
         let search_params = SearchParams::from_map(params);
-        let query = build_search_query("Patient", &search_params).unwrap();
+        let query = build_search_query("Patient", &search_params, &test_registry()).unwrap();
 
         assert_eq!(query.resource_type, "Patient");
         assert_eq!(query.count, Some(10));
@@ -666,7 +588,7 @@ mod tests {
         params.insert("name:exact".to_string(), "Smith".to_string());
 
         let search_params = SearchParams::from_map(params);
-        let query = build_search_query("Patient", &search_params).unwrap();
+        let query = build_search_query("Patient", &search_params, &test_registry()).unwrap();
 
         assert_eq!(query.parameters.len(), 1);
         assert_eq!(query.parameters[0].name, "name");
@@ -679,7 +601,7 @@ mod tests {
         params.insert("birthdate".to_string(), "gt2000-01-01".to_string());
 
         let search_params = SearchParams::from_map(params);
-        let query = build_search_query("Patient", &search_params).unwrap();
+        let query = build_search_query("Patient", &search_params, &test_registry()).unwrap();
 
         assert_eq!(query.parameters.len(), 1);
         assert_eq!(
@@ -695,7 +617,7 @@ mod tests {
         params.insert("_sort".to_string(), "-date,name".to_string());
 
         let search_params = SearchParams::from_map(params);
-        let query = build_search_query("Observation", &search_params).unwrap();
+        let query = build_search_query("Observation", &search_params, &test_registry()).unwrap();
 
         assert_eq!(query.sort.len(), 2);
         assert_eq!(query.sort[0].parameter, "date");
@@ -716,7 +638,7 @@ mod tests {
         params.insert("_include".to_string(), "Observation:patient".to_string());
 
         let search_params = SearchParams::from_map(params);
-        let query = build_search_query("Observation", &search_params).unwrap();
+        let query = build_search_query("Observation", &search_params, &test_registry()).unwrap();
 
         assert_eq!(query.includes.len(), 1);
         assert_eq!(query.includes[0].source_type, "Observation");
@@ -724,32 +646,28 @@ mod tests {
     }
 
     #[test]
-    fn test_infer_param_type() {
-        // Known string params
-        assert_eq!(
-            infer_param_type("name", &None, &[]),
-            SearchParamType::String
-        );
+    fn test_param_type_resolved_from_registry() {
+        let registry = test_registry();
+        let name = parse_search_parameter("Patient", "name", "Smith", &registry).unwrap();
+        assert_eq!(name.param_type, SearchParamType::String);
 
-        // Known token params
-        assert_eq!(infer_param_type("code", &None, &[]), SearchParamType::Token);
+        let code = parse_search_parameter("Observation", "code", "1234-5", &registry).unwrap();
+        assert_eq!(code.param_type, SearchParamType::Token);
 
-        // Known reference params
-        assert_eq!(
-            infer_param_type("patient", &None, &[]),
-            SearchParamType::Reference
-        );
+        let patient =
+            parse_search_parameter("Observation", "patient", "Patient/1", &registry).unwrap();
+        assert_eq!(patient.param_type, SearchParamType::Reference);
+    }
 
-        // Modifier hints
-        assert_eq!(
-            infer_param_type("custom", &Some(SearchModifier::Exact), &[]),
-            SearchParamType::String
-        );
+    #[test]
+    fn test_param_type_unregistered_falls_back_to_value_shape() {
+        // No entry for "made-up" anywhere — value heuristic kicks in.
+        let registry = SearchParameterRegistry::new();
+        let date_param =
+            parse_search_parameter("Custom", "made-up", "2020-01-01", &registry).unwrap();
+        assert_eq!(date_param.param_type, SearchParamType::Date);
 
-        // Special params
-        assert_eq!(
-            infer_param_type("_id", &None, &[]),
-            SearchParamType::Special
-        );
+        let plain = parse_search_parameter("Custom", "made-up", "hello", &registry).unwrap();
+        assert_eq!(plain.param_type, SearchParamType::String);
     }
 }

--- a/crates/rest/src/handlers/compartment.rs
+++ b/crates/rest/src/handlers/compartment.rs
@@ -138,8 +138,12 @@ where
         state.max_page_size(),
     );
 
-    // Convert REST params to persistence SearchQuery
-    let query = build_search_query_from_map(&target_type, &params)?;
+    // Convert REST params to persistence SearchQuery. Scope the registry read
+    // guard tightly so it doesn't span any await.
+    let query = {
+        let registry = state.storage().search_param_registry().read();
+        build_search_query_from_map(&target_type, &params, &registry)?
+    };
 
     // Execute the search
     let result = state

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -184,8 +184,13 @@ where
         params = expand_terminology_params(params, ts_url).await?;
     }
 
-    // Convert REST params to persistence SearchQuery
-    let query = build_search_query_from_map(resource_type, &params)?;
+    // Convert REST params to persistence SearchQuery. Scope the registry read
+    // guard tightly so it doesn't span any await — parking_lot guards aren't
+    // Send by default, which would make this async fn !Send.
+    let query = {
+        let registry = state.storage().search_param_registry().read();
+        build_search_query_from_map(resource_type, &params, &registry)?
+    };
 
     // Execute the search
     // Note: The search provider is responsible for resolving _include/_revinclude
@@ -258,8 +263,12 @@ where
         .map(|t| t.split(',').collect())
         .unwrap_or_default();
 
-    // Build a search query (resource type doesn't matter much for system search)
-    let query = build_search_query_from_map("Resource", &params)?;
+    // Build a search query (resource type doesn't matter much for system search).
+    // Scope the registry read guard tightly so it doesn't span any await.
+    let query = {
+        let registry = state.storage().search_param_registry().read();
+        build_search_query_from_map("Resource", &params, &registry)?
+    };
 
     // Execute the multi-type search
     let result = state


### PR DESCRIPTION
## Summary

- Eliminates the hardcoded "well-known param name → `SearchParamType`" lookup in the REST extractor (and three duplicates in the SQLite + MongoDB backends) in favor of a single deterministic resolver that consults the `SearchParameterRegistry` already loaded from `data/search-parameters-{r4,r4b,r5,r6}.json`.
- Fixes the `Goal?patient=…&target-date=…` HTTP 400 surfaced by Inferno against the mongodb backend (Bug 2 from the recent inferno run).
- Net **-150 lines of redundant hardcoded mappings**, +30 lines of resolver. Eight new unit tests.

## Why

The previous flow:

```
REST  --infer_param_type("target-date")--> ???
        not in hardcoded list → fall through to value-shape heuristic
                              → wrong type → mongodb's strict typed query
                                builder rejects with HTTP 400
```

Every storage backend already owned an `Arc<RwLock<SearchParameterRegistry>>` populated from canonical FHIR spec data (1,375 R4 entries with the correct `param_type`). The REST layer simply never had access to it. Three other places (`sqlite/search/chain_builder.rs`, `sqlite/search_impl.rs`, `mongodb/search_impl.rs`) carried *additional* hardcoded fallback tables that drifted from the REST one and from each other.

## What

**Single source of truth** — `crates/persistence/src/search/registry.rs`:
- `resolve_param_type(registry, resource_type, name, values)` — registry-by-type → registry-by-`"Resource"` (global params like `_lastUpdated`) → value-shape heuristic (only reached for genuinely unregistered custom params)
- `resolve_param_targets(registry, resource_type, name)` — for reference target resolution

**Trait surface** — `SearchProvider::search_param_registry()` added; one-line forwarding impl on every backend (sqlite, postgres, mongodb, elasticsearch, s3, composite). All five backends already owned the field.

**REST extractor** — `build_search_query{,_from_map}` now take `&SearchParameterRegistry`. The 90-line `infer_param_type` hardcoded match plus its `infer_from_value` heuristic are deleted; the extractor delegates to the shared resolver. Three handler call sites (`search.rs` ×2, `compartment.rs` ×1) acquire the registry via `state.storage().search_param_registry().read()`, scoped tightly so the parking_lot guard never crosses an `await`.

**Backend cleanup**:
- mongodb's `build_search_params` collapses the 9-line "registry-first then hardcoded fallback" block into one `resolve_param_type` call; removed the now-orphan `lookup_param_type` helper.
- sqlite chain_builder's `infer_param_type` (~15 lines) deleted.
- sqlite search_impl's dead-code `infer_target_type` and its test deleted (was `#[allow(dead_code)]`, called nowhere in production).

## Test plan

- [x] 642 `helios-persistence` lib tests pass with `--features R4,sqlite,postgres,elasticsearch,mongodb`.
- [x] 184 `helios-rest` lib tests pass.
- [x] `cargo clippy --all-targets ... -- -D warnings` clean with the project's CI flags.
- [x] 8 new unit tests in `search::registry::tests` and `search_query_builder::tests` cover: registry hit (`Goal.target-date → Date`), `"Resource"`-base fallback (`_lastUpdated`), value heuristic (date / reference / token / default), multi-target lookup, and the regression case via `parse_search_parameter`.
- [x] End-to-end smoke against in-memory sqlite via the `hfs` binary: `GET /Goal?patient=x&target-date=ge2010-01-01` and `GET /Goal?patient=x&target-date=2010` both return HTTP 200 (vs. the mongodb 400 they were failing with).
- [ ] Confirm inferno mongodb workflow run no longer reports `*_goal_patient_target_date_search_test` as failing — needs an `inferno.yml` re-trigger after merge.

## Out of scope

- The two `DiagnosticReport?patient=…&status=…` HTTP 400 failures from the same inferno run are *not* fixed here. `status` was already correctly typed as Token by both the old hardcoded list and the registry, so this refactor doesn't change their behavior. Their root cause needs separate triage with the actual HFS error response body (Inferno's `result_message` only carries the HTTP status).
- `chain_builder::infer_target_type` (which picks ONE target from the registry's declared multi-target list for chained queries) is intentionally left alone — that's target *disambiguation*, not type inference, and changing it would shift product behavior on chained queries.