### PR TITLE
fix(sof): SQL-on-FHIR v2 spec follow-up fixes

### DIFF
--- a/crates/pysof/tests/lib_coverage_tests.rs
+++ b/crates/pysof/tests/lib_coverage_tests.rs
@@ -43,6 +43,7 @@ fn test_rust_sof_error_to_py_err_coverage() {
             RustSofError::InvalidSourceContent(_) => {}
             RustSofError::UnsupportedSourceProtocol(_) => {}
             RustSofError::ParquetConversionError(_) => {}
+            RustSofError::ReferencedResourceNotFound(_) => {}
         }
     }
 }

--- a/crates/rest/src/export/controller.rs
+++ b/crates/rest/src/export/controller.rs
@@ -81,6 +81,10 @@ pub enum JobStatus {
         message: String,
         /// Time the job was submitted.
         submitted_at: DateTime<Utc>,
+        /// Time the worker recorded the failure. Captured once at the
+        /// transition into `Failed` so successive polls of the result URL
+        /// report a stable `exportEndTime` / `exportDuration`.
+        failed_at: DateTime<Utc>,
     },
     /// Job was cancelled by the caller.
     Cancelled,

--- a/crates/rest/src/export/in_memory.rs
+++ b/crates/rest/src/export/in_memory.rs
@@ -137,6 +137,7 @@ impl<Sink: ExportSink + 'static> ExportJobController for InMemoryController<Sink
                             JobStatus::Failed {
                                 message: e.to_string(),
                                 submitted_at,
+                                failed_at: Utc::now(),
                             },
                         );
                         return;
@@ -176,6 +177,7 @@ impl<Sink: ExportSink + 'static> ExportJobController for InMemoryController<Sink
                                 JobStatus::Failed {
                                     message: e.to_string(),
                                     submitted_at,
+                                    failed_at: Utc::now(),
                                 },
                             );
                             return;
@@ -207,6 +209,7 @@ impl<Sink: ExportSink + 'static> ExportJobController for InMemoryController<Sink
                                 JobStatus::Failed {
                                     message: e.to_string(),
                                     submitted_at,
+                                    failed_at: Utc::now(),
                                 },
                             );
                             return;

--- a/crates/rest/src/handlers/sof/export.rs
+++ b/crates/rest/src/handlers/sof/export.rs
@@ -62,6 +62,12 @@ const ALLOWED_BODY_PARAMS: &[&str] = &[
     "source",
 ];
 
+/// Output formats this server can serialize. The spec binds `_format` to
+/// the extensible `OutputFormatCodes` value set; we reject anything outside
+/// this list with 400 per the spec's "reject unsupported parameters" rule
+/// rather than silently downgrading the output to NDJSON.
+const SUPPORTED_FORMATS: &[&str] = &["ndjson", "csv", "json", "parquet"];
+
 /// Query parameters for `$viewdefinition-export`.
 ///
 /// `deny_unknown_fields` enforces the spec's "reject unsupported parameters
@@ -361,6 +367,56 @@ async fn submit_export_job<S>(
 where
     S: ResourceStorage + SearchProvider + Send + Sync + 'static,
 {
+    // Reject unsupported `_format` values up-front. The serializer in the
+    // controller falls back to NDJSON on unknown formats; without this guard
+    // the kick-off would 202-accept the job and the completion manifest would
+    // echo the bogus format while the files are actually NDJSON.
+    if !SUPPORTED_FORMATS.contains(&inputs.format.as_str()) {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "error",
+                    "code": "not-supported",
+                    "diagnostics": format!(
+                        "unsupported `_format` value '{}'; supported: {}",
+                        inputs.format,
+                        SUPPORTED_FORMATS.join(", ")
+                    )
+                }]
+            })),
+        )
+            .into_response());
+    }
+
+    // Spec implies one `output` per submitted view. The completion manifest
+    // groups files by view name, so two views with the same name would
+    // silently collapse into a single `output` entry. Detect collisions at
+    // submit time and reject.
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for nv in &views {
+        if !seen.insert(nv.name.as_str()) {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                axum::Json(json!({
+                    "resourceType": "OperationOutcome",
+                    "issue": [{
+                        "severity": "error",
+                        "code": "invalid",
+                        "diagnostics": format!(
+                            "duplicate view name '{}'; each submitted view must have a unique \
+                             name (set `view.part[name=name].valueString` or \
+                             `ViewDefinition.name` to disambiguate)",
+                            nv.name
+                        )
+                    }]
+                })),
+            )
+                .into_response());
+        }
+    }
+
     // Validate that each view has a `resource` field (basic check).
     for nv in &views {
         if nv.view.get("resource").and_then(|v| v.as_str()).is_none() {
@@ -590,6 +646,7 @@ where
         Some(JobStatus::Failed {
             message,
             submitted_at,
+            failed_at,
         }) => {
             // Spec status-code table: "500 Internal Server Error: Unexpected
             // server error (at result URL indicates operation failure)". The
@@ -597,8 +654,7 @@ where
             // `status=failed` and an OperationOutcome in the bulk-data-style
             // `error` part — the 500 surfaces failure to clients that only
             // inspect the status line.
-            let now = chrono::Utc::now();
-            let duration_secs = (now - submitted_at).num_seconds().max(0);
+            let duration_secs = (failed_at - submitted_at).num_seconds().max(0);
             let status_url = format!(
                 "{base}/export/{job_id}/status",
                 base = state.base_url().trim_end_matches('/'),
@@ -620,7 +676,7 @@ where
                         {"name": "status", "valueCode": "failed"},
                         {"name": "location", "valueUri": status_url},
                         {"name": "exportStartTime", "valueInstant": submitted_at.to_rfc3339()},
-                        {"name": "exportEndTime", "valueInstant": now.to_rfc3339()},
+                        {"name": "exportEndTime", "valueInstant": failed_at.to_rfc3339()},
                         {"name": "exportDuration", "valueInteger": duration_secs},
                         {"name": "error", "resource": outcome}
                     ]

--- a/crates/rest/src/handlers/sof/run.rs
+++ b/crates/rest/src/handlers/sof/run.rs
@@ -487,19 +487,17 @@ where
         split_csv_refs(params.group.as_deref())
     };
 
-    // Track absent-target warnings (audit item #5) to surface as `Warning:`
-    // HTTP headers on the response.
-    let mut filter_warnings: Vec<String> = Vec::new();
+    // Per SoF v2 spec: absent `patient` / `group` targets are a hard 400
+    // (mapped from `SofError::ReferencedResourceNotFound` by
+    // `map_sof_lib_error_to_rest`), not a "200 + Warning: 199" path.
     if !patient_refs.is_empty() || !group_refs.is_empty() {
-        let outcome = filter_resources_by_patient_and_group(
+        resources = filter_resources_by_patient_and_group(
             resources,
             &patient_refs,
             &group_refs,
             fhir_version,
         )
         .map_err(map_sof_lib_error_to_rest)?;
-        resources = outcome.resources;
-        filter_warnings.extend(outcome.warnings);
     }
 
     let since = params.since.as_deref().and_then(|s| s.parse().ok());
@@ -529,13 +527,12 @@ where
 
     let (ct_header, response_format) = content_type_headers(content_type);
 
-    Ok(build_response_with_warnings(
+    Ok(build_response(
         StatusCode::OK,
         ct_header,
         body,
         "in-process",
         response_format,
-        &filter_warnings,
     ))
 }
 
@@ -634,6 +631,12 @@ fn map_sof_lib_error_to_rest(e: helios_sof::SofError) -> RestError {
             RestError::UnprocessableEntity { message: msg }
         }
         LibErr::UnsupportedContentType(msg) => RestError::BadRequest { message: msg },
+        // Per SoF v2 spec error table: a `patient` / `group` reference that
+        // doesn't resolve against the supplied / queryable resources is a
+        // `400 Bad Request`. (No `RestError::NotFound`-with-400 variant
+        // exists, so the OperationOutcome's `code = invalid`; the
+        // 400/spec-status is what matters.)
+        LibErr::ReferencedResourceNotFound(msg) => RestError::BadRequest { message: msg },
         other => {
             warn!(error = %other, "in-process SOF evaluator error");
             RestError::InternalError {
@@ -748,28 +751,16 @@ async fn drain_stream(
     Ok(rows)
 }
 
-/// Builds the final `Response` with `X-HFS-Runner` and optional Content-Disposition.
+/// Builds the final `Response` with `X-HFS-Runner` and an optional
+/// `Content-Disposition` attachment header for parquet. Absent
+/// `patient` / `group` targets are surfaced as a 400 + OperationOutcome
+/// upstream, not as `Warning: 199` headers on this response.
 fn build_response(
     status: StatusCode,
     content_type: &'static str,
     body: Vec<u8>,
     runner_label: &str,
     format: &str,
-) -> Response {
-    build_response_with_warnings(status, content_type, body, runner_label, format, &[])
-}
-
-/// Like [`build_response`] but appends one `Warning:` header per
-/// absent-target message (RFC 7234 §5.5, warn-code 199). Audit item #5
-/// — surfaces `patient` / `group` absence to clients regardless of body
-/// format.
-fn build_response_with_warnings(
-    status: StatusCode,
-    content_type: &'static str,
-    body: Vec<u8>,
-    runner_label: &str,
-    format: &str,
-    warnings: &[String],
 ) -> Response {
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
@@ -782,12 +773,6 @@ fn build_response_with_warnings(
             header::CONTENT_DISPOSITION,
             HeaderValue::from_static("attachment; filename=\"output.parquet\""),
         );
-    }
-    for msg in warnings {
-        let safe = msg.replace('"', "'");
-        if let Ok(v) = HeaderValue::from_str(&format!("199 - \"{}\"", safe)) {
-            headers.append("warning", v);
-        }
     }
     (status, headers, body).into_response()
 }

--- a/crates/rest/tests/sof_export.rs
+++ b/crates/rest/tests/sof_export.rs
@@ -1030,6 +1030,12 @@ mod sof_export_tests {
     struct FailingController {
         tenant: String,
         job_id: String,
+        // Captured once at construction so successive polls of the result URL
+        // report a stable `exportEndTime` / `exportDuration`. Mirrors how the
+        // real `InMemoryController` records `failed_at` at the failure
+        // transition rather than on every read.
+        submitted_at: chrono::DateTime<chrono::Utc>,
+        failed_at: chrono::DateTime<chrono::Utc>,
     }
 
     impl ExportJobController for FailingController {
@@ -1042,7 +1048,8 @@ mod sof_export_tests {
             }
             Some(JobStatus::Failed {
                 message: "view runner exploded".to_string(),
-                submitted_at: chrono::Utc::now(),
+                submitted_at: self.submitted_at,
+                failed_at: self.failed_at,
             })
         }
         fn cancel(&self, _t: &str, _j: &str) -> bool {
@@ -1060,9 +1067,13 @@ mod sof_export_tests {
         backend.init_schema().expect("failed to init schema");
         let backend = Arc::new(backend);
 
+        let submitted_at = chrono::Utc::now() - chrono::Duration::seconds(7);
+        let failed_at = chrono::Utc::now() - chrono::Duration::seconds(2);
         let controller = FailingController {
             tenant: "test-tenant".to_string(),
             job_id: "fail-1".to_string(),
+            submitted_at,
+            failed_at,
         };
         let config = ServerConfig::for_testing();
         let state = helios_rest::AppState::new(Arc::clone(&backend), config)
@@ -1633,6 +1644,268 @@ mod sof_export_tests {
         assert!(
             diag.contains("missing-1"),
             "diagnostics must name the missing ref: {body}"
+        );
+    }
+
+    // =========================================================================
+    // 27. `_format` validation: unknown formats must be rejected at submit
+    //     time rather than silently downgraded to NDJSON by the serializer.
+    //     Spec: "If server does not support a parameter, request should be
+    //     rejected with 400 Bad Request".
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_export_unknown_format_returns_400() {
+        let (server, backend) = create_test_server_with_export().await;
+        seed_patients(&backend).await;
+
+        let resp = server
+            .post("/ViewDefinition/$viewdefinition-export?_format=xml")
+            .add_header(PREFER, "respond-async")
+            .add_header(X_TENANT_ID, "test-tenant")
+            .json(&patient_view())
+            .await;
+        assert_eq!(
+            resp.status_code(),
+            StatusCode::BAD_REQUEST,
+            "unknown _format must 400, got: {} {}",
+            resp.status_code(),
+            resp.text()
+        );
+        let body: Value = resp.json();
+        assert_eq!(body["resourceType"].as_str(), Some("OperationOutcome"));
+        assert_eq!(body["issue"][0]["code"].as_str(), Some("not-supported"));
+        let diag = body["issue"][0]["diagnostics"].as_str().unwrap_or("");
+        assert!(
+            diag.contains("xml") && diag.contains("ndjson"),
+            "diagnostics must name the bad value and list supported formats: {body}"
+        );
+    }
+
+    // =========================================================================
+    // 28. Duplicate view names: two `view` parts with the same name would
+    //     silently collapse into one `output` entry in the manifest. The
+    //     handler rejects this at submit time so callers don't lose shards.
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_export_duplicate_view_names_returns_400() {
+        let (server, backend) = create_test_server_with_export().await;
+        seed_patients(&backend).await;
+
+        // Both views are explicitly named "demographics".
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "view", "part": [
+                    {"name": "name", "valueString": "demographics"},
+                    {"name": "viewResource", "resource": patient_view()}
+                ]},
+                {"name": "view", "part": [
+                    {"name": "name", "valueString": "demographics"},
+                    {"name": "viewResource", "resource": patient_view()}
+                ]}
+            ]
+        });
+
+        let resp = server
+            .post("/ViewDefinition/$viewdefinition-export")
+            .add_header(PREFER, "respond-async")
+            .add_header(X_TENANT_ID, "test-tenant")
+            .json(&body)
+            .await;
+        assert_eq!(
+            resp.status_code(),
+            StatusCode::BAD_REQUEST,
+            "duplicate view names must 400, got: {} {}",
+            resp.status_code(),
+            resp.text()
+        );
+        let payload: Value = resp.json();
+        assert_eq!(payload["resourceType"].as_str(), Some("OperationOutcome"));
+        assert_eq!(payload["issue"][0]["code"].as_str(), Some("invalid"));
+        let diag = payload["issue"][0]["diagnostics"].as_str().unwrap_or("");
+        assert!(
+            diag.contains("demographics"),
+            "diagnostics must name the duplicate: {payload}"
+        );
+    }
+
+    // =========================================================================
+    // 29. Failed job manifest reports a stable `exportEndTime` / `exportDuration`
+    //     across multiple polls of the result URL. Captured once at the failure
+    //     transition (`JobStatus::Failed.failed_at`), not recomputed per poll.
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_export_failed_manifest_export_end_time_is_stable() {
+        let backend = SqliteBackend::with_config(":memory:", Default::default())
+            .expect("failed to create SQLite backend");
+        backend.init_schema().expect("failed to init schema");
+        let backend = Arc::new(backend);
+
+        // FailingController stores submitted_at/failed_at once at construction,
+        // mirroring how the real InMemoryController records `failed_at` at the
+        // transition into Failed.
+        let submitted_at = chrono::Utc::now() - chrono::Duration::seconds(7);
+        let failed_at = chrono::Utc::now() - chrono::Duration::seconds(2);
+        let controller = FailingController {
+            tenant: "test-tenant".to_string(),
+            job_id: "stable-fail".to_string(),
+            submitted_at,
+            failed_at,
+        };
+        let config = ServerConfig::for_testing();
+        let state = helios_rest::AppState::new(Arc::clone(&backend), config)
+            .with_export_controller(Arc::new(controller));
+        let app = helios_rest::routing::fhir_routes::create_routes(state);
+        let server = TestServer::new(app).expect("failed to create test server");
+
+        let fetch = || async {
+            let r = server
+                .get("/export/stable-fail/result")
+                .add_header(X_TENANT_ID, "test-tenant")
+                .await;
+            assert_eq!(r.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+            let body: Value = r.json();
+            let params = body["parameter"].as_array().unwrap().clone();
+            let pick = |name: &str, field: &str| -> Option<String> {
+                params
+                    .iter()
+                    .find(|p| p["name"].as_str() == Some(name))
+                    .and_then(|p| p[field].as_str())
+                    .map(|s| s.to_string())
+            };
+            let end_time = pick("exportEndTime", "valueInstant").expect("exportEndTime missing");
+            let duration = params
+                .iter()
+                .find(|p| p["name"].as_str() == Some("exportDuration"))
+                .and_then(|p| p["valueInteger"].as_i64())
+                .expect("exportDuration missing");
+            (end_time, duration)
+        };
+
+        let (end_a, dur_a) = fetch().await;
+        // Sleep across a second boundary so a clock-recomputed value would shift.
+        tokio::time::sleep(tokio::time::Duration::from_millis(1100)).await;
+        let (end_b, dur_b) = fetch().await;
+
+        assert_eq!(
+            end_a, end_b,
+            "exportEndTime must be stable across polls (got {end_a} then {end_b})"
+        );
+        assert_eq!(
+            dur_a, dur_b,
+            "exportDuration must be stable across polls (got {dur_a} then {dur_b})"
+        );
+        // Sanity: the duration matches the (failed_at - submitted_at) window
+        // we constructed (5s). Allow ±1s for clock granularity in formatting.
+        assert!(
+            (4..=6).contains(&dur_a),
+            "expected ~5s duration, got {dur_a}"
+        );
+    }
+
+    // =========================================================================
+    // 30. Cancel after completion is a no-op: the cancel call returns 202
+    //     (the job exists) but does not overwrite the `Completed` state, so
+    //     the result URL keeps serving the manifest.
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_export_cancel_after_completion_preserves_completed_state() {
+        let (server, backend) = create_test_server_with_export().await;
+        seed_patients(&backend).await;
+
+        let submit_resp = server
+            .post("/ViewDefinition/$viewdefinition-export")
+            .add_header(PREFER, "respond-async")
+            .add_header(X_TENANT_ID, "test-tenant")
+            .json(&patient_view())
+            .await;
+        assert_eq!(submit_resp.status_code(), StatusCode::ACCEPTED);
+        let status_url = submit_resp
+            .headers()
+            .get("content-location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Drive the job to completion and capture the manifest.
+        let manifest_before = poll_to_manifest(&server, &status_url, "test-tenant").await;
+        let export_id_before = manifest_before["parameter"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["name"].as_str() == Some("exportId"))
+            .and_then(|p| p["valueString"].as_str())
+            .expect("manifest missing exportId")
+            .to_string();
+
+        // DELETE on a completed job: cancel returns true (job found) so the
+        // handler responds 202, but the controller MUST NOT overwrite the
+        // Completed state with Cancelled.
+        let cancel = server
+            .delete(&status_url)
+            .add_header(X_TENANT_ID, "test-tenant")
+            .await;
+        assert_eq!(
+            cancel.status_code(),
+            StatusCode::ACCEPTED,
+            "cancel of completed job should still 202 (job exists), got: {} {}",
+            cancel.status_code(),
+            cancel.text()
+        );
+
+        // Status URL must still 303 to the result URL (terminal state).
+        let poll = server
+            .get(&status_url)
+            .add_header(X_TENANT_ID, "test-tenant")
+            .await;
+        assert_eq!(
+            poll.status_code(),
+            StatusCode::SEE_OTHER,
+            "completed job should still 303 after spurious cancel: {} {}",
+            poll.status_code(),
+            poll.text()
+        );
+        let result_url = poll
+            .headers()
+            .get("location")
+            .expect("303 missing Location")
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Result URL must still serve the same Completed manifest.
+        let result_after = server
+            .get(&result_url)
+            .add_header(X_TENANT_ID, "test-tenant")
+            .await;
+        assert_eq!(result_after.status_code(), StatusCode::OK);
+        let manifest_after: Value = result_after.json();
+        let status_after = manifest_after["parameter"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["name"].as_str() == Some("status"))
+            .and_then(|p| p["valueCode"].as_str());
+        assert_eq!(
+            status_after,
+            Some("completed"),
+            "manifest status must remain `completed` after cancel: {manifest_after}"
+        );
+        let export_id_after = manifest_after["parameter"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["name"].as_str() == Some("exportId"))
+            .and_then(|p| p["valueString"].as_str())
+            .expect("manifest missing exportId after cancel");
+        assert_eq!(
+            export_id_after, export_id_before,
+            "exportId must be unchanged after spurious cancel"
         );
     }
 }

--- a/crates/rest/tests/sof_run.rs
+++ b/crates/rest/tests/sof_run.rs
@@ -473,13 +473,12 @@ mod sof_run_tests {
         );
     }
 
-    /// Audit item #5: a `patient` reference whose target Patient resource
-    /// isn't in the supplied bundle SHOULD produce an OperationOutcome
-    /// warning. We surface it as a `Warning:` HTTP header (RFC 7234 §5.5)
-    /// so the absence signal reaches the client regardless of the
-    /// `_format` output.
+    /// Spec error table: a `patient` reference whose target Patient resource
+    /// isn't in the supplied bundle is a `400 Bad Request` with an
+    /// OperationOutcome — not a `200` plus a `Warning:` header (the prior
+    /// behavior we've now retired to align with the spec).
     #[tokio::test]
-    async fn test_inline_run_emits_warning_for_absent_patient_target() {
+    async fn test_inline_run_rejects_absent_patient_target_with_400() {
         let (server, _backend) = create_test_server().await;
 
         let view = patient_view_definition();
@@ -509,18 +508,16 @@ mod sof_run_tests {
             .json(&parameters_body)
             .await;
 
-        response.assert_status(StatusCode::OK);
-        let warning_headers: Vec<String> = response
-            .headers()
-            .get_all("warning")
-            .iter()
-            .filter_map(|v| v.to_str().ok().map(String::from))
-            .collect();
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["resourceType"], "OperationOutcome");
+        let diagnostics = body["issue"][0]["diagnostics"]
+            .as_str()
+            .or_else(|| body["issue"][0]["details"]["text"].as_str())
+            .unwrap_or_default();
         assert!(
-            warning_headers
-                .iter()
-                .any(|w| w.contains("Patient/alice") && w.contains("not found")),
-            "expected a Warning header for absent Patient/alice, got {warning_headers:?}"
+            diagnostics.contains("Patient/alice"),
+            "OperationOutcome must name the absent reference: {body}"
         );
     }
 
@@ -628,11 +625,15 @@ mod sof_run_tests {
             "id": "ai-other",
             "patient": {"reference": "Patient/xyz"}
         });
+        // Patient/abc must be present in the bundle: absent `patient`
+        // references are now a hard 400 per the SoF v2 spec error table.
+        let pt_abc = json!({"resourceType": "Patient", "id": "abc"});
 
         let parameters_body = json!({
             "resourceType": "Parameters",
             "parameter": [
                 {"name": "viewResource", "resource": view},
+                {"name": "resource", "resource": pt_abc},
                 {"name": "resource", "resource": ai_match},
                 {"name": "resource", "resource": ai_other},
                 {"name": "patient", "valueReference": {"reference": "Patient/abc"}}

--- a/crates/sof/docs/spec-inconsistencies.md
+++ b/crates/sof/docs/spec-inconsistencies.md
@@ -176,3 +176,10 @@ Other spec ambiguities surfaced during audit but **not** classified as inconsist
 - R4-only build exposing type+instance routes (spec's R4 OperationDefinition restricts to system-level).
 - GET requests carrying `viewResource`/`resource` body (spec text reserves these for POST).
 - `$viewdefinition-export` adds `status: in-progress` to its polling Parameters body — the spec's status-polling parameter table lists only `exportId` and `estimatedTimeRemaining`. Additive, no behavioral impact for spec-compliant clients.
+- sof-server and HFS REST both accept a bare `ViewDefinition` body as a shortcut for a `Parameters` body containing a single `viewResource` entry. Spec examples only show the `Parameters` shape; we accept either because the bare form is a common ergonomic convenience for CLI/pipe callers and unambiguous to detect (`resourceType=ViewDefinition`).
+
+## Resolved spec deviations
+
+Items that previously appeared above but have been brought into alignment with the spec:
+
+- **Absent `patient` / `group` targets now return `400 Bad Request` with an `OperationOutcome` (`code = not-found`).** Earlier the implementation surfaced absence as `200 OK` with one `Warning: 199 - "..."` header per missing reference, citing the spec's "SHOULD return OperationOutcome" language and RFC 7234 §5.5 as motivation. The spec's error table is explicit (`Referenced patient/group not found (400)`), so the warning-header path was retired. Carrier: `SofError::ReferencedResourceNotFound`, mapped to 400 by both binaries.

--- a/crates/sof/src/error.rs
+++ b/crates/sof/src/error.rs
@@ -19,6 +19,12 @@ pub enum ServerError {
     /// Invalid request parameters or body
     BadRequest(String),
 
+    /// A reference supplied in a request (e.g. `patient` / `group` on
+    /// `$viewdefinition-run`) does not resolve. Surfaces as `400 Bad Request`
+    /// + `OperationOutcome.issue.code = not-found`, per the SoF v2 spec's
+    /// error table.
+    ReferencedResourceNotFound(String),
+
     /// Requested resource not found
     NotFound(String),
 
@@ -42,6 +48,9 @@ impl fmt::Display for ServerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ServerError::BadRequest(msg) => write!(f, "Bad request: {}", msg),
+            ServerError::ReferencedResourceNotFound(msg) => {
+                write!(f, "Referenced resource not found: {}", msg)
+            }
             ServerError::NotFound(msg) => write!(f, "Not found: {}", msg),
             ServerError::UnsupportedMediaType(msg) => write!(f, "Unsupported media type: {}", msg),
             ServerError::ProcessingError(err) => write!(f, "Processing error: {}", err),
@@ -63,6 +72,9 @@ impl From<SofError> for ServerError {
             SofError::InvalidSource(_)
             | SofError::SourceNotFound(_)
             | SofError::UnsupportedSourceProtocol(_) => ServerError::BadRequest(err.to_string()),
+            SofError::ReferencedResourceNotFound(_) => {
+                ServerError::ReferencedResourceNotFound(err.to_string())
+            }
             SofError::SourceFetchError(_)
             | SofError::SourceReadError(_)
             | SofError::InvalidSourceContent(_) => ServerError::ProcessingError(err),
@@ -81,6 +93,9 @@ impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
         let (status, error_code, details) = match &self {
             ServerError::BadRequest(msg) => (StatusCode::BAD_REQUEST, "invalid", msg.clone()),
+            ServerError::ReferencedResourceNotFound(msg) => {
+                (StatusCode::BAD_REQUEST, "not-found", msg.clone())
+            }
             ServerError::NotFound(msg) => (StatusCode::NOT_FOUND, "not-found", msg.clone()),
             ServerError::UnsupportedMediaType(msg) => (
                 StatusCode::UNSUPPORTED_MEDIA_TYPE,

--- a/crates/sof/src/handlers.rs
+++ b/crates/sof/src/handlers.rs
@@ -6,7 +6,7 @@
 use axum::{
     Json,
     extract::Query,
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use chrono::{DateTime, Utc};
@@ -25,8 +25,8 @@ use tracing::{debug, info};
 use super::{
     error::{ServerError, ServerResult},
     models::{
-        RunParameters, RunQueryParams, extract_all_parameters, parse_content_type,
-        validate_query_params,
+        ExtractedParameters, RunParameters, RunQueryParams, extract_all_parameters,
+        parse_content_type, validate_query_params,
     },
 };
 
@@ -52,6 +52,15 @@ pub async fn capability_statement() -> ServerResult<impl IntoResponse> {
 /// * `params` - Query parameters for filtering, pagination, and output format
 /// * `headers` - HTTP headers including Accept for content negotiation
 /// * `body` - FHIR Parameters resource containing ViewDefinition and resources
+///
+/// # Body shapes
+///
+/// The request body may be either:
+/// - A FHIR `Parameters` resource (full form, recommended), or
+/// - A bare `ViewDefinition` resource (shortcut — equivalent to a Parameters
+///   body with a single `viewResource` entry). Other operation parameters
+///   (`patient`, `group`, `_format`, `_limit`, `_since`, `header`, `source`)
+///   must come from the query string when this shape is used.
 ///
 /// # Parameters (in specification order)
 ///
@@ -106,11 +115,27 @@ pub async fn run_view_definition_handler(
     let validated_params =
         validate_query_params(&params, accept_header).map_err(ServerError::BadRequest)?;
 
-    // Parse the Parameters resource using version detection
-    let parameters = parse_parameters(body)?;
-
-    // Extract all parameters including filters
-    let extracted_params = extract_all_parameters(parameters).map_err(ServerError::BadRequest)?;
+    // sof-server accepts two body shapes — match the HFS REST handler:
+    //   - A FHIR `Parameters` resource carrying `viewResource`, optional
+    //     `resource` entries, and operation parameters (`_format`, `_limit`,
+    //     `_since`, `patient`, `group`, `header`, `source`).
+    //   - A bare `ViewDefinition` resource — equivalent to a `Parameters`
+    //     body with a single `viewResource` entry and no others.
+    // The bare-ViewDefinition shortcut keeps the CLI/server ergonomic for
+    // callers that just want to pipe a ViewDefinition without building a
+    // Parameters wrapper. Other parameters (filters, limits, format) must
+    // come from the query string when this shape is used.
+    let is_bare_view_definition =
+        body.get("resourceType").and_then(|v| v.as_str()) == Some("ViewDefinition");
+    let extracted_params = if is_bare_view_definition {
+        ExtractedParameters {
+            view_definition: Some(body),
+            ..Default::default()
+        }
+    } else {
+        let parameters = parse_parameters(body)?;
+        extract_all_parameters(parameters).map_err(ServerError::BadRequest)?
+    };
 
     // Check for not-yet-implemented parameters
     if extracted_params.view_reference.is_some() {
@@ -123,9 +148,11 @@ pub async fn run_view_definition_handler(
     // helios_sof::compartment::resolve_group_members_to_patient_refs): each
     // supplied `Group/{id}` is resolved against Group resources in the
     // inline bundle, and its `member.entity` Patient references join the
-    // effective patient-compartment set. Unresolved groups simply produce
-    // no member refs — audit item #5 (SHOULD emit OperationOutcome) is a
-    // separate follow-up.
+    // effective patient-compartment set. Absent `patient` / `group`
+    // references are rejected by `filter_resources_by_patient_and_group`
+    // with `SofError::ReferencedResourceNotFound`, which the error mapper
+    // surfaces as `400 Bad Request` + `OperationOutcome.issue.code =
+    // not-found` per the SoF v2 spec error table.
 
     // For backward compatibility, extract the legacy tuple format
     let view_def_json = extracted_params.view_definition;
@@ -179,11 +206,6 @@ pub async fn run_view_definition_handler(
 
     // Apply patient and group filters from body parameters to resources if provided
     let mut filtered_resources = resources_json.unwrap_or_default();
-    // Accumulates absent-target warnings from every filter pass below
-    // (audit item #5). Surfaced as `Warning:` HTTP headers at response
-    // construction time so clients see the absence signal regardless of
-    // output format.
-    let mut filter_warnings: Vec<String> = Vec::new();
 
     // Merge filter parameters from body and query. Body takes precedence
     // when non-empty; otherwise comma-split the query value into the spec's
@@ -275,14 +297,12 @@ pub async fn run_view_definition_handler(
 
             // Apply filters
             if !patient_filter.is_empty() || !group_filter.is_empty() {
-                let outcome = filter_resources_by_patient_and_group(
+                source_resources = filter_resources_by_patient_and_group(
                     source_resources,
                     &patient_filter,
                     &group_filter,
                     source_fhir_version.unwrap(),
                 )?;
-                source_resources = outcome.resources;
-                filter_warnings.extend(outcome.warnings);
             }
 
             if let Some(since) = validated_params.since {
@@ -316,14 +336,12 @@ pub async fn run_view_definition_handler(
     // Apply filters to provided resources
     if !patient_filter.is_empty() || !group_filter.is_empty() {
         let effective_version = source_fhir_version.unwrap_or_else(get_newest_enabled_fhir_version);
-        let outcome = filter_resources_by_patient_and_group(
+        filtered_resources = filter_resources_by_patient_and_group(
             filtered_resources,
             &patient_filter,
             &group_filter,
             effective_version,
         )?;
-        filtered_resources = outcome.resources;
-        filter_warnings.extend(outcome.warnings);
     }
 
     // Apply _since filter if provided
@@ -396,7 +414,7 @@ pub async fn run_view_definition_handler(
                 file_buffers.len()
             );
             let zip = crate::parquet_zip::create_zip_from_buffers(file_buffers, "data")?;
-            let mut response = (
+            Ok((
                 StatusCode::OK,
                 [
                     (header::CONTENT_TYPE, "application/zip"),
@@ -407,14 +425,12 @@ pub async fn run_view_definition_handler(
                 ],
                 zip,
             )
-                .into_response();
-            attach_filter_warnings(response.headers_mut(), &filter_warnings);
-            Ok(response)
+                .into_response())
         } else {
             // Per SoF v2 spec Accept table, parquet uses
             // `application/octet-stream`; Content-Disposition makes browsers
             // download as `.parquet` (audit item #8).
-            let mut response = (
+            Ok((
                 StatusCode::OK,
                 [
                     (header::CONTENT_TYPE, "application/octet-stream"),
@@ -425,9 +441,7 @@ pub async fn run_view_definition_handler(
                 ],
                 file_buffers.into_iter().next().unwrap_or_default(),
             )
-                .into_response();
-            attach_filter_warnings(response.headers_mut(), &filter_warnings);
-            Ok(response)
+                .into_response())
         }
     } else {
         // Standard processing
@@ -455,7 +469,7 @@ pub async fn run_view_definition_handler(
             ContentType::Parquet => "application/octet-stream",
         };
 
-        let mut response = if matches!(validated_params.format, ContentType::Parquet) {
+        let response = if matches!(validated_params.format, ContentType::Parquet) {
             // Add Content-Disposition for parquet so browsers download as
             // `.parquet` rather than rendering octet-stream as binary noise.
             (
@@ -478,24 +492,7 @@ pub async fn run_view_definition_handler(
             )
                 .into_response()
         };
-        attach_filter_warnings(response.headers_mut(), &filter_warnings);
         Ok(response)
-    }
-}
-
-/// Appends one `Warning:` header per absent-target message
-/// (RFC 7234 §5.5, warn-code 199 = Miscellaneous warning). Carries the
-/// `patient` / `group` absence signal from
-/// [`helios_sof::PatientGroupFilterOutcome::warnings`] to the client,
-/// regardless of response body format (audit item #5).
-fn attach_filter_warnings(headers: &mut HeaderMap, warnings: &[String]) {
-    for msg in warnings {
-        // Strip quotes from the message to keep the header value valid;
-        // ASCII control chars would also break `HeaderValue::from_str`.
-        let safe = msg.replace('"', "'");
-        if let Ok(v) = HeaderValue::from_str(&format!("199 - \"{}\"", safe)) {
-            headers.append("warning", v);
-        }
     }
 }
 
@@ -801,7 +798,7 @@ fn filter_resources_by_patient_and_group(
     patient_refs: &[String],
     group_refs: &[String],
     fhir_version: helios_fhir::FhirVersion,
-) -> ServerResult<helios_sof::PatientGroupFilterOutcome> {
+) -> ServerResult<Vec<serde_json::Value>> {
     sof_filter_resources_by_patient_and_group(resources, patient_refs, group_refs, fhir_version)
         .map_err(ServerError::from)
 }
@@ -1058,7 +1055,7 @@ mod tests {
             }),
         ];
 
-        let outcome = filter_resources_by_patient_and_group(
+        let filtered = filter_resources_by_patient_and_group(
             resources,
             &["Patient/123".to_string()],
             &[],
@@ -1066,40 +1063,43 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(outcome.resources.len(), 2);
-        assert_eq!(outcome.resources[0]["id"], "123");
-        assert_eq!(outcome.resources[1]["id"], "obs1");
-        assert!(
-            outcome.warnings.is_empty(),
-            "Patient/123 is in the bundle; no absent-target warning expected"
-        );
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0]["id"], "123");
+        assert_eq!(filtered[1]["id"], "obs1");
     }
 
+    /// Absent `patient` / `group` references are a hard 400 per the SoF v2
+    /// spec error table — not the previous "200 + Warning: 199" path. We
+    /// assert both the `ServerError` variant and the rendered HTTP status.
     #[cfg(feature = "R4")]
     #[test]
-    fn test_filter_with_unresolvable_group_returns_empty() {
-        // With the new compartment-aware filter, an unresolved group_ref
-        // (no Group/test resource in the bundle) means no effective patient
-        // refs, so the filter returns empty rather than erroring out.
+    fn test_filter_with_unresolvable_group_returns_bad_request() {
         let resources = vec![serde_json::json!({
             "resourceType": "Patient",
             "id": "123"
         })];
 
-        let outcome = filter_resources_by_patient_and_group(
+        let err = filter_resources_by_patient_and_group(
             resources,
             &[],
             &["Group/test".to_string()],
             helios_fhir::FhirVersion::R4,
         )
-        .unwrap();
-
-        assert!(outcome.resources.is_empty());
-        // Audit item #5: absent group target should produce a warning.
-        assert!(
-            outcome.warnings.iter().any(|w| w.contains("Group/test")),
-            "expected an absent-target warning for Group/test, got {:?}",
-            outcome.warnings
+        .expect_err("absent Group target must error");
+        match &err {
+            ServerError::ReferencedResourceNotFound(msg) => {
+                assert!(
+                    msg.contains("Group/test"),
+                    "error must name the absent reference: {msg}"
+                );
+            }
+            other => panic!("expected ReferencedResourceNotFound, got {other:?}"),
+        }
+        let response = err.into_response();
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "absent reference must surface as 400"
         );
     }
 

--- a/crates/sof/src/lib.rs
+++ b/crates/sof/src/lib.rs
@@ -576,6 +576,13 @@ pub enum SofError {
     /// This error occurs when converting data to Parquet format fails.
     #[error("Parquet conversion error: {0}")]
     ParquetConversionError(String),
+
+    /// A `patient` / `group` reference supplied to `$viewdefinition-run` does
+    /// not resolve against the supplied resources. Per the SoF v2 spec, this
+    /// is a `400 Bad Request` (mapped to OperationOutcome `not-found` /
+    /// `invalid`), not a silent empty-result.
+    #[error("Referenced resource not found: {0}")]
+    ReferencedResourceNotFound(String),
 }
 
 /// Supported output content types for ViewDefinition transformations.
@@ -1069,21 +1076,6 @@ pub fn create_bundle_from_resources_for_version(
     }
 }
 
-/// Result of applying the patient/group filter to a resource list.
-///
-/// `warnings` carries human-readable messages for SoF v2 audit item #5
-/// ("Server SHOULD return OperationOutcome if requested patients absent",
-/// same for `group`). Callers typically surface them as `Warning:` HTTP
-/// headers (RFC 7234 §5.5, warn-code 199) so clients see the absence
-/// signal regardless of output format (CSV/JSON/NDJSON/Parquet).
-#[derive(Debug, Default, Clone)]
-pub struct PatientGroupFilterOutcome {
-    /// Resources that survived the compartment filter.
-    pub resources: Vec<serde_json::Value>,
-    /// Warning messages for absent `patient` / `group` targets.
-    pub warnings: Vec<String>,
-}
-
 /// Filters raw FHIR resource JSON by patient and/or group references using
 /// the FHIR `CompartmentDefinition-patient` spec data.
 ///
@@ -1103,31 +1095,29 @@ pub struct PatientGroupFilterOutcome {
 /// This replaces the prior hand-rolled `(subject|patient)` allowlist
 /// (audit item #3) without any runtime data-file dependency.
 ///
-/// Returns a [`PatientGroupFilterOutcome`] containing the filtered
-/// resources plus any `Warning:`-header-bound messages for absent
-/// `patient` / `group` targets (audit item #5).
+/// **Absent-target handling (SoF v2 spec):** any `patient` / `group` reference
+/// that does not resolve against the supplied resources is a hard error,
+/// returned as [`SofError::ReferencedResourceNotFound`]. Callers surface this
+/// as `400 Bad Request` + an `OperationOutcome` per the spec's error table.
+/// Previously this path emitted a `Warning: 199` HTTP header and continued
+/// with a (possibly empty) result; the warning-header behavior was
+/// removed to align with the spec.
 pub fn filter_resources_by_patient_and_group(
     resources: Vec<serde_json::Value>,
     patient_refs: &[String],
     group_refs: &[String],
     fhir_version: FhirVersion,
-) -> Result<PatientGroupFilterOutcome, SofError> {
+) -> Result<Vec<serde_json::Value>, SofError> {
     use std::collections::HashSet;
 
     if patient_refs.is_empty() && group_refs.is_empty() {
-        return Ok(PatientGroupFilterOutcome {
-            resources,
-            warnings: Vec::new(),
-        });
+        return Ok(resources);
     }
 
-    let mut warnings = Vec::new();
-
-    // Absent-target detection (audit item #5): a `patient` / `group`
-    // reference is "absent" when the target resource isn't in the
-    // supplied bundle. We emit a warning per missing reference; the
-    // filter still runs (partial results are fine — the warning is
-    // advisory, not an error).
+    // Absent-target detection: any `patient` / `group` reference that
+    // isn't represented by a resource in the supplied bundle is a hard
+    // error per the SoF v2 spec error table.
+    let mut absent: Vec<String> = Vec::new();
     for r in patient_refs {
         let canonical = if r.starts_with("Patient/") {
             r.clone()
@@ -1146,7 +1136,7 @@ pub fn filter_resources_by_patient_and_group(
             })
             .unwrap_or(false);
         if !found {
-            warnings.push(format!("{} not found in supplied resources", canonical));
+            absent.push(canonical);
         }
     }
     for g in group_refs {
@@ -1167,8 +1157,14 @@ pub fn filter_resources_by_patient_and_group(
             })
             .unwrap_or(false);
         if !found {
-            warnings.push(format!("{} not found in supplied resources", canonical));
+            absent.push(canonical);
         }
+    }
+    if !absent.is_empty() {
+        return Err(SofError::ReferencedResourceNotFound(format!(
+            "{} not found in supplied resources",
+            absent.join(", ")
+        )));
     }
 
     // Build the effective patient-compartment set: explicit patient refs +
@@ -1192,14 +1188,11 @@ pub fn filter_resources_by_patient_and_group(
         ));
     }
 
-    // No effective patient targets (e.g. group ref didn't resolve to any
-    // Patient members in the bundle) → empty result; mirrors bulk-export
-    // behavior for an empty Group.
+    // No effective patient targets (e.g. supplied Group resolved to zero
+    // Patient members). The targets themselves are present (they got past
+    // the absent-target check above), so this is an empty-but-valid result.
     if targets.is_empty() {
-        return Ok(PatientGroupFilterOutcome {
-            resources: Vec::new(),
-            warnings,
-        });
+        return Ok(Vec::new());
     }
 
     let mut filtered = Vec::with_capacity(resources.len());
@@ -1227,10 +1220,7 @@ pub fn filter_resources_by_patient_and_group(
         }
     }
 
-    Ok(PatientGroupFilterOutcome {
-        resources: filtered,
-        warnings,
-    })
+    Ok(filtered)
 }
 
 /// Filters raw FHIR resource JSON by their `meta.lastUpdated` timestamp,

--- a/crates/sof/tests/common/mod.rs
+++ b/crates/sof/tests/common/mod.rs
@@ -162,8 +162,12 @@ async fn run_view_definition_handler(
         return error_response(axum::http::StatusCode::BAD_REQUEST, &e);
     }
 
-    // Basic parameter parsing
-    if body["resourceType"] != "Parameters" {
+    // sof-server accepts two body shapes:
+    //   - A FHIR `Parameters` resource (full form), or
+    //   - A bare `ViewDefinition` resource (shortcut — equivalent to a
+    //     Parameters body with a single `viewResource` entry).
+    let is_bare_view_definition = body["resourceType"] == "ViewDefinition";
+    if !is_bare_view_definition && body["resourceType"] != "Parameters" {
         return error_response(
             axum::http::StatusCode::BAD_REQUEST,
             "Request body must be a Parameters resource",
@@ -178,7 +182,10 @@ async fn run_view_definition_handler(
     let mut patient_filter = None;
     let mut count_from_body = None;
 
-    if let Some(parameters) = body["parameter"].as_array() {
+    if is_bare_view_definition {
+        // Body itself is the ViewDefinition; no resources, no operation params.
+        view_def_json = body.as_object().cloned();
+    } else if let Some(parameters) = body["parameter"].as_array() {
         for param in parameters {
             match param["name"].as_str() {
                 Some("viewResource") => {

--- a/crates/sof/tests/server_tests.rs
+++ b/crates/sof/tests/server_tests.rs
@@ -274,6 +274,45 @@ async fn test_run_view_definition_error_no_view() {
     assert_eq!(json["resourceType"], "OperationOutcome");
 }
 
+/// A bare `ViewDefinition` body (no `Parameters` wrapper) is a valid shortcut
+/// shape: callers piping a stored ViewDefinition straight to the server
+/// shouldn't have to build a Parameters envelope. Other operation parameters
+/// must come from the query string in this shape.
+#[tokio::test]
+async fn test_run_view_definition_bare_body() {
+    let server = common::test_server().await;
+
+    let bare_view = json!({
+        "resourceType": "ViewDefinition",
+        "status": "active",
+        "resource": "Patient",
+        "select": [{
+            "column": [
+                {"name": "id", "path": "id"},
+                {"name": "gender", "path": "gender"}
+            ]
+        }]
+    });
+
+    // No `Parameters` wrapper, no `resource` entries. The view runs
+    // against zero input resources — what matters is that the body
+    // shape (`resourceType=ViewDefinition`, not `Parameters`) is
+    // accepted instead of being rejected with `400 Bad Request +
+    // "Request body must be a Parameters resource"`.
+    let response = server
+        .post("/ViewDefinition/$viewdefinition-run")
+        .add_query_param("_format", "application/json")
+        .json(&bare_view)
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        StatusCode::OK,
+        "bare ViewDefinition body must be accepted: {:?}",
+        response.text()
+    );
+}
+
 #[tokio::test]
 async fn test_run_view_definition_unsupported_format() {
     let server = common::test_server().await;


### PR DESCRIPTION
## Summary

Three-commit stacked PR on top of #66 with follow-up spec-compliance fixes for `$viewdefinition-export` (and an unrelated pysof CI break).

- **`$viewdefinition-export` spec gaps** (2e511d68):
  - Reject unsupported `_format` values at submit time with 400 + OperationOutcome. Previously unknown formats silently downgraded to NDJSON while the manifest echoed the bogus value.
  - Reject duplicate view names in multi-view submissions with 400. The completion manifest groups files by view name, so colliding names would silently merge separate views' shards into a single `output` entry.
  - Add `failed_at: DateTime<Utc>` to `JobStatus::Failed` and use it in the failed-job manifest. Previously the result handler called `chrono::Utc::now()` on every poll, so `exportEndTime` / `exportDuration` shifted between calls.
- **Pysof CI fix** (b67d21c3): cover `SofError::ReferencedResourceNotFound` in the exhaustive match in `lib_coverage_tests.rs`. The variant was introduced in 66f701d1 but the pysof coverage test wasn't updated, breaking the Code Coverage CI job (`cargo test --workspace`).
- **Previous commit** (66f701d1, already on `feat/sof-integration`): align `$viewdefinition-run` with v2 spec error & body shapes — context for the pysof breakage.

Spec assessment was conducted against [OperationDefinition-ViewDefinitionExport](https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/OperationDefinition-ViewDefinitionExport.html); these are the three concrete bugs surfaced by that read-through. Persistent job storage and `source`-parameter support remain intentionally out of scope.

## Test plan

- [x] `cargo test -p helios-rest --test sof_export` — 34/34 pass (4 new tests included)
- [x] `cargo clippy -p helios-rest --all-targets` with CI flags — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo check --tests` in `crates/pysof/` — compiles (was the CI blocker)
- [ ] Full CI green on this branch (Code Coverage job in particular)

### New tests added in `crates/rest/tests/sof_export.rs`

- `test_export_unknown_format_returns_400`
- `test_export_duplicate_view_names_returns_400`
- `test_export_failed_manifest_export_end_time_is_stable` (polls twice across a 1.1s sleep, asserts identical times)
- `test_export_cancel_after_completion_preserves_completed_state` (locks in the existing controller behavior that a cancel on a completed job is a no-op)