### PR TITLE
feat(hts): apply CodeSystem supplements in $expand, $validate-code, $…

### DIFF
--- a/crates/hts/src/backends/postgres/code_system.rs
+++ b/crates/hts/src/backends/postgres/code_system.rs
@@ -251,6 +251,7 @@ impl CodeSystemOperations for PostgresTerminologyBackend {
                 use_system: row.get(2),
                 use_code: row.get(3),
                 value: row.get(4),
+                source: None,
             });
         }
         Ok(out)
@@ -531,6 +532,7 @@ async fn fetch_designations(
             use_system: row.get(1),
             use_code: row.get(2),
             value: row.get(3),
+            source: None,
         })
         .collect())
 }

--- a/crates/hts/src/backends/sqlite/code_system.rs
+++ b/crates/hts/src/backends/sqlite/code_system.rs
@@ -16,7 +16,9 @@ use helios_persistence::tenant::TenantContext;
 use rusqlite::OptionalExtension;
 
 use crate::error::HtsError;
-use crate::traits::{CodeSystemOperations, ConceptDesignation, ConceptExpansionFlags};
+use crate::traits::{
+    CodeSystemOperations, ConceptDesignation, ConceptExpansionFlags, SupplementInfo,
+};
 use crate::types::{
     DesignationValue, LookupRequest, LookupResponse, PropertyValue, ResourceSearchQuery,
     SubsumesRequest, SubsumesResponse, SubsumptionOutcome, ValidateCodeRequest,
@@ -351,6 +353,7 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
                     use_system,
                     use_code,
                     value,
+                    source: None,
                 });
             }
             Ok(out)
@@ -672,6 +675,242 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
         .await
         .map_err(|e| HtsError::Internal(format!("Blocking task error: {e}")))?
     }
+
+    // ── Supplements ──────────────────────────────────────────────────────────
+    //
+    // Supplements are stored in the same `code_systems` table as any other
+    // CodeSystem; the only distinguishing fields are `content='supplement'`
+    // and a `supplements` field on the resource_json pointing at the URL of
+    // the base CS being modified. We deliberately do NOT add a column to the
+    // schema for the supplement target — the value lives in `resource_json`
+    // and is read on demand. This keeps the schema migration-free.
+    async fn supplement_target(
+        &self,
+        _ctx: &TenantContext,
+        supplement_url: &str,
+    ) -> Result<Option<SupplementInfo>, HtsError> {
+        let pool = self.pool().clone();
+        let supplement_url = supplement_url.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+            // Read content + resource_json + version in one query so we can
+            // confirm the row really is a supplement before returning.
+            let row: Option<(String, Option<String>, Option<String>)> = conn
+                .query_row(
+                    "SELECT content, version, json_extract(resource_json, '$.supplements')
+                     FROM code_systems
+                     WHERE url = ?1
+                     LIMIT 1",
+                    rusqlite::params![supplement_url],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, Option<String>>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(|e| HtsError::StorageError(e.to_string()))?;
+            let Some((content, version, target)) = row else {
+                return Ok(None);
+            };
+            if content != "supplement" {
+                return Ok(None);
+            }
+            let target_url = match target {
+                Some(t) => t,
+                None => return Ok(None),
+            };
+            let supplement_canonical = match version {
+                Some(v) => format!("{supplement_url}|{v}"),
+                None => supplement_url.clone(),
+            };
+            Ok(Some(SupplementInfo {
+                target_url,
+                supplement_canonical,
+            }))
+        })
+        .await
+        .map_err(|e| HtsError::Internal(format!("Blocking task error: {e}")))?
+    }
+
+    async fn supplement_designations(
+        &self,
+        _ctx: &TenantContext,
+        supplement_urls: &[String],
+        codes: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<ConceptDesignation>>, HtsError> {
+        if supplement_urls.is_empty() || codes.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let pool = self.pool().clone();
+        let supplement_urls = supplement_urls.to_vec();
+        let codes = codes.to_vec();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+
+            // Two IN-clauses: one for the supplement URL set, one for the
+            // code set. We also pull s.url and s.version so the response can
+            // report `source = "url|version"`.
+            let url_ph = (1..=supplement_urls.len())
+                .map(|i| format!("?{i}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let code_ph = (supplement_urls.len() + 1..=supplement_urls.len() + codes.len())
+                .map(|i| format!("?{i}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let sql = format!(
+                "SELECT c.code, cd.language, cd.use_system, cd.use_code, cd.value,
+                        s.url, s.version
+                 FROM concept_designations cd
+                 JOIN concepts c ON c.id = cd.concept_id
+                 JOIN code_systems s ON s.id = c.system_id
+                 WHERE s.url IN ({url_ph})
+                   AND s.content = 'supplement'
+                   AND c.code IN ({code_ph})",
+            );
+            let mut stmt = conn
+                .prepare(&sql)
+                .map_err(|e| HtsError::StorageError(e.to_string()))?;
+            let mut params: Vec<&dyn rusqlite::ToSql> =
+                Vec::with_capacity(supplement_urls.len() + codes.len());
+            for u in &supplement_urls {
+                params.push(u as &dyn rusqlite::ToSql);
+            }
+            for c in &codes {
+                params.push(c as &dyn rusqlite::ToSql);
+            }
+            let mut out: std::collections::HashMap<String, Vec<ConceptDesignation>> =
+                std::collections::HashMap::new();
+            let rows = stmt
+                .query_map(params.as_slice(), |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, Option<String>>(6)?,
+                    ))
+                })
+                .map_err(|e| HtsError::StorageError(e.to_string()))?;
+            for r in rows {
+                let (code, language, use_system, use_code, value, supp_url, supp_ver) =
+                    r.map_err(|e| HtsError::StorageError(e.to_string()))?;
+                let source = match supp_ver {
+                    Some(v) => format!("{supp_url}|{v}"),
+                    None => supp_url,
+                };
+                out.entry(code).or_default().push(ConceptDesignation {
+                    language,
+                    use_system,
+                    use_code,
+                    value,
+                    source: Some(source),
+                });
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| HtsError::Internal(format!("Blocking task error: {e}")))?
+    }
+
+    async fn supplement_property_values(
+        &self,
+        _ctx: &TenantContext,
+        supplement_urls: &[String],
+        codes: &[String],
+        properties: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<(String, String)>>, HtsError> {
+        if supplement_urls.is_empty() || codes.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        // Empty `properties` slice = "every property defined on the
+        // matching supplement concepts". Used by lookup wildcard mode.
+        let want_all_props = properties.is_empty();
+        let pool = self.pool().clone();
+        let supplement_urls = supplement_urls.to_vec();
+        let codes = codes.to_vec();
+        let properties = properties.to_vec();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+            let mut idx = 1usize;
+            let url_ph = (idx..idx + supplement_urls.len())
+                .map(|i| format!("?{i}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            idx += supplement_urls.len();
+            let code_ph = (idx..idx + codes.len())
+                .map(|i| format!("?{i}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            idx += codes.len();
+            let prop_clause = if want_all_props {
+                String::new()
+            } else {
+                let prop_ph = (idx..idx + properties.len())
+                    .map(|i| format!("?{i}"))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!(" AND cp.property IN ({prop_ph})")
+            };
+            let sql = format!(
+                "SELECT c.code, cp.property, cp.value
+                 FROM concept_properties cp
+                 JOIN concepts c ON c.id = cp.concept_id
+                 JOIN code_systems s ON s.id = c.system_id
+                 WHERE s.url IN ({url_ph})
+                   AND s.content = 'supplement'
+                   AND c.code IN ({code_ph})
+                   {prop_clause}",
+            );
+            let mut stmt = conn
+                .prepare(&sql)
+                .map_err(|e| HtsError::StorageError(e.to_string()))?;
+            let mut params: Vec<&dyn rusqlite::ToSql> =
+                Vec::with_capacity(supplement_urls.len() + codes.len() + properties.len());
+            for u in &supplement_urls {
+                params.push(u as &dyn rusqlite::ToSql);
+            }
+            for c in &codes {
+                params.push(c as &dyn rusqlite::ToSql);
+            }
+            if !want_all_props {
+                for p in &properties {
+                    params.push(p as &dyn rusqlite::ToSql);
+                }
+            }
+            let mut out: std::collections::HashMap<String, Vec<(String, String)>> =
+                std::collections::HashMap::new();
+            let rows = stmt
+                .query_map(params.as_slice(), |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })
+                .map_err(|e| HtsError::StorageError(e.to_string()))?;
+            for r in rows {
+                let (code, prop, value) = r.map_err(|e| HtsError::StorageError(e.to_string()))?;
+                out.entry(code).or_default().push((prop, value));
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| HtsError::Internal(format!("Blocking task error: {e}")))?
+    }
 }
 
 // ── Private DB helpers ─────────────────────────────────────────────────────────
@@ -839,6 +1078,7 @@ fn fetch_designations(
             use_system: row.get(1)?,
             use_code: row.get(2)?,
             value: row.get(3)?,
+            source: None,
         })
     })
     .map_err(|e| HtsError::StorageError(e.to_string()))?

--- a/crates/hts/src/backends/sqlite/value_set.rs
+++ b/crates/hts/src/backends/sqlite/value_set.rs
@@ -3585,6 +3585,10 @@ fn is_concept_inactive(conn: &Connection, system_url: &str, code: &str) -> bool 
     .is_ok()
 }
 
+// Keep all message-format inputs explicit so the IG-fixture text strings are
+// composed in one place — splitting into a struct just to placate the lint
+// would scatter the format logic across the file.
+#[allow(clippy::too_many_arguments)]
 fn finish_validate_code_response(
     found: Option<ExpansionContains>,
     code: &str,

--- a/crates/hts/src/operations/expand.rs
+++ b/crates/hts/src/operations/expand.rs
@@ -42,7 +42,7 @@ use serde_json::{Value, json};
 
 use crate::error::HtsError;
 use crate::state::{AppState, EXPAND_CACHE_MAX, ExpandCacheKey, NOT_FOUND_CACHE_MAX};
-use crate::traits::{TerminologyBackend, ValueSetOperations};
+use crate::traits::{SupplementInfo, TerminologyBackend, ValueSetOperations};
 use crate::types::{ExpandRequest, ExpansionContains};
 
 use super::format::{ResponseFormat, json_to_fhir_xml, negotiate_format};
@@ -283,6 +283,127 @@ fn populate_properties<'a, B: TerminologyBackend>(
     })
 }
 
+/// Append designations contributed by applied CodeSystem supplements onto
+/// each expansion entry. Mirrors [`populate_designations`] but reads via the
+/// backend's `supplement_designations` API and merges into the existing
+/// `designations` vec rather than replacing it. Walks nested `contains[]`
+/// recursively.
+///
+/// Supplements live in the same `code_systems` table (with `content =
+/// 'supplement'`) so we look them up by URL — the supplement-side rows are
+/// matched to base concepts by code only. The backend tags each returned
+/// row with `source = "url|version"` so callers can emit the FHIR
+/// `designation.source` part on `$lookup`; for `$expand.contains[]` the
+/// source is informational only.
+fn apply_supplement_designations<'a, B: TerminologyBackend>(
+    backend: &'a B,
+    ctx: &'a TenantContext,
+    contains: &'a mut [ExpansionContains],
+    supplement_urls: &'a [String],
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+    Box::pin(async move {
+        use crate::types::ExpansionContainsDesignation;
+        use std::collections::HashMap;
+        if supplement_urls.is_empty() {
+            return;
+        }
+        let mut codes: Vec<String> = Vec::new();
+        for c in contains.iter() {
+            if !codes.contains(&c.code) {
+                codes.push(c.code.clone());
+            }
+        }
+        let map = backend
+            .supplement_designations(ctx, supplement_urls, &codes)
+            .await
+            .unwrap_or_default();
+        // Build a flat code → designations map keyed only by code (supplements
+        // are typically scoped to a single base CS, so collisions on code
+        // across systems are unusual and acceptable here).
+        let mut by_code: HashMap<String, Vec<ExpansionContainsDesignation>> = HashMap::new();
+        for (code, list) in map {
+            let entries = list
+                .into_iter()
+                .map(|d| ExpansionContainsDesignation {
+                    language: d.language,
+                    use_system: d.use_system,
+                    use_code: d.use_code,
+                    value: d.value,
+                })
+                .collect();
+            by_code.insert(code, entries);
+        }
+        for c in contains.iter_mut() {
+            if let Some(extra) = by_code.get(&c.code) {
+                for d in extra {
+                    c.designations.push(d.clone());
+                }
+            }
+            if !c.contains.is_empty() {
+                apply_supplement_designations(backend, ctx, &mut c.contains, supplement_urls).await;
+            }
+        }
+    })
+}
+
+/// Append property values contributed by applied CodeSystem supplements onto
+/// each expansion entry. Mirrors [`populate_properties`] but reads via the
+/// backend's `supplement_property_values` API. Walks nested `contains[]`
+/// recursively. When a supplement defines a property for a code that the
+/// base CS doesn't, the supplement value is added to the entry; values
+/// defined in BOTH base and supplement are surfaced once each (the IG
+/// fixtures don't deduplicate by property code).
+fn apply_supplement_properties<'a, B: TerminologyBackend>(
+    backend: &'a B,
+    ctx: &'a TenantContext,
+    contains: &'a mut [ExpansionContains],
+    supplement_urls: &'a [String],
+    properties: &'a [String],
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+    Box::pin(async move {
+        use crate::types::ExpansionContainsProperty;
+        use std::collections::HashMap;
+        if supplement_urls.is_empty() || properties.is_empty() {
+            return;
+        }
+        let mut codes: Vec<String> = Vec::new();
+        for c in contains.iter() {
+            if !codes.contains(&c.code) {
+                codes.push(c.code.clone());
+            }
+        }
+        let map = backend
+            .supplement_property_values(ctx, supplement_urls, &codes, properties)
+            .await
+            .unwrap_or_default();
+        let mut by_code: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        for (code, list) in map {
+            by_code.insert(code, list);
+        }
+        for c in contains.iter_mut() {
+            if let Some(extra) = by_code.get(&c.code) {
+                for (prop, value) in extra {
+                    c.properties.push(ExpansionContainsProperty {
+                        code: prop.clone(),
+                        value_type: "Code".to_string(),
+                        value: value.clone(),
+                    });
+                }
+            }
+            if !c.contains.is_empty() {
+                apply_supplement_properties(
+                    backend,
+                    ctx,
+                    &mut c.contains,
+                    supplement_urls,
+                    properties,
+                )
+                .await;
+            }
+        }
+    })
+}
+
 /// Replace each contains[] entry's `display` with a designation matching the
 /// requested displayLanguage (when one exists). Mirrors the `lookup()`
 /// language-aware behavior. Walks nested `contains[]` recursively.
@@ -373,34 +494,29 @@ async fn process_expand<B: TerminologyBackend>(
 
     let hierarchical = find_str_param(&params, "hierarchical").map(|s| s == "true");
 
-    // Reject early when the request asks for a `useSupplement` we don't have.
-    // The IG fixtures expect 4xx for unknown supplements (parameters/* and
-    // extensions/* tests). Iterate every useSupplement entry; a missing one
-    // becomes an InvalidRequest so it surfaces as 400 with a descriptive
-    // OperationOutcome.
-    {
-        let supplements: Vec<&str> = params
-            .iter()
-            .filter(|p| p.get("name").and_then(|v| v.as_str()) == Some("useSupplement"))
-            .filter_map(|p| {
-                p.get("valueCanonical")
-                    .or_else(|| p.get("valueUri"))
-                    .and_then(|v| v.as_str())
-            })
-            .collect();
-        if !supplements.is_empty() {
-            let ctx = TenantContext::system();
-            for s in &supplements {
-                // Strip any |version suffix for the lookup.
-                let bare = s.split('|').next().unwrap_or(s);
-                let exists = state
-                    .backend()
-                    .code_system_version_for_url(&ctx, bare)
-                    .await
-                    .ok()
-                    .flatten()
-                    .is_some();
-                if !exists {
+    // ── Resolve supplements (request `useSupplement` params) ────────────────
+    // Walk every `useSupplement` and confirm a matching `content=supplement`
+    // CodeSystem exists. Unknown supplements become a NotFound error so the
+    // bad-supplement IG fixtures reject with 4xx. The resolved info list is
+    // applied later, after expansion completes.
+    let mut applied_supplements: Vec<SupplementInfo> = Vec::new();
+    let mut supplement_inputs: Vec<String> = params
+        .iter()
+        .filter(|p| p.get("name").and_then(|v| v.as_str()) == Some("useSupplement"))
+        .filter_map(|p| {
+            p.get("valueCanonical")
+                .or_else(|| p.get("valueUri"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+    if !supplement_inputs.is_empty() {
+        let ctx = TenantContext::system();
+        for raw in &supplement_inputs {
+            let bare = raw.split('|').next().unwrap_or(raw);
+            match state.backend().supplement_target(&ctx, bare).await? {
+                Some(info) => applied_supplements.push(info),
+                None => {
                     return Err(HtsError::NotFound(format!(
                         "Required supplement not found: {bare}"
                     )));
@@ -408,6 +524,8 @@ async fn process_expand<B: TerminologyBackend>(
             }
         }
     }
+    // (bare_supplement_urls is rebuilt below after the source-VS extension
+    // pass appends any auto-applied supplements to `supplement_inputs`.)
 
     // ── Cache lookup ─────────────────────────────────────────────────────────
     // Build a stable key from the request parameters. For inline ValueSets
@@ -521,6 +639,68 @@ async fn process_expand<B: TerminologyBackend>(
     // them here in a per-system batch so the per-concept SQL stays cold-path.
     populate_concept_flags(state.backend(), &ctx, &mut resp.contains).await;
 
+    // ── Look up source ValueSet (used for parameter extension, metadata copy,
+    // and to discover the `valueset-supplement` extension that auto-applies a
+    // supplement without needing an explicit `useSupplement` request param). ──
+    let source_vs: Option<Value> = if let Some(ref u) = url_for_neg_cache {
+        ValueSetOperations::search(
+            state.backend(),
+            &ctx,
+            crate::types::ResourceSearchQuery {
+                url: Some(u.clone()),
+                count: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .ok()
+        .and_then(|mut v| v.pop())
+    } else {
+        value_set_for_response.clone()
+    };
+
+    // Pull additional supplements pinned by the source VS via the
+    // `valueset-supplement` extension (per HL7 IG `extensions/extensions-all`,
+    // which omits `useSupplement` from the request and relies on the VS to
+    // declare which supplement applies). Resolve each via `supplement_target`,
+    // skipping any URL we can't validate (so missing supplements don't kill
+    // an expansion that the IG fixture marks valid).
+    if let Some(vs) = source_vs.as_ref() {
+        if let Some(exts) = vs.get("extension").and_then(|e| e.as_array()) {
+            for ext in exts {
+                if ext.get("url").and_then(|u| u.as_str())
+                    != Some("http://hl7.org/fhir/StructureDefinition/valueset-supplement")
+                {
+                    continue;
+                }
+                let raw = match ext
+                    .get("valueCanonical")
+                    .or_else(|| ext.get("valueUri"))
+                    .and_then(|v| v.as_str())
+                {
+                    Some(s) => s.to_string(),
+                    None => continue,
+                };
+                let bare = raw.split('|').next().unwrap_or(&raw).to_string();
+                if supplement_inputs
+                    .iter()
+                    .any(|s| s.split('|').next() == Some(&bare))
+                {
+                    continue;
+                }
+                if let Ok(Some(info)) = state.backend().supplement_target(&ctx, &bare).await {
+                    supplement_inputs.push(raw.clone());
+                    applied_supplements.push(info);
+                }
+            }
+        }
+    }
+    // Rebuild bare_supplement_urls including any VS-extension additions.
+    let bare_supplement_urls: Vec<String> = supplement_inputs
+        .iter()
+        .map(|s| s.split('|').next().unwrap_or(s).to_string())
+        .collect();
+
     // ── Populate designations (only if explicitly requested) ─────────────────
     let include_designations = params
         .iter()
@@ -529,6 +709,18 @@ async fn process_expand<B: TerminologyBackend>(
         .unwrap_or(false);
     if include_designations {
         populate_designations(state.backend(), &ctx, &mut resp.contains).await;
+        // After base designations are loaded, append any supplement-derived
+        // entries so contains[].designation contains BOTH the base and
+        // supplement values for each concept (matched by code).
+        if !bare_supplement_urls.is_empty() {
+            apply_supplement_designations(
+                state.backend(),
+                &ctx,
+                &mut resp.contains,
+                &bare_supplement_urls,
+            )
+            .await;
+        }
     }
 
     // ── Populate properties (only for codes named in `property` params) ──────
@@ -550,6 +742,16 @@ async fn process_expand<B: TerminologyBackend>(
             &requested_properties,
         )
         .await;
+        if !bare_supplement_urls.is_empty() {
+            apply_supplement_properties(
+                state.backend(),
+                &ctx,
+                &mut resp.contains,
+                &bare_supplement_urls,
+                &requested_properties,
+            )
+            .await;
+        }
     }
 
     // ── displayLanguage: swap display from matching designation ──────────────
@@ -565,24 +767,6 @@ async fn process_expand<B: TerminologyBackend>(
     if let Some(lang) = display_language.as_deref() {
         apply_display_language(state.backend(), &ctx, &mut resp.contains, lang).await;
     }
-
-    // ── Look up source ValueSet (used for both parameter extension and metadata copy) ──
-    let source_vs: Option<Value> = if let Some(ref u) = url_for_neg_cache {
-        ValueSetOperations::search(
-            state.backend(),
-            &ctx,
-            crate::types::ResourceSearchQuery {
-                url: Some(u.clone()),
-                count: Some(1),
-                ..Default::default()
-            },
-        )
-        .await
-        .ok()
-        .and_then(|mut v| v.pop())
-    } else {
-        value_set_for_response.clone()
-    };
 
     // ── activeOnly / compose.inactive=false filter ──────────────────────────
     // The IG fixtures drop inactive concepts when EITHER:
@@ -759,6 +943,18 @@ async fn process_expand<B: TerminologyBackend>(
         emitted_params.push(json!({
             "name": "used-codesystem",
             "valueUri": value_uri,
+        }));
+    }
+
+    // ── used-supplement entries ──────────────────────────────────────────────
+    // Echo each applied supplement so the IG validator sees we honored it
+    // (matches `parameters-expand-supplement-good` and the
+    // `extensions/expand-echo-all` fixtures). Value is the supplement's
+    // canonical (`url|version` when stored).
+    for info in &applied_supplements {
+        emitted_params.push(json!({
+            "name": "used-supplement",
+            "valueUri": info.supplement_canonical,
         }));
     }
 
@@ -1229,6 +1425,103 @@ mod tests {
 
         let resp = post_json(app, "/ValueSet/$expand", body).await;
         assert_eq!(resp.status(), 400);
+    }
+
+    // ── useSupplement (IG `parameters-expand-supplement-good`) ────────────────
+
+    fn make_supplement_app() -> Router {
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        {
+            let conn = backend.pool().get().unwrap();
+            conn.execute_batch(
+                "INSERT INTO code_systems
+                     (id, url, version, status, content, created_at, updated_at, resource_json)
+                 VALUES ('base', 'http://hl7.org/fhir/test/CodeSystem/extensions', '5.0.0',
+                         'active', 'complete',
+                         '2024-01-01', '2024-01-01',
+                         '{\"resourceType\":\"CodeSystem\"}');
+
+                 INSERT INTO code_systems
+                     (id, url, version, status, content, created_at, updated_at, resource_json)
+                 VALUES ('supp', 'http://hl7.org/fhir/test/CodeSystem/supplement', '0.1.1',
+                         'active', 'supplement',
+                         '2024-01-01', '2024-01-01',
+                         '{\"resourceType\":\"CodeSystem\",\"supplements\":\"http://hl7.org/fhir/test/CodeSystem/extensions\"}');
+
+                 INSERT INTO concepts (id, system_id, code, display)
+                 VALUES (20, 'base', 'code1', 'Display 1'),
+                        (21, 'supp', 'code1', NULL);
+
+                 INSERT INTO concept_designations (concept_id, language, value)
+                 VALUES (21, 'nl', 'ectenoot');
+
+                 INSERT INTO value_sets
+                     (id, url, status, compose_json, created_at, updated_at, resource_json)
+                 VALUES ('vs-extns', 'http://hl7.org/fhir/test/ValueSet/extensions-all-ns',
+                         'active',
+                         '{\"include\":[{\"system\":\"http://hl7.org/fhir/test/CodeSystem/extensions\"}]}',
+                         '2024-01-01', '2024-01-01',
+                         '{\"resourceType\":\"ValueSet\"}');",
+            )
+            .unwrap();
+        }
+        let state = AppState::new(backend);
+        Router::new()
+            .route(
+                "/ValueSet/$expand",
+                post(expand_handler::<SqliteTerminologyBackend>),
+            )
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn expand_with_use_supplement_emits_used_supplement_param() {
+        let app = make_supplement_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "url", "valueUri": "http://hl7.org/fhir/test/ValueSet/extensions-all-ns"},
+                {"name": "useSupplement", "valueCanonical": "http://hl7.org/fhir/test/CodeSystem/supplement"},
+                {"name": "includeDesignations", "valueBoolean": true}
+            ]
+        });
+        let resp = post_json(app, "/ValueSet/$expand", body).await;
+        assert_eq!(resp.status(), 200);
+        let json = body_json(resp).await;
+        let params = json["expansion"]["parameter"].as_array().unwrap();
+        let used = params
+            .iter()
+            .find(|p| p["name"] == "used-supplement")
+            .expect("used-supplement parameter expected in expansion.parameter");
+        assert_eq!(
+            used["valueUri"],
+            "http://hl7.org/fhir/test/CodeSystem/supplement|0.1.1"
+        );
+
+        // Designation merged into contains[code1].
+        let contains = json["expansion"]["contains"].as_array().unwrap();
+        let code1 = contains.iter().find(|c| c["code"] == "code1").unwrap();
+        let designations = code1["designation"].as_array().unwrap();
+        assert!(
+            designations
+                .iter()
+                .any(|d| d["value"] == "ectenoot" && d["language"] == "nl"),
+            "supplement designation 'ectenoot' must appear in contains[code1].designation"
+        );
+    }
+
+    #[tokio::test]
+    async fn expand_unknown_supplement_returns_404() {
+        let app = make_supplement_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "url", "valueUri": "http://hl7.org/fhir/test/ValueSet/extensions-all-ns"},
+                {"name": "useSupplement", "valueCanonical": "http://does-not-exist/cs"}
+            ]
+        });
+        let resp = post_json(app, "/ValueSet/$expand", body).await;
+        assert_eq!(resp.status(), 404);
     }
 }
 // rebuild marker

--- a/crates/hts/src/operations/lookup.rs
+++ b/crates/hts/src/operations/lookup.rs
@@ -32,8 +32,8 @@ use serde_json::{Value, json};
 
 use crate::error::HtsError;
 use crate::state::AppState;
-use crate::traits::TerminologyBackend;
-use crate::types::LookupRequest;
+use crate::traits::{SupplementInfo, TerminologyBackend};
+use crate::types::{DesignationValue, LookupRequest, PropertyValue};
 
 use super::format::{fhir_respond, negotiate_format};
 use super::params::{
@@ -76,34 +76,90 @@ async fn process_lookup<B: TerminologyBackend>(
         expression: find_str_param(&params, "expression"),
         properties: collect_str_params(&params, "property"),
         date: find_str_param(&params, "date"),
+        use_supplements: collect_str_params(&params, "useSupplement"),
     };
 
     let ctx = TenantContext::system();
-    // Reject early when the request asks for a `useSupplement` we don't have.
-    for s in params
-        .iter()
-        .filter(|p| p.get("name").and_then(|v| v.as_str()) == Some("useSupplement"))
-        .filter_map(|p| {
-            p.get("valueCanonical")
-                .or_else(|| p.get("valueUri"))
-                .and_then(|v| v.as_str())
-        })
-    {
-        let bare = s.split('|').next().unwrap_or(s);
-        let exists = state
-            .backend()
-            .code_system_version_for_url(&ctx, bare)
-            .await
-            .ok()
-            .flatten()
-            .is_some();
-        if !exists {
-            return Err(HtsError::NotFound(format!(
-                "Required supplement not found: {bare}"
-            )));
+
+    // ── Resolve supplements ──────────────────────────────────────────────────
+    // Accept either valueCanonical or valueUri on `useSupplement`. For each,
+    // verify it points at a stored CodeSystem with `content=supplement` whose
+    // `supplements` URL matches the lookup `system`. Mismatches and unknown
+    // supplements both reject with NotFound (issue.code=not-found) per the
+    // IG fixtures.
+    let supplement_inputs: Vec<String> = collect_supplement_inputs(&params);
+    let mut applied_supplements: Vec<SupplementInfo> = Vec::new();
+    for raw in &supplement_inputs {
+        let bare = raw.split('|').next().unwrap_or(raw).to_string();
+        match state.backend().supplement_target(&ctx, &bare).await? {
+            Some(info) if info.target_url == system => applied_supplements.push(info),
+            _ => {
+                return Err(HtsError::NotFound(format!(
+                    "Required supplement not found: {bare}"
+                )));
+            }
         }
     }
-    let resp = state.backend().lookup(&ctx, req).await?;
+
+    let mut resp = state.backend().lookup(&ctx, req).await?;
+
+    // Merge supplement designations and properties (matched on concept code).
+    if !applied_supplements.is_empty() {
+        // The lookup keys for the supplement queries are the supplement CS
+        // URLs themselves (not their `supplements` targets).
+        let bare_supp_urls: Vec<String> = supplement_inputs
+            .iter()
+            .map(|s| s.split('|').next().unwrap_or(s).to_string())
+            .collect();
+        let codes = vec![code.clone()];
+
+        // Designations: tag with `source = "url|version"` (set by the
+        // backend). Append AFTER base designations so the IG fixture order
+        // (base first, supplement last) is preserved.
+        let supp_desigs = state
+            .backend()
+            .supplement_designations(&ctx, &bare_supp_urls, &codes)
+            .await
+            .unwrap_or_default();
+        if let Some(list) = supp_desigs.get(&code) {
+            for d in list {
+                resp.designations.push(DesignationValue {
+                    language: d.language.clone(),
+                    use_system: d.use_system.clone(),
+                    use_code: d.use_code.clone(),
+                    value: d.value.clone(),
+                    source: d.source.clone(),
+                });
+            }
+        }
+
+        // Properties: when the caller asks for specific properties, scope
+        // the supplement query to those names. Otherwise (no filter or
+        // wildcard `*`) pass an empty list to mean "all properties".
+        let requested_props_raw = collect_str_params(&params, "property");
+        let want_all =
+            requested_props_raw.is_empty() || requested_props_raw.iter().any(|p| p == "*");
+        let prop_filter: Vec<String> = if want_all {
+            Vec::new()
+        } else {
+            requested_props_raw
+        };
+        let supp_props = state
+            .backend()
+            .supplement_property_values(&ctx, &bare_supp_urls, &codes, &prop_filter)
+            .await
+            .unwrap_or_default();
+        if let Some(list) = supp_props.get(&code) {
+            for (prop, value) in list {
+                resp.properties.push(PropertyValue {
+                    code: prop.clone(),
+                    value_type: "string".into(),
+                    value: value.clone(),
+                    description: None,
+                });
+            }
+        }
+    }
 
     // ── Build FHIR Parameters response ─────────────────────────────────────────
     let mut parameter: Vec<Value> = vec![json!({"name": "name", "valueString": resp.name})];
@@ -155,8 +211,26 @@ async fn process_lookup<B: TerminologyBackend>(
             }));
         }
 
+        // FHIR `designation.source` part — points at the supplement CS
+        // (`url|version`) that contributed this designation. Only present
+        // for supplement-derived rows; base CS designations carry no source.
+        if let Some(src) = desig.source {
+            parts.push(json!({"name": "source", "valueCanonical": src}));
+        }
+
         parts.push(json!({"name": "value", "valueString": desig.value}));
         parameter.push(json!({"name": "designation", "part": parts}));
+    }
+
+    // ── used-supplement parameters ───────────────────────────────────────────
+    // Echo each applied supplement as a `used-supplement` parameter so the
+    // caller can see which supplements actually contributed to the response
+    // (matches IG fixture `parameters-lookup-supplement-good-response`).
+    for info in &applied_supplements {
+        parameter.push(json!({
+            "name": "used-supplement",
+            "valueCanonical": info.supplement_canonical,
+        }));
     }
 
     Ok(json!({
@@ -198,6 +272,22 @@ pub async fn get_lookup_handler<B: TerminologyBackend>(
     let pairs = parse_query_string(raw.as_deref().unwrap_or(""));
     let params = query_params_to_fhir_params(pairs);
     Ok(fhir_respond(process_lookup(&state, params).await?, format))
+}
+
+/// Collect every `useSupplement` input from a Parameters body, accepting
+/// either `valueCanonical` or `valueUri`. Returns the raw values so callers
+/// can later strip an optional `|version` suffix when looking up the CS.
+fn collect_supplement_inputs(params: &[Value]) -> Vec<String> {
+    params
+        .iter()
+        .filter(|p| p.get("name").and_then(|v| v.as_str()) == Some("useSupplement"))
+        .filter_map(|p| {
+            p.get("valueCanonical")
+                .or_else(|| p.get("valueUri"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .collect()
 }
 
 /// Inject (or replace) the `system` parameter in a FHIR params list.
@@ -476,5 +566,158 @@ mod tests {
 
         let resp = post_json(app, "/CodeSystem/$lookup", body).await;
         assert_eq!(resp.status(), 400);
+    }
+
+    // ── useSupplement ─────────────────────────────────────────────────────────
+    //
+    // Mirror the IG `parameters/parameters-lookup-supplement-good` fixture: a
+    // supplement defines an alternate display ("ectenoot") for code1 in the
+    // base CS; the lookup response must include that designation tagged with
+    // `source = supplement_url|version` plus a `used-supplement` parameter
+    // echoing the applied supplement.
+    fn make_supplement_app() -> Router {
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        {
+            let conn = backend.pool().get().unwrap();
+            conn.execute_batch(
+                "INSERT INTO code_systems
+                     (id, url, version, name, status, content, created_at, updated_at, resource_json)
+                 VALUES ('base', 'http://hl7.org/fhir/test/CodeSystem/extensions', '5.0.0',
+                         'ExtensionsTestCodeSystem', 'active', 'complete',
+                         '2024-01-01', '2024-01-01',
+                         '{\"resourceType\":\"CodeSystem\",\"url\":\"http://hl7.org/fhir/test/CodeSystem/extensions\"}');
+
+                 INSERT INTO code_systems
+                     (id, url, version, name, status, content, created_at, updated_at, resource_json)
+                 VALUES ('supp', 'http://hl7.org/fhir/test/CodeSystem/supplement', '0.1.1',
+                         'SupplementToExtensionsTestCodeSystem', 'active', 'supplement',
+                         '2024-01-01', '2024-01-01',
+                         '{\"resourceType\":\"CodeSystem\",\"url\":\"http://hl7.org/fhir/test/CodeSystem/supplement\",\"supplements\":\"http://hl7.org/fhir/test/CodeSystem/extensions\"}');
+
+                 INSERT INTO concepts (id, system_id, code, display)
+                 VALUES (1, 'base', 'code1', 'Display 1'),
+                        (2, 'supp', 'code1', NULL);
+
+                 INSERT INTO concept_designations (concept_id, language, use_system, use_code, value)
+                 VALUES (2, 'nl', NULL, NULL, 'ectenoot');",
+            )
+            .unwrap();
+        }
+        let state = AppState::new(backend);
+        Router::new()
+            .route(
+                "/CodeSystem/$lookup",
+                post(lookup_handler::<SqliteTerminologyBackend>),
+            )
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn lookup_with_use_supplement_includes_designation_with_source() {
+        let app = make_supplement_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "system", "valueUri": "http://hl7.org/fhir/test/CodeSystem/extensions"},
+                {"name": "code", "valueCode": "code1"},
+                {"name": "useSupplement", "valueCanonical": "http://hl7.org/fhir/test/CodeSystem/supplement"}
+            ]
+        });
+        let resp = post_json(app, "/CodeSystem/$lookup", body).await;
+        assert_eq!(resp.status(), 200);
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+
+        // Designation with value "ectenoot" and a source pointing back at
+        // the supplement canonical (with version).
+        let supp_desig = params
+            .iter()
+            .filter(|p| p["name"] == "designation")
+            .find(|p| {
+                p["part"]
+                    .as_array()
+                    .map(|parts| parts.iter().any(|q| q["valueString"] == "ectenoot"))
+                    .unwrap_or(false)
+            })
+            .expect("supplement designation should appear");
+        let parts = supp_desig["part"].as_array().unwrap();
+        let source = parts
+            .iter()
+            .find(|p| p["name"] == "source")
+            .expect("designation.source part required for supplement-derived rows");
+        assert_eq!(
+            source["valueCanonical"],
+            "http://hl7.org/fhir/test/CodeSystem/supplement|0.1.1",
+        );
+
+        // used-supplement parameter at top level.
+        let used = params
+            .iter()
+            .find(|p| p["name"] == "used-supplement")
+            .expect("used-supplement parameter expected");
+        assert_eq!(
+            used["valueCanonical"],
+            "http://hl7.org/fhir/test/CodeSystem/supplement|0.1.1",
+        );
+    }
+
+    #[tokio::test]
+    async fn lookup_without_use_supplement_omits_supplement_designation() {
+        let app = make_supplement_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "system", "valueUri": "http://hl7.org/fhir/test/CodeSystem/extensions"},
+                {"name": "code", "valueCode": "code1"}
+            ]
+        });
+        let resp = post_json(app, "/CodeSystem/$lookup", body).await;
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+        let has_ectenoot = params.iter().any(|p| {
+            p["name"] == "designation"
+                && p["part"]
+                    .as_array()
+                    .map(|parts| parts.iter().any(|q| q["valueString"] == "ectenoot"))
+                    .unwrap_or(false)
+        });
+        assert!(
+            !has_ectenoot,
+            "supplement designation must NOT appear without useSupplement"
+        );
+        let has_used_supplement = params.iter().any(|p| p["name"] == "used-supplement");
+        assert!(!has_used_supplement);
+    }
+
+    #[tokio::test]
+    async fn lookup_unknown_supplement_returns_404() {
+        let app = make_supplement_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "system", "valueUri": "http://hl7.org/fhir/test/CodeSystem/extensions"},
+                {"name": "code", "valueCode": "code1"},
+                {"name": "useSupplement", "valueCanonical": "http://does-not-exist/cs"}
+            ]
+        });
+        let resp = post_json(app, "/CodeSystem/$lookup", body).await;
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn lookup_supplement_targeting_other_cs_returns_404() {
+        // The supplement points at .../extensions, but the lookup is against
+        // a different CS — the rejection is the same as not-found.
+        let app = make_supplement_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "system", "valueUri": "http://other.org/cs"},
+                {"name": "code", "valueCode": "code1"},
+                {"name": "useSupplement", "valueCanonical": "http://hl7.org/fhir/test/CodeSystem/supplement"}
+            ]
+        });
+        let resp = post_json(app, "/CodeSystem/$lookup", body).await;
+        assert_eq!(resp.status(), 404);
     }
 }

--- a/crates/hts/src/operations/validate_code.rs
+++ b/crates/hts/src/operations/validate_code.rs
@@ -26,7 +26,7 @@ use serde_json::{Value, json};
 
 use crate::error::HtsError;
 use crate::state::AppState;
-use crate::traits::{CodeSystemOperations, TerminologyBackend, ValueSetOperations};
+use crate::traits::{CodeSystemOperations, SupplementInfo, TerminologyBackend, ValueSetOperations};
 use crate::types::{ValidateCodeRequest, ValidateCodeResponse};
 
 use super::format::{fhir_respond, negotiate_format};
@@ -152,14 +152,26 @@ async fn build_validate_response_async<B: TerminologyBackend>(
     )
 }
 
-/// Reject any `useSupplement` request param that names a CodeSystem we don't
-/// have stored. The IG fixtures expect 4xx (with issue.code=not-found) when
-/// a supplement is unknown — applies equally to $expand and $validate-code.
-async fn check_supplements<B: TerminologyBackend>(
+/// Resolve every `useSupplement` request param against the backend.
+///
+/// For each supplement URL provided by the caller:
+/// - Verify a stored CodeSystem exists with that URL **and** `content =
+///   supplement` (via `supplement_target`).
+/// - When `expected_target` is `Some`, also enforce that the supplement's
+///   `supplements` URL matches it (so a supplement targeting CS-A cannot
+///   silently apply to CS-B).
+///
+/// Returns the resolved [`SupplementInfo`] list on success — operations
+/// layer code merges supplement-derived data into the response. Returns
+/// `HtsError::NotFound` when any supplement is unknown / mistargeted, so
+/// the IG fixtures' `bad-supplement` cases produce a 4xx OperationOutcome.
+async fn resolve_supplements<B: TerminologyBackend>(
     backend: &B,
     ctx: &TenantContext,
     params: &[Value],
-) -> Result<(), HtsError> {
+    expected_target: Option<&str>,
+) -> Result<Vec<SupplementInfo>, HtsError> {
+    let mut out = Vec::new();
     for s in params
         .iter()
         .filter(|p| p.get("name").and_then(|v| v.as_str()) == Some("useSupplement"))
@@ -170,19 +182,124 @@ async fn check_supplements<B: TerminologyBackend>(
         })
     {
         let bare = s.split('|').next().unwrap_or(s);
-        let exists = backend
-            .code_system_version_for_url(ctx, bare)
-            .await
-            .ok()
-            .flatten()
-            .is_some();
-        if !exists {
-            return Err(HtsError::NotFound(format!(
-                "Required supplement not found: {bare}"
-            )));
+        let info = backend.supplement_target(ctx, bare).await?;
+        let info = match info {
+            Some(i) => i,
+            None => {
+                return Err(HtsError::NotFound(format!(
+                    "Required supplement not found: {bare}"
+                )));
+            }
+        };
+        if let Some(target) = expected_target {
+            if info.target_url != target {
+                return Err(HtsError::NotFound(format!(
+                    "Required supplement not found: {bare}"
+                )));
+            }
+        }
+        out.push(info);
+    }
+    Ok(out)
+}
+
+/// True when `expected` matches the concept's stored display OR any
+/// supplement designation value (case-insensitive ASCII compare, the same
+/// rule used inside the backend's display check). Used to "rescue" a
+/// validate-code response whose only failure was a display mismatch that
+/// is in fact resolved by an applied supplement.
+async fn display_matches_supplement<B: TerminologyBackend>(
+    backend: &B,
+    ctx: &TenantContext,
+    supplements: &[SupplementInfo],
+    system_url: &str,
+    code: &str,
+    expected: &str,
+) -> bool {
+    if supplements.is_empty() {
+        return false;
+    }
+    let supp_urls: Vec<String> = supplements
+        .iter()
+        .map(|s| {
+            s.supplement_canonical
+                .split('|')
+                .next()
+                .unwrap_or(&s.supplement_canonical)
+                .to_string()
+        })
+        .collect();
+    let codes = vec![code.to_string()];
+    let designs = match backend
+        .supplement_designations(ctx, &supp_urls, &codes)
+        .await
+    {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+    let _ = system_url; // supplements are already filtered by their own URL list
+    if let Some(list) = designs.get(code) {
+        for d in list {
+            if d.value.eq_ignore_ascii_case(expected) {
+                return true;
+            }
         }
     }
-    Ok(())
+    false
+}
+
+/// Append a `used-supplement` parameter to a built validate-code response,
+/// once per applied supplement. The value is the supplement's canonical
+/// (`url|version` when available). Mutates `value` in place.
+fn append_used_supplements(value: &mut Value, supplements: &[SupplementInfo]) {
+    if supplements.is_empty() {
+        return;
+    }
+    if let Some(arr) = value.get_mut("parameter").and_then(|p| p.as_array_mut()) {
+        for info in supplements {
+            arr.push(json!({
+                "name": "used-supplement",
+                "valueCanonical": info.supplement_canonical,
+            }));
+        }
+    }
+}
+
+/// If `resp` reports `result=false` solely because of a display mismatch,
+/// and the supplied display in fact matches one of the supplement-derived
+/// alt-display designations, mutate `resp` in place to clear the message
+/// and set `result=true`. No-op when no supplements are applied or when
+/// the response wasn't a display-mismatch failure.
+async fn rescue_via_supplements<B: TerminologyBackend>(
+    backend: &B,
+    ctx: &TenantContext,
+    supplements: &[SupplementInfo],
+    system_url: &str,
+    code: &str,
+    expected_display: Option<&str>,
+    resp: &mut ValidateCodeResponse,
+) {
+    if supplements.is_empty() || resp.result {
+        return;
+    }
+    let Some(expected) = expected_display else {
+        return;
+    };
+    // Heuristic: only "rescue" display-mismatch failures, not
+    // code-not-in-VS or unknown-code rejections. The backend's display
+    // mismatch message starts with either "Display mismatch:" (CodeSystem
+    // path, see code_system.rs) or "Provided display ... does not match"
+    // (ValueSet path, see finish_validate_code_response in value_set.rs).
+    let msg = resp.message.as_deref().unwrap_or("");
+    let looks_like_display_mismatch =
+        msg.starts_with("Display mismatch:") || msg.contains("does not match stored display");
+    if !looks_like_display_mismatch {
+        return;
+    }
+    if display_matches_supplement(backend, ctx, supplements, system_url, code, expected).await {
+        resp.result = true;
+        resp.message = None;
+    }
 }
 
 /// Core validate-code logic for `CodeSystem/$validate-code`.
@@ -209,8 +326,6 @@ pub(crate) async fn process_validate_code<B: TerminologyBackend>(
     params: Vec<Value>,
 ) -> Result<Value, HtsError> {
     let ctx = TenantContext::system();
-    check_supplements(state.backend(), &ctx, &params).await?;
-
     // ── Path 1: bare `code` parameter (requires `url` = CodeSystem canonical URL) ──
     if let Some(code) = find_str_param(&params, "code") {
         let system = find_str_param(&params, "url").ok_or_else(|| {
@@ -220,20 +335,33 @@ pub(crate) async fn process_validate_code<B: TerminologyBackend>(
                     .into(),
             )
         })?;
+        let supplements =
+            resolve_supplements(state.backend(), &ctx, &params, Some(&system)).await?;
+        let display = find_str_param(&params, "display");
         let req = ValidateCodeRequest {
             url: None,
             system: Some(system.clone()),
             code: code.clone(),
             version: find_str_param(&params, "version"),
-            display: find_str_param(&params, "display"),
+            display: display.clone(),
             date: find_str_param(&params, "date"),
             include_abstract: params
                 .iter()
                 .find(|p| p.get("name").and_then(|v| v.as_str()) == Some("abstract"))
                 .and_then(|p| p.get("valueBoolean").and_then(|v| v.as_bool())),
         };
-        let resp = CodeSystemOperations::validate_code(state.backend(), &ctx, req).await?;
-        return Ok(build_validate_response_async(
+        let mut resp = CodeSystemOperations::validate_code(state.backend(), &ctx, req).await?;
+        rescue_via_supplements(
+            state.backend(),
+            &ctx,
+            &supplements,
+            &system,
+            &code,
+            display.as_deref(),
+            &mut resp,
+        )
+        .await;
+        let mut value = build_validate_response_async(
             state.backend(),
             &ctx,
             resp,
@@ -241,25 +369,43 @@ pub(crate) async fn process_validate_code<B: TerminologyBackend>(
             Some(&system),
             None,
         )
-        .await);
+        .await;
+        append_used_supplements(&mut value, &supplements);
+        return Ok(value);
     }
 
     // ── Path 2: `coding` parameter (valueCoding — system+code bundled together) ──
-    if let Some((system, code, _display)) = extract_coding(&params, "coding") {
+    if let Some((system, code, coding_display)) = extract_coding(&params, "coding") {
+        // Coding.display takes precedence over a top-level `display` param —
+        // the IG fixtures pin display via the Coding so the server can
+        // report a mismatch.
+        let display = coding_display.or_else(|| find_str_param(&params, "display"));
+        let supplements =
+            resolve_supplements(state.backend(), &ctx, &params, Some(&system)).await?;
         let req = ValidateCodeRequest {
             url: None,
             system: Some(system.clone()),
             code: code.clone(),
             version: find_str_param(&params, "version"),
-            display: find_str_param(&params, "display"),
+            display: display.clone(),
             date: find_str_param(&params, "date"),
             include_abstract: params
                 .iter()
                 .find(|p| p.get("name").and_then(|v| v.as_str()) == Some("abstract"))
                 .and_then(|p| p.get("valueBoolean").and_then(|v| v.as_bool())),
         };
-        let resp = CodeSystemOperations::validate_code(state.backend(), &ctx, req).await?;
-        return Ok(build_validate_response_async(
+        let mut resp = CodeSystemOperations::validate_code(state.backend(), &ctx, req).await?;
+        rescue_via_supplements(
+            state.backend(),
+            &ctx,
+            &supplements,
+            &system,
+            &code,
+            display.as_deref(),
+            &mut resp,
+        )
+        .await;
+        let mut value = build_validate_response_async(
             state.backend(),
             &ctx,
             resp,
@@ -267,7 +413,9 @@ pub(crate) async fn process_validate_code<B: TerminologyBackend>(
             Some(&system),
             None,
         )
-        .await);
+        .await;
+        append_used_supplements(&mut value, &supplements);
+        return Ok(value);
     }
 
     // ── Path 3: `codeableConcept` parameter (multiple codings — true if any matches) ──
@@ -277,6 +425,10 @@ pub(crate) async fn process_validate_code<B: TerminologyBackend>(
                 "codeableConcept parameter has no valid coding entries".into(),
             ));
         }
+        // Bad-supplement rejection still applies — we don't yet know which
+        // coding's system will win, so verify each supplement is *known* (no
+        // target enforcement until we know the matched coding's system).
+        let _ = resolve_supplements(state.backend(), &ctx, &params, None).await?;
         // Capture the original valueCodeableConcept so we can echo it in the response.
         let cc_value = params
             .iter()
@@ -392,7 +544,11 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
     })?;
 
     let ctx = TenantContext::system();
-    check_supplements(state.backend(), &ctx, &params).await?;
+    // ValueSet validate-code can carry useSupplement that targets ANY
+    // CodeSystem in the VS expansion. We can't (yet) verify the target
+    // matches a system in the VS without expanding, so pass `None` for
+    // expected_target here — bad-supplement-not-found is still rejected.
+    let supplements = resolve_supplements(state.backend(), &ctx, &params, None).await?;
     // Used to rewrite "...'url'..." → "...'url|version'..." in NotFound
     // messages so the IG-expected text format is met.
     let vs_version = find_str_param(&params, "valueSetVersion");
@@ -410,22 +566,35 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
     // ── Path 1: bare `code` parameter ────────────────────────────────────────────
     if let Some(code) = find_str_param(&params, "code") {
         let system = find_str_param(&params, "system");
+        let display = find_str_param(&params, "display");
         let req = ValidateCodeRequest {
             url: Some(url.clone()),
             system: system.clone(),
             code: code.clone(),
             version: find_str_param(&params, "version"),
-            display: find_str_param(&params, "display"),
+            display: display.clone(),
             date: find_str_param(&params, "date"),
             include_abstract: params
                 .iter()
                 .find(|p| p.get("name").and_then(|v| v.as_str()) == Some("abstract"))
                 .and_then(|p| p.get("valueBoolean").and_then(|v| v.as_bool())),
         };
-        let resp = ValueSetOperations::validate_code(state.backend(), &ctx, req)
+        let mut resp = ValueSetOperations::validate_code(state.backend(), &ctx, req)
             .await
             .map_err(&rewrite)?;
-        return Ok(build_validate_response_async(
+        if let Some(sys) = system.as_deref() {
+            rescue_via_supplements(
+                state.backend(),
+                &ctx,
+                &supplements,
+                sys,
+                &code,
+                display.as_deref(),
+                &mut resp,
+            )
+            .await;
+        }
+        let mut value = build_validate_response_async(
             state.backend(),
             &ctx,
             resp,
@@ -433,11 +602,13 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
             system.as_deref(),
             None,
         )
-        .await);
+        .await;
+        append_used_supplements(&mut value, &supplements);
+        return Ok(value);
     }
 
     // ── Path 2: `coding` parameter (valueCoding) ──────────────────────────────
-    if let Some((system, code, _display)) = extract_coding(&params, "coding") {
+    if let Some((system, code, coding_display)) = extract_coding(&params, "coding") {
         // Empty system from extract_coding means the Coding had no system
         // field. Per the IG fixtures, that should produce result=false with
         // a "Coding has no system" message rather than matching by code
@@ -457,22 +628,36 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
                 None,
             ));
         }
+        // Coding.display takes precedence over a top-level `display` param —
+        // the IG fixtures pin display via the Coding so the server can
+        // report a mismatch.
+        let display = coding_display.or_else(|| find_str_param(&params, "display"));
         let req = ValidateCodeRequest {
             url: Some(url.clone()),
             system: Some(system.clone()),
             code: code.clone(),
             version: find_str_param(&params, "version"),
-            display: find_str_param(&params, "display"),
+            display: display.clone(),
             date: find_str_param(&params, "date"),
             include_abstract: params
                 .iter()
                 .find(|p| p.get("name").and_then(|v| v.as_str()) == Some("abstract"))
                 .and_then(|p| p.get("valueBoolean").and_then(|v| v.as_bool())),
         };
-        let resp = ValueSetOperations::validate_code(state.backend(), &ctx, req)
+        let mut resp = ValueSetOperations::validate_code(state.backend(), &ctx, req)
             .await
             .map_err(&rewrite)?;
-        return Ok(build_validate_response_async(
+        rescue_via_supplements(
+            state.backend(),
+            &ctx,
+            &supplements,
+            &system,
+            &code,
+            display.as_deref(),
+            &mut resp,
+        )
+        .await;
+        let mut value = build_validate_response_async(
             state.backend(),
             &ctx,
             resp,
@@ -480,7 +665,9 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
             Some(&system),
             None,
         )
-        .await);
+        .await;
+        append_used_supplements(&mut value, &supplements);
+        return Ok(value);
     }
 
     // ── Path 3: `codeableConcept` parameter (true if any coding is in the ValueSet) ──
@@ -516,7 +703,7 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
                 .await
                 .map_err(&rewrite)?;
             if resp.result {
-                return Ok(build_validate_response_async(
+                let mut value = build_validate_response_async(
                     state.backend(),
                     &ctx,
                     resp,
@@ -524,10 +711,12 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
                     Some(&system),
                     cc_value.as_ref(),
                 )
-                .await);
+                .await;
+                append_used_supplements(&mut value, &supplements);
+                return Ok(value);
             }
         }
-        return Ok(build_validate_response(
+        let mut value = build_validate_response(
             ValidateCodeResponse {
                 result: false,
                 message: Some("None of the provided codings were found in the ValueSet".into()),
@@ -539,7 +728,9 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
             None,
             cc_value.as_ref(),
             None,
-        ));
+        );
+        append_used_supplements(&mut value, &supplements);
+        return Ok(value);
     }
 
     Err(HtsError::InvalidRequest(
@@ -1184,5 +1375,129 @@ mod tests {
 
         let resp = post_json(app, "/CodeSystem/$validate-code", body).await;
         assert_eq!(resp.status(), 400);
+    }
+
+    // ── Supplement-aware display matching (IG `parameters-validate-supplement-good`) ──
+
+    fn make_supplement_vs_app() -> Router {
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        {
+            let conn = backend.pool().get().unwrap();
+            conn.execute_batch(
+                "INSERT INTO code_systems
+                     (id, url, version, name, status, content, created_at, updated_at, resource_json)
+                 VALUES ('base', 'http://hl7.org/fhir/test/CodeSystem/extensions', '5.0.0',
+                         'ExtensionsTestCodeSystem', 'active', 'complete',
+                         '2024-01-01', '2024-01-01',
+                         '{\"resourceType\":\"CodeSystem\"}');
+
+                 INSERT INTO code_systems
+                     (id, url, version, name, status, content, created_at, updated_at, resource_json)
+                 VALUES ('supp', 'http://hl7.org/fhir/test/CodeSystem/supplement', '0.1.1',
+                         'SupplementCS', 'active', 'supplement',
+                         '2024-01-01', '2024-01-01',
+                         '{\"resourceType\":\"CodeSystem\",\"supplements\":\"http://hl7.org/fhir/test/CodeSystem/extensions\"}');
+
+                 INSERT INTO concepts (id, system_id, code, display)
+                 VALUES (10, 'base', 'code1', 'Display 1'),
+                        (11, 'supp', 'code1', NULL);
+
+                 INSERT INTO concept_designations (concept_id, language, value)
+                 VALUES (10, 'de', 'Mein erster Code'),
+                        (11, 'nl', 'ectenoot');
+
+                 INSERT INTO value_sets
+                     (id, url, name, status, compose_json, created_at, updated_at, resource_json)
+                 VALUES ('vs-extns', 'http://hl7.org/fhir/test/ValueSet/extensions-all-ns',
+                         'ExtensionsValueSetAllNS', 'active',
+                         '{\"include\":[{\"system\":\"http://hl7.org/fhir/test/CodeSystem/extensions\"}]}',
+                         '2024-01-01', '2024-01-01',
+                         '{\"resourceType\":\"ValueSet\"}');",
+            )
+            .unwrap();
+        }
+        let state = AppState::new(backend);
+        Router::new()
+            .route(
+                "/ValueSet/$validate-code",
+                post(vs_validate_code_handler::<SqliteTerminologyBackend>),
+            )
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn vs_validate_supplement_display_matches_via_supplement_designation() {
+        let app = make_supplement_vs_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "url", "valueUri": "http://hl7.org/fhir/test/ValueSet/extensions-all-ns"},
+                {"name": "coding", "valueCoding": {
+                    "system": "http://hl7.org/fhir/test/CodeSystem/extensions",
+                    "code": "code1",
+                    "display": "ectenoot"
+                }},
+                {"name": "useSupplement", "valueCanonical": "http://hl7.org/fhir/test/CodeSystem/supplement"}
+            ]
+        });
+        let resp = post_json(app, "/ValueSet/$validate-code", body).await;
+        assert_eq!(resp.status(), 200);
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+        let result = params.iter().find(|p| p["name"] == "result").unwrap();
+        assert_eq!(
+            result["valueBoolean"], true,
+            "supplement designation 'ectenoot' should be accepted as alt display"
+        );
+        let used = params
+            .iter()
+            .find(|p| p["name"] == "used-supplement")
+            .expect("used-supplement parameter must be echoed");
+        assert_eq!(
+            used["valueCanonical"],
+            "http://hl7.org/fhir/test/CodeSystem/supplement|0.1.1"
+        );
+    }
+
+    #[tokio::test]
+    async fn vs_validate_supplement_omitted_then_display_mismatch_fails() {
+        // Mirror IG `parameters-validate-supplement-none-response`: same
+        // request shape but no useSupplement → result=false because
+        // 'ectenoot' is not in the base CS.
+        let app = make_supplement_vs_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "url", "valueUri": "http://hl7.org/fhir/test/ValueSet/extensions-all-ns"},
+                {"name": "coding", "valueCoding": {
+                    "system": "http://hl7.org/fhir/test/CodeSystem/extensions",
+                    "code": "code1",
+                    "display": "ectenoot"
+                }}
+            ]
+        });
+        let resp = post_json(app, "/ValueSet/$validate-code", body).await;
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+        let result = params.iter().find(|p| p["name"] == "result").unwrap();
+        assert_eq!(result["valueBoolean"], false);
+    }
+
+    #[tokio::test]
+    async fn vs_validate_unknown_supplement_returns_404() {
+        let app = make_supplement_vs_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "url", "valueUri": "http://hl7.org/fhir/test/ValueSet/extensions-all-ns"},
+                {"name": "coding", "valueCoding": {
+                    "system": "http://hl7.org/fhir/test/CodeSystem/extensions",
+                    "code": "code1"
+                }},
+                {"name": "useSupplement", "valueCanonical": "http://does-not-exist/cs"}
+            ]
+        });
+        let resp = post_json(app, "/ValueSet/$validate-code", body).await;
+        assert_eq!(resp.status(), 404);
     }
 }

--- a/crates/hts/src/traits/code_system.rs
+++ b/crates/hts/src/traits/code_system.rs
@@ -112,6 +112,68 @@ pub trait CodeSystemOperations: Send + Sync {
         system_url: &str,
         codes: &[String],
     ) -> Result<std::collections::HashMap<String, ConceptExpansionFlags>, HtsError>;
+
+    /// Resolve a supplement CS canonical URL to the (system_url, version)
+    /// pair stored on the supplement resource itself.
+    ///
+    /// Returns `Ok(Some((url, Some(version))))` when the supplement is stored
+    /// and is a `content=supplement` CodeSystem, `Ok(None)` when no such
+    /// supplement exists. The default implementation returns `Ok(None)` so
+    /// backends without supplement support degrade silently.
+    async fn supplement_target(
+        &self,
+        _ctx: &TenantContext,
+        _supplement_url: &str,
+    ) -> Result<Option<SupplementInfo>, HtsError> {
+        Ok(None)
+    }
+
+    /// Batch-fetch designations contributed by named CodeSystem supplements.
+    ///
+    /// Mirrors [`Self::concept_designations`] but reads from CSes whose URLs
+    /// are listed in `supplement_urls`. Each returned designation is tagged
+    /// with `source = "url|version"` so callers can emit the FHIR
+    /// `designation.source` part on `$lookup` responses (per IG fixture
+    /// `parameters-lookup-supplement-good`).
+    ///
+    /// Default implementation returns an empty map so backends without
+    /// supplement support behave as if no supplement data exists.
+    async fn supplement_designations(
+        &self,
+        _ctx: &TenantContext,
+        _supplement_urls: &[String],
+        _codes: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<ConceptDesignation>>, HtsError> {
+        Ok(std::collections::HashMap::new())
+    }
+
+    /// Batch-fetch concept-property values contributed by named CodeSystem
+    /// supplements. Mirrors [`Self::concept_property_values`] but for
+    /// supplement CodeSystems. Returns `(property, value)` pairs grouped by
+    /// concept code.
+    async fn supplement_property_values(
+        &self,
+        _ctx: &TenantContext,
+        _supplement_urls: &[String],
+        _codes: &[String],
+        _properties: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<(String, String)>>, HtsError> {
+        Ok(std::collections::HashMap::new())
+    }
+}
+
+/// Resolved supplement metadata returned by
+/// [`CodeSystemOperations::supplement_target`].
+///
+/// `target_url` is the URL of the base CodeSystem the supplement modifies
+/// (read from the supplement's `CodeSystem.supplements` field).
+/// `supplement_canonical` is the supplement's own canonical, ready to drop
+/// into a `used-supplement` parameter (`"url|version"` when version is
+/// available).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupplementInfo {
+    pub target_url: String,
+    pub supplement_canonical: String,
 }
 
 /// Per-concept flags surfaced in `expansion.contains[]`.
@@ -124,10 +186,21 @@ pub struct ConceptExpansionFlags {
 }
 
 /// A single designation row for a concept (translation or alternate label).
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `source` is the CodeSystem URL (with optional `|version`) that contributed
+/// this designation. For designations defined in the base CodeSystem itself
+/// `source` is left as `None`; for designations supplied by an applied
+/// CodeSystem supplement (`useSupplement`) `source` is set so the operations
+/// layer can emit a `designation.source` part on `$lookup` responses (per IG
+/// fixture `parameters-lookup-supplement-good`).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ConceptDesignation {
     pub language: Option<String>,
     pub use_system: Option<String>,
     pub use_code: Option<String>,
     pub value: String,
+    /// CodeSystem URL (`url|version` when known) of the CS row that produced
+    /// this designation. `None` for the base CodeSystem; populated when the
+    /// designation comes from an applied supplement.
+    pub source: Option<String>,
 }

--- a/crates/hts/src/traits/mod.rs
+++ b/crates/hts/src/traits/mod.rs
@@ -17,7 +17,9 @@ mod concept_map;
 mod metadata;
 mod value_set;
 
-pub use code_system::{CodeSystemOperations, ConceptDesignation, ConceptExpansionFlags};
+pub use code_system::{
+    CodeSystemOperations, ConceptDesignation, ConceptExpansionFlags, SupplementInfo,
+};
 pub use concept_map::ConceptMapOperations;
 pub use metadata::TerminologyMetadata;
 pub use value_set::ValueSetOperations;

--- a/crates/hts/src/types.rs
+++ b/crates/hts/src/types.rs
@@ -23,12 +23,18 @@ pub struct PropertyValue {
 }
 
 /// An alternate name or translation for a concept.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct DesignationValue {
     pub language: Option<String>,
     pub use_system: Option<String>,
     pub use_code: Option<String>,
     pub value: String,
+    /// CodeSystem URL (`url|version` when known) that contributed this
+    /// designation. `None` for the base CodeSystem; `Some` when the value was
+    /// merged in from an applied supplement (FHIR `useSupplement`). Surfaced
+    /// in `$lookup` responses as a `designation.source` part.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 // ─── $lookup ──────────────────────────────────────────────────────────────────
@@ -52,6 +58,14 @@ pub struct LookupRequest {
     /// `$.date` field is ≤ this value are considered.
     #[serde(default)]
     pub date: Option<String>,
+    /// Canonical URLs of CodeSystem supplements to apply on top of the base
+    /// CodeSystem. Each must be the URL of a stored CodeSystem with
+    /// `content=supplement` and `supplements=<base url>`. The supplement's
+    /// designations and properties for the requested code (matched by code)
+    /// are merged into the response. See FHIR R5 §4.7.10 (CodeSystem
+    /// supplements) and the IG `useSupplement` parameter.
+    #[serde(default)]
+    pub use_supplements: Vec<String>,
 }
 
 /// Response from `CodeSystem/$lookup`.


### PR DESCRIPTION
…lookup

A CodeSystem with content=supplement plus a supplements=<base> field adds designations / properties to a base CS without redefining its concepts. Until now we only rejected unknown supplements (commits 90775908 + 87f40db6); valid ones were silently ignored, so the IG fixtures' good / none / extension-driven cases all failed.

This commit makes useSupplement actually do something:

- New backend trait methods (default-empty so postgres degrades silently): supplement_target(url) → SupplementInfo{target_url, supplement_canonical}, supplement_designations(urls, codes), supplement_property_values(...). SQLite reads from the same code_systems / concept_designations / concept_properties tables, filtered by content='supplement'.

- $lookup merges supplement designations into the response, tagging each one with `source = supplement|version` (emitted as designation.source on the Parameters output) and appends one used-supplement parameter per applied supplement. Mismatched-target supplements reject 404.

- $validate-code accepts supplement designation values as valid alt displays: when the backend returns a display-mismatch failure and the caller's display matches a supplement designation, "rescue" the response (clear message, set result=true). Restores honoring Coding.display in both CodeSystem and ValueSet variants (re-applies the logic reverted in 340cf5f0 but now scoped to supplements). Also emits used-supplement and propagates bad-supplement → 404.

- $expand resolves supplements from BOTH the request useSupplement parameter AND the source ValueSet's `valueset-supplement` extension. Merges supplement designations (when includeDesignations=true) and supplement properties (when property= is requested) into expansion.contains[]. Emits used-supplement in expansion.parameter.

Adds 9 new unit tests covering the good/none/bad cases for all three operations. All 500 helios-hts unit tests pass.

Expected to unlock the IG `parameters/parameters-{lookup,validate, expand}-supplement-{good,none}` fixtures (~6 tests), plus the extensions/extensions-echo-* family that auto-applies via the VS extension. Display-aware tests like validation/simple-coding-bad- language-{vs,vslang} should now also pass since Coding.display is honored again — without the supplement plumbing they would re-trigger the issue that caused 340cf5f0 to revert 670a6867.