### PR TITLE
feat(persistence/composite): iterative forward-chain resolution

### DIFF
--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -1605,21 +1605,7 @@ impl ChainedSearchProvider for CompositeStorage {
         chain: &str,
         value: &str,
     ) -> StorageResult<Vec<String>> {
-        // Chain resolution - delegate to graph backend if available
-        let graph_backend = self
-            .config
-            .backends_with_role(super::config::BackendRole::Graph)
-            .next();
-
-        if let Some(backend) = graph_backend {
-            if let Some(_provider) = self.search_providers.get(&backend.id) {
-                // Would need to downcast to ChainedSearchProvider
-                // For now, fall back to iterative resolution
-            }
-        }
-
-        // Fallback: iterative chain resolution
-        self.resolve_chain_iterative(tenant, base_type, chain, value)
+        self.resolve_chain_via_search(tenant, base_type, chain, value)
             .await
     }
 
@@ -1666,27 +1652,160 @@ impl ChainedSearchProvider for CompositeStorage {
 }
 
 impl CompositeStorage {
-    /// Resolves a chain iteratively.
-    async fn resolve_chain_iterative(
+    /// Resolves a forward chain by issuing iterative SearchQueries against
+    /// composite's regular search routing.
+    ///
+    /// For `Observation?subject.organization.name=Hospital`:
+    ///   1. Parse the chain via the registry: links = [(subject -> Patient),
+    ///      (organization -> Organization)], terminal = name.
+    ///   2. Search Organization for `name=Hospital` — collect refs.
+    ///   3. Search Patient for `organization=<refs>` — collect refs.
+    ///   4. Search Observation for `subject=<refs>` — return resource IDs.
+    ///
+    /// Each step issues exactly one SearchQuery, so the cost is proportional
+    /// to the chain depth, not the result-set fan-out (the inner backend
+    /// applies the multi-value `OR` semantics natively).
+    async fn resolve_chain_via_search(
         &self,
-        _tenant: &TenantContext,
-        _base_type: &str,
+        tenant: &TenantContext,
+        base_type: &str,
         chain: &str,
-        _value: &str,
+        value: &str,
     ) -> StorageResult<Vec<String>> {
-        // Parse chain: "patient.organization.name" -> ["patient", "organization", "name"]
-        let parts: Vec<&str> = chain.split('.').collect();
+        use crate::types::{SearchParameter, SearchQuery, SearchValue};
 
-        if parts.is_empty() {
+        let parts: Vec<&str> = chain.split('.').collect();
+        if parts.len() < 2 {
             return Ok(Vec::new());
         }
 
-        // This is a simplified implementation
-        // A full implementation would handle multiple chain segments
-        // and different parameter types
+        // Resolve target type per chain link from the registry. Mirrors
+        // chain_builder::resolve_target_type so composite agrees with SQLite
+        // and Postgres on ambiguous reference disambiguation.
+        let target_types: Vec<String> = {
+            let registry = self.search_param_registry().read();
+            let mut types = Vec::with_capacity(parts.len() - 1);
+            let mut current = base_type.to_string();
+            for ref_param in parts.iter().take(parts.len() - 1) {
+                let next = registry
+                    .get_param(&current, ref_param)
+                    .and_then(|def| {
+                        def.target.as_ref().and_then(|t| {
+                            if t.len() == 1 {
+                                Some(t[0].clone())
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .unwrap_or_else(|| infer_chain_target_type(ref_param));
+                types.push(next.clone());
+                current = next;
+            }
+            types
+        };
 
-        // For now, just return empty - this would need FHIRPath evaluation
-        Ok(Vec::new())
+        // Innermost: search the deepest target type for the terminal param.
+        let terminal_param = parts[parts.len() - 1];
+        let deepest_type = target_types.last().map(String::as_str).unwrap_or(base_type);
+
+        let terminal_query = SearchQuery::new(deepest_type).with_parameter(SearchParameter {
+            name: terminal_param.to_string(),
+            param_type: {
+                let registry = self.search_param_registry().read();
+                crate::search::resolve_param_type(
+                    &registry,
+                    deepest_type,
+                    terminal_param,
+                    &[SearchValue::eq(value)],
+                )
+            },
+            modifier: None,
+            values: vec![SearchValue::eq(value)],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = self.search(tenant, &terminal_query).await?;
+        let mut current_refs: Vec<String> = result
+            .resources
+            .items
+            .into_iter()
+            .map(|r| format!("{}/{}", r.resource_type(), r.id()))
+            .collect();
+
+        if current_refs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Walk back: for each link from deepest to outermost, search the
+        // parent type for resources whose reference param matches the
+        // accumulated refs.
+        for i in (0..parts.len() - 1).rev() {
+            let ref_param = parts[i];
+            let parent_type = if i == 0 {
+                base_type
+            } else {
+                &target_types[i - 1]
+            };
+
+            let values: Vec<SearchValue> =
+                current_refs.iter().map(SearchValue::eq).collect();
+            let query = SearchQuery::new(parent_type).with_parameter(SearchParameter {
+                name: ref_param.to_string(),
+                param_type: crate::types::SearchParamType::Reference,
+                modifier: None,
+                values,
+                chain: vec![],
+                components: vec![],
+            });
+
+            let r = self.search(tenant, &query).await?;
+            current_refs = r
+                .resources
+                .items
+                .into_iter()
+                .map(|res| {
+                    if i == 0 {
+                        // Outermost: caller wants raw IDs, not refs.
+                        res.id().to_string()
+                    } else {
+                        format!("{}/{}", res.resource_type(), res.id())
+                    }
+                })
+                .collect();
+
+            if current_refs.is_empty() {
+                return Ok(Vec::new());
+            }
+        }
+
+        Ok(current_refs)
+    }
+}
+
+/// Hardcoded fallback for ambiguous reference targets. Matches
+/// `sqlite/search/chain_builder::infer_target_type` so composite agrees with
+/// the underlying backends. See the open-question note in the plan about
+/// migrating to a registry-driven first-target pick.
+fn infer_chain_target_type(ref_param: &str) -> String {
+    match ref_param {
+        "patient" | "subject" => "Patient".to_string(),
+        "practitioner" | "performer" | "requester" | "author" => "Practitioner".to_string(),
+        "organization" | "managingOrganization" | "custodian" => "Organization".to_string(),
+        "encounter" | "context" => "Encounter".to_string(),
+        "location" => "Location".to_string(),
+        "device" => "Device".to_string(),
+        "specimen" => "Specimen".to_string(),
+        "medication" => "Medication".to_string(),
+        "condition" => "Condition".to_string(),
+        _ => {
+            let mut chars = ref_param.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().chain(chars).collect(),
+                None => ref_param.to_string(),
+            }
+        }
     }
 }
 
@@ -2838,6 +2957,65 @@ mod tests {
         let tenant = make_tenant();
         let result = composite.delete(&tenant, "Patient", "1").await;
         assert!(result.is_ok());
+    }
+
+    fn make_composite_with_search_provider() -> CompositeStorage {
+        let composite = make_composite_no_secondary();
+        let mut providers = HashMap::new();
+        providers.insert(
+            "primary".to_string(),
+            Arc::new(MockStorage) as DynSearchProvider,
+        );
+        composite.with_search_providers(providers)
+    }
+
+    /// `resolve_chain` should run iterative SearchQueries against composite's
+    /// own search routing rather than the previous stub that returned an
+    /// empty Vec for any chain longer than 2 segments. This test uses
+    /// MockStorage (which returns no results) so the assertion is just that
+    /// the implementation runs to completion and yields empty (not that it
+    /// finds anything) — full end-to-end coverage comes from inferno against
+    /// real backends.
+    #[tokio::test]
+    async fn test_resolve_chain_three_segments_does_not_error() {
+        use crate::core::ChainedSearchProvider;
+        let composite = make_composite_with_search_provider();
+        let tenant = make_tenant();
+        let result = composite
+            .resolve_chain(
+                &tenant,
+                "Observation",
+                "subject.organization.name",
+                "Hospital",
+            )
+            .await;
+        assert!(result.is_ok(), "resolve_chain failed: {:?}", result.err());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_chain_short_chain_does_not_error() {
+        use crate::core::ChainedSearchProvider;
+        let composite = make_composite_with_search_provider();
+        let tenant = make_tenant();
+        let result = composite
+            .resolve_chain(&tenant, "Observation", "patient.name", "Smith")
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_chain_invalid_chain_returns_empty() {
+        use crate::core::ChainedSearchProvider;
+        let composite = make_composite_with_search_provider();
+        let tenant = make_tenant();
+        // Single segment isn't a chain — must return empty, not error.
+        let result = composite
+            .resolve_chain(&tenant, "Observation", "patient", "x")
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
     }
 
     // SearchProvider impl for MockStorage (must live inside test module).


### PR DESCRIPTION
## Summary

- Composite's \`resolve_chain\` was a stub (\`resolve_chain_iterative\` -> \`Ok(Vec::new())\`) for any forward chain. Silent wrong-empty results.
- Replace with iterative SearchQuery resolution — parse chain via registry, walk deepest-to-outermost issuing one search per link, accumulate refs.
- Drops the stub method entirely.

## Why

Same anti-pattern as #80, #81, #82: \`// This is a simplified implementation\` / \`// For now, just return empty\`. Inferno chained-search tests against composite stacks were silently passing-by-empty.

## Approach

For \`Observation?subject.organization.name=Hospital\`:

1. Resolve target types per chain link from the registry (mirrors SQLite's chain_builder; same \`Patient\` default for ambiguous multi-target references — kept aligned via shared infer_chain_target_type fallback).
2. Search deepest type (\`Organization\`) for the terminal param (\`name=Hospital\`) -> refs.
3. Walk back: search parent type (\`Patient\`) for \`organization=<refs>\` -> refs.
4. Outermost: search base type (\`Observation\`) for \`subject=<refs>\` -> raw IDs.

Each step is one SearchQuery; inner backends apply multi-value OR natively. Cost is O(chain_depth), not O(fan-out).

## Test plan

- [x] 3 new unit tests covering 3-segment, 2-segment, and single-part (invalid) chains using MockStorage. Asserts the implementation runs to completion without erroring — full correctness comes from inferno against real backends.
- [x] All 612 \`helios-persistence\` lib tests pass
- [x] Clippy clean
- [ ] Inferno chained-search regression check post-merge

## Stacked on

Depends on #80 (registry/trait) and #81 (Postgres chain_builder so composite-with-Postgres-primary doesn't regress). Targeting \`feat/postgres-multi-step-chains\`.