### PR TITLE
feat(persistence): honor _sort and add :missing/:not on PostgreSQL; reconcile search matrix

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -315,6 +315,8 @@ let query_with_include = SearchQuery::new("Observation")
 
 The matrix below shows which FHIR operations each backend supports. This reflects the actual implementation status, not aspirational goals.
 
+For a capability-by-capability narrative of FHIR Search against the [spec](https://build.fhir.org/search.html) — including the REST-layer vs. backend boundary and a roadmap of known gaps — see [`docs/search-spec-assessment.md`](docs/search-spec-assessment.md).
+
 > **Note:** Documentation links reference [build.fhir.org](https://build.fhir.org), which contains the current FHIR development version. Some features marked as planned are new and may be labeled "Trial Use" in the specification.
 
 **Legend:** ✓ Implemented | ◐ Partial | ○ Planned | ✗ Not planned | † Requires external service
@@ -345,24 +347,24 @@ The matrix below shows which FHIR operations each backend supports. This reflect
 | [Number](https://build.fhir.org/search.html#number)                         | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ○   |
 | [Quantity](https://build.fhir.org/search.html#quantity)                     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ○   |
 | [URI](https://build.fhir.org/search.html#uri)                               | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
-| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ○          | ○       | ✗         | ○     | ✓             | ✗   |
+| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ○          | ○       | ✗         | ○     | ◐             | ✗   |
 | **[Search Modifiers](https://build.fhir.org/search.html#modifiers)**        |
-| [:exact](https://build.fhir.org/search.html#modifiers)                      | ✓      | ✓          | ○       | ○         | ○     | ✓             | ○   |
-| [:contains](https://build.fhir.org/search.html#modifiers)                   | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
+| [:exact](https://build.fhir.org/search.html#modifiers)                      | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
+| [:contains](https://build.fhir.org/search.html#modifiers)                   | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | [:text](https://build.fhir.org/search.html#modifiers) (full-text)           | ✓      | ◐          | ○       | ✗         | ✗     | ✓             | ✗   |
-| [:not](https://build.fhir.org/search.html#modifiers)                        | ✓      | ○          | ○       | ✗         | ○     | ✓             | ○   |
-| [:missing](https://build.fhir.org/search.html#modifiers)                    | ✓      | ○          | ○       | ✗         | ○     | ✓             | ○   |
-| [:above / :below](https://build.fhir.org/search.html#modifiers)             | ✗      | †○         | †○      | ✗         | ○     | ✓             | ✗   |
+| [:not](https://build.fhir.org/search.html#modifiers)                        | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ○   |
+| [:missing](https://build.fhir.org/search.html#modifiers)                    | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ○   |
+| [:above / :below](https://build.fhir.org/search.html#modifiers)             | ◐      | ◐          | †○      | ✗         | ○     | ◐             | ✗   |
 | [:in / :not-in](https://build.fhir.org/search.html#modifiers)               | ✗      | †○         | †○      | ✗         | ○     | †○            | ✗   |
 | [:of-type](https://build.fhir.org/search.html#modifiers)                    | ✓      | ○          | ○       | ✗         | ○     | ✓             | ✗   |
 | [:text-advanced](https://build.fhir.org/search.html#modifiertextadvanced)   | ✓      | †○         | †○      | ✗         | ✗     | ✓             | ✗   |
 | **[Special Parameters](https://build.fhir.org/search.html#all)**            |
-| [\_text](https://build.fhir.org/search.html#_text) (narrative search)       | ✓      | ◐          | ○       | ✗         | ✗     | ✓             | ✗   |
-| [\_content](https://build.fhir.org/search.html#_content) (full content)     | ✓      | ◐          | ○       | ✗         | ✗     | ✓             | ✗   |
+| [\_text](https://build.fhir.org/search.html#_text) (narrative search)       | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ✗   |
+| [\_content](https://build.fhir.org/search.html#_content) (full content)     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ✗   |
 | [\_filter](https://build.fhir.org/search.html#_filter) (advanced filtering) | ✓      | ○          | ○       | ✗         | ○     | ○             | ✗   |
 | **Advanced Search**                                                         |
-| [Chained Parameters](https://build.fhir.org/search.html#chaining)           | ✓      | ◐          | ○       | ✗         | ○     | ✗             | ✗   |
-| [Reverse Chaining (\_has)](https://build.fhir.org/search.html#has)          | ✓      | ◐          | ○       | ✗         | ○     | ✗             | ✗   |
+| [Chained Parameters](https://build.fhir.org/search.html#chaining)           | ✓      | ✓          | ○       | ✗         | ○     | ✗             | ✗   |
+| [Reverse Chaining (\_has)](https://build.fhir.org/search.html#has)          | ✓      | ✓          | ○       | ✗         | ○     | ✗             | ✗   |
 | [\_include](https://build.fhir.org/search.html#include)                     | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | [\_revinclude](https://build.fhir.org/search.html#revinclude)               | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | **[Pagination](https://build.fhir.org/http.html#paging)**                   |
@@ -370,10 +372,26 @@ The matrix below shows which FHIR operations each backend supports. This reflect
 | Cursor (keyset)                                                             | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
 | **[Sorting](https://build.fhir.org/search.html#sort)**                      |
 | Single field                                                                | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
-| Multiple fields                                                             | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
+| Multiple fields                                                             | ✓      | ✓          | ◐       | ✗         | ○     | ✓             | ✗   |
 | **[Bulk Operations](https://hl7.org/fhir/uv/bulkdata/)**                    |
 | [Bulk Export](https://hl7.org/fhir/uv/bulkdata/export.html)                 | ✓      | ✓          | ○       | ○         | ○     | ○             | ◐   |
 | [Bulk Submit](https://hackmd.io/@argonaut/rJoqHZrPle)                       | ✓      | ✓          | ○       | ○         | ○     | ○             | ✓   |
+
+**Notes on partial cells:**
+
+- **Sorting** — "Single/Multiple field" covers `_id` and `_lastUpdated` only on every
+  backend; sorting by an arbitrary search parameter is not yet implemented (it would require a
+  join against the search index). Sort is applied on the first-page and offset paths; cursor
+  (keyset) pages always use the default `_lastUpdated` ordering. MongoDB cannot combine a custom
+  sort with cursor pagination, hence ◐ for multiple fields.
+- **`:above` / `:below`** — SQLite, PostgreSQL, and Elasticsearch implement hierarchical URI
+  prefix matching (no external service needed), shown as ◐. Token/code hierarchy expansion
+  (which needs a terminology server) is not implemented natively.
+- **`:in` / `:not-in`** — handled at the REST layer: `:in` is expanded against a terminology
+  server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
+  backend resolves these natively.
+- **Elasticsearch Composite** — matches on the composite parameter name only; individual
+  component values are not yet evaluated, hence ◐.
 
 The S3 backend is intentionally storage-focused (CRUD/version/history/bulk submit) and does not act as a full FHIR search engine. For bulk export, S3 can feed system-level batches through `ExportDataProvider` and can store output files through `S3OutputStore`, but job state belongs to SQLite or PostgreSQL. Patient-level and Group-level export compartment enumeration are not supported by S3 as the resource store. For query-heavy deployments, use a DB/search backend as primary query engine and compose S3 as archive/history/output storage.
 
@@ -537,10 +555,12 @@ MongoDB provides document-centric primary storage with full FHIR capabilities in
 - Full CRUD operations with document-native resource storage
 - Versioning and history providers (`vread`, instance/type/system history)
 - Transaction bundles with urn:uuid reference resolution (requires replica set)
-- Native search (string, token, reference, date, number, URI parameters)
+- Native search (string, token, reference, date, number, URI parameters; quantity and composite
+  parameters, chained/`_has`, `_text`/`_content`, and most modifiers are not yet supported)
 - `_include` and `_revinclude` resolution
 - Conditional create, update, and delete operations
-- Cursor and offset pagination with multi-field sorting
+- Cursor and offset pagination; sorting by `_id`/`_lastUpdated` (a custom sort cannot be combined
+  with cursor pagination)
 - Shared-schema multitenancy with strict tenant filtering
 - Optimistic locking with ETag support
 
@@ -1089,7 +1109,8 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
 - [x] Index schema and mappings (nested objects for multi-value search params)
 - [x] ResourceStorage implementation for composite sync support
 - [x] Search query translation (FHIR SearchQuery → ES Query DSL)
-- [x] All 8 parameter type handlers (string, token, date, number, quantity, reference, URI, composite)
+- [x] Parameter type handlers (string, token, date, number, quantity, reference, URI; composite
+      matches on the parameter name only — component values are not yet evaluated)
 - [x] Full-text search (`_text`, `_content`, `:text-advanced`)
 - [x] Modifier support (:exact, :contains, :text, :not, :missing, :above, :below, :of-type)
 - [x] `_include` and `_revinclude` resolution
@@ -1106,9 +1127,13 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
 - [x] History providers (instance, type, system)
 - [x] TransactionProvider with configurable isolation levels
 - [x] Conditional operations (conditional create/update/delete)
-- [x] SearchProvider with all parameter types
+- [x] SearchProvider with all parameter types except composite (string, token, reference, date,
+      number, quantity, URI; supports `:exact`/`:contains`/`:not`/`:missing` and URI
+      `:above`/`:below`; composite and the `:of-type`/`:text-advanced` modifiers are not yet
+      implemented)
 - [x] ChainedSearchProvider and reverse chaining (\_has)
 - [x] Full-text search (tsvector/tsquery)
+- [x] `_sort` by `_id`/`_lastUpdated` (first-page and offset paths)
 - [x] `_include` and `_revinclude` resolution
 - [x] BulkExportStorage and BulkSubmitProvider
 - [x] Search offloading support

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -1,0 +1,166 @@
+# FHIR Search — Implementation Assessment
+
+This document assesses the Helios FHIR Server (HFS) implementation of FHIR Search against the
+[FHIR R4+ Search specification](https://build.fhir.org/search.html). It is the narrative companion
+to the **Backend Capability Matrix** in [`../README.md`](../README.md): the matrix gives the
+per-backend ✓/◐/○/✗ grid; this document explains *what* each capability means, *where* it is
+implemented (REST layer vs. persistence backend), and *what is missing*.
+
+Last reconciled against the code: see git history of this file. Evidence is cited as
+`crate/path:line` where useful.
+
+## How a search request flows
+
+```
+HTTP request
+  → helios-rest: parse query string → build SearchQuery        (crates/rest/src/extractors/)
+  → helios-rest: terminology pre-processing (:in expansion)     (crates/rest/src/handlers/search.rs)
+  → helios-persistence: SearchProvider::search(tenant, query)   (per-backend search_impl.rs)
+  → helios-rest: post-process (_summary / _elements subsetting) (crates/rest/src/responses/subsetting.rs)
+  → Bundle with self / next / previous links
+```
+
+The REST layer is **version-agnostic and backend-agnostic**: it parses essentially the full search
+grammar into a `SearchQuery` (`crates/persistence/src/types/search_params.rs`). What actually
+executes depends on the configured backend. Most gaps are therefore in the backends, not in REST.
+
+Supported backends for search: **SQLite** (reference implementation), **PostgreSQL**, **MongoDB**
+(partial native), **Elasticsearch** (search-optimized secondary). **S3** is storage-only and
+returns `UnsupportedCapability` for all search operations (`backends/s3/storage.rs`). Cassandra and
+Neo4j are not implemented.
+
+## 1. Search parameter types
+
+| Type | SQLite | PostgreSQL | MongoDB | Elasticsearch | Notes |
+|------|:------:|:----------:|:-------:|:-------------:|-------|
+| string | ✓ | ✓ | ✓ | ✓ | prefix (default), `:exact`, `:contains` |
+| token | ✓ | ✓ | ✓ | ✓ | `system\|code`, `\|code`, `system\|`, code-only |
+| reference | ✓ | ✓ | ✓ | ✓ | type modifier + `:identifier` (SQLite/ES) |
+| date | ✓ | ✓ | ✓ | ✓ | precision-aware ranges + all prefixes |
+| number | ✓ | ✓ | ✓ | ✓ | implicit-precision ranges + all prefixes |
+| quantity | ✓ | ✓ | ✗ | ✓ | MongoDB rejects with `UnsupportedParameterType` |
+| uri | ✓ | ✓ | ✓ | ✓ | exact + `:above`/`:below` prefix matching |
+| composite | ✓ | ✗ | ✗ | ◐ | PG/Mongo return no condition; ES matches name only |
+
+The `resource` and `special` parameter types from the spec are modeled in the `SearchParamType`
+enum but have no dedicated execution path beyond the special common parameters below.
+
+## 2. Search modifiers
+
+| Modifier | SQLite | PostgreSQL | MongoDB | Elasticsearch |
+|----------|:------:|:----------:|:-------:|:-------------:|
+| `:missing` | ✓ | ✓ | ✗ | ✓ |
+| `:exact` | ✓ | ✓ | ✓ | ✓ |
+| `:contains` | ✓ | ✓ | ✓ | ✓ |
+| `:text` | ✓ | ◐¹ | ✗ | ✓ |
+| `:not` | ✓ | ✓ | ✗ | ✓ |
+| `:of-type` | ✓ | ✗ | ✗ | ✓ |
+| `:text-advanced` | ✓ | ✗ | ✗ | ✓ |
+| `:above` / `:below` (URI) | ✓ | ✓ | ✗ | ✓ |
+| `:above` / `:below` (token hierarchy) | ✗ | ✗ | ✗ | ✗ |
+| `:in` / `:not-in` | †² | †² | †² | †² |
+| `:identifier` (reference) | ✓ | ✗ | ✗ | ✓ |
+| `:[type]` (reference) | ✓ | ✗ | ✓ | ✓ |
+| `:code-text` | ✗ | ✗ | ✗ | ✗ |
+
+¹ PostgreSQL implements `_text`/`_content` full-text search via `tsvector`, but the token `:text`
+  modifier itself is not wired up.
+² `:in` is expanded by the REST layer against a configured terminology server before the query
+  reaches the backend (`crates/rest/src/handlers/search.rs`); `:not-in` returns `501 Not
+  Implemented`. No backend resolves either modifier natively.
+
+The REST layer parses **all** of these modifiers (`crates/rest/src/extractors/search_query_builder.rs`)
+regardless of backend; unsupported ones either no-op, error, or (for some ES/Mongo cases) return no
+matches. MongoDB fails closed with an explicit error on unsupported modifiers; Elasticsearch tends
+to silently match nothing — see Known Limitations.
+
+## 3. Comparator prefixes
+
+All nine prefixes (`eq`, `ne`, `gt`, `lt`, `ge`, `le`, `sa`, `eb`, `ap`) are parsed by REST and
+honored by the date / number / quantity handlers on SQLite, PostgreSQL, MongoDB, and Elasticsearch.
+Prefixes are only extracted for ordered types; a token value such as `appended` is preserved
+verbatim and not misread as the `ap` prefix (regression-tested in the REST extractor).
+
+## 4. Special / common parameters
+
+| Parameter | Where handled | SQLite | PostgreSQL | MongoDB | Elasticsearch |
+|-----------|---------------|:------:|:----------:|:-------:|:-------------:|
+| `_id` | backend | ✓ | ✓ | ✓ | ✓ |
+| `_lastUpdated` | backend | ✓ | ✓ | ✓ | ✓ |
+| `_tag` / `_profile` / `_security` / `_source` | backend (token/uri) | ✓ | ✓ | ✓ | ✓ |
+| `_text` (narrative) | backend FTS | ✓ | ✓ | ✗ | ✓ |
+| `_content` (full content) | backend FTS | ✓ | ✓ | ✗ | ✓ |
+| `_filter` | backend | ✓ | ✗ | ✗ | ✗ |
+| `_has` (reverse chaining) | REST + backend | ✓ | ✓ | ✗ | ✗ |
+| `_type` (system search) | REST | ✓ | ✓ | ✓ | ✓ |
+| `_list` | passthrough param | ○ | ○ | ○ | ○ |
+| `_query` | — | ✗ | ✗ | ✗ | ✗ |
+| `_contained` / `_containedType` | stripped by REST | ✗ | ✗ | ✗ | ✗ |
+
+`_filter` is parsed and executed only by the SQLite backend (full expression parser in
+`backends/sqlite/search/filter_parser.rs`). Note the REST layer does not give `_filter` special
+handling; SQLite picks it up as a recognized parameter name. On other backends `_filter` is
+effectively a no-op.
+
+## 5. Chaining, reverse chaining, include/revinclude
+
+| Capability | SQLite | PostgreSQL | MongoDB | Elasticsearch |
+|------------|:------:|:----------:|:-------:|:-------------:|
+| Forward chained params (N-level) | ✓ | ✓ | ✗ | ✗ |
+| Reverse chaining (`_has`, nested) | ✓ | ✓ | ✗ | ✗ |
+| `_include` | ✓ | ✓ | ✓ | ✓ |
+| `_revinclude` | ✓ | ✓ | ✓ | ✓ |
+| `:iterate` on include | parsed | parsed | parsed | parsed |
+
+SQLite and PostgreSQL resolve chains via nested `search_index` subqueries with configurable depth
+limits. MongoDB returns `ChainedSearchNotSupported` / `ReverseChainNotSupported`; Elasticsearch
+silently returns no matches when `param.chain` or `reverse_chains` are present.
+
+## 6. Result control (paging, sort, total, summary, elements)
+
+These are parsed and largely orchestrated by the REST layer.
+
+| Parameter | Status | Notes |
+|-----------|--------|-------|
+| `_count` | ✓ | page size; `_offset`/`_cursor` for paging |
+| `_sort` | ◐ | applied for `_id`/`_lastUpdated` only; see below |
+| `_total` | ✓ | `none` / `estimate` / `accurate` parsed and applied |
+| `_summary` | ✓ | `true`/`text`/`data`/`count`/`false`, applied in `subsetting.rs` |
+| `_elements` | ✓ | applied post-search with nested-path support |
+| `_include` / `_revinclude` | ✓ | see §5 |
+| `_maxresults` | ✗ | not handled |
+| `_score` | ✗ | bundle field exists but is never populated |
+| Bundle `self` link | ✓ | echoes executed params |
+| `next` / `previous` links | ✓ | cursor-based |
+| `first` / `last` links | ✗ | not generated |
+
+**`_sort` detail.** `_sort` is parsed into `SearchQuery.sort` for every backend. The backends map
+sort fields to columns via a small allow-list — `_id` → `id`, `_lastUpdated` → `last_updated` —
+and fall back to `id` for anything else. So sorting by an arbitrary search parameter (e.g.
+`_sort=birthdate`) currently degrades to a stable-but-not-meaningful `id` ordering on all backends.
+Sort is applied on the first-page and offset query paths; cursor (keyset) pages always use the
+default `_lastUpdated, id` ordering because the keyset `WHERE` comparison depends on it. MongoDB
+additionally cannot combine a custom sort with cursor pagination.
+
+## 7. Known limitations & roadmap
+
+Ordered roughly by impact:
+
+1. **Sort by arbitrary search parameter** — unsupported on all backends (only `_id`/`_lastUpdated`).
+   Would require sorting on `search_index` values via a join. Cursor pages ignore custom sort.
+2. **Terminology-dependent modifiers** — token `:above`/`:below`, `:in`, `:not-in` need a
+   terminology server. `:in` is partially handled via REST-side expansion; the rest are not native.
+   URI `:above`/`:below` (hierarchical prefix, no service needed) *is* implemented on SQLite/PG/ES.
+3. **PostgreSQL modifier/param gaps** — composite parameters and the `:of-type` and
+   `:text-advanced` modifiers are not implemented (`:not` and `:missing` are now supported; SQLite
+   implements all of these).
+4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
+   chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
+5. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
+   forward chaining and `_has` silently return nothing rather than erroring; `_filter` unsupported.
+6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
+   unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
+   unsupported everywhere.
+
+SQLite is the most complete backend and serves as the reference for the others; closing the
+PostgreSQL gaps (composite, `:not`/`:missing`) to reach SQLite parity is the most direct next step.

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -109,6 +109,62 @@ impl PostgresQueryBuilder {
         Some(combined)
     }
 
+    /// Builds an `ORDER BY` clause from the query's `_sort` directives.
+    ///
+    /// Mirrors the SQLite backend's ordering semantics so the two backends stay
+    /// at parity. Multiple directives (e.g. `_sort=_lastUpdated,-_id`) are
+    /// honored in order, with an `id ASC` tie-breaker appended for stable
+    /// pagination when `_id` is not already part of the sort.
+    ///
+    /// # Supported sort parameters
+    ///
+    /// - `_id` → `id`
+    /// - `_lastUpdated` → `last_updated`
+    ///
+    /// Any other parameter currently falls back to `id`. Sorting by arbitrary
+    /// search parameters would require an additional join against `search_index`
+    /// and is not yet implemented (see the search spec assessment).
+    ///
+    /// Note: this is applied to the first-page and offset paths only. The
+    /// cursor (keyset) paths keep their `(last_updated, id)` ordering, which is
+    /// required by the keyset `WHERE` comparison; cursor pages therefore always
+    /// use the default ordering.
+    pub fn build_order_by(query: &SearchQuery) -> String {
+        if query.sort.is_empty() {
+            return "ORDER BY last_updated DESC, id ASC".to_string();
+        }
+
+        let mut clauses: Vec<String> = query
+            .sort
+            .iter()
+            .map(|s| {
+                let dir = match s.direction {
+                    crate::types::SortDirection::Ascending => "ASC",
+                    crate::types::SortDirection::Descending => "DESC",
+                };
+                format!("{} {}", Self::sort_column(&s.parameter), dir)
+            })
+            .collect();
+
+        let sorts_by_id = query.sort.iter().any(|s| s.parameter == "_id");
+        if !sorts_by_id {
+            clauses.push("id ASC".to_string());
+        }
+
+        format!("ORDER BY {}", clauses.join(", "))
+    }
+
+    /// Maps a FHIR sort parameter name to a `resources` table column.
+    fn sort_column(parameter: &str) -> &'static str {
+        match parameter {
+            "_id" => "id",
+            "_lastUpdated" => "last_updated",
+            // Arbitrary search parameters are not yet sortable; fall back to a
+            // stable column.
+            _ => "id",
+        }
+    }
+
     /// Builds a condition for a single search parameter.
     fn build_parameter_condition(
         param: &SearchParameter,
@@ -116,6 +172,12 @@ impl PostgresQueryBuilder {
     ) -> Option<SqlFragment> {
         if param.values.is_empty() {
             return None;
+        }
+
+        // The `:missing` modifier is type-agnostic and resolved purely from the
+        // presence/absence of a search_index entry for the parameter.
+        if let Some(SearchModifier::Missing) = param.modifier {
+            return Some(Self::build_missing_condition(param));
         }
 
         // Handle special parameters
@@ -178,6 +240,30 @@ impl PostgresQueryBuilder {
             combined = combined.and(cond);
         }
         Some(combined)
+    }
+
+    /// Builds an `id IN/NOT IN` condition for the `:missing` modifier.
+    ///
+    /// `param:missing=true` matches resources with **no** `search_index` entry
+    /// for the parameter; `:missing=false` matches resources that **have** one.
+    /// Uses only the always-present `$1`/`$2` (tenant, resource type) bind
+    /// params, so it adds no parameters to the surrounding query.
+    fn build_missing_condition(param: &SearchParameter) -> SqlFragment {
+        let is_missing = param
+            .values
+            .first()
+            .map(|v| v.value == "true")
+            .unwrap_or(false);
+        let inner = format!(
+            "SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}'",
+            param.name
+        );
+        let sql = if is_missing {
+            format!("id NOT IN ({})", inner)
+        } else {
+            format!("id IN ({})", inner)
+        };
+        SqlFragment::new(sql)
     }
 
     fn build_string_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
@@ -284,6 +370,15 @@ impl PostgresQueryBuilder {
         for cond in conditions {
             combined = combined.or(cond);
         }
+
+        // `:not` reverses the match: include resources that have no matching
+        // value (including those with no value at all). Negating the whole
+        // OR-set gives `NOT (id IN (...) OR id IN (...))`.
+        if let Some(SearchModifier::Not) = param.modifier {
+            let sql = format!("NOT ({})", combined.sql);
+            combined = SqlFragment::with_params(sql, combined.params);
+        }
+
         Some(combined)
     }
 

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -68,6 +68,17 @@ impl SearchProvider for PostgresBackend {
             None
         };
 
+        // ORDER BY derived from `_sort` (first-page and offset paths only).
+        // When no `_sort` is supplied we keep the original default ordering
+        // (`id DESC` tie-break) so cursor "next" paging stays consistent. The
+        // cursor/keyset paths always keep their `(last_updated, id)` ordering,
+        // which the keyset WHERE comparison depends on.
+        let order_by = if query.sort.is_empty() {
+            "ORDER BY last_updated DESC, id DESC".to_string()
+        } else {
+            PostgresQueryBuilder::build_order_by(query)
+        };
+
         // Build query based on pagination mode
         let (sql, has_previous, search_params) = if let Some(ref cursor) = cursor {
             match cursor.direction() {
@@ -135,9 +146,10 @@ impl SearchProvider for PostgresBackend {
                     "SELECT id, version_id, data, last_updated, fhir_version FROM resources
                      WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
                      AND ({})
-                     ORDER BY last_updated DESC, id DESC
+                     {}
                      LIMIT {} OFFSET {}",
                     filter.sql,
+                    order_by,
                     count + 1,
                     offset
                 )
@@ -145,8 +157,9 @@ impl SearchProvider for PostgresBackend {
                 format!(
                     "SELECT id, version_id, data, last_updated, fhir_version FROM resources
                      WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     ORDER BY last_updated DESC, id DESC
+                     {}
                      LIMIT {} OFFSET {}",
+                    order_by,
                     count + 1,
                     offset
                 )
@@ -163,17 +176,19 @@ impl SearchProvider for PostgresBackend {
                     "SELECT id, version_id, data, last_updated, fhir_version FROM resources
                      WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
                      AND ({})
-                     ORDER BY last_updated DESC, id DESC
+                     {}
                      LIMIT {}",
                     filter.sql,
+                    order_by,
                     count + 1
                 )
             } else {
                 format!(
                     "SELECT id, version_id, data, last_updated, fhir_version FROM resources
                      WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     ORDER BY last_updated DESC, id DESC
+                     {}
                      LIMIT {}",
+                    order_by,
                     count + 1
                 )
             };

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -77,6 +77,17 @@ impl SearchProvider for SqliteBackend {
             None
         };
 
+        // ORDER BY derived from `_sort` (first-page and offset paths only).
+        // When no `_sort` is supplied we keep the original default ordering
+        // (`id DESC` tie-break) so cursor "next" paging stays consistent. The
+        // cursor/keyset paths always keep their `(last_updated, id)` ordering,
+        // which the keyset WHERE comparison depends on.
+        let order_by = if query.sort.is_empty() {
+            "ORDER BY last_updated DESC, id DESC".to_string()
+        } else {
+            QueryBuilder::new(tenant_id, resource_type).build_order_by(query)
+        };
+
         // Build query based on pagination mode
         let (sql, has_previous, search_params) = if let Some(ref cursor) = cursor {
             // Cursor-based pagination using keyset
@@ -145,9 +156,10 @@ impl SearchProvider for SqliteBackend {
                     "SELECT id, version_id, data, last_updated, fhir_version FROM resources
                      WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
                      AND id IN ({})
-                     ORDER BY last_updated DESC, id DESC
+                     {}
                      LIMIT {} OFFSET {}",
                     filter.sql,
+                    order_by,
                     count + 1,
                     offset
                 )
@@ -155,8 +167,9 @@ impl SearchProvider for SqliteBackend {
                 format!(
                     "SELECT id, version_id, data, last_updated, fhir_version FROM resources
                      WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     ORDER BY last_updated DESC, id DESC
+                     {}
                      LIMIT {} OFFSET {}",
+                    order_by,
                     count + 1,
                     offset
                 )
@@ -173,17 +186,19 @@ impl SearchProvider for SqliteBackend {
                     "SELECT id, version_id, data, last_updated, fhir_version FROM resources
                      WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
                      AND id IN ({})
-                     ORDER BY last_updated DESC, id DESC
+                     {}
                      LIMIT {}",
                     filter.sql,
+                    order_by,
                     count + 1
                 )
             } else {
                 format!(
                     "SELECT id, version_id, data, last_updated, fhir_version FROM resources
                      WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     ORDER BY last_updated DESC, id DESC
+                     {}
                      LIMIT {}",
+                    order_by,
                     count + 1
                 )
             };

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -1189,6 +1189,172 @@ mod postgres_integration {
         );
     }
 
+    #[tokio::test]
+    async fn postgres_integration_search_sort_by_id() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{SearchQuery, SortDirective};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        // Create in non-sorted insertion order to prove ORDER BY is applied.
+        for id in ["p3", "p1", "p2"] {
+            let patient = json!({ "resourceType": "Patient", "id": id });
+            backend
+                .create(&tenant, "Patient", patient, FhirVersion::default())
+                .await
+                .unwrap();
+        }
+
+        // Ascending _sort=_id
+        let asc = SearchQuery::new("Patient").with_sort(SortDirective::parse("_id"));
+        let result = backend.search(&tenant, &asc).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["p1", "p2", "p3"],
+            "_sort=_id should return ascending id order"
+        );
+
+        // Descending _sort=-_id
+        let desc = SearchQuery::new("Patient").with_sort(SortDirective::parse("-_id"));
+        let result = backend.search(&tenant, &desc).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["p3", "p2", "p1"],
+            "_sort=-_id should return descending id order"
+        );
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_search_missing_modifier() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": "with-gender", "gender": "male" }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": "no-gender" }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        let missing = |present: &str| {
+            SearchQuery::new("Patient").with_parameter(SearchParameter {
+                name: "gender".to_string(),
+                param_type: SearchParamType::Token,
+                modifier: Some(SearchModifier::Missing),
+                values: vec![SearchValue::eq(present)],
+                chain: vec![],
+                components: vec![],
+            })
+        };
+
+        let result = backend.search(&tenant, &missing("true")).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        assert_eq!(ids, vec!["no-gender"], "gender:missing=true → no-gender");
+
+        let result = backend.search(&tenant, &missing("false")).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["with-gender"],
+            "gender:missing=false → with-gender"
+        );
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_search_not_modifier() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        for (id, gender) in [("male1", Some("male")), ("female1", Some("female"))] {
+            let mut patient = json!({ "resourceType": "Patient", "id": id });
+            if let Some(g) = gender {
+                patient["gender"] = json!(g);
+            }
+            backend
+                .create(&tenant, "Patient", patient, FhirVersion::default())
+                .await
+                .unwrap();
+        }
+        // A patient with no gender at all should also be returned by :not.
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": "none1" }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "gender".to_string(),
+            param_type: SearchParamType::Token,
+            modifier: Some(SearchModifier::Not),
+            values: vec![SearchValue::eq("male")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = backend.search(&tenant, &query).await.unwrap();
+        let mut ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["female1", "none1"],
+            "gender:not=male → non-male incl. resources with no gender"
+        );
+    }
+
     // ========================================================================
     // Backend Health Check Tests
     // ========================================================================


### PR DESCRIPTION
## Context

Audited HFS FHIR Search against the [spec](https://build.fhir.org/search.html). The Backend Capability Matrix in `crates/persistence/README.md` was stale in **both** directions, and one discrepancy was a real functional bug: PostgreSQL claimed full `_sort` support but ignored `query.sort` and hardcoded `ORDER BY last_updated DESC, id DESC`.

## Changes

### Code
- **PostgreSQL `_sort`** — added `PostgresQueryBuilder::build_order_by` and wired it into the first-page and offset search paths. SQLite had the same latent bug (its `build_order_by` was only exercised by unit tests), so it's wired in there too for parity. The no-`_sort` default ordering is byte-identical to before — **no pagination regression**; cursor/keyset pages keep the default ordering (a pre-existing constraint, now documented).
- **PostgreSQL `:missing` / `:not`** — `:missing` resolves from presence/absence of a `search_index` entry; `:not` (token) negates the match and correctly includes resources with no value. Mirrors SQLite.

### Docs
- Reconciled the capability matrix with code evidence — downgraded overstated cells (ES composite ◐, ES/SQLite/PG `:above`/`:below` ◐ for URI-only, Mongo multi-field sort ◐) and upgraded understated ones (PG chained/`_has`/`_text`/`_content` ✓, Mongo `:exact`/`:contains` ✓, PG `:not`/`:missing` ✓). Added clarifying notes and fixed contradicting prose.
- New `crates/persistence/docs/search-spec-assessment.md`: capability-by-capability assessment vs. the spec, the REST/backend boundary, and a roadmap of remaining gaps.

## Tests
New PostgreSQL integration tests: `_sort` (asc/desc), `:missing` (true/false), `:not` (incl. resources with no value). Full PG search suite + SQLite suite pass; `clippy -D warnings` clean.

## Remaining gaps (documented, not in this PR)
Sort by arbitrary search parameter (all backends), PG composite + `:of-type`/`:text-advanced`, ES real composite components + chaining, MongoDB native search gaps, and minor REST result params (`_maxresults`, `_score`, `first`/`last` links).