### PR TITLE
feat(persistence,rest): composite search end-to-end + fix value[x] choice-type extraction

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -391,10 +391,10 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.
 - **Composite** — SQLite and PostgreSQL evaluate composite component values (token, string,
-  number, quantity, date) at the backend level (✓); Elasticsearch matches on the composite
-  parameter name only (◐). Note: the REST layer does not yet populate composite component
-  definitions from the registry, so composite search is currently reachable via the direct
-  backend API rather than over HTTP. See `docs/search-spec-assessment.md`.
+  number, quantity, date) end-to-end (✓): the REST layer resolves component types from the
+  registry, the extractor indexes each composite instance as a `composite_group`, and the backend
+  matches all components within one group. Elasticsearch matches on the composite parameter name
+  only (◐). See `docs/search-spec-assessment.md`.
 
 The S3 backend is intentionally storage-focused (CRUD/version/history/bulk submit) and does not act as a full FHIR search engine. For bulk export, S3 can feed system-level batches through `ExportDataProvider` and can store output files through `S3OutputStore`, but job state belongs to SQLite or PostgreSQL. Patient-level and Group-level export compartment enumeration are not supported by S3 as the resource store. For query-heavy deployments, use a DB/search backend as primary query engine and compose S3 as archive/history/output storage.
 
@@ -1133,7 +1133,7 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
 - [x] SearchProvider with all parameter types including composite (string, token, reference, date,
       number, quantity, URI, composite; supports `:exact`/`:contains`/`:not`/`:missing`/`:of-type`
       and URI `:above`/`:below`; the `:text-advanced` modifier is not yet implemented). Composite
-      component definitions are not yet wired through the REST layer.
+      search works end-to-end (REST → registry-resolved components → grouped index → query).
 - [x] ChainedSearchProvider and reverse chaining (\_has)
 - [x] Full-text search (tsvector/tsquery)
 - [x] `_sort` by `_id`/`_lastUpdated` (first-page and offset paths)

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -45,13 +45,19 @@ Neo4j are not implemented.
 The `resource` and `special` parameter types from the spec are modeled in the `SearchParamType`
 enum but have no dedicated execution path beyond the special common parameters below.
 
-**Composite caveat (all backends):** the SQLite and PostgreSQL composite handlers evaluate each
-component (token/string/number/quantity/date) against the columns of a single `search_index` row.
-However, the REST layer builds the outgoing `SearchParameter` with empty `components`
-(`crates/rest/src/extractors/search_query_builder.rs`), so composite search is currently exercised
-through the direct backend API (with components supplied), not over HTTP. Wiring component
-definitions from the registry into the REST query builder is a prerequisite for end-to-end
-composite search on any backend.
+**Composite (SQLite, PostgreSQL):** works end-to-end. The REST layer resolves each component's
+type and code from the registry (by the component `definition` URL); the extractor indexes every
+composite instance as a set of `search_index` rows sharing a `composite_group`; and the backend
+matches with `GROUP BY resource_id, composite_group HAVING <every component present>`, so all
+components must be satisfied within the same instance. Elasticsearch still matches the composite
+name only (◐).
+
+**Choice types (`value[x]`):** the extractor evaluates FHIRPath against schema-less JSON, where a
+cast such as `value as Quantity` / `value.ofType(Quantity)` cannot resolve to the stored
+`valueQuantity` field. `rewrite_choice_types` in `search/extractor.rs` rewrites these casts to the
+concrete element name (`valueQuantity`, `medicationCodeableConcept`, `occurrenceDateTime`, …)
+before evaluation. This fixed both composite value components and plain `value[x]` parameters
+(e.g. `value-quantity`), which previously indexed nothing.
 
 ## 2. Search modifiers
 
@@ -161,17 +167,14 @@ Ordered roughly by impact:
    URI `:above`/`:below` (hierarchical prefix, no service needed) *is* implemented on SQLite/PG/ES.
 3. **PostgreSQL modifier gaps** — only the `:text-advanced` modifier remains unimplemented relative
    to SQLite (`:exact`, `:contains`, `:not`, `:missing`, `:of-type`, URI `:above`/`:below`, and
-   composite parameters are all supported at the backend level now).
-4. **Composite REST wiring** — composite search works at the backend level (SQLite, PostgreSQL) but
-   the REST layer does not yet populate composite component definitions, so it is not reachable over
-   HTTP on any backend. See the composite caveat in §1.
-5. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
+   composite parameters are all supported now).
+4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
    chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
-6. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
+5. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
    forward chaining and `_has` silently return nothing rather than erroring; `_filter` unsupported.
-7. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
+6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
    unsupported everywhere.
 
 SQLite is the most complete backend and serves as the reference for the others; PostgreSQL is now
-at near-parity (only `:text-advanced` and REST-side composite wiring remain).
+at near-parity (only `:text-advanced` remains).

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -444,12 +444,11 @@ impl PostgresQueryBuilder {
     /// Builds a composite-parameter condition.
     ///
     /// Composite values join their components with `$` (e.g.
-    /// `http://loinc.org|8480-6$lt60`). Each component is matched as a bare
-    /// predicate against the columns of a single `search_index` row scoped to
-    /// the composite parameter name — mirroring the SQLite backend. Requires
-    /// `param.components` to be populated (the REST layer does not yet wire
-    /// these from the registry, so this is reachable via the direct backend
-    /// API; see `docs/search-spec-assessment.md`).
+    /// `http://loinc.org|8480-6$lt60`). Each component of a composite instance
+    /// is indexed as its own `search_index` row sharing a `composite_group`, so
+    /// a resource matches when there is a group in which every component is
+    /// satisfied by some row. This is expressed with
+    /// `GROUP BY resource_id, composite_group HAVING <every component present>`.
     fn build_composite_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
         if param.components.is_empty() {
             return None;
@@ -461,35 +460,37 @@ impl PostgresQueryBuilder {
 
         for value in &param.values {
             let parts: Vec<&str> = value.value.split('$').collect();
-            let inner = if parts.len() != param.components.len() {
-                "1 = 0".to_string()
-            } else {
-                let mut comp_sqls = Vec::new();
-                let mut ok = true;
-                for (part, component) in parts.iter().zip(param.components.iter()) {
-                    let cv = Self::parse_component_value(part);
-                    match Self::build_composite_component(&cv, component.param_type, current) {
-                        Some((sql, params)) => {
-                            current += params.len();
-                            all_params.extend(params);
-                            comp_sqls.push(sql);
-                        }
-                        None => {
-                            ok = false;
-                            break;
-                        }
+            if parts.len() != param.components.len() {
+                value_conditions.push("1 = 0".to_string());
+                continue;
+            }
+
+            let mut havings = Vec::new();
+            let mut ok = true;
+            for (part, component) in parts.iter().zip(param.components.iter()) {
+                let cv = Self::parse_component_value(part);
+                match Self::build_composite_component(&cv, component.param_type, current) {
+                    Some((sql, params)) => {
+                        current += params.len();
+                        all_params.extend(params);
+                        havings.push(format!("MAX(CASE WHEN {} THEN 1 ELSE 0 END) = 1", sql));
+                    }
+                    None => {
+                        ok = false;
+                        break;
                     }
                 }
-                if ok && !comp_sqls.is_empty() {
-                    comp_sqls.join(" AND ")
-                } else {
-                    "1 = 0".to_string()
-                }
-            };
+            }
+
+            if !ok || havings.is_empty() {
+                value_conditions.push("1 = 0".to_string());
+                continue;
+            }
 
             value_conditions.push(format!(
-                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
-                param.name, inner
+                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' GROUP BY resource_id, composite_group HAVING {})",
+                param.name,
+                havings.join(" AND ")
             ));
         }
 

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/composite.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/composite.rs
@@ -75,6 +75,41 @@ impl CompositeHandler {
         SqlFragment::with_params(format!("({})", conditions_sql), all_params)
     }
 
+    /// Builds one bare predicate fragment per component.
+    ///
+    /// Returns `None` if the value's part count does not match the component
+    /// count, or if any component value cannot be built. The caller wraps each
+    /// fragment in a `MAX(CASE WHEN ... THEN 1 ELSE 0 END) = 1` aggregate and
+    /// groups by `(resource_id, composite_group)` so that all components are
+    /// matched within the same composite instance.
+    pub fn build_component_fragments(
+        value: &SearchValue,
+        components: &[CompositeSearchComponent],
+        param_offset: usize,
+    ) -> Option<Vec<SqlFragment>> {
+        let parts: Vec<&str> = value.value.split('$').collect();
+        if parts.len() != components.len() || components.is_empty() {
+            return None;
+        }
+
+        let mut fragments = Vec::new();
+        let mut current_offset = param_offset;
+        for (part, component) in parts.iter().zip(components.iter()) {
+            let component_value = Self::parse_component_value(part);
+            let fragment = Self::build_component_sql_from_type(
+                &component_value,
+                component.param_type,
+                current_offset,
+            );
+            if fragment.sql == "1 = 0" {
+                return None;
+            }
+            current_offset += fragment.params.len();
+            fragments.push(fragment);
+        }
+        Some(fragments)
+    }
+
     /// Builds SQL for a composite parameter value.
     ///
     /// The value should be in the format "value1$value2$..." where each value

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -207,6 +207,11 @@ impl QueryBuilder {
             return self.build_special_parameter_condition(param, param_offset);
         }
 
+        // Composite parameters need a group-aware subquery (see below).
+        if matches!(param.param_type, SearchParamType::Composite) {
+            return self.build_composite_parameter_condition(param, param_offset);
+        }
+
         // Multiple values are ORed together
         let mut or_conditions = Vec::new();
         let mut total_params = 0usize;
@@ -237,6 +242,56 @@ impl QueryBuilder {
             ),
             combined.params,
         ))
+    }
+
+    /// Builds a condition for a composite parameter.
+    ///
+    /// Each composite instance is indexed as a set of `search_index` rows that
+    /// share a `composite_group`. A resource matches when there is a group in
+    /// which every component is satisfied by some row, expressed as
+    /// `GROUP BY resource_id, composite_group HAVING <every component present>`.
+    fn build_composite_parameter_condition(
+        &self,
+        param: &SearchParameter,
+        param_offset: usize,
+    ) -> Option<SqlFragment> {
+        if param.components.is_empty() {
+            return None;
+        }
+
+        let mut or_conditions = Vec::new();
+        let mut params = Vec::new();
+        let mut total_params = 0usize;
+
+        for value in &param.values {
+            match CompositeHandler::build_component_fragments(
+                value,
+                &param.components,
+                param_offset + total_params,
+            ) {
+                Some(fragments) if !fragments.is_empty() => {
+                    let havings: Vec<String> = fragments
+                        .iter()
+                        .map(|f| format!("MAX(CASE WHEN {} THEN 1 ELSE 0 END) = 1", f.sql))
+                        .collect();
+                    for f in fragments {
+                        total_params += f.params.len();
+                        params.extend(f.params);
+                    }
+                    or_conditions.push(format!(
+                        "resource_id IN (SELECT resource_id FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND param_name = '{}' GROUP BY resource_id, composite_group HAVING {})",
+                        param.name,
+                        havings.join(" AND ")
+                    ));
+                }
+                _ => or_conditions.push("0 = 1".to_string()),
+            }
+        }
+
+        if or_conditions.is_empty() {
+            return None;
+        }
+        Some(SqlFragment::with_params(or_conditions.join(" OR "), params))
     }
 
     /// Builds a condition for a special parameter (_id, _lastUpdated, etc.).

--- a/crates/persistence/src/search/extractor.rs
+++ b/crates/persistence/src/search/extractor.rs
@@ -3,11 +3,12 @@
 //! Uses FHIRPath expressions to extract searchable values from FHIR resources.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use helios_fhirpath::EvaluationContext;
 use helios_fhirpath_support::EvaluationResult;
 use parking_lot::RwLock;
+use regex::Regex;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -152,6 +153,12 @@ impl SearchParameterExtractor {
         resource: &Value,
         param: &SearchParameterDefinition,
     ) -> Result<Vec<ExtractedValue>, ExtractionError> {
+        // Composite parameters are indexed component-by-component, with all the
+        // components of one composite instance sharing a `composite_group`.
+        if matches!(param.param_type, SearchParamType::Composite) {
+            return self.extract_composite(resource, param);
+        }
+
         if param.expression.is_empty() {
             return Ok(Vec::new());
         }
@@ -162,8 +169,10 @@ impl SearchParameterExtractor {
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        // Filter the expression to only include parts relevant to this resource type
-        let filtered_expr = self.filter_expression_for_resource(&param.expression, resource_type);
+        // Rewrite choice-type casts (`value as Quantity` → `valueQuantity`) so they
+        // resolve against schema-less JSON, then filter to this resource type.
+        let rewritten = rewrite_choice_types(&param.expression);
+        let filtered_expr = self.filter_expression_for_resource(&rewritten, resource_type);
 
         if filtered_expr.is_empty() {
             return Ok(Vec::new());
@@ -182,6 +191,75 @@ impl SearchParameterExtractor {
                     param.param_type,
                     idx_value,
                 ));
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Extracts index rows for a composite search parameter.
+    ///
+    /// The composite's `expression` (e.g. `Observation` or
+    /// `Observation.component`) selects the base instances. Each instance gets a
+    /// `composite_group` id, and every component sub-expression is evaluated
+    /// relative to that instance and stored as its own row under the composite
+    /// parameter's code. Component value types are resolved from the registry by
+    /// the component `definition` URL.
+    fn extract_composite(
+        &self,
+        resource: &Value,
+        param: &SearchParameterDefinition,
+    ) -> Result<Vec<ExtractedValue>, ExtractionError> {
+        let components = match &param.component {
+            Some(c) if !c.is_empty() => c,
+            _ => return Ok(Vec::new()),
+        };
+
+        let resource_type = resource
+            .get("resourceType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let rewritten_base = rewrite_choice_types(&param.expression);
+        let base_expr = self.filter_expression_for_resource(&rewritten_base, resource_type);
+        if base_expr.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Resolve each component's value type from the registry (by definition URL).
+        let component_types: Vec<Option<SearchParamType>> = {
+            let registry = self.registry.read();
+            components
+                .iter()
+                .map(|c| registry.get_by_url(&c.definition).map(|d| d.param_type))
+                .collect()
+        };
+
+        // Each base instance becomes a composite group.
+        let base_nodes = self.evaluate_fhirpath(resource, &base_expr)?;
+
+        let mut results = Vec::new();
+        for (group_idx, node) in base_nodes.iter().enumerate() {
+            let group = group_idx as u32;
+            for (component, sub_type) in components.iter().zip(component_types.iter()) {
+                let sub_type = match sub_type {
+                    Some(t) => *t,
+                    None => continue, // unknown component definition — skip
+                };
+                if component.expression.is_empty() {
+                    continue;
+                }
+                let comp_expr = rewrite_choice_types(&component.expression);
+                let values = self.evaluate_fhirpath(node, &comp_expr)?;
+                for value in values {
+                    let converted = ValueConverter::convert(&value, sub_type, &param.code)?;
+                    for idx_value in converted {
+                        results.push(
+                            ExtractedValue::new(&param.code, &param.url, sub_type, idx_value)
+                                .with_composite_group(group),
+                        );
+                    }
+                }
             }
         }
 
@@ -264,6 +342,61 @@ impl SearchParameterExtractor {
         // Convert EvaluationResult back to JSON values
         evaluation_result_to_json_values(&result)
     }
+}
+
+/// Rewrites FHIRPath choice-type casts to concrete element names.
+///
+/// The extractor evaluates expressions against schema-less JSON, where a cast
+/// like `value as Quantity` cannot resolve `value` to the stored `valueQuantity`
+/// field. FHIR choice elements are serialized as `<element><Type>` (e.g.
+/// `valueQuantity`, `medicationCodeableConcept`, `occurrenceDateTime`), so we
+/// rewrite the three cast forms used in SearchParameter expressions to that
+/// concrete name:
+///
+/// - `(Observation.value as Quantity)` → `Observation.valueQuantity`
+/// - `value.as(Quantity)`              → `valueQuantity`
+/// - `Observation.value.ofType(Quantity)` → `Observation.valueQuantity`
+/// - `Observation.value as Quantity`   → `Observation.valueQuantity`
+///
+/// (The loader normalizes the `X as Type` form to `X.ofType(Type)`, so that
+/// form is what usually reaches the extractor.)
+///
+/// Stripping the parentheses in the `(... as Type)` form is intentional: it also
+/// lets `filter_expression_for_resource` recognize the `ResourceType.` prefix,
+/// which it otherwise drops for parenthesized union members.
+fn rewrite_choice_types(expression: &str) -> String {
+    static AS_FN: OnceLock<Regex> = OnceLock::new();
+    static OF_TYPE: OnceLock<Regex> = OnceLock::new();
+    static PAREN_AS: OnceLock<Regex> = OnceLock::new();
+    static BARE_AS: OnceLock<Regex> = OnceLock::new();
+
+    let path = r"[A-Za-z_][A-Za-z0-9_.]*";
+    let ty = r"[A-Za-z][A-Za-z0-9]*";
+    let as_fn =
+        AS_FN.get_or_init(|| Regex::new(&format!(r"({path})\.as\(\s*({ty})\s*\)")).unwrap());
+    let of_type =
+        OF_TYPE.get_or_init(|| Regex::new(&format!(r"({path})\.ofType\(\s*({ty})\s*\)")).unwrap());
+    let paren_as =
+        PAREN_AS.get_or_init(|| Regex::new(&format!(r"\(\s*({path})\s+as\s+({ty})\s*\)")).unwrap());
+    let bare_as = BARE_AS.get_or_init(|| Regex::new(&format!(r"({path})\s+as\s+({ty})")).unwrap());
+
+    let concrete = |caps: &regex::Captures| -> String {
+        let base = &caps[1];
+        let type_name = &caps[2];
+        let mut chars = type_name.chars();
+        let capitalized = match chars.next() {
+            Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+            None => String::new(),
+        };
+        format!("{}{}", base, capitalized)
+    };
+
+    // `.as(Type)` / `.ofType(Type)` and `(path as Type)` first (the latter also
+    // drops parens), then any remaining bare `path as Type`.
+    let step1 = as_fn.replace_all(expression, &concrete);
+    let step2 = of_type.replace_all(&step1, &concrete);
+    let step3 = paren_as.replace_all(&step2, &concrete);
+    bare_as.replace_all(&step3, &concrete).into_owned()
 }
 
 /// Converts a serde_json::Value to an EvaluationResult.
@@ -375,6 +508,33 @@ mod tests {
     use helios_fhir::FhirVersion;
     use serde_json::json;
     use std::path::PathBuf;
+
+    #[test]
+    fn rewrite_choice_types_handles_all_forms() {
+        // `.as(Type)` form.
+        assert_eq!(rewrite_choice_types("value.as(Quantity)"), "valueQuantity");
+        // `.ofType(Type)` form (what the loader normalizes `as` to).
+        assert_eq!(
+            rewrite_choice_types("(Observation.value.ofType(Quantity))"),
+            "(Observation.valueQuantity)"
+        );
+        // Parenthesized `as` form drops the parens.
+        assert_eq!(
+            rewrite_choice_types("(Observation.value as Quantity)"),
+            "Observation.valueQuantity"
+        );
+        // Lower-case primitive type names are capitalized.
+        assert_eq!(
+            rewrite_choice_types("(RiskAssessment.occurrence as dateTime)"),
+            "RiskAssessment.occurrenceDateTime"
+        );
+        // Unions are rewritten member-by-member; non-cast parts are untouched.
+        assert_eq!(
+            rewrite_choice_types("value.as(Quantity) | value.as(Range)"),
+            "valueQuantity | valueRange"
+        );
+        assert_eq!(rewrite_choice_types("Observation.code"), "Observation.code");
+    }
 
     fn create_test_extractor() -> SearchParameterExtractor {
         let loader = SearchParameterLoader::new(FhirVersion::R4);

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -1355,6 +1355,72 @@ mod postgres_integration {
         );
     }
 
+    #[tokio::test]
+    async fn postgres_integration_search_composite_code_value_quantity() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            CompositeSearchComponent, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        let observation = json!({
+            "resourceType": "Observation",
+            "id": "obs-bp",
+            "status": "final",
+            "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6" }] },
+            "valueQuantity": { "value": 107, "unit": "mmHg", "system": "http://unitsofmeasure.org" }
+        });
+        backend
+            .create(&tenant, "Observation", observation, FhirVersion::default())
+            .await
+            .unwrap();
+
+        let query = |value: &str| {
+            SearchQuery::new("Observation").with_parameter(SearchParameter {
+                name: "code-value-quantity".to_string(),
+                param_type: SearchParamType::Composite,
+                modifier: None,
+                values: vec![SearchValue::eq(value)],
+                chain: vec![],
+                components: vec![
+                    CompositeSearchComponent {
+                        param_type: SearchParamType::Token,
+                        param_name: "code".to_string(),
+                    },
+                    CompositeSearchComponent {
+                        param_type: SearchParamType::Quantity,
+                        param_name: "value-quantity".to_string(),
+                    },
+                ],
+            })
+        };
+
+        let result = backend
+            .search(&tenant, &query("8480-6$ge100"))
+            .await
+            .unwrap();
+        assert_eq!(
+            result.resources.items.len(),
+            1,
+            "code + value match → 1 hit"
+        );
+        assert_eq!(result.resources.items[0].id(), "obs-bp");
+
+        let result = backend
+            .search(&tenant, &query("8480-6$ge200"))
+            .await
+            .unwrap();
+        assert!(result.resources.items.is_empty(), "value too low → no hit");
+
+        let result = backend
+            .search(&tenant, &query("9999-9$ge100"))
+            .await
+            .unwrap();
+        assert!(result.resources.items.is_empty(), "code mismatch → no hit");
+    }
+
     // ========================================================================
     // Backend Health Check Tests
     // ========================================================================

--- a/crates/persistence/tests/sqlite_tests.rs
+++ b/crates/persistence/tests/sqlite_tests.rs
@@ -1146,7 +1146,114 @@ async fn test_history_system_tenant_isolation() {
 // ============================================================================
 
 use helios_persistence::core::SearchProvider;
-use helios_persistence::types::{SearchParamType, SearchParameter, SearchQuery, SearchValue};
+use helios_persistence::types::{
+    CompositeSearchComponent, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+};
+
+/// Builds the `code-value-quantity` composite query with the component types
+/// the registry would supply, mirroring what the REST layer now wires up.
+fn code_value_quantity_query(value: &str) -> SearchQuery {
+    SearchQuery::new("Observation").with_parameter(SearchParameter {
+        name: "code-value-quantity".to_string(),
+        param_type: SearchParamType::Composite,
+        modifier: None,
+        values: vec![SearchValue::eq(value)],
+        chain: vec![],
+        components: vec![
+            CompositeSearchComponent {
+                param_type: SearchParamType::Token,
+                param_name: "code".to_string(),
+            },
+            CompositeSearchComponent {
+                param_type: SearchParamType::Quantity,
+                param_name: "value-quantity".to_string(),
+            },
+        ],
+    })
+}
+
+#[tokio::test]
+async fn test_search_value_quantity_choice_type() {
+    // Regression: choice-type elements (`value[x]`) must be indexed. The
+    // `value-quantity` expression is `(Observation.value as Quantity)`.
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    let observation = json!({
+        "resourceType": "Observation",
+        "id": "obs-q",
+        "status": "final",
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "29463-7" }] },
+        "valueQuantity": { "value": 72.5, "unit": "kg", "system": "http://unitsofmeasure.org" }
+    });
+    backend
+        .create(&tenant, "Observation", observation, FhirVersion::default())
+        .await
+        .unwrap();
+
+    let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+        name: "value-quantity".to_string(),
+        param_type: SearchParamType::Quantity,
+        modifier: None,
+        values: vec![SearchValue::new(
+            helios_persistence::types::SearchPrefix::Ge,
+            "70",
+        )],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = backend.search(&tenant, &query).await.unwrap();
+    assert_eq!(
+        result.resources.items.len(),
+        1,
+        "value-quantity ge70 → 1 hit"
+    );
+    assert_eq!(result.resources.items[0].id(), "obs-q");
+}
+
+#[tokio::test]
+async fn test_search_composite_code_value_quantity() {
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    let observation = json!({
+        "resourceType": "Observation",
+        "id": "obs-bp",
+        "status": "final",
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6" }] },
+        "valueQuantity": { "value": 107, "unit": "mmHg", "system": "http://unitsofmeasure.org" }
+    });
+    backend
+        .create(&tenant, "Observation", observation, FhirVersion::default())
+        .await
+        .unwrap();
+
+    // Matches: correct code AND value satisfies the quantity comparison.
+    let result = backend
+        .search(&tenant, &code_value_quantity_query("8480-6$ge100"))
+        .await
+        .unwrap();
+    assert_eq!(
+        result.resources.items.len(),
+        1,
+        "code + value both match → 1 hit"
+    );
+    assert_eq!(result.resources.items[0].id(), "obs-bp");
+
+    // Value component fails (107 is not >= 200).
+    let result = backend
+        .search(&tenant, &code_value_quantity_query("8480-6$ge200"))
+        .await
+        .unwrap();
+    assert!(result.resources.items.is_empty(), "value too low → no hit");
+
+    // Code component fails.
+    let result = backend
+        .search(&tenant, &code_value_quantity_query("9999-9$ge100"))
+        .await
+        .unwrap();
+    assert!(result.resources.items.is_empty(), "code mismatch → no hit");
+}
 
 // Note: These tests verify that search indexing infrastructure is integrated into
 // storage operations. Full end-to-end search filtering requires updating search_impl.rs
@@ -2814,7 +2921,7 @@ async fn test_fts_delete_does_not_fail() {
 // _content Parameter Tests (Full Content Search)
 // ============================================================================
 
-use helios_persistence::types::{CompositeSearchComponent, SearchModifier};
+use helios_persistence::types::SearchModifier;
 
 #[tokio::test]
 async fn test_content_search_basic() {

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -6,8 +6,9 @@ use std::collections::HashMap;
 
 use helios_persistence::search::{SearchParameterRegistry, resolve_param_type};
 use helios_persistence::types::{
-    IncludeDirective, IncludeType, ReverseChainedParameter, SearchModifier, SearchParamType,
-    SearchParameter, SearchQuery, SearchValue, SortDirective, SummaryMode, TotalMode,
+    CompositeSearchComponent, IncludeDirective, IncludeType, ReverseChainedParameter,
+    SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue, SortDirective,
+    SummaryMode, TotalMode,
 };
 
 use super::SearchParams;
@@ -165,6 +166,27 @@ fn parse_search_parameter(
         chain,
         components: vec![],
     };
+
+    // For composite parameters, resolve the component sub-parameters from the
+    // registry (type + code), so the backend can match each component within
+    // the same composite instance.
+    if matches!(param_type, SearchParamType::Composite) {
+        if let Some(def) = registry.get_param(resource_type, base_name) {
+            if let Some(comps) = def.component.as_ref() {
+                param.components = comps
+                    .iter()
+                    .filter_map(|c| {
+                        registry
+                            .get_by_url(&c.definition)
+                            .map(|sub| CompositeSearchComponent {
+                                param_type: sub.param_type,
+                                param_name: sub.code.clone(),
+                            })
+                    })
+                    .collect();
+            }
+        }
+    }
 
     // Handle :missing modifier specially
     if param


### PR DESCRIPTION
Stacked on #119.

## Context
Composite search wasn't reachable over HTTP, and — discovered while wiring it — the extractor couldn't index `value[x]` choice-type parameters at all (so even plain `value-quantity` search returned nothing).

## Composite, end-to-end (SQLite + PostgreSQL)
- **Extractor** indexes each composite *instance* as a set of `search_index` rows sharing a `composite_group`; each component sub-expression is evaluated relative to the base instance, and component value types are resolved from the registry by `definition` URL.
- **Both backends** now match composites with `GROUP BY resource_id, composite_group HAVING <every component present>`, enforcing correct same-instance semantics (replaces the single-row approximation from #119).
- **REST** resolves the component `(type, code)` from the registry and populates `SearchParameter.components`.

## Choice-type fix (`value[x]`)
The extractor evaluates FHIRPath against schema-less JSON, where `value as Quantity` / `value.ofType(Quantity)` can't resolve to the stored `valueQuantity`. New `rewrite_choice_types` rewrites the cast forms (`.as(T)`, `.ofType(T)`, `(X as T)`, `X as T`) to the concrete element name (`valueQuantity`, `medicationCodeableConcept`, `occurrenceDateTime`, …) and drops the wrapping parens — which also fixes a second bug where `filter_expression_for_resource` dropped parenthesized `(ResourceType.x as T)` union members.

This fixed **both** composite value components **and** plain `value[x]` params. Note the loader normalizes `X as Type` → `X.ofType(Type)`, so the `.ofType` form is what actually reaches the extractor for non-composite params.

## Tests
- SQLite: end-to-end composite (`code-value-quantity` match + value/code mismatch exclusion) and a `value-quantity` choice-type regression test.
- PostgreSQL: end-to-end composite via testcontainers.
- Unit: `rewrite_choice_types` covers all four cast forms + unions.
- Full persistence lib suite (619), SQLite (74), PG search (13) green; clippy `-D warnings` clean on persistence + rest.

## Remaining (documented in `docs/search-spec-assessment.md`)
ES real composite components; MongoDB native-search gaps; PG `:text-advanced`; minor REST result params.