### PR TITLE
feat(persistence): stateless keyset cursor pagination consistent with _sort

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -382,10 +382,11 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 - **Sorting** — SQLite and PostgreSQL sort by any indexed search parameter (string, token,
   date, number, quantity, reference, URI) via a correlated subquery into the search index, taking
   the min value ascending / max descending for multi-valued params; `_id`/`_lastUpdated` sort on
-  the resources table directly. Sort is applied on the first-page and offset paths; cursor
-  (keyset) pages always use the default `_lastUpdated` ordering. MongoDB sorts by `_id`/
-  `_lastUpdated` only and cannot combine a custom sort with cursor pagination, hence ◐ for
-  multiple fields.
+  the resources table directly. Cursor (keyset) pagination is consistent with the active sort: the
+  sort key value is encoded into the opaque cursor and the keyset comparison runs on it, so deep
+  paging preserves the sort order. A multi-field `_sort` returns a single page (no cursor). MongoDB
+  sorts by `_id`/`_lastUpdated` only and cannot combine a custom sort with cursor pagination, hence
+  ◐ for multiple fields.
 - **`:above` / `:below`** — SQLite, PostgreSQL, and Elasticsearch implement hierarchical URI
   prefix matching (no external service needed), shown as ◐. Token/code hierarchy expansion
   (which needs a terminology server) is not implemented natively.

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -152,19 +152,21 @@ These are parsed and largely orchestrated by the REST layer.
 field's type from the registry (`SortDirective.param_type`). On SQLite and PostgreSQL, `_id` and
 `_lastUpdated` sort on the `resources` table, while any other indexed parameter sorts on a
 correlated subquery into `search_index` — `MIN(value_col)` for ascending, `MAX(value_col)` for
-descending (FHIR multi-value sort), with the value column chosen by the parameter type. Sort is
-applied on the first-page and offset query paths; cursor (keyset) pages always use the default
-`_lastUpdated, id` ordering because the keyset `WHERE` comparison depends on it. MongoDB sorts by
+descending (FHIR multi-value sort), with the value column chosen by the parameter type. Cursor
+(keyset) pagination is consistent with the sort: the boundary row's sort value is selected, encoded
+into the opaque `PageCursor` alongside the id, and the next/previous page applies a keyset `WHERE`
+`(sort_expr, id)` comparison on it — so deep paging preserves the order. A multi-field `_sort`
+returns a single page (no cursor) rather than risk an inconsistent keyset. MongoDB sorts by
 `_id`/`_lastUpdated` only and cannot combine a custom sort with cursor pagination; Elasticsearch
-sorts on its mapped fields.
+sorts on its mapped fields via `search_after`.
 
 ## 7. Known limitations & roadmap
 
 Ordered roughly by impact:
 
-1. **Cursor pagination + custom sort** — SQLite/PG now sort by any indexed parameter on the
-   first-page and offset paths, but cursor (keyset) pages still use the default `_lastUpdated`
-   ordering. Reconciling keyset pagination with arbitrary sort keys remains open. MongoDB still
+1. **Multi-field `_sort` + cursor** — single-field sorts (and the default `_lastUpdated`) page
+   correctly via the keyset cursor on SQLite/PG. A multi-field `_sort` currently returns a single
+   page (no cursor); extending the keyset to a multi-key tuple is the remaining work. MongoDB still
    sorts by `_id`/`_lastUpdated` only.
 2. **Terminology-dependent modifiers** — token `:above`/`:below`, `:in`, `:not-in` need a
    terminology server. `:in` is partially handled via REST-side expansion; the rest are not native.

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -10,6 +10,47 @@ use crate::types::{
     SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
 };
 
+/// How a sort key's value is typed for cursor (keyset) binding and comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortValueKind {
+    /// Text column (string/token/uri/reference/`_id`).
+    Text,
+    /// Floating-point column (number/quantity).
+    Number,
+    /// Timestamp column (`_lastUpdated`, date).
+    Timestamp,
+}
+
+/// A single keyset sort key: the SQL value expression, its direction, and the
+/// value kind used to bind/read the cursor boundary value.
+#[derive(Debug, Clone)]
+pub struct KeysetKey {
+    /// SQL expression yielding the sort value (column or correlated subquery).
+    pub expr: String,
+    /// Sort direction.
+    pub direction: crate::types::SortDirection,
+    /// How the value is typed for binding/reading.
+    pub kind: SortValueKind,
+}
+
+/// Determines the value kind for a sort parameter.
+pub(crate) fn sort_value_kind(
+    parameter: &str,
+    param_type: Option<SearchParamType>,
+) -> SortValueKind {
+    match parameter {
+        "_id" => SortValueKind::Text,
+        "_lastUpdated" => SortValueKind::Timestamp,
+        _ => match param_type {
+            Some(SearchParamType::Number) | Some(SearchParamType::Quantity) => {
+                SortValueKind::Number
+            }
+            Some(SearchParamType::Date) => SortValueKind::Timestamp,
+            _ => SortValueKind::Text,
+        },
+    }
+}
+
 /// Maps a search-parameter type to the `search_index` value column used when
 /// sorting on that parameter. Returns `None` for types that are not sortable via
 /// a single value column (composite, special).
@@ -168,6 +209,28 @@ impl PostgresQueryBuilder {
         }
 
         format!("ORDER BY {}", clauses.join(", "))
+    }
+
+    /// Returns the keyset sort key for cursor pagination, or `None` when the
+    /// query has multiple sort fields (those are returned as a single page
+    /// rather than paged with a possibly-inconsistent keyset).
+    pub fn primary_keyset_key(query: &SearchQuery) -> Option<KeysetKey> {
+        match query.sort.len() {
+            0 => Some(KeysetKey {
+                expr: "last_updated".to_string(),
+                direction: crate::types::SortDirection::Descending,
+                kind: SortValueKind::Timestamp,
+            }),
+            1 => {
+                let directive = &query.sort[0];
+                Some(KeysetKey {
+                    expr: Self::sort_expression(directive),
+                    direction: directive.direction,
+                    kind: sort_value_kind(&directive.parameter, directive.param_type),
+                })
+            }
+            _ => None,
+        }
     }
 
     /// Builds the ORDER BY expression for a single sort directive.

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -26,7 +26,7 @@ use crate::types::{
 
 use super::PostgresBackend;
 use super::search::chain_builder::ChainQueryBuilder;
-use super::search::query_builder::{PostgresQueryBuilder, SqlParam};
+use super::search::query_builder::{PostgresQueryBuilder, SortValueKind, SqlParam};
 
 fn internal_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::Internal {
@@ -50,226 +50,156 @@ impl SearchProvider for PostgresBackend {
         // Get count with default
         let count = query.count.unwrap_or(100) as usize;
 
-        // Check for cursor-based pagination
-        let cursor = query
-            .cursor
-            .as_ref()
-            .and_then(|c| PageCursor::decode(c).ok());
+        // Keyset key for cursor pagination. `None` for multi-field sorts, which
+        // are returned as a single page rather than paged with an inconsistent
+        // keyset.
+        let keyset = PostgresQueryBuilder::primary_keyset_key(query);
 
-        // Determine param offset based on pagination mode
-        // Cursor pagination: $1=tenant, $2=type, $3=timestamp, $4=id -> offset=4
-        // Non-cursor: $1=tenant, $2=type -> offset=2
+        // Only honor an inbound cursor when we can build a keyset comparison.
+        let cursor = if keyset.is_some() {
+            query
+                .cursor
+                .as_ref()
+                .and_then(|c| PageCursor::decode(c).ok())
+        } else {
+            None
+        };
+
+        // Param layout: $1=tenant, $2=type, then (cursor) $3=sort value, $4=id,
+        // then the search-filter params.
         let param_offset = if cursor.is_some() { 4 } else { 2 };
 
-        // Build the search filter subquery if there are search parameters
         let search_filter = if !query.parameters.is_empty() {
             PostgresQueryBuilder::build_search_query(query, param_offset)
         } else {
             None
         };
+        let filter_clause = search_filter
+            .as_ref()
+            .map(|f| format!(" AND ({})", f.sql))
+            .unwrap_or_default();
+        let search_params = search_filter.map(|f| f.params).unwrap_or_default();
 
-        // ORDER BY derived from `_sort` (first-page and offset paths only).
-        // When no `_sort` is supplied we keep the original default ordering
-        // (`id DESC` tie-break) so cursor "next" paging stays consistent. The
-        // cursor/keyset paths always keep their `(last_updated, id)` ordering,
-        // which the keyset WHERE comparison depends on.
+        // SELECT the sort key alongside the row so the next cursor can be built.
+        let select_cols = match &keyset {
+            Some(k) => format!(
+                "id, version_id, data, last_updated, fhir_version, {} AS sort_key",
+                k.expr
+            ),
+            None => "id, version_id, data, last_updated, fhir_version".to_string(),
+        };
+
+        // ORDER BY for the first-page / offset paths.
         let order_by = if query.sort.is_empty() {
-            "ORDER BY last_updated DESC, id DESC".to_string()
+            "ORDER BY last_updated DESC, id ASC".to_string()
         } else {
             PostgresQueryBuilder::build_order_by(query)
         };
 
-        // Build query based on pagination mode
-        let (sql, has_previous, search_params) = if let Some(ref cursor) = cursor {
+        // Build query based on pagination mode.
+        let (sql, has_previous) = if let (Some(cursor), Some(k)) = (&cursor, &keyset) {
+            let e = &k.expr;
+            let asc = k.direction == crate::types::SortDirection::Ascending;
             match cursor.direction() {
                 CursorDirection::Next => {
-                    let sql = if let Some(ref filter) = search_filter {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                             AND ({})
-                             AND (last_updated < $3 OR (last_updated = $3 AND id < $4))
-                             ORDER BY last_updated DESC, id DESC
-                             LIMIT {}",
-                            filter.sql,
-                            count + 1
-                        )
-                    } else {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                             AND (last_updated < $3 OR (last_updated = $3 AND id < $4))
-                             ORDER BY last_updated DESC, id DESC
-                             LIMIT {}",
-                            count + 1
-                        )
-                    };
-                    (
-                        sql,
-                        true,
-                        search_filter.map(|f| f.params).unwrap_or_default(),
-                    )
+                    let e_op = if asc { ">" } else { "<" };
+                    let sql = format!(
+                        "SELECT {cols} FROM resources \
+                         WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE{filter} \
+                         AND ({e} {e_op} $3 OR ({e} = $3 AND id > $4)) \
+                         ORDER BY {e} {dir}, id ASC LIMIT {lim}",
+                        cols = select_cols,
+                        filter = filter_clause,
+                        e = e,
+                        e_op = e_op,
+                        dir = if asc { "ASC" } else { "DESC" },
+                        lim = count + 1,
+                    );
+                    (sql, true)
                 }
                 CursorDirection::Previous => {
-                    let sql = if let Some(ref filter) = search_filter {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                             AND ({})
-                             AND (last_updated > $3 OR (last_updated = $3 AND id > $4))
-                             ORDER BY last_updated ASC, id ASC
-                             LIMIT {}",
-                            filter.sql,
-                            count + 1
-                        )
-                    } else {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                             AND (last_updated > $3 OR (last_updated = $3 AND id > $4))
-                             ORDER BY last_updated ASC, id ASC
-                             LIMIT {}",
-                            count + 1
-                        )
-                    };
-                    (
-                        sql,
-                        false,
-                        search_filter.map(|f| f.params).unwrap_or_default(),
-                    )
+                    let e_op = if asc { "<" } else { ">" };
+                    let sql = format!(
+                        "SELECT {cols} FROM resources \
+                         WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE{filter} \
+                         AND ({e} {e_op} $3 OR ({e} = $3 AND id < $4)) \
+                         ORDER BY {e} {dir}, id DESC LIMIT {lim}",
+                        cols = select_cols,
+                        filter = filter_clause,
+                        e = e,
+                        e_op = e_op,
+                        dir = if asc { "DESC" } else { "ASC" },
+                        lim = count + 1,
+                    );
+                    (sql, false)
                 }
             }
         } else if let Some(offset) = query.offset {
-            // Offset-based pagination (legacy support)
-            let sql = if let Some(ref filter) = search_filter {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     AND ({})
-                     {}
-                     LIMIT {} OFFSET {}",
-                    filter.sql,
-                    order_by,
-                    count + 1,
-                    offset
-                )
-            } else {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     {}
-                     LIMIT {} OFFSET {}",
-                    order_by,
-                    count + 1,
-                    offset
-                )
-            };
-            (
-                sql,
-                offset > 0,
-                search_filter.map(|f| f.params).unwrap_or_default(),
-            )
+            let sql = format!(
+                "SELECT {cols} FROM resources \
+                 WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE{filter} \
+                 {order} LIMIT {lim} OFFSET {off}",
+                cols = select_cols,
+                filter = filter_clause,
+                order = order_by,
+                lim = count + 1,
+                off = offset,
+            );
+            (sql, offset > 0)
         } else {
-            // First page (no cursor, no offset)
-            let sql = if let Some(ref filter) = search_filter {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     AND ({})
-                     {}
-                     LIMIT {}",
-                    filter.sql,
-                    order_by,
-                    count + 1
-                )
-            } else {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     {}
-                     LIMIT {}",
-                    order_by,
-                    count + 1
-                )
-            };
-            (
-                sql,
-                false,
-                search_filter.map(|f| f.params).unwrap_or_default(),
-            )
+            let sql = format!(
+                "SELECT {cols} FROM resources \
+                 WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE{filter} \
+                 {order} LIMIT {lim}",
+                cols = select_cols,
+                filter = filter_clause,
+                order = order_by,
+                lim = count + 1,
+            );
+            (sql, false)
         };
 
-        // Build parameter list for binding
-        let rows = if let Some(ref cursor) = cursor {
-            let (cursor_timestamp, cursor_id) = Self::extract_cursor_values(cursor)?;
-
-            // Build params: [tenant_id, resource_type, cursor_timestamp, cursor_id, ...search_params]
-            let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![
-                Box::new(tenant_id.to_string()),
-                Box::new(resource_type.to_string()),
-                Box::new(cursor_timestamp),
-                Box::new(cursor_id),
-            ];
-
-            for param in &search_params {
-                match param {
-                    SqlParam::Text(s) => params.push(Box::new(s.clone())),
-                    SqlParam::Float(f) => params.push(Box::new(*f)),
-                    SqlParam::Integer(i) => params.push(Box::new(*i)),
-                    SqlParam::Bool(b) => params.push(Box::new(*b)),
-                    SqlParam::Timestamp(dt) => params.push(Box::new(*dt)),
-                    SqlParam::Null => params.push(Box::new(Option::<String>::None)),
-                }
+        // Build parameter list for binding.
+        let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![
+            Box::new(tenant_id.to_string()),
+            Box::new(resource_type.to_string()),
+        ];
+        if let (Some(cursor), Some(k)) = (&cursor, &keyset) {
+            Self::bind_cursor_value(&mut params, k.kind, cursor)?;
+            params.push(Box::new(cursor.resource_id().to_string()));
+        }
+        for param in &search_params {
+            match param {
+                SqlParam::Text(s) => params.push(Box::new(s.clone())),
+                SqlParam::Float(f) => params.push(Box::new(*f)),
+                SqlParam::Integer(i) => params.push(Box::new(*i)),
+                SqlParam::Bool(b) => params.push(Box::new(*b)),
+                SqlParam::Timestamp(dt) => params.push(Box::new(*dt)),
+                SqlParam::Null => params.push(Box::new(Option::<String>::None)),
             }
+        }
+        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
+            .iter()
+            .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
+        let rows = client
+            .query(&sql, &param_refs)
+            .await
+            .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?;
 
-            let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
-                .iter()
-                .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
-                .collect();
-
-            client
-                .query(&sql, &param_refs)
-                .await
-                .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?
-        } else {
-            // Build params: [tenant_id, resource_type, ...search_params]
-            let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![
-                Box::new(tenant_id.to_string()),
-                Box::new(resource_type.to_string()),
-            ];
-
-            for param in &search_params {
-                match param {
-                    SqlParam::Text(s) => params.push(Box::new(s.clone())),
-                    SqlParam::Float(f) => params.push(Box::new(*f)),
-                    SqlParam::Integer(i) => params.push(Box::new(*i)),
-                    SqlParam::Bool(b) => params.push(Box::new(*b)),
-                    SqlParam::Timestamp(dt) => params.push(Box::new(*dt)),
-                    SqlParam::Null => params.push(Box::new(Option::<String>::None)),
-                }
-            }
-
-            let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
-                .iter()
-                .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
-                .collect();
-
-            client
-                .query(&sql, &param_refs)
-                .await
-                .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?
-        };
-
-        let mut resources = Vec::new();
+        // Parse rows, capturing the sort key for cursor construction.
+        let mut parsed: Vec<(StoredResource, Option<CursorValue>)> = Vec::new();
         for row in &rows {
             let id: String = row.get(0);
             let version_id: String = row.get(1);
             let json_data: serde_json::Value = row.get(2);
             let last_updated: chrono::DateTime<Utc> = row.get(3);
             let fhir_version_str: String = row.get(4);
+            let sort_key = keyset
+                .as_ref()
+                .map(|k| Self::read_cursor_value(row, 5, k.kind));
 
             let fhir_version = FhirVersion::from_storage(&fhir_version_str).unwrap_or_default();
-
             let resource = StoredResource::from_storage(
                 resource_type.clone(),
                 id,
@@ -281,50 +211,40 @@ impl SearchProvider for PostgresBackend {
                 None,
                 fhir_version,
             );
-
-            resources.push(resource);
+            parsed.push((resource, sort_key));
         }
 
-        // For backward pagination, reverse the results to maintain DESC order
+        // Backward pagination fetched in reverse order — restore sort order.
         if cursor
             .as_ref()
             .map(|c| c.direction() == CursorDirection::Previous)
             .unwrap_or(false)
         {
-            resources.reverse();
+            parsed.reverse();
         }
 
-        // Check if there are more results (we fetched one extra)
-        let has_next = resources.len() > count;
+        // We fetched one extra to detect a further page.
+        let has_next = parsed.len() > count;
         if has_next {
-            resources.pop();
+            parsed.pop();
         }
 
-        // Generate cursors for pagination
         let next_cursor = if has_next {
-            resources.last().map(|r| {
-                let cursor = PageCursor::new(
-                    vec![CursorValue::String(r.last_modified().to_rfc3339())],
-                    r.id(),
-                );
-                cursor.encode()
+            parsed.last().map(|(r, sk)| {
+                PageCursor::new(vec![sk.clone().unwrap_or(CursorValue::Null)], r.id()).encode()
             })
         } else {
             None
         };
-
         let previous_cursor = if has_previous {
-            resources.first().map(|r| {
-                let cursor = PageCursor::previous(
-                    vec![CursorValue::String(r.last_modified().to_rfc3339())],
-                    r.id(),
-                );
-                cursor.encode()
+            parsed.first().map(|(r, sk)| {
+                PageCursor::previous(vec![sk.clone().unwrap_or(CursorValue::Null)], r.id()).encode()
             })
         } else {
             None
         };
 
+        let resources: Vec<StoredResource> = parsed.into_iter().map(|(r, _)| r).collect();
         let page_info = PageInfo {
             next_cursor,
             previous_cursor,
@@ -332,7 +252,6 @@ impl SearchProvider for PostgresBackend {
             has_next,
             has_previous,
         };
-
         let page = Page::new(resources, page_info);
 
         Ok(SearchResult {
@@ -914,18 +833,73 @@ impl TextSearchProvider for PostgresBackend {
 // Helper methods for search implementations
 impl PostgresBackend {
     /// Extract timestamp and ID from a cursor for keyset pagination.
-    fn extract_cursor_values(cursor: &PageCursor) -> StorageResult<(String, String)> {
-        let sort_values = cursor.sort_values();
-        let timestamp = match sort_values.first() {
-            Some(CursorValue::String(s)) => s.clone(),
-            _ => {
-                return Err(internal_error(
-                    "Invalid cursor: missing or invalid timestamp".to_string(),
-                ));
+    /// Binds the cursor's boundary sort value as `$3`, typed per the sort key
+    /// kind so PostgreSQL compares it correctly against the sort expression.
+    fn bind_cursor_value(
+        params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
+        kind: SortValueKind,
+        cursor: &PageCursor,
+    ) -> StorageResult<()> {
+        let value = cursor.sort_values().first();
+        match kind {
+            SortValueKind::Timestamp => {
+                let dt = match value {
+                    Some(CursorValue::String(s)) => chrono::DateTime::parse_from_rfc3339(s)
+                        .map(|d| d.with_timezone(&Utc))
+                        .map_err(|_| internal_error("Invalid cursor timestamp".to_string()))?,
+                    _ => {
+                        return Err(internal_error(
+                            "Invalid cursor: expected timestamp".to_string(),
+                        ));
+                    }
+                };
+                params.push(Box::new(dt));
             }
-        };
-        let id = cursor.resource_id().to_string();
-        Ok((timestamp, id))
+            SortValueKind::Number => {
+                let n = match value {
+                    Some(CursorValue::Decimal(f)) => *f,
+                    Some(CursorValue::Number(i)) => *i as f64,
+                    Some(CursorValue::String(s)) => s.parse().unwrap_or(0.0),
+                    _ => {
+                        return Err(internal_error(
+                            "Invalid cursor: expected number".to_string(),
+                        ));
+                    }
+                };
+                params.push(Box::new(n));
+            }
+            SortValueKind::Text => match value {
+                Some(CursorValue::String(s)) => params.push(Box::new(s.clone())),
+                Some(CursorValue::Null) | None => params.push(Box::new(Option::<String>::None)),
+                _ => {
+                    return Err(internal_error("Invalid cursor: expected text".to_string()));
+                }
+            },
+        }
+        Ok(())
+    }
+
+    /// Reads the `sort_key` column (index 5) as a `CursorValue` per the key kind.
+    fn read_cursor_value(
+        row: &tokio_postgres::Row,
+        idx: usize,
+        kind: SortValueKind,
+    ) -> CursorValue {
+        match kind {
+            SortValueKind::Timestamp => {
+                let v: Option<chrono::DateTime<Utc>> = row.try_get(idx).ok().flatten();
+                v.map(|d| CursorValue::String(d.to_rfc3339()))
+                    .unwrap_or(CursorValue::Null)
+            }
+            SortValueKind::Number => {
+                let v: Option<f64> = row.try_get(idx).ok().flatten();
+                v.map(CursorValue::Decimal).unwrap_or(CursorValue::Null)
+            }
+            SortValueKind::Text => {
+                let v: Option<String> = row.try_get(idx).ok().flatten();
+                v.map(CursorValue::String).unwrap_or(CursorValue::Null)
+            }
+        }
     }
 
     /// Extract references from a resource for a given search parameter.

--- a/crates/persistence/src/backends/sqlite/search/mod.rs
+++ b/crates/persistence/src/backends/sqlite/search/mod.rs
@@ -22,6 +22,6 @@ pub mod writer;
 pub use chain_builder::{ChainError, ChainLink, ChainQueryBuilder, ParsedChain};
 pub use filter_parser::{FilterExpr, FilterOp, FilterParseError, FilterParser, FilterSqlGenerator};
 pub use parameter_handlers::CompositeComponentDef;
-pub use query_builder::{QueryBuilder, SqlFragment, SqlParam};
+pub use query_builder::{KeysetKey, QueryBuilder, SortValueKind, SqlFragment, SqlParam};
 pub use strategy::{SearchStrategyCapability, SqliteSearchStrategy};
 pub use writer::{SqlValue, SqliteSearchIndexWriter};

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -12,6 +12,47 @@ use super::parameter_handlers::{
     TokenHandler, UriHandler,
 };
 
+/// How a sort key's value is typed for cursor (keyset) binding and comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortValueKind {
+    /// Text column (string/token/uri/reference/`_id`).
+    Text,
+    /// Floating-point column (number/quantity).
+    Number,
+    /// Timestamp column, stored as RFC3339 text (`_lastUpdated`, date).
+    Timestamp,
+}
+
+/// A single keyset sort key: the SQL value expression, its direction, and the
+/// value kind used to bind/read the cursor boundary value.
+#[derive(Debug, Clone)]
+pub struct KeysetKey {
+    /// SQL expression yielding the sort value (column or correlated subquery).
+    pub expr: String,
+    /// Sort direction.
+    pub direction: crate::types::SortDirection,
+    /// How the value is typed for binding/reading.
+    pub kind: SortValueKind,
+}
+
+/// Determines the value kind for a sort parameter.
+pub(crate) fn sort_value_kind(
+    parameter: &str,
+    param_type: Option<SearchParamType>,
+) -> SortValueKind {
+    match parameter {
+        "_id" => SortValueKind::Text,
+        "_lastUpdated" => SortValueKind::Timestamp,
+        _ => match param_type {
+            Some(SearchParamType::Number) | Some(SearchParamType::Quantity) => {
+                SortValueKind::Number
+            }
+            Some(SearchParamType::Date) => SortValueKind::Timestamp,
+            _ => SortValueKind::Text,
+        },
+    }
+}
+
 /// Maps a search-parameter type to the `search_index` value column used when
 /// sorting on that parameter. Returns `None` for types that are not sortable via
 /// a single value column (composite, special).
@@ -619,6 +660,28 @@ impl QueryBuilder {
         }
 
         format!("ORDER BY {}", clauses.join(", "))
+    }
+
+    /// Returns the keyset sort key for cursor pagination, or `None` when the
+    /// query has multiple sort fields (those are returned as a single page
+    /// rather than paged with a possibly-inconsistent keyset).
+    pub fn primary_keyset_key(&self, query: &SearchQuery) -> Option<KeysetKey> {
+        match query.sort.len() {
+            0 => Some(KeysetKey {
+                expr: "last_updated".to_string(),
+                direction: crate::types::SortDirection::Descending,
+                kind: SortValueKind::Timestamp,
+            }),
+            1 => {
+                let directive = &query.sort[0];
+                Some(KeysetKey {
+                    expr: self.sort_expression(directive),
+                    direction: directive.direction,
+                    kind: sort_value_kind(&directive.parameter, directive.param_type),
+                })
+            }
+            _ => None,
+        }
     }
 
     /// Builds the ORDER BY expression for a single sort directive.

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -26,7 +26,7 @@ use crate::types::{
 };
 
 use super::SqliteBackend;
-use super::search::{QueryBuilder, SqlParam};
+use super::search::{QueryBuilder, SortValueKind, SqlParam};
 
 fn internal_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::Internal {
@@ -34,6 +34,39 @@ fn internal_error(message: String) -> StorageError {
         message,
         source: None,
     })
+}
+
+/// Binds the cursor's boundary sort value as `?3`, typed per the sort key kind.
+/// Timestamps are stored as RFC3339 text, so they bind (and compare) as text.
+fn bind_cursor_value(
+    params: &mut Vec<Box<dyn rusqlite::ToSql>>,
+    kind: SortValueKind,
+    cursor: &PageCursor,
+) -> StorageResult<()> {
+    let value = cursor.sort_values().first();
+    match kind {
+        SortValueKind::Number => {
+            let n = match value {
+                Some(CursorValue::Decimal(f)) => *f,
+                Some(CursorValue::Number(i)) => *i as f64,
+                Some(CursorValue::String(s)) => s.parse().unwrap_or(0.0),
+                _ => {
+                    return Err(internal_error(
+                        "Invalid cursor: expected number".to_string(),
+                    ));
+                }
+            };
+            params.push(Box::new(n));
+        }
+        SortValueKind::Timestamp | SortValueKind::Text => match value {
+            Some(CursorValue::String(s)) => params.push(Box::new(s.clone())),
+            Some(CursorValue::Null) | None => params.push(Box::new(Option::<String>::None)),
+            _ => {
+                return Err(internal_error("Invalid cursor: expected text".to_string()));
+            }
+        },
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -50,25 +83,30 @@ impl SearchProvider for SqliteBackend {
         // Get count with default
         let count = query.count.unwrap_or(100) as usize;
 
-        // Check for cursor-based pagination
-        let cursor = query
-            .cursor
-            .as_ref()
-            .and_then(|c| PageCursor::decode(c).ok());
+        // Keyset key for cursor pagination. `None` for multi-field sorts, which
+        // are returned as a single page rather than paged with an inconsistent
+        // keyset.
+        let keyset = QueryBuilder::new(tenant_id, resource_type).primary_keyset_key(query);
 
-        // Determine param offset based on pagination mode
-        // Cursor pagination: ?1=tenant, ?2=type, ?3=timestamp, ?4=id -> offset=4
-        // Non-cursor: ?1=tenant, ?2=type -> offset=2
+        // Only honor an inbound cursor when we can build a keyset comparison.
+        let cursor = if keyset.is_some() {
+            query
+                .cursor
+                .as_ref()
+                .and_then(|c| PageCursor::decode(c).ok())
+        } else {
+            None
+        };
+
+        // Param layout: ?1=tenant, ?2=type, then (cursor) ?3=sort value, ?4=id,
+        // then the search-filter params.
         let param_offset = if cursor.is_some() { 4 } else { 2 };
 
-        // Build the search filter subquery if there are search parameters
         let search_filter = if !query.parameters.is_empty() {
             let builder =
                 QueryBuilder::new(tenant_id, resource_type).with_param_offset(param_offset);
             let fragment = builder.build(query);
             if !fragment.sql.is_empty() {
-                // The QueryBuilder returns a SELECT DISTINCT resource_id query
-                // We use this as a subquery to filter the resources table
                 Some(fragment)
             } else {
                 None
@@ -76,222 +114,140 @@ impl SearchProvider for SqliteBackend {
         } else {
             None
         };
+        let filter_clause = search_filter
+            .as_ref()
+            .map(|f| format!(" AND id IN ({})", f.sql))
+            .unwrap_or_default();
+        let search_params = search_filter.map(|f| f.params).unwrap_or_default();
 
-        // ORDER BY derived from `_sort` (first-page and offset paths only).
-        // When no `_sort` is supplied we keep the original default ordering
-        // (`id DESC` tie-break) so cursor "next" paging stays consistent. The
-        // cursor/keyset paths always keep their `(last_updated, id)` ordering,
-        // which the keyset WHERE comparison depends on.
+        // SELECT the sort key alongside the row so the next cursor can be built.
+        let select_cols = match &keyset {
+            Some(k) => format!(
+                "id, version_id, data, last_updated, fhir_version, {} AS sort_key",
+                k.expr
+            ),
+            None => "id, version_id, data, last_updated, fhir_version".to_string(),
+        };
+
+        // ORDER BY for the first-page / offset paths.
         let order_by = if query.sort.is_empty() {
-            "ORDER BY last_updated DESC, id DESC".to_string()
+            "ORDER BY last_updated DESC, id ASC".to_string()
         } else {
             QueryBuilder::new(tenant_id, resource_type).build_order_by(query)
         };
 
-        // Build query based on pagination mode
-        let (sql, has_previous, search_params) = if let Some(ref cursor) = cursor {
-            // Cursor-based pagination using keyset
+        // Build query based on pagination mode.
+        let (sql, has_previous) = if let (Some(cursor), Some(k)) = (&cursor, &keyset) {
+            let e = &k.expr;
+            let asc = k.direction == crate::types::SortDirection::Ascending;
             match cursor.direction() {
                 CursorDirection::Next => {
-                    let sql = if let Some(ref filter) = search_filter {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                             AND id IN ({})
-                             AND (last_updated < ?3 OR (last_updated = ?3 AND id < ?4))
-                             ORDER BY last_updated DESC, id DESC
-                             LIMIT {}",
-                            filter.sql,
-                            count + 1
-                        )
-                    } else {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                             AND (last_updated < ?3 OR (last_updated = ?3 AND id < ?4))
-                             ORDER BY last_updated DESC, id DESC
-                             LIMIT {}",
-                            count + 1
-                        )
-                    };
-                    (
-                        sql,
-                        true,
-                        search_filter.map(|f| f.params).unwrap_or_default(),
-                    )
+                    let e_op = if asc { ">" } else { "<" };
+                    let sql = format!(
+                        "SELECT {cols} FROM resources \
+                         WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0{filter} \
+                         AND ({e} {e_op} ?3 OR ({e} = ?3 AND id > ?4)) \
+                         ORDER BY {e} {dir}, id ASC LIMIT {lim}",
+                        cols = select_cols,
+                        filter = filter_clause,
+                        e = e,
+                        e_op = e_op,
+                        dir = if asc { "ASC" } else { "DESC" },
+                        lim = count + 1,
+                    );
+                    (sql, true)
                 }
                 CursorDirection::Previous => {
-                    let sql = if let Some(ref filter) = search_filter {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                             AND id IN ({})
-                             AND (last_updated > ?3 OR (last_updated = ?3 AND id > ?4))
-                             ORDER BY last_updated ASC, id ASC
-                             LIMIT {}",
-                            filter.sql,
-                            count + 1
-                        )
-                    } else {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                             AND (last_updated > ?3 OR (last_updated = ?3 AND id > ?4))
-                             ORDER BY last_updated ASC, id ASC
-                             LIMIT {}",
-                            count + 1
-                        )
-                    };
-                    (
-                        sql,
-                        false,
-                        search_filter.map(|f| f.params).unwrap_or_default(),
-                    )
+                    let e_op = if asc { "<" } else { ">" };
+                    let sql = format!(
+                        "SELECT {cols} FROM resources \
+                         WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0{filter} \
+                         AND ({e} {e_op} ?3 OR ({e} = ?3 AND id < ?4)) \
+                         ORDER BY {e} {dir}, id DESC LIMIT {lim}",
+                        cols = select_cols,
+                        filter = filter_clause,
+                        e = e,
+                        e_op = e_op,
+                        dir = if asc { "DESC" } else { "ASC" },
+                        lim = count + 1,
+                    );
+                    (sql, false)
                 }
             }
         } else if let Some(offset) = query.offset {
-            // Offset-based pagination (legacy support)
-            let sql = if let Some(ref filter) = search_filter {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     AND id IN ({})
-                     {}
-                     LIMIT {} OFFSET {}",
-                    filter.sql,
-                    order_by,
-                    count + 1,
-                    offset
-                )
-            } else {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     {}
-                     LIMIT {} OFFSET {}",
-                    order_by,
-                    count + 1,
-                    offset
-                )
-            };
-            (
-                sql,
-                offset > 0,
-                search_filter.map(|f| f.params).unwrap_or_default(),
-            )
+            let sql = format!(
+                "SELECT {cols} FROM resources \
+                 WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0{filter} \
+                 {order} LIMIT {lim} OFFSET {off}",
+                cols = select_cols,
+                filter = filter_clause,
+                order = order_by,
+                lim = count + 1,
+                off = offset,
+            );
+            (sql, offset > 0)
         } else {
-            // First page (no cursor, no offset)
-            let sql = if let Some(ref filter) = search_filter {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     AND id IN ({})
-                     {}
-                     LIMIT {}",
-                    filter.sql,
-                    order_by,
-                    count + 1
-                )
-            } else {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     {}
-                     LIMIT {}",
-                    order_by,
-                    count + 1
-                )
-            };
-            (
-                sql,
-                false,
-                search_filter.map(|f| f.params).unwrap_or_default(),
-            )
+            let sql = format!(
+                "SELECT {cols} FROM resources \
+                 WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0{filter} \
+                 {order} LIMIT {lim}",
+                cols = select_cols,
+                filter = filter_clause,
+                order = order_by,
+                lim = count + 1,
+            );
+            (sql, false)
         };
 
         let mut stmt = conn
             .prepare(&sql)
             .map_err(|e| internal_error(format!("Failed to prepare search query: {}", e)))?;
 
-        // Build the parameter list for binding
-        // Base params are always tenant_id and resource_type
-        // For cursor pagination, add cursor_timestamp and cursor_id
-        // Then append any search params from the QueryBuilder
-        let raw_rows: Vec<(String, String, Vec<u8>, String, String)> =
-            if let Some(ref cursor) = cursor {
-                let (cursor_timestamp, cursor_id) = Self::extract_cursor_values(cursor)?;
+        // Bind params: tenant, type, then (cursor) sort value + id, then filter params.
+        let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = vec![
+            Box::new(tenant_id.to_string()),
+            Box::new(resource_type.to_string()),
+        ];
+        if let (Some(cursor), Some(k)) = (&cursor, &keyset) {
+            bind_cursor_value(&mut all_params, k.kind, cursor)?;
+            all_params.push(Box::new(cursor.resource_id().to_string()));
+        }
+        for param in &search_params {
+            match param {
+                SqlParam::String(s) => all_params.push(Box::new(s.clone())),
+                SqlParam::Integer(i) => all_params.push(Box::new(*i)),
+                SqlParam::Float(f) => all_params.push(Box::new(*f)),
+                SqlParam::Null => all_params.push(Box::new(Option::<String>::None)),
+            }
+        }
+        let param_refs: Vec<&dyn rusqlite::ToSql> = all_params.iter().map(|p| p.as_ref()).collect();
 
-                // Build params: [tenant_id, resource_type, cursor_timestamp, cursor_id, ...search_params]
-                let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = vec![
-                    Box::new(tenant_id.to_string()),
-                    Box::new(resource_type.to_string()),
-                    Box::new(cursor_timestamp),
-                    Box::new(cursor_id),
-                ];
-
-                // Add search params
-                for param in &search_params {
-                    match param {
-                        SqlParam::String(s) => all_params.push(Box::new(s.clone())),
-                        SqlParam::Integer(i) => all_params.push(Box::new(*i)),
-                        SqlParam::Float(f) => all_params.push(Box::new(*f)),
-                        SqlParam::Null => all_params.push(Box::new(Option::<String>::None)),
+        // The sort key (column 5) is selected only when keyset paging is active.
+        let sort_kind = keyset.as_ref().map(|k| k.kind);
+        let raw_rows: Vec<(String, String, Vec<u8>, String, String, Option<CursorValue>)> = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                let id: String = row.get(0)?;
+                let version_id: String = row.get(1)?;
+                let data: Vec<u8> = row.get(2)?;
+                let last_updated: String = row.get(3)?;
+                let fhir_version: String = row.get(4)?;
+                let sort_key = match sort_kind {
+                    Some(SortValueKind::Number) => {
+                        row.get::<_, Option<f64>>(5)?.map(CursorValue::Decimal)
                     }
-                }
+                    // Timestamps are stored as RFC3339 text, so read text.
+                    Some(_) => row.get::<_, Option<String>>(5)?.map(CursorValue::String),
+                    None => None,
+                };
+                Ok((id, version_id, data, last_updated, fhir_version, sort_key))
+            })
+            .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| internal_error(format!("Failed to read row: {}", e)))?;
 
-                let param_refs: Vec<&dyn rusqlite::ToSql> =
-                    all_params.iter().map(|p| p.as_ref()).collect();
-
-                let rows = stmt
-                    .query_map(param_refs.as_slice(), |row| {
-                        let id: String = row.get(0)?;
-                        let version_id: String = row.get(1)?;
-                        let data: Vec<u8> = row.get(2)?;
-                        let last_updated: String = row.get(3)?;
-                        let fhir_version: String = row.get(4)?;
-                        Ok((id, version_id, data, last_updated, fhir_version))
-                    })
-                    .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?;
-
-                rows.collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| internal_error(format!("Failed to read row: {}", e)))?
-            } else {
-                // Build params: [tenant_id, resource_type, ...search_params]
-                let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = vec![
-                    Box::new(tenant_id.to_string()),
-                    Box::new(resource_type.to_string()),
-                ];
-
-                // Add search params
-                for param in &search_params {
-                    match param {
-                        SqlParam::String(s) => all_params.push(Box::new(s.clone())),
-                        SqlParam::Integer(i) => all_params.push(Box::new(*i)),
-                        SqlParam::Float(f) => all_params.push(Box::new(*f)),
-                        SqlParam::Null => all_params.push(Box::new(Option::<String>::None)),
-                    }
-                }
-
-                let param_refs: Vec<&dyn rusqlite::ToSql> =
-                    all_params.iter().map(|p| p.as_ref()).collect();
-
-                let rows = stmt
-                    .query_map(param_refs.as_slice(), |row| {
-                        let id: String = row.get(0)?;
-                        let version_id: String = row.get(1)?;
-                        let data: Vec<u8> = row.get(2)?;
-                        let last_updated: String = row.get(3)?;
-                        let fhir_version: String = row.get(4)?;
-                        Ok((id, version_id, data, last_updated, fhir_version))
-                    })
-                    .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?;
-
-                rows.collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| internal_error(format!("Failed to read row: {}", e)))?
-            };
-
-        let mut resources = Vec::new();
-        for (id, version_id, data, last_updated_str, fhir_version_str) in raw_rows {
+        // Parse rows, carrying the sort key for cursor construction.
+        let mut parsed: Vec<(StoredResource, Option<CursorValue>)> = Vec::new();
+        for (id, version_id, data, last_updated_str, fhir_version_str, sort_key) in raw_rows {
             let json_data: serde_json::Value = serde_json::from_slice(&data)
                 .map_err(|e| internal_error(format!("Failed to deserialize resource: {}", e)))?;
 
@@ -313,49 +269,40 @@ impl SearchProvider for SqliteBackend {
                 fhir_version,
             );
 
-            resources.push(resource);
+            parsed.push((resource, sort_key));
         }
 
-        // For backward pagination, reverse the results to maintain DESC order
+        // Backward pagination fetched in reverse order — restore sort order.
         if cursor
             .as_ref()
             .map(|c| c.direction() == CursorDirection::Previous)
             .unwrap_or(false)
         {
-            resources.reverse();
+            parsed.reverse();
         }
 
-        // Check if there are more results (we fetched one extra)
-        let has_next = resources.len() > count;
+        // We fetched one extra to detect a further page.
+        let has_next = parsed.len() > count;
         if has_next {
-            resources.pop(); // Remove the extra one
+            parsed.pop();
         }
 
-        // Generate cursors for pagination
         let next_cursor = if has_next {
-            resources.last().map(|r| {
-                let cursor = PageCursor::new(
-                    vec![CursorValue::String(r.last_modified().to_rfc3339())],
-                    r.id(),
-                );
-                cursor.encode()
+            parsed.last().map(|(r, sk)| {
+                PageCursor::new(vec![sk.clone().unwrap_or(CursorValue::Null)], r.id()).encode()
             })
         } else {
             None
         };
-
         let previous_cursor = if has_previous {
-            resources.first().map(|r| {
-                let cursor = PageCursor::previous(
-                    vec![CursorValue::String(r.last_modified().to_rfc3339())],
-                    r.id(),
-                );
-                cursor.encode()
+            parsed.first().map(|(r, sk)| {
+                PageCursor::previous(vec![sk.clone().unwrap_or(CursorValue::Null)], r.id()).encode()
             })
         } else {
             None
         };
 
+        let resources: Vec<StoredResource> = parsed.into_iter().map(|(r, _)| r).collect();
         let page_info = PageInfo {
             next_cursor,
             previous_cursor,
@@ -885,21 +832,6 @@ impl ChainedSearchProvider for SqliteBackend {
 
 // Helper methods for search implementations
 impl SqliteBackend {
-    /// Extract timestamp and ID from a cursor for keyset pagination.
-    fn extract_cursor_values(cursor: &PageCursor) -> StorageResult<(String, String)> {
-        let sort_values = cursor.sort_values();
-        let timestamp = match sort_values.first() {
-            Some(CursorValue::String(s)) => s.clone(),
-            _ => {
-                return Err(internal_error(
-                    "Invalid cursor: missing or invalid timestamp".to_string(),
-                ));
-            }
-        };
-        let id = cursor.resource_id().to_string();
-        Ok((timestamp, id))
-    }
-
     /// Extract references from a resource for a given search parameter.
     fn extract_references(&self, content: &serde_json::Value, search_param: &str) -> Vec<String> {
         let mut refs = Vec::new();

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -1238,6 +1238,58 @@ mod postgres_integration {
     }
 
     #[tokio::test]
+    async fn postgres_integration_search_cursor_with_custom_sort() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{SearchParamType, SearchQuery, SortDirective};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        // Insert out of order; page size 1 to force keyset paging across pages.
+        for (id, family) in [
+            ("p-charlie", "Charlie"),
+            ("p-alice", "Alice"),
+            ("p-bob", "Bob"),
+        ] {
+            backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({ "resourceType": "Patient", "id": id, "name": [{ "family": family }] }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let mut collected = Vec::new();
+        let mut cursor: Option<String> = None;
+        for _ in 0..5 {
+            let mut q = SearchQuery::new("Patient")
+                .with_sort(
+                    SortDirective::parse("family").with_param_type(Some(SearchParamType::String)),
+                )
+                .with_count(1);
+            q.cursor = cursor.clone();
+            let result = backend.search(&tenant, &q).await.unwrap();
+            for r in &result.resources.items {
+                collected.push(r.id().to_string());
+            }
+            match result.resources.page_info.next_cursor {
+                Some(c) => cursor = Some(c),
+                None => break,
+            }
+        }
+
+        // Keyset paging must yield the full set in family order, no dups/gaps.
+        assert_eq!(
+            collected,
+            vec!["p-alice", "p-bob", "p-charlie"],
+            "cursor paging with custom sort must preserve global order"
+        );
+    }
+
+    #[tokio::test]
     async fn postgres_integration_search_sort_by_indexed_param() {
         use helios_persistence::core::SearchProvider;
         use helios_persistence::types::{SearchParamType, SearchQuery, SortDirective};

--- a/crates/persistence/tests/sqlite_tests.rs
+++ b/crates/persistence/tests/sqlite_tests.rs
@@ -1168,6 +1168,87 @@ async fn search_ids(
 }
 
 #[tokio::test]
+async fn test_search_cursor_with_custom_sort() {
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    // Insert out of order; page size 1 to force keyset paging across pages.
+    for (id, family) in [
+        ("p-charlie", "Charlie"),
+        ("p-alice", "Alice"),
+        ("p-bob", "Bob"),
+    ] {
+        let patient =
+            json!({ "resourceType": "Patient", "id": id, "name": [{ "family": family }] });
+        backend
+            .create(&tenant, "Patient", patient, FhirVersion::default())
+            .await
+            .unwrap();
+    }
+
+    let mut collected = Vec::new();
+    let mut cursor: Option<String> = None;
+    for _ in 0..5 {
+        let mut q = SearchQuery::new("Patient")
+            .with_sort(
+                SortDirective::parse("family").with_param_type(Some(SearchParamType::String)),
+            )
+            .with_count(1);
+        q.cursor = cursor.clone();
+        let result = backend.search(&tenant, &q).await.unwrap();
+        for r in &result.resources.items {
+            collected.push(r.id().to_string());
+        }
+        match result.resources.page_info.next_cursor {
+            Some(c) => cursor = Some(c),
+            None => break,
+        }
+    }
+
+    assert_eq!(
+        collected,
+        vec!["p-alice", "p-bob", "p-charlie"],
+        "cursor paging with custom sort must preserve global order"
+    );
+}
+
+#[tokio::test]
+async fn test_search_cursor_default_sort_paging() {
+    // The default (no _sort) keyset still pages correctly across pages.
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    for id in ["a", "b", "c", "d"] {
+        let patient = json!({ "resourceType": "Patient", "id": id });
+        backend
+            .create(&tenant, "Patient", patient, FhirVersion::default())
+            .await
+            .unwrap();
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut total = 0;
+    let mut cursor: Option<String> = None;
+    for _ in 0..10 {
+        let mut q = SearchQuery::new("Patient").with_count(2);
+        q.cursor = cursor.clone();
+        let result = backend.search(&tenant, &q).await.unwrap();
+        for r in &result.resources.items {
+            assert!(
+                seen.insert(r.id().to_string()),
+                "no duplicate ids across pages"
+            );
+            total += 1;
+        }
+        match result.resources.page_info.next_cursor {
+            Some(c) => cursor = Some(c),
+            None => break,
+        }
+    }
+    assert_eq!(total, 4, "all four resources returned exactly once");
+}
+
+#[tokio::test]
 async fn test_search_sort_by_indexed_param() {
     let backend = create_backend();
     let tenant = create_tenant("test-tenant");


### PR DESCRIPTION
Stacked on #121. Closes the "silently-wrong" cursor + custom sort gap.

## Problem
Cursor paging hardcoded a `last_updated` keyset. After PR #121 made `_sort` work on the first page, paging past it via the `next` link silently reverted to `_lastUpdated` order — producing duplicates/gaps relative to the requested sort.

## Approach (stateless keyset)
The cursor stays opaque and stateless — the sort key value + resource id are encoded inside the base64 `PageCursor`, carried in the Bundle's `next`/`previous` links. No server-side state.

- The boundary row's sort value is selected (`<sort_expr> AS sort_key`), read back typed, and encoded into the cursor's `sort_values`.
- `primary_keyset_key` derives the sort `(expr, direction, value-kind)` from the query. The next/previous page applies a keyset `(sort_expr, id)` comparison bound to the cursor value, with `ORDER BY` matched to it.
- Binding/reading is typed per value-kind (text / number / timestamp). This also **fixes a latent bug** where the default `last_updated` cursor bound a `String` against a `timestamptz` column on PostgreSQL.
- **Scope:** single-field sorts (and the default `_lastUpdated`) page correctly; a multi-field `_sort` returns a single page (no cursor) rather than risk an inconsistent keyset. Extending to a multi-key tuple is noted as the remaining follow-up.

## Tests
- SQLite: paging a `_sort=family` result one-per-page reassembles the full set in order; default-sort multi-page paging has no duplicates/gaps.
- PostgreSQL: `_sort=family` multi-page paging via testcontainers.
- Full persistence suite (628 lib + 77 SQLite + 63 PG) and clippy `-D warnings` clean.

## Docs
README sorting note + `docs/search-spec-assessment.md` (`_sort` detail + roadmap item reframed to "multi-field `_sort` + cursor").