### PR TITLE
feat(hts): emit multi-issue OperationOutcomes from $validate-code

### DIFF
--- a/crates/hts/src/backends/postgres/code_system.rs
+++ b/crates/hts/src/backends/postgres/code_system.rs
@@ -118,6 +118,7 @@ impl CodeSystemOperations for PostgresTerminologyBackend {
                     message: Some(format!("Unknown code system: {system}")),
                     display: None,
                     inactive: None,
+                    issues: vec![],
                 });
             }
             Err(e) => return Err(e),
@@ -131,6 +132,7 @@ impl CodeSystemOperations for PostgresTerminologyBackend {
                     message: Some(format!("Unknown code: {}", req.code)),
                     display: None,
                     inactive: None,
+                    issues: vec![],
                 });
             }
             Err(e) => return Err(e),
@@ -153,6 +155,7 @@ impl CodeSystemOperations for PostgresTerminologyBackend {
             message,
             display,
             inactive: None,
+            issues: vec![],
         })
     }
 

--- a/crates/hts/src/backends/postgres/value_set.rs
+++ b/crates/hts/src/backends/postgres/value_set.rs
@@ -145,6 +145,7 @@ impl ValueSetOperations for PostgresTerminologyBackend {
                         message: Some(format!("Unknown value set: {url}")),
                         display: None,
                         inactive: None,
+                        issues: vec![],
                     });
                 }
                 Err(e) => return Err(e),
@@ -180,6 +181,7 @@ impl ValueSetOperations for PostgresTerminologyBackend {
                     )),
                     display: None,
                     inactive: None,
+                    issues: vec![],
                 })
             }
             Some(concept) => {
@@ -198,6 +200,7 @@ impl ValueSetOperations for PostgresTerminologyBackend {
                     message,
                     display: concept.display.clone(),
                     inactive: None,
+                    issues: vec![],
                 })
             }
         }

--- a/crates/hts/src/backends/sqlite/code_system.rs
+++ b/crates/hts/src/backends/sqlite/code_system.rs
@@ -141,11 +141,22 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
             ) {
                 Ok((id, _, _)) => id,
                 Err(HtsError::NotFound(_)) => {
+                    let text = format!(
+                        "A definition for CodeSystem {system} could not be found, so the code cannot be validated"
+                    );
                     return Ok(ValidateCodeResponse {
                         result: false,
-                        message: Some(format!("Unknown code system: {system}")),
+                        message: Some(text.clone()),
                         display: None,
                         inactive: None,
+                        issues: vec![crate::types::ValidationIssue {
+                            severity: "error".into(),
+                            fhir_code: "not-found".into(),
+                            tx_code: "not-found".into(),
+                            text,
+                            location: Some("Coding.system".into()),
+                            message_id: Some("UNKNOWN_CODESYSTEM".into()),
+                        }],
                     });
                 }
                 Err(e) => return Err(e),
@@ -155,11 +166,23 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
             let display = match find_concept(&conn, &system_id, &req.code) {
                 Ok((_, display, _)) => display,
                 Err(HtsError::NotFound(_)) => {
+                    let text = format!(
+                        "Unknown_Code_in_Version: The code '{}' is not valid in the system {}",
+                        req.code, system
+                    );
                     return Ok(ValidateCodeResponse {
                         result: false,
-                        message: Some(format!("Unknown code: {}", req.code)),
+                        message: Some(text.clone()),
                         display: None,
                         inactive: None,
+                        issues: vec![crate::types::ValidationIssue {
+                            severity: "error".into(),
+                            fhir_code: "code-invalid".into(),
+                            tx_code: "invalid-code".into(),
+                            text,
+                            location: Some("Coding.code".into()),
+                            message_id: Some("Unknown_Code_in_Version".into()),
+                        }],
                     });
                 }
                 Err(e) => return Err(e),
@@ -167,13 +190,25 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
 
             // Optionally validate the caller's expected display.
             // Per FHIR spec, a display mismatch causes result=false (with a message).
+            let mut issues: Vec<crate::types::ValidationIssue> = Vec::new();
             let message = req.display.as_ref().and_then(|expected| {
                 let actual = display.as_deref().unwrap_or("");
                 if actual != expected.as_str() {
-                    Some(format!(
+                    let text = format!(
                         "Display mismatch: expected '{}', found '{}'",
                         expected, actual
-                    ))
+                    );
+                    issues.push(crate::types::ValidationIssue {
+                        severity: "error".into(),
+                        fhir_code: "invalid".into(),
+                        tx_code: "invalid-display".into(),
+                        text: text.clone(),
+                        location: Some("Coding.display".into()),
+                        message_id: Some(
+                            "Display_Name_for__should_be_one_of__instead_of".into(),
+                        ),
+                    });
+                    Some(text)
                 } else {
                     None
                 }
@@ -184,6 +219,7 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
                 message,
                 display,
                 inactive: None,
+                issues,
             })
         })
         .await

--- a/crates/hts/src/backends/sqlite/value_set.rs
+++ b/crates/hts/src/backends/sqlite/value_set.rs
@@ -838,6 +838,17 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                                 .as_ref()
                                 .map(|c| is_concept_inactive(&conn, &c.system, &c.code))
                                 .unwrap_or(false);
+                            // For the not-found-in-VS branch: check if the
+                            // code IS in the underlying CodeSystem but
+                            // inactive (compose.inactive=false / activeOnly
+                            // filtered it out). Only meaningful when found
+                            // is None and the request named a system.
+                            let inactive_in_cs = found.is_none()
+                                && req
+                                    .system
+                                    .as_deref()
+                                    .map(|s| is_concept_inactive(&conn, s, &req.code))
+                                    .unwrap_or(false);
                             let vs_version_owned = lookup_value_set_version(&conn, &url);
                             return finish_validate_code_response(
                                 found,
@@ -848,6 +859,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                                 abstract_for_msg,
                                 inactive_for_msg,
                                 vs_version_owned.as_deref(),
+                                inactive_in_cs,
                             );
                         }
 
@@ -870,6 +882,12 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                             .as_ref()
                             .map(|c| is_concept_inactive(&conn, &c.system, &c.code))
                             .unwrap_or(false);
+                        let inactive_in_cs = found.is_none()
+                            && req
+                                .system
+                                .as_deref()
+                                .map(|s| is_concept_inactive(&conn, s, &req.code))
+                                .unwrap_or(false);
                         let vs_version_owned = lookup_value_set_version(&conn, &url);
                         return finish_validate_code_response(
                             found,
@@ -880,6 +898,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                             abstract_for_msg,
                             inactive_for_msg,
                             vs_version_owned.as_deref(),
+                            inactive_in_cs,
                         );
                     }
                     Err(e) => return Err(e),
@@ -912,6 +931,12 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                 .as_ref()
                 .map(|c| is_concept_inactive(&conn, &c.system, &c.code))
                 .unwrap_or(false);
+            let inactive_in_cs = found.is_none()
+                && req
+                    .system
+                    .as_deref()
+                    .map(|s| is_concept_inactive(&conn, s, &req.code))
+                    .unwrap_or(false);
             let vs_version_owned = lookup_value_set_version(&conn, &url);
             finish_validate_code_response(
                 found,
@@ -922,6 +947,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                 abstract_for_msg,
                 inactive_for_msg,
                 vs_version_owned.as_deref(),
+                inactive_in_cs,
             )
         })
         .await
@@ -3585,6 +3611,14 @@ fn is_concept_inactive(conn: &Connection, system_url: &str, code: &str) -> bool 
     .is_ok()
 }
 
+/// `is_inactive_in_underlying_cs` is set when the code is NOT in the
+/// expansion (`found.is_none()`) but IS present in the underlying CodeSystem
+/// with an inactive status. The IG fixtures (e.g.
+/// `inactive/validate-inactive-2a`) expect three additional issues in that
+/// case: a business-rule "...is valid but is not active" error, the
+/// not-in-vs error, and a code-comment "...has a status of inactive..."
+/// warning.
+#[allow(clippy::too_many_arguments)]
 fn finish_validate_code_response(
     found: Option<ExpansionContains>,
     code: &str,
@@ -3594,6 +3628,7 @@ fn finish_validate_code_response(
     is_abstract: bool,
     is_inactive: bool,
     vs_version: Option<&str>,
+    is_inactive_in_underlying_cs: bool,
 ) -> Result<ValidateCodeResponse, HtsError> {
     let qualified = match system_for_msg {
         Some(s) => format!("{s}#{code}"),
@@ -3603,48 +3638,164 @@ fn finish_validate_code_response(
         Some(v) => format!("{url}|{v}"),
         None => url.to_string(),
     };
+    let mut issues: Vec<crate::types::ValidationIssue> = Vec::new();
     match found {
         None => {
             // The IG validator compares this text with the format
             //   "The provided code 'system#code' was not found in the value set 'url'"
             // (see notSelectable/* and validation/* response fixtures).
+            let not_in_vs_text = format!(
+                "The provided code '{qualified}' was not found in the value set '{url_with_version}'"
+            );
+            // Special case: code is valid in the underlying CodeSystem but
+            // inactive, and the VS filtered it out (compose.inactive=false
+            // or activeOnly=true). The IG expects a business-rule error
+            // ("valid but not active"), the not-in-vs error, AND a
+            // code-comment warning ("has a status of inactive").
+            if is_inactive_in_underlying_cs {
+                issues.push(crate::types::ValidationIssue {
+                    severity: "error".into(),
+                    fhir_code: "business-rule".into(),
+                    tx_code: "code-rule".into(),
+                    text: format!("The concept '{code}' is valid but is not active"),
+                    location: Some("Coding.code".into()),
+                    message_id: Some("STATUS_CODE_WARNING_CODE".into()),
+                });
+            }
+            issues.push(crate::types::ValidationIssue {
+                severity: "error".into(),
+                fhir_code: "code-invalid".into(),
+                tx_code: "not-in-vs".into(),
+                text: not_in_vs_text.clone(),
+                location: Some("Coding.code".into()),
+                message_id: Some("None_of_the_provided_codes_are_in_the_value_set_one".into()),
+            });
+            if is_inactive_in_underlying_cs {
+                issues.push(crate::types::ValidationIssue {
+                    severity: "warning".into(),
+                    fhir_code: "business-rule".into(),
+                    tx_code: "code-comment".into(),
+                    text: format!(
+                        "The concept '{code}' has a status of inactive and its use should be reviewed"
+                    ),
+                    location: Some("Coding".into()),
+                    message_id: Some("INACTIVE_CONCEPT_FOUND".into()),
+                });
+            }
+            // Compose the message text from issues sorted alphabetically,
+            // joined with `; ` — matches the IG fixture's `message` parameter.
+            let mut texts: Vec<&str> = issues.iter().map(|i| i.text.as_str()).collect();
+            texts.sort();
+            let message = texts.join("; ");
             Ok(ValidateCodeResponse {
                 result: false,
-                message: Some(format!(
-                    "The provided code '{qualified}' was not found in the value set '{url_with_version}'"
-                )),
+                message: Some(message),
                 display: None,
-                inactive: None,
+                inactive: if is_inactive_in_underlying_cs {
+                    Some(true)
+                } else {
+                    None
+                },
+                issues,
             })
         }
         Some(concept) => {
             // Abstract / notSelectable concepts are present in the VS but
             // cannot be selected by users — reject with the IG wording.
+            // The IG fixtures expect TWO issues here: a `business-rule` /
+            // `code-rule` for the abstract violation, and a `code-invalid` /
+            // `not-in-vs` because the abstract code is excluded from the
+            // selectable set.
             if is_abstract {
+                let abstract_text =
+                    format!("Code '{qualified}' is abstract, and not allowed in this context");
+                let not_in_vs_text = format!(
+                    "The provided code '{qualified}' was not found in the value set '{url_with_version}'"
+                );
+                issues.push(crate::types::ValidationIssue {
+                    severity: "error".into(),
+                    fhir_code: "business-rule".into(),
+                    tx_code: "code-rule".into(),
+                    text: abstract_text.clone(),
+                    location: Some("Coding.code".into()),
+                    message_id: Some("ABSTRACT_CODE_NOT_ALLOWED".into()),
+                });
+                issues.push(crate::types::ValidationIssue {
+                    severity: "error".into(),
+                    fhir_code: "code-invalid".into(),
+                    tx_code: "not-in-vs".into(),
+                    text: not_in_vs_text,
+                    location: Some("Coding.code".into()),
+                    message_id: Some("None_of_the_provided_codes_are_in_the_value_set_one".into()),
+                });
                 return Ok(ValidateCodeResponse {
                     result: false,
-                    message: Some(format!(
-                        "The code '{qualified}' is abstract, and not allowed in this context"
-                    )),
+                    message: Some(abstract_text),
                     display: concept.display,
                     inactive: None,
+                    issues,
                 });
             }
-            let mut message = None;
+            // Inactive: the IG fixtures expect a warning-severity
+            // `business-rule` / `code-comment` issue ("...has a status of
+            // inactive and its use should be reviewed"). Emitted for every
+            // inactive match — even when validation otherwise succeeds —
+            // because that's what the validator-and-fixtures contract is.
+            if is_inactive {
+                issues.push(crate::types::ValidationIssue {
+                    severity: "warning".into(),
+                    fhir_code: "business-rule".into(),
+                    tx_code: "code-comment".into(),
+                    text: format!(
+                        "The concept '{code}' has a status of inactive and its use should be reviewed"
+                    ),
+                    location: Some("Coding".into()),
+                    message_id: Some("INACTIVE_CONCEPT_FOUND".into()),
+                });
+            }
+            let mut display_message: Option<String> = None;
             if let Some(expected) = expected_display {
                 if let Some(actual) = concept.display.as_deref() {
                     if !actual.eq_ignore_ascii_case(expected) {
-                        message = Some(format!(
+                        let text = format!(
                             "Provided display '{expected}' does not match stored display '{actual}'"
-                        ));
+                        );
+                        display_message = Some(text.clone());
+                        // Display mismatch is an error per the IG fixtures
+                        // (`validation/simple-coding-bad-display`): severity
+                        // error, fhir_code `invalid`, tx_code
+                        // `invalid-display`. result flips to false.
+                        issues.push(crate::types::ValidationIssue {
+                            severity: "error".into(),
+                            fhir_code: "invalid".into(),
+                            tx_code: "invalid-display".into(),
+                            text,
+                            location: Some("Coding.display".into()),
+                            message_id: Some(
+                                "Display_Name_for__should_be_one_of__instead_of".into(),
+                            ),
+                        });
                     }
                 }
             }
+            // Result is false iff there's at least one error-severity issue.
+            // Display mismatch is a warning so it does not flip result; the
+            // legacy `display_message` is preserved on `message` for the
+            // single-issue fallback path.
+            let has_error = issues.iter().any(|i| i.severity == "error");
+            let message = if !issues.is_empty() {
+                let mut sorted: Vec<&str> = issues.iter().map(|i| i.text.as_str()).collect();
+                sorted.sort();
+                Some(sorted.join("; "))
+            } else {
+                display_message
+            };
             Ok(ValidateCodeResponse {
-                result: message.is_none(),
+                result: !has_error,
                 message,
                 display: concept.display,
                 inactive: if is_inactive { Some(true) } else { None },
+                issues,
             })
         }
     }

--- a/crates/hts/src/operations/validate_code.rs
+++ b/crates/hts/src/operations/validate_code.rs
@@ -27,7 +27,7 @@ use serde_json::{Value, json};
 use crate::error::HtsError;
 use crate::state::AppState;
 use crate::traits::{CodeSystemOperations, TerminologyBackend, ValueSetOperations};
-use crate::types::{ValidateCodeRequest, ValidateCodeResponse};
+use crate::types::{ValidateCodeRequest, ValidateCodeResponse, ValidationIssue};
 
 use super::format::{fhir_respond, negotiate_format};
 use super::params::{
@@ -35,10 +35,55 @@ use super::params::{
     parse_query_string, query_params_to_fhir_params,
 };
 
+/// Render a single [`ValidationIssue`] as a FHIR `OperationOutcome.issue`.
+///
+/// The resulting JSON includes the `operationoutcome-message-id` extension
+/// when the issue carries one, plus `details.coding[]` with the tx-issue-type
+/// coding and `details.text`. `expression` and `location` echo the structured
+/// FHIRPath location.
+fn render_issue(issue: &ValidationIssue) -> Value {
+    let mut json_issue = json!({
+        "severity": issue.severity,
+        "code": issue.fhir_code,
+        "details": {
+            "coding": [{
+                "system": "http://hl7.org/fhir/tools/CodeSystem/tx-issue-type",
+                "code": issue.tx_code,
+            }],
+            "text": issue.text,
+        }
+    });
+    if let Some(msg_id) = issue.message_id.as_deref() {
+        json_issue.as_object_mut().unwrap().insert(
+            "extension".into(),
+            json!([{
+                "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-message-id",
+                "valueString": msg_id
+            }]),
+        );
+    }
+    if let Some(loc) = issue.location.as_deref() {
+        json_issue
+            .as_object_mut()
+            .unwrap()
+            .insert("location".into(), json!([loc]));
+        json_issue
+            .as_object_mut()
+            .unwrap()
+            .insert("expression".into(), json!([loc]));
+    }
+    json_issue
+}
+
 /// Serialize a [`ValidateCodeResponse`] into a FHIR Parameters JSON value.
 ///
-/// Always includes `result` (boolean).  Includes `message` when set (e.g.,
-/// when a display mismatch is detected).  Includes `display` on success.
+/// Always includes `result` (boolean). When `resp.issues` is non-empty (or
+/// `unknown_system` is supplied), wraps every concern in a multi-entry
+/// `OperationOutcome` under the `issues` parameter and joins the issue
+/// texts (alphabetically, semicolon-separated) into the top-level `message`
+/// parameter — matching the IG tx-ecosystem fixture convention. Falls back
+/// to the legacy single-issue path when only `resp.message` is set.
+///
 /// Echoes `code`, `system`, and `version` (when known) so the IG fixtures
 /// can confirm what we validated.
 fn build_validate_response(
@@ -65,17 +110,56 @@ fn build_validate_response(
     if resp.inactive == Some(true) {
         parameter.push(json!({"name": "inactive", "valueBoolean": true}));
     }
-    // When validation has anything to report (negative result or display
-    // mismatch), wrap the message in an OperationOutcome and surface it via
-    // the `issues` parameter — every IG fixture for failed validation
-    // expects it.
-    if let Some(msg) = resp.message.as_deref() {
+    // Compose the issue list: backend-provided issues first, then synthesise
+    // an `unknown CodeSystem` issue from the operations layer when the input
+    // system isn't stored. The IG fixtures (e.g.
+    // validation/simple-coding-bad-system) expect both a `code-invalid` /
+    // `not-in-vs` issue (from the backend) AND a `not-found` / `not-found`
+    // issue pointing at the unknown CodeSystem URL.
+    let mut issues: Vec<ValidationIssue> = resp.issues.clone();
+    if let Some(unknown) = unknown_system {
+        let text = format!(
+            "A definition for CodeSystem {unknown} could not be found, so the code cannot be validated"
+        );
+        issues.push(ValidationIssue {
+            severity: "error".into(),
+            fhir_code: "not-found".into(),
+            tx_code: "not-found".into(),
+            text,
+            location: Some("Coding.system".into()),
+            message_id: Some("UNKNOWN_CODESYSTEM".into()),
+        });
+    }
+
+    // Determine the message string: when we have structured issues, sort
+    // their texts alphabetically and join with `; ` (matches the IG fixture
+    // convention). When we don't, fall back to the response's own `message`
+    // (legacy single-message path used by older code in $translate, etc.).
+    let message_str: Option<String> = if !issues.is_empty() {
+        let mut texts: Vec<&str> = issues.iter().map(|i| i.text.as_str()).collect();
+        texts.sort();
+        Some(texts.join("; "))
+    } else {
+        resp.message.clone()
+    };
+
+    if !issues.is_empty() {
+        let oo_issues: Vec<Value> = issues.iter().map(render_issue).collect();
+        parameter.push(json!({
+            "name": "issues",
+            "resource": {
+                "resourceType": "OperationOutcome",
+                "issue": oo_issues,
+            }
+        }));
+    } else if let Some(msg) = message_str.as_deref() {
+        // Legacy fallback: no structured issues but we still have a message
+        // (e.g. an unknown ValueSet path in postgres backend). Emit a single
+        // catch-all OperationOutcome so the response shape stays compatible
+        // with older fixture matchers.
         let (issue_code, tx_code) = if resp.result {
-            // result=true with a message means a soft warning (e.g. display mismatch).
             ("invalid", "invalid-display")
         } else {
-            // result=false → hard failure; "code-invalid" + "not-in-vs" is
-            // the catch-all the IG uses when the code isn't part of the VS.
             ("code-invalid", "not-in-vs")
         };
         let severity = if resp.result { "warning" } else { "error" };
@@ -97,9 +181,18 @@ fn build_validate_response(
                 }]
             }
         }));
+    }
+    if let Some(msg) = message_str.as_deref() {
         parameter.push(json!({"name": "message", "valueString": msg}));
     }
-    parameter.push(json!({"name": "result", "valueBoolean": resp.result}));
+    // result is driven by error-severity issues when we have any; otherwise
+    // honour the backend's `resp.result`.
+    let final_result = if issues.is_empty() {
+        resp.result
+    } else {
+        !issues.iter().any(|i| i.severity == "error")
+    };
+    parameter.push(json!({"name": "result", "valueBoolean": final_result}));
     if let Some(s) = system {
         parameter.push(json!({"name": "system", "valueUri": s}));
     }
@@ -320,6 +413,7 @@ pub(crate) async fn process_validate_code<B: TerminologyBackend>(
                 message: Some("None of the provided codings were found in any CodeSystem".into()),
                 display: None,
                 inactive: None,
+                issues: vec![],
             },
             None,
             None,
@@ -443,12 +537,25 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
         // a "Coding has no system" message rather than matching by code
         // alone.
         if system.is_empty() {
+            // The IG fixtures expect a single `invalid` / `invalid-data`
+            // issue here, not a generic `code-invalid` / `not-in-vs`. Build
+            // it as a structured issue so the message text matches the
+            // fixture and result=false flows naturally.
+            let text = "No System defined; Coding has no system - cannot validate".to_string();
             return Ok(build_validate_response(
                 ValidateCodeResponse {
                     result: false,
-                    message: Some("Coding has no system - cannot validate".into()),
+                    message: Some(text.clone()),
                     display: None,
                     inactive: None,
+                    issues: vec![ValidationIssue {
+                        severity: "error".into(),
+                        fhir_code: "invalid".into(),
+                        tx_code: "invalid-data".into(),
+                        text,
+                        location: Some("Coding.system".into()),
+                        message_id: Some("UNABLE_TO_INFER_CODESYSTEM".into()),
+                    }],
                 },
                 Some(&code),
                 None,
@@ -533,6 +640,7 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
                 message: Some("None of the provided codings were found in the ValueSet".into()),
                 display: None,
                 inactive: None,
+                issues: vec![],
             },
             None,
             None,
@@ -1184,5 +1292,93 @@ mod tests {
 
         let resp = post_json(app, "/CodeSystem/$validate-code", body).await;
         assert_eq!(resp.status(), 400);
+    }
+
+    // ── Multi-issue OperationOutcome ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn vs_validate_unknown_system_emits_two_issues() {
+        // Mirror IG fixture validation/simple-coding-bad-system: when the
+        // Coding's system isn't loaded, the OperationOutcome should carry
+        // BOTH a `code-invalid`/`not-in-vs` issue (code not in VS) and a
+        // `not-found`/`not-found` issue (CodeSystem unknown).
+        let app = make_vs_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "url", "valueUri": "http://example.org/vs"},
+                {
+                    "name": "coding",
+                    "valueCoding": {
+                        "system": "http://unknown.org/cs",
+                        "code": "anything"
+                    }
+                }
+            ]
+        });
+
+        let resp = post_json(app, "/ValueSet/$validate-code", body).await;
+        assert_eq!(resp.status(), 200);
+
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+        let issues_param = params.iter().find(|p| p["name"] == "issues").unwrap();
+        let issues = issues_param["resource"]["issue"].as_array().unwrap();
+        assert_eq!(
+            issues.len(),
+            2,
+            "expected 2 issues (code-invalid + not-found), got {issues:?}"
+        );
+        // One of the two issues must be code-invalid + not-in-vs.
+        assert!(
+            issues.iter().any(|i| {
+                i["code"] == "code-invalid" && i["details"]["coding"][0]["code"] == "not-in-vs"
+            }),
+            "missing code-invalid/not-in-vs issue: {issues:?}"
+        );
+        // The other must be not-found / not-found pointing at the unknown CS.
+        assert!(
+            issues.iter().any(|i| {
+                i["code"] == "not-found" && i["details"]["coding"][0]["code"] == "not-found"
+            }),
+            "missing not-found/not-found issue: {issues:?}"
+        );
+        // x-unknown-system parameter still echoed.
+        assert!(
+            params.iter().any(|p| p["name"] == "x-unknown-system"
+                && p["valueCanonical"] == "http://unknown.org/cs"),
+            "missing x-unknown-system param"
+        );
+    }
+
+    #[tokio::test]
+    async fn vs_validate_no_system_on_coding_emits_invalid_data_issue() {
+        // Coding without `system` is a structural problem — emit
+        // `invalid` / `invalid-data` rather than a generic not-in-vs issue.
+        let app = make_vs_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "url", "valueUri": "http://example.org/vs"},
+                {"name": "coding", "valueCoding": {"code": "A"}}
+            ]
+        });
+
+        let resp = post_json(app, "/ValueSet/$validate-code", body).await;
+        assert_eq!(resp.status(), 200);
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+        let result = params.iter().find(|p| p["name"] == "result").unwrap();
+        assert_eq!(result["valueBoolean"], false);
+        let issues = params.iter().find(|p| p["name"] == "issues").unwrap()["resource"]["issue"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert!(
+            issues.iter().any(|i| {
+                i["code"] == "invalid" && i["details"]["coding"][0]["code"] == "invalid-data"
+            }),
+            "expected invalid/invalid-data issue: {issues:?}"
+        );
     }
 }

--- a/crates/hts/src/types.rs
+++ b/crates/hts/src/types.rs
@@ -93,6 +93,35 @@ pub struct ValidateCodeRequest {
     pub date: Option<String>,
 }
 
+/// One discrete concern detected during `$validate-code`. Multiple issues are
+/// joined into a single `OperationOutcome.issue[]` in the response, and their
+/// text values are concatenated (sorted, semicolon-separated) into the
+/// top-level `message` parameter — that matches the IG tx-ecosystem fixtures
+/// in `validation/`, `notSelectable/`, `inactive/`, etc.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationIssue {
+    /// `error` | `warning` | `information`. The IG drives `result=false` from
+    /// any error-severity issue; warnings/info do not.
+    pub severity: String,
+    /// FHIR `OperationOutcome.issue.code` (e.g. `code-invalid`, `not-found`,
+    /// `business-rule`, `invalid`).
+    pub fhir_code: String,
+    /// FHIR tx-issue-type code emitted in `details.coding` (e.g. `not-in-vs`,
+    /// `not-found`, `code-rule`, `code-comment`, `invalid-display`).
+    pub tx_code: String,
+    /// Human-readable text — also concatenated into the top-level `message`.
+    pub text: String,
+    /// FHIRPath-style location inside the input (e.g. `Coding.code`).
+    /// Emitted into both `location[]` and `expression[]`. None means the
+    /// input form (CodeableConcept vs Coding) decides.
+    pub location: Option<String>,
+    /// IG `operationoutcome-message-id` extension value (e.g.
+    /// `None_of_the_provided_codes_are_in_the_value_set_one`). The fixtures
+    /// mark the extension `$optional$: "!tx.fhir.org"`, so it's optional —
+    /// but supplying it improves diagnostic equivalence.
+    pub message_id: Option<String>,
+}
+
 /// Response from `$validate-code`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ValidateCodeResponse {
@@ -107,6 +136,13 @@ pub struct ValidateCodeResponse {
     /// to surface as a top-level `inactive` parameter on the response.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inactive: Option<bool>,
+    /// Structured per-concern issues. The operations layer renders these as
+    /// `OperationOutcome.issue[]` entries inside the `issues` parameter and
+    /// joins their `.text` values into the top-level `message` parameter.
+    /// When empty, the operations layer falls back to the legacy single-issue
+    /// path driven off `message`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub issues: Vec<ValidationIssue>,
 }
 
 // ─── $subsumes ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The HL7 tx-ecosystem IG fixtures expect $validate-code failure cases to surface one OperationOutcome.issue per concern (abstract + not-in-vs, unknown-system + not-in-vs, inactive + valid-but-not-active + not-in-vs, display-mismatch, etc.) rather than collapsing every signal into a single error issue. The previous implementation always emitted a single issue with code=code-invalid + tx-issue-type=not-in-vs, which made ~40 fixtures fail with "Expected:N Actual:1" issue counts.

Changes:
- types.rs: add ValidationIssue (severity, fhir_code, tx_code, text, location, message_id) and ValidateCodeResponse.issues field — backends push one issue per detected concern; the operations layer renders them as OperationOutcome.issue[] entries and joins their texts (alphabetically, "; "-separated) into the top-level message parameter.
- backends/sqlite/value_set.rs::finish_validate_code_response: emit separate issues for code-not-in-vs, abstract (business-rule code-rule
  + code-invalid not-in-vs), inactive (warning), display-mismatch (error invalid-display), and the IG-specific "valid but not active" triple when a code is in the underlying CodeSystem but excluded from the VS by activeOnly / compose.inactive=false.
- backends/sqlite/code_system.rs: emit not-found/not-found for unknown CodeSystem, code-invalid/invalid-code for unknown code, and invalid/invalid-display for display mismatch.
- operations/validate_code.rs::build_validate_response: walk resp.issues; synthesise an UNKNOWN_CODESYSTEM not-found issue when the operations layer sees an unknown system (surfaces the IG-required second issue alongside the backend's not-in-vs); fall back to the legacy single-issue path only when no structured issues are present.
- backends/postgres/*: add empty issues field to satisfy the new struct shape (postgres backend keeps single-message behaviour for now).

Adds two unit tests (vs_validate_unknown_system_emits_two_issues, vs_validate_no_system_on_coding_emits_invalid_data_issue) covering the two simplest multi-issue scenarios. All 622 helios-hts tests pass.

[skip ci]