### PR TITLE
feat(persistence): PostgreSQL composite params + :of-type modifier

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -347,7 +347,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [Number](https://build.fhir.org/search.html#number)                         | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ○   |
 | [Quantity](https://build.fhir.org/search.html#quantity)                     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ○   |
 | [URI](https://build.fhir.org/search.html#uri)                               | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
-| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ○          | ○       | ✗         | ○     | ◐             | ✗   |
+| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ✓          | ○       | ✗         | ○     | ◐             | ✗   |
 | **[Search Modifiers](https://build.fhir.org/search.html#modifiers)**        |
 | [:exact](https://build.fhir.org/search.html#modifiers)                      | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
 | [:contains](https://build.fhir.org/search.html#modifiers)                   | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
@@ -356,7 +356,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [:missing](https://build.fhir.org/search.html#modifiers)                    | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ○   |
 | [:above / :below](https://build.fhir.org/search.html#modifiers)             | ◐      | ◐          | †○      | ✗         | ○     | ◐             | ✗   |
 | [:in / :not-in](https://build.fhir.org/search.html#modifiers)               | ✗      | †○         | †○      | ✗         | ○     | †○            | ✗   |
-| [:of-type](https://build.fhir.org/search.html#modifiers)                    | ✓      | ○          | ○       | ✗         | ○     | ✓             | ✗   |
+| [:of-type](https://build.fhir.org/search.html#modifiers)                    | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
 | [:text-advanced](https://build.fhir.org/search.html#modifiertextadvanced)   | ✓      | †○         | †○      | ✗         | ✗     | ✓             | ✗   |
 | **[Special Parameters](https://build.fhir.org/search.html#all)**            |
 | [\_text](https://build.fhir.org/search.html#_text) (narrative search)       | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ✗   |
@@ -390,8 +390,11 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 - **`:in` / `:not-in`** — handled at the REST layer: `:in` is expanded against a terminology
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.
-- **Elasticsearch Composite** — matches on the composite parameter name only; individual
-  component values are not yet evaluated, hence ◐.
+- **Composite** — SQLite and PostgreSQL evaluate composite component values (token, string,
+  number, quantity, date) at the backend level (✓); Elasticsearch matches on the composite
+  parameter name only (◐). Note: the REST layer does not yet populate composite component
+  definitions from the registry, so composite search is currently reachable via the direct
+  backend API rather than over HTTP. See `docs/search-spec-assessment.md`.
 
 The S3 backend is intentionally storage-focused (CRUD/version/history/bulk submit) and does not act as a full FHIR search engine. For bulk export, S3 can feed system-level batches through `ExportDataProvider` and can store output files through `S3OutputStore`, but job state belongs to SQLite or PostgreSQL. Patient-level and Group-level export compartment enumeration are not supported by S3 as the resource store. For query-heavy deployments, use a DB/search backend as primary query engine and compose S3 as archive/history/output storage.
 
@@ -1127,10 +1130,10 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
 - [x] History providers (instance, type, system)
 - [x] TransactionProvider with configurable isolation levels
 - [x] Conditional operations (conditional create/update/delete)
-- [x] SearchProvider with all parameter types except composite (string, token, reference, date,
-      number, quantity, URI; supports `:exact`/`:contains`/`:not`/`:missing` and URI
-      `:above`/`:below`; composite and the `:of-type`/`:text-advanced` modifiers are not yet
-      implemented)
+- [x] SearchProvider with all parameter types including composite (string, token, reference, date,
+      number, quantity, URI, composite; supports `:exact`/`:contains`/`:not`/`:missing`/`:of-type`
+      and URI `:above`/`:below`; the `:text-advanced` modifier is not yet implemented). Composite
+      component definitions are not yet wired through the REST layer.
 - [x] ChainedSearchProvider and reverse chaining (\_has)
 - [x] Full-text search (tsvector/tsquery)
 - [x] `_sort` by `_id`/`_lastUpdated` (first-page and offset paths)

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -40,10 +40,18 @@ Neo4j are not implemented.
 | number | ✓ | ✓ | ✓ | ✓ | implicit-precision ranges + all prefixes |
 | quantity | ✓ | ✓ | ✗ | ✓ | MongoDB rejects with `UnsupportedParameterType` |
 | uri | ✓ | ✓ | ✓ | ✓ | exact + `:above`/`:below` prefix matching |
-| composite | ✓ | ✗ | ✗ | ◐ | PG/Mongo return no condition; ES matches name only |
+| composite | ✓ | ✓ | ✗ | ◐ | SQLite/PG evaluate components; ES matches name only; Mongo returns no condition |
 
 The `resource` and `special` parameter types from the spec are modeled in the `SearchParamType`
 enum but have no dedicated execution path beyond the special common parameters below.
+
+**Composite caveat (all backends):** the SQLite and PostgreSQL composite handlers evaluate each
+component (token/string/number/quantity/date) against the columns of a single `search_index` row.
+However, the REST layer builds the outgoing `SearchParameter` with empty `components`
+(`crates/rest/src/extractors/search_query_builder.rs`), so composite search is currently exercised
+through the direct backend API (with components supplied), not over HTTP. Wiring component
+definitions from the registry into the REST query builder is a prerequisite for end-to-end
+composite search on any backend.
 
 ## 2. Search modifiers
 
@@ -54,7 +62,7 @@ enum but have no dedicated execution path beyond the special common parameters b
 | `:contains` | ✓ | ✓ | ✓ | ✓ |
 | `:text` | ✓ | ◐¹ | ✗ | ✓ |
 | `:not` | ✓ | ✓ | ✗ | ✓ |
-| `:of-type` | ✓ | ✗ | ✗ | ✓ |
+| `:of-type` | ✓ | ✓ | ✗ | ✓ |
 | `:text-advanced` | ✓ | ✗ | ✗ | ✓ |
 | `:above` / `:below` (URI) | ✓ | ✓ | ✗ | ✓ |
 | `:above` / `:below` (token hierarchy) | ✗ | ✗ | ✗ | ✗ |
@@ -151,16 +159,19 @@ Ordered roughly by impact:
 2. **Terminology-dependent modifiers** — token `:above`/`:below`, `:in`, `:not-in` need a
    terminology server. `:in` is partially handled via REST-side expansion; the rest are not native.
    URI `:above`/`:below` (hierarchical prefix, no service needed) *is* implemented on SQLite/PG/ES.
-3. **PostgreSQL modifier/param gaps** — composite parameters and the `:of-type` and
-   `:text-advanced` modifiers are not implemented (`:not` and `:missing` are now supported; SQLite
-   implements all of these).
-4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
+3. **PostgreSQL modifier gaps** — only the `:text-advanced` modifier remains unimplemented relative
+   to SQLite (`:exact`, `:contains`, `:not`, `:missing`, `:of-type`, URI `:above`/`:below`, and
+   composite parameters are all supported at the backend level now).
+4. **Composite REST wiring** — composite search works at the backend level (SQLite, PostgreSQL) but
+   the REST layer does not yet populate composite component definitions, so it is not reachable over
+   HTTP on any backend. See the composite caveat in §1.
+5. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
    chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
-5. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
+6. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
    forward chaining and `_has` silently return nothing rather than erroring; `_filter` unsupported.
-6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
+7. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
    unsupported everywhere.
 
-SQLite is the most complete backend and serves as the reference for the others; closing the
-PostgreSQL gaps (composite, `:not`/`:missing`) to reach SQLite parity is the most direct next step.
+SQLite is the most complete backend and serves as the reference for the others; PostgreSQL is now
+at near-parity (only `:text-advanced` and REST-side composite wiring remain).

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -198,7 +198,7 @@ impl PostgresQueryBuilder {
             SearchParamType::Quantity => Self::build_quantity_condition(param, param_offset),
             SearchParamType::Reference => Self::build_reference_condition(param, param_offset),
             SearchParamType::Uri => Self::build_uri_condition(param, param_offset),
-            SearchParamType::Composite => None,
+            SearchParamType::Composite => Self::build_composite_condition(param, param_offset),
             SearchParamType::Special => None,
         }
     }
@@ -312,6 +312,12 @@ impl PostgresQueryBuilder {
     }
 
     fn build_token_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
+        // `:of-type` matches an Identifier by its type (system|code) and value,
+        // in the three-part form `type-system|type-code|identifier-value`.
+        if let Some(SearchModifier::OfType) = param.modifier {
+            return Self::build_of_type_condition(param, offset);
+        }
+
         let mut conditions = Vec::new();
 
         for (i, value) in param.values.iter().enumerate() {
@@ -380,6 +386,230 @@ impl PostgresQueryBuilder {
         }
 
         Some(combined)
+    }
+
+    /// Builds an `:of-type` identifier condition (token modifier).
+    ///
+    /// Value form: `type-system|type-code|identifier-value`. Empty parts are
+    /// dropped, so e.g. `||MR12345` matches by identifier value only.
+    fn build_of_type_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
+        let mut value_conditions = Vec::new();
+        let mut all_params: Vec<SqlParam> = Vec::new();
+        let mut current = offset;
+
+        for value in &param.values {
+            let parts: Vec<&str> = value.value.splitn(3, '|').collect();
+            if parts.len() != 3 {
+                continue;
+            }
+            let (type_system, type_code, identifier_value) = (parts[0], parts[1], parts[2]);
+
+            let mut conds = Vec::new();
+            // Identifier value (matched against the token code column).
+            if !identifier_value.is_empty() {
+                current += 1;
+                conds.push(format!("value_token_code = ${}", current));
+                all_params.push(SqlParam::text(identifier_value));
+            }
+            if !type_system.is_empty() {
+                current += 1;
+                conds.push(format!("value_identifier_type_system = ${}", current));
+                all_params.push(SqlParam::text(type_system));
+            }
+            if !type_code.is_empty() {
+                current += 1;
+                conds.push(format!("value_identifier_type_code = ${}", current));
+                all_params.push(SqlParam::text(type_code));
+            }
+            if conds.is_empty() {
+                continue;
+            }
+
+            value_conditions.push(format!(
+                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
+                param.name,
+                conds.join(" AND ")
+            ));
+        }
+
+        if value_conditions.is_empty() {
+            return None;
+        }
+        Some(SqlFragment::with_params(
+            value_conditions.join(" OR "),
+            all_params,
+        ))
+    }
+
+    /// Builds a composite-parameter condition.
+    ///
+    /// Composite values join their components with `$` (e.g.
+    /// `http://loinc.org|8480-6$lt60`). Each component is matched as a bare
+    /// predicate against the columns of a single `search_index` row scoped to
+    /// the composite parameter name — mirroring the SQLite backend. Requires
+    /// `param.components` to be populated (the REST layer does not yet wire
+    /// these from the registry, so this is reachable via the direct backend
+    /// API; see `docs/search-spec-assessment.md`).
+    fn build_composite_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
+        if param.components.is_empty() {
+            return None;
+        }
+
+        let mut value_conditions = Vec::new();
+        let mut all_params: Vec<SqlParam> = Vec::new();
+        let mut current = offset;
+
+        for value in &param.values {
+            let parts: Vec<&str> = value.value.split('$').collect();
+            let inner = if parts.len() != param.components.len() {
+                "1 = 0".to_string()
+            } else {
+                let mut comp_sqls = Vec::new();
+                let mut ok = true;
+                for (part, component) in parts.iter().zip(param.components.iter()) {
+                    let cv = Self::parse_component_value(part);
+                    match Self::build_composite_component(&cv, component.param_type, current) {
+                        Some((sql, params)) => {
+                            current += params.len();
+                            all_params.extend(params);
+                            comp_sqls.push(sql);
+                        }
+                        None => {
+                            ok = false;
+                            break;
+                        }
+                    }
+                }
+                if ok && !comp_sqls.is_empty() {
+                    comp_sqls.join(" AND ")
+                } else {
+                    "1 = 0".to_string()
+                }
+            };
+
+            value_conditions.push(format!(
+                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
+                param.name, inner
+            ));
+        }
+
+        if value_conditions.is_empty() {
+            return None;
+        }
+        Some(SqlFragment::with_params(
+            value_conditions.join(" OR "),
+            all_params,
+        ))
+    }
+
+    /// Parses a composite component value, stripping any comparison prefix.
+    fn parse_component_value(part: &str) -> SearchValue {
+        let prefixes = [
+            ("ne", SearchPrefix::Ne),
+            ("gt", SearchPrefix::Gt),
+            ("lt", SearchPrefix::Lt),
+            ("ge", SearchPrefix::Ge),
+            ("le", SearchPrefix::Le),
+            ("sa", SearchPrefix::Sa),
+            ("eb", SearchPrefix::Eb),
+            ("ap", SearchPrefix::Ap),
+            ("eq", SearchPrefix::Eq),
+        ];
+        for (prefix_str, prefix) in prefixes {
+            if let Some(stripped) = part.strip_prefix(prefix_str) {
+                return SearchValue {
+                    prefix,
+                    value: stripped.to_string(),
+                };
+            }
+        }
+        SearchValue {
+            prefix: SearchPrefix::Eq,
+            value: part.to_string(),
+        }
+    }
+
+    /// Builds a single composite component as a bare column predicate (no
+    /// `id IN (...)` wrapper — the caller scopes it to the composite row).
+    /// Returns `None` if the value cannot be parsed for the component type.
+    fn build_composite_component(
+        value: &SearchValue,
+        param_type: SearchParamType,
+        offset: usize,
+    ) -> Option<(String, Vec<SqlParam>)> {
+        match param_type {
+            SearchParamType::Token => {
+                if let Some((system, code)) = value.value.split_once('|') {
+                    if system.is_empty() {
+                        Some((
+                            format!("value_token_code = ${}", offset + 1),
+                            vec![SqlParam::text(code)],
+                        ))
+                    } else if code.is_empty() {
+                        Some((
+                            format!("value_token_system = ${}", offset + 1),
+                            vec![SqlParam::text(system)],
+                        ))
+                    } else {
+                        Some((
+                            format!(
+                                "value_token_system = ${} AND value_token_code = ${}",
+                                offset + 1,
+                                offset + 2
+                            ),
+                            vec![SqlParam::text(system), SqlParam::text(code)],
+                        ))
+                    }
+                } else {
+                    Some((
+                        format!("value_token_code = ${}", offset + 1),
+                        vec![SqlParam::text(&value.value)],
+                    ))
+                }
+            }
+            SearchParamType::String => Some((
+                format!("value_string ILIKE ${}", offset + 1),
+                vec![SqlParam::text(&format!("{}%", value.value))],
+            )),
+            SearchParamType::Number => {
+                let num = value.value.parse::<f64>().ok()?;
+                let op = Self::prefix_to_operator(&value.prefix);
+                Some((
+                    format!("value_number {} ${}", op, offset + 1),
+                    vec![SqlParam::Float(num)],
+                ))
+            }
+            SearchParamType::Quantity => {
+                let parts: Vec<&str> = value.value.splitn(3, '|').collect();
+                let num = parts.first().and_then(|s| s.parse::<f64>().ok())?;
+                let op = Self::prefix_to_operator(&value.prefix);
+                if parts.len() >= 3 {
+                    Some((
+                        format!(
+                            "value_quantity_value {} ${} AND value_quantity_unit = ${}",
+                            op,
+                            offset + 1,
+                            offset + 2
+                        ),
+                        vec![SqlParam::Float(num), SqlParam::text(parts[2])],
+                    ))
+                } else {
+                    Some((
+                        format!("value_quantity_value {} ${}", op, offset + 1),
+                        vec![SqlParam::Float(num)],
+                    ))
+                }
+            }
+            SearchParamType::Date => {
+                let op = Self::prefix_to_operator(&value.prefix);
+                let ts = Self::parse_date_value(&value.value);
+                Some((
+                    format!("value_date {} ${}", op, offset + 1),
+                    vec![SqlParam::Timestamp(ts)],
+                ))
+            }
+            _ => None,
+        }
     }
 
     fn build_date_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
@@ -581,5 +811,84 @@ impl PostgresQueryBuilder {
             .map(|dt| dt.with_timezone(&Utc))
             .or_else(|_| normalized.parse::<DateTime<Utc>>())
             .unwrap_or_else(|_| Utc::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{CompositeSearchComponent, SearchModifier, SearchQuery};
+
+    #[test]
+    fn composite_token_quantity_sql() {
+        let param = SearchParameter {
+            name: "code-value-quantity".to_string(),
+            param_type: SearchParamType::Composite,
+            modifier: None,
+            values: vec![SearchValue::new(
+                SearchPrefix::Eq,
+                "http://loinc.org|8480-6$lt60",
+            )],
+            chain: vec![],
+            components: vec![
+                CompositeSearchComponent {
+                    param_type: SearchParamType::Token,
+                    param_name: "code".to_string(),
+                },
+                CompositeSearchComponent {
+                    param_type: SearchParamType::Quantity,
+                    param_name: "value".to_string(),
+                },
+            ],
+        };
+        let query = SearchQuery::new("Observation").with_parameter(param);
+        // Non-cursor search binds $1=tenant, $2=type, so params start at $3.
+        let frag = PostgresQueryBuilder::build_search_query(&query, 2)
+            .expect("composite should produce a condition");
+
+        assert!(frag.sql.contains("param_name = 'code-value-quantity'"));
+        assert!(frag.sql.contains("value_token_system = $3"));
+        assert!(frag.sql.contains("value_token_code = $4"));
+        assert!(frag.sql.contains("value_quantity_value < $5"));
+        // token (system+code) = 2 params, quantity (no unit) = 1 param.
+        assert_eq!(frag.params.len(), 3);
+    }
+
+    #[test]
+    fn composite_returns_none_without_components() {
+        let param = SearchParameter {
+            name: "code-value-quantity".to_string(),
+            param_type: SearchParamType::Composite,
+            modifier: None,
+            values: vec![SearchValue::new(SearchPrefix::Eq, "a$b")],
+            chain: vec![],
+            components: vec![],
+        };
+        let query = SearchQuery::new("Observation").with_parameter(param);
+        assert!(PostgresQueryBuilder::build_search_query(&query, 2).is_none());
+    }
+
+    #[test]
+    fn of_type_identifier_sql() {
+        let param = SearchParameter {
+            name: "identifier".to_string(),
+            param_type: SearchParamType::Token,
+            modifier: Some(SearchModifier::OfType),
+            values: vec![SearchValue::new(
+                SearchPrefix::Eq,
+                "http://terminology.hl7.org/CodeSystem/v2-0203|MR|12345",
+            )],
+            chain: vec![],
+            components: vec![],
+        };
+        let query = SearchQuery::new("Patient").with_parameter(param);
+        let frag = PostgresQueryBuilder::build_search_query(&query, 2)
+            .expect(":of-type should produce a condition");
+
+        assert!(frag.sql.contains("param_name = 'identifier'"));
+        assert!(frag.sql.contains("value_token_code = $3"));
+        assert!(frag.sql.contains("value_identifier_type_system = $4"));
+        assert!(frag.sql.contains("value_identifier_type_code = $5"));
+        assert_eq!(frag.params.len(), 3);
     }
 }


### PR DESCRIPTION
Stacked on #118.

## Context
Continues PostgreSQL→SQLite search parity. Before this PR, PostgreSQL returned no condition for composite parameters and ignored the `:of-type` modifier.

## Changes
- **Composite parameters** — `build_composite_condition` splits the `$`-separated value, builds a bare column predicate per component (token / string / number / quantity / date) against a single `search_index` row, and scopes it to the composite parameter name. Mirrors the SQLite handler.
- **`:of-type` token modifier** — matches an Identifier by `type-system|type-code|identifier-value` using the `value_identifier_type_system` / `value_identifier_type_code` columns.

## Reachability note
Both are implemented at the backend SQL level. As with SQLite, the shared extractor does not populate `composite_group` / identifier-type columns during indexing, and the REST layer builds outgoing params with empty `components`. So these are reachable via the **direct backend API** (verified by unit tests), not yet end-to-end over HTTP. This is documented in `docs/search-spec-assessment.md` (composite caveat + roadmap item) and the matrix notes. Wiring composite components through REST is a follow-up that benefits all backends.

## Docs
Matrix: PostgreSQL **Composite** and **:of-type** ○ → ✓, with a clarifying composite note. Phase 5b status and assessment doc updated.

## Tests
`query_builder` unit tests: composite token+quantity SQL (column refs + param count), the no-components guard returns `None`, and `:of-type` identifier SQL. Full PG integration search suite still green; clippy `-D warnings` clean.