### PR TITLE
Wire history read endpoints and vread

### DIFF
--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -49,7 +49,8 @@ use crate::core::{
     ConditionalUpdateResult, ExportDataProvider, ExportRequest, GroupExportProvider,
     IncludeProvider, InstanceHistoryProvider, NdjsonBatch, PatchFormat, PatientExportProvider,
     ResourceStorage, RevincludeProvider, SearchProvider, SearchResult, StorageCapabilities,
-    TerminologySearchProvider, TextSearchProvider, VersionedStorage,
+    SystemHistoryProvider, TerminologySearchProvider, TextSearchProvider, TypeHistoryProvider,
+    VersionedStorage,
 };
 use crate::error::{BackendError, StorageError, StorageResult, TransactionError};
 use crate::tenant::TenantContext;
@@ -77,6 +78,9 @@ pub type DynVersionedStorage = Arc<dyn VersionedStorage + Send + Sync>;
 
 /// A dynamically typed instance history provider.
 pub type DynInstanceHistoryProvider = Arc<dyn InstanceHistoryProvider + Send + Sync>;
+
+/// A dynamically typed system history provider (also covers Type + Instance).
+pub type DynSystemHistoryProvider = Arc<dyn SystemHistoryProvider + Send + Sync>;
 
 /// A dynamically typed bundle provider.
 pub type DynBundleProvider = Arc<dyn BundleProvider + Send + Sync>;
@@ -129,6 +133,9 @@ pub struct CompositeStorage {
 
     /// Primary as InstanceHistoryProvider (if supported).
     history_provider: Option<DynInstanceHistoryProvider>,
+
+    /// Primary as SystemHistoryProvider (if supported) — covers Type + System history.
+    system_history_provider: Option<DynSystemHistoryProvider>,
 
     /// Primary as BundleProvider (if supported).
     bundle_provider: Option<DynBundleProvider>,
@@ -291,6 +298,7 @@ impl CompositeStorage {
             conditional_storage: None,
             versioned_storage: None,
             history_provider: None,
+            system_history_provider: None,
             bundle_provider: None,
             export_provider: None,
         })
@@ -343,6 +351,8 @@ impl CompositeStorage {
             + ConditionalStorage
             + VersionedStorage
             + InstanceHistoryProvider
+            + TypeHistoryProvider
+            + SystemHistoryProvider
             + BundleProvider
             + GroupExportProvider
             + Send
@@ -352,6 +362,7 @@ impl CompositeStorage {
         self.conditional_storage = Some(primary.clone() as DynConditionalStorage);
         self.versioned_storage = Some(primary.clone() as DynVersionedStorage);
         self.history_provider = Some(primary.clone() as DynInstanceHistoryProvider);
+        self.system_history_provider = Some(primary.clone() as DynSystemHistoryProvider);
         self.bundle_provider = Some(primary.clone() as DynBundleProvider);
         self.export_provider = Some(primary as DynGroupExportProvider);
         self
@@ -1401,6 +1412,69 @@ impl InstanceHistoryProvider for CompositeStorage {
         provider
             .history_instance_count(tenant, resource_type, id)
             .await
+    }
+}
+
+#[async_trait]
+impl TypeHistoryProvider for CompositeStorage {
+    async fn history_type(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        params: &HistoryParams,
+    ) -> StorageResult<crate::core::HistoryPage> {
+        let provider = self.system_history_provider.as_ref().ok_or_else(|| {
+            StorageError::Backend(BackendError::UnsupportedCapability {
+                backend_name: "composite".to_string(),
+                capability: "TypeHistoryProvider".to_string(),
+            })
+        })?;
+
+        provider.history_type(tenant, resource_type, params).await
+    }
+
+    async fn history_type_count(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+    ) -> StorageResult<u64> {
+        let provider = self.system_history_provider.as_ref().ok_or_else(|| {
+            StorageError::Backend(BackendError::UnsupportedCapability {
+                backend_name: "composite".to_string(),
+                capability: "TypeHistoryProvider".to_string(),
+            })
+        })?;
+
+        provider.history_type_count(tenant, resource_type).await
+    }
+}
+
+#[async_trait]
+impl SystemHistoryProvider for CompositeStorage {
+    async fn history_system(
+        &self,
+        tenant: &TenantContext,
+        params: &HistoryParams,
+    ) -> StorageResult<crate::core::HistoryPage> {
+        let provider = self.system_history_provider.as_ref().ok_or_else(|| {
+            StorageError::Backend(BackendError::UnsupportedCapability {
+                backend_name: "composite".to_string(),
+                capability: "SystemHistoryProvider".to_string(),
+            })
+        })?;
+
+        provider.history_system(tenant, params).await
+    }
+
+    async fn history_system_count(&self, tenant: &TenantContext) -> StorageResult<u64> {
+        let provider = self.system_history_provider.as_ref().ok_or_else(|| {
+            StorageError::Backend(BackendError::UnsupportedCapability {
+                backend_name: "composite".to_string(),
+                capability: "SystemHistoryProvider".to_string(),
+            })
+        })?;
+
+        provider.history_system_count(tenant).await
     }
 }
 

--- a/crates/rest/src/handlers/history.rs
+++ b/crates/rest/src/handlers/history.rs
@@ -9,21 +9,30 @@
 //! - Delete instance history: `DELETE [base]/[type]/[id]/_history`
 //! - Delete specific version: `DELETE [base]/[type]/[id]/_history/[vid]`
 //!
-//! Note: Full history functionality requires a backend that implements
-//! the InstanceHistoryProvider, TypeHistoryProvider, and SystemHistoryProvider traits.
+//! History reads are backed by the `InstanceHistoryProvider`,
+//! `TypeHistoryProvider`, and `SystemHistoryProvider` traits, which every
+//! first-class storage backend (SQLite, PostgreSQL, MongoDB, S3) implements
+//! and which `CompositeStorage` delegates to its primary.
 
 use axum::{
     Json,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
-use helios_persistence::core::{InstanceHistoryProvider, ResourceStorage};
+use chrono::{DateTime, Utc};
+use helios_persistence::core::{
+    HistoryEntry, HistoryMethod, HistoryParams, InstanceHistoryProvider, ResourceStorage,
+    SystemHistoryProvider, TypeHistoryProvider,
+};
 use serde::Deserialize;
+use serde_json::{Value, json};
 use tracing::{debug, warn};
 
 use crate::error::{RestError, RestResult};
 use crate::extractors::TenantExtractor;
+use crate::middleware::content_type::negotiate_format;
+use crate::responses::format_resource_response;
 use crate::state::AppState;
 
 /// Query parameters for history requests.
@@ -41,6 +50,98 @@ pub struct HistoryQuery {
     #[serde(rename = "_at")]
     #[allow(dead_code)]
     pub at: Option<String>,
+
+    /// Response format override (`json` / `xml` / full media types).
+    #[serde(rename = "_format")]
+    pub format: Option<String>,
+}
+
+/// Builds [`HistoryParams`] from the request query, applying the configured
+/// page-size limits and parsing the optional `_since` instant.
+fn build_history_params<S>(params: &HistoryQuery, state: &AppState<S>) -> RestResult<HistoryParams>
+where
+    S: ResourceStorage + Send + Sync,
+{
+    let count = params
+        .count
+        .unwrap_or(state.default_page_size())
+        .min(state.max_page_size()) as u32;
+
+    let mut history_params = HistoryParams::new().count(count).include_deleted(true);
+
+    if let Some(since_str) = params.since.as_deref() {
+        let since = DateTime::parse_from_rfc3339(since_str)
+            .map_err(|_| RestError::BadRequest {
+                message: format!("Invalid _since value (expected an RFC3339 instant): {since_str}"),
+            })?
+            .with_timezone(&Utc);
+        history_params = history_params.since(since);
+    }
+
+    Ok(history_params)
+}
+
+/// Converts a single [`HistoryEntry`] into a FHIR history Bundle entry.
+fn history_entry_to_json(entry: &HistoryEntry, base_url: &str) -> Value {
+    let resource = &entry.resource;
+    let resource_type = resource.resource_type();
+    let id = resource.id();
+    let version_id = resource.version_id();
+
+    let (method, request_url, status) = match entry.method {
+        HistoryMethod::Post => ("POST", resource_type.to_string(), "201"),
+        HistoryMethod::Put => ("PUT", format!("{resource_type}/{id}"), "200"),
+        HistoryMethod::Patch => ("PATCH", format!("{resource_type}/{id}"), "200"),
+        HistoryMethod::Delete => ("DELETE", format!("{resource_type}/{id}"), "204"),
+    };
+
+    let mut bundle_entry = json!({
+        "fullUrl": format!("{base_url}/{resource_type}/{id}"),
+        "request": {
+            "method": method,
+            "url": request_url,
+        },
+        "response": {
+            "status": status,
+            "etag": format!("W/\"{version_id}\""),
+            "lastModified": entry.timestamp.to_rfc3339(),
+        },
+    });
+
+    // Deleted versions carry no resource body.
+    if entry.method != HistoryMethod::Delete {
+        bundle_entry["resource"] = resource.content().clone();
+    }
+
+    bundle_entry
+}
+
+/// Builds a FHIR `history` Bundle from a page of history entries.
+fn build_history_bundle(entries: &[HistoryEntry], base_url: &str, total: u64) -> Value {
+    let bundle_entries: Vec<Value> = entries
+        .iter()
+        .map(|entry| history_entry_to_json(entry, base_url))
+        .collect();
+
+    json!({
+        "resourceType": "Bundle",
+        "type": "history",
+        "total": total,
+        "entry": bundle_entries,
+    })
+}
+
+/// Serializes a history Bundle in the negotiated response format.
+fn respond_with_bundle(
+    bundle: &Value,
+    req_headers: &HeaderMap,
+    format_param: Option<&str>,
+) -> Response {
+    let negotiated = negotiate_format(req_headers, format_param);
+    match format_resource_response(StatusCode::OK, HeaderMap::new(), bundle, negotiated.format) {
+        Ok(response) => response,
+        Err(response) => response,
+    }
 }
 
 /// Handler for instance history.
@@ -58,15 +159,17 @@ pub struct HistoryQuery {
 ///
 /// # Response
 ///
-/// Returns a Bundle of type "history".
+/// - `200 OK` - Returns a Bundle of type "history"
+/// - `404 Not Found` - The resource has no history (never existed)
 pub async fn history_instance_handler<S>(
     State(state): State<AppState<S>>,
     Path((resource_type, id)): Path<(String, String)>,
     tenant: TenantExtractor,
+    req_headers: HeaderMap,
     Query(params): Query<HistoryQuery>,
 ) -> RestResult<Response>
 where
-    S: ResourceStorage + Send + Sync,
+    S: ResourceStorage + InstanceHistoryProvider + Send + Sync,
 {
     debug!(
         resource_type = %resource_type,
@@ -75,14 +178,33 @@ where
         "Processing instance history request"
     );
 
-    let _count = params.count.unwrap_or(state.default_page_size());
-    let _since = params.since.as_deref();
+    let history_params = build_history_params(&params, &state)?;
 
-    // For now, return a not implemented error
-    // Full implementation requires InstanceHistoryProvider
-    Err(RestError::NotImplemented {
-        feature: format!("Instance history for {}/{}", resource_type, id),
-    })
+    let page = state
+        .storage()
+        .history_instance(tenant.context(), &resource_type, &id, &history_params)
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "Instance history failed");
+            RestError::from(e)
+        })?;
+
+    // An existing resource always has at least its current version in history,
+    // so an empty *unfiltered* page means the resource never existed. When a
+    // `_since` filter is in play, an empty page just means nothing matched, so
+    // we return an empty history Bundle rather than a 404.
+    if page.items.is_empty() && params.since.is_none() {
+        return Err(RestError::NotFound { resource_type, id });
+    }
+
+    let total = page.page_info.total.unwrap_or(page.items.len() as u64);
+    let bundle = build_history_bundle(&page.items, state.base_url(), total);
+
+    Ok(respond_with_bundle(
+        &bundle,
+        &req_headers,
+        params.format.as_deref(),
+    ))
 }
 
 /// Handler for type history.
@@ -96,10 +218,11 @@ pub async fn history_type_handler<S>(
     State(state): State<AppState<S>>,
     Path(resource_type): Path<String>,
     tenant: TenantExtractor,
+    req_headers: HeaderMap,
     Query(params): Query<HistoryQuery>,
 ) -> RestResult<Response>
 where
-    S: ResourceStorage + Send + Sync,
+    S: ResourceStorage + TypeHistoryProvider + Send + Sync,
 {
     debug!(
         resource_type = %resource_type,
@@ -107,14 +230,25 @@ where
         "Processing type history request"
     );
 
-    let _count = params.count.unwrap_or(state.default_page_size());
-    let _since = params.since.as_deref();
+    let history_params = build_history_params(&params, &state)?;
 
-    // For now, return a not implemented error
-    // Full implementation requires TypeHistoryProvider
-    Err(RestError::NotImplemented {
-        feature: format!("Type history for {}", resource_type),
-    })
+    let page = state
+        .storage()
+        .history_type(tenant.context(), &resource_type, &history_params)
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "Type history failed");
+            RestError::from(e)
+        })?;
+
+    let total = page.page_info.total.unwrap_or(page.items.len() as u64);
+    let bundle = build_history_bundle(&page.items, state.base_url(), total);
+
+    Ok(respond_with_bundle(
+        &bundle,
+        &req_headers,
+        params.format.as_deref(),
+    ))
 }
 
 /// Handler for system history.
@@ -127,24 +261,36 @@ where
 pub async fn history_system_handler<S>(
     State(state): State<AppState<S>>,
     tenant: TenantExtractor,
+    req_headers: HeaderMap,
     Query(params): Query<HistoryQuery>,
 ) -> RestResult<Response>
 where
-    S: ResourceStorage + Send + Sync,
+    S: ResourceStorage + SystemHistoryProvider + Send + Sync,
 {
     debug!(
         tenant = %tenant.tenant_id(),
         "Processing system history request"
     );
 
-    let _count = params.count.unwrap_or(state.default_page_size());
-    let _since = params.since.as_deref();
+    let history_params = build_history_params(&params, &state)?;
 
-    // For now, return a not implemented error
-    // Full implementation requires SystemHistoryProvider
-    Err(RestError::NotImplemented {
-        feature: "System history".to_string(),
-    })
+    let page = state
+        .storage()
+        .history_system(tenant.context(), &history_params)
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "System history failed");
+            RestError::from(e)
+        })?;
+
+    let total = page.page_info.total.unwrap_or(page.items.len() as u64);
+    let bundle = build_history_bundle(&page.items, state.base_url(), total);
+
+    Ok(respond_with_bundle(
+        &bundle,
+        &req_headers,
+        params.format.as_deref(),
+    ))
 }
 
 /// Handler for deleting instance history.
@@ -256,77 +402,4 @@ where
     );
 
     Ok(StatusCode::NO_CONTENT.into_response())
-}
-
-/// Builds a history Bundle from history entries.
-#[allow(dead_code)]
-fn build_history_bundle(entries: &[HistoryBundleEntry], base_url: &str) -> serde_json::Value {
-    let bundle_entries: Vec<serde_json::Value> = entries
-        .iter()
-        .map(|e| {
-            let mut entry = serde_json::json!({
-                "fullUrl": format!(
-                    "{}/{}/{}/_history/{}",
-                    base_url, e.resource_type, e.id, e.version_id
-                ),
-            });
-
-            // Add request info based on method
-            let request = match e.method.as_str() {
-                "POST" => serde_json::json!({
-                    "method": "POST",
-                    "url": e.resource_type
-                }),
-                "PUT" => serde_json::json!({
-                    "method": "PUT",
-                    "url": format!("{}/{}", e.resource_type, e.id)
-                }),
-                "DELETE" => serde_json::json!({
-                    "method": "DELETE",
-                    "url": format!("{}/{}", e.resource_type, e.id)
-                }),
-                _ => serde_json::json!({
-                    "method": e.method,
-                    "url": format!("{}/{}", e.resource_type, e.id)
-                }),
-            };
-            entry["request"] = request;
-
-            // Add response info
-            let response = serde_json::json!({
-                "status": if e.method == "DELETE" { "204" } else { "200" },
-                "etag": format!("W/\"{}\"", e.version_id),
-                "lastModified": e.timestamp
-            });
-            entry["response"] = response;
-
-            // Add resource if not deleted
-            if e.method != "DELETE" {
-                if let Some(content) = &e.content {
-                    entry["resource"] = content.clone();
-                }
-            }
-
-            entry
-        })
-        .collect();
-
-    serde_json::json!({
-        "resourceType": "Bundle",
-        "type": "history",
-        "total": bundle_entries.len(),
-        "entry": bundle_entries
-    })
-}
-
-/// A history bundle entry for internal use.
-#[derive(Debug)]
-#[allow(dead_code)]
-struct HistoryBundleEntry {
-    resource_type: String,
-    id: String,
-    version_id: String,
-    method: String,
-    timestamp: String,
-    content: Option<serde_json::Value>,
 }

--- a/crates/rest/src/handlers/vread.rs
+++ b/crates/rest/src/handlers/vread.rs
@@ -3,18 +3,25 @@
 //! Implements the FHIR [vread interaction](https://hl7.org/fhir/http.html#vread):
 //! `GET [base]/[type]/[id]/_history/[vid]`
 //!
-//! Note: Full vread functionality requires a backend that implements
-//! the VersionedStorage trait.
+//! Backed by the `VersionedStorage::vread` operation, which every first-class
+//! storage backend implements and which `CompositeStorage` delegates to its
+//! primary.
+
+use std::collections::HashMap;
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode, header},
     response::Response,
 };
-use helios_persistence::core::ResourceStorage;
+use helios_persistence::core::{ResourceStorage, VersionedStorage};
 use tracing::debug;
 
 use crate::error::{RestError, RestResult};
-use crate::extractors::TenantExtractor;
+use crate::extractors::{FhirVersionExtractor, TenantExtractor};
+use crate::middleware::content_type::{FhirContentType, negotiate_format};
+use crate::responses::format_resource_response;
+use crate::responses::headers::ResourceHeaders;
 use crate::state::AppState;
 
 /// Handler for the vread interaction.
@@ -38,12 +45,15 @@ use crate::state::AppState;
 /// Accept: application/fhir+json
 /// ```
 pub async fn vread_handler<S>(
-    State(_state): State<AppState<S>>,
+    State(state): State<AppState<S>>,
     Path((resource_type, id, version_id)): Path<(String, String, String)>,
     tenant: TenantExtractor,
+    version: FhirVersionExtractor,
+    req_headers: HeaderMap,
+    Query(params): Query<HashMap<String, String>>,
 ) -> RestResult<Response>
 where
-    S: ResourceStorage + Send + Sync,
+    S: ResourceStorage + VersionedStorage + Send + Sync,
 {
     debug!(
         resource_type = %resource_type,
@@ -53,12 +63,58 @@ where
         "Processing vread request"
     );
 
-    // For now, return a not implemented error
-    // Full implementation requires VersionedStorage trait
-    Err(RestError::NotImplemented {
-        feature: format!(
-            "Version read for {}/{}/_history/{}",
-            resource_type, id, version_id
-        ),
-    })
+    let stored = state
+        .storage()
+        .vread(tenant.context(), &resource_type, &id, &version_id)
+        .await?;
+
+    match stored {
+        Some(stored) => {
+            // If the client requested a specific FHIR version, verify it matches.
+            if let Some(requested) = version.accept_version() {
+                if stored.fhir_version() != requested {
+                    return Err(RestError::NotAcceptable {
+                        message: format!(
+                            "Resource is FHIR {} but {} was requested",
+                            stored.fhir_version().as_mime_param(),
+                            requested.as_mime_param()
+                        ),
+                    });
+                }
+            }
+
+            // Negotiate response format.
+            let format_param = params.get("_format").map(|s| s.as_str());
+            let negotiated = negotiate_format(&req_headers, format_param);
+
+            // Build response headers, including fhirVersion in Content-Type.
+            let content_type =
+                FhirContentType::with_version(negotiated.format, stored.fhir_version());
+            let mut headers = ResourceHeaders::from_stored(&stored, &state)
+                .with_content_type(content_type.to_header_value())
+                .to_header_map();
+            headers.insert(
+                header::CONTENT_TYPE,
+                content_type.to_header_value().parse().unwrap(),
+            );
+
+            debug!(
+                resource_type = %resource_type,
+                id = %id,
+                version = %stored.version_id(),
+                fhir_version = %stored.fhir_version(),
+                "Returning resource version"
+            );
+
+            format_resource_response(StatusCode::OK, headers, stored.content(), negotiated.format)
+                .map_err(|_| RestError::InternalError {
+                    message: "Failed to serialize response".to_string(),
+                })
+        }
+        None => Err(RestError::VersionNotFound {
+            resource_type,
+            id,
+            version_id,
+        }),
+    }
 }

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -163,6 +163,7 @@ use std::sync::Arc;
 use axum::{Router, extract::DefaultBodyLimit};
 use helios_persistence::core::{
     BundleProvider, ConditionalStorage, InstanceHistoryProvider, ResourceStorage, SearchProvider,
+    SystemHistoryProvider, TypeHistoryProvider,
 };
 use tower::ServiceBuilder;
 use tower_http::{
@@ -196,6 +197,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider
@@ -237,6 +240,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider
@@ -284,6 +289,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider
@@ -317,6 +324,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider
@@ -350,6 +359,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider

--- a/crates/rest/src/routing/fhir_routes.rs
+++ b/crates/rest/src/routing/fhir_routes.rs
@@ -12,6 +12,7 @@ use axum::{
 use helios_fhir::FhirVersion;
 use helios_persistence::core::{
     BundleProvider, ConditionalStorage, InstanceHistoryProvider, ResourceStorage, SearchProvider,
+    SystemHistoryProvider, TypeHistoryProvider,
 };
 use tower::ServiceExt;
 
@@ -58,6 +59,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider
@@ -80,6 +83,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider
@@ -101,6 +106,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider
@@ -127,6 +134,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider
@@ -192,6 +201,8 @@ where
         + ConditionalStorage
         + SearchProvider
         + InstanceHistoryProvider
+        + TypeHistoryProvider
+        + SystemHistoryProvider
         + BundleProvider
         + helios_persistence::core::ExportDataProvider
         + helios_persistence::core::PatientExportProvider

--- a/crates/rest/tests/rest_conformance.rs
+++ b/crates/rest/tests/rest_conformance.rs
@@ -1004,3 +1004,200 @@ mod delete_history {
         response.assert_status(StatusCode::NOT_FOUND);
     }
 }
+
+// =============================================================================
+// History reads: instance / type / system history + vread
+// =============================================================================
+
+mod history_reads {
+    use super::*;
+
+    /// Creates a Patient and updates it twice, yielding versions 1, 2, 3.
+    async fn seed_versioned_patient(server: &TestServer, id: &str) {
+        let create = json!({
+            "resourceType": "Patient",
+            "id": id,
+            "name": [{"family": "V1"}]
+        });
+        server
+            .put(&format!("/Patient/{id}"))
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .add_header(
+                CONTENT_TYPE,
+                HeaderValue::from_static("application/fhir+json"),
+            )
+            .json(&create)
+            .await;
+
+        for family in ["V2", "V3"] {
+            let update = json!({
+                "resourceType": "Patient",
+                "id": id,
+                "name": [{"family": family}]
+            });
+            server
+                .put(&format!("/Patient/{id}"))
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .add_header(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/fhir+json"),
+                )
+                .json(&update)
+                .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_instance_history_returns_all_versions() {
+        let (server, _backend) = create_test_server().await;
+        seed_versioned_patient(&server, "hist-inst").await;
+
+        let response = server
+            .get("/Patient/hist-inst/_history")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let bundle: Value = response.json();
+        assert_eq!(bundle["resourceType"], "Bundle");
+        assert_eq!(bundle["type"], "history");
+        assert_eq!(bundle["total"], 3);
+
+        let entries = bundle["entry"].as_array().expect("entry array");
+        assert_eq!(entries.len(), 3);
+
+        // Each entry carries request + response metadata with a weak ETag.
+        for entry in entries {
+            assert!(entry["request"]["method"].is_string());
+            assert!(
+                entry["response"]["etag"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .starts_with("W/\"")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_instance_history_not_found() {
+        let (server, _backend) = create_test_server().await;
+
+        let response = server
+            .get("/Patient/does-not-exist/_history")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status(StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_instance_history_count_limits_entries() {
+        let (server, _backend) = create_test_server().await;
+        seed_versioned_patient(&server, "hist-count").await;
+
+        let response = server
+            .get("/Patient/hist-count/_history?_count=1")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let bundle: Value = response.json();
+        let entries = bundle["entry"].as_array().expect("entry array");
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected _count=1 to return a single entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_instance_history_invalid_since_is_bad_request() {
+        let (server, _backend) = create_test_server().await;
+        seed_versioned_patient(&server, "hist-since").await;
+
+        let response = server
+            .get("/Patient/hist-since/_history?_since=not-a-date")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status(StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_type_history_returns_bundle() {
+        let (server, _backend) = create_test_server().await;
+        seed_versioned_patient(&server, "hist-type-a").await;
+        seed_versioned_patient(&server, "hist-type-b").await;
+
+        let response = server
+            .get("/Patient/_history")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let bundle: Value = response.json();
+        assert_eq!(bundle["type"], "history");
+        let entries = bundle["entry"].as_array().expect("entry array");
+        // Two resources × three versions each.
+        assert!(
+            entries.len() >= 6,
+            "expected >= 6 entries, got {}",
+            entries.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_system_history_returns_bundle() {
+        let (server, _backend) = create_test_server().await;
+        seed_versioned_patient(&server, "hist-sys").await;
+
+        let response = server
+            .get("/_history")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let bundle: Value = response.json();
+        assert_eq!(bundle["resourceType"], "Bundle");
+        assert_eq!(bundle["type"], "history");
+        assert!(!bundle["entry"].as_array().expect("entry array").is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_vread_returns_specific_version() {
+        let (server, _backend) = create_test_server().await;
+        seed_versioned_patient(&server, "vread-test").await;
+
+        // Version 1 was the original ("V1"); version 3 is current ("V3").
+        let v1 = server
+            .get("/Patient/vread-test/_history/1")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        v1.assert_status_ok();
+        let v1_body: Value = v1.json();
+        assert_eq!(v1_body["resourceType"], "Patient");
+        assert_eq!(v1_body["id"], "vread-test");
+        assert_eq!(v1_body["name"][0]["family"], "V1");
+
+        let v3 = server
+            .get("/Patient/vread-test/_history/3")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        v3.assert_status_ok();
+        let v3_body: Value = v3.json();
+        assert_eq!(v3_body["name"][0]["family"], "V3");
+    }
+
+    #[tokio::test]
+    async fn test_vread_unknown_version_not_found() {
+        let (server, _backend) = create_test_server().await;
+        seed_versioned_patient(&server, "vread-missing").await;
+
+        let response = server
+            .get("/Patient/vread-missing/_history/999")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status(StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## Summary

The history **storage layer** was fully implemented (versioned `resource_history` table + `InstanceHistoryProvider`/`TypeHistoryProvider`/`SystemHistoryProvider` traits), but the REST **read** handlers returned `501 Not Implemented` even though the CapabilityStatement advertised the interactions. This PR wires them up so advertised capability matches runtime behavior.

## Changes

- **`handlers/history.rs`** — instance/type/system history handlers now call the providers and build `type: history` Bundles. Each entry carries `request` (method+url), `response` (status, weak ETag, `lastModified`), and the resource body for non-delete versions. Supports `_count` (capped at max page size) and `_since` (RFC3339; malformed → `400`). Instance history returns `404` only when the result is empty **and** unfiltered (an existing resource always has ≥1 version), so a `_since` that excludes everything still yields an empty Bundle.
- **`handlers/vread.rs`** — calls `VersionedStorage::vread`, mirrors the read handler response (ETag, `Content-Type` with `fhirVersion`), and `404`s an unknown version.
- **`composite/storage.rs`** — `CompositeStorage` only delegated up to `InstanceHistoryProvider`. Added a `DynSystemHistoryProvider` field, implemented `TypeHistoryProvider` + `SystemHistoryProvider` (delegating to the primary), and raised the `with_full_primary` bound so type/system history work on the `-elasticsearch` composite variants.
- **`lib.rs` + `routing/fhir_routes.rs`** — raised router/app-builder trait bounds to require `TypeHistoryProvider + SystemHistoryProvider`. All four base backends already implement these; `CompositeStorage` now does too.

## Endpoints now Live

| Endpoint | Method | Status |
|----------|--------|--------|
| `/{type}/{id}/_history` | GET | instance history Bundle (404 if resource never existed) |
| `/{type}/_history` | GET | type history Bundle |
| `/_history` | GET | system history Bundle |
| `/{type}/{id}/_history/{vid}` | GET | vread (404 if version unknown) |

(The R6 Trial Use `DELETE` history/version endpoints were already Live.)

## Testing

- Added `mod history_reads` to `rest_conformance.rs` (**8 tests**): instance/type/system history, `_count` limiting, malformed `_since` → 400, vread of specific versions, and not-found cases.
- Full `helios-rest` suite green (194 unit + all integration binaries); composite tests green (`--features R4`).
- Builds verified with default features **and** `--features postgres,elasticsearch,s3,mongodb`.
- `cargo fmt` + clippy (CI flags) clean.