### PR TITLE
fix(ci): pin mongo to 7.0 — MongoDB 8.x crashes on CI host kernel 6.19

### DIFF
--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -292,7 +292,8 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-audit-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 --replSet rs0 --bind_ip_all
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
 
@@ -863,7 +864,8 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-audit-db-${{ matrix.mode }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 --replSet rs0 --bind_ip_all
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
 

--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -292,7 +292,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-audit-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
@@ -864,7 +864,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-audit-db-${{ matrix.mode }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV

--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -292,7 +292,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-audit-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
@@ -864,7 +864,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-audit-db-${{ matrix.mode }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV

--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -292,8 +292,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-audit-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
-            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
 
@@ -864,8 +863,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-audit-db-${{ matrix.mode }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
-            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
 

--- a/.github/workflows/bulk-export-smoke.yml
+++ b/.github/workflows/bulk-export-smoke.yml
@@ -177,7 +177,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-bulk-export-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.bulk_mode }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
 

--- a/.github/workflows/bulk-export-smoke.yml
+++ b/.github/workflows/bulk-export-smoke.yml
@@ -177,8 +177,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-bulk-export-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.bulk_mode }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
-            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
 
           for i in {1..30}; do

--- a/.github/workflows/bulk-export-smoke.yml
+++ b/.github/workflows/bulk-export-smoke.yml
@@ -177,8 +177,8 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-bulk-export-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.bulk_mode }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7 \
-            --replSet rs0 --bind_ip_all
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
 
           for i in {1..30}; do

--- a/.github/workflows/bulk-export-smoke.yml
+++ b/.github/workflows/bulk-export-smoke.yml
@@ -177,7 +177,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-bulk-export-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.bulk_mode }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
 

--- a/.github/workflows/inferno-subscription.yml
+++ b/.github/workflows/inferno-subscription.yml
@@ -269,7 +269,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-inferno-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"

--- a/.github/workflows/inferno-subscription.yml
+++ b/.github/workflows/inferno-subscription.yml
@@ -269,7 +269,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-inferno-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"

--- a/.github/workflows/inferno-subscription.yml
+++ b/.github/workflows/inferno-subscription.yml
@@ -269,7 +269,8 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-inferno-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 --replSet rs0 --bind_ip_all
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
 

--- a/.github/workflows/inferno-subscription.yml
+++ b/.github/workflows/inferno-subscription.yml
@@ -269,8 +269,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-inferno-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
-            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
 

--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -243,7 +243,8 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-${{ matrix.suite_id }}-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 --replSet rs0 --bind_ip_all
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
 

--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -685,6 +685,31 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
+      # Diagnostics: capture why mongod died (host-OOM vs cgroup-OOM vs crash)
+      # without needing shell access to the Docker host. Runs before Cleanup
+      # removes the container.
+      - name: Diagnose MongoDB failure
+        if: failure() && matrix.backend == 'mongodb'
+        run: |
+          echo "::group::MongoDB container state (OOMKilled / exit code)"
+          docker inspect "${MONGO_CONTAINER:-none}" \
+            --format 'OOMKilled={{.State.OOMKilled}} ExitCode={{.State.ExitCode}} Status={{.State.Status}} Error={{.State.Error}} FinishedAt={{.State.FinishedAt}}' 2>&1 || true
+          echo "::endgroup::"
+          echo "::group::mongod logs (last 60 lines)"
+          docker logs "${MONGO_CONTAINER:-none}" --tail 60 2>&1 || true
+          echo "::endgroup::"
+          echo "::group::Host OOM-killer (kernel ring buffer)"
+          docker run --rm --privileged busybox dmesg 2>/dev/null \
+            | grep -iE "out of memory|killed process|oom" | tail -25 || true
+          echo "(end of OOM grep — empty means no OOM lines found)"
+          echo "::endgroup::"
+          echo "::group::Docker host memory + containers"
+          docker run --rm busybox sh -c \
+            'grep -E "MemTotal|MemFree|MemAvailable|SwapTotal|SwapFree" /proc/meminfo' 2>&1 || true
+          docker info --format 'MemTotal={{.MemTotal}} Containers={{.Containers}} Running={{.ContainersRunning}}' 2>&1 || true
+          docker stats --no-stream --format 'table {{.Name}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.CPUPerc}}' 2>&1 || true
+          echo "::endgroup::"
+
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -243,8 +243,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-${{ matrix.suite_id }}-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
-            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
 

--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -243,7 +243,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-${{ matrix.suite_id }}-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV

--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -243,7 +243,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-${{ matrix.suite_id }}-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV

--- a/.github/workflows/subscriptions-smoke.yml
+++ b/.github/workflows/subscriptions-smoke.yml
@@ -221,7 +221,8 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.build_key }}-${{ matrix.fhir_version }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 --replSet rs0 --bind_ip_all
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
 

--- a/.github/workflows/subscriptions-smoke.yml
+++ b/.github/workflows/subscriptions-smoke.yml
@@ -221,7 +221,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.build_key }}-${{ matrix.fhir_version }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV

--- a/.github/workflows/subscriptions-smoke.yml
+++ b/.github/workflows/subscriptions-smoke.yml
@@ -221,7 +221,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.build_key }}-${{ matrix.fhir_version }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.3 \
+          docker run -d --name "$MONGO_CONTAINER" --memory=2g -p 0:27017 mongo:8.0 \
             --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV

--- a/.github/workflows/subscriptions-smoke.yml
+++ b/.github/workflows/subscriptions-smoke.yml
@@ -221,8 +221,7 @@ jobs:
         run: |
           MONGO_CONTAINER="mongo-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.build_key }}-${{ matrix.fhir_version }}"
           docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:8.0 \
-            --replSet rs0 --bind_ip_all --wiredTigerCacheSizeGB 0.5
+          docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2407,18 +2407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,7 +2430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3279,23 +3267,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -3304,21 +3291,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3544,7 +3556,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3795,6 +3807,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -3804,7 +3819,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3854,6 +3869,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -4296,9 +4360,9 @@ checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
 
 [[package]]
 name = "mongodb"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef2c933617431ad0246fb5b43c425ebdae18c7f7259c87de0726d93b0e7e91b"
+checksum = "276ba0cd571553d1f6936c6f180964776ece6ab7507dc8765f8a9c9c49d8cd00"
 dependencies = [
  "base64",
  "bitflags 2.11.1",
@@ -4309,6 +4373,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hex",
+ "hickory-net",
  "hickory-proto",
  "hickory-resolver",
  "hmac 0.12.1",
@@ -4321,7 +4386,6 @@ dependencies = [
  "rand 0.9.4",
  "rustc_version_runtime",
  "rustls",
- "rustversion",
  "serde",
  "serde_bytes",
  "serde_with",
@@ -4342,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb-internal-macros"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5758dc828eb2d02ec30563cba365609d56ddd833190b192beaee2b475a7bb3"
+checksum = "99ceb1a9a1018e470077ec94cf3a8c2d0e6da542b2c05ea95a59a0a627147375"
 dependencies = [
  "macro_magic",
  "proc-macro2",
@@ -4368,6 +4432,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "neo4rs"
@@ -4422,7 +4492,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5089,6 +5159,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5318,7 +5399,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5355,7 +5436,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5860,7 +5941,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6282,6 +6363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6361,7 +6452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6390,7 +6481,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6553,7 +6644,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6851,6 +6942,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -7555,7 +7647,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -35,7 +35,7 @@ use tracing::info;
 use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
 
 #[cfg(feature = "mongodb")]
-use helios_persistence::backends::mongodb::MongoBackend;
+use helios_persistence::backends::mongodb::{MongoBackend, MongoBackendConfig};
 fn is_database_audit_dedicated(config: &AuditConfig, backend_kind: BackendKind) -> bool {
     match backend_kind {
         BackendKind::Sqlite | BackendKind::Postgres => config.database_url.is_some(),
@@ -68,6 +68,48 @@ fn is_postgres_url(url: &str) -> bool {
 #[cfg(feature = "mongodb")]
 fn is_mongodb_url(url: &str) -> bool {
     url.starts_with("mongodb://") || url.starts_with("mongodb+srv://")
+}
+
+#[cfg(feature = "mongodb")]
+fn build_mongodb_config(config: &ServerConfig, search_offloaded: bool) -> MongoBackendConfig {
+    build_mongodb_config_with_env(config, search_offloaded, |name| std::env::var(name).ok())
+}
+
+#[cfg(feature = "mongodb")]
+fn build_mongodb_config_with_env<F>(
+    config: &ServerConfig,
+    search_offloaded: bool,
+    env: F,
+) -> MongoBackendConfig
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mongo_specific_url = env("HFS_MONGODB_URL").or_else(|| env("HFS_MONGODB_URI"));
+    let connection_string = match config.database_url.as_deref() {
+        Some(url) if is_mongodb_url(url) => url.to_string(),
+        Some(_) => mongo_specific_url.unwrap_or_else(|| "mongodb://localhost:27017".to_string()),
+        None => mongo_specific_url
+            .or_else(|| env("HFS_DATABASE_URL").filter(|url| is_mongodb_url(url)))
+            .unwrap_or_else(|| "mongodb://localhost:27017".to_string()),
+    };
+
+    let database_name = env("HFS_MONGODB_DATABASE").unwrap_or_else(|| "helios".to_string());
+    let max_connections = env("HFS_MONGODB_MAX_CONNECTIONS")
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(10);
+    let connect_timeout_ms = env("HFS_MONGODB_CONNECT_TIMEOUT_MS")
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(5000);
+
+    MongoBackendConfig {
+        connection_string,
+        database_name,
+        max_connections,
+        connect_timeout_ms,
+        fhir_version: config.default_fhir_version,
+        data_dir: config.data_dir.clone(),
+        search_offloaded,
+    }
 }
 
 fn validate_shared_sqlite_audit_path(path: &str, dedicated: bool) -> anyhow::Result<()> {
@@ -231,8 +273,6 @@ async fn create_audit_mongodb_storage(
     audit_config: &AuditConfig,
     dedicated: bool,
 ) -> anyhow::Result<Arc<dyn ResourceStorage>> {
-    use helios_persistence::backends::mongodb::MongoBackendConfig;
-
     let backend = if dedicated {
         let connection_string = match audit_config.database_url.as_deref() {
             Some(url) => {
@@ -287,14 +327,8 @@ async fn create_audit_mongodb_storage(
             search_offloaded: false,
         };
         MongoBackend::new(config)?
-    } else if let Some(ref url) = server_config.database_url {
-        if is_mongodb_url(url) {
-            MongoBackend::from_connection_string(url)?
-        } else {
-            MongoBackend::from_env()?
-        }
     } else {
-        MongoBackend::from_env()?
+        MongoBackend::new(build_mongodb_config(server_config, false))?
     };
 
     backend.init_schema().await?;
@@ -418,20 +452,13 @@ async fn start_mongodb(
     auth_state: Option<Arc<AuthMiddlewareState>>,
     audit_state: Option<Arc<AuditMiddlewareState>>,
 ) -> anyhow::Result<()> {
-    let backend = if let Some(ref url) = config.database_url {
-        if url.starts_with("mongodb://") || url.starts_with("mongodb+srv://") {
-            info!(url = %url, "Initializing MongoDB backend from connection string");
-            MongoBackend::from_connection_string(url)?
-        } else {
-            info!(
-                "Initializing MongoDB backend from environment variables (database_url is not MongoDB URI)"
-            );
-            MongoBackend::from_env()?
-        }
-    } else {
-        info!("Initializing MongoDB backend from environment variables");
-        MongoBackend::from_env()?
-    };
+    let backend_config = build_mongodb_config(&config, false);
+    info!(
+        url = %backend_config.connection_string,
+        database = %backend_config.database_name,
+        "Initializing MongoDB backend"
+    );
+    let backend = MongoBackend::new(backend_config)?;
 
     backend.init_schema().await?;
 
@@ -1108,26 +1135,17 @@ async fn start_mongodb_elasticsearch(
     use helios_persistence::core::BackendKind;
 
     // Create MongoDB backend
-    let backend = if let Some(ref url) = config.database_url {
-        if url.starts_with("mongodb://") || url.starts_with("mongodb+srv://") {
-            info!(url = %url, "Initializing MongoDB backend from connection string");
-            MongoBackend::from_connection_string(url)?
-        } else {
-            info!(
-                "Initializing MongoDB backend from environment variables (database_url is not MongoDB URI)"
-            );
-            MongoBackend::from_env()?
-        }
-    } else {
-        info!("Initializing MongoDB backend from environment variables");
-        MongoBackend::from_env()?
-    };
+    let backend_config = build_mongodb_config(&config, true);
+    info!(
+        url = %backend_config.connection_string,
+        database = %backend_config.database_name,
+        "Initializing MongoDB backend"
+    );
+    let backend = MongoBackend::new(backend_config)?;
 
     backend.init_schema().await?;
 
     // Offload search to Elasticsearch
-    let mut backend = backend;
-    backend.set_search_offloaded(true);
     let mongo = Arc::new(backend);
     info!("MongoDB search indexing disabled (offloaded to Elasticsearch)");
 
@@ -1564,6 +1582,74 @@ mod tests {
         let registry = build_search_registry(FhirVersion::R4, None);
         // Registry should be a valid Arc<RwLock<…>> and not panic when read.
         let _guard = registry.read();
+    }
+
+    #[cfg(feature = "mongodb")]
+    #[test]
+    fn test_build_mongodb_config_overlays_env_with_mongo_database_url() {
+        use helios_fhir::FhirVersion;
+
+        let data_dir = std::path::PathBuf::from("/tmp/hfs-data");
+        let config = ServerConfig {
+            database_url: Some("mongodb://mongo.example:27017/?replicaSet=rs0".to_string()),
+            default_fhir_version: FhirVersion::R4,
+            data_dir: Some(data_dir.clone()),
+            ..Default::default()
+        };
+
+        let mongo_config = build_mongodb_config_with_env(&config, false, |name| match name {
+            "HFS_MONGODB_DATABASE" => Some("inferno_suite".to_string()),
+            "HFS_MONGODB_MAX_CONNECTIONS" => Some("24".to_string()),
+            "HFS_MONGODB_CONNECT_TIMEOUT_MS" => Some("7500".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(
+            mongo_config.connection_string,
+            "mongodb://mongo.example:27017/?replicaSet=rs0"
+        );
+        assert_eq!(mongo_config.database_name, "inferno_suite");
+        assert_eq!(mongo_config.max_connections, 24);
+        assert_eq!(mongo_config.connect_timeout_ms, 7500);
+        assert_eq!(mongo_config.fhir_version, FhirVersion::R4);
+        assert_eq!(mongo_config.data_dir, Some(data_dir));
+        assert!(!mongo_config.search_offloaded);
+    }
+
+    #[cfg(feature = "mongodb")]
+    #[test]
+    fn test_build_mongodb_config_ignores_non_mongo_database_url() {
+        let config = ServerConfig {
+            database_url: Some("postgres://localhost/hfs".to_string()),
+            ..Default::default()
+        };
+
+        let mongo_config = build_mongodb_config_with_env(&config, true, |name| match name {
+            "HFS_DATABASE_URL" => Some("postgres://localhost/hfs".to_string()),
+            "HFS_MONGODB_DATABASE" => Some("mongo_db".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(mongo_config.connection_string, "mongodb://localhost:27017");
+        assert_eq!(mongo_config.database_name, "mongo_db");
+        assert!(mongo_config.search_offloaded);
+    }
+
+    #[cfg(feature = "mongodb")]
+    #[test]
+    fn test_build_mongodb_config_uses_mongo_specific_url_before_database_url_fallback() {
+        let config = ServerConfig::default();
+
+        let mongo_config = build_mongodb_config_with_env(&config, false, |name| match name {
+            "HFS_MONGODB_URI" => Some("mongodb://mongo-specific:27017".to_string()),
+            "HFS_DATABASE_URL" => Some("mongodb://database-url:27017".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(
+            mongo_config.connection_string,
+            "mongodb://mongo-specific:27017"
+        );
     }
 
     // ── ServerConfig validation is exercised at startup ──────────

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -549,7 +549,7 @@ cargo build --bin hfs --features mongodb --release
 
 # Start MongoDB (example using Docker)
 docker run -d --name mongo -p 27017:27017 \
-  mongo:8.3
+  mongo:8.0
 
 # Start the server
 HFS_STORAGE_BACKEND=mongodb \
@@ -582,7 +582,7 @@ cargo build --bin hfs --features mongodb,elasticsearch --release
 
 # Start MongoDB (example using Docker)
 docker run -d --name mongo -p 27017:27017 \
-  mongo:8.3
+  mongo:8.0
 
 # Start Elasticsearch (example using Docker)
 docker run -d --name es -p 9200:9200 \

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -549,7 +549,7 @@ cargo build --bin hfs --features mongodb --release
 
 # Start MongoDB (example using Docker)
 docker run -d --name mongo -p 27017:27017 \
-  mongo:8.0
+  mongo:8.3
 
 # Start the server
 HFS_STORAGE_BACKEND=mongodb \
@@ -582,7 +582,7 @@ cargo build --bin hfs --features mongodb,elasticsearch --release
 
 # Start MongoDB (example using Docker)
 docker run -d --name mongo -p 27017:27017 \
-  mongo:8.0
+  mongo:8.3
 
 # Start Elasticsearch (example using Docker)
 docker run -d --name es -p 9200:9200 \

--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -19,6 +19,13 @@ use crate::search::{SearchParameterExtractor, SearchParameterLoader, SearchParam
 
 use super::schema;
 
+/// Upper bound for selecting a usable server before an operation gives up.
+const SERVER_SELECTION_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Connections idle longer than this are closed rather than reused, so a
+/// connection silently dropped by a NAT/firewall is never handed to a request.
+const MAX_CONNECTION_IDLE_TIME: Duration = Duration::from_secs(60);
+
 /// MongoDB backend for FHIR resource storage.
 ///
 /// The Phase 4 implementation provides backend wiring, schema bootstrap,
@@ -318,6 +325,14 @@ impl MongoBackend {
         client_options.connect_timeout =
             Some(Duration::from_millis(self.config.connect_timeout_ms));
         client_options.app_name = Some("helios-persistence".to_string());
+
+        // Fail fast when no healthy server can be selected. `connect_timeout`
+        // only covers new TCP handshakes; this caps requests once server
+        // monitoring has marked the server unavailable.
+        client_options.server_selection_timeout = Some(SERVER_SELECTION_TIMEOUT);
+        // Recycle idle connections so stale ones (e.g. silently dropped by a
+        // NAT/firewall on a long-lived network path) are not handed out.
+        client_options.max_idle_time = Some(MAX_CONNECTION_IDLE_TIME);
 
         Client::with_options(client_options).map_err(|e| {
             StorageError::Backend(BackendError::Internal {

--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use mongodb::{Client, Database, bson::doc, options::ClientOptions};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
+use tokio::sync::OnceCell;
 
 use helios_fhir::FhirVersion;
 
@@ -28,6 +29,9 @@ use super::schema;
 /// Advanced search/composite behavior remains in later phases.
 pub struct MongoBackend {
     config: MongoBackendConfig,
+    /// Lazily initialized MongoDB client. MongoDB clients own their connection
+    /// pools, so each backend instance must reuse one client.
+    client: OnceCell<Client>,
     /// Search parameter registry (in-memory cache of active parameters).
     search_registry: Arc<RwLock<SearchParameterRegistry>>,
     /// Extractor for deriving searchable values from resources.
@@ -120,6 +124,7 @@ impl MongoBackend {
 
         Ok(Self {
             config,
+            client: OnceCell::new(),
             search_registry,
             search_extractor,
         })
@@ -299,7 +304,7 @@ impl MongoBackend {
     }
 
     /// Creates a MongoDB client from backend configuration.
-    pub(crate) async fn get_client(&self) -> StorageResult<Client> {
+    async fn create_client(&self) -> StorageResult<Client> {
         let mut client_options = ClientOptions::parse(&self.config.connection_string)
             .await
             .map_err(|e| {
@@ -321,6 +326,14 @@ impl MongoBackend {
                 source: None,
             })
         })
+    }
+
+    /// Returns the shared MongoDB client for this backend.
+    pub(crate) async fn get_client(&self) -> StorageResult<Client> {
+        self.client
+            .get_or_try_init(|| self.create_client())
+            .await
+            .cloned()
     }
 
     /// Returns the configured MongoDB database handle.

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -8,6 +8,8 @@
 
 #![cfg(feature = "mongodb")]
 
+use std::sync::Arc;
+
 use helios_fhir::FhirVersion;
 use helios_persistence::backends::mongodb::{MongoBackend, MongoBackendConfig};
 use helios_persistence::core::{
@@ -233,6 +235,21 @@ async fn search_index_entry_count(
         .expect("failed to count search_index entries")
 }
 
+async fn mongodb_total_created_connections(connection_string: &str) -> Option<i64> {
+    let client = Client::with_uri_str(connection_string).await.ok()?;
+    let status = client
+        .database("admin")
+        .run_command(doc! { "serverStatus": 1_i32 })
+        .await
+        .ok()?;
+    let connections = status.get_document("connections").ok()?;
+
+    connections
+        .get_i64("totalCreated")
+        .or_else(|_| connections.get_i32("totalCreated").map(i64::from))
+        .ok()
+}
+
 #[tokio::test]
 async fn mongodb_integration_create_read_update_delete() {
     let Some(backend) = create_backend("crud").await else {
@@ -288,6 +305,97 @@ async fn mongodb_integration_create_read_update_delete() {
         read_after_delete,
         Err(StorageError::Resource(ResourceError::Gone { .. }))
     ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn mongodb_integration_reuses_client_pool_under_concurrent_read_search() {
+    let Some(connection_string) = test_mongo_url() else {
+        eprintln!(
+            "Skipping mongodb_integration_reuses_client_pool_under_concurrent_read_search (set HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let config = MongoBackendConfig {
+        connection_string: connection_string.clone(),
+        database_name: build_test_database_name("client_pool_reuse"),
+        max_connections: 8,
+        ..Default::default()
+    };
+    let backend = MongoBackend::new(config).expect("failed to create MongoBackend");
+    backend
+        .initialize()
+        .await
+        .expect("failed to initialize MongoDB schema");
+
+    let tenant = create_tenant("tenant-client-pool");
+    backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "id": "patient-client-pool",
+                "identifier": [{
+                    "system": "http://hospital.org/mrn",
+                    "value": "MRN-CLIENT-POOL"
+                }],
+                "name": [{ "family": "Pool" }],
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let Some(before) = mongodb_total_created_connections(&connection_string).await else {
+        eprintln!(
+            "Skipping mongodb_integration_reuses_client_pool_under_concurrent_read_search (serverStatus unavailable)"
+        );
+        return;
+    };
+
+    let backend = Arc::new(backend);
+    let mut tasks = Vec::new();
+    for _ in 0..32 {
+        let backend = backend.clone();
+        let tenant = tenant.clone();
+        tasks.push(tokio::spawn(async move {
+            for _ in 0..20 {
+                backend
+                    .read(&tenant, "Patient", "patient-client-pool")
+                    .await
+                    .unwrap();
+
+                let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+                    name: "identifier".to_string(),
+                    param_type: SearchParamType::Token,
+                    modifier: None,
+                    values: vec![SearchValue::eq("http://hospital.org/mrn|MRN-CLIENT-POOL")],
+                    chain: vec![],
+                    components: vec![],
+                });
+                backend.search(&tenant, &query).await.unwrap();
+            }
+        }));
+    }
+
+    for task in tasks {
+        task.await.unwrap();
+    }
+
+    let Some(after) = mongodb_total_created_connections(&connection_string).await else {
+        eprintln!(
+            "Skipping mongodb_integration_reuses_client_pool_under_concurrent_read_search (serverStatus unavailable)"
+        );
+        return;
+    };
+
+    let created_during_test = after - before;
+    assert!(
+        created_during_test <= 50,
+        "MongoDB backend should reuse one client pool; created {} connections during concurrent read/search",
+        created_during_test
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

The Inferno US Core **MongoDB** matrix jobs were failing while every other storage backend passed.

**Root cause:** the CI Docker host (a Proxmox LXC) shares a Linux kernel **≥ 6.19**, which is incompatible with MongoDB 8.0+. MongoDB's vendored TCMalloc violates the kernel's `rseq` ABI, so **mongod SIGSEGV-crashes ~25–30 s after startup** ([SERVER-121912](https://jira.mongodb.org/browse/SERVER-121912)). A diagnostic step added in this PR confirmed it: `docker inspect` reports `OOMKilled=false ExitCode=139` (a crash, not an OOM kill) on a host with 92 GiB RAM / 58 GiB free — not a memory problem. Full write-up and sources are in [this comment](https://github.com/HeliosSoftware/hfs/pull/113#issuecomment-4521680193).

(The commit history shows an earlier, incorrect OOM/swap-thrash diagnosis — the diagnostic step is what corrected it. The net diff reflects the real fix.)

## Changes

- **Pin the mongo image to `mongo:7.0`** in all 5 workflows that start mongod (`inferno-us-core`, `inferno-subscription`, `audit-events`, `subscriptions-smoke`, `bulk-export-smoke`). MongoDB 7.x is unaffected by SERVER-121912 — this is what unblocks CI.
- Add an `if: failure()` **diagnostic step** to the mongodb jobs: captures `docker inspect` (OOMKilled / exit code), mongod logs, host memory and the kernel OOM log — so future mongo failures are diagnosable without shell access to the host.
- Reuse a single cached MongoDB client / connection pool instead of creating one per request (avoids a connection storm against mongod); build the Mongo config during HFS startup.
- Bump the `mongodb` crate 3.6 → 3.7; set `server_selection_timeout` / `max_idle_time` on the client so requests fail fast against an unavailable server.

## The real fix is host-side

`mongo:7.0` unblocks CI, but the proper fix is to **downgrade/pin the Proxmox host kernel to ≤ 6.18** (or run the Docker host in a VM with its own older kernel). MongoDB 8.x stays unusable on that host until then, or until MongoDB ships a patched TCMalloc.

## Test plan

- [ ] `inferno-us-core` workflow green for the `mongodb` matrix jobs
- [ ] other backends (sqlite / postgres / elasticsearch / s3) still pass
- [ ] `cargo test -p helios-persistence --features mongodb` passes