### PR TITLE
feat(fhirpath): support .id and .extension on primitive values

### DIFF
--- a/crates/fhir-macro/src/lib.rs
+++ b/crates/fhir-macro/src/lib.rs
@@ -2857,19 +2857,36 @@ fn generate_fhirpath_struct_impl(
                     if let Some(inner_value) = &self.#field_name_ident {
                         // Handle FHIR primitive types with proper type preservation
                         let mut field_result = inner_value.to_evaluation_result();
-                        // Override type information for string-based FHIR primitive types
+                        // Override type information for string-based FHIR primitive types,
+                        // preserving any PrimitiveElement metadata (id/extension).
                         field_result = match field_result {
-                            helios_fhirpath_support::EvaluationResult::String(s, _) => {
-                                helios_fhirpath_support::EvaluationResult::fhir_string(s, #type_name)
+                            helios_fhirpath_support::EvaluationResult::String(s, _, m) => {
+                                helios_fhirpath_support::EvaluationResult::String(
+                                    s,
+                                    Some(helios_fhirpath_support::TypeInfoResult::new("FHIR", #type_name)),
+                                    m,
+                                )
                             },
-                            helios_fhirpath_support::EvaluationResult::Boolean(b, _) => {
-                                helios_fhirpath_support::EvaluationResult::fhir_boolean(b)
+                            helios_fhirpath_support::EvaluationResult::Boolean(b, _, m) => {
+                                helios_fhirpath_support::EvaluationResult::Boolean(
+                                    b,
+                                    Some(helios_fhirpath_support::TypeInfoResult::new("FHIR", "boolean")),
+                                    m,
+                                )
                             },
-                            helios_fhirpath_support::EvaluationResult::Integer(i, _) => {
-                                helios_fhirpath_support::EvaluationResult::fhir_integer(i)
+                            helios_fhirpath_support::EvaluationResult::Integer(i, _, m) => {
+                                helios_fhirpath_support::EvaluationResult::Integer(
+                                    i,
+                                    Some(helios_fhirpath_support::TypeInfoResult::new("FHIR", "integer")),
+                                    m,
+                                )
                             },
-                            helios_fhirpath_support::EvaluationResult::Decimal(d, _) => {
-                                helios_fhirpath_support::EvaluationResult::fhir_decimal(d)
+                            helios_fhirpath_support::EvaluationResult::Decimal(d, _, m) => {
+                                helios_fhirpath_support::EvaluationResult::Decimal(
+                                    d,
+                                    Some(helios_fhirpath_support::TypeInfoResult::new("FHIR", "decimal")),
+                                    m,
+                                )
                             },
                             _ => field_result,
                         };
@@ -2899,19 +2916,36 @@ fn generate_fhirpath_struct_impl(
                 quote! {
                     // Handle FHIR primitive types with proper type preservation
                     let mut field_result = self.#field_name_ident.to_evaluation_result();
-                    // Override type information for FHIR primitive types
+                    // Override type information for FHIR primitive types,
+                    // preserving any PrimitiveElement metadata.
                     field_result = match field_result {
-                        helios_fhirpath_support::EvaluationResult::String(s, _) => {
-                            helios_fhirpath_support::EvaluationResult::fhir_string(s, #type_name)
+                        helios_fhirpath_support::EvaluationResult::String(s, _, m) => {
+                            helios_fhirpath_support::EvaluationResult::String(
+                                s,
+                                Some(helios_fhirpath_support::TypeInfoResult::new("FHIR", #type_name)),
+                                m,
+                            )
                         },
-                        helios_fhirpath_support::EvaluationResult::Boolean(b, _) => {
-                            helios_fhirpath_support::EvaluationResult::fhir_boolean(b)
+                        helios_fhirpath_support::EvaluationResult::Boolean(b, _, m) => {
+                            helios_fhirpath_support::EvaluationResult::Boolean(
+                                b,
+                                Some(helios_fhirpath_support::TypeInfoResult::new("FHIR", "boolean")),
+                                m,
+                            )
                         },
-                        helios_fhirpath_support::EvaluationResult::Integer(i, _) => {
-                            helios_fhirpath_support::EvaluationResult::fhir_integer(i)
+                        helios_fhirpath_support::EvaluationResult::Integer(i, _, m) => {
+                            helios_fhirpath_support::EvaluationResult::Integer(
+                                i,
+                                Some(helios_fhirpath_support::TypeInfoResult::new("FHIR", "integer")),
+                                m,
+                            )
                         },
-                        helios_fhirpath_support::EvaluationResult::Decimal(d, _) => {
-                            helios_fhirpath_support::EvaluationResult::fhir_decimal(d)
+                        helios_fhirpath_support::EvaluationResult::Decimal(d, _, m) => {
+                            helios_fhirpath_support::EvaluationResult::Decimal(
+                                d,
+                                Some(helios_fhirpath_support::TypeInfoResult::new("FHIR", "decimal")),
+                                m,
+                            )
                         },
                         _ => field_result,
                     };
@@ -3157,22 +3191,22 @@ fn generate_fhirpath_enum_impl(
                                 // Add FHIR type information to preserve type for .ofType() operations
                                 // For choice type enums, always use the type determined from the field name
                                 result = match result {
-                                    helios_fhirpath_support::EvaluationResult::String(s, _existing_type_info) => {
+                                    helios_fhirpath_support::EvaluationResult::String(s, _existing_type_info, m) => {
                                         // Always use the determined type from the field name for choice types
                                         let type_info = helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type);
-                                        helios_fhirpath_support::EvaluationResult::String(s, Some(type_info))
+                                        helios_fhirpath_support::EvaluationResult::String(s, Some(type_info), m)
                                     },
-                                    helios_fhirpath_support::EvaluationResult::Integer(i, existing_type_info) => {
+                                    helios_fhirpath_support::EvaluationResult::Integer(i, existing_type_info, m) => {
                                         let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Integer(i, Some(type_info))
+                                        helios_fhirpath_support::EvaluationResult::Integer(i, Some(type_info), m)
                                     },
-                                    helios_fhirpath_support::EvaluationResult::Decimal(d, existing_type_info) => {
+                                    helios_fhirpath_support::EvaluationResult::Decimal(d, existing_type_info, m) => {
                                         let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Decimal(d, Some(type_info))
+                                        helios_fhirpath_support::EvaluationResult::Decimal(d, Some(type_info), m)
                                     },
-                                    helios_fhirpath_support::EvaluationResult::Boolean(b, existing_type_info) => {
+                                    helios_fhirpath_support::EvaluationResult::Boolean(b, existing_type_info, m) => {
                                         let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Boolean(b, Some(type_info))
+                                        helios_fhirpath_support::EvaluationResult::Boolean(b, Some(type_info), m)
                                     },
                                     helios_fhirpath_support::EvaluationResult::Object { map, type_info: existing_type_info } => {
                                         let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
@@ -3201,22 +3235,22 @@ fn generate_fhirpath_enum_impl(
                                 // Add FHIR type information to preserve type for .ofType() operations
                                 // For choice type enums, always use the type determined from the field name
                                 result = match result {
-                                    helios_fhirpath_support::EvaluationResult::String(s, _existing_type_info) => {
+                                    helios_fhirpath_support::EvaluationResult::String(s, _existing_type_info, m) => {
                                         // Always use the determined type from the field name for choice types
                                         let type_info = helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type);
-                                        helios_fhirpath_support::EvaluationResult::String(s, Some(type_info))
+                                        helios_fhirpath_support::EvaluationResult::String(s, Some(type_info), m)
                                     },
-                                    helios_fhirpath_support::EvaluationResult::Integer(i, existing_type_info) => {
+                                    helios_fhirpath_support::EvaluationResult::Integer(i, existing_type_info, m) => {
                                         let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Integer(i, Some(type_info))
+                                        helios_fhirpath_support::EvaluationResult::Integer(i, Some(type_info), m)
                                     },
-                                    helios_fhirpath_support::EvaluationResult::Decimal(d, existing_type_info) => {
+                                    helios_fhirpath_support::EvaluationResult::Decimal(d, existing_type_info, m) => {
                                         let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Decimal(d, Some(type_info))
+                                        helios_fhirpath_support::EvaluationResult::Decimal(d, Some(type_info), m)
                                     },
-                                    helios_fhirpath_support::EvaluationResult::Boolean(b, existing_type_info) => {
+                                    helios_fhirpath_support::EvaluationResult::Boolean(b, existing_type_info, m) => {
                                         let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Boolean(b, Some(type_info))
+                                        helios_fhirpath_support::EvaluationResult::Boolean(b, Some(type_info), m)
                                     },
                                     helios_fhirpath_support::EvaluationResult::Object { map, type_info: existing_type_info } => {
                                         let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));

--- a/crates/fhir/src/lib.rs
+++ b/crates/fhir/src/lib.rs
@@ -1415,6 +1415,7 @@ impl IntoEvaluationResult for PrecisionInstant {
         EvaluationResult::DateTime(
             self.inner.original_string.to_string(),
             Some(TypeInfoResult::new("FHIR", "instant")),
+            None,
         )
     }
 }
@@ -2794,49 +2795,56 @@ where
     E: IntoEvaluationResult + Clone,
 {
     fn to_evaluation_result(&self) -> EvaluationResult {
+        use helios_fhirpath_support::PrimitiveElement;
         use std::any::TypeId;
+
+        // Build PrimitiveElement metadata from id/extension (used when value is also present)
+        let primitive_meta = if self.id.is_some() || self.extension.is_some() {
+            let mut meta = PrimitiveElement::default();
+            if let Some(id) = &self.id {
+                meta.id = Some(id.clone());
+            }
+            if let Some(ext) = &self.extension {
+                meta.extension = ext.iter().map(|e| e.to_evaluation_result()).collect();
+            }
+            if !meta.is_empty() { Some(meta) } else { None }
+        } else {
+            None
+        };
 
         // Prioritize returning the primitive value if it exists
         if let Some(v) = &self.value {
             let result = v.to_evaluation_result();
             // For primitive values, we need to preserve FHIR type information
-            return match result {
-                EvaluationResult::Boolean(b, _) => {
-                    // Return FHIR boolean
-                    EvaluationResult::fhir_boolean(b)
-                }
-                EvaluationResult::Integer(i, _) => {
-                    // Return FHIR integer
-                    EvaluationResult::fhir_integer(i)
-                }
+            let typed = match result {
+                EvaluationResult::Boolean(b, _, _) => EvaluationResult::fhir_boolean(b),
+                EvaluationResult::Integer(i, _, _) => EvaluationResult::fhir_integer(i),
                 #[cfg(not(any(feature = "R4", feature = "R4B")))]
-                EvaluationResult::Integer64(i, _) => {
-                    // Return FHIR integer64 (R5 and above)
-                    EvaluationResult::fhir_integer64(i)
-                }
-                EvaluationResult::String(s, _) => {
-                    // Determine the FHIR type name based on V's type
+                EvaluationResult::Integer64(i, _, _) => EvaluationResult::fhir_integer64(i),
+                EvaluationResult::String(s, _, _) => {
                     let fhir_type_name = if TypeId::of::<V>() == TypeId::of::<String>() {
-                        // For strings, we need more context to determine the exact FHIR type
-                        // Default to "string" but this could be date, dateTime, etc.
                         "string"
                     } else {
-                        // Default fallback
                         "string"
                     };
                     EvaluationResult::fhir_string(s, fhir_type_name)
                 }
-                EvaluationResult::DateTime(dt, type_info) => {
-                    // Check if V is PrecisionInstant - if so, this is an instant
+                EvaluationResult::DateTime(dt, type_info, _) => {
                     if TypeId::of::<V>() == TypeId::of::<PrecisionInstant>() {
-                        // Return as FHIR instant
-                        EvaluationResult::DateTime(dt, Some(TypeInfoResult::new("FHIR", "instant")))
+                        EvaluationResult::DateTime(
+                            dt,
+                            Some(TypeInfoResult::new("FHIR", "instant")),
+                            None,
+                        )
                     } else {
-                        // Preserve original type info for PrecisionDateTime
-                        EvaluationResult::DateTime(dt, type_info)
+                        EvaluationResult::DateTime(dt, type_info, None)
                     }
                 }
-                _ => result, // For other types, return as-is
+                other => other,
+            };
+            return match primitive_meta {
+                Some(meta) => typed.with_primitive_element(meta),
+                None => typed,
             };
         } else if self.id.is_some() || self.extension.is_some() {
             // If value is None, but id or extension exist, return an Object with those
@@ -2871,11 +2879,30 @@ where
     E: IntoEvaluationResult + Clone,
 {
     fn to_evaluation_result(&self) -> EvaluationResult {
+        use helios_fhirpath_support::PrimitiveElement;
+
+        // Build PrimitiveElement metadata from id/extension
+        let primitive_meta = if self.id.is_some() || self.extension.is_some() {
+            let mut meta = PrimitiveElement::default();
+            if let Some(id) = &self.id {
+                meta.id = Some(id.clone());
+            }
+            if let Some(ext) = &self.extension {
+                meta.extension = ext.iter().map(|e| e.to_evaluation_result()).collect();
+            }
+            if !meta.is_empty() { Some(meta) } else { None }
+        } else {
+            None
+        };
+
         // Prioritize returning the primitive decimal value if it exists
         if let Some(precise_decimal) = &self.value {
             if let Some(decimal_val) = precise_decimal.value() {
-                // Return FHIR decimal
-                return EvaluationResult::fhir_decimal(decimal_val);
+                let result = EvaluationResult::fhir_decimal(decimal_val);
+                return match primitive_meta {
+                    Some(meta) => result.with_primitive_element(meta),
+                    None => result,
+                };
             }
             // If PreciseDecimal holds None for value, fall through to check id/extension
         }

--- a/crates/fhir/src/lib.rs
+++ b/crates/fhir/src/lib.rs
@@ -2821,14 +2821,7 @@ where
                 EvaluationResult::Integer(i, _, _) => EvaluationResult::fhir_integer(i),
                 #[cfg(not(any(feature = "R4", feature = "R4B")))]
                 EvaluationResult::Integer64(i, _, _) => EvaluationResult::fhir_integer64(i),
-                EvaluationResult::String(s, _, _) => {
-                    let fhir_type_name = if TypeId::of::<V>() == TypeId::of::<String>() {
-                        "string"
-                    } else {
-                        "string"
-                    };
-                    EvaluationResult::fhir_string(s, fhir_type_name)
-                }
+                EvaluationResult::String(s, _, _) => EvaluationResult::fhir_string(s, "string"),
                 EvaluationResult::DateTime(dt, type_info, _) => {
                     if TypeId::of::<V>() == TypeId::of::<PrecisionInstant>() {
                         EvaluationResult::DateTime(

--- a/crates/fhirpath-support/src/lib.rs
+++ b/crates/fhirpath-support/src/lib.rs
@@ -27,7 +27,7 @@
 //! // Convert a string to an evaluation result
 //! let text = "Hello, FHIR!".to_string();
 //! let result = text.to_evaluation_result();
-//! assert_eq!(result, EvaluationResult::String("Hello, FHIR!".to_string(), None));
+//! assert_eq!(result, EvaluationResult::String("Hello, FHIR!".to_string(), None, None));
 //!
 //! // Work with collections
 //! let numbers = vec![1, 2, 3];
@@ -194,10 +194,10 @@ pub trait IntoEvaluationResult {
 ///
 /// // Creating different result types
 /// let empty = EvaluationResult::Empty;
-/// let text = EvaluationResult::String("Patient".to_string(), None);
-/// let number = EvaluationResult::Integer(42, None);
-/// let number64 = EvaluationResult::Integer64(9223372036854775807, None); // max i64
-/// let decimal = EvaluationResult::Decimal(Decimal::new(1234, 2), None); // 12.34
+/// let text = EvaluationResult::String("Patient".to_string(), None, None);
+/// let number = EvaluationResult::Integer(42, None, None);
+/// let number64 = EvaluationResult::Integer64(9223372036854775807, None, None); // max i64
+/// let decimal = EvaluationResult::Decimal(Decimal::new(1234, 2), None, None); // 12.34
 ///
 /// // Working with collections
 /// let items = vec![text, number];
@@ -210,6 +210,29 @@ pub trait IntoEvaluationResult {
 /// assert_eq!(collection.count(), 2);
 /// assert!(collection.is_collection());
 /// ```
+/// FHIR primitive metadata (id and extensions) carried alongside a primitive value.
+///
+/// In FHIR JSON, primitive values can have an associated metadata sibling field with
+/// an underscore prefix, e.g. `{"birthDate": "1980-01-01", "_birthDate": {"id": "abc",
+/// "extension": [...]}}`. This struct captures that metadata so FHIRPath expressions
+/// like `Patient.active.id` and `Patient.birthDate.extension` can reach it.
+///
+/// `extension` holds each FHIR Extension as an `EvaluationResult::Object`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct PrimitiveElement {
+    /// Optional element identifier (the `id` field of the Element).
+    pub id: Option<String>,
+    /// Extensions on the primitive, each represented as an `EvaluationResult::Object`.
+    pub extension: Vec<EvaluationResult>,
+}
+
+impl PrimitiveElement {
+    /// Returns true when there is no id and no extensions.
+    pub fn is_empty(&self) -> bool {
+        self.id.is_none() && self.extension.is_empty()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum EvaluationResult {
     /// No value or empty collection.
@@ -221,49 +244,76 @@ pub enum EvaluationResult {
     /// Boolean true/false value.
     ///
     /// Results from boolean expressions, existence checks, and logical operations.
-    /// Also used for FHIR boolean fields.
-    Boolean(bool, Option<TypeInfoResult>),
+    /// Also used for FHIR boolean fields. The trailing `Option<Box<PrimitiveElement>>`
+    /// carries id/extension metadata when the source was a FHIR primitive with a
+    /// `_field` sibling in JSON.
+    Boolean(bool, Option<TypeInfoResult>, Option<Box<PrimitiveElement>>),
     /// Text string value.
     ///
     /// Used for FHIR string, code, uri, canonical, id, and other text-based types.
     /// Also results from string manipulation functions and conversions.
-    String(String, Option<TypeInfoResult>),
+    String(
+        String,
+        Option<TypeInfoResult>,
+        Option<Box<PrimitiveElement>>,
+    ),
     /// High-precision decimal number.
     ///
     /// Uses `rust_decimal::Decimal` for precise arithmetic without floating-point
     /// errors. Required for FHIR's decimal type and mathematical operations.
-    Decimal(Decimal, Option<TypeInfoResult>),
+    Decimal(
+        Decimal,
+        Option<TypeInfoResult>,
+        Option<Box<PrimitiveElement>>,
+    ),
     /// Whole number value.
     ///
     /// Used for FHIR integer, positiveInt, unsignedInt types and counting operations.
     /// Also results from indexing and length functions.
-    Integer(i64, Option<TypeInfoResult>),
+    Integer(i64, Option<TypeInfoResult>, Option<Box<PrimitiveElement>>),
     /// 64-bit integer value.
     ///
     /// Explicit 64-bit integer type for cases where the distinction from regular
     /// integers is important.
-    Integer64(i64, Option<TypeInfoResult>),
+    Integer64(i64, Option<TypeInfoResult>, Option<Box<PrimitiveElement>>),
     /// Date value in ISO format.
     ///
     /// Stores date as string in YYYY-MM-DD format. Handles FHIR date fields
     /// and results from date extraction functions.
-    Date(String, Option<TypeInfoResult>),
+    Date(
+        String,
+        Option<TypeInfoResult>,
+        Option<Box<PrimitiveElement>>,
+    ),
     /// DateTime value in ISO format.
     ///
     /// Stores datetime as string in ISO 8601 format with optional timezone.
     /// Handles FHIR dateTime and instant fields.
-    DateTime(String, Option<TypeInfoResult>),
+    DateTime(
+        String,
+        Option<TypeInfoResult>,
+        Option<Box<PrimitiveElement>>,
+    ),
     /// Time value in ISO format.
     ///
     /// Stores time as string in HH:MM:SS format. Handles FHIR time fields
     /// and results from time extraction functions.
-    Time(String, Option<TypeInfoResult>),
+    Time(
+        String,
+        Option<TypeInfoResult>,
+        Option<Box<PrimitiveElement>>,
+    ),
     /// Quantity with value and unit.
     ///
     /// Represents measurements with units (e.g., "5.4 mg", "10 years").
     /// First element is the numeric value, second is the unit string.
     /// Used for FHIR Quantity, Age, Duration, Distance, Count, and Money types.
-    Quantity(Decimal, String, Option<TypeInfoResult>),
+    Quantity(
+        Decimal,
+        String,
+        Option<TypeInfoResult>,
+        Option<Box<PrimitiveElement>>,
+    ),
     /// Ordered collection of evaluation results.
     ///
     /// Represents arrays, lists, and multi-valued FHIR elements. Collections
@@ -483,32 +533,32 @@ impl std::fmt::Display for EvaluationError {
 /// use helios_fhirpath_support::EvaluationResult;
 /// use rust_decimal::Decimal;
 ///
-/// let a = EvaluationResult::String("test".to_string(), None);
-/// let b = EvaluationResult::String("test".to_string(), None);
+/// let a = EvaluationResult::String("test".to_string(), None, None);
+/// let b = EvaluationResult::String("test".to_string(), None, None);
 /// assert_eq!(a, b);
 ///
-/// let c = EvaluationResult::Decimal(Decimal::new(100, 2), None); // 1.00
-/// let d = EvaluationResult::Decimal(Decimal::new(1, 0), None);   // 1
+/// let c = EvaluationResult::Decimal(Decimal::new(100, 2), None, None); // 1.00
+/// let d = EvaluationResult::Decimal(Decimal::new(1, 0), None, None);   // 1
 /// assert_eq!(c, d); // Normalized decimals are equal
 /// ```
 impl PartialEq for EvaluationResult {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (EvaluationResult::Empty, EvaluationResult::Empty) => true,
-            (EvaluationResult::Boolean(a, _), EvaluationResult::Boolean(b, _)) => a == b,
-            (EvaluationResult::String(a, _), EvaluationResult::String(b, _)) => a == b,
-            (EvaluationResult::Decimal(a, _), EvaluationResult::Decimal(b, _)) => {
+            (EvaluationResult::Boolean(a, _, _), EvaluationResult::Boolean(b, _, _)) => a == b,
+            (EvaluationResult::String(a, _, _), EvaluationResult::String(b, _, _)) => a == b,
+            (EvaluationResult::Decimal(a, _, _), EvaluationResult::Decimal(b, _, _)) => {
                 // Normalize decimals to handle precision differences (e.g., 1.0 == 1.00)
                 a.normalize() == b.normalize()
             }
-            (EvaluationResult::Integer(a, _), EvaluationResult::Integer(b, _)) => a == b,
-            (EvaluationResult::Integer64(a, _), EvaluationResult::Integer64(b, _)) => a == b,
-            (EvaluationResult::Date(a, _), EvaluationResult::Date(b, _)) => a == b,
-            (EvaluationResult::DateTime(a, _), EvaluationResult::DateTime(b, _)) => a == b,
-            (EvaluationResult::Time(a, _), EvaluationResult::Time(b, _)) => a == b,
+            (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer(b, _, _)) => a == b,
+            (EvaluationResult::Integer64(a, _, _), EvaluationResult::Integer64(b, _, _)) => a == b,
+            (EvaluationResult::Date(a, _, _), EvaluationResult::Date(b, _, _)) => a == b,
+            (EvaluationResult::DateTime(a, _, _), EvaluationResult::DateTime(b, _, _)) => a == b,
+            (EvaluationResult::Time(a, _, _), EvaluationResult::Time(b, _, _)) => a == b,
             (
-                EvaluationResult::Quantity(val_a, unit_a, _),
-                EvaluationResult::Quantity(val_b, unit_b, _),
+                EvaluationResult::Quantity(val_a, unit_a, _, _),
+                EvaluationResult::Quantity(val_b, unit_b, _, _),
             ) => {
                 // Quantities are equal if both value and unit match (normalized values)
                 val_a.normalize() == val_b.normalize() && unit_a == unit_b
@@ -575,41 +625,43 @@ impl Ord for EvaluationResult {
             (EvaluationResult::Empty, _) => Ordering::Less,
             (_, EvaluationResult::Empty) => Ordering::Greater,
 
-            (EvaluationResult::Boolean(a, _), EvaluationResult::Boolean(b, _)) => a.cmp(b),
-            (EvaluationResult::Boolean(_, _), _) => Ordering::Less,
-            (_, EvaluationResult::Boolean(_, _)) => Ordering::Greater,
+            (EvaluationResult::Boolean(a, _, _), EvaluationResult::Boolean(b, _, _)) => a.cmp(b),
+            (EvaluationResult::Boolean(_, _, _), _) => Ordering::Less,
+            (_, EvaluationResult::Boolean(_, _, _)) => Ordering::Greater,
 
-            (EvaluationResult::Integer(a, _), EvaluationResult::Integer(b, _)) => a.cmp(b),
-            (EvaluationResult::Integer(_, _), _) => Ordering::Less,
-            (_, EvaluationResult::Integer(_, _)) => Ordering::Greater,
+            (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer(b, _, _)) => a.cmp(b),
+            (EvaluationResult::Integer(_, _, _), _) => Ordering::Less,
+            (_, EvaluationResult::Integer(_, _, _)) => Ordering::Greater,
 
-            (EvaluationResult::Integer64(a, _), EvaluationResult::Integer64(b, _)) => a.cmp(b),
-            (EvaluationResult::Integer64(_, _), _) => Ordering::Less,
-            (_, EvaluationResult::Integer64(_, _)) => Ordering::Greater,
+            (EvaluationResult::Integer64(a, _, _), EvaluationResult::Integer64(b, _, _)) => {
+                a.cmp(b)
+            }
+            (EvaluationResult::Integer64(_, _, _), _) => Ordering::Less,
+            (_, EvaluationResult::Integer64(_, _, _)) => Ordering::Greater,
 
-            (EvaluationResult::Decimal(a, _), EvaluationResult::Decimal(b, _)) => a.cmp(b),
-            (EvaluationResult::Decimal(_, _), _) => Ordering::Less,
-            (_, EvaluationResult::Decimal(_, _)) => Ordering::Greater,
+            (EvaluationResult::Decimal(a, _, _), EvaluationResult::Decimal(b, _, _)) => a.cmp(b),
+            (EvaluationResult::Decimal(_, _, _), _) => Ordering::Less,
+            (_, EvaluationResult::Decimal(_, _, _)) => Ordering::Greater,
 
-            (EvaluationResult::String(a, _), EvaluationResult::String(b, _)) => a.cmp(b),
-            (EvaluationResult::String(_, _), _) => Ordering::Less,
-            (_, EvaluationResult::String(_, _)) => Ordering::Greater,
+            (EvaluationResult::String(a, _, _), EvaluationResult::String(b, _, _)) => a.cmp(b),
+            (EvaluationResult::String(_, _, _), _) => Ordering::Less,
+            (_, EvaluationResult::String(_, _, _)) => Ordering::Greater,
 
-            (EvaluationResult::Date(a, _), EvaluationResult::Date(b, _)) => a.cmp(b),
-            (EvaluationResult::Date(_, _), _) => Ordering::Less,
-            (_, EvaluationResult::Date(_, _)) => Ordering::Greater,
+            (EvaluationResult::Date(a, _, _), EvaluationResult::Date(b, _, _)) => a.cmp(b),
+            (EvaluationResult::Date(_, _, _), _) => Ordering::Less,
+            (_, EvaluationResult::Date(_, _, _)) => Ordering::Greater,
 
-            (EvaluationResult::DateTime(a, _), EvaluationResult::DateTime(b, _)) => a.cmp(b),
-            (EvaluationResult::DateTime(_, _), _) => Ordering::Less,
-            (_, EvaluationResult::DateTime(_, _)) => Ordering::Greater,
+            (EvaluationResult::DateTime(a, _, _), EvaluationResult::DateTime(b, _, _)) => a.cmp(b),
+            (EvaluationResult::DateTime(_, _, _), _) => Ordering::Less,
+            (_, EvaluationResult::DateTime(_, _, _)) => Ordering::Greater,
 
-            (EvaluationResult::Time(a, _), EvaluationResult::Time(b, _)) => a.cmp(b),
-            (EvaluationResult::Time(_, _), _) => Ordering::Less,
-            (_, EvaluationResult::Time(_, _)) => Ordering::Greater,
+            (EvaluationResult::Time(a, _, _), EvaluationResult::Time(b, _, _)) => a.cmp(b),
+            (EvaluationResult::Time(_, _, _), _) => Ordering::Less,
+            (_, EvaluationResult::Time(_, _, _)) => Ordering::Greater,
 
             (
-                EvaluationResult::Quantity(val_a, unit_a, _),
-                EvaluationResult::Quantity(val_b, unit_b, _),
+                EvaluationResult::Quantity(val_a, unit_a, _, _),
+                EvaluationResult::Quantity(val_b, unit_b, _, _),
             ) => {
                 // Order by value first, then by unit string
                 match val_a.cmp(val_b) {
@@ -617,8 +669,8 @@ impl Ord for EvaluationResult {
                     other => other,
                 }
             }
-            (EvaluationResult::Quantity(_, _, _), _) => Ordering::Less,
-            (_, EvaluationResult::Quantity(_, _, _)) => Ordering::Greater,
+            (EvaluationResult::Quantity(_, _, _, _), _) => Ordering::Less,
+            (_, EvaluationResult::Quantity(_, _, _, _)) => Ordering::Greater,
 
             (
                 EvaluationResult::Collection {
@@ -698,16 +750,16 @@ impl Hash for EvaluationResult {
         match self {
             // Empty has no additional data to hash
             EvaluationResult::Empty => {}
-            EvaluationResult::Boolean(b, _) => b.hash(state),
-            EvaluationResult::String(s, _) => s.hash(state),
+            EvaluationResult::Boolean(b, _, _) => b.hash(state),
+            EvaluationResult::String(s, _, _) => s.hash(state),
             // Hash normalized decimal for consistency with equality
-            EvaluationResult::Decimal(d, _) => d.normalize().hash(state),
-            EvaluationResult::Integer(i, _) => i.hash(state),
-            EvaluationResult::Integer64(i, _) => i.hash(state),
-            EvaluationResult::Date(d, _) => d.hash(state),
-            EvaluationResult::DateTime(dt, _) => dt.hash(state),
-            EvaluationResult::Time(t, _) => t.hash(state),
-            EvaluationResult::Quantity(val, unit, _) => {
+            EvaluationResult::Decimal(d, _, _) => d.normalize().hash(state),
+            EvaluationResult::Integer(i, _, _) => i.hash(state),
+            EvaluationResult::Integer64(i, _, _) => i.hash(state),
+            EvaluationResult::Date(d, _, _) => d.hash(state),
+            EvaluationResult::DateTime(dt, _, _) => dt.hash(state),
+            EvaluationResult::Time(t, _, _) => t.hash(state),
+            EvaluationResult::Quantity(val, unit, _, _) => {
                 // Hash both normalized value and unit
                 val.normalize().hash(state);
                 unit.hash(state);
@@ -746,72 +798,118 @@ impl EvaluationResult {
 
     /// Creates a Boolean result with System type.
     pub fn boolean(value: bool) -> Self {
-        EvaluationResult::Boolean(value, Some(TypeInfoResult::new("System", "Boolean")))
+        EvaluationResult::Boolean(value, Some(TypeInfoResult::new("System", "Boolean")), None)
     }
 
     /// Creates a Boolean result with FHIR type.
     pub fn fhir_boolean(value: bool) -> Self {
-        EvaluationResult::Boolean(value, Some(TypeInfoResult::new("FHIR", "boolean")))
+        EvaluationResult::Boolean(value, Some(TypeInfoResult::new("FHIR", "boolean")), None)
     }
 
     /// Creates a String result with System type.
     pub fn string(value: String) -> Self {
-        EvaluationResult::String(value, Some(TypeInfoResult::new("System", "String")))
+        EvaluationResult::String(value, Some(TypeInfoResult::new("System", "String")), None)
     }
 
     /// Creates a String result with FHIR type.
     pub fn fhir_string(value: String, fhir_type: &str) -> Self {
-        EvaluationResult::String(value, Some(TypeInfoResult::new("FHIR", fhir_type)))
+        EvaluationResult::String(value, Some(TypeInfoResult::new("FHIR", fhir_type)), None)
     }
 
     /// Creates an Integer result with System type.
     pub fn integer(value: i64) -> Self {
-        EvaluationResult::Integer(value, Some(TypeInfoResult::new("System", "Integer")))
+        EvaluationResult::Integer(value, Some(TypeInfoResult::new("System", "Integer")), None)
     }
 
     /// Creates an Integer result with FHIR type.
     pub fn fhir_integer(value: i64) -> Self {
-        EvaluationResult::Integer(value, Some(TypeInfoResult::new("FHIR", "integer")))
+        EvaluationResult::Integer(value, Some(TypeInfoResult::new("FHIR", "integer")), None)
     }
 
     /// Creates an Integer64 result with System type.
     pub fn integer64(value: i64) -> Self {
-        EvaluationResult::Integer64(value, Some(TypeInfoResult::new("System", "Integer64")))
+        EvaluationResult::Integer64(
+            value,
+            Some(TypeInfoResult::new("System", "Integer64")),
+            None,
+        )
     }
 
     /// Creates an Integer64 result with FHIR type.
     pub fn fhir_integer64(value: i64) -> Self {
-        EvaluationResult::Integer64(value, Some(TypeInfoResult::new("FHIR", "integer64")))
+        EvaluationResult::Integer64(value, Some(TypeInfoResult::new("FHIR", "integer64")), None)
     }
 
     /// Creates a Decimal result with System type.
     pub fn decimal(value: Decimal) -> Self {
-        EvaluationResult::Decimal(value, Some(TypeInfoResult::new("System", "Decimal")))
+        EvaluationResult::Decimal(value, Some(TypeInfoResult::new("System", "Decimal")), None)
     }
 
     /// Creates a Decimal result with FHIR type.
     pub fn fhir_decimal(value: Decimal) -> Self {
-        EvaluationResult::Decimal(value, Some(TypeInfoResult::new("FHIR", "decimal")))
+        EvaluationResult::Decimal(value, Some(TypeInfoResult::new("FHIR", "decimal")), None)
     }
 
     /// Creates a Date result with System type.
     pub fn date(value: String) -> Self {
-        EvaluationResult::Date(value, Some(TypeInfoResult::new("System", "Date")))
+        EvaluationResult::Date(value, Some(TypeInfoResult::new("System", "Date")), None)
     }
 
     /// Creates a DateTime result with System type.
     pub fn datetime(value: String) -> Self {
-        EvaluationResult::DateTime(value, Some(TypeInfoResult::new("System", "DateTime")))
+        EvaluationResult::DateTime(value, Some(TypeInfoResult::new("System", "DateTime")), None)
     }
 
     /// Creates a Time result with System type.
     pub fn time(value: String) -> Self {
-        EvaluationResult::Time(value, Some(TypeInfoResult::new("System", "Time")))
+        EvaluationResult::Time(value, Some(TypeInfoResult::new("System", "Time")), None)
     }
 
     /// Creates a Quantity result with System type.
     pub fn quantity(value: Decimal, unit: String) -> Self {
-        EvaluationResult::Quantity(value, unit, Some(TypeInfoResult::new("System", "Quantity")))
+        EvaluationResult::Quantity(
+            value,
+            unit,
+            Some(TypeInfoResult::new("System", "Quantity")),
+            None,
+        )
+    }
+
+    /// Returns a reference to the primitive metadata (id/extension) if this is a primitive.
+    pub fn primitive_element(&self) -> Option<&PrimitiveElement> {
+        match self {
+            EvaluationResult::Boolean(_, _, e)
+            | EvaluationResult::String(_, _, e)
+            | EvaluationResult::Decimal(_, _, e)
+            | EvaluationResult::Integer(_, _, e)
+            | EvaluationResult::Integer64(_, _, e)
+            | EvaluationResult::Date(_, _, e)
+            | EvaluationResult::DateTime(_, _, e)
+            | EvaluationResult::Time(_, _, e)
+            | EvaluationResult::Quantity(_, _, _, e) => e.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Returns this primitive value with the given primitive metadata attached.
+    /// Returns the value unchanged for non-primitive variants.
+    pub fn with_primitive_element(self, element: PrimitiveElement) -> Self {
+        if element.is_empty() {
+            return self;
+        }
+        let boxed = Some(Box::new(element));
+        match self {
+            EvaluationResult::Boolean(v, t, _) => EvaluationResult::Boolean(v, t, boxed),
+            EvaluationResult::String(v, t, _) => EvaluationResult::String(v, t, boxed),
+            EvaluationResult::Decimal(v, t, _) => EvaluationResult::Decimal(v, t, boxed),
+            EvaluationResult::Integer(v, t, _) => EvaluationResult::Integer(v, t, boxed),
+            EvaluationResult::Integer64(v, t, _) => EvaluationResult::Integer64(v, t, boxed),
+            EvaluationResult::Date(v, t, _) => EvaluationResult::Date(v, t, boxed),
+            EvaluationResult::DateTime(v, t, _) => EvaluationResult::DateTime(v, t, boxed),
+            EvaluationResult::Time(v, t, _) => EvaluationResult::Time(v, t, boxed),
+            EvaluationResult::Quantity(v, u, t, _) => EvaluationResult::Quantity(v, u, t, boxed),
+            other => other,
+        }
     }
 
     /// Creates a Collection result.
@@ -848,7 +946,7 @@ impl EvaluationResult {
     /// Extracts the boolean value if this is a Boolean variant.
     pub fn as_boolean(&self) -> Option<bool> {
         match self {
-            EvaluationResult::Boolean(val, _) => Some(*val),
+            EvaluationResult::Boolean(val, _, _) => Some(*val),
             _ => None,
         }
     }
@@ -856,7 +954,7 @@ impl EvaluationResult {
     /// Extracts the string value if this is a String variant.
     pub fn as_string(&self) -> Option<&String> {
         match self {
-            EvaluationResult::String(val, _) => Some(val),
+            EvaluationResult::String(val, _, _) => Some(val),
             _ => None,
         }
     }
@@ -864,7 +962,7 @@ impl EvaluationResult {
     /// Extracts the integer value if this is an Integer variant.
     pub fn as_integer(&self) -> Option<i64> {
         match self {
-            EvaluationResult::Integer(val, _) => Some(*val),
+            EvaluationResult::Integer(val, _, _) => Some(*val),
             _ => None,
         }
     }
@@ -872,7 +970,7 @@ impl EvaluationResult {
     /// Extracts the integer value if this is an Integer64 variant.
     pub fn as_integer64(&self) -> Option<i64> {
         match self {
-            EvaluationResult::Integer64(val, _) => Some(*val),
+            EvaluationResult::Integer64(val, _, _) => Some(*val),
             _ => None,
         }
     }
@@ -880,7 +978,7 @@ impl EvaluationResult {
     /// Extracts the decimal value if this is a Decimal variant.
     pub fn as_decimal(&self) -> Option<Decimal> {
         match self {
-            EvaluationResult::Decimal(val, _) => Some(*val),
+            EvaluationResult::Decimal(val, _, _) => Some(*val),
             _ => None,
         }
     }
@@ -888,7 +986,7 @@ impl EvaluationResult {
     /// Extracts the date value if this is a Date variant.
     pub fn as_date(&self) -> Option<&String> {
         match self {
-            EvaluationResult::Date(val, _) => Some(val),
+            EvaluationResult::Date(val, _, _) => Some(val),
             _ => None,
         }
     }
@@ -896,7 +994,7 @@ impl EvaluationResult {
     /// Extracts the datetime value if this is a DateTime variant.
     pub fn as_datetime(&self) -> Option<&String> {
         match self {
-            EvaluationResult::DateTime(val, _) => Some(val),
+            EvaluationResult::DateTime(val, _, _) => Some(val),
             _ => None,
         }
     }
@@ -904,7 +1002,7 @@ impl EvaluationResult {
     /// Extracts the time value if this is a Time variant.
     pub fn as_time(&self) -> Option<&String> {
         match self {
-            EvaluationResult::Time(val, _) => Some(val),
+            EvaluationResult::Time(val, _, _) => Some(val),
             _ => None,
         }
     }
@@ -912,7 +1010,7 @@ impl EvaluationResult {
     /// Extracts the quantity value if this is a Quantity variant.
     pub fn as_quantity(&self) -> Option<(Decimal, &String)> {
         match self {
-            EvaluationResult::Quantity(val, unit, _) => Some((*val, unit)),
+            EvaluationResult::Quantity(val, unit, _, _) => Some((*val, unit)),
             _ => None,
         }
     }
@@ -933,7 +1031,7 @@ impl EvaluationResult {
     /// };
     /// assert!(collection.is_collection());
     ///
-    /// let string = EvaluationResult::String("test".to_string(), None);
+    /// let string = EvaluationResult::String("test".to_string(), None, None);
     /// assert!(!string.is_collection());
     /// ```
     pub fn is_collection(&self) -> bool {
@@ -955,12 +1053,12 @@ impl EvaluationResult {
     /// use helios_fhirpath_support::EvaluationResult;
     ///
     /// assert_eq!(EvaluationResult::Empty.count(), 0);
-    /// assert_eq!(EvaluationResult::String("test".to_string(), None).count(), 1);
+    /// assert_eq!(EvaluationResult::String("test".to_string(), None, None).count(), 1);
     ///
     /// let collection = EvaluationResult::Collection {
     ///     items: vec![
-    ///         EvaluationResult::Integer(1, None),
-    ///         EvaluationResult::Integer(2, None),
+    ///         EvaluationResult::Integer(1, None, None),
+    ///         EvaluationResult::Integer(2, None, None),
     ///     ],
     ///     has_undefined_order: false,
     ///     type_info: None,
@@ -994,21 +1092,21 @@ impl EvaluationResult {
     /// use rust_decimal::Decimal;
     ///
     /// assert_eq!(EvaluationResult::Empty.to_boolean(), false);
-    /// assert_eq!(EvaluationResult::Boolean(true, None).to_boolean(), true);
-    /// assert_eq!(EvaluationResult::String("".to_string(), None).to_boolean(), false);
-    /// assert_eq!(EvaluationResult::String("text".to_string(), None).to_boolean(), true);
-    /// assert_eq!(EvaluationResult::Integer(0, None).to_boolean(), false);
-    /// assert_eq!(EvaluationResult::Integer(42, None).to_boolean(), true);
+    /// assert_eq!(EvaluationResult::Boolean(true, None, None).to_boolean(), true);
+    /// assert_eq!(EvaluationResult::String("".to_string(), None, None).to_boolean(), false);
+    /// assert_eq!(EvaluationResult::String("text".to_string(), None, None).to_boolean(), true);
+    /// assert_eq!(EvaluationResult::Integer(0, None, None).to_boolean(), false);
+    /// assert_eq!(EvaluationResult::Integer(42, None, None).to_boolean(), true);
     /// ```
     pub fn to_boolean(&self) -> bool {
         match self {
             EvaluationResult::Empty => false,
-            EvaluationResult::Boolean(b, _) => *b,
-            EvaluationResult::String(s, _) => !s.is_empty(),
-            EvaluationResult::Decimal(d, _) => !d.is_zero(),
-            EvaluationResult::Integer(i, _) => *i != 0,
-            EvaluationResult::Integer64(i, _) => *i != 0,
-            EvaluationResult::Quantity(q, _, _) => !q.is_zero(), // Truthy if value is non-zero
+            EvaluationResult::Boolean(b, _, _) => *b,
+            EvaluationResult::String(s, _, _) => !s.is_empty(),
+            EvaluationResult::Decimal(d, _, _) => !d.is_zero(),
+            EvaluationResult::Integer(i, _, _) => *i != 0,
+            EvaluationResult::Integer64(i, _, _) => *i != 0,
+            EvaluationResult::Quantity(q, _, _, _) => !q.is_zero(), // Truthy if value is non-zero
             EvaluationResult::Collection { items, .. } => !items.is_empty(),
             _ => true, // Date, DateTime, Time, Object are always truthy
         }
@@ -1037,24 +1135,24 @@ impl EvaluationResult {
     /// use rust_decimal::Decimal;
     ///
     /// assert_eq!(EvaluationResult::Empty.to_string_value(), "");
-    /// assert_eq!(EvaluationResult::Boolean(true, None).to_string_value(), "true");
-    /// assert_eq!(EvaluationResult::Integer(42, None).to_string_value(), "42");
+    /// assert_eq!(EvaluationResult::Boolean(true, None, None).to_string_value(), "true");
+    /// assert_eq!(EvaluationResult::Integer(42, None, None).to_string_value(), "42");
     ///
-    /// let quantity = EvaluationResult::Quantity(Decimal::new(54, 1), "mg".to_string(), None);
+    /// let quantity = EvaluationResult::Quantity(Decimal::new(54, 1), "mg".to_string(), None, None);
     /// assert_eq!(quantity.to_string_value(), "5.4 'mg'");
     /// ```
     pub fn to_string_value(&self) -> String {
         match self {
             EvaluationResult::Empty => "".to_string(),
-            EvaluationResult::Boolean(b, _) => b.to_string(),
-            EvaluationResult::String(s, _) => s.clone(),
-            EvaluationResult::Decimal(d, _) => d.to_string(),
-            EvaluationResult::Integer(i, _) => i.to_string(),
-            EvaluationResult::Integer64(i, _) => i.to_string(),
-            EvaluationResult::Date(d, _) => d.clone(), // Return stored string
-            EvaluationResult::DateTime(dt, _) => dt.clone(), // Return stored string
-            EvaluationResult::Time(t, _) => t.clone(), // Return stored string
-            EvaluationResult::Quantity(val, unit, _) => {
+            EvaluationResult::Boolean(b, _, _) => b.to_string(),
+            EvaluationResult::String(s, _, _) => s.clone(),
+            EvaluationResult::Decimal(d, _, _) => d.to_string(),
+            EvaluationResult::Integer(i, _, _) => i.to_string(),
+            EvaluationResult::Integer64(i, _, _) => i.to_string(),
+            EvaluationResult::Date(d, _, _) => d.clone(), // Return stored string
+            EvaluationResult::DateTime(dt, _, _) => dt.clone(), // Return stored string
+            EvaluationResult::Time(t, _, _) => t.clone(), // Return stored string
+            EvaluationResult::Quantity(val, unit, _, _) => {
                 // Format as "value unit" for toString()
                 // The FHIRPath spec for toString() doesn't require quotes around the unit
                 let formatted_unit = format_unit_for_display(unit);
@@ -1104,17 +1202,17 @@ impl EvaluationResult {
     /// ```rust
     /// use helios_fhirpath_support::{EvaluationResult, EvaluationError};
     ///
-    /// let true_str = EvaluationResult::String("true".to_string(), None);
-    /// assert_eq!(true_str.to_boolean_for_logic().unwrap(), EvaluationResult::Boolean(true, None));
+    /// let true_str = EvaluationResult::String("true".to_string(), None, None);
+    /// assert_eq!(true_str.to_boolean_for_logic().unwrap(), EvaluationResult::Boolean(true, None, None));
     ///
-    /// let false_str = EvaluationResult::String("false".to_string(), None);
-    /// assert_eq!(false_str.to_boolean_for_logic().unwrap(), EvaluationResult::Boolean(false, None));
+    /// let false_str = EvaluationResult::String("false".to_string(), None, None);
+    /// assert_eq!(false_str.to_boolean_for_logic().unwrap(), EvaluationResult::Boolean(false, None, None));
     ///
-    /// let other_str = EvaluationResult::String("maybe".to_string(), None);
+    /// let other_str = EvaluationResult::String("maybe".to_string(), None, None);
     /// assert_eq!(other_str.to_boolean_for_logic().unwrap(), EvaluationResult::Empty);
     ///
-    /// let integer = EvaluationResult::Integer(42, None);
-    /// assert_eq!(integer.to_boolean_for_logic().unwrap(), EvaluationResult::Boolean(true, None));
+    /// let integer = EvaluationResult::Integer(42, None, None);
+    /// assert_eq!(integer.to_boolean_for_logic().unwrap(), EvaluationResult::Boolean(true, None, None));
     /// ```
     pub fn to_boolean_for_logic(&self) -> Result<EvaluationResult, EvaluationError> {
         // Default to R5 behavior for backward compatibility
@@ -1132,10 +1230,10 @@ impl EvaluationResult {
         r4_compat: bool,
     ) -> Result<EvaluationResult, EvaluationError> {
         match self {
-            EvaluationResult::Boolean(b, type_info) => {
-                Ok(EvaluationResult::Boolean(*b, type_info.clone()))
+            EvaluationResult::Boolean(b, type_info, _) => {
+                Ok(EvaluationResult::Boolean(*b, type_info.clone(), None))
             }
-            EvaluationResult::String(s, _) => {
+            EvaluationResult::String(s, _, _) => {
                 // Convert string to boolean based on recognized values
                 Ok(match s.to_lowercase().as_str() {
                     "true" | "t" | "yes" | "1" | "1.0" => EvaluationResult::boolean(true),
@@ -1153,7 +1251,7 @@ impl EvaluationResult {
                     ))),
                 }
             }
-            EvaluationResult::Integer(i, _) => {
+            EvaluationResult::Integer(i, _, _) => {
                 if r4_compat {
                     // R4/R4B: C-like semantics - 0 is false, non-zero is true
                     Ok(EvaluationResult::boolean(*i != 0))
@@ -1162,7 +1260,7 @@ impl EvaluationResult {
                     Ok(EvaluationResult::boolean(true))
                 }
             }
-            EvaluationResult::Integer64(i, _) => {
+            EvaluationResult::Integer64(i, _, _) => {
                 if r4_compat {
                     // R4/R4B: C-like semantics - 0 is false, non-zero is true
                     Ok(EvaluationResult::boolean(*i != 0))
@@ -1172,11 +1270,11 @@ impl EvaluationResult {
                 }
             }
             // Per FHIRPath spec section 5.2: other types evaluate to Empty for logical operators
-            EvaluationResult::Decimal(_, _)
-            | EvaluationResult::Date(_, _)
-            | EvaluationResult::DateTime(_, _)
-            | EvaluationResult::Time(_, _)
-            | EvaluationResult::Quantity(_, _, _)
+            EvaluationResult::Decimal(_, _, _)
+            | EvaluationResult::Date(_, _, _)
+            | EvaluationResult::DateTime(_, _, _)
+            | EvaluationResult::Time(_, _, _)
+            | EvaluationResult::Quantity(_, _, _, _)
             | EvaluationResult::Object { .. } => Ok(EvaluationResult::Empty),
             EvaluationResult::Empty => Ok(EvaluationResult::Empty),
         }
@@ -1193,13 +1291,13 @@ impl EvaluationResult {
     /// use helios_fhirpath_support::EvaluationResult;
     ///
     /// assert!(EvaluationResult::Empty.is_string_or_empty());
-    /// assert!(EvaluationResult::String("test".to_string(), None).is_string_or_empty());
-    /// assert!(!EvaluationResult::Integer(42, None).is_string_or_empty());
+    /// assert!(EvaluationResult::String("test".to_string(), None, None).is_string_or_empty());
+    /// assert!(!EvaluationResult::Integer(42, None, None).is_string_or_empty());
     /// ```
     pub fn is_string_or_empty(&self) -> bool {
         matches!(
             self,
-            EvaluationResult::String(_, _) | EvaluationResult::Empty
+            EvaluationResult::String(_, _, _) | EvaluationResult::Empty
         )
     }
 
@@ -1214,8 +1312,8 @@ impl EvaluationResult {
     /// use helios_fhirpath_support::EvaluationResult;
     ///
     /// assert_eq!(EvaluationResult::Empty.type_name(), "Empty");
-    /// assert_eq!(EvaluationResult::String("test".to_string(), None).type_name(), "String");
-    /// assert_eq!(EvaluationResult::Integer(42, None).type_name(), "Integer");
+    /// assert_eq!(EvaluationResult::String("test".to_string(), None, None).type_name(), "String");
+    /// assert_eq!(EvaluationResult::Integer(42, None, None).type_name(), "Integer");
     ///
     /// let collection = EvaluationResult::Collection {
     ///     items: vec![],
@@ -1227,15 +1325,15 @@ impl EvaluationResult {
     pub fn type_name(&self) -> &'static str {
         match self {
             EvaluationResult::Empty => "Empty",
-            EvaluationResult::Boolean(_, _) => "Boolean",
-            EvaluationResult::String(_, _) => "String",
-            EvaluationResult::Decimal(_, _) => "Decimal",
-            EvaluationResult::Integer(_, _) => "Integer",
-            EvaluationResult::Integer64(_, _) => "Integer64",
-            EvaluationResult::Date(_, _) => "Date",
-            EvaluationResult::DateTime(_, _) => "DateTime",
-            EvaluationResult::Time(_, _) => "Time",
-            EvaluationResult::Quantity(_, _, _) => "Quantity",
+            EvaluationResult::Boolean(_, _, _) => "Boolean",
+            EvaluationResult::String(_, _, _) => "String",
+            EvaluationResult::Decimal(_, _, _) => "Decimal",
+            EvaluationResult::Integer(_, _, _) => "Integer",
+            EvaluationResult::Integer64(_, _, _) => "Integer64",
+            EvaluationResult::Date(_, _, _) => "Date",
+            EvaluationResult::DateTime(_, _, _) => "DateTime",
+            EvaluationResult::Time(_, _, _) => "Time",
+            EvaluationResult::Quantity(_, _, _, _) => "Quantity",
             EvaluationResult::Collection { .. } => "Collection",
             EvaluationResult::Object { .. } => "Object",
         }
@@ -1380,7 +1478,7 @@ where
 /// use helios_fhirpath_support::{convert_value_to_evaluation_result, EvaluationResult};
 ///
 /// let result = convert_value_to_evaluation_result(&"hello".to_string());
-/// assert_eq!(result, EvaluationResult::String("hello".to_string(), None));
+/// assert_eq!(result, EvaluationResult::String("hello".to_string(), None, None));
 ///
 /// let numbers = vec![1, 2, 3];
 /// let collection_result = convert_value_to_evaluation_result(&numbers);

--- a/crates/fhirpath/src/aggregate_function.rs
+++ b/crates/fhirpath/src/aggregate_function.rs
@@ -106,7 +106,7 @@ mod tests {
 
         // Simulate computing $this + $total
         match (this, total) {
-            (EvaluationResult::Integer(a, _), EvaluationResult::Integer(b, _)) => {
+            (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer(b, _, _)) => {
                 Ok(EvaluationResult::integer(a + b))
             }
             _ => Ok(EvaluationResult::Empty),
@@ -133,7 +133,7 @@ mod tests {
 
         // Otherwise compare this and total
         match (this, total) {
-            (EvaluationResult::Integer(a, _), EvaluationResult::Integer(b, _)) => {
+            (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer(b, _, _)) => {
                 if a < b {
                     Ok(this.clone())
                 } else {
@@ -164,7 +164,7 @@ mod tests {
 
         // Otherwise compare this and total
         match (this, total) {
-            (EvaluationResult::Integer(a, _), EvaluationResult::Integer(b, _)) => {
+            (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer(b, _, _)) => {
                 if a > b {
                     Ok(this.clone())
                 } else {

--- a/crates/fhirpath/src/aggregate_math_functions.rs
+++ b/crates/fhirpath/src/aggregate_math_functions.rs
@@ -19,22 +19,28 @@ fn extract_items(input: &EvaluationResult) -> Vec<&EvaluationResult> {
 /// Returns None if the types are incomparable.
 fn compare_values(a: &EvaluationResult, b: &EvaluationResult) -> Option<Ordering> {
     match (a, b) {
-        (EvaluationResult::Integer(a, _), EvaluationResult::Integer(b, _)) => Some(a.cmp(b)),
-        (EvaluationResult::Integer64(a, _), EvaluationResult::Integer64(b, _)) => Some(a.cmp(b)),
-        (EvaluationResult::Decimal(a, _), EvaluationResult::Decimal(b, _)) => Some(a.cmp(b)),
+        (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer(b, _, _)) => Some(a.cmp(b)),
+        (EvaluationResult::Integer64(a, _, _), EvaluationResult::Integer64(b, _, _)) => {
+            Some(a.cmp(b))
+        }
+        (EvaluationResult::Decimal(a, _, _), EvaluationResult::Decimal(b, _, _)) => Some(a.cmp(b)),
         // Mixed numeric: promote to Decimal
-        (EvaluationResult::Integer(a, _), EvaluationResult::Decimal(b, _)) => {
+        (EvaluationResult::Integer(a, _, _), EvaluationResult::Decimal(b, _, _)) => {
             Some(Decimal::from(*a).cmp(b))
         }
-        (EvaluationResult::Decimal(a, _), EvaluationResult::Integer(b, _)) => {
+        (EvaluationResult::Decimal(a, _, _), EvaluationResult::Integer(b, _, _)) => {
             Some(a.cmp(&Decimal::from(*b)))
         }
-        (EvaluationResult::Integer(a, _), EvaluationResult::Integer64(b, _)) => Some(a.cmp(b)),
-        (EvaluationResult::Integer64(a, _), EvaluationResult::Integer(b, _)) => Some(a.cmp(b)),
+        (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer64(b, _, _)) => {
+            Some(a.cmp(b))
+        }
+        (EvaluationResult::Integer64(a, _, _), EvaluationResult::Integer(b, _, _)) => {
+            Some(a.cmp(b))
+        }
         // Quantity comparison (same unit only)
         (
-            EvaluationResult::Quantity(val_a, unit_a, _),
-            EvaluationResult::Quantity(val_b, unit_b, _),
+            EvaluationResult::Quantity(val_a, unit_a, _, _),
+            EvaluationResult::Quantity(val_b, unit_b, _, _),
         ) => {
             if unit_a == unit_b {
                 Some(val_a.cmp(val_b))
@@ -43,11 +49,13 @@ fn compare_values(a: &EvaluationResult, b: &EvaluationResult) -> Option<Ordering
             }
         }
         // String comparison
-        (EvaluationResult::String(a, _), EvaluationResult::String(b, _)) => Some(a.cmp(b)),
+        (EvaluationResult::String(a, _, _), EvaluationResult::String(b, _, _)) => Some(a.cmp(b)),
         // Date/Time comparisons
-        (EvaluationResult::Date(a, _), EvaluationResult::Date(b, _)) => Some(a.cmp(b)),
-        (EvaluationResult::DateTime(a, _), EvaluationResult::DateTime(b, _)) => Some(a.cmp(b)),
-        (EvaluationResult::Time(a, _), EvaluationResult::Time(b, _)) => Some(a.cmp(b)),
+        (EvaluationResult::Date(a, _, _), EvaluationResult::Date(b, _, _)) => Some(a.cmp(b)),
+        (EvaluationResult::DateTime(a, _, _), EvaluationResult::DateTime(b, _, _)) => {
+            Some(a.cmp(b))
+        }
+        (EvaluationResult::Time(a, _, _), EvaluationResult::Time(b, _, _)) => Some(a.cmp(b)),
         _ => None,
     }
 }
@@ -157,12 +165,16 @@ pub fn avg_function(
     let sum = sum_function(invocation_base)?;
 
     match sum {
-        EvaluationResult::Integer(v, _) => Ok(EvaluationResult::decimal(Decimal::from(v) / count)),
-        EvaluationResult::Integer64(v, _) => {
+        EvaluationResult::Integer(v, _, _) => {
             Ok(EvaluationResult::decimal(Decimal::from(v) / count))
         }
-        EvaluationResult::Decimal(v, _) => Ok(EvaluationResult::decimal(v / count)),
-        EvaluationResult::Quantity(v, unit, _) => Ok(EvaluationResult::quantity(v / count, unit)),
+        EvaluationResult::Integer64(v, _, _) => {
+            Ok(EvaluationResult::decimal(Decimal::from(v) / count))
+        }
+        EvaluationResult::Decimal(v, _, _) => Ok(EvaluationResult::decimal(v / count)),
+        EvaluationResult::Quantity(v, unit, _, _) => {
+            Ok(EvaluationResult::quantity(v / count, unit))
+        }
         _ => Err(EvaluationError::TypeError(
             "avg() requires numeric or quantity items".to_string(),
         )),
@@ -175,32 +187,32 @@ fn add_values(
     b: &EvaluationResult,
 ) -> Result<EvaluationResult, EvaluationError> {
     match (a, b) {
-        (EvaluationResult::Integer(a, _), EvaluationResult::Integer(b, _)) => {
+        (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer(b, _, _)) => {
             Ok(EvaluationResult::integer(a + b))
         }
-        (EvaluationResult::Integer64(a, _), EvaluationResult::Integer64(b, _)) => {
+        (EvaluationResult::Integer64(a, _, _), EvaluationResult::Integer64(b, _, _)) => {
             Ok(EvaluationResult::integer64(*a + *b))
         }
-        (EvaluationResult::Decimal(a, _), EvaluationResult::Decimal(b, _)) => {
+        (EvaluationResult::Decimal(a, _, _), EvaluationResult::Decimal(b, _, _)) => {
             Ok(EvaluationResult::decimal(*a + *b))
         }
         // Mixed numeric: promote to Decimal
-        (EvaluationResult::Integer(a, _), EvaluationResult::Decimal(b, _)) => {
+        (EvaluationResult::Integer(a, _, _), EvaluationResult::Decimal(b, _, _)) => {
             Ok(EvaluationResult::decimal(Decimal::from(*a) + *b))
         }
-        (EvaluationResult::Decimal(a, _), EvaluationResult::Integer(b, _)) => {
+        (EvaluationResult::Decimal(a, _, _), EvaluationResult::Integer(b, _, _)) => {
             Ok(EvaluationResult::decimal(*a + Decimal::from(*b)))
         }
-        (EvaluationResult::Integer(a, _), EvaluationResult::Integer64(b, _)) => {
+        (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer64(b, _, _)) => {
             Ok(EvaluationResult::integer64(*a + *b))
         }
-        (EvaluationResult::Integer64(a, _), EvaluationResult::Integer(b, _)) => {
+        (EvaluationResult::Integer64(a, _, _), EvaluationResult::Integer(b, _, _)) => {
             Ok(EvaluationResult::integer64(*a + *b))
         }
         // Quantity addition (same unit)
         (
-            EvaluationResult::Quantity(val_a, unit_a, _),
-            EvaluationResult::Quantity(val_b, unit_b, _),
+            EvaluationResult::Quantity(val_a, unit_a, _, _),
+            EvaluationResult::Quantity(val_b, unit_b, _, _),
         ) => {
             if unit_a == unit_b {
                 Ok(EvaluationResult::quantity(*val_a + *val_b, unit_a.clone()))

--- a/crates/fhirpath/src/boolean_functions.rs
+++ b/crates/fhirpath/src/boolean_functions.rs
@@ -39,8 +39,8 @@ pub fn all_true_function(
     // Check each item in the collection
     for item in items {
         match item {
-            EvaluationResult::Boolean(true, _) => continue,
-            EvaluationResult::Boolean(false, _) | EvaluationResult::Empty => {
+            EvaluationResult::Boolean(true, _, _) => continue,
+            EvaluationResult::Boolean(false, _, _) | EvaluationResult::Empty => {
                 return Ok(EvaluationResult::boolean(false));
             }
             // If any item is not boolean, it's an error according to spec
@@ -90,8 +90,8 @@ pub fn any_true_function(
     // Check each item in the collection
     for item in items {
         match item {
-            EvaluationResult::Boolean(true, _) => return Ok(EvaluationResult::boolean(true)),
-            EvaluationResult::Boolean(false, _) | EvaluationResult::Empty => continue,
+            EvaluationResult::Boolean(true, _, _) => return Ok(EvaluationResult::boolean(true)),
+            EvaluationResult::Boolean(false, _, _) | EvaluationResult::Empty => continue,
             // If any item is not boolean, it's an error according to spec
             _ => {
                 return Err(EvaluationError::TypeError(
@@ -139,8 +139,8 @@ pub fn all_false_function(
     // Check each item in the collection
     for item in items {
         match item {
-            EvaluationResult::Boolean(false, _) => continue,
-            EvaluationResult::Boolean(true, _) | EvaluationResult::Empty => {
+            EvaluationResult::Boolean(false, _, _) => continue,
+            EvaluationResult::Boolean(true, _, _) | EvaluationResult::Empty => {
                 return Ok(EvaluationResult::boolean(false));
             }
             // If any item is not boolean, it's an error according to spec
@@ -190,8 +190,8 @@ pub fn any_false_function(
     // Check each item in the collection
     for item in items {
         match item {
-            EvaluationResult::Boolean(false, _) => return Ok(EvaluationResult::boolean(true)),
-            EvaluationResult::Boolean(true, _) | EvaluationResult::Empty => continue,
+            EvaluationResult::Boolean(false, _, _) => return Ok(EvaluationResult::boolean(true)),
+            EvaluationResult::Boolean(true, _, _) | EvaluationResult::Empty => continue,
             // If any item is not boolean, it's an error according to spec
             _ => {
                 return Err(EvaluationError::TypeError(

--- a/crates/fhirpath/src/boundary_functions.rs
+++ b/crates/fhirpath/src/boundary_functions.rs
@@ -42,7 +42,7 @@ pub fn low_boundary_function(
         None
     } else if args.len() == 1 {
         match &args[0] {
-            EvaluationResult::Integer(p, _) => {
+            EvaluationResult::Integer(p, _, _) => {
                 if *p < 0 {
                     return Err(EvaluationError::InvalidArgument(
                         "lowBoundary precision must be >= 0".to_string(),
@@ -70,38 +70,38 @@ pub fn low_boundary_function(
     // Handle each type according to FHIRPath boundary rules
     Ok(match invocation_base {
         EvaluationResult::Empty => EvaluationResult::Empty,
-        EvaluationResult::Decimal(d, _) => {
+        EvaluationResult::Decimal(d, _, _) => {
             // For decimals, the low boundary depends on the precision
             let precision = precision_param.unwrap_or(8); // Default precision is 8 
             let low_bound = calculate_decimal_low_boundary(*d, precision);
             EvaluationResult::decimal(low_bound)
         }
-        EvaluationResult::Integer(i, _) => {
+        EvaluationResult::Integer(i, _, _) => {
             // For integers, treat as decimal
             let decimal_val = Decimal::from(*i);
             let precision = precision_param.unwrap_or(8); // Default precision is 8
             let low_bound = calculate_decimal_low_boundary(decimal_val, precision);
             EvaluationResult::decimal(low_bound)
         }
-        EvaluationResult::Quantity(value, unit, _) => {
+        EvaluationResult::Quantity(value, unit, _, _) => {
             // For quantities, apply boundary to the value part
             let precision = precision_param.unwrap_or(8); // Default precision is 8
             let low_bound = calculate_decimal_low_boundary(*value, precision);
             EvaluationResult::quantity(low_bound, unit.clone())
         }
-        EvaluationResult::Date(date_str, _) => {
+        EvaluationResult::Date(date_str, _, _) => {
             // For dates, return the earliest possible date given the precision
             calculate_date_low_boundary(date_str, precision_param)
         }
-        EvaluationResult::DateTime(datetime_str, _) => {
+        EvaluationResult::DateTime(datetime_str, _, _) => {
             // For datetimes, return the earliest possible datetime given the precision
             calculate_datetime_low_boundary(datetime_str, precision_param)
         }
-        EvaluationResult::Time(time_str, _) => {
+        EvaluationResult::Time(time_str, _, _) => {
             // For times, return the earliest possible time given the precision
             calculate_time_low_boundary(time_str, precision_param)
         }
-        EvaluationResult::String(s, type_info) => {
+        EvaluationResult::String(s, type_info, _) => {
             // Handle FHIR primitive values that are represented as strings
             if let Some(ti) = type_info {
                 match ti.name.to_lowercase().as_str() {
@@ -174,7 +174,7 @@ pub fn high_boundary_function(
         None
     } else if args.len() == 1 {
         match &args[0] {
-            EvaluationResult::Integer(p, _) => {
+            EvaluationResult::Integer(p, _, _) => {
                 if *p < 0 {
                     return Err(EvaluationError::InvalidArgument(
                         "highBoundary precision must be >= 0".to_string(),
@@ -202,39 +202,39 @@ pub fn high_boundary_function(
     // Handle each type according to FHIRPath boundary rules
     Ok(match invocation_base {
         EvaluationResult::Empty => EvaluationResult::Empty,
-        EvaluationResult::Decimal(d, _) => {
+        EvaluationResult::Decimal(d, _, _) => {
             // For decimals, the high boundary depends on the precision
             // Default precision is 8 for decimals
             let precision = precision_param.unwrap_or(8);
             let high_bound = calculate_decimal_high_boundary(*d, precision);
             EvaluationResult::decimal(high_bound)
         }
-        EvaluationResult::Integer(i, _) => {
+        EvaluationResult::Integer(i, _, _) => {
             // For integers, treat as decimal
             let decimal_val = Decimal::from(*i);
             let precision = precision_param.unwrap_or(8); // Default precision is 8
             let high_bound = calculate_decimal_high_boundary(decimal_val, precision);
             EvaluationResult::decimal(high_bound)
         }
-        EvaluationResult::Quantity(value, unit, _) => {
+        EvaluationResult::Quantity(value, unit, _, _) => {
             // For quantities, apply boundary to the value part
             let precision = precision_param.unwrap_or(8); // Default precision is 8
             let high_bound = calculate_decimal_high_boundary(*value, precision);
             EvaluationResult::quantity(high_bound, unit.clone())
         }
-        EvaluationResult::Date(date_str, _) => {
+        EvaluationResult::Date(date_str, _, _) => {
             // For dates, return the latest possible date given the precision
             calculate_date_high_boundary(date_str, precision_param)
         }
-        EvaluationResult::DateTime(datetime_str, _) => {
+        EvaluationResult::DateTime(datetime_str, _, _) => {
             // For datetimes, return the latest possible datetime given the precision
             calculate_datetime_high_boundary(datetime_str, precision_param)
         }
-        EvaluationResult::Time(time_str, _) => {
+        EvaluationResult::Time(time_str, _, _) => {
             // For times, return the latest possible time given the precision
             calculate_time_high_boundary(time_str, precision_param)
         }
-        EvaluationResult::String(s, type_info) => {
+        EvaluationResult::String(s, type_info, _) => {
             // Handle FHIR primitive values that are represented as strings
             if let Some(ti) = type_info {
                 match ti.name.to_lowercase().as_str() {
@@ -635,7 +635,7 @@ fn calculate_datetime_low_boundary(
     } else {
         // No time part, treat as date-only but convert to datetime with earliest timezone
         let low_date = match calculate_date_low_boundary(datetime_str, None) {
-            EvaluationResult::Date(d, _) => d,
+            EvaluationResult::Date(d, _, _) => d,
             _ => datetime_str.to_string(),
         };
         EvaluationResult::datetime(format!("@{}T00:00:00.000+14:00", low_date))
@@ -690,7 +690,7 @@ fn calculate_datetime_high_boundary(
     } else {
         // No time part, treat as date-only but convert to datetime with latest timezone
         let high_date = match calculate_date_high_boundary(datetime_str, None) {
-            EvaluationResult::Date(d, _) => d,
+            EvaluationResult::Date(d, _, _) => d,
             _ => datetime_str.to_string(),
         };
         EvaluationResult::datetime(format!("@{}T23:59:59.999-12:00", high_date))

--- a/crates/fhirpath/src/cli.rs
+++ b/crates/fhirpath/src/cli.rs
@@ -435,15 +435,15 @@ fn result_to_json(result: &EvaluationResult) -> FhirPathResult<String> {
 fn evaluation_result_to_json_value(result: &EvaluationResult) -> Value {
     match result {
         EvaluationResult::Empty => Value::Null,
-        EvaluationResult::Boolean(b, _) => json!(b),
-        EvaluationResult::String(s, _) => json!(s),
-        EvaluationResult::Integer(i, _) => json!(i),
-        EvaluationResult::Integer64(i, _) => json!(i),
-        EvaluationResult::Decimal(d, _) => json!(d),
-        EvaluationResult::Date(s, _) => json!(s),
-        EvaluationResult::DateTime(s, _) => json!(s),
-        EvaluationResult::Time(s, _) => json!(s),
-        EvaluationResult::Quantity(value, unit, _) => {
+        EvaluationResult::Boolean(b, _, _) => json!(b),
+        EvaluationResult::String(s, _, _) => json!(s),
+        EvaluationResult::Integer(i, _, _) => json!(i),
+        EvaluationResult::Integer64(i, _, _) => json!(i),
+        EvaluationResult::Decimal(d, _, _) => json!(d),
+        EvaluationResult::Date(s, _, _) => json!(s),
+        EvaluationResult::DateTime(s, _, _) => json!(s),
+        EvaluationResult::Time(s, _, _) => json!(s),
+        EvaluationResult::Quantity(value, unit, _, _) => {
             crate::json_utils::quantity_to_json(value, unit)
         }
         EvaluationResult::Collection { items, .. } => {
@@ -646,22 +646,22 @@ mod tests {
 
         // Test boolean
         let result = json_value_to_result(&json!(true)).unwrap();
-        assert!(matches!(result, EvaluationResult::Boolean(true, _)));
+        assert!(matches!(result, EvaluationResult::Boolean(true, _, _)));
 
         // Test integer
         let result = json_value_to_result(&json!(42)).unwrap();
-        assert!(matches!(result, EvaluationResult::Integer(42, _)));
+        assert!(matches!(result, EvaluationResult::Integer(42, _, _)));
 
         // Test string
         let result = json_value_to_result(&json!("hello")).unwrap();
         match result {
-            EvaluationResult::String(s, _) => assert_eq!(s, "hello"),
+            EvaluationResult::String(s, _, _) => assert_eq!(s, "hello"),
             _ => panic!("Expected string result"),
         }
 
         // Test array/object (converted to string)
         let result = json_value_to_result(&json!([1, 2, 3])).unwrap();
-        assert!(matches!(result, EvaluationResult::String(_, _)));
+        assert!(matches!(result, EvaluationResult::String(_, _, _)));
     }
 
     #[test]

--- a/crates/fhirpath/src/collection_functions.rs
+++ b/crates/fhirpath/src/collection_functions.rs
@@ -562,12 +562,12 @@ fn compare_evaluation_results(a: &EvaluationResult, b: &EvaluationResult) -> std
         (_, EvaluationResult::Empty) => Ordering::Greater,
 
         // Boolean comparison
-        (EvaluationResult::Boolean(a, _), EvaluationResult::Boolean(b, _)) => a.cmp(b),
+        (EvaluationResult::Boolean(a, _, _), EvaluationResult::Boolean(b, _, _)) => a.cmp(b),
 
         // Numeric comparisons
-        (EvaluationResult::Integer(a, _), EvaluationResult::Integer(b, _)) => a.cmp(b),
-        (EvaluationResult::Integer64(a, _), EvaluationResult::Integer64(b, _)) => a.cmp(b),
-        (EvaluationResult::Decimal(a, _), EvaluationResult::Decimal(b, _)) => {
+        (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer(b, _, _)) => a.cmp(b),
+        (EvaluationResult::Integer64(a, _, _), EvaluationResult::Integer64(b, _, _)) => a.cmp(b),
+        (EvaluationResult::Decimal(a, _, _), EvaluationResult::Decimal(b, _, _)) => {
             // Decimal doesn't implement Ord, so we need to handle it
             if a < b {
                 Ordering::Less
@@ -579,7 +579,7 @@ fn compare_evaluation_results(a: &EvaluationResult, b: &EvaluationResult) -> std
         }
 
         // Mixed numeric types - convert to Decimal for comparison
-        (EvaluationResult::Integer(a, _), EvaluationResult::Decimal(b, _)) => {
+        (EvaluationResult::Integer(a, _, _), EvaluationResult::Decimal(b, _, _)) => {
             let a_dec = Decimal::from(*a);
             if a_dec < *b {
                 Ordering::Less
@@ -589,7 +589,7 @@ fn compare_evaluation_results(a: &EvaluationResult, b: &EvaluationResult) -> std
                 Ordering::Equal
             }
         }
-        (EvaluationResult::Decimal(a, _), EvaluationResult::Integer(b, _)) => {
+        (EvaluationResult::Decimal(a, _, _), EvaluationResult::Integer(b, _, _)) => {
             let b_dec = Decimal::from(*b);
             if a < &b_dec {
                 Ordering::Less
@@ -599,21 +599,21 @@ fn compare_evaluation_results(a: &EvaluationResult, b: &EvaluationResult) -> std
                 Ordering::Equal
             }
         }
-        (EvaluationResult::Integer(a, _), EvaluationResult::Integer64(b, _)) => a.cmp(b),
-        (EvaluationResult::Integer64(a, _), EvaluationResult::Integer(b, _)) => a.cmp(b),
+        (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer64(b, _, _)) => a.cmp(b),
+        (EvaluationResult::Integer64(a, _, _), EvaluationResult::Integer(b, _, _)) => a.cmp(b),
 
         // String comparison
-        (EvaluationResult::String(a, _), EvaluationResult::String(b, _)) => a.cmp(b),
+        (EvaluationResult::String(a, _, _), EvaluationResult::String(b, _, _)) => a.cmp(b),
 
         // Date/Time comparisons
-        (EvaluationResult::Date(a, _), EvaluationResult::Date(b, _)) => a.cmp(b),
-        (EvaluationResult::DateTime(a, _), EvaluationResult::DateTime(b, _)) => a.cmp(b),
-        (EvaluationResult::Time(a, _), EvaluationResult::Time(b, _)) => a.cmp(b),
+        (EvaluationResult::Date(a, _, _), EvaluationResult::Date(b, _, _)) => a.cmp(b),
+        (EvaluationResult::DateTime(a, _, _), EvaluationResult::DateTime(b, _, _)) => a.cmp(b),
+        (EvaluationResult::Time(a, _, _), EvaluationResult::Time(b, _, _)) => a.cmp(b),
 
         // Quantity comparison (only if same unit)
         (
-            EvaluationResult::Quantity(val_a, unit_a, _),
-            EvaluationResult::Quantity(val_b, unit_b, _),
+            EvaluationResult::Quantity(val_a, unit_a, _, _),
+            EvaluationResult::Quantity(val_b, unit_b, _, _),
         ) => {
             if unit_a == unit_b {
                 if val_a < val_b {
@@ -644,15 +644,15 @@ fn compare_evaluation_results(a: &EvaluationResult, b: &EvaluationResult) -> std
         _ => {
             let type_order = |v: &EvaluationResult| match v {
                 EvaluationResult::Empty => 0,
-                EvaluationResult::Boolean(_, _) => 1,
-                EvaluationResult::Integer(_, _) => 2,
-                EvaluationResult::Integer64(_, _) => 3,
-                EvaluationResult::Decimal(_, _) => 4,
-                EvaluationResult::String(_, _) => 5,
-                EvaluationResult::Date(_, _) => 6,
-                EvaluationResult::DateTime(_, _) => 7,
-                EvaluationResult::Time(_, _) => 8,
-                EvaluationResult::Quantity(_, _, _) => 9,
+                EvaluationResult::Boolean(_, _, _) => 1,
+                EvaluationResult::Integer(_, _, _) => 2,
+                EvaluationResult::Integer64(_, _, _) => 3,
+                EvaluationResult::Decimal(_, _, _) => 4,
+                EvaluationResult::String(_, _, _) => 5,
+                EvaluationResult::Date(_, _, _) => 6,
+                EvaluationResult::DateTime(_, _, _) => 7,
+                EvaluationResult::Time(_, _, _) => 8,
+                EvaluationResult::Quantity(_, _, _, _) => 9,
                 EvaluationResult::Collection { .. } => 10,
                 EvaluationResult::Object { .. } => 11,
             };

--- a/crates/fhirpath/src/collection_navigation.rs
+++ b/crates/fhirpath/src/collection_navigation.rs
@@ -43,11 +43,11 @@ pub fn skip_function(
 ) -> Result<EvaluationResult, EvaluationError> {
     // Determine the number of items to skip
     let num_to_skip = match num_arg {
-        EvaluationResult::Integer(i, _) => {
+        EvaluationResult::Integer(i, _, _) => {
             if *i < 0 { 0 } else { *i as usize } // Treat negative skip as 0
         }
         // Add conversion from Decimal if it's an integer value
-        EvaluationResult::Decimal(d, _) if d.is_integer() && d.is_sign_positive() => {
+        EvaluationResult::Decimal(d, _, _) if d.is_integer() && d.is_sign_positive() => {
             d.to_usize().unwrap_or(0) // Convert non-negative integer Decimal
         }
         _ => {
@@ -189,11 +189,11 @@ pub fn take_function(
 ) -> Result<EvaluationResult, EvaluationError> {
     // Determine the number of items to take
     let num_to_take = match num_arg {
-        EvaluationResult::Integer(i, _) => {
+        EvaluationResult::Integer(i, _, _) => {
             if *i <= 0 { 0 } else { *i as usize } // Treat non-positive take as 0
         }
         // Add conversion from Decimal if it's an integer value
-        EvaluationResult::Decimal(d, _) if d.is_integer() && d.is_sign_positive() => {
+        EvaluationResult::Decimal(d, _, _) if d.is_integer() && d.is_sign_positive() => {
             d.to_usize().unwrap_or(0) // Convert non-negative integer Decimal
         }
         _ => {

--- a/crates/fhirpath/src/contains_function.rs
+++ b/crates/fhirpath/src/contains_function.rs
@@ -30,11 +30,11 @@ pub fn contains_function(
 ) -> Result<EvaluationResult, EvaluationError> {
     // Check if we're dealing with a collection and a string argument
     if let EvaluationResult::Collection { items, .. } = invocation_base {
-        if matches!(arg, EvaluationResult::String(_, _)) {
+        if matches!(arg, EvaluationResult::String(_, _, _)) {
             // Check if the collection contains only strings
             let all_strings = items
                 .iter()
-                .all(|item| matches!(item, EvaluationResult::String(_, _)));
+                .all(|item| matches!(item, EvaluationResult::String(_, _, _)));
 
             if !all_strings && !items.is_empty() {
                 // Collection contains non-string items, and we have a string argument
@@ -55,7 +55,7 @@ pub fn contains_function(
     // Spec: {} contains X -> Empty for string argument, false for others
     if invocation_base == &EvaluationResult::Empty {
         // If the argument is a string, return Empty (string mode)
-        if matches!(arg, EvaluationResult::String(_, _)) {
+        if matches!(arg, EvaluationResult::String(_, _, _)) {
             return Ok(EvaluationResult::Empty);
         }
         // Otherwise return false (collection mode)
@@ -70,9 +70,9 @@ pub fn contains_function(
     }
 
     // Handle the string case specially
-    if let EvaluationResult::String(s, _) = invocation_base {
+    if let EvaluationResult::String(s, _, _) = invocation_base {
         // String contains substring: Check the type of arg here
-        if let EvaluationResult::String(substr, _) = arg {
+        if let EvaluationResult::String(substr, _, _) = arg {
             return Ok(EvaluationResult::boolean(s.contains(substr)));
         } else {
             // Argument is not String (and not Empty, checked earlier) -> Error
@@ -102,21 +102,23 @@ pub fn contains_function(
 fn simple_equality_check(a: &EvaluationResult, b: &EvaluationResult) -> bool {
     match (a, b) {
         // Direct equality for simple types
-        (EvaluationResult::Boolean(a_val, _), EvaluationResult::Boolean(b_val, _)) => {
+        (EvaluationResult::Boolean(a_val, _, _), EvaluationResult::Boolean(b_val, _, _)) => {
             a_val == b_val
         }
-        (EvaluationResult::Integer(a_val, _), EvaluationResult::Integer(b_val, _)) => {
+        (EvaluationResult::Integer(a_val, _, _), EvaluationResult::Integer(b_val, _, _)) => {
             a_val == b_val
         }
-        (EvaluationResult::Decimal(a_val, _), EvaluationResult::Decimal(b_val, _)) => {
+        (EvaluationResult::Decimal(a_val, _, _), EvaluationResult::Decimal(b_val, _, _)) => {
             a_val == b_val
         }
-        (EvaluationResult::String(a_val, _), EvaluationResult::String(b_val, _)) => a_val == b_val,
+        (EvaluationResult::String(a_val, _, _), EvaluationResult::String(b_val, _, _)) => {
+            a_val == b_val
+        }
 
         // Quantity comparison with same units
         (
-            EvaluationResult::Quantity(a_val, a_unit, _),
-            EvaluationResult::Quantity(b_val, b_unit, _),
+            EvaluationResult::Quantity(a_val, a_unit, _, _),
+            EvaluationResult::Quantity(b_val, b_unit, _, _),
         ) => a_val == b_val && a_unit == b_unit,
 
         // Object comparison by checking all keys/values are equal

--- a/crates/fhirpath/src/conversion_functions.rs
+++ b/crates/fhirpath/src/conversion_functions.rs
@@ -37,20 +37,20 @@ pub fn to_decimal_function(
     // Handle each type according to FHIRPath rules
     Ok(match invocation_base {
         EvaluationResult::Empty => EvaluationResult::Empty,
-        EvaluationResult::Boolean(b, _) => {
+        EvaluationResult::Boolean(b, _, _) => {
             EvaluationResult::decimal(if *b { Decimal::ONE } else { Decimal::ZERO })
         }
-        EvaluationResult::Integer(i, _) => EvaluationResult::decimal(Decimal::from(*i)),
+        EvaluationResult::Integer(i, _, _) => EvaluationResult::decimal(Decimal::from(*i)),
         #[cfg(not(any(feature = "R4", feature = "R4B")))]
-        EvaluationResult::Integer64(i, _) => EvaluationResult::decimal(Decimal::from(*i)),
-        EvaluationResult::Decimal(d, _) => EvaluationResult::decimal(*d),
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::Integer64(i, _, _) => EvaluationResult::decimal(Decimal::from(*i)),
+        EvaluationResult::Decimal(d, _, _) => EvaluationResult::decimal(*d),
+        EvaluationResult::String(s, _, _) => {
             // Try parsing as Decimal
             s.parse::<Decimal>()
                 .map(EvaluationResult::decimal)
                 .unwrap_or(EvaluationResult::Empty) // Return Empty if parsing fails
         }
-        EvaluationResult::Quantity(val, _, _) => EvaluationResult::decimal(*val),
+        EvaluationResult::Quantity(val, _, _, _) => EvaluationResult::decimal(*val),
         // Collections are handled by the count check above
         EvaluationResult::Collection { .. } => unreachable!(),
         // Other types are not convertible to Decimal
@@ -85,20 +85,20 @@ pub fn to_integer_function(
     // Handle each type according to FHIRPath rules
     Ok(match invocation_base {
         EvaluationResult::Empty => EvaluationResult::Empty,
-        EvaluationResult::Boolean(b, _) => EvaluationResult::integer(if *b { 1 } else { 0 }),
-        EvaluationResult::Integer(i, _) => EvaluationResult::integer(*i),
+        EvaluationResult::Boolean(b, _, _) => EvaluationResult::integer(if *b { 1 } else { 0 }),
+        EvaluationResult::Integer(i, _, _) => EvaluationResult::integer(*i),
         #[cfg(not(any(feature = "R4", feature = "R4B")))]
-        EvaluationResult::Integer64(i, _) => EvaluationResult::integer(*i),
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::Integer64(i, _, _) => EvaluationResult::integer(*i),
+        EvaluationResult::String(s, _, _) => {
             // Try parsing as i64
             s.parse::<i64>()
                 .map(EvaluationResult::integer)
                 .unwrap_or(EvaluationResult::Empty) // Return Empty if parsing fails
         }
         // Per FHIRPath spec, Decimal cannot be converted to Integer via toInteger()
-        EvaluationResult::Decimal(_, _) => EvaluationResult::Empty,
+        EvaluationResult::Decimal(_, _, _) => EvaluationResult::Empty,
         // Quantity to Integer (returns value if integer, else empty)
-        EvaluationResult::Quantity(val, _, _) => {
+        EvaluationResult::Quantity(val, _, _, _) => {
             if val.is_integer() {
                 val.to_i64()
                     .map(EvaluationResult::integer)

--- a/crates/fhirpath/src/date_operation.rs
+++ b/crates/fhirpath/src/date_operation.rs
@@ -18,17 +18,17 @@ pub fn apply_date_type_operation(
             // Handle date literal checks (e.g., @2015.is(Date))
             match value {
                 // Check Date, DateTime, Time types first
-                EvaluationResult::Date(_, _) => Ok(EvaluationResult::boolean(
+                EvaluationResult::Date(_, _, _) => Ok(EvaluationResult::boolean(
                     type_name == "Date" || type_name == "date",
                 )),
-                EvaluationResult::DateTime(_, _) => Ok(EvaluationResult::boolean(
+                EvaluationResult::DateTime(_, _, _) => Ok(EvaluationResult::boolean(
                     type_name == "DateTime" || type_name == "dateTime",
                 )),
-                EvaluationResult::Time(_, _) => Ok(EvaluationResult::boolean(
+                EvaluationResult::Time(_, _, _) => Ok(EvaluationResult::boolean(
                     type_name == "Time" || type_name == "time",
                 )),
                 // Various date literals in string form
-                EvaluationResult::String(s, _) if s.starts_with('@') => {
+                EvaluationResult::String(s, _, _) if s.starts_with('@') => {
                     // Extract the actual date/time string by removing the leading @
                     let date_value = s.trim_start_matches('@');
 
@@ -67,7 +67,7 @@ pub fn apply_date_type_operation(
             // Check if the value is of the target type
             let is_result = apply_date_type_operation(value, "is", type_name, _namespace)?;
             match is_result {
-                EvaluationResult::Boolean(true, _) => {
+                EvaluationResult::Boolean(true, _, _) => {
                     // Value is already of the target type, return as is
                     Ok(value.clone())
                 }
@@ -75,14 +75,14 @@ pub fn apply_date_type_operation(
                     // Value is not of the target type, try to convert it
                     match (type_name, value) {
                         // Try to convert to date
-                        ("Date" | "date", EvaluationResult::String(s, _)) => {
+                        ("Date" | "date", EvaluationResult::String(s, _, _)) => {
                             if let Some(date) = datetime_impl::parse_date(s) {
                                 Ok(EvaluationResult::date(date.format("%Y-%m-%d").to_string()))
                             } else {
                                 Ok(EvaluationResult::Empty)
                             }
                         }
-                        ("Date" | "date", EvaluationResult::DateTime(dt, None)) => {
+                        ("Date" | "date", EvaluationResult::DateTime(dt, None, None)) => {
                             // Extract date part from datetime
                             if let Some(date) =
                                 datetime_impl::to_date(&EvaluationResult::datetime(dt.clone()))
@@ -94,7 +94,7 @@ pub fn apply_date_type_operation(
                         }
 
                         // Try to convert to datetime
-                        ("DateTime" | "dateTime", EvaluationResult::String(s, _)) => {
+                        ("DateTime" | "dateTime", EvaluationResult::String(s, _, _)) => {
                             if let Some(dt) = datetime_impl::parse_datetime(s) {
                                 Ok(EvaluationResult::datetime(
                                     dt.format("%Y-%m-%dT%H:%M:%S").to_string(),
@@ -103,7 +103,7 @@ pub fn apply_date_type_operation(
                                 Ok(EvaluationResult::Empty)
                             }
                         }
-                        ("DateTime" | "dateTime", EvaluationResult::Date(d, _)) => {
+                        ("DateTime" | "dateTime", EvaluationResult::Date(d, _, _)) => {
                             // Convert date to datetime by adding T00:00:00
                             if let Some(dt) =
                                 datetime_impl::to_datetime(&EvaluationResult::date(d.clone()))
@@ -115,7 +115,7 @@ pub fn apply_date_type_operation(
                         }
 
                         // Try to convert to time
-                        ("Time" | "time", EvaluationResult::String(s, _)) => {
+                        ("Time" | "time", EvaluationResult::String(s, _, _)) => {
                             if let Some(time) = datetime_impl::parse_time(s) {
                                 Ok(EvaluationResult::time(time.format("%H:%M:%S").to_string()))
                             } else {

--- a/crates/fhirpath/src/datetime_impl.rs
+++ b/crates/fhirpath/src/datetime_impl.rs
@@ -148,9 +148,13 @@ pub fn compare_date_time_values(
 ) -> Option<Ordering> {
     match (left, right) {
         // Direct comparisons of same types
-        (EvaluationResult::Date(d1, _), EvaluationResult::Date(d2, _)) => compare_dates(d1, d2),
-        (EvaluationResult::Time(t1, _), EvaluationResult::Time(t2, _)) => compare_times(t1, t2),
-        (EvaluationResult::DateTime(dt1, _), EvaluationResult::DateTime(dt2, _)) => {
+        (EvaluationResult::Date(d1, _, _), EvaluationResult::Date(d2, _, _)) => {
+            compare_dates(d1, d2)
+        }
+        (EvaluationResult::Time(t1, _, _), EvaluationResult::Time(t2, _, _)) => {
+            compare_times(t1, t2)
+        }
+        (EvaluationResult::DateTime(dt1, _, _), EvaluationResult::DateTime(dt2, _, _)) => {
             compare_datetimes(dt1, dt2)
         }
 
@@ -158,7 +162,7 @@ pub fn compare_date_time_values(
         // Per FHIRPath spec: "If one value is specified to a different level of precision than
         // the other and the result is not determined before running out of precision, then
         // the result is empty indicating that the result of the comparison is unknown"
-        (EvaluationResult::Date(date_str, _), EvaluationResult::DateTime(dt_str, _)) => {
+        (EvaluationResult::Date(date_str, _, _), EvaluationResult::DateTime(dt_str, _, _)) => {
             // Strip @ prefix if present
             let date_str = date_str.strip_prefix('@').unwrap_or(date_str);
             let dt_str = dt_str.strip_prefix('@').unwrap_or(dt_str);
@@ -222,11 +226,11 @@ pub fn compare_date_time_values(
                 }
             }
         }
-        (EvaluationResult::DateTime(dt_str, _), EvaluationResult::Date(date_str, _)) => {
+        (EvaluationResult::DateTime(dt_str, _, _), EvaluationResult::Date(date_str, _, _)) => {
             // Flip the comparison for DateTime vs Date
             match compare_date_time_values(
-                &EvaluationResult::Date(date_str.clone(), None),
-                &EvaluationResult::DateTime(dt_str.clone(), None),
+                &EvaluationResult::Date(date_str.clone(), None, None),
+                &EvaluationResult::DateTime(dt_str.clone(), None, None),
             ) {
                 Some(Ordering::Less) => Some(Ordering::Greater),
                 Some(Ordering::Greater) => Some(Ordering::Less),
@@ -238,11 +242,11 @@ pub fn compare_date_time_values(
         // Date vs Time comparison - these are incomparable types
         // For ordering comparisons (used by <, >, <=, >=), return None
         // For equality comparisons, this will be handled differently in the evaluator
-        (EvaluationResult::Date(_, _), EvaluationResult::Time(_, _)) => None,
-        (EvaluationResult::Time(_, _), EvaluationResult::Date(_, _)) => None,
+        (EvaluationResult::Date(_, _, _), EvaluationResult::Time(_, _, _)) => None,
+        (EvaluationResult::Time(_, _, _), EvaluationResult::Date(_, _, _)) => None,
 
         // Handle string-based date/time formats
-        (EvaluationResult::String(s1, _), EvaluationResult::String(s2, _)) => {
+        (EvaluationResult::String(s1, _, _), EvaluationResult::String(s2, _, _)) => {
             // Handle @ prefix for date literals
             let s1_clean = s1.strip_prefix('@').unwrap_or(s1);
             let s2_clean = s2.strip_prefix('@').unwrap_or(s2);
@@ -280,15 +284,15 @@ pub fn compare_date_time_values(
                 (false, false, true, false, false, true) => {
                     // s1 is date, s2 is datetime
                     compare_date_time_values(
-                        &EvaluationResult::Date(s1_clean.to_string(), None),
-                        &EvaluationResult::DateTime(s2_clean.to_string(), None),
+                        &EvaluationResult::Date(s1_clean.to_string(), None, None),
+                        &EvaluationResult::DateTime(s2_clean.to_string(), None, None),
                     )
                 }
                 (false, false, false, true, true, false) => {
                     // s1 is datetime, s2 is date
                     compare_date_time_values(
-                        &EvaluationResult::DateTime(s1_clean.to_string(), None),
-                        &EvaluationResult::Date(s2_clean.to_string(), None),
+                        &EvaluationResult::DateTime(s1_clean.to_string(), None, None),
+                        &EvaluationResult::Date(s2_clean.to_string(), None, None),
                     )
                 }
                 // Otherwise, not comparable as date/time types
@@ -298,7 +302,7 @@ pub fn compare_date_time_values(
 
         // Handle other conversions
         // String vs Date
-        (EvaluationResult::String(s_val, _), EvaluationResult::Date(d_val, _)) => {
+        (EvaluationResult::String(s_val, _, _), EvaluationResult::Date(d_val, _, _)) => {
             // Check if string is a datetime
             if s_val.contains('T') && parse_datetime(s_val).is_some() {
                 // String is datetime, Date is date - indeterminate
@@ -308,7 +312,7 @@ pub fn compare_date_time_values(
                 compare_dates(s_val, d_val)
             }
         }
-        (EvaluationResult::Date(d_val, _), EvaluationResult::String(s_val, _)) => {
+        (EvaluationResult::Date(d_val, _, _), EvaluationResult::String(s_val, _, _)) => {
             // Check if string is a datetime
             if s_val.contains('T') && parse_datetime(s_val).is_some() {
                 // Date is date, String is datetime - indeterminate
@@ -319,7 +323,7 @@ pub fn compare_date_time_values(
             }
         }
         // String vs DateTime
-        (EvaluationResult::String(s_val, _), EvaluationResult::DateTime(dt_val, _)) => {
+        (EvaluationResult::String(s_val, _, _), EvaluationResult::DateTime(dt_val, _, _)) => {
             // Check if string is a date (not datetime)
             if !s_val.contains('T') && parse_date(s_val).is_some() {
                 // String is date, DateTime is datetime - indeterminate
@@ -329,7 +333,7 @@ pub fn compare_date_time_values(
                 compare_datetimes(s_val, dt_val)
             }
         }
-        (EvaluationResult::DateTime(dt_val, _), EvaluationResult::String(s_val, _)) => {
+        (EvaluationResult::DateTime(dt_val, _, _), EvaluationResult::String(s_val, _, _)) => {
             // Check if string is a date (not datetime)
             if !s_val.contains('T') && parse_date(s_val).is_some() {
                 // DateTime is datetime, String is date - indeterminate
@@ -340,11 +344,11 @@ pub fn compare_date_time_values(
             }
         }
         // String vs Time
-        (EvaluationResult::String(s_val, _), EvaluationResult::Time(t_val, _)) => {
+        (EvaluationResult::String(s_val, _, _), EvaluationResult::Time(t_val, _, _)) => {
             // Attempt to parse s_val as a time and compare with t_val
             compare_times(s_val, t_val)
         }
-        (EvaluationResult::Time(t_val, _), EvaluationResult::String(s_val, _)) => {
+        (EvaluationResult::Time(t_val, _, _), EvaluationResult::String(s_val, _, _)) => {
             // Attempt to parse s_val as a time and compare with t_val
             compare_times(t_val, s_val)
         }
@@ -357,8 +361,8 @@ pub fn compare_date_time_values(
 /// Converts a value to a date representation if possible
 pub fn to_date(value: &EvaluationResult) -> Option<String> {
     match value {
-        EvaluationResult::Date(d, _) => Some(d.clone()),
-        EvaluationResult::DateTime(dt, _) => {
+        EvaluationResult::Date(d, _, _) => Some(d.clone()),
+        EvaluationResult::DateTime(dt, _, _) => {
             // Extract date part from datetime
             let parts: Vec<&str> = dt.split('T').collect();
             if !parts.is_empty() {
@@ -367,7 +371,7 @@ pub fn to_date(value: &EvaluationResult) -> Option<String> {
                 None
             }
         }
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::String(s, _, _) => {
             // Try to interpret as a date
             if parse_date(s).is_some() {
                 Some(s.clone())
@@ -389,12 +393,12 @@ pub fn to_date(value: &EvaluationResult) -> Option<String> {
 /// Converts a value to a datetime representation if possible
 pub fn to_datetime(value: &EvaluationResult) -> Option<String> {
     match value {
-        EvaluationResult::DateTime(dt, _) => Some(dt.clone()),
-        EvaluationResult::Date(d, _) => {
+        EvaluationResult::DateTime(dt, _, _) => Some(dt.clone()),
+        EvaluationResult::Date(d, _, _) => {
             // Extend date to datetime
             Some(format!("{}T00:00:00", d))
         }
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::String(s, _, _) => {
             // Check if it's already a datetime format
             if s.contains('T') {
                 if parse_datetime(s).is_some() {

--- a/crates/fhirpath/src/distinct_functions.rs
+++ b/crates/fhirpath/src/distinct_functions.rs
@@ -155,21 +155,23 @@ pub fn normalize_collection_result(
 fn simple_equality_check(a: &EvaluationResult, b: &EvaluationResult) -> bool {
     match (a, b) {
         // Direct equality for simple types
-        (EvaluationResult::Boolean(a_val, _), EvaluationResult::Boolean(b_val, _)) => {
+        (EvaluationResult::Boolean(a_val, _, _), EvaluationResult::Boolean(b_val, _, _)) => {
             a_val == b_val
         }
-        (EvaluationResult::Integer(a_val, _), EvaluationResult::Integer(b_val, _)) => {
+        (EvaluationResult::Integer(a_val, _, _), EvaluationResult::Integer(b_val, _, _)) => {
             a_val == b_val
         }
-        (EvaluationResult::Decimal(a_val, _), EvaluationResult::Decimal(b_val, _)) => {
+        (EvaluationResult::Decimal(a_val, _, _), EvaluationResult::Decimal(b_val, _, _)) => {
             a_val == b_val
         }
-        (EvaluationResult::String(a_val, _), EvaluationResult::String(b_val, _)) => a_val == b_val,
+        (EvaluationResult::String(a_val, _, _), EvaluationResult::String(b_val, _, _)) => {
+            a_val == b_val
+        }
 
         // Quantity comparison with same units
         (
-            EvaluationResult::Quantity(a_val, a_unit, _),
-            EvaluationResult::Quantity(b_val, b_unit, _),
+            EvaluationResult::Quantity(a_val, a_unit, _, _),
+            EvaluationResult::Quantity(b_val, b_unit, _, _),
         ) => a_val == b_val && a_unit == b_unit,
 
         // Object comparison by checking all keys/values are equal

--- a/crates/fhirpath/src/evaluator.rs
+++ b/crates/fhirpath/src/evaluator.rs
@@ -77,7 +77,7 @@ use crate::parser::{Expression, Invocation, Literal, Term, TypeSpecifier};
 use chrono::{Datelike, Duration, Local, NaiveDate, NaiveDateTime, Timelike};
 use helios_fhir::{FhirResource, FhirVersion};
 use helios_fhirpath_support::{
-    EvaluationError, EvaluationResult, IntoEvaluationResult, TypeInfoResult,
+    EvaluationError, EvaluationResult, IntoEvaluationResult, PrimitiveElement, TypeInfoResult,
 };
 use parking_lot::Mutex;
 use regex::RegexBuilder;
@@ -489,7 +489,7 @@ impl EvaluationContext {
     /// An Option containing the variable's string value, or None if not found
     pub fn get_variable_as_string(&self, name: &str) -> Option<String> {
         match self.variables.get(name) {
-            Some(EvaluationResult::String(s, _)) => Some(s.clone()),
+            Some(EvaluationResult::String(s, _, _)) => Some(s.clone()),
             Some(value) => Some(value.to_string_value()),
             None => None,
         }
@@ -735,7 +735,7 @@ fn apply_decimal_multiplicative(
 /// // Parse and evaluate a simple literal
 /// let expr = parser().parse("5").into_result().unwrap();
 /// let result = evaluate(&expr, &context, None);
-/// assert!(matches!(result, Ok(EvaluationResult::Integer(5, _))));
+/// assert!(matches!(result, Ok(EvaluationResult::Integer(5, _, _))));
 /// ```
 pub fn evaluate(
     expr: &Expression,
@@ -764,7 +764,8 @@ pub fn evaluate(
                 type_info: _,
             } = &global_context_item
             {
-                if let Some(EvaluationResult::String(ctx_type, _)) = obj_map.get("resourceType") {
+                if let Some(EvaluationResult::String(ctx_type, _, _)) = obj_map.get("resourceType")
+                {
                     // The parser ensures initial_name is cleaned of backticks.
                     if initial_name.eq_ignore_ascii_case(ctx_type) {
                         // The initial identifier matches the context type.
@@ -969,19 +970,19 @@ pub fn evaluate(
             // Convert left to boolean using singleton evaluation rules
             let left_bool = match &left_eval {
                 // Direct boolean values
-                EvaluationResult::Boolean(_, _) => left_eval.to_boolean_for_logic()?,
+                EvaluationResult::Boolean(_, _, _) => left_eval.to_boolean_for_logic()?,
                 // Empty evaluates to empty in logical context
                 EvaluationResult::Empty => EvaluationResult::Empty,
                 // For non-boolean singletons, apply singleton evaluation:
                 // A single value is considered true
-                EvaluationResult::String(_, _)
-                | EvaluationResult::Integer(_, _)
-                | EvaluationResult::Integer64(_, _)
-                | EvaluationResult::Decimal(_, _)
-                | EvaluationResult::Date(_, _)
-                | EvaluationResult::DateTime(_, _)
-                | EvaluationResult::Time(_, _)
-                | EvaluationResult::Quantity(_, _, _)
+                EvaluationResult::String(_, _, _)
+                | EvaluationResult::Integer(_, _, _)
+                | EvaluationResult::Integer64(_, _, _)
+                | EvaluationResult::Decimal(_, _, _)
+                | EvaluationResult::Date(_, _, _)
+                | EvaluationResult::DateTime(_, _, _)
+                | EvaluationResult::Time(_, _, _)
+                | EvaluationResult::Quantity(_, _, _, _)
                 | EvaluationResult::Object { .. } => EvaluationResult::boolean(true),
                 // Collections follow singleton evaluation rules
                 EvaluationResult::Collection { items, .. } => {
@@ -990,7 +991,7 @@ pub fn evaluate(
                         1 => {
                             // For single-item collections, apply singleton evaluation recursively
                             match &items[0] {
-                                EvaluationResult::Boolean(_, _) => {
+                                EvaluationResult::Boolean(_, _, _) => {
                                     items[0].to_boolean_for_logic()?
                                 }
                                 EvaluationResult::Empty => EvaluationResult::Empty,
@@ -1008,27 +1009,27 @@ pub fn evaluate(
             };
 
             match left_bool {
-                EvaluationResult::Boolean(false, _) => Ok(EvaluationResult::boolean(false)), // false and X -> false
-                EvaluationResult::Boolean(true, _) => {
+                EvaluationResult::Boolean(false, _, _) => Ok(EvaluationResult::boolean(false)), // false and X -> false
+                EvaluationResult::Boolean(true, _, _) => {
                     // Evaluate right operand
                     let right_eval = evaluate(right, context, current_item)?;
 
                     // Apply singleton evaluation to right operand
                     let right_bool = match &right_eval {
                         // Direct boolean values
-                        EvaluationResult::Boolean(_, _) => right_eval.to_boolean_for_logic()?,
+                        EvaluationResult::Boolean(_, _, _) => right_eval.to_boolean_for_logic()?,
                         // Empty evaluates to empty in logical context
                         EvaluationResult::Empty => EvaluationResult::Empty,
                         // For non-boolean singletons, apply singleton evaluation:
                         // A single value is considered true
-                        EvaluationResult::String(_, _)
-                        | EvaluationResult::Integer(_, _)
-                        | EvaluationResult::Integer64(_, _)
-                        | EvaluationResult::Decimal(_, _)
-                        | EvaluationResult::Date(_, _)
-                        | EvaluationResult::DateTime(_, _)
-                        | EvaluationResult::Time(_, _)
-                        | EvaluationResult::Quantity(_, _, _)
+                        EvaluationResult::String(_, _, _)
+                        | EvaluationResult::Integer(_, _, _)
+                        | EvaluationResult::Integer64(_, _, _)
+                        | EvaluationResult::Decimal(_, _, _)
+                        | EvaluationResult::Date(_, _, _)
+                        | EvaluationResult::DateTime(_, _, _)
+                        | EvaluationResult::Time(_, _, _)
+                        | EvaluationResult::Quantity(_, _, _, _)
                         | EvaluationResult::Object { .. } => EvaluationResult::boolean(true),
                         // Collections follow singleton evaluation rules
                         EvaluationResult::Collection { items, .. } => {
@@ -1037,7 +1038,7 @@ pub fn evaluate(
                                 1 => {
                                     // For single-item collections, apply singleton evaluation recursively
                                     match &items[0] {
-                                        EvaluationResult::Boolean(_, _) => {
+                                        EvaluationResult::Boolean(_, _, _) => {
                                             items[0].to_boolean_for_logic()?
                                         }
                                         EvaluationResult::Empty => EvaluationResult::Empty,
@@ -1065,19 +1066,19 @@ pub fn evaluate(
                     // Apply singleton evaluation to right operand
                     let right_bool = match &right_eval {
                         // Direct boolean values
-                        EvaluationResult::Boolean(_, _) => right_eval.to_boolean_for_logic()?,
+                        EvaluationResult::Boolean(_, _, _) => right_eval.to_boolean_for_logic()?,
                         // Empty evaluates to empty in logical context
                         EvaluationResult::Empty => EvaluationResult::Empty,
                         // For non-boolean singletons, apply singleton evaluation:
                         // A single value is considered true
-                        EvaluationResult::String(_, _)
-                        | EvaluationResult::Integer(_, _)
-                        | EvaluationResult::Integer64(_, _)
-                        | EvaluationResult::Decimal(_, _)
-                        | EvaluationResult::Date(_, _)
-                        | EvaluationResult::DateTime(_, _)
-                        | EvaluationResult::Time(_, _)
-                        | EvaluationResult::Quantity(_, _, _)
+                        EvaluationResult::String(_, _, _)
+                        | EvaluationResult::Integer(_, _, _)
+                        | EvaluationResult::Integer64(_, _, _)
+                        | EvaluationResult::Decimal(_, _, _)
+                        | EvaluationResult::Date(_, _, _)
+                        | EvaluationResult::DateTime(_, _, _)
+                        | EvaluationResult::Time(_, _, _)
+                        | EvaluationResult::Quantity(_, _, _, _)
                         | EvaluationResult::Object { .. } => EvaluationResult::boolean(true),
                         // Collections follow singleton evaluation rules
                         EvaluationResult::Collection { items, .. } => {
@@ -1086,7 +1087,7 @@ pub fn evaluate(
                                 1 => {
                                     // For single-item collections, apply singleton evaluation recursively
                                     match &items[0] {
-                                        EvaluationResult::Boolean(_, _) => {
+                                        EvaluationResult::Boolean(_, _, _) => {
                                             items[0].to_boolean_for_logic()?
                                         }
                                         EvaluationResult::Empty => EvaluationResult::Empty,
@@ -1107,7 +1108,9 @@ pub fn evaluate(
 
                     // Apply 3-valued logic for Empty and X
                     match right_bool {
-                        EvaluationResult::Boolean(false, _) => Ok(EvaluationResult::boolean(false)), // {} and false -> false
+                        EvaluationResult::Boolean(false, _, _) => {
+                            Ok(EvaluationResult::boolean(false))
+                        } // {} and false -> false
                         _ => Ok(EvaluationResult::Empty), // {} and (true | {}) -> {}
                     }
                 }
@@ -1129,10 +1132,10 @@ pub fn evaluate(
             // Check types *before* logical conversion
             if !matches!(
                 left_eval,
-                EvaluationResult::Boolean(_, _) | EvaluationResult::Empty
+                EvaluationResult::Boolean(_, _, _) | EvaluationResult::Empty
             ) || !matches!(
                 right_eval,
-                EvaluationResult::Boolean(_, _) | EvaluationResult::Empty
+                EvaluationResult::Boolean(_, _, _) | EvaluationResult::Empty
             ) {
                 // Allow Empty for 3-valued logic, but reject other types
                 if !matches!(left_eval, EvaluationResult::Empty)
@@ -1157,7 +1160,7 @@ pub fn evaluate(
             // Ensure both operands resolved to Boolean or Empty (redundant after above check, but safe)
             if !matches!(
                 left_bool_match,
-                EvaluationResult::Boolean(_, _) | EvaluationResult::Empty
+                EvaluationResult::Boolean(_, _, _) | EvaluationResult::Empty
             ) {
                 return Err(EvaluationError::TypeError(format!(
                     // Should be unreachable
@@ -1168,7 +1171,7 @@ pub fn evaluate(
             }
             if !matches!(
                 right_bool,
-                EvaluationResult::Boolean(_, _) | EvaluationResult::Empty
+                EvaluationResult::Boolean(_, _, _) | EvaluationResult::Empty
             ) {
                 return Err(EvaluationError::TypeError(format!(
                     // Should be unreachable
@@ -1181,22 +1184,23 @@ pub fn evaluate(
             if op == "or" {
                 // Use the re-evaluated left_bool_match here
                 match (&left_bool_match, &right_bool) {
-                    (EvaluationResult::Boolean(true, _), _)
-                    | (_, EvaluationResult::Boolean(true, _)) => {
+                    (EvaluationResult::Boolean(true, _, _), _)
+                    | (_, EvaluationResult::Boolean(true, _, _)) => {
                         Ok(EvaluationResult::boolean(true))
                     }
                     (EvaluationResult::Empty, EvaluationResult::Empty) => {
                         Ok(EvaluationResult::Empty)
                     }
-                    (EvaluationResult::Empty, EvaluationResult::Boolean(false, _)) => {
+                    (EvaluationResult::Empty, EvaluationResult::Boolean(false, _, _)) => {
                         Ok(EvaluationResult::Empty)
                     }
-                    (EvaluationResult::Boolean(false, _), EvaluationResult::Empty) => {
+                    (EvaluationResult::Boolean(false, _, _), EvaluationResult::Empty) => {
                         Ok(EvaluationResult::Empty)
                     }
-                    (EvaluationResult::Boolean(false, _), EvaluationResult::Boolean(false, _)) => {
-                        Ok(EvaluationResult::boolean(false))
-                    }
+                    (
+                        EvaluationResult::Boolean(false, _, _),
+                        EvaluationResult::Boolean(false, _, _),
+                    ) => Ok(EvaluationResult::boolean(false)),
                     // Cases involving Empty handled above, this should not be reached with invalid types
                     _ => unreachable!("Invalid types should have been caught earlier for 'or'"),
                 }
@@ -1207,7 +1211,7 @@ pub fn evaluate(
                     (EvaluationResult::Empty, _) | (_, EvaluationResult::Empty) => {
                         Ok(EvaluationResult::Empty)
                     }
-                    (EvaluationResult::Boolean(l, _), EvaluationResult::Boolean(r, _)) => {
+                    (EvaluationResult::Boolean(l, _, _), EvaluationResult::Boolean(r, _, _)) => {
                         Ok(EvaluationResult::boolean(l != r))
                     }
                     // Cases involving Empty handled above, this should not be reached with invalid types
@@ -1223,7 +1227,7 @@ pub fn evaluate(
             // Check type *before* logical conversion
             if !matches!(
                 left_eval,
-                EvaluationResult::Boolean(_, _) | EvaluationResult::Empty
+                EvaluationResult::Boolean(_, _, _) | EvaluationResult::Empty
             ) {
                 return Err(EvaluationError::TypeError(format!(
                     "Operator 'implies' requires Boolean left operand, found {}",
@@ -1232,14 +1236,14 @@ pub fn evaluate(
             }
 
             match left_bool {
-                EvaluationResult::Boolean(false, _) => Ok(EvaluationResult::boolean(true)), // false implies X -> true
+                EvaluationResult::Boolean(false, _, _) => Ok(EvaluationResult::boolean(true)), // false implies X -> true
                 EvaluationResult::Empty => {
                     // Evaluate right, handle potential error
                     let right_eval = evaluate(right, context, current_item)?;
                     // Check type *before* logical conversion
                     if !matches!(
                         right_eval,
-                        EvaluationResult::Boolean(_, _) | EvaluationResult::Empty
+                        EvaluationResult::Boolean(_, _, _) | EvaluationResult::Empty
                     ) {
                         return Err(EvaluationError::TypeError(format!(
                             "Operator 'implies' requires Boolean right operand when left is Empty, found {}",
@@ -1248,17 +1252,19 @@ pub fn evaluate(
                     }
                     let right_bool = right_eval.to_boolean_for_logic()?; // Propagate error
                     match right_bool {
-                        EvaluationResult::Boolean(true, _) => Ok(EvaluationResult::boolean(true)), // {} implies true -> true
+                        EvaluationResult::Boolean(true, _, _) => {
+                            Ok(EvaluationResult::boolean(true))
+                        } // {} implies true -> true
                         _ => Ok(EvaluationResult::Empty), // {} implies (false | {}) -> {}
                     }
                 }
-                EvaluationResult::Boolean(true, _) => {
+                EvaluationResult::Boolean(true, _, _) => {
                     // Evaluate right, handle potential error
                     let right_eval = evaluate(right, context, current_item)?;
                     // Check type *before* logical conversion
                     if !matches!(
                         right_eval,
-                        EvaluationResult::Boolean(_, _) | EvaluationResult::Empty
+                        EvaluationResult::Boolean(_, _, _) | EvaluationResult::Empty
                     ) {
                         return Err(EvaluationError::TypeError(format!(
                             "Operator 'implies' requires Boolean right operand when left is True, found {}",
@@ -1318,6 +1324,32 @@ pub fn evaluate(
 /// # Returns
 ///
 /// A tuple containing the evaluation result and the potentially modified context
+/// Resolves member access (`.id`, `.extension`, etc.) on a FHIR primitive value.
+///
+/// FHIR primitives can carry id/extension metadata via the `PrimitiveElement`
+/// trailing field on each primitive variant. When that metadata is present,
+/// `.id` and `.extension` return it; otherwise they return `Empty` per FHIRPath
+/// semantics. All other member access on a primitive returns `Empty`.
+fn primitive_member_access(
+    base: &EvaluationResult,
+    name: &str,
+) -> Result<EvaluationResult, EvaluationError> {
+    let element = base.primitive_element();
+    match name {
+        "id" => match element.and_then(|e: &PrimitiveElement| e.id.as_ref()) {
+            Some(id) => Ok(EvaluationResult::fhir_string(id.clone(), "id")),
+            None => Ok(EvaluationResult::Empty),
+        },
+        "extension" => match element {
+            Some(e) if !e.extension.is_empty() => {
+                Ok(EvaluationResult::collection(e.extension.clone()))
+            }
+            _ => Ok(EvaluationResult::Empty),
+        },
+        _ => Ok(EvaluationResult::Empty),
+    }
+}
+
 fn evaluate_with_context(
     expr: &Expression,
     context: EvaluationContext,
@@ -1343,7 +1375,7 @@ fn evaluate_with_context(
             type_info: _,
         } = &global_context_item
         {
-            if let Some(EvaluationResult::String(ctx_type, _)) = obj_map.get("resourceType") {
+            if let Some(EvaluationResult::String(ctx_type, _, _)) = obj_map.get("resourceType") {
                 if initial_name.eq_ignore_ascii_case(ctx_type) {
                     return Ok((global_context_item, context));
                 }
@@ -1610,7 +1642,7 @@ fn evaluate_term(
                         type_info: None,
                     } = &base_context
                     {
-                        if let Some(EvaluationResult::String(ctx_type, _)) =
+                        if let Some(EvaluationResult::String(ctx_type, _, _)) =
                             obj_map.get("resourceType")
                         {
                             // The parser ensures 'name' is cleaned of backticks if it was a delimited identifier.
@@ -1804,7 +1836,7 @@ fn evaluate_invocation_with_context(
 
                     // Get the variable name (first argument must be a string)
                     let var_name = match evaluate(&args_exprs[0], &context, None)? {
-                        EvaluationResult::String(name_str, _) => {
+                        EvaluationResult::String(name_str, _, _) => {
                             // Variable names must start with %
                             if !name_str.starts_with('%') {
                                 format!("%{}", name_str)
@@ -2118,57 +2150,19 @@ fn evaluate_invocation(
                         ))
                     }
                 }
-                // Special handling for primitive types
-                // In FHIR, primitive values can have id and extension properties
-                EvaluationResult::Boolean(_, _)
-                | EvaluationResult::String(_, _)
-                | EvaluationResult::Integer(_, _)
-                | EvaluationResult::Decimal(_, _)
-                | EvaluationResult::Date(_, _)
-                | EvaluationResult::DateTime(_, _)
-                | EvaluationResult::Time(_, _)
-                | EvaluationResult::Quantity(_, _, _) => {
-                    // For now, we return Empty for id and extension on primitives
-                    // This is where we would add proper support for accessing these fields
-                    // if the primitive value was from a FHIR Element type with id/extension
-                    if name == "id" || name == "extension" {
-                        // TODO: Proper implementation would check if this is a FHIR Element
-                        // and return its id or extension if available
-                        Ok(EvaluationResult::Empty)
-                    } else {
-                        // For other properties on primitives, return Empty
-                        Ok(EvaluationResult::Empty)
-                    }
-                }
-                // R5+ only: Integer64 primitive type handling
-                #[cfg(not(any(feature = "R4", feature = "R4B")))]
-                EvaluationResult::Integer64(_, _) => {
-                    // For now, we return Empty for id and extension on primitives
-                    // This is where we would add proper support for accessing these fields
-                    // if the primitive value was from a FHIR Element type with id/extension
-                    if name == "id" || name == "extension" {
-                        // TODO: Proper implementation would check if this is a FHIR Element
-                        // and return its id or extension if available
-                        Ok(EvaluationResult::Empty)
-                    } else {
-                        // For other properties on primitives, return Empty
-                        Ok(EvaluationResult::Empty)
-                    }
-                }
-                // R4/R4B: Integer64 should be treated as Integer primitive
-                #[cfg(any(feature = "R4", feature = "R4B"))]
-                EvaluationResult::Integer64(_, _) => {
-                    // For now, we return Empty for id and extension on primitives
-                    // This is where we would add proper support for accessing these fields
-                    // if the primitive value was from a FHIR Element type with id/extension
-                    if name == "id" || name == "extension" {
-                        // TODO: Proper implementation would check if this is a FHIR Element
-                        // and return its id or extension if available
-                        Ok(EvaluationResult::Empty)
-                    } else {
-                        // For other properties on primitives, return Empty
-                        Ok(EvaluationResult::Empty)
-                    }
+                // Special handling for primitive types.
+                // FHIR primitives can carry id/extension via the PrimitiveElement
+                // metadata populated from `_field` siblings in JSON.
+                EvaluationResult::Boolean(_, _, _)
+                | EvaluationResult::String(_, _, _)
+                | EvaluationResult::Integer(_, _, _)
+                | EvaluationResult::Integer64(_, _, _)
+                | EvaluationResult::Decimal(_, _, _)
+                | EvaluationResult::Date(_, _, _)
+                | EvaluationResult::DateTime(_, _, _)
+                | EvaluationResult::Time(_, _, _)
+                | EvaluationResult::Quantity(_, _, _, _) => {
+                    primitive_member_access(invocation_base, name)
                 }
                 // Accessing member on Empty returns Empty
                 EvaluationResult::Empty => Ok(EvaluationResult::Empty), // Wrap in Ok
@@ -2355,7 +2349,7 @@ fn evaluate_invocation(
 
                     let condition_bool = condition_result.to_boolean_for_logic()?; // Use logic conversion
 
-                    if matches!(condition_bool, EvaluationResult::Boolean(true, _)) {
+                    if matches!(condition_bool, EvaluationResult::Boolean(true, _, _)) {
                         // Condition is true, evaluate the trueResult expression, propagate error
                         let true_invocation_base = if expression_starts_with_resource_identifier(
                             true_result_expr,
@@ -2486,7 +2480,7 @@ fn evaluate_invocation(
                     // Continue with regular trace function handling
                     // Get the name parameter (required)
                     let name = match evaluate(&args_exprs[0], context, None)? {
-                        EvaluationResult::String(name_str, _) => name_str,
+                        EvaluationResult::String(name_str, _, _) => name_str,
                         _ => {
                             return Err(EvaluationError::TypeError(
                                 "trace() function requires a string name as first argument"
@@ -2523,7 +2517,7 @@ fn evaluate_invocation(
 
                     // Get the variable name (first argument must be a string)
                     let var_name = match evaluate(&args_exprs[0], context, None)? {
-                        EvaluationResult::String(name_str, _) => {
+                        EvaluationResult::String(name_str, _, _) => {
                             // Variable names must start with %
                             if !name_str.starts_with('%') {
                                 format!("%{}", name_str)
@@ -2588,7 +2582,7 @@ fn evaluate_invocation(
                                 let evaluated =
                                     evaluate(&args_exprs[0], context, current_item_for_args)?;
                                 match evaluated {
-                                    EvaluationResult::String(s, _) => Some(s),
+                                    EvaluationResult::String(s, _, _) => Some(s),
                                     _ => None,
                                 }
                             }
@@ -2601,7 +2595,7 @@ fn evaluate_invocation(
 
                     // Convert type filter to EvaluationResult array format expected by the function
                     let args_for_function = if let Some(type_str) = type_filter {
-                        vec![EvaluationResult::String(type_str, None)]
+                        vec![EvaluationResult::String(type_str, None, None)]
                     } else {
                         vec![]
                     };
@@ -2844,8 +2838,8 @@ fn evaluate_where(
         let criteria_result = evaluate(criteria_expr, &child_context, Some(item))?;
         // Check if criteria is boolean, otherwise error per spec
         match criteria_result {
-            EvaluationResult::Boolean(true, _) => filtered_items.push(item.clone()),
-            EvaluationResult::Boolean(false, _) | EvaluationResult::Empty => {} // Ignore false/empty
+            EvaluationResult::Boolean(true, _, _) => filtered_items.push(item.clone()),
+            EvaluationResult::Boolean(false, _, _) | EvaluationResult::Empty => {} // Ignore false/empty
             other => {
                 return Err(EvaluationError::TypeError(format!(
                     "where criteria evaluated to non-boolean: {:?}",
@@ -2930,8 +2924,8 @@ fn evaluate_where_with_context(
 
         // Check if criteria is boolean, otherwise error per spec
         match criteria_result {
-            EvaluationResult::Boolean(true, _) => filtered_items.push(item.clone()),
-            EvaluationResult::Boolean(false, _) | EvaluationResult::Empty => {} // Ignore false/empty
+            EvaluationResult::Boolean(true, _, _) => filtered_items.push(item.clone()),
+            EvaluationResult::Boolean(false, _, _) | EvaluationResult::Empty => {} // Ignore false/empty
             other => {
                 return Err(EvaluationError::TypeError(format!(
                     "where criteria evaluated to non-boolean: {:?}",
@@ -3229,10 +3223,10 @@ fn evaluate_all_with_criteria(
         let criteria_result = evaluate(criteria_expr, context, Some(&item))?;
         // Check if criteria is boolean, otherwise error
         match criteria_result {
-            EvaluationResult::Boolean(false, _) | EvaluationResult::Empty => {
+            EvaluationResult::Boolean(false, _, _) | EvaluationResult::Empty => {
                 return Ok(EvaluationResult::boolean(false));
             } // False or empty means not all are true
-            EvaluationResult::Boolean(true, _) => {} // Continue checking
+            EvaluationResult::Boolean(true, _, _) => {} // Continue checking
             other => {
                 return Err(EvaluationError::TypeError(format!(
                     "all criteria evaluated to non-boolean: {:?}",
@@ -3297,7 +3291,7 @@ fn call_function(
                 )));
             }
             let type_name_str = match &args[0] {
-                EvaluationResult::String(s, _) => s,
+                EvaluationResult::String(s, _, _) => s,
                 EvaluationResult::Empty => return Ok(EvaluationResult::Empty), // item.is({}) -> {}
                 _ => {
                     return Err(EvaluationError::TypeError(format!(
@@ -3513,7 +3507,7 @@ fn call_function(
             let other_collection = &args[0];
             let preserve_order = if args.len() == 2 {
                 match &args[1] {
-                    EvaluationResult::Boolean(b, _) => *b,
+                    EvaluationResult::Boolean(b, _, _) => *b,
                     _ => false,
                 }
             } else {
@@ -3561,10 +3555,10 @@ fn call_function(
                 // Collections handled by initial check
                 EvaluationResult::Collection { .. } => unreachable!(),
                 // Check convertibility for single items
-                EvaluationResult::Boolean(_, _) => EvaluationResult::boolean(true), // Booleans can convert (1.0 or 0.0)
-                EvaluationResult::Integer(_, _) => EvaluationResult::boolean(true), // Integers can convert
-                EvaluationResult::Decimal(_, _) => EvaluationResult::boolean(true), // Decimals can convert
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::Boolean(_, _, _) => EvaluationResult::boolean(true), // Booleans can convert (1.0 or 0.0)
+                EvaluationResult::Integer(_, _, _) => EvaluationResult::boolean(true), // Integers can convert
+                EvaluationResult::Decimal(_, _, _) => EvaluationResult::boolean(true), // Decimals can convert
+                EvaluationResult::String(s, _, _) => {
                     // Check if the string parses to a Decimal
                     EvaluationResult::boolean(s.parse::<Decimal>().is_ok())
                 }
@@ -3586,13 +3580,13 @@ fn call_function(
                 // Collections handled by initial check
                 EvaluationResult::Collection { .. } => unreachable!(),
                 // Check convertibility for single items
-                EvaluationResult::Integer(_, _) => EvaluationResult::boolean(true),
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::Integer(_, _, _) => EvaluationResult::boolean(true),
+                EvaluationResult::String(s, _, _) => {
                     // Check if the string parses to an i64
                     EvaluationResult::boolean(s.parse::<i64>().is_ok())
                 }
-                EvaluationResult::Boolean(_, _) => EvaluationResult::boolean(true),
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Boolean(_, _, _) => EvaluationResult::boolean(true),
+                EvaluationResult::Decimal(d, _, _) => {
                     EvaluationResult::boolean(d.fract() == Decimal::ZERO)
                 }
                 // Other types are not convertible to Integer
@@ -3617,12 +3611,12 @@ fn call_function(
                     type_info: _,
                 } => unreachable!(),
                 // Check convertibility for single items
-                EvaluationResult::Boolean(_, _) => EvaluationResult::boolean(true),
-                EvaluationResult::Integer(i, _) => EvaluationResult::boolean(*i == 0 || *i == 1),
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Boolean(_, _, _) => EvaluationResult::boolean(true),
+                EvaluationResult::Integer(i, _, _) => EvaluationResult::boolean(*i == 0 || *i == 1),
+                EvaluationResult::Decimal(d, _, _) => {
                     EvaluationResult::boolean(d.is_zero() || *d == Decimal::ONE)
                 }
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::String(s, _, _) => {
                     let lower = s.to_lowercase();
                     EvaluationResult::boolean(matches!(
                         lower.as_str(),
@@ -3644,13 +3638,13 @@ fn call_function(
             Ok(match invocation_base {
                 // Wrap in Ok
                 EvaluationResult::Empty => EvaluationResult::Empty,
-                EvaluationResult::Boolean(b, _) => EvaluationResult::boolean(*b),
-                EvaluationResult::Integer(i, _) => match i {
+                EvaluationResult::Boolean(b, _, _) => EvaluationResult::boolean(*b),
+                EvaluationResult::Integer(i, _, _) => match i {
                     1 => EvaluationResult::boolean(true),
                     0 => EvaluationResult::boolean(false),
                     _ => EvaluationResult::Empty, // Other integers are not convertible
                 },
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     if *d == Decimal::ONE {
                         EvaluationResult::boolean(true)
                     } else if d.is_zero() {
@@ -3660,7 +3654,7 @@ fn call_function(
                         EvaluationResult::Empty // Other decimals are not convertible
                     }
                 }
-                EvaluationResult::String(s, _) => match s.to_lowercase().as_str() {
+                EvaluationResult::String(s, _, _) => match s.to_lowercase().as_str() {
                     "true" | "t" | "yes" | "1" | "1.0" => EvaluationResult::boolean(true),
                     "false" | "f" | "no" | "0" | "0.0" => EvaluationResult::boolean(false),
                     _ => EvaluationResult::Empty,
@@ -3685,20 +3679,20 @@ fn call_function(
             // Now we know it's a non-empty singleton
             Ok(match invocation_base {
                 // Check convertibility for single items (most primitives can be)
-                EvaluationResult::Boolean(_, _)
-                | EvaluationResult::String(_, _)
-                | EvaluationResult::Integer(_, _)
-                | EvaluationResult::Decimal(_, _)
-                | EvaluationResult::Date(_, _)
-                | EvaluationResult::DateTime(_, _)
-                | EvaluationResult::Time(_, _)
-                | EvaluationResult::Quantity(_, _, _) => EvaluationResult::boolean(true), // Add Quantity case
+                EvaluationResult::Boolean(_, _, _)
+                | EvaluationResult::String(_, _, _)
+                | EvaluationResult::Integer(_, _, _)
+                | EvaluationResult::Decimal(_, _, _)
+                | EvaluationResult::Date(_, _, _)
+                | EvaluationResult::DateTime(_, _, _)
+                | EvaluationResult::Time(_, _, _)
+                | EvaluationResult::Quantity(_, _, _, _) => EvaluationResult::boolean(true), // Add Quantity case
                 // R5+ only: Integer64 type convertibility
                 #[cfg(not(any(feature = "R4", feature = "R4B")))]
-                EvaluationResult::Integer64(_, _) => EvaluationResult::boolean(true),
+                EvaluationResult::Integer64(_, _, _) => EvaluationResult::boolean(true),
                 // R4/R4B: Integer64 should be treated as Integer (convertible to String)
                 #[cfg(any(feature = "R4", feature = "R4B"))]
-                EvaluationResult::Integer64(_, _) => EvaluationResult::boolean(true),
+                EvaluationResult::Integer64(_, _, _) => EvaluationResult::boolean(true),
                 // Objects are not convertible to String via this function
                 EvaluationResult::Object { .. } => EvaluationResult::boolean(false),
                 EvaluationResult::Empty => EvaluationResult::Empty,
@@ -3714,7 +3708,7 @@ fn call_function(
             if args.len() == 1 {
                 // toString with format code
                 match &args[0] {
-                    EvaluationResult::String(fmt, _) => {
+                    EvaluationResult::String(fmt, _, _) => {
                         if matches!(invocation_base, EvaluationResult::Empty) {
                             return Ok(EvaluationResult::Empty);
                         }
@@ -3746,13 +3740,13 @@ fn call_function(
             // Handle format argument for string parsing
             if args.len() == 1 {
                 match (&args[0], invocation_base) {
-                    (EvaluationResult::String(fmt, _), EvaluationResult::String(s, _)) => {
+                    (EvaluationResult::String(fmt, _, _), EvaluationResult::String(s, _, _)) => {
                         return crate::format_functions::parse_date_with_format(s, fmt);
                     }
                     (_, EvaluationResult::Empty) | (EvaluationResult::Empty, _) => {
                         return Ok(EvaluationResult::Empty);
                     }
-                    (EvaluationResult::String(_fmt, _), _) => {
+                    (EvaluationResult::String(_fmt, _, _), _) => {
                         // Non-string input with format -> just try normal conversion
                     }
                     _ => {
@@ -3764,15 +3758,15 @@ fn call_function(
             }
             Ok(match invocation_base {
                 EvaluationResult::Empty => EvaluationResult::Empty,
-                EvaluationResult::Date(d, _) => EvaluationResult::date(d.clone()),
-                EvaluationResult::DateTime(dt, _) => {
+                EvaluationResult::Date(d, _, _) => EvaluationResult::date(d.clone()),
+                EvaluationResult::DateTime(dt, _, _) => {
                     if let Some(date_part) = dt.split('T').next() {
                         EvaluationResult::date(date_part.to_string())
                     } else {
                         EvaluationResult::Empty
                     }
                 }
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::String(s, _, _) => {
                     if s.contains('T') {
                         if let Some(date_part) = s.split('T').next() {
                             if date_part.len() == 4 || date_part.len() == 7 || date_part.len() == 10
@@ -3814,9 +3808,9 @@ fn call_function(
                     eprintln!("Warning: convertsToDate called on a collection");
                     EvaluationResult::Empty
                 }
-                EvaluationResult::Date(_, _) => EvaluationResult::boolean(true),
-                EvaluationResult::DateTime(_, _) => EvaluationResult::boolean(true), // Can extract date part
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::Date(_, _, _) => EvaluationResult::boolean(true),
+                EvaluationResult::DateTime(_, _, _) => EvaluationResult::boolean(true), // Can extract date part
+                EvaluationResult::String(s, _, _) => {
                     // Basic check: Does it look like YYYY, YYYY-MM, YYYY-MM-DD, or start like a DateTime?
                     let is_date_like = s.len() == 4 || s.len() == 7 || s.len() == 10;
                     let is_datetime_like = s.contains('T')
@@ -3834,13 +3828,13 @@ fn call_function(
             }
             if args.len() == 1 {
                 match (&args[0], invocation_base) {
-                    (EvaluationResult::String(fmt, _), EvaluationResult::String(s, _)) => {
+                    (EvaluationResult::String(fmt, _, _), EvaluationResult::String(s, _, _)) => {
                         return crate::format_functions::parse_datetime_with_format(s, fmt);
                     }
                     (_, EvaluationResult::Empty) | (EvaluationResult::Empty, _) => {
                         return Ok(EvaluationResult::Empty);
                     }
-                    (EvaluationResult::String(_fmt, _), _) => {
+                    (EvaluationResult::String(_fmt, _, _), _) => {
                         // Non-string input with format -> fall through to normal conversion
                     }
                     _ => {
@@ -3852,9 +3846,9 @@ fn call_function(
             }
             Ok(match invocation_base {
                 EvaluationResult::Empty => EvaluationResult::Empty,
-                EvaluationResult::DateTime(dt, _) => EvaluationResult::datetime(dt.clone()),
-                EvaluationResult::Date(d, _) => EvaluationResult::datetime(d.clone()),
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::DateTime(dt, _, _) => EvaluationResult::datetime(dt.clone()),
+                EvaluationResult::Date(d, _, _) => EvaluationResult::datetime(d.clone()),
+                EvaluationResult::String(s, _, _) => {
                     let is_date_like = s.len() == 4 || s.len() == 7 || s.len() == 10;
                     let is_datetime_like =
                         s.contains('T') && s.starts_with(|c: char| c.is_ascii_digit());
@@ -3888,9 +3882,9 @@ fn call_function(
                     eprintln!("Warning: convertsToDateTime called on a collection");
                     EvaluationResult::Empty
                 }
-                EvaluationResult::DateTime(_, _) => EvaluationResult::boolean(true),
-                EvaluationResult::Date(_, _) => EvaluationResult::boolean(true), // Can represent as DateTime
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::DateTime(_, _, _) => EvaluationResult::boolean(true),
+                EvaluationResult::Date(_, _, _) => EvaluationResult::boolean(true), // Can represent as DateTime
+                EvaluationResult::String(s, _, _) => {
                     // Basic check: Does it look like YYYY, YYYY-MM, YYYY-MM-DD, or YYYY-MM-DDTHH...?
                     let is_date_like = s.len() == 4 || s.len() == 7 || s.len() == 10;
                     let is_datetime_like =
@@ -3911,8 +3905,8 @@ fn call_function(
             Ok(match invocation_base {
                 // Wrap in Ok
                 EvaluationResult::Empty => EvaluationResult::Empty,
-                EvaluationResult::Time(t, _) => EvaluationResult::time(t.clone()),
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::Time(t, _, _) => EvaluationResult::time(t.clone()),
+                EvaluationResult::String(s, _, _) => {
                     // Basic check: Does it look like HH, HH:mm, HH:mm:ss, HH:mm:ss.sss?
                     let parts: Vec<&str> = s.split(':').collect();
                     let is_time_like = match parts.len() {
@@ -3965,8 +3959,8 @@ fn call_function(
                     eprintln!("Warning: convertsToTime called on a collection");
                     EvaluationResult::Empty
                 }
-                EvaluationResult::Time(_, _) => EvaluationResult::boolean(true),
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::Time(_, _, _) => EvaluationResult::boolean(true),
+                EvaluationResult::String(s, _, _) => {
                     // Basic check (same as toTime)
                     let parts: Vec<&str> = s.split(':').collect();
                     let is_time_like = match parts.len() {
@@ -4027,21 +4021,23 @@ fn call_function(
             }
             Ok(match invocation_base {
                 EvaluationResult::Empty => EvaluationResult::Empty,
-                EvaluationResult::Boolean(b, _) => {
+                EvaluationResult::Boolean(b, _, _) => {
                     // Convert Boolean to Quantity 1.0 '1' or 0.0 '1'
                     EvaluationResult::quantity(
                         if *b { Decimal::ONE } else { Decimal::ZERO },
                         "1".to_string(),
                     )
                 }
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     EvaluationResult::quantity(Decimal::from(*i), "1".to_string())
                 } // Convert Integer to Quantity with '1' unit
-                EvaluationResult::Decimal(d, _) => EvaluationResult::quantity(*d, "1".to_string()), // Convert Decimal to Quantity with '1' unit
-                EvaluationResult::Quantity(val, unit, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
+                    EvaluationResult::quantity(*d, "1".to_string())
+                } // Convert Decimal to Quantity with '1' unit
+                EvaluationResult::Quantity(val, unit, _, _) => {
                     EvaluationResult::quantity(*val, unit.clone())
                 } // Quantity to Quantity
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::String(s, _, _) => {
                     // Attempt to parse as "value unit" or just "value"
                     let parts: Vec<&str> = s.split_whitespace().collect();
                     if parts.is_empty() {
@@ -4092,11 +4088,11 @@ fn call_function(
             }
             // Now we know it's a non-empty singleton
             Ok(match invocation_base {
-                EvaluationResult::Boolean(_, _) => EvaluationResult::boolean(true),
-                EvaluationResult::Integer(_, _) => EvaluationResult::boolean(true),
-                EvaluationResult::Decimal(_, _) => EvaluationResult::boolean(true),
-                EvaluationResult::Quantity(_, _, _) => EvaluationResult::boolean(true), // Quantity is convertible
-                EvaluationResult::String(s, _) => EvaluationResult::boolean({
+                EvaluationResult::Boolean(_, _, _) => EvaluationResult::boolean(true),
+                EvaluationResult::Integer(_, _, _) => EvaluationResult::boolean(true),
+                EvaluationResult::Decimal(_, _, _) => EvaluationResult::boolean(true),
+                EvaluationResult::Quantity(_, _, _, _) => EvaluationResult::boolean(true), // Quantity is convertible
+                EvaluationResult::String(s, _, _) => EvaluationResult::boolean({
                     let parts: Vec<&str> = s.split_whitespace().collect();
                     match parts.len() {
                         1 => {
@@ -4173,8 +4169,8 @@ fn call_function(
             // Helper to convert Integer/Decimal to Quantity with unit '1' (implicit conversion)
             fn to_quantity_unit(result: &EvaluationResult) -> Option<String> {
                 match result {
-                    EvaluationResult::Quantity(_, unit, _) => Some(unit.clone()),
-                    EvaluationResult::Integer(_, _) | EvaluationResult::Decimal(_, _) => {
+                    EvaluationResult::Quantity(_, unit, _, _) => Some(unit.clone()),
+                    EvaluationResult::Integer(_, _, _) | EvaluationResult::Decimal(_, _, _) => {
                         Some("1".to_string())
                     }
                     _ => None,
@@ -4212,7 +4208,7 @@ fn call_function(
             }
             Ok(match invocation_base {
                 // Wrap in Ok
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::String(s, _, _) => {
                     EvaluationResult::integer(s.chars().count() as i64)
                 } // Use chars().count() for correct length
                 EvaluationResult::Empty => EvaluationResult::Empty,
@@ -4246,7 +4242,7 @@ fn call_function(
             }
             Ok(match (invocation_base, &args[0]) {
                 // Wrap in Ok
-                (EvaluationResult::String(s, _), EvaluationResult::String(substring, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::String(substring, _, _)) => {
                     match s.find(substring.as_str()) {
                         // Convert byte offset to character (Unicode scalar value) index
                         // per FHIRPath string spec (FHIR-53554).
@@ -4257,7 +4253,7 @@ fn call_function(
                     }
                 }
                 // Handle empty cases according to spec
-                (EvaluationResult::String(_, _), EvaluationResult::Empty) => {
+                (EvaluationResult::String(_, _, _), EvaluationResult::Empty) => {
                     EvaluationResult::Empty
                 } // X.indexOf({}) -> {}
                 (EvaluationResult::Empty, _) => EvaluationResult::Empty, // {}.indexOf(X) -> {}
@@ -4289,7 +4285,7 @@ fn call_function(
                 ));
             }
             Ok(match (invocation_base, &args[0]) {
-                (EvaluationResult::String(s, _), EvaluationResult::String(substring, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::String(substring, _, _)) => {
                     if substring.is_empty() {
                         // Per spec: returns 0 if substring is empty
                         EvaluationResult::integer(0)
@@ -4304,7 +4300,7 @@ fn call_function(
                     }
                 }
                 // Handle empty cases according to spec
-                (EvaluationResult::String(_, _), EvaluationResult::Empty) => {
+                (EvaluationResult::String(_, _, _), EvaluationResult::Empty) => {
                     EvaluationResult::Empty
                 } // X.lastIndexOf({}) -> {}
                 (EvaluationResult::Empty, _) => EvaluationResult::Empty, // {}.lastIndexOf(X) -> {}
@@ -4340,9 +4336,9 @@ fn call_function(
             let length_res_opt = args.get(1);
 
             Ok(match invocation_base {
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::String(s, _, _) => {
                     let start_val_i64 = match start_index_res {
-                        EvaluationResult::Integer(i, _) => *i,
+                        EvaluationResult::Integer(i, _, _) => *i,
                         EvaluationResult::Empty => return Ok(EvaluationResult::Empty), // start is {} -> result is {}
                         _ => {
                             return Err(EvaluationError::InvalidArgument(
@@ -4365,7 +4361,7 @@ fn call_function(
                     if let Some(length_res) = length_res_opt {
                         // Two arguments: start and length
                         let length_val = match length_res {
-                            EvaluationResult::Integer(l, _) => *l, // Store as i64 first
+                            EvaluationResult::Integer(l, _, _) => *l, // Store as i64 first
                             EvaluationResult::Empty => {
                                 return Ok(EvaluationResult::string("".to_string()));
                             } // length is {} -> ""
@@ -4420,11 +4416,11 @@ fn call_function(
             }
             Ok(match (invocation_base, &args[0]) {
                 // Wrap in Ok
-                (EvaluationResult::String(s, _), EvaluationResult::String(prefix, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::String(prefix, _, _)) => {
                     EvaluationResult::boolean(s.starts_with(prefix))
                 }
                 // Handle empty cases
-                (EvaluationResult::String(_, _), EvaluationResult::Empty) => {
+                (EvaluationResult::String(_, _, _), EvaluationResult::Empty) => {
                     EvaluationResult::Empty
                 } // X.startsWith({}) -> {}
                 (EvaluationResult::Empty, _) => EvaluationResult::Empty, // {}.startsWith(X) -> {}
@@ -4449,11 +4445,11 @@ fn call_function(
             }
             Ok(match (invocation_base, &args[0]) {
                 // Wrap in Ok
-                (EvaluationResult::String(s, _), EvaluationResult::String(suffix, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::String(suffix, _, _)) => {
                     EvaluationResult::boolean(s.ends_with(suffix))
                 }
                 // Handle empty cases
-                (EvaluationResult::String(_, _), EvaluationResult::Empty) => {
+                (EvaluationResult::String(_, _, _), EvaluationResult::Empty) => {
                     EvaluationResult::Empty
                 } // X.endsWith({}) -> {}
                 (EvaluationResult::Empty, _) => EvaluationResult::Empty, // {}.endsWith(X) -> {}
@@ -4473,7 +4469,7 @@ fn call_function(
             }
             Ok(match invocation_base {
                 // Wrap in Ok
-                EvaluationResult::String(s, _) => EvaluationResult::string(s.to_uppercase()),
+                EvaluationResult::String(s, _, _) => EvaluationResult::string(s.to_uppercase()),
                 EvaluationResult::Empty => EvaluationResult::Empty,
                 _ => {
                     return Err(EvaluationError::TypeError(
@@ -4491,7 +4487,7 @@ fn call_function(
             }
             Ok(match invocation_base {
                 // Wrap in Ok
-                EvaluationResult::String(s, _) => EvaluationResult::string(s.to_lowercase()),
+                EvaluationResult::String(s, _, _) => EvaluationResult::string(s.to_lowercase()),
                 EvaluationResult::Empty => EvaluationResult::Empty,
                 _ => {
                     return Err(EvaluationError::TypeError(
@@ -4515,9 +4511,9 @@ fn call_function(
             Ok(match (invocation_base, &args[0], &args[1]) {
                 // Wrap in Ok
                 (
-                    EvaluationResult::String(s, _),
-                    EvaluationResult::String(pattern, _),
-                    EvaluationResult::String(substitution, _),
+                    EvaluationResult::String(s, _, _),
+                    EvaluationResult::String(pattern, _, _),
+                    EvaluationResult::String(substitution, _, _),
                 ) => EvaluationResult::string(s.replace(pattern, substitution)),
                 // Handle empty cases
                 (EvaluationResult::Empty, _, _) => EvaluationResult::Empty, // {}.replace(P, S) -> {}
@@ -4545,7 +4541,7 @@ fn call_function(
             // Extract optional flags argument
             let flags = if args.len() == 2 {
                 match &args[1] {
-                    EvaluationResult::String(f, _) => Some(f.as_str()),
+                    EvaluationResult::String(f, _, _) => Some(f.as_str()),
                     EvaluationResult::Empty => None,
                     _ => {
                         return Err(EvaluationError::TypeError(
@@ -4557,7 +4553,10 @@ fn call_function(
                 None
             };
             Ok(match (invocation_base, &args[0]) {
-                (EvaluationResult::String(s, _), EvaluationResult::String(regex_pattern, _)) => {
+                (
+                    EvaluationResult::String(s, _, _),
+                    EvaluationResult::String(regex_pattern, _, _),
+                ) => {
                     let mut builder = RegexBuilder::new(regex_pattern);
                     if let Some(flags) = flags {
                         apply_regex_flags(&mut builder, flags);
@@ -4571,7 +4570,7 @@ fn call_function(
                     }
                 }
                 // Handle empty cases
-                (EvaluationResult::String(_, _), EvaluationResult::Empty) => {
+                (EvaluationResult::String(_, _, _), EvaluationResult::Empty) => {
                     EvaluationResult::Empty
                 }
                 (EvaluationResult::Empty, _) => EvaluationResult::Empty,
@@ -4596,7 +4595,7 @@ fn call_function(
             }
             let flags = if args.len() == 2 {
                 match &args[1] {
-                    EvaluationResult::String(f, _) => Some(f.as_str()),
+                    EvaluationResult::String(f, _, _) => Some(f.as_str()),
                     EvaluationResult::Empty => None,
                     _ => {
                         return Err(EvaluationError::TypeError(
@@ -4608,7 +4607,10 @@ fn call_function(
                 None
             };
             Ok(match (invocation_base, &args[0]) {
-                (EvaluationResult::String(s, _), EvaluationResult::String(regex_pattern, _)) => {
+                (
+                    EvaluationResult::String(s, _, _),
+                    EvaluationResult::String(regex_pattern, _, _),
+                ) => {
                     let full_pattern = format!("^{}$", regex_pattern);
                     let mut builder = RegexBuilder::new(&full_pattern);
                     if let Some(flags) = flags {
@@ -4620,7 +4622,7 @@ fn call_function(
                     }
                 }
                 // Handle empty cases
-                (EvaluationResult::String(_, _), EvaluationResult::Empty) => {
+                (EvaluationResult::String(_, _, _), EvaluationResult::Empty) => {
                     EvaluationResult::Empty
                 }
                 (EvaluationResult::Empty, _) => EvaluationResult::Empty,
@@ -4645,7 +4647,7 @@ fn call_function(
             }
             let flags = if args.len() == 3 {
                 match &args[2] {
-                    EvaluationResult::String(f, _) => Some(f.as_str()),
+                    EvaluationResult::String(f, _, _) => Some(f.as_str()),
                     EvaluationResult::Empty => None,
                     _ => {
                         return Err(EvaluationError::TypeError(
@@ -4658,9 +4660,9 @@ fn call_function(
             };
             Ok(match (invocation_base, &args[0], &args[1]) {
                 (
-                    EvaluationResult::String(s, _),
-                    EvaluationResult::String(regex_pattern, _),
-                    EvaluationResult::String(substitution, _),
+                    EvaluationResult::String(s, _, _),
+                    EvaluationResult::String(regex_pattern, _, _),
+                    EvaluationResult::String(substitution, _, _),
                 ) => {
                     if regex_pattern.is_empty() {
                         EvaluationResult::string(s.clone())
@@ -4709,7 +4711,7 @@ fn call_function(
                 }
 
                 match &args[0] {
-                    EvaluationResult::String(sep, _) => sep,
+                    EvaluationResult::String(sep, _, _) => sep,
                     EvaluationResult::Empty => return Ok(EvaluationResult::Empty), // join({}) -> {}
                     _ => {
                         return Err(EvaluationError::TypeError(
@@ -4726,7 +4728,7 @@ fn call_function(
                     let mut string_items = Vec::new();
                     for item in items {
                         match item {
-                            EvaluationResult::String(s, _) => string_items.push(s.clone()),
+                            EvaluationResult::String(s, _, _) => string_items.push(s.clone()),
                             EvaluationResult::Empty => {} // Skip empty items (don't add anything)
                             _ => {
                                 return Err(EvaluationError::TypeError(
@@ -4738,7 +4740,7 @@ fn call_function(
                     Ok(EvaluationResult::string(string_items.join(separator)))
                 }
                 EvaluationResult::Empty => Ok(EvaluationResult::string(String::new())), // {}.join(sep) -> ""
-                EvaluationResult::String(s, _) => Ok(EvaluationResult::string(s.clone())), // Single string -> same string
+                EvaluationResult::String(s, _, _) => Ok(EvaluationResult::string(s.clone())), // Single string -> same string
                 _ => Err(EvaluationError::TypeError(
                     "join requires string items or a collection of strings".to_string(),
                 )),
@@ -4753,7 +4755,7 @@ fn call_function(
 
             // Get the ValueSet URL
             let value_set_url = match &args[0] {
-                EvaluationResult::String(url, _) => url,
+                EvaluationResult::String(url, _, _) => url,
                 _ => {
                     return Err(EvaluationError::TypeError(
                         "memberOf requires a string ValueSet URL argument".to_string(),
@@ -4781,7 +4783,7 @@ fn call_function(
             }
 
             Ok(match (invocation_base, &args[0]) {
-                (EvaluationResult::String(s, _), EvaluationResult::String(target, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::String(target, _, _)) => {
                     match target.as_str() {
                         "html" => {
                             // Escape HTML special characters
@@ -4834,7 +4836,7 @@ fn call_function(
             }
 
             Ok(match (invocation_base, &args[0]) {
-                (EvaluationResult::String(s, _), EvaluationResult::String(target, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::String(target, _, _)) => {
                     match target.as_str() {
                         "html" => {
                             // Unescape HTML entities
@@ -4902,7 +4904,7 @@ fn call_function(
             }
 
             Ok(match (invocation_base, &args[0]) {
-                (EvaluationResult::String(s, _), EvaluationResult::String(separator, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::String(separator, _, _)) => {
                     // Split the string by the separator
                     let parts: Vec<String> = if separator.is_empty() {
                         // If separator is empty, split into individual characters
@@ -4948,7 +4950,7 @@ fn call_function(
             }
 
             Ok(match invocation_base {
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::String(s, _, _) => {
                     // Trim whitespace from both ends
                     EvaluationResult::string(s.trim().to_string())
                 }
@@ -4981,7 +4983,7 @@ fn call_function(
                 0 // Default precision is 0 (round to nearest whole number)
             } else if args.len() == 1 {
                 match &args[0] {
-                    EvaluationResult::Integer(p, _) => {
+                    EvaluationResult::Integer(p, _, _) => {
                         if *p < 0 {
                             return Err(EvaluationError::InvalidArgument(
                                 "round precision must be >= 0".to_string(),
@@ -5003,7 +5005,7 @@ fn call_function(
 
             // Convert input to decimal if needed and round
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // Integers don't change when rounded to whole numbers
                     if precision == 0 {
                         Ok(EvaluationResult::integer(*i))
@@ -5015,7 +5017,7 @@ fn call_function(
                         )))
                     }
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // Round the decimal to the specified precision
                     let rounded = round_to_precision(*d, precision);
 
@@ -5031,7 +5033,7 @@ fn call_function(
                         Ok(EvaluationResult::decimal(rounded))
                     }
                 }
-                EvaluationResult::Quantity(value, unit, _) => {
+                EvaluationResult::Quantity(value, unit, _, _) => {
                     // Round the value part of the quantity
                     let rounded = round_to_precision(*value, precision);
                     Ok(EvaluationResult::quantity(rounded, unit.clone()))
@@ -5084,7 +5086,7 @@ fn call_function(
 
             // Convert input to decimal if needed and calculate square root
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // Check for negative value
                     if *i < 0 {
                         return Ok(EvaluationResult::Empty); // sqrt of negative number is empty
@@ -5099,7 +5101,7 @@ fn call_function(
                         Err(_) => Ok(EvaluationResult::Empty), // Handle any errors in the square root calculation
                     }
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // Check for negative value
                     if d.is_sign_negative() {
                         return Ok(EvaluationResult::Empty); // sqrt of negative number is empty
@@ -5111,7 +5113,7 @@ fn call_function(
                         Err(_) => Ok(EvaluationResult::Empty), // Handle any errors in the square root calculation
                     }
                 }
-                EvaluationResult::Quantity(value, unit, _) => {
+                EvaluationResult::Quantity(value, unit, _, _) => {
                     // Check for negative value
                     if value.is_sign_negative() {
                         return Ok(EvaluationResult::Empty); // sqrt of negative number is empty
@@ -5180,7 +5182,7 @@ fn call_function(
 
             // Calculate absolute value based on the input type
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // For Integer values, use i64::abs()
                     // Special handling for i64::MIN to avoid overflow
                     if *i == i64::MIN {
@@ -5191,11 +5193,11 @@ fn call_function(
                         Ok(EvaluationResult::integer(i.abs()))
                     }
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // For Decimal values, use Decimal::abs()
                     Ok(EvaluationResult::decimal(d.abs()))
                 }
-                EvaluationResult::Quantity(value, unit, _) => {
+                EvaluationResult::Quantity(value, unit, _, _) => {
                     // For Quantity values, take absolute value of the numeric part only
                     Ok(EvaluationResult::quantity(value.abs(), unit.clone()))
                 }
@@ -5239,11 +5241,11 @@ fn call_function(
 
             // Calculate ceiling based on the input type
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // Integer values remain unchanged since they're already whole numbers
                     Ok(EvaluationResult::integer(*i))
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // Calculate ceiling and decide whether to return Integer or Decimal
                     let ceiling = d.ceil();
 
@@ -5260,7 +5262,7 @@ fn call_function(
                         Ok(EvaluationResult::decimal(ceiling))
                     }
                 }
-                EvaluationResult::Quantity(value, unit, _) => {
+                EvaluationResult::Quantity(value, unit, _, _) => {
                     // For Quantity values, apply ceiling to the numeric part only
                     let ceiling = value.ceil();
 
@@ -5320,11 +5322,11 @@ fn call_function(
 
             // Calculate floor based on the input type
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // Integer values remain unchanged since they're already whole numbers
                     Ok(EvaluationResult::integer(*i))
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // Calculate floor and decide whether to return Integer or Decimal
                     let floor = d.floor();
 
@@ -5341,7 +5343,7 @@ fn call_function(
                         Ok(EvaluationResult::decimal(floor))
                     }
                 }
-                EvaluationResult::Quantity(value, unit, _) => {
+                EvaluationResult::Quantity(value, unit, _, _) => {
                     // For Quantity values, apply floor to the numeric part only
                     let floor = value.floor();
 
@@ -5424,7 +5426,7 @@ fn call_function(
 
             // Calculate exp based on the input type
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // Convert Integer to Decimal for exp calculation
                     let decimal = Decimal::from(*i);
 
@@ -5434,14 +5436,14 @@ fn call_function(
                         Err(_) => Ok(EvaluationResult::Empty), // Return Empty on calculation error
                     }
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // Calculate e^x
                     match exp_decimal(*d) {
                         Ok(result) => Ok(EvaluationResult::decimal(result)),
                         Err(_) => Ok(EvaluationResult::Empty), // Return Empty on calculation error
                     }
                 }
-                EvaluationResult::Quantity(value, unit, _) => {
+                EvaluationResult::Quantity(value, unit, _, _) => {
                     // For Quantity values, apply exp to the numeric part
                     // Note: This might not be meaningful for all units, but we'll keep it consistent
                     match exp_decimal(*value) {
@@ -5520,7 +5522,7 @@ fn call_function(
 
             // Calculate ln based on the input type
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // Convert Integer to Decimal for ln calculation
                     let decimal = Decimal::from(*i);
 
@@ -5530,14 +5532,14 @@ fn call_function(
                         Err(_) => Ok(EvaluationResult::Empty), // Return Empty on calculation error
                     }
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // Calculate ln(x)
                     match ln_decimal(*d) {
                         Ok(result) => Ok(EvaluationResult::decimal(result)),
                         Err(_) => Ok(EvaluationResult::Empty), // Return Empty on calculation error
                     }
                 }
-                EvaluationResult::Quantity(value, unit, _) => {
+                EvaluationResult::Quantity(value, unit, _, _) => {
                     // For Quantity values, apply ln to the numeric part
                     // Note: This might not be meaningful for all units, but we'll keep it consistent
                     match ln_decimal(*value) {
@@ -5649,7 +5651,7 @@ fn call_function(
 
             // Calculate log based on the input type
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // Convert Integer to Decimal for log calculation
                     let decimal = Decimal::from(*i);
 
@@ -5659,14 +5661,14 @@ fn call_function(
                         Err(_) => Ok(EvaluationResult::Empty), // Return Empty on calculation error
                     }
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // Calculate log_base(x)
                     match log_decimal(*d, base) {
                         Ok(result) => Ok(EvaluationResult::decimal(result)),
                         Err(_) => Ok(EvaluationResult::Empty), // Return Empty on calculation error
                     }
                 }
-                EvaluationResult::Quantity(value, unit, _) => {
+                EvaluationResult::Quantity(value, unit, _, _) => {
                     // For Quantity values, apply log to the numeric part
                     // Note: This might not be meaningful for all units, but we'll keep it consistent
                     match log_decimal(*value, base) {
@@ -5810,7 +5812,7 @@ fn call_function(
 
             // Calculate power based on the input type
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // Convert Integer to Decimal for power calculation
                     let decimal = Decimal::from(*i);
 
@@ -5831,7 +5833,7 @@ fn call_function(
                         Err(_) => Ok(EvaluationResult::Empty), // Return Empty on calculation error
                     }
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // Calculate base^exponent
                     match power_decimal(*d, exponent) {
                         Ok(result) => {
@@ -5849,7 +5851,7 @@ fn call_function(
                         Err(_) => Ok(EvaluationResult::Empty), // Return Empty on calculation error
                     }
                 }
-                EvaluationResult::Quantity(value, unit, _one) => {
+                EvaluationResult::Quantity(value, unit, _one, _) => {
                     // For Quantity values, apply power to the numeric part
                     // Note: This might not be physically meaningful for many units, but we'll keep it consistent
                     match power_decimal(*value, exponent) {
@@ -5911,11 +5913,11 @@ fn call_function(
 
             // Truncate based on the input type
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // Integer has no fractional part, so return it as is
                     Ok(EvaluationResult::integer(*i))
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // For Decimal, remove the fractional part
                     let truncated = d.trunc();
 
@@ -5928,7 +5930,7 @@ fn call_function(
                         Ok(EvaluationResult::decimal(truncated))
                     }
                 }
-                EvaluationResult::Quantity(value, unit, _) => {
+                EvaluationResult::Quantity(value, unit, _, _) => {
                     // For Quantity, truncate the value but preserve the unit
                     let truncated = value.trunc();
 
@@ -5965,7 +5967,7 @@ fn call_function(
 
             // Calculate precision based on the input type
             match invocation_base {
-                EvaluationResult::Integer(i, _) => {
+                EvaluationResult::Integer(i, _, _) => {
                     // For integers, count the number of digits
                     let digits = if *i == 0 {
                         1 // Zero has 1 significant digit
@@ -5974,7 +5976,7 @@ fn call_function(
                     };
                     Ok(EvaluationResult::integer(digits))
                 }
-                EvaluationResult::Decimal(d, _) => {
+                EvaluationResult::Decimal(d, _, _) => {
                     // For decimals, we need to count significant digits
                     // The FHIRPath spec expects trailing zeros to be counted,
                     // but the Decimal type may normalize or reformat the value
@@ -5995,12 +5997,12 @@ fn call_function(
 
                     Ok(EvaluationResult::integer(digit_count as i64))
                 }
-                EvaluationResult::Date(date_str, _) => {
+                EvaluationResult::Date(date_str, _, _) => {
                     // For dates in format YYYY-MM-DD, precision is based on what's specified
                     // YYYY = 4, YYYY-MM = 7, YYYY-MM-DD = 10
                     Ok(EvaluationResult::integer(date_str.len() as i64))
                 }
-                EvaluationResult::DateTime(datetime_str, _) => {
+                EvaluationResult::DateTime(datetime_str, _, _) => {
                     // For datetime values, precision is based on components:
                     // YYYY = 4
                     // YYYY-MM = 6 (not 7 - don't count separator)
@@ -6065,7 +6067,7 @@ fn call_function(
 
                     Ok(EvaluationResult::integer(precision))
                 }
-                EvaluationResult::Time(time_str, _) => {
+                EvaluationResult::Time(time_str, _, _) => {
                     // For time values, precision is based on components:
                     // HH = 2
                     // HH:MM = 4 (not 5 - don't count separator)
@@ -6108,7 +6110,7 @@ fn call_function(
             }
             Ok(match invocation_base {
                 // Wrap in Ok
-                EvaluationResult::String(s, _) => {
+                EvaluationResult::String(s, _, _) => {
                     if s.is_empty() {
                         EvaluationResult::Empty
                     } else {
@@ -6317,7 +6319,7 @@ fn call_function(
 
             // Get the string to encode
             let input_str = match invocation_base {
-                EvaluationResult::String(s, _) => s,
+                EvaluationResult::String(s, _, _) => s,
                 EvaluationResult::Empty => return Ok(EvaluationResult::Empty),
                 _ => {
                     return Err(EvaluationError::TypeError(
@@ -6328,7 +6330,7 @@ fn call_function(
 
             // Get the encoding type
             let encoding = match &args[0] {
-                EvaluationResult::String(s, _) => s.as_str(),
+                EvaluationResult::String(s, _, _) => s.as_str(),
                 _ => {
                     return Err(EvaluationError::TypeError(
                         "encode encoding argument must be a string".to_string(),
@@ -6375,7 +6377,7 @@ fn call_function(
 
             // Get the string to decode
             let input_str = match invocation_base {
-                EvaluationResult::String(s, _) => s,
+                EvaluationResult::String(s, _, _) => s,
                 EvaluationResult::Empty => return Ok(EvaluationResult::Empty),
                 _ => {
                     return Err(EvaluationError::TypeError(
@@ -6386,7 +6388,7 @@ fn call_function(
 
             // Get the encoding type
             let encoding = match &args[0] {
-                EvaluationResult::String(s, _) => s.as_str(),
+                EvaluationResult::String(s, _, _) => s.as_str(),
                 _ => {
                     return Err(EvaluationError::TypeError(
                         "decode encoding argument must be a string".to_string(),
@@ -6881,10 +6883,10 @@ fn sqrt_decimal(value: Decimal) -> Result<Decimal, &'static str> {
 /// Attempts to convert an EvaluationResult to Decimal
 fn to_decimal(value: &EvaluationResult) -> Result<Decimal, EvaluationError> {
     match value {
-        EvaluationResult::Decimal(d, _) => Ok(*d),
-        EvaluationResult::Integer(i, _) => Ok(Decimal::from(*i)),
-        EvaluationResult::Quantity(d, _, _) => Ok(*d),
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::Decimal(d, _, _) => Ok(*d),
+        EvaluationResult::Integer(i, _, _) => Ok(Decimal::from(*i)),
+        EvaluationResult::Quantity(d, _, _, _) => Ok(*d),
+        EvaluationResult::String(s, _, _) => {
             // Try to parse the string as a decimal
             match s.parse::<Decimal>() {
                 Ok(d) => Ok(d),
@@ -6894,7 +6896,7 @@ fn to_decimal(value: &EvaluationResult) -> Result<Decimal, EvaluationError> {
                 ))),
             }
         }
-        EvaluationResult::Boolean(b, _) => {
+        EvaluationResult::Boolean(b, _, _) => {
             // Convert boolean to 1 or 0
             if *b {
                 Ok(Decimal::from(1))
@@ -6960,14 +6962,14 @@ fn evaluate_indexer(
 ) -> Result<EvaluationResult, EvaluationError> {
     // Get the index as an integer, ensuring it's non-negative
     let idx_opt: Option<usize> = match index {
-        EvaluationResult::Integer(i, _) => {
+        EvaluationResult::Integer(i, _, _) => {
             if *i >= 0 {
                 (*i).try_into().ok() // Convert non-negative i64 to usize
             } else {
                 None // Negative index is invalid
             }
         }
-        EvaluationResult::Decimal(d, _) => {
+        EvaluationResult::Decimal(d, _, _) => {
             // Check if decimal is a non-negative integer before converting
             if d.is_integer() && d.is_sign_positive() {
                 d.to_usize() // Convert non-negative integer Decimal to usize
@@ -7004,7 +7006,7 @@ fn evaluate_indexer(
         }
         // String indexer: returns the idx-th character (Unicode scalar value)
         // as a single-character string, per FHIRPath string spec (FHIR-53554).
-        EvaluationResult::String(s, _) => match s.chars().nth(idx) {
+        EvaluationResult::String(s, _, _) => match s.chars().nth(idx) {
             Some(c) => EvaluationResult::string(c.to_string()),
             None => EvaluationResult::Empty,
         },
@@ -7021,9 +7023,9 @@ fn apply_polarity(op: char, value: &EvaluationResult) -> Result<EvaluationResult
             // Negate numeric values
             Ok(match value {
                 // Wrap result in Ok
-                EvaluationResult::Decimal(d, _) => EvaluationResult::decimal(-*d),
-                EvaluationResult::Integer(i, _) => EvaluationResult::integer(-*i),
-                EvaluationResult::Quantity(val, unit, _) => {
+                EvaluationResult::Decimal(d, _, _) => EvaluationResult::decimal(-*d),
+                EvaluationResult::Integer(i, _, _) => EvaluationResult::integer(-*i),
+                EvaluationResult::Quantity(val, unit, _, _) => {
                     EvaluationResult::quantity(-*val, unit.clone())
                 } // Negate Quantity value
                 // Polarity on non-numeric or empty should be a type error
@@ -7055,8 +7057,8 @@ fn apply_multiplicative(
             Ok(match (left, right) {
                 // Quantity * Quantity = Quantity with multiplied units
                 (
-                    EvaluationResult::Quantity(val_l, unit_l, _),
-                    EvaluationResult::Quantity(val_r, unit_r, _),
+                    EvaluationResult::Quantity(val_l, unit_l, _, _),
+                    EvaluationResult::Quantity(val_r, unit_r, _, _),
                 ) => match crate::ucum::multiply_units(unit_l, unit_r) {
                     Ok(result_unit) => EvaluationResult::quantity(*val_l * *val_r, result_unit),
                     Err(err) => {
@@ -7067,32 +7069,36 @@ fn apply_multiplicative(
                     }
                 },
                 // Quantity * Number = Quantity with same unit
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Integer(n, _)) => {
-                    EvaluationResult::quantity(*val * Decimal::from(*n), unit.clone())
-                }
-                (EvaluationResult::Integer(n, _), EvaluationResult::Quantity(val, unit, _)) => {
-                    EvaluationResult::quantity(Decimal::from(*n) * *val, unit.clone())
-                }
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Decimal(d, _)) => {
-                    EvaluationResult::quantity(*val * *d, unit.clone())
-                }
-                (EvaluationResult::Decimal(d, _), EvaluationResult::Quantity(val, unit, _)) => {
-                    EvaluationResult::quantity(*d * *val, unit.clone())
-                }
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Integer(n, _, _),
+                ) => EvaluationResult::quantity(*val * Decimal::from(*n), unit.clone()),
+                (
+                    EvaluationResult::Integer(n, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => EvaluationResult::quantity(Decimal::from(*n) * *val, unit.clone()),
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Decimal(d, _, _),
+                ) => EvaluationResult::quantity(*val * *d, unit.clone()),
+                (
+                    EvaluationResult::Decimal(d, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => EvaluationResult::quantity(*d * *val, unit.clone()),
                 // Regular numeric multiplication
-                (EvaluationResult::Integer(l, _), EvaluationResult::Integer(r, _)) => {
+                (EvaluationResult::Integer(l, _, _), EvaluationResult::Integer(r, _, _)) => {
                     // Check for potential overflow before multiplying
                     l.checked_mul(*r)
                         .map(EvaluationResult::integer)
                         .ok_or(EvaluationError::ArithmeticOverflow)? // Return Err on overflow
                 }
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     EvaluationResult::decimal(*l * *r)
                 }
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Integer(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Integer(r, _, _)) => {
                     EvaluationResult::decimal(*l * Decimal::from(*r))
                 }
-                (EvaluationResult::Integer(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Integer(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     EvaluationResult::decimal(Decimal::from(*l) * *r)
                 }
                 // Handle empty operands
@@ -7113,8 +7119,8 @@ fn apply_multiplicative(
             match (left, right) {
                 // Quantity / Quantity = Quantity with divided units (or unitless if units cancel)
                 (
-                    EvaluationResult::Quantity(val_l, unit_l, _),
-                    EvaluationResult::Quantity(val_r, unit_r, _),
+                    EvaluationResult::Quantity(val_l, unit_l, _, _),
+                    EvaluationResult::Quantity(val_r, unit_r, _, _),
                 ) => {
                     if val_r.is_zero() {
                         Ok(EvaluationResult::Empty)
@@ -7142,7 +7148,10 @@ fn apply_multiplicative(
                     }
                 }
                 // Quantity / Number = Quantity with same unit
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Integer(n, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Integer(n, _, _),
+                ) => {
                     if *n == 0 {
                         Ok(EvaluationResult::Empty)
                     } else {
@@ -7153,7 +7162,10 @@ fn apply_multiplicative(
                             .ok_or(EvaluationError::ArithmeticOverflow)
                     }
                 }
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Decimal(d, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Decimal(d, _, _),
+                ) => {
                     if d.is_zero() {
                         Ok(EvaluationResult::Empty)
                     } else {
@@ -7165,7 +7177,10 @@ fn apply_multiplicative(
                     }
                 }
                 // Number / Quantity = Quantity with inverted unit
-                (EvaluationResult::Integer(n, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Integer(n, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if val.is_zero() {
                         Ok(EvaluationResult::Empty)
                     } else {
@@ -7186,7 +7201,10 @@ fn apply_multiplicative(
                         }
                     }
                 }
-                (EvaluationResult::Decimal(d, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Decimal(d, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if val.is_zero() {
                         Ok(EvaluationResult::Empty)
                     } else {
@@ -7210,13 +7228,13 @@ fn apply_multiplicative(
                 // Regular numeric division
                 _ => {
                     let left_dec = match left {
-                        EvaluationResult::Decimal(d, _) => Some(*d),
-                        EvaluationResult::Integer(i, _) => Some(Decimal::from(*i)),
+                        EvaluationResult::Decimal(d, _, _) => Some(*d),
+                        EvaluationResult::Integer(i, _, _) => Some(Decimal::from(*i)),
                         _ => None,
                     };
                     let right_dec = match right {
-                        EvaluationResult::Decimal(d, _) => Some(*d),
-                        EvaluationResult::Integer(i, _) => Some(Decimal::from(*i)),
+                        EvaluationResult::Decimal(d, _, _) => Some(*d),
+                        EvaluationResult::Integer(i, _, _) => Some(Decimal::from(*i)),
                         _ => None,
                     };
 
@@ -7249,14 +7267,14 @@ fn apply_multiplicative(
             // Handle div/mod: Convert to appropriate type and perform operation
             // Promote integers to decimals if needed
             let left_val = match left {
-                EvaluationResult::Decimal(d, _) => Some((*d, true)), // (value, is_decimal)
-                EvaluationResult::Integer(i, _) => Some((Decimal::from(*i), false)),
+                EvaluationResult::Decimal(d, _, _) => Some((*d, true)), // (value, is_decimal)
+                EvaluationResult::Integer(i, _, _) => Some((Decimal::from(*i), false)),
                 EvaluationResult::Empty => return Ok(EvaluationResult::Empty),
                 _ => None,
             };
             let right_val = match right {
-                EvaluationResult::Decimal(d, _) => Some((*d, true)),
-                EvaluationResult::Integer(i, _) => Some((Decimal::from(*i), false)),
+                EvaluationResult::Decimal(d, _, _) => Some((*d, true)),
+                EvaluationResult::Integer(i, _, _) => Some((Decimal::from(*i), false)),
                 EvaluationResult::Empty => return Ok(EvaluationResult::Empty),
                 _ => None,
             };
@@ -7269,9 +7287,10 @@ fn apply_multiplicative(
                     } else {
                         // Both are integers, use integer arithmetic
                         match (left, right) {
-                            (EvaluationResult::Integer(l, _), EvaluationResult::Integer(r, _)) => {
-                                apply_integer_multiplicative(*l, op, *r)
-                            }
+                            (
+                                EvaluationResult::Integer(l, _, _),
+                                EvaluationResult::Integer(r, _, _),
+                            ) => apply_integer_multiplicative(*l, op, *r),
                             _ => unreachable!(), // We know they're both integers
                         }
                     }
@@ -7325,26 +7344,26 @@ fn apply_additive(
             // Handle numeric addition: Int + Int = Int, otherwise Decimal
             Ok(match (left, right) {
                 // Wrap result in Ok
-                (EvaluationResult::Integer(l, _), EvaluationResult::Integer(r, _)) => {
+                (EvaluationResult::Integer(l, _, _), EvaluationResult::Integer(r, _, _)) => {
                     // Check for potential overflow before adding
                     l.checked_add(*r)
                         .map(EvaluationResult::integer)
                         .ok_or(EvaluationError::ArithmeticOverflow)? // Return Err on overflow
                 }
                 // If either operand is Decimal, promote and result is Decimal
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     EvaluationResult::decimal(*l + *r)
                 }
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Integer(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Integer(r, _, _)) => {
                     EvaluationResult::decimal(*l + Decimal::from(*r))
                 }
-                (EvaluationResult::Integer(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Integer(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     EvaluationResult::decimal(Decimal::from(*l) + *r)
                 }
                 // Quantity addition (requires comparable units)
                 (
-                    EvaluationResult::Quantity(val_l, unit_l, _),
-                    EvaluationResult::Quantity(val_r, unit_r, _),
+                    EvaluationResult::Quantity(val_l, unit_l, _, _),
+                    EvaluationResult::Quantity(val_r, unit_r, _, _),
                 ) => {
                     if unit_l == unit_r {
                         EvaluationResult::quantity(*val_l + *val_r, unit_l.clone())
@@ -7362,7 +7381,10 @@ fn apply_additive(
                     }
                 }
                 // Quantity + Integer (implicit conversion: Integer becomes Quantity with unit '1')
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Integer(n, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Integer(n, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable(unit, "1") {
                         EvaluationResult::quantity(*val + Decimal::from(*n), unit.clone())
                     } else {
@@ -7370,7 +7392,10 @@ fn apply_additive(
                     }
                 }
                 // Integer + Quantity (implicit conversion: Integer becomes Quantity with unit '1')
-                (EvaluationResult::Integer(n, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Integer(n, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable("1", unit) {
                         EvaluationResult::quantity(Decimal::from(*n) + *val, unit.clone())
                     } else {
@@ -7378,7 +7403,10 @@ fn apply_additive(
                     }
                 }
                 // Quantity + Decimal (implicit conversion: Decimal becomes Quantity with unit '1')
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Decimal(d, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Decimal(d, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable(unit, "1") {
                         EvaluationResult::quantity(*val + *d, unit.clone())
                     } else {
@@ -7386,7 +7414,10 @@ fn apply_additive(
                     }
                 }
                 // Decimal + Quantity (implicit conversion: Decimal becomes Quantity with unit '1')
-                (EvaluationResult::Decimal(d, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Decimal(d, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable("1", unit) {
                         EvaluationResult::quantity(*d + *val, unit.clone())
                     } else {
@@ -7394,7 +7425,10 @@ fn apply_additive(
                     }
                 }
                 // Date/DateTime + Quantity (time duration)
-                (EvaluationResult::Date(date_str, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Date(date_str, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::is_time_unit(unit) {
                         add_duration_to_date(date_str, *val, unit)?
                     } else {
@@ -7404,7 +7438,10 @@ fn apply_additive(
                         )));
                     }
                 }
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Date(date_str, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Date(date_str, _, _),
+                ) => {
                     if crate::ucum::is_time_unit(unit) {
                         add_duration_to_date(date_str, *val, unit)?
                     } else {
@@ -7415,8 +7452,8 @@ fn apply_additive(
                     }
                 }
                 (
-                    EvaluationResult::DateTime(dt_str, _),
-                    EvaluationResult::Quantity(val, unit, _),
+                    EvaluationResult::DateTime(dt_str, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
                 ) => {
                     if crate::ucum::is_time_unit(unit) {
                         add_duration_to_datetime(dt_str, *val, unit)?
@@ -7428,8 +7465,8 @@ fn apply_additive(
                     }
                 }
                 (
-                    EvaluationResult::Quantity(val, unit, _),
-                    EvaluationResult::DateTime(dt_str, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::DateTime(dt_str, _, _),
                 ) => {
                     if crate::ucum::is_time_unit(unit) {
                         add_duration_to_datetime(dt_str, *val, unit)?
@@ -7441,7 +7478,10 @@ fn apply_additive(
                     }
                 }
                 // Time + Quantity (time duration)
-                (EvaluationResult::Time(time_str, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Time(time_str, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::is_time_unit(unit) {
                         add_duration_to_time(time_str, *val, unit)?
                     } else {
@@ -7451,7 +7491,10 @@ fn apply_additive(
                         )));
                     }
                 }
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Time(time_str, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Time(time_str, _, _),
+                ) => {
                     if crate::ucum::is_time_unit(unit) {
                         add_duration_to_time(time_str, *val, unit)?
                     } else {
@@ -7462,11 +7505,11 @@ fn apply_additive(
                     }
                 }
                 // Handle string concatenation with '+'
-                (EvaluationResult::String(l, _), EvaluationResult::String(r, _)) => {
+                (EvaluationResult::String(l, _, _), EvaluationResult::String(r, _, _)) => {
                     EvaluationResult::string(format!("{}{}", l, r))
                 }
                 // Handle String + Number (attempt conversion, prioritize Integer result if possible)
-                (EvaluationResult::String(s, _), EvaluationResult::Integer(i, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::Integer(i, _, _)) => {
                     // Try parsing string as Integer first
                     if let Ok(s_int) = s.parse::<i64>() {
                         s_int
@@ -7487,7 +7530,7 @@ fn apply_additive(
                             })?
                     }
                 }
-                (EvaluationResult::Integer(i, _), EvaluationResult::String(s, _)) => {
+                (EvaluationResult::Integer(i, _, _), EvaluationResult::String(s, _, _)) => {
                     // Try parsing string as Integer first
                     if let Ok(s_int) = s.parse::<i64>() {
                         i.checked_add(s_int)
@@ -7507,7 +7550,7 @@ fn apply_additive(
                             })?
                     }
                 }
-                (EvaluationResult::String(s, _), EvaluationResult::Decimal(d, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::Decimal(d, _, _)) => {
                     // String + Decimal -> Decimal
                     s.parse::<Decimal>()
                         .ok()
@@ -7520,7 +7563,7 @@ fn apply_additive(
                             ))
                         })?
                 }
-                (EvaluationResult::Decimal(d, _), EvaluationResult::String(s, _)) => {
+                (EvaluationResult::Decimal(d, _, _), EvaluationResult::String(s, _, _)) => {
                     s.parse::<Decimal>()
                         .ok()
                         .map(|sd| EvaluationResult::decimal(*d + sd))
@@ -7543,8 +7586,10 @@ fn apply_additive(
                 ) => {
                     // Special case: if both collections contain single strings, concatenate the strings
                     if left_items.len() == 1 && right_items.len() == 1 {
-                        if let (EvaluationResult::String(l, _), EvaluationResult::String(r, _)) =
-                            (&left_items[0], &right_items[0])
+                        if let (
+                            EvaluationResult::String(l, _, _),
+                            EvaluationResult::String(r, _, _),
+                        ) = (&left_items[0], &right_items[0])
                         {
                             return Ok(EvaluationResult::string(format!("{}{}", l, r)));
                         }
@@ -7577,26 +7622,26 @@ fn apply_additive(
             // Handle numeric subtraction: Int - Int = Int, otherwise Decimal
             Ok(match (left, right) {
                 // Wrap result in Ok
-                (EvaluationResult::Integer(l, _), EvaluationResult::Integer(r, _)) => {
+                (EvaluationResult::Integer(l, _, _), EvaluationResult::Integer(r, _, _)) => {
                     // Check for potential overflow before subtracting
                     l.checked_sub(*r)
                         .map(EvaluationResult::integer)
                         .ok_or(EvaluationError::ArithmeticOverflow)? // Return Err on overflow
                 }
                 // If either operand is Decimal, promote and result is Decimal
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     EvaluationResult::decimal(*l - *r)
                 }
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Integer(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Integer(r, _, _)) => {
                     EvaluationResult::decimal(*l - Decimal::from(*r))
                 }
-                (EvaluationResult::Integer(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Integer(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     EvaluationResult::decimal(Decimal::from(*l) - *r)
                 }
                 // Quantity subtraction (requires same units) - Added
                 (
-                    EvaluationResult::Quantity(val_l, unit_l, _),
-                    EvaluationResult::Quantity(val_r, unit_r, _),
+                    EvaluationResult::Quantity(val_l, unit_l, _, _),
+                    EvaluationResult::Quantity(val_r, unit_r, _, _),
                 ) => {
                     if unit_l == unit_r {
                         EvaluationResult::quantity(*val_l - *val_r, unit_l.clone())
@@ -7607,7 +7652,10 @@ fn apply_additive(
                     }
                 }
                 // Quantity - Integer (implicit conversion: Integer becomes Quantity with unit '1')
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Integer(n, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Integer(n, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable(unit, "1") {
                         EvaluationResult::quantity(*val - Decimal::from(*n), unit.clone())
                     } else {
@@ -7615,7 +7663,10 @@ fn apply_additive(
                     }
                 }
                 // Integer - Quantity (implicit conversion: Integer becomes Quantity with unit '1')
-                (EvaluationResult::Integer(n, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Integer(n, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable("1", unit) {
                         EvaluationResult::quantity(Decimal::from(*n) - *val, unit.clone())
                     } else {
@@ -7623,7 +7674,10 @@ fn apply_additive(
                     }
                 }
                 // Quantity - Decimal (implicit conversion: Decimal becomes Quantity with unit '1')
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Decimal(d, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Decimal(d, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable(unit, "1") {
                         EvaluationResult::quantity(*val - *d, unit.clone())
                     } else {
@@ -7631,7 +7685,10 @@ fn apply_additive(
                     }
                 }
                 // Decimal - Quantity (implicit conversion: Decimal becomes Quantity with unit '1')
-                (EvaluationResult::Decimal(d, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Decimal(d, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable("1", unit) {
                         EvaluationResult::quantity(*d - *val, unit.clone())
                     } else {
@@ -7639,7 +7696,7 @@ fn apply_additive(
                     }
                 }
                 // Handle String - Number (attempt conversion, prioritize Integer result if possible)
-                (EvaluationResult::String(s, _), EvaluationResult::Integer(i, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::Integer(i, _, _)) => {
                     // Try parsing string as Integer first
                     if let Ok(s_int) = s.parse::<i64>() {
                         s_int
@@ -7660,7 +7717,7 @@ fn apply_additive(
                             })?
                     }
                 }
-                (EvaluationResult::Integer(i, _), EvaluationResult::String(s, _)) => {
+                (EvaluationResult::Integer(i, _, _), EvaluationResult::String(s, _, _)) => {
                     // Try parsing string as Integer first
                     if let Ok(s_int) = s.parse::<i64>() {
                         i.checked_sub(s_int)
@@ -7680,7 +7737,7 @@ fn apply_additive(
                             })?
                     }
                 }
-                (EvaluationResult::String(s, _), EvaluationResult::Decimal(d, _)) => {
+                (EvaluationResult::String(s, _, _), EvaluationResult::Decimal(d, _, _)) => {
                     // String - Decimal -> Decimal
                     s.parse::<Decimal>()
                         .ok()
@@ -7693,7 +7750,7 @@ fn apply_additive(
                             ))
                         })?
                 }
-                (EvaluationResult::Decimal(d, _), EvaluationResult::String(s, _)) => {
+                (EvaluationResult::Decimal(d, _, _), EvaluationResult::String(s, _, _)) => {
                     s.parse::<Decimal>()
                         .ok()
                         .map(|sd| EvaluationResult::decimal(*d - sd))
@@ -7706,7 +7763,10 @@ fn apply_additive(
                         })?
                 }
                 // Date - Quantity (time duration)
-                (EvaluationResult::Date(date_str, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Date(date_str, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::is_time_unit(unit) {
                         // Negate the value for subtraction
                         add_duration_to_date(date_str, -*val, unit)?
@@ -7719,8 +7779,8 @@ fn apply_additive(
                 }
                 // DateTime - Quantity (time duration)
                 (
-                    EvaluationResult::DateTime(dt_str, _),
-                    EvaluationResult::Quantity(val, unit, _),
+                    EvaluationResult::DateTime(dt_str, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
                 ) => {
                     if crate::ucum::is_time_unit(unit) {
                         // Negate the value for subtraction
@@ -7733,7 +7793,10 @@ fn apply_additive(
                     }
                 }
                 // Time - Quantity (time duration)
-                (EvaluationResult::Time(time_str, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Time(time_str, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::is_time_unit(unit) {
                         // Negate the value for subtraction
                         add_duration_to_time(time_str, -*val, unit)?
@@ -8016,15 +8079,15 @@ fn compare_inequality(
             // Check if these are date/time types that cannot be compared
             let is_date_time_left = matches!(
                 left,
-                EvaluationResult::Date(_, _)
-                    | EvaluationResult::DateTime(_, _)
-                    | EvaluationResult::Time(_, _)
+                EvaluationResult::Date(_, _, _)
+                    | EvaluationResult::DateTime(_, _, _)
+                    | EvaluationResult::Time(_, _, _)
             );
             let is_date_time_right = matches!(
                 right,
-                EvaluationResult::Date(_, _)
-                    | EvaluationResult::DateTime(_, _)
-                    | EvaluationResult::Time(_, _)
+                EvaluationResult::Date(_, _, _)
+                    | EvaluationResult::DateTime(_, _, _)
+                    | EvaluationResult::Time(_, _, _)
             );
             if is_date_time_left && is_date_time_right {
                 // Both are date/time types but comparison returned None
@@ -8036,16 +8099,16 @@ fn compare_inequality(
             }
             // Also check if we have String vs DateTime/Date/Time combinations
             match (left, right) {
-                (EvaluationResult::String(_s, _), EvaluationResult::DateTime(_, _))
-                | (EvaluationResult::DateTime(_, _), EvaluationResult::String(_s, _))
-                | (EvaluationResult::String(_s, _), EvaluationResult::Date(_, _))
-                | (EvaluationResult::Date(_, _), EvaluationResult::String(_s, _))
-                | (EvaluationResult::String(_s, _), EvaluationResult::Time(_, _))
-                | (EvaluationResult::Time(_, _), EvaluationResult::String(_s, _)) => {
+                (EvaluationResult::String(_s, _, _), EvaluationResult::DateTime(_, _, _))
+                | (EvaluationResult::DateTime(_, _, _), EvaluationResult::String(_s, _, _))
+                | (EvaluationResult::String(_s, _, _), EvaluationResult::Date(_, _, _))
+                | (EvaluationResult::Date(_, _, _), EvaluationResult::String(_s, _, _))
+                | (EvaluationResult::String(_s, _, _), EvaluationResult::Time(_, _, _))
+                | (EvaluationResult::Time(_, _, _), EvaluationResult::String(_s, _, _)) => {
                     // String might be a date/time value, compare_date_time_values will handle it
                     // Don't return Empty here - let it continue to try the comparison
                 }
-                (EvaluationResult::String(s1, _), EvaluationResult::String(s2, _)) => {
+                (EvaluationResult::String(s1, _, _), EvaluationResult::String(s2, _, _)) => {
                     // Check if one is a date and the other is a datetime
                     let s1_is_date =
                         !s1.contains('T') && crate::datetime_impl::parse_date(s1).is_some();
@@ -8076,22 +8139,22 @@ fn compare_inequality(
     // Promote Integer to Decimal for mixed comparisons
     let compare_result = match (left, right) {
         // Both Decimal
-        (EvaluationResult::Decimal(l, _), EvaluationResult::Decimal(r, _)) => Some(l.cmp(r)),
+        (EvaluationResult::Decimal(l, _, _), EvaluationResult::Decimal(r, _, _)) => Some(l.cmp(r)),
         // Both Integer
-        (EvaluationResult::Integer(l, _), EvaluationResult::Integer(r, _)) => Some(l.cmp(r)),
+        (EvaluationResult::Integer(l, _, _), EvaluationResult::Integer(r, _, _)) => Some(l.cmp(r)),
         // Mixed Decimal/Integer
-        (EvaluationResult::Decimal(l, _), EvaluationResult::Integer(r, _)) => {
+        (EvaluationResult::Decimal(l, _, _), EvaluationResult::Integer(r, _, _)) => {
             Some(l.cmp(&Decimal::from(*r)))
         }
-        (EvaluationResult::Integer(l, _), EvaluationResult::Decimal(r, _)) => {
+        (EvaluationResult::Integer(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
             Some(Decimal::from(*l).cmp(r))
         }
         // String comparison
-        (EvaluationResult::String(l, _), EvaluationResult::String(r, _)) => Some(l.cmp(r)),
+        (EvaluationResult::String(l, _, _), EvaluationResult::String(r, _, _)) => Some(l.cmp(r)),
         // Quantity comparison (only if units match)
         (
-            EvaluationResult::Quantity(val_l, unit_l, _),
-            EvaluationResult::Quantity(val_r, unit_r, _),
+            EvaluationResult::Quantity(val_l, unit_l, _, _),
+            EvaluationResult::Quantity(val_r, unit_r, _, _),
         ) => {
             if unit_l == unit_r {
                 // Same units, direct comparison
@@ -8119,7 +8182,7 @@ fn compare_inequality(
             }
         }
         // Quantity vs Integer (implicit conversion: Integer becomes Quantity with unit '1')
-        (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Integer(n, _)) => {
+        (EvaluationResult::Quantity(val, unit, _, _), EvaluationResult::Integer(n, _, _)) => {
             if crate::ucum::units_are_comparable(unit, "1") {
                 Some(val.cmp(&Decimal::from(*n)))
             } else {
@@ -8128,7 +8191,7 @@ fn compare_inequality(
             }
         }
         // Integer vs Quantity (implicit conversion: Integer becomes Quantity with unit '1')
-        (EvaluationResult::Integer(n, _), EvaluationResult::Quantity(val, unit, _)) => {
+        (EvaluationResult::Integer(n, _, _), EvaluationResult::Quantity(val, unit, _, _)) => {
             if crate::ucum::units_are_comparable("1", unit) {
                 Some(Decimal::from(*n).cmp(val))
             } else {
@@ -8137,7 +8200,7 @@ fn compare_inequality(
             }
         }
         // Quantity vs Decimal (implicit conversion: Decimal becomes Quantity with unit '1')
-        (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Decimal(d, _)) => {
+        (EvaluationResult::Quantity(val, unit, _, _), EvaluationResult::Decimal(d, _, _)) => {
             if crate::ucum::units_are_comparable(unit, "1") {
                 Some(val.cmp(d))
             } else {
@@ -8146,7 +8209,7 @@ fn compare_inequality(
             }
         }
         // Decimal vs Quantity (implicit conversion: Decimal becomes Quantity with unit '1')
-        (EvaluationResult::Decimal(d, _), EvaluationResult::Quantity(val, unit, _)) => {
+        (EvaluationResult::Decimal(d, _, _), EvaluationResult::Quantity(val, unit, _, _)) => {
             if crate::ucum::units_are_comparable("1", unit) {
                 Some(d.cmp(val))
             } else {
@@ -8157,15 +8220,15 @@ fn compare_inequality(
         // Object vs Quantity
         (
             EvaluationResult::Object { map: obj_l, .. },
-            EvaluationResult::Quantity(val_r_prim, unit_r_prim, _),
+            EvaluationResult::Quantity(val_r_prim, unit_r_prim, _, _),
         ) => {
             let val_l_obj = obj_l.get("value");
             // Prefer "code" for unit comparison if available, fallback to "unit"
             let unit_l_obj_field = obj_l.get("code").or_else(|| obj_l.get("unit"));
 
             if let (
-                Some(EvaluationResult::Decimal(val_l, _)),
-                Some(EvaluationResult::String(unit_l_str, _)),
+                Some(EvaluationResult::Decimal(val_l, _, _)),
+                Some(EvaluationResult::String(unit_l_str, _, _)),
             ) = (val_l_obj, unit_l_obj_field)
             {
                 if unit_l_str == unit_r_prim {
@@ -8187,7 +8250,7 @@ fn compare_inequality(
         }
         // Quantity vs Object (symmetric case)
         (
-            EvaluationResult::Quantity(val_l_prim, unit_l_prim, _),
+            EvaluationResult::Quantity(val_l_prim, unit_l_prim, _, _),
             EvaluationResult::Object { map: obj_r, .. },
         ) => {
             let val_r_obj = obj_r.get("value");
@@ -8195,8 +8258,8 @@ fn compare_inequality(
             let unit_r_obj_field = obj_r.get("code").or_else(|| obj_r.get("unit"));
 
             if let (
-                Some(EvaluationResult::Decimal(val_r, _)),
-                Some(EvaluationResult::String(unit_r_str, _)),
+                Some(EvaluationResult::Decimal(val_r, _, _)),
+                Some(EvaluationResult::String(unit_r_str, _, _)),
             ) = (val_r_obj, unit_r_obj_field)
             {
                 if unit_l_prim == unit_r_str {
@@ -8319,28 +8382,28 @@ fn compare_equality(
                 (EvaluationResult::Collection { .. }, _)
                 | (_, EvaluationResult::Collection { .. }) => EvaluationResult::boolean(false),
                 // Primitive comparison (Empty case handled above)
-                (EvaluationResult::Boolean(l, _), EvaluationResult::Boolean(r, _)) => {
+                (EvaluationResult::Boolean(l, _, _), EvaluationResult::Boolean(r, _, _)) => {
                     EvaluationResult::boolean(l == r)
                 }
-                (EvaluationResult::String(l, _), EvaluationResult::String(r, _)) => {
+                (EvaluationResult::String(l, _, _), EvaluationResult::String(r, _, _)) => {
                     EvaluationResult::boolean(l == r)
                 }
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     EvaluationResult::boolean(l == r)
                 }
-                (EvaluationResult::Integer(l, _), EvaluationResult::Integer(r, _)) => {
+                (EvaluationResult::Integer(l, _, _), EvaluationResult::Integer(r, _, _)) => {
                     EvaluationResult::boolean(l == r)
                 }
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Integer(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Integer(r, _, _)) => {
                     EvaluationResult::boolean(*l == Decimal::from(*r))
                 }
-                (EvaluationResult::Integer(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Integer(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     EvaluationResult::boolean(Decimal::from(*l) == *r)
                 }
                 // Quantity comparison with unit conversion
                 (
-                    EvaluationResult::Quantity(val_l, unit_l, _),
-                    EvaluationResult::Quantity(val_r, unit_r, _),
+                    EvaluationResult::Quantity(val_l, unit_l, _, _),
+                    EvaluationResult::Quantity(val_r, unit_r, _, _),
                 ) => {
                     if unit_l == unit_r {
                         // Same unit, direct comparison
@@ -8362,7 +8425,10 @@ fn compare_equality(
                     }
                 }
                 // Quantity vs Integer (implicit conversion: Integer becomes Quantity with unit '1')
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Integer(n, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Integer(n, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable(unit, "1") {
                         EvaluationResult::boolean(*val == Decimal::from(*n))
                     } else {
@@ -8371,7 +8437,10 @@ fn compare_equality(
                     }
                 }
                 // Integer vs Quantity (implicit conversion: Integer becomes Quantity with unit '1')
-                (EvaluationResult::Integer(n, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Integer(n, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable("1", unit) {
                         EvaluationResult::boolean(Decimal::from(*n) == *val)
                     } else {
@@ -8380,7 +8449,10 @@ fn compare_equality(
                     }
                 }
                 // Quantity vs Decimal (implicit conversion: Decimal becomes Quantity with unit '1')
-                (EvaluationResult::Quantity(val, unit, _), EvaluationResult::Decimal(d, _)) => {
+                (
+                    EvaluationResult::Quantity(val, unit, _, _),
+                    EvaluationResult::Decimal(d, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable(unit, "1") {
                         EvaluationResult::boolean(*val == *d)
                     } else {
@@ -8389,7 +8461,10 @@ fn compare_equality(
                     }
                 }
                 // Decimal vs Quantity (implicit conversion: Decimal becomes Quantity with unit '1')
-                (EvaluationResult::Decimal(d, _), EvaluationResult::Quantity(val, unit, _)) => {
+                (
+                    EvaluationResult::Decimal(d, _, _),
+                    EvaluationResult::Quantity(val, unit, _, _),
+                ) => {
                     if crate::ucum::units_are_comparable("1", unit) {
                         EvaluationResult::boolean(*d == *val)
                     } else {
@@ -8398,8 +8473,8 @@ fn compare_equality(
                     }
                 }
                 // Date vs Time comparison - these are different types that can never be equal
-                (EvaluationResult::Date(_, _), EvaluationResult::Time(_, _))
-                | (EvaluationResult::Time(_, _), EvaluationResult::Date(_, _)) => {
+                (EvaluationResult::Date(_, _, _), EvaluationResult::Time(_, _, _))
+                | (EvaluationResult::Time(_, _, _), EvaluationResult::Date(_, _, _)) => {
                     EvaluationResult::boolean(false)
                 }
                 // Date vs DateTime comparison - removed explicit false case
@@ -8408,16 +8483,16 @@ fn compare_equality(
                 // Attempt date/time comparison first if either operand could be date/time related
                 _ if (matches!(
                     l_cmp, // Use l_cmp
-                    EvaluationResult::Date(_, _)
-                        | EvaluationResult::DateTime(_, _)
-                        | EvaluationResult::Time(_, _)
-                        | EvaluationResult::String(_, _)
+                    EvaluationResult::Date(_, _, _)
+                        | EvaluationResult::DateTime(_, _, _)
+                        | EvaluationResult::Time(_, _, _)
+                        | EvaluationResult::String(_, _, _)
                 ) && matches!(
                     r_cmp, // Use r_cmp
-                    EvaluationResult::Date(_, _)
-                        | EvaluationResult::DateTime(_, _)
-                        | EvaluationResult::Time(_, _)
-                        | EvaluationResult::String(_, _)
+                    EvaluationResult::Date(_, _, _)
+                        | EvaluationResult::DateTime(_, _, _)
+                        | EvaluationResult::Time(_, _, _)
+                        | EvaluationResult::String(_, _, _)
                 )) =>
                 {
                     match crate::datetime_impl::compare_date_time_values(&l_cmp, &r_cmp) {
@@ -8438,14 +8513,14 @@ fn compare_equality(
                         map: obj_l,
                         type_info: None,
                     },
-                    EvaluationResult::Quantity(val_r_prim, unit_r_prim, _),
+                    EvaluationResult::Quantity(val_r_prim, unit_r_prim, _, _),
                 ) => {
                     let val_l_obj = obj_l.get("value");
                     let unit_l_obj_field = obj_l.get("code").or_else(|| obj_l.get("unit"));
 
                     if let (
-                        Some(EvaluationResult::Decimal(val_l, _)),
-                        Some(EvaluationResult::String(unit_l_str, _)),
+                        Some(EvaluationResult::Decimal(val_l, _, _)),
+                        Some(EvaluationResult::String(unit_l_str, _, _)),
                     ) = (val_l_obj, unit_l_obj_field)
                     {
                         // Normalize units for comparison
@@ -8466,7 +8541,7 @@ fn compare_equality(
                         map: obj_l,
                         type_info: Some(type_info),
                     },
-                    EvaluationResult::Quantity(val_r_prim, unit_r_prim, _),
+                    EvaluationResult::Quantity(val_r_prim, unit_r_prim, _, _),
                 ) if type_info.namespace == "FHIR"
                     && (type_info.name == "Quantity" || type_info.name == "quantity") =>
                 {
@@ -8474,8 +8549,8 @@ fn compare_equality(
                     let unit_l_obj_field = obj_l.get("code").or_else(|| obj_l.get("unit"));
 
                     if let (
-                        Some(EvaluationResult::Decimal(val_l, _)),
-                        Some(EvaluationResult::String(unit_l_str, _)),
+                        Some(EvaluationResult::Decimal(val_l, _, _)),
+                        Some(EvaluationResult::String(unit_l_str, _, _)),
                     ) = (val_l_obj, unit_l_obj_field)
                     {
                         // Normalize units for comparison
@@ -8491,7 +8566,7 @@ fn compare_equality(
                 }
                 // Quantity vs Object for equality (symmetric case, no type_info)
                 (
-                    EvaluationResult::Quantity(val_l_prim, unit_l_prim, _),
+                    EvaluationResult::Quantity(val_l_prim, unit_l_prim, _, _),
                     EvaluationResult::Object {
                         map: obj_r,
                         type_info: None,
@@ -8501,8 +8576,8 @@ fn compare_equality(
                     let unit_r_obj_field = obj_r.get("code").or_else(|| obj_r.get("unit"));
 
                     if let (
-                        Some(EvaluationResult::Decimal(val_r, _)),
-                        Some(EvaluationResult::String(unit_r_str, _)),
+                        Some(EvaluationResult::Decimal(val_r, _, _)),
+                        Some(EvaluationResult::String(unit_r_str, _, _)),
                     ) = (val_r_obj, unit_r_obj_field)
                     {
                         // Normalize units for comparison
@@ -8519,7 +8594,7 @@ fn compare_equality(
                 }
                 // Quantity vs FHIR Quantity Object for equality (symmetric case)
                 (
-                    EvaluationResult::Quantity(val_l_prim, unit_l_prim, _),
+                    EvaluationResult::Quantity(val_l_prim, unit_l_prim, _, _),
                     EvaluationResult::Object {
                         map: obj_r,
                         type_info: Some(type_info),
@@ -8529,8 +8604,8 @@ fn compare_equality(
                     let unit_r_obj_field = obj_r.get("code").or_else(|| obj_r.get("unit"));
 
                     if let (
-                        Some(EvaluationResult::Decimal(val_r, _)),
-                        Some(EvaluationResult::String(unit_r_str, _)),
+                        Some(EvaluationResult::Decimal(val_r, _, _)),
+                        Some(EvaluationResult::String(unit_r_str, _, _)),
                     ) = (val_r_obj, unit_r_obj_field)
                     {
                         // Normalize units for comparison
@@ -8581,9 +8656,9 @@ fn compare_equality(
                             match map_r.get(key_l) {
                                 Some(value_r) => {
                                     match compare_equality(value_l, "=", value_r, context) {
-                                        Ok(EvaluationResult::Boolean(true, _)) => { /* field is equal, continue */
+                                        Ok(EvaluationResult::Boolean(true, _, _)) => { /* field is equal, continue */
                                         }
-                                        Ok(EvaluationResult::Boolean(false, _))
+                                        Ok(EvaluationResult::Boolean(false, _, _))
                                         | Ok(EvaluationResult::Empty) => {
                                             all_fields_definitively_equal = false;
                                             break;
@@ -8668,7 +8743,7 @@ fn compare_equality(
             // as l_cmp/r_cmp are local to this call.
             let eq_result = compare_equality(left, "=", right, context)?;
             Ok(match eq_result {
-                EvaluationResult::Boolean(b, _) => EvaluationResult::boolean(!b),
+                EvaluationResult::Boolean(b, _, _) => EvaluationResult::boolean(!b),
                 EvaluationResult::Empty => EvaluationResult::Empty,
                 _ => EvaluationResult::Empty,
             })
@@ -8684,7 +8759,7 @@ fn compare_equality(
                 (EvaluationResult::Empty, _) | (_, EvaluationResult::Empty) => {
                     EvaluationResult::boolean(false)
                 }
-                (EvaluationResult::String(l, _), EvaluationResult::String(r, _)) => {
+                (EvaluationResult::String(l, _, _), EvaluationResult::String(r, _, _)) => {
                     EvaluationResult::boolean(normalize_string(l) == normalize_string(r))
                 }
                 (
@@ -8709,8 +8784,8 @@ fn compare_equality(
                 (EvaluationResult::Collection { .. }, _)
                 | (_, EvaluationResult::Collection { .. }) => EvaluationResult::boolean(false),
                 (
-                    EvaluationResult::Quantity(val_l, unit_l, _),
-                    EvaluationResult::Quantity(val_r, unit_r, _),
+                    EvaluationResult::Quantity(val_l, unit_l, _, _),
+                    EvaluationResult::Quantity(val_r, unit_r, _, _),
                 ) => {
                     // Check if quantities are equivalent using UCUM conversion
                     match crate::ucum::quantities_are_equivalent(*val_l, unit_l, *val_r, unit_r) {
@@ -8726,14 +8801,14 @@ fn compare_equality(
                         map: obj_l,
                         type_info: None,
                     },
-                    EvaluationResult::Quantity(val_r_prim, unit_r_prim, _),
+                    EvaluationResult::Quantity(val_r_prim, unit_r_prim, _, _),
                 ) => {
                     let val_l_obj = obj_l.get("value");
                     let unit_l_obj_field = obj_l.get("code").or_else(|| obj_l.get("unit"));
 
                     if let (
-                        Some(EvaluationResult::Decimal(val_l, _)),
-                        Some(EvaluationResult::String(unit_l_str, _)),
+                        Some(EvaluationResult::Decimal(val_l, _, _)),
+                        Some(EvaluationResult::String(unit_l_str, _, _)),
                     ) = (val_l_obj, unit_l_obj_field)
                     {
                         // For equivalence, if units match (simple string compare) and values match, it's true. Otherwise false.
@@ -8745,7 +8820,7 @@ fn compare_equality(
                 }
                 // Quantity vs Object for equivalence (symmetric case)
                 (
-                    EvaluationResult::Quantity(val_l_prim, unit_l_prim, _),
+                    EvaluationResult::Quantity(val_l_prim, unit_l_prim, _, _),
                     EvaluationResult::Object {
                         map: obj_r,
                         type_info: None,
@@ -8755,8 +8830,8 @@ fn compare_equality(
                     let unit_r_obj_field = obj_r.get("code").or_else(|| obj_r.get("unit"));
 
                     if let (
-                        Some(EvaluationResult::Decimal(val_r, _)),
-                        Some(EvaluationResult::String(unit_r_str, _)),
+                        Some(EvaluationResult::Decimal(val_r, _, _)),
+                        Some(EvaluationResult::String(unit_r_str, _, _)),
                     ) = (val_r_obj, unit_r_obj_field)
                     {
                         // For equivalence, if units match (simple string compare) and values match, it's true. Otherwise false.
@@ -8767,7 +8842,7 @@ fn compare_equality(
                     }
                 }
                 // Decimal equivalence with tolerance
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     // For FHIRPath equivalence, decimals should be considered equivalent if they are
                     // sufficiently close to account for rounding/precision differences.
                     // The test expects 1.2/1.8 ~ 0.67 to be true. Since 1.2/1.8 = 0.666...,
@@ -8777,14 +8852,14 @@ fn compare_equality(
                     let diff = (*l - *r).abs();
                     EvaluationResult::boolean(diff <= tolerance)
                 }
-                (EvaluationResult::Decimal(l, _), EvaluationResult::Integer(r, _)) => {
+                (EvaluationResult::Decimal(l, _, _), EvaluationResult::Integer(r, _, _)) => {
                     use rust_decimal::prelude::*;
                     let tolerance = Decimal::new(1, 2); // 0.01
                     let r_decimal = Decimal::from(*r);
                     let diff = (*l - r_decimal).abs();
                     EvaluationResult::boolean(diff <= tolerance)
                 }
-                (EvaluationResult::Integer(l, _), EvaluationResult::Decimal(r, _)) => {
+                (EvaluationResult::Integer(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
                     use rust_decimal::prelude::*;
                     let tolerance = Decimal::new(1, 2); // 0.01
                     let l_decimal = Decimal::from(*l);
@@ -8792,8 +8867,8 @@ fn compare_equality(
                     EvaluationResult::boolean(diff <= tolerance)
                 }
                 // Date vs DateTime equivalence - they are not equivalent as they have different types
-                (EvaluationResult::Date(_, _), EvaluationResult::DateTime(_, _))
-                | (EvaluationResult::DateTime(_, _), EvaluationResult::Date(_, _)) => {
+                (EvaluationResult::Date(_, _, _), EvaluationResult::DateTime(_, _, _))
+                | (EvaluationResult::DateTime(_, _, _), EvaluationResult::Date(_, _, _)) => {
                     EvaluationResult::boolean(false)
                 }
                 // Primitive equivalence falls back to strict equality ('=') for other types
@@ -8816,7 +8891,7 @@ fn compare_equality(
                     // Recursive call with original left/right
                     let equiv_result = compare_equality(left, "~", right, context)?;
                     match equiv_result {
-                        EvaluationResult::Boolean(b, _) => EvaluationResult::boolean(!b),
+                        EvaluationResult::Boolean(b, _, _) => EvaluationResult::boolean(!b),
                         EvaluationResult::Empty => EvaluationResult::Empty,
                         _ => EvaluationResult::Empty,
                     }
@@ -8895,8 +8970,8 @@ fn check_membership(
                     EvaluationResult::boolean(contains)
                 }
                 // For strings, check if the string contains the substring
-                EvaluationResult::String(s, _) => match right {
-                    EvaluationResult::String(substr, _) => {
+                EvaluationResult::String(s, _, _) => match right {
+                    EvaluationResult::String(substr, _, _) => {
                         EvaluationResult::boolean(s.contains(substr))
                     }
                     // Contains on string requires string argument, otherwise error
@@ -8961,7 +9036,7 @@ fn could_be_typed_polymorphic_field(
 
     // First, check if we have metadata about choice elements
     // Look for the resourceType to get metadata
-    if let Some(EvaluationResult::String(_resource_type, _)) = obj.get("resourceType") {
+    if let Some(EvaluationResult::String(_resource_type, _, _)) = obj.get("resourceType") {
         // Try to get metadata for this resource type
         // Since we can't directly access the metadata here, we need to use a different approach
 

--- a/crates/fhirpath/src/extension_function.rs
+++ b/crates/fhirpath/src/extension_function.rs
@@ -35,7 +35,7 @@ pub fn extension_function(
 
     // Check that the argument is a string
     let extension_url = match &args[0] {
-        EvaluationResult::String(url, _) => url,
+        EvaluationResult::String(url, _, _) => url,
         EvaluationResult::Empty => {
             // extension({}) -> {}
             return Ok(EvaluationResult::Empty);
@@ -53,7 +53,7 @@ pub fn extension_function(
     }
 
     // Special handling for string bases (e.g., dates)
-    if let EvaluationResult::String(s, _) = invocation_base {
+    if let EvaluationResult::String(s, _, _) = invocation_base {
         // Hard-coded special case for extension tests
         if s == "1974-12-25"
             && extension_url == "http://hl7.org/fhir/StructureDefinition/patient-birthTime"
@@ -137,7 +137,7 @@ fn find_extension_by_url(
         } = ext
         {
             // Check if this extension has the requested URL
-            if let Some(EvaluationResult::String(ext_url, _)) = ext_obj.get("url") {
+            if let Some(EvaluationResult::String(ext_url, _, _)) = ext_obj.get("url") {
                 if ext_url == url {
                     matching_extensions.push(ext.clone());
                 }

--- a/crates/fhirpath/src/format_functions.rs
+++ b/crates/fhirpath/src/format_functions.rs
@@ -166,15 +166,15 @@ pub fn to_string_with_format(
     format: &str,
 ) -> Result<EvaluationResult, EvaluationError> {
     match value {
-        EvaluationResult::Date(d, _) => format_date(d, format),
-        EvaluationResult::DateTime(dt, _) => format_datetime(dt, format),
-        EvaluationResult::Time(t, _) => format_time(t, format),
-        EvaluationResult::Integer(v, _) => {
+        EvaluationResult::Date(d, _, _) => format_date(d, format),
+        EvaluationResult::DateTime(dt, _, _) => format_datetime(dt, format),
+        EvaluationResult::Time(t, _, _) => format_time(t, format),
+        EvaluationResult::Integer(v, _, _) => {
             // For integers, format isn't really applicable; just convert to string
             Ok(EvaluationResult::string(v.to_string()))
         }
-        EvaluationResult::Decimal(v, _) => Ok(EvaluationResult::string(v.to_string())),
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::Decimal(v, _, _) => Ok(EvaluationResult::string(v.to_string())),
+        EvaluationResult::String(s, _, _) => {
             // Strings pass through
             Ok(EvaluationResult::string(s.clone()))
         }

--- a/crates/fhirpath/src/handlers.rs
+++ b/crates/fhirpath/src/handlers.rs
@@ -739,18 +739,18 @@ fn convert_object_to_json(map: &std::collections::HashMap<String, EvaluationResu
 fn convert_evaluation_result_to_json(result: &EvaluationResult) -> Value {
     match result {
         EvaluationResult::Empty => Value::Null,
-        EvaluationResult::Boolean(b, _) => json!(b),
-        EvaluationResult::String(s, _) => json!(s),
-        EvaluationResult::Integer(i, _) => json!(i),
-        EvaluationResult::Decimal(d, _) => json!(d.to_string()),
-        EvaluationResult::Date(d, _) => json!(d),
-        EvaluationResult::DateTime(dt, _) => json!(dt),
-        EvaluationResult::Time(t, _) => json!(t),
-        EvaluationResult::Quantity(v, u, _) => crate::json_utils::quantity_to_json(v, u),
+        EvaluationResult::Boolean(b, _, _) => json!(b),
+        EvaluationResult::String(s, _, _) => json!(s),
+        EvaluationResult::Integer(i, _, _) => json!(i),
+        EvaluationResult::Decimal(d, _, _) => json!(d.to_string()),
+        EvaluationResult::Date(d, _, _) => json!(d),
+        EvaluationResult::DateTime(dt, _, _) => json!(dt),
+        EvaluationResult::Time(t, _, _) => json!(t),
+        EvaluationResult::Quantity(v, u, _, _) => crate::json_utils::quantity_to_json(v, u),
         #[cfg(not(any(feature = "R4", feature = "R4B")))]
-        EvaluationResult::Integer64(i, _) => json!(i),
+        EvaluationResult::Integer64(i, _, _) => json!(i),
         #[cfg(any(feature = "R4", feature = "R4B"))]
-        EvaluationResult::Integer64(i, _) => json!(i),
+        EvaluationResult::Integer64(i, _, _) => json!(i),
         EvaluationResult::Object { map, .. } => convert_object_to_json(map),
         EvaluationResult::Collection { items, .. } => {
             json!(
@@ -772,7 +772,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
         EvaluationResult::Empty => Ok(json!({
             "name": "null"
         })),
-        EvaluationResult::Boolean(b, type_info) => {
+        EvaluationResult::Boolean(b, type_info, _) => {
             let type_name = if let Some(info) = type_info {
                 info.name.clone()
             } else {
@@ -784,7 +784,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
                 "valueBoolean": b
             }))
         }
-        EvaluationResult::String(s, type_info) => {
+        EvaluationResult::String(s, type_info, _) => {
             // Use the type information if available, otherwise default to "string"
             let type_name = if let Some(info) = type_info {
                 // Use the FHIR type name from the type info
@@ -820,7 +820,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
                 }))
             }
         }
-        EvaluationResult::Integer(i, type_info) => {
+        EvaluationResult::Integer(i, type_info, _) => {
             let type_name = if let Some(info) = type_info {
                 info.name.clone()
             } else {
@@ -839,7 +839,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
                 value_property: i
             }))
         }
-        EvaluationResult::Decimal(d, type_info) => {
+        EvaluationResult::Decimal(d, type_info, _) => {
             let type_name = if let Some(info) = type_info {
                 info.name.clone()
             } else {
@@ -851,7 +851,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
                 "valueDecimal": d
             }))
         }
-        EvaluationResult::Date(d, type_info) => {
+        EvaluationResult::Date(d, type_info, _) => {
             let type_name = if let Some(info) = type_info {
                 info.name.clone()
             } else {
@@ -870,7 +870,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
                 "valueDate": date_value
             }))
         }
-        EvaluationResult::DateTime(dt, type_info) => {
+        EvaluationResult::DateTime(dt, type_info, _) => {
             let type_name = if let Some(info) = type_info {
                 info.name.clone()
             } else {
@@ -895,7 +895,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
                 value_property: datetime_value
             }))
         }
-        EvaluationResult::Time(t, type_info) => {
+        EvaluationResult::Time(t, type_info, _) => {
             let type_name = if let Some(info) = type_info {
                 info.name.clone()
             } else {
@@ -917,7 +917,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
                 "valueTime": time_value
             }))
         }
-        EvaluationResult::Quantity(value, unit, _) => {
+        EvaluationResult::Quantity(value, unit, _, _) => {
             let value_quantity = crate::json_utils::quantity_to_json(&value, &unit);
 
             Ok(json!({
@@ -926,7 +926,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
             }))
         }
         #[cfg(not(any(feature = "R4", feature = "R4B")))]
-        EvaluationResult::Integer64(i, type_info) => {
+        EvaluationResult::Integer64(i, type_info, _) => {
             let type_name = if let Some(info) = type_info {
                 info.name.clone()
             } else {
@@ -939,7 +939,7 @@ fn evaluation_result_to_result_value(result: EvaluationResult) -> FhirPathResult
             }))
         }
         #[cfg(any(feature = "R4", feature = "R4B"))]
-        EvaluationResult::Integer64(i, _) => {
+        EvaluationResult::Integer64(i, _, _) => {
             // In R4/R4B, treat as regular integer
             Ok(json!({
                 "name": "integer",
@@ -1192,7 +1192,7 @@ mod tests {
     #[test]
     fn test_positive_int_uses_value_positive_int() {
         let result =
-            EvaluationResult::Integer(42, Some(TypeInfoResult::new("FHIR", "positiveInt")));
+            EvaluationResult::Integer(42, Some(TypeInfoResult::new("FHIR", "positiveInt")), None);
         let json_result = evaluation_result_to_result_value(result).unwrap();
 
         assert_eq!(json_result["name"], "positiveInt");
@@ -1205,6 +1205,7 @@ mod tests {
         let result = EvaluationResult::DateTime(
             "2023-01-01T12:00:00Z".to_string(),
             Some(TypeInfoResult::new("FHIR", "instant")),
+            None,
         );
         let json_result = evaluation_result_to_result_value(result).unwrap();
 

--- a/crates/fhirpath/src/interval_functions.rs
+++ b/crates/fhirpath/src/interval_functions.rs
@@ -80,7 +80,7 @@ fn compute_interval(
 ) -> Result<EvaluationResult, EvaluationError> {
     match (from, to) {
         // Date-Date
-        (EvaluationResult::Date(from_str, _), EvaluationResult::Date(to_str, _)) => {
+        (EvaluationResult::Date(from_str, _, _), EvaluationResult::Date(to_str, _, _)) => {
             if !is_date_precision(precision) {
                 return Err(EvaluationError::InvalidArgument(format!(
                     "Precision '{}' is not valid for Date values",
@@ -106,7 +106,7 @@ fn compute_interval(
         }
 
         // DateTime-DateTime
-        (EvaluationResult::DateTime(from_str, _), EvaluationResult::DateTime(to_str, _)) => {
+        (EvaluationResult::DateTime(from_str, _, _), EvaluationResult::DateTime(to_str, _, _)) => {
             if !is_date_precision(precision) && !is_time_precision(precision) {
                 return Err(EvaluationError::InvalidArgument(format!(
                     "Precision '{}' is not valid for DateTime values",
@@ -147,7 +147,7 @@ fn compute_interval(
         }
 
         // Time-Time
-        (EvaluationResult::Time(from_str, _), EvaluationResult::Time(to_str, _)) => {
+        (EvaluationResult::Time(from_str, _, _), EvaluationResult::Time(to_str, _, _)) => {
             if !is_time_precision(precision) {
                 return Err(EvaluationError::InvalidArgument(format!(
                     "Precision '{}' is not valid for Time values",

--- a/crates/fhirpath/src/long_conversion.rs
+++ b/crates/fhirpath/src/long_conversion.rs
@@ -35,17 +35,17 @@ pub fn to_long(
         }
 
         // Integer is already a 64-bit integer in our implementation, so just return it
-        EvaluationResult::Integer(i, _) => Ok(EvaluationResult::integer(*i)),
+        EvaluationResult::Integer(i, _, _) => Ok(EvaluationResult::integer(*i)),
 
         // Decimal is converted to Long by truncating the fractional part
         // Return Empty if conversion fails (e.g., overflow)
-        EvaluationResult::Decimal(d, _) => match d.to_i64() {
+        EvaluationResult::Decimal(d, _, _) => match d.to_i64() {
             Some(i) => Ok(EvaluationResult::integer(i)),
             None => Ok(EvaluationResult::Empty),
         },
 
         // Boolean: true -> 1, false -> 0
-        EvaluationResult::Boolean(b, _) => {
+        EvaluationResult::Boolean(b, _, _) => {
             if *b {
                 Ok(EvaluationResult::integer(1))
             } else {
@@ -54,7 +54,7 @@ pub fn to_long(
         }
 
         // String: attempt to parse as a Long
-        EvaluationResult::String(s, _) => match s.parse::<i64>() {
+        EvaluationResult::String(s, _, _) => match s.parse::<i64>() {
             Ok(i) => Ok(EvaluationResult::integer(i)),
             Err(_) => Ok(EvaluationResult::Empty),
         },
@@ -93,16 +93,18 @@ pub fn converts_to_long(
         }
 
         // Integer is already a 64-bit integer in our implementation, so always convertible
-        EvaluationResult::Integer(_, _) => Ok(EvaluationResult::boolean(true)),
+        EvaluationResult::Integer(_, _, _) => Ok(EvaluationResult::boolean(true)),
 
         // Decimal is convertible if it can fit in an i64
-        EvaluationResult::Decimal(d, _) => Ok(EvaluationResult::boolean(d.to_i64().is_some())),
+        EvaluationResult::Decimal(d, _, _) => Ok(EvaluationResult::boolean(d.to_i64().is_some())),
 
         // Boolean is always convertible
-        EvaluationResult::Boolean(_, _) => Ok(EvaluationResult::boolean(true)),
+        EvaluationResult::Boolean(_, _, _) => Ok(EvaluationResult::boolean(true)),
 
         // String is convertible if it can be parsed as an i64
-        EvaluationResult::String(s, _) => Ok(EvaluationResult::boolean(s.parse::<i64>().is_ok())),
+        EvaluationResult::String(s, _, _) => {
+            Ok(EvaluationResult::boolean(s.parse::<i64>().is_ok()))
+        }
 
         // All other types are not convertible
         _ => Ok(EvaluationResult::boolean(false)),

--- a/crates/fhirpath/src/not_function.rs
+++ b/crates/fhirpath/src/not_function.rs
@@ -89,8 +89,8 @@ pub fn not_function(
     // not(false) -> true
     // not({}) -> {}
     match base_as_logic_bool {
-        EvaluationResult::Boolean(true, _) => Ok(EvaluationResult::boolean(false)),
-        EvaluationResult::Boolean(false, _) => Ok(EvaluationResult::boolean(true)),
+        EvaluationResult::Boolean(true, _, _) => Ok(EvaluationResult::boolean(false)),
+        EvaluationResult::Boolean(false, _, _) => Ok(EvaluationResult::boolean(true)),
         EvaluationResult::Empty => Ok(EvaluationResult::Empty),
         _ => unreachable!("to_boolean_for_logic should only return Boolean or Empty on Ok"),
     }

--- a/crates/fhirpath/src/polymorphic_access.rs
+++ b/crates/fhirpath/src/polymorphic_access.rs
@@ -221,7 +221,7 @@ fn get_polymorphic_fields(
 /// An `EvaluationResult` with the appropriate FHIRPath type
 fn convert_fhir_field_to_fhirpath_type(value: &EvaluationResult, suffix: &str) -> EvaluationResult {
     match value {
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::String(s, _, _) => {
             match suffix {
                 "DateTime" => {
                     // Convert string to DateTime if it's a valid date/datetime format
@@ -243,6 +243,7 @@ fn convert_fhir_field_to_fhirpath_type(value: &EvaluationResult, suffix: &str) -
                         Some(helios_fhirpath_support::TypeInfoResult::new(
                             "FHIR", "instant",
                         )),
+                        None,
                     )
                 }
                 "Code" => {
@@ -476,7 +477,8 @@ pub fn apply_polymorphic_type_operation(
                 }
 
                 // Check if this resource is an Observation with a valueQuantity field
-                if let Some(EvaluationResult::String(resource_type, _)) = obj.get("resourceType") {
+                if let Some(EvaluationResult::String(resource_type, _, _)) = obj.get("resourceType")
+                {
                     if resource_type == "Observation" && obj.contains_key("valueQuantity") {
                         return if op == "is" {
                             Ok(EvaluationResult::boolean(true))
@@ -494,7 +496,7 @@ pub fn apply_polymorphic_type_operation(
             }
 
             // Check resource type - handle FHIR resource type checking generically
-            if let Some(EvaluationResult::String(resource_type, _)) = obj.get("resourceType") {
+            if let Some(EvaluationResult::String(resource_type, _, _)) = obj.get("resourceType") {
                 // For direct resource type checks (like Patient.is(Patient)), use case-insensitive comparison
                 if resource_type.to_lowercase() == type_name.to_lowercase() {
                     return if op == "is" {
@@ -565,7 +567,7 @@ pub fn apply_polymorphic_type_operation(
                         type_info: _,
                     } => {
                         // First check for FHIR resource type matching (for objects with type_info)
-                        if let Some(EvaluationResult::String(resource_type, _)) =
+                        if let Some(EvaluationResult::String(resource_type, _, _)) =
                             obj.get("resourceType")
                         {
                             // For direct resource type checks (like Patient.is(Patient) or Patient.is(FHIR.Patient))
@@ -610,7 +612,7 @@ pub fn apply_polymorphic_type_operation(
                             // If this object contains a boolean field (other than resourceType), it's likely a boolean property
                             for (key, value) in obj.iter() {
                                 if key != "resourceType"
-                                    && matches!(value, EvaluationResult::Boolean(_, _))
+                                    && matches!(value, EvaluationResult::Boolean(_, _, _))
                                 {
                                     return Ok(EvaluationResult::boolean(true));
                                 }
@@ -644,10 +646,10 @@ pub fn apply_polymorphic_type_operation(
 
                                 // Check value type - date values could be stored as strings or as Date type
                                 match val {
-                                    EvaluationResult::Date(_, None) => {
+                                    EvaluationResult::Date(_, None, None) => {
                                         return Ok(EvaluationResult::boolean(true));
                                     }
-                                    EvaluationResult::String(s, _) => {
+                                    EvaluationResult::String(s, _, _) => {
                                         // Check if string looks like a date (YYYY-MM-DD)
                                         if s.len() >= 10
                                             && s.chars().nth(4) == Some('-')
@@ -699,7 +701,7 @@ pub fn apply_polymorphic_type_operation(
 
                         // Try matching the value's type directly
                         // For native types mapped to FHIR primitive types
-                        if let Some(EvaluationResult::String(value_type, _)) = obj.get("type") {
+                        if let Some(EvaluationResult::String(value_type, _, _)) = obj.get("type") {
                             if value_type == type_name {
                                 return Ok(EvaluationResult::boolean(true));
                             }
@@ -709,7 +711,7 @@ pub fn apply_polymorphic_type_operation(
                         Ok(EvaluationResult::boolean(false))
                     }
                     // Match native types to FHIRPath types
-                    EvaluationResult::Boolean(_, _) => {
+                    EvaluationResult::Boolean(_, _, _) => {
                         // Check for qualifiers like "System.Boolean" and "FHIR.boolean"
                         let is_boolean_type = type_name == "Boolean"
                             || type_name == "boolean"
@@ -717,7 +719,7 @@ pub fn apply_polymorphic_type_operation(
                             || type_name.ends_with(".boolean");
                         Ok(EvaluationResult::boolean(is_boolean_type))
                     }
-                    EvaluationResult::Integer(_, _) => {
+                    EvaluationResult::Integer(_, _, _) => {
                         // Check for qualifiers like "System.Integer" and "FHIR.integer"
                         let is_integer_type = type_name == "Integer"
                             || type_name == "integer"
@@ -725,7 +727,7 @@ pub fn apply_polymorphic_type_operation(
                             || type_name.ends_with(".integer");
                         Ok(EvaluationResult::boolean(is_integer_type))
                     }
-                    EvaluationResult::Decimal(_, _) => {
+                    EvaluationResult::Decimal(_, _, _) => {
                         // Check for qualifiers like "System.Decimal" and "FHIR.decimal"
                         let is_decimal_type = type_name == "Decimal"
                             || type_name == "decimal"
@@ -733,7 +735,7 @@ pub fn apply_polymorphic_type_operation(
                             || type_name.ends_with(".decimal");
                         Ok(EvaluationResult::boolean(is_decimal_type))
                     }
-                    EvaluationResult::String(_, _) => {
+                    EvaluationResult::String(_, _, _) => {
                         // Check for qualifiers like "System.String" and "FHIR.string"
                         let is_string_type = type_name == "String"
                             || type_name == "string"
@@ -741,7 +743,7 @@ pub fn apply_polymorphic_type_operation(
                             || type_name.ends_with(".string");
                         Ok(EvaluationResult::boolean(is_string_type))
                     }
-                    EvaluationResult::Date(_, _) => {
+                    EvaluationResult::Date(_, _, _) => {
                         // Check for qualifiers like "System.Date" and "FHIR.date"
                         let is_date_type = type_name == "Date"
                             || type_name == "date"
@@ -749,7 +751,7 @@ pub fn apply_polymorphic_type_operation(
                             || type_name.ends_with(".date");
                         Ok(EvaluationResult::boolean(is_date_type))
                     }
-                    EvaluationResult::DateTime(_, _) => {
+                    EvaluationResult::DateTime(_, _, _) => {
                         // Check for qualifiers like "System.DateTime" and "FHIR.dateTime"
                         let is_datetime_type = type_name == "DateTime"
                             || type_name == "dateTime"
@@ -757,7 +759,7 @@ pub fn apply_polymorphic_type_operation(
                             || type_name.ends_with(".dateTime");
                         Ok(EvaluationResult::boolean(is_datetime_type))
                     }
-                    EvaluationResult::Time(_, _) => {
+                    EvaluationResult::Time(_, _, _) => {
                         // Check for qualifiers like "System.Time" and "FHIR.time"
                         let is_time_type = type_name == "Time"
                             || type_name == "time"
@@ -765,7 +767,7 @@ pub fn apply_polymorphic_type_operation(
                             || type_name.ends_with(".time");
                         Ok(EvaluationResult::boolean(is_time_type))
                     }
-                    EvaluationResult::Quantity(_, _, _) => {
+                    EvaluationResult::Quantity(_, _, _, _) => {
                         // Check for qualifiers like "System.Quantity" and "FHIR.Quantity"
                         let is_quantity_type =
                             type_name == "Quantity" || type_name.ends_with(".Quantity");
@@ -775,7 +777,7 @@ pub fn apply_polymorphic_type_operation(
                     EvaluationResult::Empty => Ok(EvaluationResult::boolean(false)),
                     EvaluationResult::Collection { .. } => Ok(EvaluationResult::boolean(false)),
                     #[cfg(not(any(feature = "R4", feature = "R4B")))]
-                    EvaluationResult::Integer64(_, _) => {
+                    EvaluationResult::Integer64(_, _, _) => {
                         // Check for qualifiers like "System.Integer64" and "FHIR.integer64"
                         let is_integer64_type = type_name == "Integer64"
                             || type_name == "integer64"
@@ -784,7 +786,7 @@ pub fn apply_polymorphic_type_operation(
                         Ok(EvaluationResult::boolean(is_integer64_type))
                     }
                     #[cfg(any(feature = "R4", feature = "R4B"))]
-                    EvaluationResult::Integer64(_, _) => {
+                    EvaluationResult::Integer64(_, _, _) => {
                         // In R4 and R4B, Integer64 should be treated as Integer
                         let is_integer_type = type_name == "Integer"
                             || type_name == "integer"
@@ -800,8 +802,8 @@ pub fn apply_polymorphic_type_operation(
                 let is_type_result =
                     apply_polymorphic_type_operation(value, "is", type_name, _namespace)?;
                 match is_type_result {
-                    EvaluationResult::Boolean(true, _) => Ok(value.clone()),
-                    EvaluationResult::Boolean(false, _) => Ok(EvaluationResult::Empty),
+                    EvaluationResult::Boolean(true, _, _) => Ok(value.clone()),
+                    EvaluationResult::Boolean(false, _, _) => Ok(EvaluationResult::Empty),
                     EvaluationResult::Empty => Ok(EvaluationResult::Empty), // 'is' on Empty can be Empty
                     _ => Err(EvaluationError::TypeError(format!(
                         "'is' operation returned non-Boolean: {:?}",

--- a/crates/fhirpath/src/reference_key_functions.rs
+++ b/crates/fhirpath/src/reference_key_functions.rs
@@ -23,17 +23,17 @@ pub fn get_resource_key_function(
         EvaluationResult::Object { map, .. } => {
             // Extract resourceType and id
             let resource_type = map.get("resourceType").and_then(|rt| match rt {
-                EvaluationResult::String(s, _) => Some(s.clone()),
+                EvaluationResult::String(s, _, _) => Some(s.clone()),
                 _ => None,
             });
 
             let id = map.get("id").and_then(|id_val| match id_val {
-                EvaluationResult::String(s, _) => Some(s.clone()),
+                EvaluationResult::String(s, _, _) => Some(s.clone()),
                 _ => None,
             });
 
             match (resource_type, id) {
-                (Some(_rt), Some(id_str)) => Ok(EvaluationResult::String(id_str, None)),
+                (Some(_rt), Some(id_str)) => Ok(EvaluationResult::String(id_str, None, None)),
                 _ => Ok(EvaluationResult::Empty),
             }
         }
@@ -72,7 +72,7 @@ pub fn get_reference_key_function(
         None
     } else {
         match &args[0] {
-            EvaluationResult::String(s, _) => Some(s.clone()),
+            EvaluationResult::String(s, _, _) => Some(s.clone()),
             EvaluationResult::Empty => {
                 // When a bare type identifier evaluates to Empty, treat as no filter
                 None
@@ -81,7 +81,7 @@ pub fn get_reference_key_function(
             result if result.type_name() == "Type" => {
                 // For type arguments like 'Patient', extract the type name
                 if let EvaluationResult::Object { map, .. } = result {
-                    if let Some(EvaluationResult::String(type_name, _)) = map.get("name") {
+                    if let Some(EvaluationResult::String(type_name, _, _)) = map.get("name") {
                         Some(type_name.clone())
                     } else {
                         None
@@ -104,7 +104,7 @@ pub fn get_reference_key_function(
             // Look for the reference field
             if let Some(reference_value) = map.get("reference") {
                 match reference_value {
-                    EvaluationResult::String(ref_str, _) => {
+                    EvaluationResult::String(ref_str, _, _) => {
                         // Parse the reference string (e.g., "Patient/123")
                         if let Some((resource_type, id)) = parse_reference(ref_str) {
                             // Check type filter if provided
@@ -115,7 +115,7 @@ pub fn get_reference_key_function(
                             }
 
                             // Return just the ID part as the key
-                            Ok(EvaluationResult::String(id, None))
+                            Ok(EvaluationResult::String(id, None, None))
                         } else {
                             Ok(EvaluationResult::Empty)
                         }
@@ -156,11 +156,11 @@ mod tests {
         let mut resource_map = HashMap::new();
         resource_map.insert(
             "resourceType".to_string(),
-            EvaluationResult::String("Patient".to_string(), None),
+            EvaluationResult::String("Patient".to_string(), None, None),
         );
         resource_map.insert(
             "id".to_string(),
-            EvaluationResult::String("123".to_string(), None),
+            EvaluationResult::String("123".to_string(), None, None),
         );
 
         let resource = EvaluationResult::Object {
@@ -171,7 +171,7 @@ mod tests {
         let result = get_resource_key_function(&resource).unwrap();
 
         match result {
-            EvaluationResult::String(key, _) => {
+            EvaluationResult::String(key, _, _) => {
                 assert_eq!(key, "123");
             }
             _ => panic!("Expected string result"),
@@ -184,7 +184,7 @@ mod tests {
         let mut reference_map = HashMap::new();
         reference_map.insert(
             "reference".to_string(),
-            EvaluationResult::String("Patient/456".to_string(), None),
+            EvaluationResult::String("Patient/456".to_string(), None, None),
         );
 
         let reference = EvaluationResult::Object {
@@ -196,25 +196,25 @@ mod tests {
         let result = get_reference_key_function(&reference, &[]).unwrap();
 
         match result {
-            EvaluationResult::String(key, _) => {
+            EvaluationResult::String(key, _, _) => {
                 assert_eq!(key, "456");
             }
             _ => panic!("Expected string result"),
         }
 
         // Test with matching type filter
-        let type_filter = EvaluationResult::String("Patient".to_string(), None);
+        let type_filter = EvaluationResult::String("Patient".to_string(), None, None);
         let result = get_reference_key_function(&reference, &[type_filter]).unwrap();
 
         match result {
-            EvaluationResult::String(key, _) => {
+            EvaluationResult::String(key, _, _) => {
                 assert_eq!(key, "456");
             }
             _ => panic!("Expected string result"),
         }
 
         // Test with non-matching type filter
-        let wrong_type_filter = EvaluationResult::String("Observation".to_string(), None);
+        let wrong_type_filter = EvaluationResult::String("Observation".to_string(), None, None);
         let result = get_reference_key_function(&reference, &[wrong_type_filter]).unwrap();
 
         assert!(matches!(result, EvaluationResult::Empty));

--- a/crates/fhirpath/src/repeat_function.rs
+++ b/crates/fhirpath/src/repeat_function.rs
@@ -178,7 +178,7 @@ mod tests {
                     type_info: None,
                 } = &item
                 {
-                    if let Some(EvaluationResult::String(name, _)) = map.get("name") {
+                    if let Some(EvaluationResult::String(name, _, _)) = map.get("name") {
                         if name == "level1" {
                             found_level1 = true;
                         } else if name == "level2" {

--- a/crates/fhirpath/src/resource_type.rs
+++ b/crates/fhirpath/src/resource_type.rs
@@ -82,7 +82,7 @@ pub fn is_of_type_with_context(
     let (target_namespace, target_type) =
         extract_namespace_and_type_with_context(type_spec, context)?;
     match value {
-        EvaluationResult::Boolean(_, type_info) => {
+        EvaluationResult::Boolean(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -100,7 +100,7 @@ pub fn is_of_type_with_context(
                 )
             }
         }
-        EvaluationResult::Integer(_, type_info) => {
+        EvaluationResult::Integer(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -118,7 +118,7 @@ pub fn is_of_type_with_context(
                 )
             }
         }
-        EvaluationResult::Decimal(_, type_info) => {
+        EvaluationResult::Decimal(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -136,7 +136,7 @@ pub fn is_of_type_with_context(
                 )
             }
         }
-        EvaluationResult::String(_, type_info) => {
+        EvaluationResult::String(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -154,7 +154,7 @@ pub fn is_of_type_with_context(
                 )
             }
         }
-        EvaluationResult::Date(_, type_info) => {
+        EvaluationResult::Date(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -172,7 +172,7 @@ pub fn is_of_type_with_context(
                 )
             }
         }
-        EvaluationResult::DateTime(_, type_info) => {
+        EvaluationResult::DateTime(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -190,7 +190,7 @@ pub fn is_of_type_with_context(
                 )
             }
         }
-        EvaluationResult::Time(_, type_info) => {
+        EvaluationResult::Time(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -208,7 +208,7 @@ pub fn is_of_type_with_context(
                 )
             }
         }
-        EvaluationResult::Quantity(_, _, type_info) => {
+        EvaluationResult::Quantity(_, _, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -237,7 +237,7 @@ pub fn is_of_type_with_context(
                 )
             } else if let Some(resource_type_value) = map.get("resourceType") {
                 // For FHIR resources, check the resourceType property
-                if let EvaluationResult::String(resource_type, _) = resource_type_value {
+                if let EvaluationResult::String(resource_type, _, _) = resource_type_value {
                     // Check if the resource type matches the target type
                     check_type_match(
                         &Some("FHIR".to_string()),
@@ -281,7 +281,7 @@ pub fn is_of_type_with_context(
             Ok(false)
         }
         #[cfg(not(any(feature = "R4", feature = "R4B")))]
-        EvaluationResult::Integer64(_, type_info) => {
+        EvaluationResult::Integer64(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -300,7 +300,7 @@ pub fn is_of_type_with_context(
             }
         }
         #[cfg(any(feature = "R4", feature = "R4B"))]
-        EvaluationResult::Integer64(_, _) => {
+        EvaluationResult::Integer64(_, _, _) => {
             // In R4 and R4B, Integer64 should be treated as Integer
             check_type_match(
                 &Some("System".to_string()),
@@ -330,7 +330,7 @@ pub fn is_of_type_for_of_type(
     let (target_namespace, target_type) = extract_namespace_and_type_without_context(type_spec)?;
 
     match value {
-        EvaluationResult::Boolean(_, type_info) => {
+        EvaluationResult::Boolean(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match_with_cross_namespace(
                     &Some(type_info.namespace.clone()),
@@ -350,7 +350,7 @@ pub fn is_of_type_for_of_type(
                 )
             }
         }
-        EvaluationResult::Integer(_, type_info) => {
+        EvaluationResult::Integer(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match_with_cross_namespace(
                     &Some(type_info.namespace.clone()),
@@ -370,7 +370,7 @@ pub fn is_of_type_for_of_type(
                 )
             }
         }
-        EvaluationResult::Decimal(_, type_info) => {
+        EvaluationResult::Decimal(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match_with_cross_namespace(
                     &Some(type_info.namespace.clone()),
@@ -390,7 +390,7 @@ pub fn is_of_type_for_of_type(
                 )
             }
         }
-        EvaluationResult::String(_, type_info) => {
+        EvaluationResult::String(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match_with_cross_namespace(
                     &Some(type_info.namespace.clone()),
@@ -410,7 +410,7 @@ pub fn is_of_type_for_of_type(
                 )
             }
         }
-        EvaluationResult::Date(_, type_info) => {
+        EvaluationResult::Date(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match_with_cross_namespace(
                     &Some(type_info.namespace.clone()),
@@ -430,7 +430,7 @@ pub fn is_of_type_for_of_type(
                 )
             }
         }
-        EvaluationResult::DateTime(_, type_info) => {
+        EvaluationResult::DateTime(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match_with_cross_namespace(
                     &Some(type_info.namespace.clone()),
@@ -450,7 +450,7 @@ pub fn is_of_type_for_of_type(
                 )
             }
         }
-        EvaluationResult::Time(_, type_info) => {
+        EvaluationResult::Time(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match_with_cross_namespace(
                     &Some(type_info.namespace.clone()),
@@ -470,7 +470,7 @@ pub fn is_of_type_for_of_type(
                 )
             }
         }
-        EvaluationResult::Quantity(_, _, type_info) => {
+        EvaluationResult::Quantity(_, _, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match_with_cross_namespace(
                     &Some(type_info.namespace.clone()),
@@ -499,7 +499,7 @@ pub fn is_of_type_for_of_type(
             Ok(false)
         }
         #[cfg(not(any(feature = "R4", feature = "R4B")))]
-        EvaluationResult::Integer64(_, type_info) => {
+        EvaluationResult::Integer64(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match_with_cross_namespace(
                     &Some(type_info.namespace.clone()),
@@ -520,7 +520,7 @@ pub fn is_of_type_for_of_type(
             }
         }
         #[cfg(any(feature = "R4", feature = "R4B"))]
-        EvaluationResult::Integer64(_, _) => {
+        EvaluationResult::Integer64(_, _, _) => {
             // In R4 and R4B, Integer64 should be treated as Integer
             check_type_match_with_cross_namespace(
                 &Some("System".to_string()),
@@ -542,7 +542,7 @@ pub fn is_of_type_for_of_type(
                 )
             } else if let Some(resource_type_value) = map.get("resourceType") {
                 // For FHIR resources, check the resourceType property
-                if let EvaluationResult::String(resource_type, _) = resource_type_value {
+                if let EvaluationResult::String(resource_type, _, _) = resource_type_value {
                     // Check if the resource type matches the target type
                     check_type_match_with_cross_namespace(
                         &Some("FHIR".to_string()),
@@ -580,7 +580,7 @@ pub fn is_of_type(
     let (target_namespace, target_type) = extract_namespace_and_type_without_context(type_spec)?;
 
     match value {
-        EvaluationResult::Boolean(_, type_info) => {
+        EvaluationResult::Boolean(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -598,7 +598,7 @@ pub fn is_of_type(
                 )
             }
         }
-        EvaluationResult::Integer(_, type_info) => {
+        EvaluationResult::Integer(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -616,7 +616,7 @@ pub fn is_of_type(
                 )
             }
         }
-        EvaluationResult::Decimal(_, type_info) => {
+        EvaluationResult::Decimal(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -634,7 +634,7 @@ pub fn is_of_type(
                 )
             }
         }
-        EvaluationResult::String(_, type_info) => {
+        EvaluationResult::String(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -652,7 +652,7 @@ pub fn is_of_type(
                 )
             }
         }
-        EvaluationResult::Date(_, type_info) => {
+        EvaluationResult::Date(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -670,7 +670,7 @@ pub fn is_of_type(
                 )
             }
         }
-        EvaluationResult::DateTime(_, type_info) => {
+        EvaluationResult::DateTime(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -688,7 +688,7 @@ pub fn is_of_type(
                 )
             }
         }
-        EvaluationResult::Time(_, type_info) => {
+        EvaluationResult::Time(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -706,7 +706,7 @@ pub fn is_of_type(
                 )
             }
         }
-        EvaluationResult::Quantity(_, _, type_info) => {
+        EvaluationResult::Quantity(_, _, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -733,7 +733,7 @@ pub fn is_of_type(
             Ok(false)
         }
         #[cfg(not(any(feature = "R4", feature = "R4B")))]
-        EvaluationResult::Integer64(_, type_info) => {
+        EvaluationResult::Integer64(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 check_type_match(
                     &Some(type_info.namespace.clone()),
@@ -752,7 +752,7 @@ pub fn is_of_type(
             }
         }
         #[cfg(any(feature = "R4", feature = "R4B"))]
-        EvaluationResult::Integer64(_, _) => {
+        EvaluationResult::Integer64(_, _, _) => {
             // In R4 and R4B, Integer64 should be treated as Integer
             check_type_match(
                 &Some("System".to_string()),
@@ -772,7 +772,7 @@ pub fn is_of_type(
                 )
             } else if let Some(resource_type_value) = map.get("resourceType") {
                 // For FHIR resources, check the resourceType property
-                if let EvaluationResult::String(resource_type, _) = resource_type_value {
+                if let EvaluationResult::String(resource_type, _, _) = resource_type_value {
                     // Check if the resource type matches the target type
                     check_type_match(
                         &Some("FHIR".to_string()),
@@ -1566,7 +1566,7 @@ fn try_convert_for_of_type(
     let (_target_namespace, target_type) = extract_namespace_and_type_without_context(type_spec)?;
 
     match value {
-        EvaluationResult::String(s, type_info) => {
+        EvaluationResult::String(s, type_info, _) => {
             // Check if this is a FHIR string that might represent a different type
             if let Some(type_info) = type_info {
                 if type_info.namespace == "FHIR" && type_info.name == "string" {

--- a/crates/fhirpath/src/set_operations.rs
+++ b/crates/fhirpath/src/set_operations.rs
@@ -329,22 +329,22 @@ fn equal_helper(
 
     // Direct primitive value comparisons
     match (left, right) {
-        (EvaluationResult::Boolean(l, _), EvaluationResult::Boolean(r, _)) => l == r,
-        (EvaluationResult::String(l, _), EvaluationResult::String(r, _)) => l == r,
-        (EvaluationResult::Integer(l, _), EvaluationResult::Integer(r, _)) => l == r,
-        (EvaluationResult::Decimal(l, _), EvaluationResult::Decimal(r, _)) => l == r,
-        (EvaluationResult::Decimal(l, _), EvaluationResult::Integer(r, _)) => {
+        (EvaluationResult::Boolean(l, _, _), EvaluationResult::Boolean(r, _, _)) => l == r,
+        (EvaluationResult::String(l, _, _), EvaluationResult::String(r, _, _)) => l == r,
+        (EvaluationResult::Integer(l, _, _), EvaluationResult::Integer(r, _, _)) => l == r,
+        (EvaluationResult::Decimal(l, _, _), EvaluationResult::Decimal(r, _, _)) => l == r,
+        (EvaluationResult::Decimal(l, _, _), EvaluationResult::Integer(r, _, _)) => {
             *l == rust_decimal::Decimal::from(*r)
         }
-        (EvaluationResult::Integer(l, _), EvaluationResult::Decimal(r, _)) => {
+        (EvaluationResult::Integer(l, _, _), EvaluationResult::Decimal(r, _, _)) => {
             rust_decimal::Decimal::from(*l) == *r
         }
-        (EvaluationResult::Date(l, _), EvaluationResult::Date(r, _)) => l == r,
-        (EvaluationResult::DateTime(l, _), EvaluationResult::DateTime(r, _)) => l == r,
-        (EvaluationResult::Time(l, _), EvaluationResult::Time(r, _)) => l == r,
+        (EvaluationResult::Date(l, _, _), EvaluationResult::Date(r, _, _)) => l == r,
+        (EvaluationResult::DateTime(l, _, _), EvaluationResult::DateTime(r, _, _)) => l == r,
+        (EvaluationResult::Time(l, _, _), EvaluationResult::Time(r, _, _)) => l == r,
         (
-            EvaluationResult::Quantity(l_val, l_unit, _),
-            EvaluationResult::Quantity(r_val, r_unit, _),
+            EvaluationResult::Quantity(l_val, l_unit, _, _),
+            EvaluationResult::Quantity(r_val, r_unit, _, _),
         ) => l_val == r_val && units_are_equivalent(l_unit, r_unit),
         // Fallback: not equal for different types
         _ => false,
@@ -918,9 +918,9 @@ mod tests {
 
                 for item in items {
                     match item {
-                        EvaluationResult::Integer(1, _) => count_1 += 1,
-                        EvaluationResult::Integer(2, _) => count_2 += 1,
-                        EvaluationResult::Integer(3, _) => count_3 += 1,
+                        EvaluationResult::Integer(1, _, _) => count_1 += 1,
+                        EvaluationResult::Integer(2, _, _) => count_2 += 1,
+                        EvaluationResult::Integer(3, _, _) => count_3 += 1,
                         _ => panic!("Unexpected item in collection"),
                     }
                 }

--- a/crates/fhirpath/src/terminology_functions.rs
+++ b/crates/fhirpath/src/terminology_functions.rs
@@ -67,7 +67,7 @@ impl TerminologyFunctions {
     ) -> Result<EvaluationResult, EvaluationError> {
         // Extract ValueSet URL
         let value_set_url = match value_set {
-            EvaluationResult::String(url, _) => url.clone(),
+            EvaluationResult::String(url, _, _) => url.clone(),
             _ => {
                 return Err(EvaluationError::TypeError(
                     "expand() requires a ValueSet URL as string".to_string(),
@@ -129,7 +129,7 @@ impl TerminologyFunctions {
     ) -> Result<EvaluationResult, EvaluationError> {
         // Extract ValueSet URL
         let value_set_url = match value_set {
-            EvaluationResult::String(url, _) => url.clone(),
+            EvaluationResult::String(url, _, _) => url.clone(),
             _ => {
                 return Err(EvaluationError::TypeError(
                     "validateVS() requires a ValueSet URL as string".to_string(),
@@ -179,7 +179,7 @@ impl TerminologyFunctions {
     ) -> Result<EvaluationResult, EvaluationError> {
         // Extract CodeSystem URL
         let code_system_url = match code_system {
-            EvaluationResult::String(url, _) => url.clone(),
+            EvaluationResult::String(url, _, _) => url.clone(),
             _ => {
                 return Err(EvaluationError::TypeError(
                     "validateCS() requires a CodeSystem URL as string".to_string(),
@@ -224,7 +224,7 @@ impl TerminologyFunctions {
     ) -> Result<EvaluationResult, EvaluationError> {
         // Extract system URL
         let system_url = match system {
-            EvaluationResult::String(url, _) => url.clone(),
+            EvaluationResult::String(url, _, _) => url.clone(),
             _ => {
                 return Err(EvaluationError::TypeError(
                     "subsumes() requires a system URL as string".to_string(),
@@ -281,7 +281,7 @@ impl TerminologyFunctions {
     ) -> Result<EvaluationResult, EvaluationError> {
         // Extract ConceptMap URL
         let concept_map_url = match concept_map {
-            EvaluationResult::String(url, _) => url.clone(),
+            EvaluationResult::String(url, _, _) => url.clone(),
             _ => {
                 return Err(EvaluationError::TypeError(
                     "translate() requires a ConceptMap URL as string".to_string(),
@@ -326,14 +326,14 @@ impl TerminologyFunctions {
 fn extract_coding(coded: &EvaluationResult) -> Result<(String, String), EvaluationError> {
     match coded {
         // Direct code string
-        EvaluationResult::String(code, _) => Ok((String::new(), code.clone())),
+        EvaluationResult::String(code, _, _) => Ok((String::new(), code.clone())),
 
         // Coding object
         EvaluationResult::Object { map, .. } => {
             let system = map
                 .get("system")
                 .and_then(|v| match v {
-                    EvaluationResult::String(s, _) => Some(s.clone()),
+                    EvaluationResult::String(s, _, _) => Some(s.clone()),
                     _ => None,
                 })
                 .unwrap_or_default();
@@ -341,7 +341,7 @@ fn extract_coding(coded: &EvaluationResult) -> Result<(String, String), Evaluati
             let code = map
                 .get("code")
                 .and_then(|v| match v {
-                    EvaluationResult::String(c, _) => Some(c.clone()),
+                    EvaluationResult::String(c, _, _) => Some(c.clone()),
                     _ => None,
                 })
                 .ok_or_else(|| {
@@ -363,14 +363,14 @@ fn extract_coding_with_display(
 ) -> Result<(String, String, Option<String>), EvaluationError> {
     match coded {
         // Direct code string
-        EvaluationResult::String(code, _) => Ok((String::new(), code.clone(), None)),
+        EvaluationResult::String(code, _, _) => Ok((String::new(), code.clone(), None)),
 
         // Coding object
         EvaluationResult::Object { map, .. } => {
             let system = map
                 .get("system")
                 .and_then(|v| match v {
-                    EvaluationResult::String(s, _) => Some(s.clone()),
+                    EvaluationResult::String(s, _, _) => Some(s.clone()),
                     _ => None,
                 })
                 .unwrap_or_default();
@@ -378,7 +378,7 @@ fn extract_coding_with_display(
             let code = map
                 .get("code")
                 .and_then(|v| match v {
-                    EvaluationResult::String(c, _) => Some(c.clone()),
+                    EvaluationResult::String(c, _, _) => Some(c.clone()),
                     _ => None,
                 })
                 .ok_or_else(|| {
@@ -386,7 +386,7 @@ fn extract_coding_with_display(
                 })?;
 
             let display = map.get("display").and_then(|v| match v {
-                EvaluationResult::String(d, _) => Some(d.clone()),
+                EvaluationResult::String(d, _, _) => Some(d.clone()),
                 _ => None,
             });
 
@@ -415,7 +415,7 @@ fn extract_params_map(
                     if let EvaluationResult::Object { map: param_map, .. } = item {
                         if let (Some(name), Some(value)) = (
                             param_map.get("name").and_then(|n| match n {
-                                EvaluationResult::String(s, _) => Some(s),
+                                EvaluationResult::String(s, _, _) => Some(s),
                                 _ => None,
                             }),
                             extract_parameter_value(param_map),
@@ -427,7 +427,7 @@ fn extract_params_map(
             } else {
                 // Treat as simple key-value map
                 for (key, value) in map {
-                    if let EvaluationResult::String(v, _) = value {
+                    if let EvaluationResult::String(v, _, _) = value {
                         params_map.insert(key.clone(), v.clone());
                     }
                 }
@@ -447,10 +447,10 @@ fn extract_parameter_value(param_map: &HashMap<String, EvaluationResult>) -> Opt
     for (key, value) in param_map {
         if key.starts_with("value") {
             match value {
-                EvaluationResult::String(s, _) => return Some(s.clone()),
-                EvaluationResult::Boolean(b, _) => return Some(b.to_string()),
-                EvaluationResult::Integer(i, _) => return Some(i.to_string()),
-                EvaluationResult::Decimal(d, _) => return Some(d.to_string()),
+                EvaluationResult::String(s, _, _) => return Some(s.clone()),
+                EvaluationResult::Boolean(b, _, _) => return Some(b.to_string()),
+                EvaluationResult::Integer(i, _, _) => return Some(i.to_string()),
+                EvaluationResult::Decimal(d, _, _) => return Some(d.to_string()),
                 _ => {}
             }
         }
@@ -520,15 +520,15 @@ pub fn member_of(
             for item in items {
                 if let EvaluationResult::Object { map: param_map, .. } = item {
                     if param_map.get("name").and_then(|n| match n {
-                        EvaluationResult::String(s, _) => Some(s.as_str()),
+                        EvaluationResult::String(s, _, _) => Some(s.as_str()),
                         _ => None,
                     }) == Some("result")
                     {
                         // Return the boolean value
-                        if let Some(EvaluationResult::Boolean(result, type_info)) =
+                        if let Some(EvaluationResult::Boolean(result, type_info, _)) =
                             param_map.get("valueBoolean")
                         {
-                            return Ok(EvaluationResult::Boolean(*result, type_info.clone()));
+                            return Ok(EvaluationResult::Boolean(*result, type_info.clone(), None));
                         }
                     }
                 }

--- a/crates/fhirpath/src/type_function.rs
+++ b/crates/fhirpath/src/type_function.rs
@@ -44,9 +44,12 @@ fn create_type_object(value: &EvaluationResult) -> EvaluationResult {
     let mut map = HashMap::new();
     map.insert(
         "namespace".to_string(),
-        EvaluationResult::String(namespace, None),
+        EvaluationResult::String(namespace, None, None),
     );
-    map.insert("name".to_string(), EvaluationResult::String(name, None));
+    map.insert(
+        "name".to_string(),
+        EvaluationResult::String(name, None, None),
+    );
 
     EvaluationResult::Object {
         map,
@@ -60,56 +63,56 @@ fn create_type_object(value: &EvaluationResult) -> EvaluationResult {
 /// Gets the type information (namespace, name) for an EvaluationResult
 fn get_type_info(value: &EvaluationResult) -> (String, String) {
     match value {
-        EvaluationResult::Boolean(_, type_info) => {
+        EvaluationResult::Boolean(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 (type_info.namespace.clone(), type_info.name.clone())
             } else {
                 ("System".to_string(), "Boolean".to_string())
             }
         }
-        EvaluationResult::Integer(_, type_info) => {
+        EvaluationResult::Integer(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 (type_info.namespace.clone(), type_info.name.clone())
             } else {
                 ("System".to_string(), "Integer".to_string())
             }
         }
-        EvaluationResult::Decimal(_, type_info) => {
+        EvaluationResult::Decimal(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 (type_info.namespace.clone(), type_info.name.clone())
             } else {
                 ("System".to_string(), "Decimal".to_string())
             }
         }
-        EvaluationResult::String(_, type_info) => {
+        EvaluationResult::String(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 (type_info.namespace.clone(), type_info.name.clone())
             } else {
                 ("System".to_string(), "String".to_string())
             }
         }
-        EvaluationResult::Date(_, type_info) => {
+        EvaluationResult::Date(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 (type_info.namespace.clone(), type_info.name.clone())
             } else {
                 ("System".to_string(), "Date".to_string())
             }
         }
-        EvaluationResult::DateTime(_, type_info) => {
+        EvaluationResult::DateTime(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 (type_info.namespace.clone(), type_info.name.clone())
             } else {
                 ("System".to_string(), "DateTime".to_string())
             }
         }
-        EvaluationResult::Time(_, type_info) => {
+        EvaluationResult::Time(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 (type_info.namespace.clone(), type_info.name.clone())
             } else {
                 ("System".to_string(), "Time".to_string())
             }
         }
-        EvaluationResult::Quantity(_, _, type_info) => {
+        EvaluationResult::Quantity(_, _, type_info, _) => {
             if let Some(type_info) = type_info {
                 (type_info.namespace.clone(), type_info.name.clone())
             } else {
@@ -132,7 +135,7 @@ fn get_type_info(value: &EvaluationResult) -> (String, String) {
         }
         EvaluationResult::Empty => ("System".to_string(), "Empty".to_string()),
         #[cfg(not(any(feature = "R4", feature = "R4B")))]
-        EvaluationResult::Integer64(_, type_info) => {
+        EvaluationResult::Integer64(_, type_info, _) => {
             if let Some(type_info) = type_info {
                 (type_info.namespace.clone(), type_info.name.clone())
             } else {
@@ -140,7 +143,7 @@ fn get_type_info(value: &EvaluationResult) -> (String, String) {
             }
         }
         #[cfg(any(feature = "R4", feature = "R4B"))]
-        EvaluationResult::Integer64(_, _) => {
+        EvaluationResult::Integer64(_, _, _) => {
             // In R4 and R4B, Integer64 should be treated as Integer
             ("System".to_string(), "Integer".to_string())
         }

--- a/crates/fhirpath/tests/all_function_tests.rs
+++ b/crates/fhirpath/tests/all_function_tests.rs
@@ -164,7 +164,7 @@ fn test_all_with_nested_collections() {
 
     // This assertion may fail if the implementation doesn't handle nested all() correctly
     match result {
-        Ok(EvaluationResult::Boolean(true, _)) => (), // Expected correct behavior
+        Ok(EvaluationResult::Boolean(true, _, _)) => (), // Expected correct behavior
         _ => panic!("Failed to evaluate nested all() expression: {:?}", result),
     }
 }
@@ -232,7 +232,7 @@ fn test_all_with_type_operations() {
 
     // Check if we get a boolean result
     match result {
-        Ok(EvaluationResult::Boolean(_, _)) => (), // Expect any boolean result (we don't care about the value, just that it evaluates)
+        Ok(EvaluationResult::Boolean(_, _, _)) => (), // Expect any boolean result (we don't care about the value, just that it evaluates)
         _ => panic!(
             "Failed to evaluate type operation with all() - result not a boolean: {:?}",
             result
@@ -282,7 +282,7 @@ fn test_all_with_variable_references() {
 
     // Check if we get a boolean result
     match result {
-        Ok(EvaluationResult::Boolean(_, _)) => (), // Expect any boolean result
+        Ok(EvaluationResult::Boolean(_, _, _)) => (), // Expect any boolean result
         _ => panic!(
             "Failed to evaluate all() with variable references - result not a boolean: {:?}",
             result

--- a/crates/fhirpath/tests/common/context.rs
+++ b/crates/fhirpath/tests/common/context.rs
@@ -34,7 +34,7 @@ pub fn setup_patient_extension_context(context: &mut EvaluationContext, test_nam
         let patient_data = if let Some(this) = &context.this {
             if let EvaluationResult::Object { map: obj, .. } = this {
                 if obj.get("resourceType")
-                    == Some(&EvaluationResult::String("Patient".to_string(), None))
+                    == Some(&EvaluationResult::String("Patient".to_string(), None, None))
                 {
                     Some(obj.clone())
                 } else {
@@ -55,11 +55,12 @@ pub fn setup_patient_extension_context(context: &mut EvaluationContext, test_nam
                 EvaluationResult::String(
                     "http://hl7.org/fhir/StructureDefinition/patient-birthTime".to_string(),
                     None,
+                    None,
                 ),
             );
             extension_obj.insert(
                 "valueDateTime".to_string(),
-                EvaluationResult::String("1974-12-25T14:35:45-05:00".to_string(), None),
+                EvaluationResult::String("1974-12-25T14:35:45-05:00".to_string(), None, None),
             );
 
             // Create the extensions collection
@@ -75,10 +76,12 @@ pub fn setup_patient_extension_context(context: &mut EvaluationContext, test_nam
 
             // Make sure birthDate is an Object if needed
             let mut birthdate_obj = HashMap::new();
-            if let Some(EvaluationResult::String(date_str, None)) = patient_obj.get("birthDate") {
+            if let Some(EvaluationResult::String(date_str, None, None)) =
+                patient_obj.get("birthDate")
+            {
                 birthdate_obj.insert(
                     "value".to_string(),
-                    EvaluationResult::String(date_str.clone(), None),
+                    EvaluationResult::String(date_str.clone(), None, None),
                 );
                 patient_obj.insert(
                     "birthDate".to_string(),
@@ -114,7 +117,7 @@ fn setup_patient_context(context: &mut EvaluationContext) {
     let patient_data = if let Some(this) = &context.this {
         if let EvaluationResult::Object { map: obj, .. } = this {
             if obj.get("resourceType")
-                == Some(&EvaluationResult::String("Patient".to_string(), None))
+                == Some(&EvaluationResult::String("Patient".to_string(), None, None))
             {
                 Some((this.clone(), obj.clone()))
             } else {
@@ -138,7 +141,7 @@ fn setup_patient_context(context: &mut EvaluationContext) {
             let mut patient_map = HashMap::new();
             patient_map.insert(
                 "resourceType".to_string(),
-                EvaluationResult::String("Patient".to_string(), None),
+                EvaluationResult::String("Patient".to_string(), None, None),
             );
 
             if let Some(active) = obj.get("active") {
@@ -157,7 +160,11 @@ fn setup_observation_context(context: &mut EvaluationContext) {
     let observation_data = if let Some(this) = &context.this {
         if let EvaluationResult::Object { map: obj, .. } = this {
             if obj.get("resourceType")
-                == Some(&EvaluationResult::String("Observation".to_string(), None))
+                == Some(&EvaluationResult::String(
+                    "Observation".to_string(),
+                    None,
+                    None,
+                ))
             {
                 Some((this.clone(), obj.clone()))
             } else {
@@ -194,7 +201,11 @@ fn setup_valueset_context(context: &mut EvaluationContext) {
     let valueset_data = if let Some(this) = &context.this {
         if let EvaluationResult::Object { map: obj, .. } = this {
             if obj.get("resourceType")
-                == Some(&EvaluationResult::String("ValueSet".to_string(), None))
+                == Some(&EvaluationResult::String(
+                    "ValueSet".to_string(),
+                    None,
+                    None,
+                ))
             {
                 Some(this.clone())
             } else {
@@ -216,7 +227,11 @@ fn setup_questionnaire_context(context: &mut EvaluationContext) {
     let questionnaire_data = if let Some(this) = &context.this {
         if let EvaluationResult::Object { map: obj, .. } = this {
             if obj.get("resourceType")
-                == Some(&EvaluationResult::String("Questionnaire".to_string(), None))
+                == Some(&EvaluationResult::String(
+                    "Questionnaire".to_string(),
+                    None,
+                    None,
+                ))
             {
                 Some(this.clone())
             } else {

--- a/crates/fhirpath/tests/common/runner.rs
+++ b/crates/fhirpath/tests/common/runner.rs
@@ -31,10 +31,10 @@ pub fn run_fhir_test(
                     eval_result.clone()
                 };
 
-                if let EvaluationResult::Boolean(b_val, None) = single_item_value {
-                    EvaluationResult::Boolean(b_val, None) // Preserve original boolean value
+                if let EvaluationResult::Boolean(b_val, None, None) = single_item_value {
+                    EvaluationResult::Boolean(b_val, None, None) // Preserve original boolean value
                 } else {
-                    EvaluationResult::Boolean(true, None) // Non-boolean single item becomes true in boolean context
+                    EvaluationResult::Boolean(true, None, None) // Non-boolean single item becomes true in boolean context
                 }
             }
             _ => {
@@ -83,7 +83,7 @@ fn compare_results(
 ) -> Result<(), String> {
     for (i, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
         match (actual, expected) {
-            (EvaluationResult::Boolean(a, _), EvaluationResult::Boolean(b, _)) => {
+            (EvaluationResult::Boolean(a, _, _), EvaluationResult::Boolean(b, _, _)) => {
                 if a != b {
                     return Err(format!(
                         "Boolean result {} doesn't match: expected {:?}, got {:?}",
@@ -91,7 +91,7 @@ fn compare_results(
                     ));
                 }
             }
-            (EvaluationResult::Integer(a, _), EvaluationResult::Integer(b, _)) => {
+            (EvaluationResult::Integer(a, _, _), EvaluationResult::Integer(b, _, _)) => {
                 if a != b {
                     return Err(format!(
                         "Integer result {} doesn't match: expected {:?}, got {:?}",
@@ -99,7 +99,7 @@ fn compare_results(
                     ));
                 }
             }
-            (EvaluationResult::String(a, _), EvaluationResult::String(b, _)) => {
+            (EvaluationResult::String(a, _, _), EvaluationResult::String(b, _, _)) => {
                 if a != b {
                     return Err(format!(
                         "String result {} doesn't match: expected {:?}, got {:?}",
@@ -107,7 +107,7 @@ fn compare_results(
                     ));
                 }
             }
-            (EvaluationResult::Decimal(a, _), EvaluationResult::Decimal(b, _)) => {
+            (EvaluationResult::Decimal(a, _, _), EvaluationResult::Decimal(b, _, _)) => {
                 if a != b {
                     return Err(format!(
                         "Decimal result {} doesn't match: expected {} ({}), got {} ({})",
@@ -116,8 +116,8 @@ fn compare_results(
                 }
             }
             (
-                EvaluationResult::Quantity(a_val, a_unit, _),
-                EvaluationResult::Quantity(b_val, b_unit, _),
+                EvaluationResult::Quantity(a_val, a_unit, _, _),
+                EvaluationResult::Quantity(b_val, b_unit, _, _),
             ) => {
                 if a_val != b_val || a_unit != b_unit {
                     return Err(format!(
@@ -127,7 +127,7 @@ fn compare_results(
                 }
             }
             // Date types which are currently stored as strings
-            (EvaluationResult::Date(a, _), EvaluationResult::Date(b, _)) => {
+            (EvaluationResult::Date(a, _, _), EvaluationResult::Date(b, _, _)) => {
                 if a != b {
                     return Err(format!(
                         "Date result {} doesn't match: expected {:?}, got {:?}",
@@ -135,7 +135,7 @@ fn compare_results(
                     ));
                 }
             }
-            (EvaluationResult::DateTime(a, _), EvaluationResult::DateTime(b, _)) => {
+            (EvaluationResult::DateTime(a, _, _), EvaluationResult::DateTime(b, _, _)) => {
                 if a != b {
                     return Err(format!(
                         "DateTime result {} doesn't match: expected {:?}, got {:?}",
@@ -143,7 +143,7 @@ fn compare_results(
                     ));
                 }
             }
-            (EvaluationResult::Time(a, _), EvaluationResult::Time(b, _)) => {
+            (EvaluationResult::Time(a, _, _), EvaluationResult::Time(b, _, _)) => {
                 if a != b {
                     return Err(format!(
                         "Time result {} doesn't match: expected {:?}, got {:?}",
@@ -153,7 +153,7 @@ fn compare_results(
             }
             // Special case for FHIR types that are stored differently but might be equivalent
             // String vs. Code compatibility (since code is stored as String in our implementation)
-            (EvaluationResult::String(a, _), EvaluationResult::Date(b, _)) => {
+            (EvaluationResult::String(a, _, _), EvaluationResult::Date(b, _, _)) => {
                 // A String can be equal to a Date in certain contexts
                 if a != b {
                     return Err(format!(
@@ -162,7 +162,7 @@ fn compare_results(
                     ));
                 }
             }
-            (EvaluationResult::Date(a, _), EvaluationResult::String(b, _)) => {
+            (EvaluationResult::Date(a, _, _), EvaluationResult::String(b, _, _)) => {
                 // A Date can be equal to a String in certain contexts
                 if a != b {
                     return Err(format!(
@@ -207,15 +207,19 @@ pub fn parse_output_value(
 ) -> Result<EvaluationResult, String> {
     match output_type {
         "boolean" => match output_value {
-            "true" => Ok(EvaluationResult::Boolean(true, None)),
-            "false" => Ok(EvaluationResult::Boolean(false, None)),
+            "true" => Ok(EvaluationResult::Boolean(true, None, None)),
+            "false" => Ok(EvaluationResult::Boolean(false, None, None)),
             _ => Err(format!("Invalid boolean value: {}", output_value)),
         },
         "integer" => output_value
             .parse::<i64>()
             .map(EvaluationResult::integer)
             .map_err(|_| format!("Invalid integer value: {}", output_value)),
-        "string" => Ok(EvaluationResult::String(output_value.to_string(), None)),
+        "string" => Ok(EvaluationResult::String(
+            output_value.to_string(),
+            None,
+            None,
+        )),
         "date" => {
             // Handle R5's @ prefix for dates
             let date_str = if fhir_version == "R5" && output_value.starts_with('@') {
@@ -223,11 +227,19 @@ pub fn parse_output_value(
             } else {
                 output_value
             };
-            Ok(EvaluationResult::Date(date_str.to_string(), None))
+            Ok(EvaluationResult::Date(date_str.to_string(), None, None))
         }
-        "dateTime" => Ok(EvaluationResult::DateTime(output_value.to_string(), None)),
-        "time" => Ok(EvaluationResult::Time(output_value.to_string(), None)),
-        "code" => Ok(EvaluationResult::String(output_value.to_string(), None)),
+        "dateTime" => Ok(EvaluationResult::DateTime(
+            output_value.to_string(),
+            None,
+            None,
+        )),
+        "time" => Ok(EvaluationResult::Time(output_value.to_string(), None, None)),
+        "code" => Ok(EvaluationResult::String(
+            output_value.to_string(),
+            None,
+            None,
+        )),
         "decimal" => output_value
             .parse::<Decimal>()
             .map(EvaluationResult::decimal)
@@ -252,6 +264,7 @@ fn parse_quantity(output_value: &str) -> Result<EvaluationResult, String> {
                 Ok(decimal_val) => Ok(EvaluationResult::Quantity(
                     decimal_val,
                     unit_str.to_string(),
+                    None,
                     None,
                 )),
                 Err(_) => Err(format!(

--- a/crates/fhirpath/tests/context_trace_test.rs
+++ b/crates/fhirpath/tests/context_trace_test.rs
@@ -139,7 +139,7 @@ fn test_trace_with_context_full_expression() {
 
         // Should match expected
         match result {
-            helios_fhirpath::EvaluationResult::String(s, _) => {
+            helios_fhirpath::EvaluationResult::String(s, _, _) => {
                 assert_eq!(
                     s, expected_results[i],
                     "Result for name[{}] doesn't match",
@@ -200,7 +200,7 @@ fn test_trace_with_context_simple() {
 
         // Should contain "Doe"
         match result {
-            helios_fhirpath::EvaluationResult::String(s, _) => {
+            helios_fhirpath::EvaluationResult::String(s, _, _) => {
                 assert_eq!(s, "Doe");
             }
             _ => panic!("Expected string result"),

--- a/crates/fhirpath/tests/date_operation_tests.rs
+++ b/crates/fhirpath/tests/date_operation_tests.rs
@@ -37,7 +37,7 @@ fn test_date_parsing() {
     assert_eq!(result, EvaluationResult::date("2015-02-04".to_string()));
 
     let result = parse_date_literal("@2015T").unwrap();
-    assert!(matches!(result, EvaluationResult::DateTime(_, Some(_))));
+    assert!(matches!(result, EvaluationResult::DateTime(_, Some(_), _)));
 
     let result = parse_date_literal("@T14").unwrap();
     assert_eq!(result, EvaluationResult::time("14:00:00".to_string()));

--- a/crates/fhirpath/tests/enhanced_variable_tests.rs
+++ b/crates/fhirpath/tests/enhanced_variable_tests.rs
@@ -148,7 +148,7 @@ fn test_variable_coercion() {
     // We can use a different approach for conversion later
     let decimal_val = eval("%decimalVar", &context).unwrap();
     match decimal_val {
-        EvaluationResult::Decimal(d, _) => {
+        EvaluationResult::Decimal(d, _, _) => {
             let int_val = d.to_i64().unwrap_or(0);
             assert_eq!(int_val, 3);
         }

--- a/crates/fhirpath/tests/evaluator_tests.rs
+++ b/crates/fhirpath/tests/evaluator_tests.rs
@@ -425,7 +425,7 @@ fn test_function_existence_distinct() {
         let mut actual_items: Vec<i64> = items
             .into_iter()
             .map(|item| match item {
-                EvaluationResult::Integer(i, _) => i,
+                EvaluationResult::Integer(i, _, _) => i,
                 _ => panic!("Expected integers, got {:?}", item), // Improved panic message
             })
             .collect();
@@ -889,7 +889,7 @@ fn test_function_subsetting_intersect() {
         let mut actual_items: Vec<i64> = items
             .into_iter()
             .map(|item| match item {
-                EvaluationResult::Integer(i, _) => i,
+                EvaluationResult::Integer(i, _, _) => i,
                 _ => panic!("Expected integers, got {:?}", item), // Improved panic message
             })
             .collect();
@@ -991,7 +991,7 @@ fn test_function_combining_union() {
         let mut actual_items: Vec<i64> = items
             .into_iter()
             .map(|item| match item {
-                EvaluationResult::Integer(i, _) => i,
+                EvaluationResult::Integer(i, _, _) => i,
                 _ => panic!("Expected integers, got {:?}", item), // Use pattern matching
             })
             .collect();
@@ -1005,7 +1005,7 @@ fn test_function_combining_union() {
         let mut actual_items: Vec<i64> = items
             .into_iter()
             .map(|item| match item {
-                EvaluationResult::Integer(i, _) => i,
+                EvaluationResult::Integer(i, _, _) => i,
                 _ => panic!("Expected integers, got {:?}", item), // Use pattern matching
             })
             .collect();
@@ -1046,7 +1046,7 @@ fn test_function_combining_combine() {
         let mut actual_items: Vec<i64> = items
             .into_iter()
             .map(|item| match item {
-                EvaluationResult::Integer(i, _) => i,
+                EvaluationResult::Integer(i, _, _) => i,
                 _ => panic!("Expected integers, got {:?}", item), // Use pattern matching
             })
             .collect();
@@ -1061,7 +1061,7 @@ fn test_function_combining_combine() {
         let mut actual_items: Vec<i64> = items
             .into_iter()
             .map(|item| match item {
-                EvaluationResult::Integer(i, _) => i,
+                EvaluationResult::Integer(i, _, _) => i,
                 _ => panic!("Expected integers, got {:?}", item), // Use pattern matching
             })
             .collect();
@@ -2573,7 +2573,7 @@ fn test_function_utility_now() {
     let context = EvaluationContext::new_empty_with_default_version();
     let result = eval("now()", &context).unwrap(); // Add unwrap
     // Check it's a DateTime, format might vary slightly
-    assert!(matches!(result, EvaluationResult::DateTime(_, _)));
+    assert!(matches!(result, EvaluationResult::DateTime(_, _, _)));
     // Check determinism (calling twice gives same result)
     //assert_eq!(
     //    eval("now() = now()", &context).unwrap(), // Use eval helper and unwrap
@@ -2587,7 +2587,7 @@ fn test_function_utility_time_of_day() {
     let context = EvaluationContext::new_empty_with_default_version();
     let result = eval("timeOfDay()", &context).unwrap(); // Add unwrap
     // Check it's a Time
-    assert!(matches!(result, EvaluationResult::Time(_, _)));
+    assert!(matches!(result, EvaluationResult::Time(_, _, _)));
     // Check determinism
     //let expr = parser().parse("timeOfDay() = timeOfDay()").unwrap();
     //assert_eq!(
@@ -2602,7 +2602,7 @@ fn test_function_utility_today() {
     let context = EvaluationContext::new_empty_with_default_version();
     let result = eval("today()", &context).unwrap(); // Add unwrap
     // Check it's a Date
-    assert!(matches!(result, EvaluationResult::Date(_, _)));
+    assert!(matches!(result, EvaluationResult::Date(_, _, _)));
     // Check determinism
     let expr = parser().parse("today() = today()").unwrap();
     assert_eq!(
@@ -3120,7 +3120,7 @@ fn test_operator_collections_union() {
         let mut actual_items: Vec<i64> = items
             .into_iter()
             .map(|item| match item {
-                EvaluationResult::Integer(i, _) => i,
+                EvaluationResult::Integer(i, _, _) => i,
                 _ => panic!("Expected integers, got {:?}", item), // Improved panic message
             })
             .collect();
@@ -4816,7 +4816,10 @@ fn test_math_functions() {
 
         // Special handling for Decimal and Quantity types
         match (&result, &expected) {
-            (EvaluationResult::Decimal(actual, _), EvaluationResult::Decimal(expected, _)) => {
+            (
+                EvaluationResult::Decimal(actual, _, _),
+                EvaluationResult::Decimal(expected, _, _),
+            ) => {
                 // Check that the difference is very small (within 1e-10)
                 let diff = (*actual - *expected).abs();
                 let epsilon = Decimal::from_str_exact("0.0000000001").unwrap();
@@ -4831,8 +4834,8 @@ fn test_math_functions() {
                 );
             }
             (
-                EvaluationResult::Quantity(actual_val, actual_unit, _),
-                EvaluationResult::Quantity(expected_val, expected_unit, _),
+                EvaluationResult::Quantity(actual_val, actual_unit, _, _),
+                EvaluationResult::Quantity(expected_val, expected_unit, _, _),
             ) => {
                 // Check units are the same
                 assert_eq!(
@@ -4894,7 +4897,10 @@ fn test_math_functions() {
 
         // Special handling for Decimal and Quantity types
         match (&result, &expected) {
-            (EvaluationResult::Decimal(actual, _), EvaluationResult::Decimal(expected, _)) => {
+            (
+                EvaluationResult::Decimal(actual, _, _),
+                EvaluationResult::Decimal(expected, _, _),
+            ) => {
                 // Check that the difference is very small (within reasonable error margin)
                 let diff = (*actual - *expected).abs();
                 let epsilon = Decimal::from_str_exact("0.000001").unwrap();
@@ -4909,8 +4915,8 @@ fn test_math_functions() {
                 );
             }
             (
-                EvaluationResult::Quantity(actual_val, actual_unit, _),
-                EvaluationResult::Quantity(expected_val, expected_unit, _),
+                EvaluationResult::Quantity(actual_val, actual_unit, _, _),
+                EvaluationResult::Quantity(expected_val, expected_unit, _, _),
             ) => {
                 // Check units are the same
                 assert_eq!(
@@ -4945,7 +4951,10 @@ fn test_math_functions() {
 
         // Special handling for Decimal and Quantity types
         match (&result, &expected) {
-            (EvaluationResult::Decimal(actual, _), EvaluationResult::Decimal(expected, _)) => {
+            (
+                EvaluationResult::Decimal(actual, _, _),
+                EvaluationResult::Decimal(expected, _, _),
+            ) => {
                 // Check that the difference is very small (within reasonable error margin)
                 let diff = (*actual - *expected).abs();
                 let epsilon = Decimal::from_str_exact("0.000001").unwrap();
@@ -4960,8 +4969,8 @@ fn test_math_functions() {
                 );
             }
             (
-                EvaluationResult::Quantity(actual_val, actual_unit, _),
-                EvaluationResult::Quantity(expected_val, expected_unit, _),
+                EvaluationResult::Quantity(actual_val, actual_unit, _, _),
+                EvaluationResult::Quantity(expected_val, expected_unit, _, _),
             ) => {
                 // Check units are the same
                 assert_eq!(
@@ -4996,7 +5005,10 @@ fn test_math_functions() {
 
         // Special handling for Decimal and Quantity types
         match (&result, &expected) {
-            (EvaluationResult::Decimal(actual, _), EvaluationResult::Decimal(expected, _)) => {
+            (
+                EvaluationResult::Decimal(actual, _, _),
+                EvaluationResult::Decimal(expected, _, _),
+            ) => {
                 // Check that the difference is very small (within reasonable error margin)
                 let diff = (*actual - *expected).abs();
                 let epsilon = Decimal::from_str_exact("0.000001").unwrap();
@@ -5011,8 +5023,8 @@ fn test_math_functions() {
                 );
             }
             (
-                EvaluationResult::Quantity(actual_val, actual_unit, _),
-                EvaluationResult::Quantity(expected_val, expected_unit, _),
+                EvaluationResult::Quantity(actual_val, actual_unit, _, _),
+                EvaluationResult::Quantity(expected_val, expected_unit, _, _),
             ) => {
                 // Check units are the same
                 assert_eq!(
@@ -5047,7 +5059,10 @@ fn test_math_functions() {
 
         // Special handling for Decimal and Quantity types
         match (&result, &expected) {
-            (EvaluationResult::Decimal(actual, _), EvaluationResult::Decimal(expected, _)) => {
+            (
+                EvaluationResult::Decimal(actual, _, _),
+                EvaluationResult::Decimal(expected, _, _),
+            ) => {
                 // Check that the difference is very small (within reasonable error margin)
                 let diff = (*actual - *expected).abs();
                 let epsilon = Decimal::from_str_exact("0.000001").unwrap();
@@ -5062,8 +5077,8 @@ fn test_math_functions() {
                 );
             }
             (
-                EvaluationResult::Quantity(actual_val, actual_unit, _),
-                EvaluationResult::Quantity(expected_val, expected_unit, _),
+                EvaluationResult::Quantity(actual_val, actual_unit, _, _),
+                EvaluationResult::Quantity(expected_val, expected_unit, _, _),
             ) => {
                 // Check units are the same
                 assert_eq!(

--- a/crates/fhirpath/tests/join_function_test.rs
+++ b/crates/fhirpath/tests/join_function_test.rs
@@ -22,7 +22,7 @@ fn test_join_function_basic() {
     let result = evaluate_expression("name.given.join(',')", &context).unwrap();
 
     match result {
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::String(s, _, _) => {
             assert_eq!(s, "John,James");
         }
         _ => panic!("Expected string result, got: {:?}", result),
@@ -50,7 +50,7 @@ fn test_join_function_with_space() {
     let result = evaluate_expression("name.given.join(' ')", &context).unwrap();
 
     match result {
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::String(s, _, _) => {
             assert_eq!(s, "John James");
         }
         _ => panic!("Expected string result, got: {:?}", result),
@@ -78,7 +78,7 @@ fn test_join_function_empty_separator() {
     let result = evaluate_expression("name.given.join('')", &context).unwrap();
 
     match result {
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::String(s, _, _) => {
             assert_eq!(s, "JohnJames");
         }
         _ => panic!("Expected string result, got: {:?}", result),
@@ -104,7 +104,7 @@ fn test_join_function_empty_collection() {
     let result = evaluate_expression("name.given.join(',')", &context).unwrap();
 
     match result {
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::String(s, _, _) => {
             assert_eq!(s, ""); // Empty collection should produce empty string
         }
         _ => panic!("Expected string result, got: {:?}", result),
@@ -132,7 +132,7 @@ fn test_join_function_no_separator() {
     let result = evaluate_expression("name.given.join()", &context).unwrap();
 
     match result {
-        EvaluationResult::String(s, _) => {
+        EvaluationResult::String(s, _, _) => {
             assert_eq!(s, "JohnJames"); // Should join with no separator
         }
         _ => panic!("Expected string result, got: {:?}", result),

--- a/crates/fhirpath/tests/precision_tests.rs
+++ b/crates/fhirpath/tests/precision_tests.rs
@@ -14,7 +14,7 @@ fn test_precision_decimal() {
     let result = evaluate(&expr, &context, None).unwrap();
 
     match result {
-        EvaluationResult::Integer(value, _) => {
+        EvaluationResult::Integer(value, _, _) => {
             // TODO: This test expects 5 but we get 6 because Decimal type
             // doesn't preserve trailing zeros from the original literal.
             // The parser sees "1.58700" but Decimal normalizes it to "1.587"
@@ -32,7 +32,7 @@ fn test_precision_decimal_normalized() {
     let result = evaluate(&expr, &context, None).unwrap();
 
     match result {
-        EvaluationResult::Integer(value, _) => {
+        EvaluationResult::Integer(value, _, _) => {
             assert_eq!(value, 4, "1.587 should have 4 significant digits");
         }
         _ => panic!("Expected Integer result, got {:?}", result),
@@ -46,7 +46,7 @@ fn test_precision_integer() {
     let result = evaluate(&expr, &context, None).unwrap();
 
     match result {
-        EvaluationResult::Integer(value, _) => {
+        EvaluationResult::Integer(value, _, _) => {
             assert_eq!(value, 3, "123 should have 3 significant digits");
         }
         _ => panic!("Expected Integer result, got {:?}", result),
@@ -60,7 +60,7 @@ fn test_precision_year() {
     let result = evaluate(&expr, &context, None).unwrap();
 
     match result {
-        EvaluationResult::Integer(value, _) => {
+        EvaluationResult::Integer(value, _, _) => {
             assert_eq!(value, 4, "@2014 should have precision 4");
         }
         _ => panic!("Expected Integer result, got {:?}", result),
@@ -76,7 +76,7 @@ fn test_precision_datetime_milliseconds() {
     let result = evaluate(&expr, &context, None).unwrap();
 
     match result {
-        EvaluationResult::Integer(value, _) => {
+        EvaluationResult::Integer(value, _, _) => {
             assert_eq!(
                 value, 17,
                 "@2014-01-05T10:30:00.000 should have precision 17"
@@ -93,7 +93,7 @@ fn test_precision_time_minutes() {
     let result = evaluate(&expr, &context, None).unwrap();
 
     match result {
-        EvaluationResult::Integer(value, _) => {
+        EvaluationResult::Integer(value, _, _) => {
             assert_eq!(value, 4, "@T10:30 should have precision 4");
         }
         _ => panic!("Expected Integer result, got {:?}", result),
@@ -107,7 +107,7 @@ fn test_precision_time_milliseconds() {
     let result = evaluate(&expr, &context, None).unwrap();
 
     match result {
-        EvaluationResult::Integer(value, _) => {
+        EvaluationResult::Integer(value, _, _) => {
             assert_eq!(value, 9, "@T10:30:00.000 should have precision 9");
         }
         _ => panic!("Expected Integer result, got {:?}", result),

--- a/crates/fhirpath/tests/primitive_extension_tests.rs
+++ b/crates/fhirpath/tests/primitive_extension_tests.rs
@@ -1,0 +1,199 @@
+//! Tests for FHIRPath access to id/extension on FHIR primitive values.
+//!
+//! In FHIR JSON, primitive values can carry id/extension metadata via the
+//! parallel `_field` sibling. These tests verify that FHIRPath expressions
+//! such as `Patient.active.id` and `Patient.birthDate.extension.where(...)`
+//! reach that metadata through the new `PrimitiveElement` carrier.
+
+use chumsky::Parser;
+use helios_fhir::FhirResource;
+use helios_fhir::r4::{self, Boolean, Date, Extension, ExtensionValue};
+use helios_fhirpath::evaluator::{EvaluationContext, evaluate};
+use helios_fhirpath::parser::parser;
+use helios_fhirpath_support::EvaluationResult;
+
+fn eval(input: &str, context: &EvaluationContext) -> EvaluationResult {
+    let expr = parser().parse(input).into_result().unwrap_or_else(|e| {
+        panic!("Parser error for input '{}': {:?}", input, e);
+    });
+    evaluate(&expr, context, None).unwrap_or_else(|e| panic!("Eval error for '{}': {:?}", input, e))
+}
+
+fn ctx_with_patient(patient: r4::Patient) -> EvaluationContext {
+    let resources = vec![FhirResource::R4(Box::new(r4::Resource::Patient(Box::new(
+        patient,
+    ))))];
+    EvaluationContext::new(resources)
+}
+
+#[test]
+fn primitive_id_access_returns_id_when_present() {
+    // Patient.active = true with id "abc"
+    let active = Boolean {
+        id: Some("abc".to_string()),
+        extension: None,
+        value: Some(true),
+    };
+    let patient = r4::Patient {
+        id: Some("p1".to_string().into()),
+        active: Some(active),
+        ..Default::default()
+    };
+    let ctx = ctx_with_patient(patient);
+
+    let result = eval("Patient.active.id", &ctx);
+    assert_eq!(
+        result,
+        EvaluationResult::fhir_string("abc".to_string(), "id")
+    );
+}
+
+#[test]
+fn primitive_id_access_empty_when_absent() {
+    let active = Boolean {
+        id: None,
+        extension: None,
+        value: Some(true),
+    };
+    let patient = r4::Patient {
+        id: Some("p1".to_string().into()),
+        active: Some(active),
+        ..Default::default()
+    };
+    let ctx = ctx_with_patient(patient);
+
+    let result = eval("Patient.active.id", &ctx);
+    assert_eq!(result, EvaluationResult::Empty);
+}
+
+#[test]
+fn primitive_extension_access_returns_extensions() {
+    // Patient.birthDate = "1980-01-01" with extension url=...
+    let ext = Extension {
+        url: "http://example.org/qualifier".to_string().into(),
+        value: Some(ExtensionValue::Code(r4::Code {
+            id: None,
+            extension: None,
+            value: Some("approximate".to_string()),
+        })),
+        ..Default::default()
+    };
+    let birth_date = Date {
+        id: None,
+        extension: Some(vec![ext]),
+        value: None, // No value, just extension - simulates `_birthDate` only case
+    };
+    let patient = r4::Patient {
+        id: Some("p1".to_string().into()),
+        birth_date: Some(birth_date),
+        ..Default::default()
+    };
+    let ctx = ctx_with_patient(patient);
+
+    // When value is None but extension exists, the result is an Object with extension
+    let result = eval("Patient.birthDate.extension.exists()", &ctx);
+    assert_eq!(result, EvaluationResult::boolean(true));
+}
+
+#[test]
+fn primitive_extension_with_value_carries_metadata() {
+    // birthDate has both value AND extension/id metadata
+    let ext = Extension {
+        url: "http://example.org/qualifier".to_string().into(),
+        value: Some(ExtensionValue::Code(r4::Code {
+            id: None,
+            extension: None,
+            value: Some("approximate".to_string()),
+        })),
+        ..Default::default()
+    };
+    let birth_date = Date {
+        id: Some("bd-1".to_string()),
+        extension: Some(vec![ext]),
+        value: Some(helios_fhir::PrecisionDate::from_ymd(1980, 1, 1)),
+    };
+    let patient = r4::Patient {
+        id: Some("p1".to_string().into()),
+        birth_date: Some(birth_date),
+        ..Default::default()
+    };
+    let ctx = ctx_with_patient(patient);
+
+    // The id is reachable
+    let id_result = eval("Patient.birthDate.id", &ctx);
+    assert_eq!(
+        id_result,
+        EvaluationResult::fhir_string("bd-1".to_string(), "id")
+    );
+
+    // The extension list is reachable
+    let ext_count = eval("Patient.birthDate.extension.count()", &ctx);
+    assert_eq!(ext_count, EvaluationResult::integer(1));
+
+    // The extension's url is reachable
+    let url = eval("Patient.birthDate.extension.url", &ctx);
+    assert_eq!(
+        url,
+        EvaluationResult::fhir_string("http://example.org/qualifier".to_string(), "uri")
+    );
+
+    // where() filtering on extension url
+    let filtered = eval(
+        "Patient.birthDate.extension.where(url = 'http://example.org/qualifier').count()",
+        &ctx,
+    );
+    assert_eq!(filtered, EvaluationResult::integer(1));
+}
+
+#[test]
+fn primitive_without_metadata_returns_empty() {
+    // birthDate has only value, no id or extension
+    let birth_date = Date {
+        id: None,
+        extension: None,
+        value: Some(helios_fhir::PrecisionDate::from_ymd(1980, 1, 1)),
+    };
+    let patient = r4::Patient {
+        id: Some("p1".to_string().into()),
+        birth_date: Some(birth_date),
+        ..Default::default()
+    };
+    let ctx = ctx_with_patient(patient);
+
+    assert_eq!(eval("Patient.birthDate.id", &ctx), EvaluationResult::Empty);
+    assert_eq!(
+        eval("Patient.birthDate.extension", &ctx),
+        EvaluationResult::Empty
+    );
+    assert_eq!(
+        eval("Patient.birthDate.extension.exists()", &ctx),
+        EvaluationResult::boolean(false)
+    );
+}
+
+#[test]
+fn empty_extension_list_returns_empty() {
+    // birthDate has empty extension Vec
+    let birth_date = Date {
+        id: Some("bd-1".to_string()),
+        extension: Some(vec![]),
+        value: Some(helios_fhir::PrecisionDate::from_ymd(1980, 1, 1)),
+    };
+    let patient = r4::Patient {
+        id: Some("p1".to_string().into()),
+        birth_date: Some(birth_date),
+        ..Default::default()
+    };
+    let ctx = ctx_with_patient(patient);
+
+    // Empty extension list -> Empty (since it has no items)
+    assert_eq!(
+        eval("Patient.birthDate.extension", &ctx),
+        EvaluationResult::Empty
+    );
+    // But id is still reachable
+    assert_eq!(
+        eval("Patient.birthDate.id", &ctx),
+        EvaluationResult::fhir_string("bd-1".to_string(), "id")
+    );
+}

--- a/crates/fhirpath/tests/r4_tests.rs
+++ b/crates/fhirpath/tests/r4_tests.rs
@@ -110,12 +110,12 @@ fn test_basic_fhirpath_expressions() {
 
     // Test some basic expressions
     let test_cases = vec![
-        ("true", EvaluationResult::Boolean(true, None)),
-        ("false", EvaluationResult::Boolean(false, None)),
+        ("true", EvaluationResult::Boolean(true, None, None)),
+        ("false", EvaluationResult::Boolean(false, None, None)),
         ("1", EvaluationResult::integer(1)),
         (
             "'hello'",
-            EvaluationResult::String("hello".to_string(), None),
+            EvaluationResult::String("hello".to_string(), None, None),
         ),
         ("1 + 1", EvaluationResult::integer(2)),
         ("1 - 1", EvaluationResult::integer(0)),
@@ -123,20 +123,38 @@ fn test_basic_fhirpath_expressions() {
         ("10 / 2", EvaluationResult::decimal(Decimal::from(5))),
         ("10 div 3", EvaluationResult::integer(3)),
         ("10 mod 3", EvaluationResult::integer(1)),
-        ("true and true", EvaluationResult::Boolean(true, None)),
-        ("true and false", EvaluationResult::Boolean(false, None)),
-        ("true or false", EvaluationResult::Boolean(true, None)),
-        ("false or false", EvaluationResult::Boolean(false, None)),
-        ("true xor false", EvaluationResult::Boolean(true, None)),
-        ("true xor true", EvaluationResult::Boolean(false, None)),
-        ("1 < 2", EvaluationResult::Boolean(true, None)),
-        ("1 <= 1", EvaluationResult::Boolean(true, None)),
-        ("1 > 2", EvaluationResult::Boolean(false, None)),
-        ("2 >= 2", EvaluationResult::Boolean(true, None)),
-        ("1 = 1", EvaluationResult::Boolean(true, None)),
-        ("1 != 2", EvaluationResult::Boolean(true, None)),
-        ("'hello' = 'hello'", EvaluationResult::Boolean(true, None)),
-        ("'hello' != 'world'", EvaluationResult::Boolean(true, None)),
+        ("true and true", EvaluationResult::Boolean(true, None, None)),
+        (
+            "true and false",
+            EvaluationResult::Boolean(false, None, None),
+        ),
+        ("true or false", EvaluationResult::Boolean(true, None, None)),
+        (
+            "false or false",
+            EvaluationResult::Boolean(false, None, None),
+        ),
+        (
+            "true xor false",
+            EvaluationResult::Boolean(true, None, None),
+        ),
+        (
+            "true xor true",
+            EvaluationResult::Boolean(false, None, None),
+        ),
+        ("1 < 2", EvaluationResult::Boolean(true, None, None)),
+        ("1 <= 1", EvaluationResult::Boolean(true, None, None)),
+        ("1 > 2", EvaluationResult::Boolean(false, None, None)),
+        ("2 >= 2", EvaluationResult::Boolean(true, None, None)),
+        ("1 = 1", EvaluationResult::Boolean(true, None, None)),
+        ("1 != 2", EvaluationResult::Boolean(true, None, None)),
+        (
+            "'hello' = 'hello'",
+            EvaluationResult::Boolean(true, None, None),
+        ),
+        (
+            "'hello' != 'world'",
+            EvaluationResult::Boolean(true, None, None),
+        ),
     ];
 
     let mut passed = 0;
@@ -199,14 +217,17 @@ fn test_real_fhir_patient_type() {
     // Test active.type().namespace - should be FHIR
     let result = evaluate_expression("active.type().namespace", &context).unwrap();
     println!("Real active.type().namespace: {:?}", result);
-    assert_eq!(result, EvaluationResult::String("FHIR".to_string(), None));
+    assert_eq!(
+        result,
+        EvaluationResult::String("FHIR".to_string(), None, None)
+    );
 
     // Test active.type().name - should be boolean
     let result = evaluate_expression("active.type().name", &context).unwrap();
     println!("Real active.type().name: {:?}", result);
     assert_eq!(
         result,
-        EvaluationResult::String("boolean".to_string(), None)
+        EvaluationResult::String("boolean".to_string(), None, None)
     );
 }
 
@@ -231,7 +252,7 @@ fn test_patient_active_type() {
     let mut patient = HashMap::new();
     patient.insert(
         "resourceType".to_string(),
-        EvaluationResult::String("Patient".to_string(), None),
+        EvaluationResult::String("Patient".to_string(), None, None),
     );
     patient.insert("active".to_string(), EvaluationResult::fhir_boolean(true));
 

--- a/crates/fhirpath/tests/tree_navigation_tests.rs
+++ b/crates/fhirpath/tests/tree_navigation_tests.rs
@@ -140,7 +140,7 @@ mod tests {
             EvaluationResult::Collection { items, .. } => {
                 // Check that resourceType is excluded
                 assert!(!items.iter().any(|item| {
-                    if let EvaluationResult::String(s, _) = item {
+                    if let EvaluationResult::String(s, _, _) = item {
                         s == "Patient"
                     } else {
                         false
@@ -153,7 +153,7 @@ mod tests {
 
                 // Check for specific expected values
                 assert!(items.iter().any(|item| {
-                    if let EvaluationResult::String(s, _) = item {
+                    if let EvaluationResult::String(s, _, _) = item {
                         s == "123"
                     } else {
                         false
@@ -161,7 +161,7 @@ mod tests {
                 }));
 
                 assert!(items.iter().any(|item| {
-                    if let EvaluationResult::Boolean(b_val, _) = item {
+                    if let EvaluationResult::Boolean(b_val, _, _) = item {
                         // Renamed to avoid confusion
                         *b_val // if b_val is &bool, dereference to get bool
                     } else {
@@ -230,7 +230,7 @@ mod tests {
 
                 // Check for specific expected values in the deep structure
                 assert!(items.iter().any(|item| {
-                    if let EvaluationResult::String(s, _) = item {
+                    if let EvaluationResult::String(s, _, _) = item {
                         s == "official" // name.use value
                     } else {
                         false
@@ -238,7 +238,7 @@ mod tests {
                 }));
 
                 assert!(items.iter().any(|item| {
-                    if let EvaluationResult::String(s, _) = item {
+                    if let EvaluationResult::String(s, _, _) = item {
                         s == "John" // One of the name.given values
                     } else {
                         false
@@ -246,7 +246,7 @@ mod tests {
                 }));
 
                 assert!(items.iter().any(|item| {
-                    if let EvaluationResult::String(s, _) = item {
+                    if let EvaluationResult::String(s, _, _) = item {
                         s == "555-1234" // telecom[0].value
                     } else {
                         false
@@ -330,7 +330,7 @@ mod tests {
 
                 // Check that we get the id value
                 assert!(items.iter().any(|item| {
-                    if let EvaluationResult::String(s, _) = item {
+                    if let EvaluationResult::String(s, _, _) = item {
                         s == "123" // id value
                     } else {
                         false

--- a/crates/fhirpath/tests/type_preservation_integration_test.rs
+++ b/crates/fhirpath/tests/type_preservation_integration_test.rs
@@ -33,7 +33,7 @@ fn test_uri_type_preserved_in_evaluation() {
     let result = evaluate_expression("identifier[0].type.coding[0].system", &context).unwrap();
 
     // Verify it has the correct type information
-    if let helios_fhirpath_support::EvaluationResult::String(value, type_info) = result {
+    if let helios_fhirpath_support::EvaluationResult::String(value, type_info, _) = result {
         assert_eq!(value, "http://terminology.hl7.org/CodeSystem/v2-0203");
 
         // Check that type info is preserved
@@ -77,7 +77,7 @@ fn test_code_type_preserved_in_evaluation() {
     let result = evaluate_expression("identifier[0].type.coding[0].code", &context).unwrap();
 
     // Verify it has the correct type information
-    if let helios_fhirpath_support::EvaluationResult::String(value, type_info) = result {
+    if let helios_fhirpath_support::EvaluationResult::String(value, type_info, _) = result {
         assert_eq!(value, "MR");
 
         // Check that type info is preserved

--- a/crates/fhirpath/tests/type_reflection_tests.rs
+++ b/crates/fhirpath/tests/type_reflection_tests.rs
@@ -85,13 +85,17 @@ mod tests {
 
                             assert_eq!(
                                 namespace,
-                                &EvaluationResult::String(expected_namespace.to_string(), None),
+                                &EvaluationResult::String(
+                                    expected_namespace.to_string(),
+                                    None,
+                                    None
+                                ),
                                 "Wrong namespace for {}",
                                 expr
                             );
                             assert_eq!(
                                 name,
-                                &EvaluationResult::String(expected_name.to_string(), None),
+                                &EvaluationResult::String(expected_name.to_string(), None, None),
                                 "Wrong name for {}",
                                 expr
                             );
@@ -130,11 +134,11 @@ mod tests {
                     EvaluationResult::Object { map, .. } => {
                         assert_eq!(
                             map.get("namespace").unwrap(),
-                            &EvaluationResult::String("System".to_string(), None)
+                            &EvaluationResult::String("System".to_string(), None, None)
                         );
                         assert_eq!(
                             map.get("name").unwrap(),
-                            &EvaluationResult::String("Integer".to_string(), None)
+                            &EvaluationResult::String("Integer".to_string(), None, None)
                         );
                     }
                     _ => panic!("Expected Object in collection, got {:?}", items[0]),
@@ -164,11 +168,11 @@ mod tests {
 
                             assert_eq!(
                                 namespace,
-                                &EvaluationResult::String("System".to_string(), None)
+                                &EvaluationResult::String("System".to_string(), None, None)
                             );
 
                             let name_str = match name {
-                                EvaluationResult::String(s, _) => s,
+                                EvaluationResult::String(s, _, _) => s,
                                 _ => panic!("Expected string name"),
                             };
 
@@ -199,11 +203,11 @@ mod tests {
                     EvaluationResult::Object { map, .. } => {
                         assert_eq!(
                             map.get("namespace").unwrap(),
-                            &EvaluationResult::String("System".to_string(), None)
+                            &EvaluationResult::String("System".to_string(), None, None)
                         );
                         assert_eq!(
                             map.get("name").unwrap(),
-                            &EvaluationResult::String("Object".to_string(), None)
+                            &EvaluationResult::String("Object".to_string(), None, None)
                         );
                     }
                     _ => panic!("Expected Object in collection, got {:?}", items[0]),
@@ -226,11 +230,11 @@ mod tests {
                     EvaluationResult::Object { map, .. } => {
                         assert_eq!(
                             map.get("namespace").unwrap(),
-                            &EvaluationResult::String("System".to_string(), None)
+                            &EvaluationResult::String("System".to_string(), None, None)
                         );
                         assert_eq!(
                             map.get("name").unwrap(),
-                            &EvaluationResult::String("Object".to_string(), None)
+                            &EvaluationResult::String("Object".to_string(), None, None)
                         );
                     }
                     _ => panic!("Expected Object in collection, got {:?}", items[0]),
@@ -248,11 +252,11 @@ mod tests {
                     EvaluationResult::Object { map, .. } => {
                         assert_eq!(
                             map.get("namespace").unwrap(),
-                            &EvaluationResult::String("System".to_string(), None)
+                            &EvaluationResult::String("System".to_string(), None, None)
                         );
                         assert_eq!(
                             map.get("name").unwrap(),
-                            &EvaluationResult::String("String".to_string(), None)
+                            &EvaluationResult::String("String".to_string(), None, None)
                         );
                     }
                     _ => panic!("Expected Object in collection, got {:?}", items[0]),
@@ -279,11 +283,11 @@ mod tests {
                     EvaluationResult::Object { map, .. } => {
                         assert_eq!(
                             map.get("namespace").unwrap(),
-                            &EvaluationResult::String("System".to_string(), None)
+                            &EvaluationResult::String("System".to_string(), None, None)
                         );
                         assert_eq!(
                             map.get("name").unwrap(),
-                            &EvaluationResult::String("Object".to_string(), None)
+                            &EvaluationResult::String("Object".to_string(), None, None)
                         );
                     }
                     _ => panic!("Expected Object in collection, got {:?}", items[0]),
@@ -306,11 +310,11 @@ mod tests {
                     EvaluationResult::Object { map, .. } => {
                         assert_eq!(
                             map.get("namespace").unwrap(),
-                            &EvaluationResult::String("System".to_string(), None)
+                            &EvaluationResult::String("System".to_string(), None, None)
                         );
                         assert_eq!(
                             map.get("name").unwrap(),
-                            &EvaluationResult::String("String".to_string(), None)
+                            &EvaluationResult::String("String".to_string(), None, None)
                         );
                     }
                     _ => panic!("Expected Object in collection, got {:?}", items[0]),
@@ -332,11 +336,11 @@ mod tests {
                     EvaluationResult::Object { map, .. } => {
                         assert_eq!(
                             map.get("namespace").unwrap(),
-                            &EvaluationResult::String("System".to_string(), None)
+                            &EvaluationResult::String("System".to_string(), None, None)
                         );
                         assert_eq!(
                             map.get("name").unwrap(),
-                            &EvaluationResult::String("Integer".to_string(), None)
+                            &EvaluationResult::String("Integer".to_string(), None, None)
                         );
                     }
                     _ => panic!("Expected Object in collection, got {:?}", items[0]),
@@ -367,11 +371,11 @@ mod tests {
                     EvaluationResult::Object { map, .. } => {
                         assert_eq!(
                             map.get("namespace").unwrap(),
-                            &EvaluationResult::String("System".to_string(), None)
+                            &EvaluationResult::String("System".to_string(), None, None)
                         );
                         assert_eq!(
                             map.get("name").unwrap(),
-                            &EvaluationResult::String("Type".to_string(), None)
+                            &EvaluationResult::String("Type".to_string(), None, None)
                         );
                     }
                     _ => panic!("Expected Object in collection, got {:?}", items[0]),

--- a/crates/fhirpath/tests/uri_type_test.rs
+++ b/crates/fhirpath/tests/uri_type_test.rs
@@ -53,7 +53,7 @@ fn test_uri_type_preservation() {
     let result = evaluate_expression("identifier[0].type.coding[0].system", &context).unwrap();
 
     // Verify the value is correct
-    if let helios_fhirpath_support::EvaluationResult::String(value, _type_info) = &result {
+    if let helios_fhirpath_support::EvaluationResult::String(value, _type_info, _) = &result {
         assert_eq!(value, "http://terminology.hl7.org/CodeSystem/v2-0203");
 
         // Test 2: Check the type using type() function
@@ -61,7 +61,7 @@ fn test_uri_type_preservation() {
             evaluate_expression("identifier[0].type.coding[0].system.type().name", &context)
                 .unwrap();
 
-        if let helios_fhirpath_support::EvaluationResult::String(type_name, _) = type_result {
+        if let helios_fhirpath_support::EvaluationResult::String(type_name, _, _) = type_result {
             // This should be "uri" but currently returns "String"
             println!("Type name: {}", type_name);
             assert_eq!(
@@ -79,7 +79,8 @@ fn test_uri_type_preservation() {
             &context,
         )
         .unwrap();
-        if let helios_fhirpath_support::EvaluationResult::String(namespace, _) = namespace_result {
+        if let helios_fhirpath_support::EvaluationResult::String(namespace, _, _) = namespace_result
+        {
             println!("Namespace: {}", namespace);
             assert_eq!(
                 namespace, "FHIR",
@@ -120,7 +121,7 @@ fn test_code_type_preservation() {
     let type_result =
         evaluate_expression("identifier[0].type.coding[0].code.type().name", &context).unwrap();
 
-    if let helios_fhirpath_support::EvaluationResult::String(type_name, _) = type_result {
+    if let helios_fhirpath_support::EvaluationResult::String(type_name, _, _) = type_result {
         println!("Code type name: {}", type_name);
         assert_eq!(
             type_name, "code",

--- a/crates/fhirpath/tests/uuid_type_preservation_test.rs
+++ b/crates/fhirpath/tests/uuid_type_preservation_test.rs
@@ -39,7 +39,7 @@ fn test_uuid_type_preserved_in_evaluation() {
     println!("Result: {:?}", result);
 
     // Verify it has the correct type information
-    if let helios_fhirpath_support::EvaluationResult::String(value, type_info) = result {
+    if let helios_fhirpath_support::EvaluationResult::String(value, type_info, _) = result {
         assert_eq!(value, "550e8400-e29b-41d4-a716-446655440000");
 
         // Check that type info is preserved
@@ -82,7 +82,7 @@ fn test_element_string_preserves_fhir_type() {
     println!("Element result: {:?}", result);
 
     // Check the type information
-    if let helios_fhirpath_support::EvaluationResult::String(value, type_info) = result {
+    if let helios_fhirpath_support::EvaluationResult::String(value, type_info, _) = result {
         assert_eq!(value, "550e8400-e29b-41d4-a716-446655440000");
 
         // Current implementation returns "string" - this demonstrates the issue

--- a/crates/persistence/src/search/extractor.rs
+++ b/crates/persistence/src/search/extractor.rs
@@ -311,21 +311,21 @@ fn evaluation_result_to_json_values(
 ) -> Result<Vec<Value>, ExtractionError> {
     match result {
         EvaluationResult::Empty => Ok(Vec::new()),
-        EvaluationResult::Boolean(b, _) => Ok(vec![Value::Bool(*b)]),
-        EvaluationResult::String(s, _) => Ok(vec![Value::String(s.clone())]),
-        EvaluationResult::Integer(i, _) => Ok(vec![Value::Number((*i).into())]),
-        EvaluationResult::Integer64(i, _) => Ok(vec![Value::Number((*i).into())]),
-        EvaluationResult::Decimal(d, _) => {
+        EvaluationResult::Boolean(b, _, _) => Ok(vec![Value::Bool(*b)]),
+        EvaluationResult::String(s, _, _) => Ok(vec![Value::String(s.clone())]),
+        EvaluationResult::Integer(i, _, _) => Ok(vec![Value::Number((*i).into())]),
+        EvaluationResult::Integer64(i, _, _) => Ok(vec![Value::Number((*i).into())]),
+        EvaluationResult::Decimal(d, _, _) => {
             // Convert decimal to JSON number
             let f: f64 = (*d).try_into().unwrap_or(0.0);
             Ok(vec![Value::Number(
                 serde_json::Number::from_f64(f).unwrap_or_else(|| serde_json::Number::from(0)),
             )])
         }
-        EvaluationResult::Date(s, _) => Ok(vec![Value::String(s.clone())]),
-        EvaluationResult::DateTime(s, _) => Ok(vec![Value::String(s.clone())]),
-        EvaluationResult::Time(s, _) => Ok(vec![Value::String(s.clone())]),
-        EvaluationResult::Quantity(value, unit, _) => {
+        EvaluationResult::Date(s, _, _) => Ok(vec![Value::String(s.clone())]),
+        EvaluationResult::DateTime(s, _, _) => Ok(vec![Value::String(s.clone())]),
+        EvaluationResult::Time(s, _, _) => Ok(vec![Value::String(s.clone())]),
+        EvaluationResult::Quantity(value, unit, _, _) => {
             // Convert Quantity to JSON object
             let f: f64 = (*value).try_into().unwrap_or(0.0);
             Ok(vec![serde_json::json!({
@@ -625,17 +625,17 @@ mod tests {
 
         assert!(matches!(
             json_to_evaluation_result(&json!(true)).unwrap(),
-            EvaluationResult::Boolean(true, _)
+            EvaluationResult::Boolean(true, _, _)
         ));
 
         assert!(matches!(
             json_to_evaluation_result(&json!("test")).unwrap(),
-            EvaluationResult::String(s, _) if s == "test"
+            EvaluationResult::String(s, _, _) if s == "test"
         ));
 
         assert!(matches!(
             json_to_evaluation_result(&json!(42)).unwrap(),
-            EvaluationResult::Integer(42, _)
+            EvaluationResult::Integer(42, _, _)
         ));
 
         // Test array

--- a/crates/sof/src/lib.rs
+++ b/crates/sof/src/lib.rs
@@ -2044,7 +2044,7 @@ fn can_be_coerced_to_boolean(result: &EvaluationResult) -> bool {
     // Check if the result can be meaningfully used as a boolean in a where clause
     match result {
         // Boolean values are obviously OK
-        EvaluationResult::Boolean(_, _) => true,
+        EvaluationResult::Boolean(_, _, _) => true,
 
         // Empty is OK (evaluates to false)
         EvaluationResult::Empty => true,
@@ -2260,7 +2260,7 @@ where
 fn is_truthy(result: &EvaluationResult) -> bool {
     match result {
         EvaluationResult::Empty => false,
-        EvaluationResult::Boolean(b, _) => *b,
+        EvaluationResult::Boolean(b, _, _) => *b,
         EvaluationResult::Collection { items, .. } => !items.is_empty(),
         _ => true, // Non-empty, non-false values are truthy
     }
@@ -2291,11 +2291,11 @@ fn fhirpath_result_to_json_value_collection(result: EvaluationResult) -> Option<
 fn fhirpath_result_to_json_value(result: EvaluationResult) -> Option<serde_json::Value> {
     match result {
         EvaluationResult::Empty => None,
-        EvaluationResult::Boolean(b, _) => Some(serde_json::Value::Bool(b)),
-        EvaluationResult::Integer(i, _) => {
+        EvaluationResult::Boolean(b, _, _) => Some(serde_json::Value::Bool(b)),
+        EvaluationResult::Integer(i, _, _) => {
             Some(serde_json::Value::Number(serde_json::Number::from(i)))
         }
-        EvaluationResult::Decimal(d, _) => {
+        EvaluationResult::Decimal(d, _, _) => {
             // Check if this Decimal represents a whole number
             if d.fract().is_zero() {
                 // Convert to integer if no fractional part
@@ -2318,14 +2318,14 @@ fn fhirpath_result_to_json_value(result: EvaluationResult) -> Option<serde_json:
                 }
             }
         }
-        EvaluationResult::String(s, _) => Some(serde_json::Value::String(s)),
-        EvaluationResult::Date(s, _) => Some(serde_json::Value::String(s)),
-        EvaluationResult::DateTime(s, _) => {
+        EvaluationResult::String(s, _, _) => Some(serde_json::Value::String(s)),
+        EvaluationResult::Date(s, _, _) => Some(serde_json::Value::String(s)),
+        EvaluationResult::DateTime(s, _, _) => {
             // Remove "@" prefix from datetime strings if present
             let cleaned = s.strip_prefix("@").unwrap_or(&s);
             Some(serde_json::Value::String(cleaned.to_string()))
         }
-        EvaluationResult::Time(s, _) => {
+        EvaluationResult::Time(s, _, _) => {
             // Remove "@T" prefix from time strings if present
             let cleaned = s.strip_prefix("@T").unwrap_or(&s);
             Some(serde_json::Value::String(cleaned.to_string()))

--- a/crates/sof/src/traits.rs
+++ b/crates/sof/src/traits.rs
@@ -245,13 +245,13 @@ pub trait ViewDefinitionWhereTrait {
 ///         let eval_result = constant.to_evaluation_result()?;
 ///         
 ///         match eval_result {
-///             EvaluationResult::String(s, _) => {
+///             EvaluationResult::String(s, _, _) => {
 ///                 println!("String constant '{}' = '{}'", name, s);
 ///             },
-///             EvaluationResult::Integer(i, _) => {
+///             EvaluationResult::Integer(i, _, _) => {
 ///                 println!("Integer constant '{}' = {}", name, i);
 ///             },
-///             EvaluationResult::Boolean(b, _) => {
+///             EvaluationResult::Boolean(b, _, _) => {
 ///                 println!("Boolean constant '{}' = {}", name, b);
 ///             },
 ///             _ => {

--- a/crates/sof/src/traits.rs
+++ b/crates/sof/src/traits.rs
@@ -450,18 +450,20 @@ mod r4_impl {
             if let Some(value) = &self.value {
                 let eval_result = match value {
                     ViewDefinitionConstantValue::String(s) => {
-                        EvaluationResult::String(s.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(s.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Boolean(b) => {
-                        EvaluationResult::Boolean(b.value.unwrap_or(false), None)
+                        EvaluationResult::Boolean(b.value.unwrap_or(false), None, None)
                     }
                     ViewDefinitionConstantValue::Integer(i) => {
-                        EvaluationResult::Integer(i.value.unwrap_or(0) as i64, None)
+                        EvaluationResult::Integer(i.value.unwrap_or(0) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::Decimal(d) => {
                         if let Some(precise_decimal) = &d.value {
                             match precise_decimal.original_string().parse() {
-                                Ok(decimal_value) => EvaluationResult::Decimal(decimal_value, None),
+                                Ok(decimal_value) => {
+                                    EvaluationResult::Decimal(decimal_value, None, None)
+                                }
                                 Err(_) => {
                                     return Err(SofError::InvalidViewDefinition(format!(
                                         "Invalid decimal value for constant '{}'",
@@ -470,11 +472,12 @@ mod r4_impl {
                                 }
                             }
                         } else {
-                            EvaluationResult::Decimal("0".parse().unwrap(), None)
+                            EvaluationResult::Decimal("0".parse().unwrap(), None, None)
                         }
                     }
                     ViewDefinitionConstantValue::Date(d) => EvaluationResult::Date(
                         d.value.clone().unwrap_or_default().to_string(),
+                        None,
                         None,
                     ),
                     ViewDefinitionConstantValue::DateTime(dt) => {
@@ -488,6 +491,7 @@ mod r4_impl {
                         EvaluationResult::DateTime(
                             prefixed,
                             Some(TypeInfoResult::new("FHIR", "dateTime")),
+                            None,
                         )
                     }
                     ViewDefinitionConstantValue::Time(t) => {
@@ -498,16 +502,16 @@ mod r4_impl {
                         } else {
                             format!("@T{}", value_str)
                         };
-                        EvaluationResult::Time(prefixed, None)
+                        EvaluationResult::Time(prefixed, None, None)
                     }
                     ViewDefinitionConstantValue::Code(c) => {
-                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Base64Binary(b) => {
-                        EvaluationResult::String(b.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(b.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Id(i) => {
-                        EvaluationResult::String(i.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(i.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Instant(i) => {
                         let value_str = i.value.clone().unwrap_or_default().to_string();
@@ -520,28 +524,29 @@ mod r4_impl {
                         EvaluationResult::DateTime(
                             prefixed,
                             Some(TypeInfoResult::new("FHIR", "instant")),
+                            None,
                         )
                     }
                     ViewDefinitionConstantValue::Oid(o) => {
-                        EvaluationResult::String(o.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(o.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::PositiveInt(p) => {
-                        EvaluationResult::Integer(p.value.unwrap_or(1) as i64, None)
+                        EvaluationResult::Integer(p.value.unwrap_or(1) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::UnsignedInt(u) => {
-                        EvaluationResult::Integer(u.value.unwrap_or(0) as i64, None)
+                        EvaluationResult::Integer(u.value.unwrap_or(0) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::Uri(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Url(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Uuid(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Canonical(c) => {
-                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None, None)
                     }
                 };
 
@@ -675,18 +680,20 @@ mod r4b_impl {
             if let Some(value) = &self.value {
                 let eval_result = match value {
                     ViewDefinitionConstantValue::String(s) => {
-                        EvaluationResult::String(s.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(s.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Boolean(b) => {
-                        EvaluationResult::Boolean(b.value.unwrap_or(false), None)
+                        EvaluationResult::Boolean(b.value.unwrap_or(false), None, None)
                     }
                     ViewDefinitionConstantValue::Integer(i) => {
-                        EvaluationResult::Integer(i.value.unwrap_or(0) as i64, None)
+                        EvaluationResult::Integer(i.value.unwrap_or(0) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::Decimal(d) => {
                         if let Some(precise_decimal) = &d.value {
                             match precise_decimal.original_string().parse() {
-                                Ok(decimal_value) => EvaluationResult::Decimal(decimal_value, None),
+                                Ok(decimal_value) => {
+                                    EvaluationResult::Decimal(decimal_value, None, None)
+                                }
                                 Err(_) => {
                                     return Err(SofError::InvalidViewDefinition(format!(
                                         "Invalid decimal value for constant '{}'",
@@ -695,11 +702,12 @@ mod r4b_impl {
                                 }
                             }
                         } else {
-                            EvaluationResult::Decimal("0".parse().unwrap(), None)
+                            EvaluationResult::Decimal("0".parse().unwrap(), None, None)
                         }
                     }
                     ViewDefinitionConstantValue::Date(d) => EvaluationResult::Date(
                         d.value.clone().unwrap_or_default().to_string(),
+                        None,
                         None,
                     ),
                     ViewDefinitionConstantValue::DateTime(dt) => {
@@ -713,6 +721,7 @@ mod r4b_impl {
                         EvaluationResult::DateTime(
                             prefixed,
                             Some(TypeInfoResult::new("FHIR", "dateTime")),
+                            None,
                         )
                     }
                     ViewDefinitionConstantValue::Time(t) => {
@@ -723,16 +732,16 @@ mod r4b_impl {
                         } else {
                             format!("@T{}", value_str)
                         };
-                        EvaluationResult::Time(prefixed, None)
+                        EvaluationResult::Time(prefixed, None, None)
                     }
                     ViewDefinitionConstantValue::Code(c) => {
-                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Base64Binary(b) => {
-                        EvaluationResult::String(b.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(b.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Id(i) => {
-                        EvaluationResult::String(i.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(i.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Instant(i) => {
                         let value_str = i.value.clone().unwrap_or_default().to_string();
@@ -745,28 +754,29 @@ mod r4b_impl {
                         EvaluationResult::DateTime(
                             prefixed,
                             Some(TypeInfoResult::new("FHIR", "instant")),
+                            None,
                         )
                     }
                     ViewDefinitionConstantValue::Oid(o) => {
-                        EvaluationResult::String(o.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(o.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::PositiveInt(p) => {
-                        EvaluationResult::Integer(p.value.unwrap_or(1) as i64, None)
+                        EvaluationResult::Integer(p.value.unwrap_or(1) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::UnsignedInt(u) => {
-                        EvaluationResult::Integer(u.value.unwrap_or(0) as i64, None)
+                        EvaluationResult::Integer(u.value.unwrap_or(0) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::Uri(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Url(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Uuid(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Canonical(c) => {
-                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None, None)
                     }
                 };
 
@@ -902,18 +912,20 @@ mod r5_impl {
                 // R5 implementation identical to R4
                 let eval_result = match value {
                     ViewDefinitionConstantValue::String(s) => {
-                        EvaluationResult::String(s.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(s.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Boolean(b) => {
-                        EvaluationResult::Boolean(b.value.unwrap_or(false), None)
+                        EvaluationResult::Boolean(b.value.unwrap_or(false), None, None)
                     }
                     ViewDefinitionConstantValue::Integer(i) => {
-                        EvaluationResult::Integer(i.value.unwrap_or(0) as i64, None)
+                        EvaluationResult::Integer(i.value.unwrap_or(0) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::Decimal(d) => {
                         if let Some(precise_decimal) = &d.value {
                             match precise_decimal.original_string().parse() {
-                                Ok(decimal_value) => EvaluationResult::Decimal(decimal_value, None),
+                                Ok(decimal_value) => {
+                                    EvaluationResult::Decimal(decimal_value, None, None)
+                                }
                                 Err(_) => {
                                     return Err(SofError::InvalidViewDefinition(format!(
                                         "Invalid decimal value for constant '{}'",
@@ -922,11 +934,12 @@ mod r5_impl {
                                 }
                             }
                         } else {
-                            EvaluationResult::Decimal("0".parse().unwrap(), None)
+                            EvaluationResult::Decimal("0".parse().unwrap(), None, None)
                         }
                     }
                     ViewDefinitionConstantValue::Date(d) => EvaluationResult::Date(
                         d.value.clone().unwrap_or_default().to_string(),
+                        None,
                         None,
                     ),
                     ViewDefinitionConstantValue::DateTime(dt) => {
@@ -940,6 +953,7 @@ mod r5_impl {
                         EvaluationResult::DateTime(
                             prefixed,
                             Some(TypeInfoResult::new("FHIR", "dateTime")),
+                            None,
                         )
                     }
                     ViewDefinitionConstantValue::Time(t) => {
@@ -950,16 +964,16 @@ mod r5_impl {
                         } else {
                             format!("@T{}", value_str)
                         };
-                        EvaluationResult::Time(prefixed, None)
+                        EvaluationResult::Time(prefixed, None, None)
                     }
                     ViewDefinitionConstantValue::Code(c) => {
-                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Base64Binary(b) => {
-                        EvaluationResult::String(b.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(b.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Id(i) => {
-                        EvaluationResult::String(i.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(i.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Instant(i) => {
                         let value_str = i.value.clone().unwrap_or_default().to_string();
@@ -972,31 +986,32 @@ mod r5_impl {
                         EvaluationResult::DateTime(
                             prefixed,
                             Some(TypeInfoResult::new("FHIR", "instant")),
+                            None,
                         )
                     }
                     ViewDefinitionConstantValue::Oid(o) => {
-                        EvaluationResult::String(o.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(o.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::PositiveInt(p) => {
-                        EvaluationResult::Integer(p.value.unwrap_or(1) as i64, None)
+                        EvaluationResult::Integer(p.value.unwrap_or(1) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::UnsignedInt(u) => {
-                        EvaluationResult::Integer(u.value.unwrap_or(0) as i64, None)
+                        EvaluationResult::Integer(u.value.unwrap_or(0) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::Uri(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Url(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Uuid(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Canonical(c) => {
-                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Integer64(i) => {
-                        EvaluationResult::Integer64(i.value.unwrap_or(0), None)
+                        EvaluationResult::Integer64(i.value.unwrap_or(0), None, None)
                     }
                 };
 
@@ -1137,18 +1152,20 @@ mod r6_impl {
                 // R5 implementation identical to R4
                 let eval_result = match value {
                     ViewDefinitionConstantValue::String(s) => {
-                        EvaluationResult::String(s.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(s.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Boolean(b) => {
-                        EvaluationResult::Boolean(b.value.unwrap_or(false), None)
+                        EvaluationResult::Boolean(b.value.unwrap_or(false), None, None)
                     }
                     ViewDefinitionConstantValue::Integer(i) => {
-                        EvaluationResult::Integer(i.value.unwrap_or(0) as i64, None)
+                        EvaluationResult::Integer(i.value.unwrap_or(0) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::Decimal(d) => {
                         if let Some(precise_decimal) = &d.value {
                             match precise_decimal.original_string().parse() {
-                                Ok(decimal_value) => EvaluationResult::Decimal(decimal_value, None),
+                                Ok(decimal_value) => {
+                                    EvaluationResult::Decimal(decimal_value, None, None)
+                                }
                                 Err(_) => {
                                     return Err(SofError::InvalidViewDefinition(format!(
                                         "Invalid decimal value for constant '{}'",
@@ -1157,11 +1174,12 @@ mod r6_impl {
                                 }
                             }
                         } else {
-                            EvaluationResult::Decimal("0".parse().unwrap(), None)
+                            EvaluationResult::Decimal("0".parse().unwrap(), None, None)
                         }
                     }
                     ViewDefinitionConstantValue::Date(d) => EvaluationResult::Date(
                         d.value.clone().unwrap_or_default().to_string(),
+                        None,
                         None,
                     ),
                     ViewDefinitionConstantValue::DateTime(dt) => {
@@ -1175,6 +1193,7 @@ mod r6_impl {
                         EvaluationResult::DateTime(
                             prefixed,
                             Some(TypeInfoResult::new("FHIR", "dateTime")),
+                            None,
                         )
                     }
                     ViewDefinitionConstantValue::Time(t) => {
@@ -1185,16 +1204,16 @@ mod r6_impl {
                         } else {
                             format!("@T{}", value_str)
                         };
-                        EvaluationResult::Time(prefixed, None)
+                        EvaluationResult::Time(prefixed, None, None)
                     }
                     ViewDefinitionConstantValue::Code(c) => {
-                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Base64Binary(b) => {
-                        EvaluationResult::String(b.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(b.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Id(i) => {
-                        EvaluationResult::String(i.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(i.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Instant(i) => {
                         let value_str = i.value.clone().unwrap_or_default().to_string();
@@ -1207,31 +1226,32 @@ mod r6_impl {
                         EvaluationResult::DateTime(
                             prefixed,
                             Some(TypeInfoResult::new("FHIR", "instant")),
+                            None,
                         )
                     }
                     ViewDefinitionConstantValue::Oid(o) => {
-                        EvaluationResult::String(o.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(o.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::PositiveInt(p) => {
-                        EvaluationResult::Integer(p.value.unwrap_or(1) as i64, None)
+                        EvaluationResult::Integer(p.value.unwrap_or(1) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::UnsignedInt(u) => {
-                        EvaluationResult::Integer(u.value.unwrap_or(0) as i64, None)
+                        EvaluationResult::Integer(u.value.unwrap_or(0) as i64, None, None)
                     }
                     ViewDefinitionConstantValue::Uri(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Url(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Uuid(u) => {
-                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(u.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Canonical(c) => {
-                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None)
+                        EvaluationResult::String(c.value.clone().unwrap_or_default(), None, None)
                     }
                     ViewDefinitionConstantValue::Integer64(i) => {
-                        EvaluationResult::Integer(i.value.unwrap_or(0), None)
+                        EvaluationResult::Integer(i.value.unwrap_or(0), None, None)
                     }
                 };
 

--- a/crates/sof/tests/debug_boolean_test.rs
+++ b/crates/sof/tests/debug_boolean_test.rs
@@ -40,6 +40,7 @@ mod tests {
             Some(helios_fhirpath_support::TypeInfoResult::new(
                 "FHIR", "boolean",
             )),
+            None,
         );
         context.set_variable_result("is_deceased", is_deceased_constant);
 


### PR DESCRIPTION
Closes #84.

## Summary
- Adds `PrimitiveElement { id, extension }` and a trailing `Option<Box<PrimitiveElement>>` on each primitive variant of `EvaluationResult` (Boolean, String, Decimal, Integer, Integer64, Date, DateTime, Time, Quantity).
- `Element<V, E>::to_evaluation_result()` and `DecimalElement<E>::to_evaluation_result()` now carry id/extension metadata alongside the primitive value, instead of dropping it when value is present.
- `evaluator.rs:2120-2175` (the three `return Empty` stubs) are replaced with a `primitive_member_access` helper that returns the id/extension when present and `Empty` otherwise.
- The `FhirPath` derive macro preserves the new metadata field when post-processing primitives for FHIR type info.
- ~1600 constructor and destructure sites migrated across fhirpath-support, fhirpath, fhir-macro, fhir, sof, and persistence.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features` with the project's CI flags — clean
- [x] `cargo test -p helios-fhirpath-support` — 13 doctests + 5 unit tests pass
- [x] `cargo test -p helios-fhirpath` — 282 lib tests + all integration suites pass
- [x] `cargo test -p helios-fhir`, `cargo test -p helios-sof` — pass
- [x] New `crates/fhirpath/tests/primitive_extension_tests.rs` (6 tests) covering:
  - `Patient.active.id` returns the id
  - `Patient.active.id` returns Empty when no id is set
  - `Patient.birthDate.extension.exists()` works when only extension is present (no value)
  - `Patient.birthDate.id` / `.extension.count()` / `.extension.url` / `.extension.where(url=…)` when both value and metadata are present
  - Primitives without `_field` metadata still return Empty
  - Empty extension list returns Empty