### PR TITLE
feat(persistence,rest): sort by any indexed search parameter (SQLite + PostgreSQL)

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -379,11 +379,13 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 
 **Notes on partial cells:**
 
-- **Sorting** — "Single/Multiple field" covers `_id` and `_lastUpdated` only on every
-  backend; sorting by an arbitrary search parameter is not yet implemented (it would require a
-  join against the search index). Sort is applied on the first-page and offset paths; cursor
-  (keyset) pages always use the default `_lastUpdated` ordering. MongoDB cannot combine a custom
-  sort with cursor pagination, hence ◐ for multiple fields.
+- **Sorting** — SQLite and PostgreSQL sort by any indexed search parameter (string, token,
+  date, number, quantity, reference, URI) via a correlated subquery into the search index, taking
+  the min value ascending / max descending for multi-valued params; `_id`/`_lastUpdated` sort on
+  the resources table directly. Sort is applied on the first-page and offset paths; cursor
+  (keyset) pages always use the default `_lastUpdated` ordering. MongoDB sorts by `_id`/
+  `_lastUpdated` only and cannot combine a custom sort with cursor pagination, hence ◐ for
+  multiple fields.
 - **`:above` / `:below`** — SQLite, PostgreSQL, and Elasticsearch implement hierarchical URI
   prefix matching (no external service needed), shown as ◐. Token/code hierarchy expansion
   (which needs a terminology server) is not implemented natively.
@@ -1136,7 +1138,8 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
       search works end-to-end (REST → registry-resolved components → grouped index → query).
 - [x] ChainedSearchProvider and reverse chaining (\_has)
 - [x] Full-text search (tsvector/tsquery)
-- [x] `_sort` by `_id`/`_lastUpdated` (first-page and offset paths)
+- [x] `_sort` by `_id`/`_lastUpdated` and any indexed search parameter via a search_index
+      correlated subquery (first-page and offset paths)
 - [x] `_include` and `_revinclude` resolution
 - [x] BulkExportStorage and BulkSubmitProvider
 - [x] Search offloading support

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -137,7 +137,7 @@ These are parsed and largely orchestrated by the REST layer.
 | Parameter | Status | Notes |
 |-----------|--------|-------|
 | `_count` | ✓ | page size; `_offset`/`_cursor` for paging |
-| `_sort` | ◐ | applied for `_id`/`_lastUpdated` only; see below |
+| `_sort` | ✓ | SQLite/PG sort by any indexed param; see below |
 | `_total` | ✓ | `none` / `estimate` / `accurate` parsed and applied |
 | `_summary` | ✓ | `true`/`text`/`data`/`count`/`false`, applied in `subsetting.rs` |
 | `_elements` | ✓ | applied post-search with nested-path support |
@@ -148,20 +148,24 @@ These are parsed and largely orchestrated by the REST layer.
 | `next` / `previous` links | ✓ | cursor-based |
 | `first` / `last` links | ✗ | not generated |
 
-**`_sort` detail.** `_sort` is parsed into `SearchQuery.sort` for every backend. The backends map
-sort fields to columns via a small allow-list — `_id` → `id`, `_lastUpdated` → `last_updated` —
-and fall back to `id` for anything else. So sorting by an arbitrary search parameter (e.g.
-`_sort=birthdate`) currently degrades to a stable-but-not-meaningful `id` ordering on all backends.
-Sort is applied on the first-page and offset query paths; cursor (keyset) pages always use the
-default `_lastUpdated, id` ordering because the keyset `WHERE` comparison depends on it. MongoDB
-additionally cannot combine a custom sort with cursor pagination.
+**`_sort` detail.** `_sort` is parsed into `SearchQuery.sort`; the REST layer resolves each sort
+field's type from the registry (`SortDirective.param_type`). On SQLite and PostgreSQL, `_id` and
+`_lastUpdated` sort on the `resources` table, while any other indexed parameter sorts on a
+correlated subquery into `search_index` — `MIN(value_col)` for ascending, `MAX(value_col)` for
+descending (FHIR multi-value sort), with the value column chosen by the parameter type. Sort is
+applied on the first-page and offset query paths; cursor (keyset) pages always use the default
+`_lastUpdated, id` ordering because the keyset `WHERE` comparison depends on it. MongoDB sorts by
+`_id`/`_lastUpdated` only and cannot combine a custom sort with cursor pagination; Elasticsearch
+sorts on its mapped fields.
 
 ## 7. Known limitations & roadmap
 
 Ordered roughly by impact:
 
-1. **Sort by arbitrary search parameter** — unsupported on all backends (only `_id`/`_lastUpdated`).
-   Would require sorting on `search_index` values via a join. Cursor pages ignore custom sort.
+1. **Cursor pagination + custom sort** — SQLite/PG now sort by any indexed parameter on the
+   first-page and offset paths, but cursor (keyset) pages still use the default `_lastUpdated`
+   ordering. Reconciling keyset pagination with arbitrary sort keys remains open. MongoDB still
+   sorts by `_id`/`_lastUpdated` only.
 2. **Terminology-dependent modifiers** — token `:above`/`:below`, `:in`, `:not-in` need a
    terminology server. `:in` is partially handled via REST-side expansion; the rest are not native.
    URI `:above`/`:below` (hierarchical prefix, no service needed) *is* implemented on SQLite/PG/ES.

--- a/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
@@ -336,6 +336,7 @@ mod tests {
         let query = SearchQuery::new("Patient").with_sort(SortDirective {
             parameter: "_id".to_string(),
             direction: SortDirection::Ascending,
+            param_type: None,
         });
 
         let builder = EsQueryBuilder::new("acme", "Patient", "hfs_acme_patient".to_string());

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -10,6 +10,22 @@ use crate::types::{
     SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
 };
 
+/// Maps a search-parameter type to the `search_index` value column used when
+/// sorting on that parameter. Returns `None` for types that are not sortable via
+/// a single value column (composite, special).
+pub(crate) fn sort_value_column(param_type: SearchParamType) -> Option<&'static str> {
+    match param_type {
+        SearchParamType::String => Some("value_string"),
+        SearchParamType::Token => Some("value_token_code"),
+        SearchParamType::Date => Some("value_date"),
+        SearchParamType::Number => Some("value_number"),
+        SearchParamType::Quantity => Some("value_quantity_value"),
+        SearchParamType::Reference => Some("value_reference"),
+        SearchParamType::Uri => Some("value_uri"),
+        SearchParamType::Composite | SearchParamType::Special => None,
+    }
+}
+
 /// A SQL fragment with associated parameters.
 #[derive(Debug, Clone)]
 pub struct SqlFragment {
@@ -142,7 +158,7 @@ impl PostgresQueryBuilder {
                     crate::types::SortDirection::Ascending => "ASC",
                     crate::types::SortDirection::Descending => "DESC",
                 };
-                format!("{} {}", Self::sort_column(&s.parameter), dir)
+                format!("{} {}", Self::sort_expression(s), dir)
             })
             .collect();
 
@@ -154,14 +170,31 @@ impl PostgresQueryBuilder {
         format!("ORDER BY {}", clauses.join(", "))
     }
 
-    /// Maps a FHIR sort parameter name to a `resources` table column.
-    fn sort_column(parameter: &str) -> &'static str {
-        match parameter {
-            "_id" => "id",
-            "_lastUpdated" => "last_updated",
-            // Arbitrary search parameters are not yet sortable; fall back to a
-            // stable column.
-            _ => "id",
+    /// Builds the ORDER BY expression for a single sort directive.
+    ///
+    /// `_id`/`_lastUpdated` map to `resources` columns. Any other indexed search
+    /// parameter sorts on a correlated subquery into `search_index`, taking the
+    /// MIN value for ascending and MAX for descending (FHIR multi-value sort).
+    fn sort_expression(directive: &crate::types::SortDirective) -> String {
+        match directive.parameter.as_str() {
+            "_id" => return "id".to_string(),
+            "_lastUpdated" => return "last_updated".to_string(),
+            _ => {}
+        }
+
+        match directive.param_type.and_then(sort_value_column) {
+            Some(col) => {
+                let agg = match directive.direction {
+                    crate::types::SortDirection::Ascending => "MIN",
+                    crate::types::SortDirection::Descending => "MAX",
+                };
+                format!(
+                    "(SELECT {}({}) FROM search_index si WHERE si.tenant_id = $1 AND si.resource_type = $2 AND si.resource_id = resources.id AND si.param_name = '{}')",
+                    agg, col, directive.parameter
+                )
+            }
+            // Unsortable (composite/special/unresolved) — stable fallback.
+            None => "id".to_string(),
         }
     }
 

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -12,6 +12,22 @@ use super::parameter_handlers::{
     TokenHandler, UriHandler,
 };
 
+/// Maps a search-parameter type to the `search_index` value column used when
+/// sorting on that parameter. Returns `None` for types that are not sortable via
+/// a single value column (composite, special).
+pub(crate) fn sort_value_column(param_type: SearchParamType) -> Option<&'static str> {
+    match param_type {
+        SearchParamType::String => Some("value_string"),
+        SearchParamType::Token => Some("value_token_code"),
+        SearchParamType::Date => Some("value_date"),
+        SearchParamType::Number => Some("value_number"),
+        SearchParamType::Quantity => Some("value_quantity_value"),
+        SearchParamType::Reference => Some("value_reference"),
+        SearchParamType::Uri => Some("value_uri"),
+        SearchParamType::Composite | SearchParamType::Special => None,
+    }
+}
+
 /// A fragment of SQL with bound parameters.
 #[derive(Debug, Clone)]
 pub struct SqlFragment {
@@ -592,10 +608,7 @@ impl QueryBuilder {
                     crate::types::SortDirection::Ascending => "ASC",
                     crate::types::SortDirection::Descending => "DESC",
                 };
-
-                // Map sort parameters to SQL columns
-                let column = self.sort_column(&s.parameter);
-                format!("{} {}", column, dir)
+                format!("{} {}", self.sort_expression(s), dir)
             })
             .collect();
 
@@ -608,17 +621,32 @@ impl QueryBuilder {
         format!("ORDER BY {}", clauses.join(", "))
     }
 
-    /// Maps a sort parameter name to the corresponding SQL column.
+    /// Builds the ORDER BY expression for a single sort directive.
     ///
-    /// This is used by `build_order_by` to translate FHIR sort parameters
-    /// to SQLite column names.
-    fn sort_column(&self, parameter: &str) -> &'static str {
-        match parameter {
-            "_id" => "id",
-            "_lastUpdated" => "last_updated",
-            // Future: could support arbitrary parameters via search_index join
-            // For now, use id as a stable fallback
-            _ => "id",
+    /// `_id`/`_lastUpdated` map to `resources` columns. Any other indexed search
+    /// parameter sorts on a correlated subquery into `search_index`, taking the
+    /// MIN value for ascending and MAX for descending (FHIR multi-value sort).
+    fn sort_expression(&self, directive: &crate::types::SortDirective) -> String {
+        match directive.parameter.as_str() {
+            "_id" => return "id".to_string(),
+            "_lastUpdated" => return "last_updated".to_string(),
+            _ => {}
+        }
+
+        let column = directive.param_type.and_then(sort_value_column);
+        match column {
+            Some(col) => {
+                let agg = match directive.direction {
+                    crate::types::SortDirection::Ascending => "MIN",
+                    crate::types::SortDirection::Descending => "MAX",
+                };
+                format!(
+                    "(SELECT {}({}) FROM search_index si WHERE si.tenant_id = ?1 AND si.resource_type = ?2 AND si.resource_id = resources.id AND si.param_name = '{}')",
+                    agg, col, directive.parameter
+                )
+            }
+            // Unsortable (composite/special/unresolved) — stable fallback.
+            None => "id".to_string(),
         }
     }
 
@@ -725,10 +753,12 @@ mod tests {
             SortDirective {
                 parameter: "_lastUpdated".to_string(),
                 direction: SortDirection::Descending,
+                param_type: None,
             },
             SortDirective {
                 parameter: "_id".to_string(),
                 direction: SortDirection::Ascending,
+                param_type: None,
             },
         ];
 
@@ -745,6 +775,7 @@ mod tests {
         query.sort = vec![SortDirective {
             parameter: "_lastUpdated".to_string(),
             direction: SortDirection::Ascending,
+            param_type: None,
         }];
 
         let order_by = builder.build_order_by(&query);

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -599,6 +599,12 @@ pub struct SortDirective {
     pub parameter: String,
     /// The sort direction.
     pub direction: SortDirection,
+    /// The resolved search-parameter type, when the sort is on an indexed
+    /// search parameter (rather than `_id` / `_lastUpdated`). Lets backends pick
+    /// the correct `search_index` value column. `None` for `_id`/`_lastUpdated`
+    /// or unresolved parameters.
+    #[serde(default)]
+    pub param_type: Option<SearchParamType>,
 }
 
 impl SortDirective {
@@ -608,13 +614,21 @@ impl SortDirective {
             Self {
                 parameter: stripped.to_string(),
                 direction: SortDirection::Descending,
+                param_type: None,
             }
         } else {
             Self {
                 parameter: s.to_string(),
                 direction: SortDirection::Ascending,
+                param_type: None,
             }
         }
+    }
+
+    /// Sets the resolved search-parameter type for this sort directive.
+    pub fn with_param_type(mut self, param_type: Option<SearchParamType>) -> Self {
+        self.param_type = param_type;
+        self
     }
 }
 

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -252,6 +252,7 @@ mod query_builder_tests {
         let query = SearchQuery::new("Patient").with_sort(SortDirective {
             parameter: "_id".to_string(),
             direction: SortDirection::Ascending,
+            param_type: None,
         });
 
         let es_query = builder.build(&query);

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -1238,6 +1238,60 @@ mod postgres_integration {
     }
 
     #[tokio::test]
+    async fn postgres_integration_search_sort_by_indexed_param() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{SearchParamType, SearchQuery, SortDirective};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        for (id, family) in [
+            ("p-charlie", "Charlie"),
+            ("p-alice", "Alice"),
+            ("p-bob", "Bob"),
+        ] {
+            let patient = json!({
+                "resourceType": "Patient",
+                "id": id,
+                "name": [{ "family": family }],
+            });
+            backend
+                .create(&tenant, "Patient", patient, FhirVersion::default())
+                .await
+                .unwrap();
+        }
+
+        let collect_ids = |result: helios_persistence::core::SearchResult| {
+            result
+                .resources
+                .items
+                .iter()
+                .map(|r| r.id().to_string())
+                .collect::<Vec<_>>()
+        };
+
+        let asc = SearchQuery::new("Patient").with_sort(
+            SortDirective::parse("family").with_param_type(Some(SearchParamType::String)),
+        );
+        let ids = collect_ids(backend.search(&tenant, &asc).await.unwrap());
+        assert_eq!(
+            ids,
+            vec!["p-alice", "p-bob", "p-charlie"],
+            "sort by family asc"
+        );
+
+        let desc = SearchQuery::new("Patient").with_sort(
+            SortDirective::parse("-family").with_param_type(Some(SearchParamType::String)),
+        );
+        let ids = collect_ids(backend.search(&tenant, &desc).await.unwrap());
+        assert_eq!(
+            ids,
+            vec!["p-charlie", "p-bob", "p-alice"],
+            "sort by family desc"
+        );
+    }
+
+    #[tokio::test]
     async fn postgres_integration_search_missing_modifier() {
         use helios_persistence::core::SearchProvider;
         use helios_persistence::types::{

--- a/crates/persistence/tests/sqlite_tests.rs
+++ b/crates/persistence/tests/sqlite_tests.rs
@@ -1148,7 +1148,70 @@ async fn test_history_system_tenant_isolation() {
 use helios_persistence::core::SearchProvider;
 use helios_persistence::types::{
     CompositeSearchComponent, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+    SortDirective,
 };
+
+async fn search_ids(
+    backend: &SqliteBackend,
+    tenant: &TenantContext,
+    query: &SearchQuery,
+) -> Vec<String> {
+    backend
+        .search(tenant, query)
+        .await
+        .unwrap()
+        .resources
+        .items
+        .iter()
+        .map(|r| r.id().to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn test_search_sort_by_indexed_param() {
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    for (id, family, birth) in [
+        ("p-charlie", "Charlie", "1990-01-01"),
+        ("p-alice", "Alice", "1985-01-01"),
+        ("p-bob", "Bob", "2000-01-01"),
+    ] {
+        let patient = json!({
+            "resourceType": "Patient",
+            "id": id,
+            "name": [{ "family": family }],
+            "birthDate": birth,
+        });
+        backend
+            .create(&tenant, "Patient", patient, FhirVersion::default())
+            .await
+            .unwrap();
+    }
+
+    // Sort by family (string), ascending then descending.
+    let asc = SearchQuery::new("Patient")
+        .with_sort(SortDirective::parse("family").with_param_type(Some(SearchParamType::String)));
+    assert_eq!(
+        search_ids(&backend, &tenant, &asc).await,
+        vec!["p-alice", "p-bob", "p-charlie"]
+    );
+
+    let desc = SearchQuery::new("Patient")
+        .with_sort(SortDirective::parse("-family").with_param_type(Some(SearchParamType::String)));
+    assert_eq!(
+        search_ids(&backend, &tenant, &desc).await,
+        vec!["p-charlie", "p-bob", "p-alice"]
+    );
+
+    // Sort by birthdate (date), ascending.
+    let by_birth = SearchQuery::new("Patient")
+        .with_sort(SortDirective::parse("birthdate").with_param_type(Some(SearchParamType::Date)));
+    assert_eq!(
+        search_ids(&backend, &tenant, &by_birth).await,
+        vec!["p-alice", "p-charlie", "p-bob"]
+    );
+}
 
 /// Builds the `code-value-quantity` composite query with the component types
 /// the registry would supply, mirroring what the REST layer now wires up.

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -53,7 +53,17 @@ pub fn build_search_query(
             } else {
                 SortDirective::parse(&format!("-{}", sort.field))
             };
-            query.sort.push(directive);
+            // Resolve the search-parameter type so backends can sort by the
+            // indexed value column. `_id`/`_lastUpdated` are columns on the
+            // resources table and need no type.
+            let param_type = if directive.parameter.starts_with('_') {
+                None
+            } else {
+                registry
+                    .get_param(resource_type, &directive.parameter)
+                    .map(|d| d.param_type)
+            };
+            query.sort.push(directive.with_param_type(param_type));
         }
     }
 


### PR DESCRIPTION
Stacked on #120.

## Context
`_sort` only honored `_id`/`_lastUpdated`; every other field silently fell back to `id` ordering, so `_sort=birthdate`, `_sort=family`, etc. did nothing meaningful.

## Changes
- **`SortDirective`** gains a resolved `param_type`; the REST layer fills it from the registry for non-underscore sort fields.
- **SQLite + PostgreSQL `build_order_by`** emit a correlated subquery into `search_index` for indexed sort params — `MIN(value_col)` for ascending, `MAX(value_col)` for descending (FHIR multi-value sort) — with the value column chosen by parameter type (`sort_value_column`). `_id`/`_lastUpdated` still sort on the `resources` table directly.
- Applied on the first-page and offset paths; cursor (keyset) pages keep the default `_lastUpdated` ordering (documented limitation — reconciling keyset paging with arbitrary sort keys is the remaining open item).

## Tests
- SQLite: sort by `family` (string) ascending + descending, and by `birthdate` (date).
- PostgreSQL: sort by `family` asc/desc via testcontainers.
- Full persistence suite (lib + SQLite + PG search) green; clippy `-D warnings` clean on persistence + rest.

## Docs
Matrix sorting note + Phase 5b status + `docs/search-spec-assessment.md` updated (sorting now ✓ for SQLite/PG on any indexed param; roadmap item reframed to "cursor + custom sort").