### PR TITLE
feat(hts): support $translate without ConceptMap URL (R5 source/targe…

### DIFF
--- a/crates/hts/src/backends/postgres/concept_map.rs
+++ b/crates/hts/src/backends/postgres/concept_map.rs
@@ -30,12 +30,27 @@ impl ConceptMapOperations for PostgresTerminologyBackend {
             .await
             .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
 
+        // Reverse mode is set explicitly via `reverse=true`, *or* implicitly
+        // when the caller supplied `targetCode` instead of `sourceCode` (R5).
+        let reverse = req.reverse || req.target_code.is_some();
+        let lookup_code: &str = if req.target_code.is_some() {
+            req.target_code.as_deref().unwrap_or("")
+        } else {
+            req.code.as_str()
+        };
+        let (search_sys, other_side_sys) = if req.target_code.is_some() {
+            (req.target_system.as_deref(), req.system.as_deref())
+        } else {
+            (req.system.as_deref(), req.target_system.as_deref())
+        };
+
         let rows = query_translate_elements(
             &client,
-            &req.code,
-            req.system.as_deref(),
+            lookup_code,
+            search_sys,
+            other_side_sys,
             req.url.as_deref(),
-            req.reverse,
+            reverse,
             req.date.as_deref(),
         )
         .await?;
@@ -48,6 +63,9 @@ impl ConceptMapOperations for PostgresTerminologyBackend {
                 concept_code: r.concept_code,
                 concept_display: r.display,
                 source: Some(r.map_url),
+                map_version: r.map_version,
+                source_system: r.input_system,
+                source_code: r.input_code,
             })
             .collect();
 
@@ -236,45 +254,56 @@ struct TranslateRow {
     concept_code: String,
     equivalence: String,
     map_url: String,
+    map_version: Option<String>,
     display: Option<String>,
+    input_system: Option<String>,
+    input_code: Option<String>,
 }
 
 /// Query `concept_map_elements` for matching translations.
 ///
 /// `reverse = false` (default): search source_code, return target.
 /// `reverse = true`: search target_code, return source.
+///
+/// `other_side_sys` restricts the result-side system (target side in forward
+/// mode, source side in reverse mode).
 async fn query_translate_elements(
     client: &tokio_postgres::Client,
     code: &str,
     system: Option<&str>,
+    other_side_sys: Option<&str>,
     map_url: Option<&str>,
     reverse: bool,
     date: Option<&str>,
 ) -> Result<Vec<TranslateRow>, HtsError> {
     let sql = if !reverse {
-        "SELECT cme.target_system, cme.target_code, cme.equivalence, cm.url, c.display
+        "SELECT cme.target_system, cme.target_code, cme.equivalence, cm.url, cm.version,
+                c.display, cme.source_system, cme.source_code
          FROM concept_map_elements cme
          JOIN concept_maps cm ON cm.id = cme.map_id
          LEFT JOIN code_systems cs_disp ON cs_disp.url = cme.target_system
          LEFT JOIN concepts c ON c.system_id = cs_disp.id AND c.code = cme.target_code
          WHERE cme.source_code = $1
            AND ($2::text IS NULL OR cme.source_system = $2)
-           AND ($3::text IS NULL OR cm.url = $3)
-           AND ($4::text IS NULL OR (cm.resource_json->>'date') <= $4)"
+           AND ($3::text IS NULL OR cme.target_system = $3)
+           AND ($4::text IS NULL OR cm.url = $4)
+           AND ($5::text IS NULL OR (cm.resource_json->>'date') <= $5)"
     } else {
-        "SELECT cme.source_system, cme.source_code, cme.equivalence, cm.url, c.display
+        "SELECT cme.source_system, cme.source_code, cme.equivalence, cm.url, cm.version,
+                c.display, cme.target_system, cme.target_code
          FROM concept_map_elements cme
          JOIN concept_maps cm ON cm.id = cme.map_id
          LEFT JOIN code_systems cs_disp ON cs_disp.url = cme.source_system
          LEFT JOIN concepts c ON c.system_id = cs_disp.id AND c.code = cme.source_code
          WHERE cme.target_code = $1
            AND ($2::text IS NULL OR cme.target_system = $2)
-           AND ($3::text IS NULL OR cm.url = $3)
-           AND ($4::text IS NULL OR (cm.resource_json->>'date') <= $4)"
+           AND ($3::text IS NULL OR cme.source_system = $3)
+           AND ($4::text IS NULL OR cm.url = $4)
+           AND ($5::text IS NULL OR (cm.resource_json->>'date') <= $5)"
     };
 
     let rows = client
-        .query(sql, &[&code, &system, &map_url, &date])
+        .query(sql, &[&code, &system, &other_side_sys, &map_url, &date])
         .await
         .map_err(|e| HtsError::StorageError(format!("Query error: {e}")))?;
 
@@ -285,7 +314,10 @@ async fn query_translate_elements(
             concept_code: row.get(1),
             equivalence: row.get(2),
             map_url: row.get(3),
-            display: row.get(4),
+            map_version: row.get(4),
+            display: row.get(5),
+            input_system: row.get(6),
+            input_code: row.get(7),
         })
         .collect())
 }

--- a/crates/hts/src/backends/sqlite/concept_map.rs
+++ b/crates/hts/src/backends/sqlite/concept_map.rs
@@ -166,12 +166,41 @@ fn translate_sync(
         }
     }
 
+    // Reverse mode is set explicitly via `reverse=true`, *or* implicitly when
+    // the caller supplied `targetCode` instead of `sourceCode` (R5 form).
+    let reverse = req.reverse || req.target_code.is_some();
+
+    // Pick the lookup code: in reverse-via-targetCode mode use `target_code`;
+    // otherwise use `code`.
+    let lookup_code: &str = if req.target_code.is_some() {
+        req.target_code.as_deref().unwrap_or("")
+    } else {
+        req.code.as_str()
+    };
+
+    // Pick the system that goes with the lookup code, and the "other side"
+    // restriction that applies to the result.
+    //   - Forward (default): search `req.system` (sourceSystem); restrict
+    //     result side to `req.target_system`.
+    //   - Reverse via `reverse=true`: callers historically pass the
+    //     target-side system in `req.system`; restrict result (source side)
+    //     to `req.target_system`.
+    //   - Reverse via `targetCode` (R5): search `req.target_system`;
+    //     restrict result (source side) to `req.system` (sourceSystem of
+    //     the request).
+    let (search_sys, other_side_sys) = if req.target_code.is_some() {
+        (req.target_system.as_deref(), req.system.as_deref())
+    } else {
+        (req.system.as_deref(), req.target_system.as_deref())
+    };
+
     let mut rows = query_translate_elements(
         conn,
-        &req.code,
-        req.system.as_deref(),
+        lookup_code,
+        search_sys,
+        other_side_sys,
         req.url.as_deref(),
-        req.reverse,
+        reverse,
         req.date.as_deref(),
     )?;
 
@@ -180,8 +209,8 @@ fn translate_sync(
     // individual rows, but clients may still send the original compound string.
     // When no exact match is found and the code contains a comma, try each
     // individual token so compound-code queries still resolve.
-    if rows.is_empty() && req.code.contains(',') {
-        for token in req.code.split(',') {
+    if rows.is_empty() && lookup_code.contains(',') {
+        for token in lookup_code.split(',') {
             let token = token.trim();
             if token.is_empty() {
                 continue;
@@ -189,9 +218,10 @@ fn translate_sync(
             let token_rows = query_translate_elements(
                 conn,
                 token,
-                req.system.as_deref(),
+                search_sys,
+                other_side_sys,
                 req.url.as_deref(),
-                req.reverse,
+                reverse,
                 req.date.as_deref(),
             )?;
             if !token_rows.is_empty() {
@@ -209,6 +239,9 @@ fn translate_sync(
             concept_code: r.concept_code,
             concept_display: r.display,
             source: Some(r.map_url),
+            map_version: r.map_version,
+            source_system: r.input_system,
+            source_code: r.input_code,
         })
         .collect();
 
@@ -231,63 +264,79 @@ struct TranslateRow {
     concept_code: String,
     equivalence: String,
     map_url: String,
+    map_version: Option<String>,
     display: Option<String>,
+    /// The "input side" system (i.e. the side the request matched against).
+    /// Used to populate the `source` Coding part in reverse responses.
+    input_system: Option<String>,
+    input_code: Option<String>,
 }
 
 /// Query `concept_map_elements` for matching translations.
 ///
 /// Uses NULL-safe parameter binding so a single prepared statement handles
-/// all combinations of optional `system` and `map_url` filters:
-///
-/// ```sql
-/// WHERE search_code_col = ?1
-///   AND (?2 IS NULL OR search_sys_col = ?2)
-///   AND (?3 IS NULL OR cm.url = ?3)
-/// ```
+/// all combinations of optional system / target-system / map_url filters.
 ///
 /// `reverse = false` (default): search source_code, return target.
 /// `reverse = true`: search target_code, return source.
+///
+/// `other_side_sys` restricts the *result* side: in forward mode it filters
+/// `target_system`; in reverse mode it filters `source_system`. This lets
+/// callers say "translate code-X from source-CS into target-CS" without
+/// pulling in unrelated maps that happen to mention the source code.
 fn query_translate_elements(
     conn: &Connection,
     code: &str,
     system: Option<&str>,
+    other_side_sys: Option<&str>,
     map_url: Option<&str>,
     reverse: bool,
     date: Option<&str>,
 ) -> Result<Vec<TranslateRow>, HtsError> {
     // Column names depend on direction.
-    let (search_code_col, search_sys_col, disp_sys_col, disp_code_col, res_sys_col, res_code_col) =
-        if !reverse {
-            (
-                "cme.source_code",
-                "cme.source_system",
-                "cme.target_system",
-                "cme.target_code",
-                "cme.target_system",
-                "cme.target_code",
-            )
-        } else {
-            (
-                "cme.target_code",
-                "cme.target_system",
-                "cme.source_system",
-                "cme.source_code",
-                "cme.source_system",
-                "cme.source_code",
-            )
-        };
+    let (
+        search_code_col,
+        search_sys_col,
+        other_sys_col,
+        disp_sys_col,
+        disp_code_col,
+        res_sys_col,
+        res_code_col,
+    ) = if !reverse {
+        (
+            "cme.source_code",
+            "cme.source_system",
+            "cme.target_system",
+            "cme.target_system",
+            "cme.target_code",
+            "cme.target_system",
+            "cme.target_code",
+        )
+    } else {
+        (
+            "cme.target_code",
+            "cme.target_system",
+            "cme.source_system",
+            "cme.source_system",
+            "cme.source_code",
+            "cme.source_system",
+            "cme.source_code",
+        )
+    };
 
     // Inline the column names into the query string (no user input touches this).
     let sql = format!(
-        "SELECT {res_sys_col}, {res_code_col}, cme.equivalence, cm.url, c.display
+        "SELECT {res_sys_col}, {res_code_col}, cme.equivalence, cm.url, cm.version,
+                c.display, {search_sys_col}, {search_code_col}
          FROM concept_map_elements cme
          JOIN concept_maps cm ON cm.id = cme.map_id
          LEFT JOIN code_systems cs_disp ON cs_disp.url = {disp_sys_col}
          LEFT JOIN concepts c ON c.system_id = cs_disp.id AND c.code = {disp_code_col}
          WHERE {search_code_col} = ?1
            AND (?2 IS NULL OR {search_sys_col} = ?2)
-           AND (?3 IS NULL OR cm.url = ?3)
-           AND (?4 IS NULL OR json_extract(cm.resource_json, '$.date') <= ?4)"
+           AND (?3 IS NULL OR {other_sys_col} = ?3)
+           AND (?4 IS NULL OR cm.url = ?4)
+           AND (?5 IS NULL OR json_extract(cm.resource_json, '$.date') <= ?5)"
     );
 
     let mut stmt = conn
@@ -295,15 +344,21 @@ fn query_translate_elements(
         .map_err(|e| HtsError::StorageError(format!("Prepare error: {e}")))?;
 
     let rows = stmt
-        .query_map(rusqlite::params![code, system, map_url, date], |row| {
-            Ok(TranslateRow {
-                concept_system: row.get(0)?,
-                concept_code: row.get(1)?,
-                equivalence: row.get(2)?,
-                map_url: row.get(3)?,
-                display: row.get(4)?,
-            })
-        })
+        .query_map(
+            rusqlite::params![code, system, other_side_sys, map_url, date],
+            |row| {
+                Ok(TranslateRow {
+                    concept_system: row.get(0)?,
+                    concept_code: row.get(1)?,
+                    equivalence: row.get(2)?,
+                    map_url: row.get(3)?,
+                    map_version: row.get(4)?,
+                    display: row.get(5)?,
+                    input_system: row.get(6)?,
+                    input_code: row.get(7)?,
+                })
+            },
+        )
         .map_err(|e| HtsError::StorageError(format!("Query error: {e}")))?
         .collect::<rusqlite::Result<Vec<_>>>()
         .map_err(|e| HtsError::StorageError(format!("Row error: {e}")))?;
@@ -639,6 +694,61 @@ mod tests {
         let resp = backend.translate(&ctx, req).await.unwrap();
         assert!(resp.result);
         assert_eq!(resp.matches[0].concept_code, "X");
+    }
+
+    /// `target_system` filter restricts the result side, not just the request.
+    /// Without a candidate map matching the requested target system, no
+    /// matches should be returned.
+    #[tokio::test]
+    async fn translate_filtered_by_target_system_no_match() {
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        seed_db(&backend);
+
+        let ctx = TenantContext::system();
+        let req = TranslateRequest {
+            system: Some("http://example.org/src".into()),
+            target_system: Some("http://nope.example.org/cs".into()),
+            code: "A".into(),
+            ..Default::default()
+        };
+
+        let resp = backend.translate(&ctx, req).await.unwrap();
+        assert!(!resp.result);
+    }
+
+    /// Reverse via R5 `target_code` returns the source-side Coding fields and
+    /// uses `target_system` as the lookup-side restriction.
+    #[tokio::test]
+    async fn translate_reverse_via_target_code_returns_source_fields() {
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        seed_db(&backend);
+
+        let ctx = TenantContext::system();
+        let req = TranslateRequest {
+            // R5-style: sourceSystem narrows source side; targetCode/system
+            // identify the code being reverse-translated.
+            system: Some("http://example.org/src".into()),
+            target_system: Some("http://example.org/tgt".into()),
+            target_code: Some("X".into()),
+            // `code` left empty intentionally (driven by `target_code`).
+            code: String::new(),
+            ..Default::default()
+        };
+
+        let resp = backend.translate(&ctx, req).await.unwrap();
+        assert!(resp.result);
+        assert_eq!(resp.matches.len(), 1);
+        // Result `concept` is the source side (A in src CS).
+        assert_eq!(resp.matches[0].concept_code, "A");
+        assert_eq!(resp.matches[0].concept_system, "http://example.org/src");
+        // The input-side fields carry the original target Coding (X in tgt CS).
+        assert_eq!(resp.matches[0].source_code.as_deref(), Some("X"));
+        assert_eq!(
+            resp.matches[0].source_system.as_deref(),
+            Some("http://example.org/tgt")
+        );
+        // Map version is included so handlers can build originMap canonicals.
+        assert_eq!(resp.matches[0].map_version.as_deref(), Some("1.0"));
     }
 
     // ── $closure ───────────────────────────────────────────────────────────────

--- a/crates/hts/src/import/bundle_parser.rs
+++ b/crates/hts/src/import/bundle_parser.rs
@@ -439,8 +439,11 @@ fn parse_concept_map(cm: &Value) -> Option<ParsedConceptMap> {
 
             for target in targets {
                 let target_code = target["code"].as_str().unwrap_or("").to_owned();
+                // R4 uses `equivalence`; R5 uses `relationship`. Accept either so
+                // ConceptMap fixtures from either FHIR version import correctly.
                 let equivalence = target["equivalence"]
                     .as_str()
+                    .or_else(|| target["relationship"].as_str())
                     .unwrap_or("equivalent")
                     .to_owned();
 
@@ -577,6 +580,47 @@ mod tests {
         assert_eq!(cm.elements[0].source_code, "A");
         assert_eq!(cm.elements[0].target_code, "X");
         assert_eq!(cm.elements[0].equivalence, "equivalent");
+    }
+
+    /// R5 ConceptMap targets use `relationship` instead of R4's `equivalence`.
+    /// The parser should accept either form so tx-ecosystem fixtures import
+    /// regardless of which FHIR version they were authored against.
+    #[test]
+    fn concept_map_relationship_field_imports_as_equivalence() {
+        let bundle = br#"{
+            "resourceType": "Bundle",
+            "type": "collection",
+            "entry": [
+                {
+                    "resource": {
+                        "resourceType": "ConceptMap",
+                        "url": "http://example.org/cm-r5",
+                        "status": "active",
+                        "group": [
+                            {
+                                "source": "http://example.org/src",
+                                "target": "http://example.org/tgt",
+                                "element": [
+                                    {
+                                        "code": "code-1",
+                                        "target": [{
+                                            "code": "code1",
+                                            "relationship": "source-is-narrower-than-target"
+                                        }]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let parsed = parse_bundle(bundle).unwrap();
+        assert_eq!(parsed.concept_maps.len(), 1);
+        let elem = &parsed.concept_maps[0].elements[0];
+        assert_eq!(elem.source_code, "code-1");
+        assert_eq!(elem.target_code, "code1");
+        assert_eq!(elem.equivalence, "source-is-narrower-than-target");
     }
 
     #[test]

--- a/crates/hts/src/operations/translate.rs
+++ b/crates/hts/src/operations/translate.rs
@@ -49,22 +49,41 @@ pub(crate) async fn process_translate<B: TerminologyBackend>(
     state: &AppState<B>,
     params: Vec<Value>,
 ) -> Result<Value, HtsError> {
-    let code = find_str_param(&params, "code")
-        .ok_or_else(|| HtsError::InvalidRequest("Missing required parameter: code".into()))?;
+    // R4 names: `code`, `system`. R5 names: `sourceCode`, `sourceSystem`,
+    // `targetCode`, `targetSystem`. Accept either form.
+    let source_code =
+        find_str_param(&params, "sourceCode").or_else(|| find_str_param(&params, "code"));
+    let target_code = find_str_param(&params, "targetCode");
+    let source_system =
+        find_str_param(&params, "sourceSystem").or_else(|| find_str_param(&params, "system"));
+    let target_system = find_str_param(&params, "targetSystem");
+
+    // Need at least one of source code (forward) or target code (reverse).
+    if source_code.is_none() && target_code.is_none() {
+        return Err(HtsError::InvalidRequest(
+            "Missing required parameter: code or sourceCode (or targetCode for reverse)".into(),
+        ));
+    }
 
     // `reverse` arrives as valueBoolean (POST) or plain string "true"/"false" (GET).
-    let reverse = find_str_param(&params, "reverse")
+    let reverse_flag = find_str_param(&params, "reverse")
         .map(|s| s == "true")
         .unwrap_or(false);
+    // The request is reverse-mode if the caller asked for it explicitly
+    // (`reverse=true`) or supplied `targetCode` instead of `sourceCode`.
+    let is_reverse = reverse_flag || target_code.is_some();
 
     let req = TranslateRequest {
         url: find_str_param(&params, "url"),
-        system: find_str_param(&params, "system"),
-        code,
+        system: source_system,
+        // `code` is the forward-mode lookup. Empty string when only
+        // `targetCode` is supplied (reverse mode keyed on `target_code`).
+        code: source_code.unwrap_or_default(),
         source: find_str_param(&params, "source"),
         target: find_str_param(&params, "target"),
-        target_system: find_str_param(&params, "targetSystem"),
-        reverse,
+        target_system,
+        target_code,
+        reverse: reverse_flag,
         date: find_str_param(&params, "date"),
     };
 
@@ -72,34 +91,63 @@ pub(crate) async fn process_translate<B: TerminologyBackend>(
     let resp = ConceptMapOperations::translate(state.backend(), &ctx, req).await?;
 
     // ── Build FHIR Parameters response ─────────────────────────────────────────
-    let mut parameter: Vec<Value> = vec![json!({
-        "name": "result",
-        "valueBoolean": resp.result
-    })];
-
-    if let Some(msg) = resp.message {
-        parameter.push(json!({
-            "name": "message",
-            "valueString": msg
-        }));
-    }
+    //
+    // The `match` parts come *before* `result` in the IG fixtures; emit in the
+    // same order so byte-for-byte comparison passes.
+    let mut parameter: Vec<Value> = Vec::with_capacity(resp.matches.len() + 2);
 
     for m in resp.matches {
-        let mut parts: Vec<Value> = vec![
-            json!({"name": "equivalence", "valueCode": m.equivalence}),
-            json!({
-                "name": "concept",
-                "valueCoding": {
-                    "system": m.concept_system,
-                    "code": m.concept_code,
-                    "display": m.concept_display
-                }
-            }),
-        ];
-        if let Some(src) = m.source {
-            parts.push(json!({"name": "source", "valueUri": src}));
+        let mut parts: Vec<Value> = Vec::with_capacity(5);
+
+        // `concept` Coding always first — fixtures rely on this ordering.
+        parts.push(json!({
+            "name": "concept",
+            "valueCoding": {
+                "system": m.concept_system,
+                "code": m.concept_code,
+                "display": m.concept_display
+            }
+        }));
+
+        // R4 emits `equivalence`; R5 emits `relationship`. Emit both — the
+        // tx-ecosystem fixtures mark each as `$optional$ version:N` so a
+        // server that includes both is conformant for either FHIR version.
+        parts.push(json!({"name": "equivalence", "valueCode": m.equivalence}));
+        parts.push(json!({"name": "relationship", "valueCode": m.equivalence}));
+
+        // `originMap` — canonical ConceptMap reference, with `|version` if known.
+        if let Some(src) = m.source.as_deref() {
+            let canonical = match m.map_version.as_deref() {
+                Some(v) if !v.is_empty() => format!("{src}|{v}"),
+                _ => src.to_owned(),
+            };
+            parts.push(json!({"name": "originMap", "valueCanonical": canonical}));
         }
+
+        // For reverse responses include the original (input-side) Coding as a
+        // `source` part — IG fixtures expect this so the caller can tell
+        // which source code each reverse match came from. Skip in forward
+        // mode: the caller already knows the source code they sent.
+        if is_reverse {
+            if let (Some(sys), Some(code)) = (m.source_system.as_deref(), m.source_code.as_deref())
+            {
+                parts.push(json!({
+                    "name": "source",
+                    "valueCoding": {
+                        "system": sys,
+                        "code": code
+                    }
+                }));
+            }
+        }
+
         parameter.push(json!({"name": "match", "part": parts}));
+    }
+
+    parameter.push(json!({"name": "result", "valueBoolean": resp.result}));
+
+    if let Some(msg) = resp.message {
+        parameter.push(json!({"name": "message", "valueString": msg}));
     }
 
     Ok(json!({
@@ -422,6 +470,170 @@ mod tests {
     async fn translate_wrong_resource_type_returns_400() {
         let app = make_app();
         let body = json!({"resourceType": "ConceptMap", "parameter": []});
+
+        let resp = post_json(app, "/ConceptMap/$translate", body).await;
+        assert_eq!(resp.status(), 400);
+    }
+
+    // ── R5 parameter names + no-URL translation (tx-ecosystem IG) ──────────────
+
+    /// `sourceCode` + `sourceSystem` + `targetSystem` (no `url`) — R5 names.
+    /// Mirrors the IG `translate/translate-1` fixture shape.
+    #[tokio::test]
+    async fn translate_r5_param_names_without_url_finds_match() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "sourceSystem", "valueUri": "http://example.org/src"},
+                {"name": "sourceCode",   "valueCode": "A"},
+                {"name": "targetSystem", "valueUri": "http://example.org/tgt"}
+            ]
+        });
+
+        let resp = post_json(app, "/ConceptMap/$translate", body).await;
+        assert_eq!(resp.status(), 200);
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+
+        let result = params.iter().find(|p| p["name"] == "result").unwrap();
+        assert_eq!(result["valueBoolean"], true);
+
+        let m = params.iter().find(|p| p["name"] == "match").unwrap();
+        let parts = m["part"].as_array().unwrap();
+        let concept = parts.iter().find(|p| p["name"] == "concept").unwrap();
+        assert_eq!(concept["valueCoding"]["code"], "X");
+        assert_eq!(concept["valueCoding"]["system"], "http://example.org/tgt");
+    }
+
+    /// Reverse mode driven by `targetCode` + `sourceSystem` (no `reverse=true`).
+    /// Mirrors `translate/translate-reverse`.
+    #[tokio::test]
+    async fn translate_reverse_via_target_code_emits_source_coding() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "sourceSystem", "valueUri": "http://example.org/src"},
+                {"name": "targetCode",   "valueCode": "X"},
+                {"name": "targetSystem", "valueUri": "http://example.org/tgt"}
+            ]
+        });
+
+        let resp = post_json(app, "/ConceptMap/$translate", body).await;
+        assert_eq!(resp.status(), 200);
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+
+        let m = params.iter().find(|p| p["name"] == "match").unwrap();
+        let parts = m["part"].as_array().unwrap();
+
+        // Reverse output: concept is the source-side Coding.
+        let concept = parts.iter().find(|p| p["name"] == "concept").unwrap();
+        assert_eq!(concept["valueCoding"]["code"], "A");
+        assert_eq!(concept["valueCoding"]["system"], "http://example.org/src");
+
+        // `source` part carries the original (input) Coding so the caller can
+        // tell which target code each reverse match came from.
+        let source = parts.iter().find(|p| p["name"] == "source").unwrap();
+        assert_eq!(source["valueCoding"]["code"], "X");
+        assert_eq!(source["valueCoding"]["system"], "http://example.org/tgt");
+    }
+
+    /// `originMap` is emitted as `url|version` when the ConceptMap has a version.
+    #[tokio::test]
+    async fn translate_emits_origin_map_canonical_with_version() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "sourceSystem", "valueUri": "http://example.org/src"},
+                {"name": "sourceCode",   "valueCode": "A"}
+            ]
+        });
+
+        let resp = post_json(app, "/ConceptMap/$translate", body).await;
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+
+        let m = params.iter().find(|p| p["name"] == "match").unwrap();
+        let parts = m["part"].as_array().unwrap();
+        let origin = parts.iter().find(|p| p["name"] == "originMap").unwrap();
+        assert_eq!(origin["valueCanonical"], "http://example.org/cm|1.0");
+    }
+
+    /// Forward translation emits both `equivalence` (R4) and `relationship` (R5)
+    /// so a single response is conformant for either FHIR version.
+    #[tokio::test]
+    async fn translate_emits_both_equivalence_and_relationship() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "sourceSystem", "valueUri": "http://example.org/src"},
+                {"name": "sourceCode",   "valueCode": "A"}
+            ]
+        });
+
+        let resp = post_json(app, "/ConceptMap/$translate", body).await;
+        let json = body_json(resp).await;
+        let parts = json["parameter"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["name"] == "match")
+            .unwrap()["part"]
+            .as_array()
+            .unwrap()
+            .clone();
+
+        let equiv = parts.iter().find(|p| p["name"] == "equivalence").unwrap();
+        let rel = parts.iter().find(|p| p["name"] == "relationship").unwrap();
+        assert_eq!(equiv["valueCode"], "equivalent");
+        assert_eq!(rel["valueCode"], "equivalent");
+    }
+
+    /// Forward responses do *not* include a `source` Coding — the caller
+    /// already knows the source code they sent.
+    #[tokio::test]
+    async fn translate_forward_omits_source_coding_part() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "sourceSystem", "valueUri": "http://example.org/src"},
+                {"name": "sourceCode",   "valueCode": "A"}
+            ]
+        });
+
+        let resp = post_json(app, "/ConceptMap/$translate", body).await;
+        let json = body_json(resp).await;
+        let parts = json["parameter"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["name"] == "match")
+            .unwrap()["part"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert!(
+            parts.iter().all(|p| p["name"] != "source"),
+            "forward response must not include `source` Coding part"
+        );
+    }
+
+    /// Neither `code` nor `targetCode` → 400.
+    #[tokio::test]
+    async fn translate_missing_both_code_and_target_code_returns_400() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "sourceSystem", "valueUri": "http://example.org/src"},
+                {"name": "targetSystem", "valueUri": "http://example.org/tgt"}
+            ]
+        });
 
         let resp = post_json(app, "/ConceptMap/$translate", body).await;
         assert_eq!(resp.status(), 400);

--- a/crates/hts/src/types.rs
+++ b/crates/hts/src/types.rs
@@ -258,16 +258,31 @@ pub struct TranslationMatch {
     pub concept_display: Option<String>,
     /// Reference to the source of the mapping (ConceptMap URL).
     pub source: Option<String>,
+    /// Optional ConceptMap version, used to build the `originMap` canonical
+    /// reference (`url|version`) in the response.
+    #[serde(default)]
+    pub map_version: Option<String>,
+    /// The source-side Coding of this mapping. Populated for reverse
+    /// translations so the response can include a `source` part identifying
+    /// the original code that was reverse-mapped from.
+    #[serde(default)]
+    pub source_system: Option<String>,
+    #[serde(default)]
+    pub source_code: Option<String>,
 }
 
 /// Request for `ConceptMap/$translate`.
+///
+/// Supports both R4 parameter names (`code`, `system`) and R5 names
+/// (`sourceCode`, `sourceSystem`, `targetCode`, `targetSystem`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct TranslateRequest {
     /// ConceptMap canonical URL (optional; if absent, all maps are searched).
     pub url: Option<String>,
-    /// Source code system URL.
+    /// Source code system URL (R4 `system` / R5 `sourceSystem`).
     pub system: Option<String>,
-    /// Source code to translate.
+    /// Source code to translate (R4 `code` / R5 `sourceCode`).
+    /// Empty string when reverse mode is driven by `target_code` instead.
     pub code: String,
     /// Source value set URL.
     pub source: Option<String>,
@@ -275,6 +290,10 @@ pub struct TranslateRequest {
     pub target: Option<String>,
     /// Target code system URL.
     pub target_system: Option<String>,
+    /// Target code (R5 `targetCode`) — used to drive reverse translations
+    /// without an explicit `reverse=true` flag.
+    #[serde(default)]
+    pub target_code: Option<String>,
     /// If `true`, reverse the mapping direction (look up target → source).
     #[serde(default)]
     pub reverse: bool,


### PR DESCRIPTION
…t params)

The tx-ecosystem IG `translate/translate-1` and `translate-reverse` fixtures post `sourceSystem`+`sourceCode`+`targetSystem` (or `targetCode` for reverse) without an explicit ConceptMap `url`. We previously rejected those requests with 400 because $translate required a URL.

Changes:

- operations/translate.rs: accept R5 parameter names alongside R4 (`sourceCode`/`code`, `sourceSystem`/`system`, `targetCode`, `targetSystem`). Reverse mode is now driven implicitly by `targetCode`. Response includes `originMap` (canonical with `|version`), both `equivalence` and `relationship` (each marked $optional$ in IG fixtures by FHIR version), and a `source` Coding for reverse responses identifying the input code.

- backends/{sqlite,postgres}/concept_map.rs: query takes an extra `other_side_sys` filter restricting the result-side system, and now selects `cm.version` plus the input-side system/code for the response.

- types.rs: TranslateRequest gains `target_code`; TranslationMatch gains `map_version`, `source_system`, `source_code`.

- import/bundle_parser.rs: ConceptMap targets accept R5 `relationship` as a fallback for R4 `equivalence` so tx-ecosystem fixtures import correctly.

Targets the 2 IG `translate/` failures (translate-1, translate-reverse). Closure has no IG tests on the bench so it's untouched.