### PR TITLE
feat(persistence): evaluate composite components in Elasticsearch

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -347,7 +347,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [Number](https://build.fhir.org/search.html#number)                         | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ○   |
 | [Quantity](https://build.fhir.org/search.html#quantity)                     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ○   |
 | [URI](https://build.fhir.org/search.html#uri)                               | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
-| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ✓          | ○       | ✗         | ○     | ◐             | ✗   |
+| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
 | **[Search Modifiers](https://build.fhir.org/search.html#modifiers)**        |
 | [:exact](https://build.fhir.org/search.html#modifiers)                      | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
 | [:contains](https://build.fhir.org/search.html#modifiers)                   | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
@@ -393,11 +393,12 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 - **`:in` / `:not-in`** — handled at the REST layer: `:in` is expanded against a terminology
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.
-- **Composite** — SQLite and PostgreSQL evaluate composite component values (token, string,
-  number, quantity, date) end-to-end (✓): the REST layer resolves component types from the
-  registry, the extractor indexes each composite instance as a `composite_group`, and the backend
-  matches all components within one group. Elasticsearch matches on the composite parameter name
-  only (◐). See `docs/search-spec-assessment.md`.
+- **Composite** — SQLite, PostgreSQL, and Elasticsearch evaluate composite component values
+  (token, string, number, quantity, date) end-to-end (✓): the REST layer resolves component types
+  from the registry and the extractor indexes each composite instance as a `composite_group`.
+  SQLite/PG match all components within one group via `GROUP BY … HAVING`; Elasticsearch indexes
+  each instance as one nested object with inline component values and matches with a single nested
+  query. See `docs/search-spec-assessment.md`.
 
 The S3 backend is intentionally storage-focused (CRUD/version/history/bulk submit) and does not act as a full FHIR search engine. For bulk export, S3 can feed system-level batches through `ExportDataProvider` and can store output files through `S3OutputStore`, but job state belongs to SQLite or PostgreSQL. Patient-level and Group-level export compartment enumeration are not supported by S3 as the resource store. For query-heavy deployments, use a DB/search backend as primary query engine and compose S3 as archive/history/output storage.
 
@@ -1115,8 +1116,9 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
 - [x] Index schema and mappings (nested objects for multi-value search params)
 - [x] ResourceStorage implementation for composite sync support
 - [x] Search query translation (FHIR SearchQuery → ES Query DSL)
-- [x] Parameter type handlers (string, token, date, number, quantity, reference, URI; composite
-      matches on the parameter name only — component values are not yet evaluated)
+- [x] Parameter type handlers (string, token, date, number, quantity, reference, URI, composite —
+      each composite instance is one nested object with inline component values, matched by a
+      single nested query)
 - [x] Full-text search (`_text`, `_content`, `:text-advanced`)
 - [x] Modifier support (:exact, :contains, :text, :not, :missing, :above, :below, :of-type)
 - [x] `_include` and `_revinclude` resolution

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -40,7 +40,7 @@ Neo4j are not implemented.
 | number | ✓ | ✓ | ✓ | ✓ | implicit-precision ranges + all prefixes |
 | quantity | ✓ | ✓ | ✗ | ✓ | MongoDB rejects with `UnsupportedParameterType` |
 | uri | ✓ | ✓ | ✓ | ✓ | exact + `:above`/`:below` prefix matching |
-| composite | ✓ | ✓ | ✗ | ◐ | SQLite/PG evaluate components; ES matches name only; Mongo returns no condition |
+| composite | ✓ | ✓ | ✗ | ✓ | SQLite/PG group by `composite_group`; ES uses one nested object per instance; Mongo returns no condition |
 
 The `resource` and `special` parameter types from the spec are modeled in the `SearchParamType`
 enum but have no dedicated execution path beyond the special common parameters below.
@@ -176,11 +176,22 @@ Ordered roughly by impact:
    composite parameters are all supported now).
 4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
    chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
-5. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
-   forward chaining and `_has` silently return nothing rather than erroring; `_filter` unsupported.
+5. **Elasticsearch gaps** — forward chaining and `_has` silently return nothing rather than
+   erroring; `_filter` unsupported. (Composite now evaluates components via inline nested objects.)
+   See the chaining note below — chained search is a cross-cutting dispatch gap, not ES-specific.
 6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
    unsupported everywhere.
+
+**Chaining dispatch (cross-cutting).** Chained (`subject.name=Smith`) and reverse-chained
+(`_has:Observation:subject:code=1234`) searches are *parsed* into `SearchQuery` (`param.chain`,
+`reverse_chains`) but the 2-arg `SearchProvider::search` that the REST layer calls does not act on
+them on any backend — the working chain logic lives in the separate `ChainedSearchProvider::
+resolve_chain` API, which `search()` never invokes. `CompositeStorage` already implements
+`resolve_chain` via iterative plain `search()` calls (which work on every backend, including ES).
+So making chained/`_has` search work end-to-end over HTTP is a single dispatch change — detect
+chained params in the `search()` path and route them through `resolve_chain` — not an
+ES-specific fix.
 
 SQLite is the most complete backend and serves as the reference for the others; PostgreSQL is now
 at near-parity (only `:text-advanced` remains).

--- a/crates/persistence/src/backends/elasticsearch/schema.rs
+++ b/crates/persistence/src/backends/elasticsearch/schema.rs
@@ -150,7 +150,31 @@ pub fn create_index_mapping(config: &super::backend::ElasticsearchConfig) -> ser
                             "type": "nested",
                             "properties": {
                                 "name": { "type": "keyword" },
-                                "group_id": { "type": "integer" }
+                                "group_id": { "type": "integer" },
+                                // Component values stored inline (as arrays) so a
+                                // single nested query matches all components of the
+                                // same composite instance.
+                                "token_system": { "type": "keyword" },
+                                "token_code": { "type": "keyword" },
+                                "string": {
+                                    "type": "keyword",
+                                    "fields": {
+                                        "lowercase": {
+                                            "type": "keyword",
+                                            "normalizer": "lowercase_normalizer"
+                                        }
+                                    }
+                                },
+                                "number": { "type": "double" },
+                                "quantity_value": { "type": "double" },
+                                "quantity_unit": { "type": "keyword" },
+                                "quantity_system": { "type": "keyword" },
+                                "date": {
+                                    "type": "date",
+                                    "format": "strict_date_optional_time||epoch_millis||yyyy||yyyy-MM||yyyy-MM-dd"
+                                },
+                                "reference": { "type": "keyword" },
+                                "uri": { "type": "keyword" }
                             }
                         }
                     }

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/composite.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/composite.rs
@@ -2,55 +2,193 @@
 
 use serde_json::{Value, json};
 
-use crate::types::SearchParameter;
+use crate::types::{SearchParamType, SearchParameter};
 
 /// Builds an ES query clause for a composite search parameter.
 ///
-/// Composite parameters combine two or more sub-parameters that must
-/// match on the same logical grouping. The value format is `value1$value2`.
+/// Composite parameters combine two or more components that must all match
+/// within the same composite instance. Each instance is indexed as one nested
+/// object under `search_params.composite` with the component values inline (as
+/// arrays), so a single nested query with one condition per component enforces
+/// same-instance matching. The value format is `value1$value2$...`.
 pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
     let name = &param.name;
-    let component_values: Vec<&str> = value.split('$').collect();
+    let parts: Vec<&str> = value.split('$').collect();
 
-    if component_values.is_empty() {
-        return None;
+    let mut must: Vec<Value> = vec![json!({ "term": { "search_params.composite.name": name } })];
+
+    if param.components.is_empty() {
+        // Component definitions not resolved (e.g. standalone ES registry) —
+        // fall back to matching the composite name only.
+        return Some(nested(must));
     }
 
-    // Build a nested query that matches on the composite group
-    // Each component must match within the same group_id
-    let must_conditions = vec![json!({ "term": { "search_params.composite.name": name } })];
+    if parts.len() != param.components.len() {
+        return Some(nested(never_match(must)));
+    }
 
-    // For now, composite matching is simplified:
-    // We match the composite name, and the actual component matching
-    // is handled by the individual parameter type handlers in the query
-    Some(json!({
+    for (part, component) in parts.iter().zip(param.components.iter()) {
+        match component_conditions(component.param_type, part) {
+            Some(conds) => must.extend(conds),
+            None => return Some(nested(never_match(must))),
+        }
+    }
+
+    Some(nested(must))
+}
+
+/// Wraps the must-conditions in a nested query on the composite path.
+fn nested(must: Vec<Value>) -> Value {
+    json!({
         "nested": {
             "path": "search_params.composite",
-            "query": {
-                "bool": {
-                    "must": must_conditions
+            "query": { "bool": { "must": must } }
+        }
+    })
+}
+
+/// Appends an impossible condition so the clause matches nothing.
+fn never_match(mut must: Vec<Value>) -> Vec<Value> {
+    must.push(json!({ "term": { "search_params.composite.group_id": -1 } }));
+    must
+}
+
+/// Builds the ES condition(s) for a single component value.
+fn component_conditions(param_type: SearchParamType, part: &str) -> Option<Vec<Value>> {
+    let field = |f: &str| format!("search_params.composite.{}", f);
+    match param_type {
+        SearchParamType::Token => {
+            let conds = if let Some((system, code)) = part.split_once('|') {
+                let mut v = Vec::new();
+                if !system.is_empty() {
+                    v.push(json!({ "term": { field("token_system"): system } }));
+                }
+                if !code.is_empty() {
+                    v.push(json!({ "term": { field("token_code"): code } }));
+                }
+                v
+            } else {
+                vec![json!({ "term": { field("token_code"): part } })]
+            };
+            Some(conds)
+        }
+        SearchParamType::String => Some(vec![json!({
+            "term": { field("string.lowercase"): part.to_lowercase() }
+        })]),
+        SearchParamType::Number => {
+            let (op, num) = parse_prefixed_number(part)?;
+            Some(vec![numeric_condition(&field("number"), op, num)])
+        }
+        SearchParamType::Quantity => {
+            let mut comps = part.splitn(3, '|');
+            let (op, num) = parse_prefixed_number(comps.next()?)?;
+            let mut v = vec![numeric_condition(&field("quantity_value"), op, num)];
+            let _system = comps.next();
+            if let Some(code) = comps.next() {
+                if !code.is_empty() {
+                    v.push(json!({ "term": { field("quantity_unit"): code } }));
                 }
             }
+            Some(v)
         }
-    }))
+        SearchParamType::Date => {
+            let (op, val) = split_prefix(part);
+            Some(vec![range_condition(&field("date"), op, json!(val))])
+        }
+        SearchParamType::Reference => Some(vec![json!({ "term": { field("reference"): part } })]),
+        SearchParamType::Uri => Some(vec![json!({ "term": { field("uri"): part } })]),
+        SearchParamType::Composite | SearchParamType::Special => None,
+    }
+}
+
+/// Splits a leading FHIR comparison prefix (`eq`/`gt`/…) from a value.
+fn split_prefix(part: &str) -> (&str, &str) {
+    for p in ["eq", "ne", "gt", "lt", "ge", "le", "sa", "eb", "ap"] {
+        if let Some(rest) = part.strip_prefix(p) {
+            return (p, rest);
+        }
+    }
+    ("eq", part)
+}
+
+fn parse_prefixed_number(part: &str) -> Option<(&str, f64)> {
+    let (op, rest) = split_prefix(part);
+    rest.parse::<f64>().ok().map(|n| (op, n))
+}
+
+/// Builds a numeric term/range condition honoring the comparison prefix.
+fn numeric_condition(field: &str, op: &str, num: f64) -> Value {
+    match op {
+        "gt" | "sa" => json!({ "range": { field: { "gt": num } } }),
+        "lt" | "eb" => json!({ "range": { field: { "lt": num } } }),
+        "ge" => json!({ "range": { field: { "gte": num } } }),
+        "le" => json!({ "range": { field: { "lte": num } } }),
+        _ => json!({ "term": { field: num } }),
+    }
+}
+
+/// Builds a date range condition honoring the comparison prefix.
+fn range_condition(field: &str, op: &str, val: Value) -> Value {
+    match op {
+        "gt" | "sa" => json!({ "range": { field: { "gt": val } } }),
+        "lt" | "eb" => json!({ "range": { field: { "lt": val } } }),
+        "ge" => json!({ "range": { field: { "gte": val } } }),
+        "le" => json!({ "range": { field: { "lte": val } } }),
+        _ => json!({ "range": { field: { "gte": val, "lte": val } } }),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{SearchParamType, SearchValue};
+    use crate::types::{CompositeSearchComponent, SearchValue};
 
-    #[test]
-    fn test_composite_clause() {
-        let param = SearchParameter {
+    fn composite_param(components: Vec<CompositeSearchComponent>) -> SearchParameter {
+        SearchParameter {
             name: "code-value-quantity".to_string(),
             param_type: SearchParamType::Composite,
             modifier: None,
             values: vec![SearchValue::eq("8867-4$120")],
             chain: vec![],
-            components: vec![],
-        };
-        let clause = build_clause(&param, "8867-4$120");
-        assert!(clause.is_some());
+            components,
+        }
+    }
+
+    #[test]
+    fn name_only_when_no_components() {
+        let clause = build_clause(&composite_param(vec![]), "8867-4$120").unwrap();
+        let s = clause.to_string();
+        assert!(s.contains("search_params.composite.name"));
+        assert!(!s.contains("token_code"));
+    }
+
+    #[test]
+    fn evaluates_token_and_quantity_components() {
+        let param = composite_param(vec![
+            CompositeSearchComponent {
+                param_type: SearchParamType::Token,
+                param_name: "code".to_string(),
+            },
+            CompositeSearchComponent {
+                param_type: SearchParamType::Quantity,
+                param_name: "value-quantity".to_string(),
+            },
+        ]);
+        let clause = build_clause(&param, "http://loinc.org|8480-6$ge100").unwrap();
+        let s = clause.to_string();
+        assert!(s.contains("token_system"));
+        assert!(s.contains("token_code"));
+        assert!(s.contains("quantity_value"));
+        assert!(s.contains("gte"));
+    }
+
+    #[test]
+    fn arity_mismatch_never_matches() {
+        let param = composite_param(vec![CompositeSearchComponent {
+            param_type: SearchParamType::Token,
+            param_name: "code".to_string(),
+        }]);
+        let clause = build_clause(&param, "a$b").unwrap();
+        assert!(clause.to_string().contains("group_id"));
     }
 }

--- a/crates/persistence/src/backends/elasticsearch/storage.rs
+++ b/crates/persistence/src/backends/elasticsearch/storage.rs
@@ -106,6 +106,50 @@ fn collect_strings(value: &Value, parts: &mut Vec<String>) {
 }
 
 /// Builds an ES document from a FHIR resource and its extracted search values.
+/// Appends a value to a JSON array field on `obj`, creating the array if needed.
+fn push_array_field(obj: &mut Value, key: &str, val: Value) {
+    match obj.get_mut(key) {
+        Some(Value::Array(arr)) => arr.push(val),
+        _ => obj[key] = json!([val]),
+    }
+}
+
+/// Merges one composite component's value into the composite instance object,
+/// placing it in the array field matching the component's value type. All
+/// components of one instance share a nested object, so a single nested query
+/// can require every component to match within the same instance.
+fn merge_composite_component(entry: &mut Value, value: &IndexValue) {
+    match value {
+        IndexValue::String(s) => push_array_field(entry, "string", json!(s)),
+        IndexValue::Token { system, code, .. } => {
+            push_array_field(entry, "token_code", json!(code));
+            if let Some(sys) = system {
+                push_array_field(entry, "token_system", json!(sys));
+            }
+        }
+        IndexValue::Number(n) => push_array_field(entry, "number", json!(n)),
+        IndexValue::Quantity {
+            value,
+            unit,
+            system,
+            ..
+        } => {
+            push_array_field(entry, "quantity_value", json!(value));
+            if let Some(u) = unit {
+                push_array_field(entry, "quantity_unit", json!(u));
+            }
+            if let Some(s) = system {
+                push_array_field(entry, "quantity_system", json!(s));
+            }
+        }
+        IndexValue::Date { value, .. } => push_array_field(entry, "date", json!(value)),
+        IndexValue::Reference { reference, .. } => {
+            push_array_field(entry, "reference", json!(reference))
+        }
+        IndexValue::Uri(u) => push_array_field(entry, "uri", json!(u)),
+    }
+}
+
 pub(crate) fn build_es_document(
     tenant_id: &str,
     resource_type: &str,
@@ -124,9 +168,22 @@ pub(crate) fn build_es_document(
     let mut quantity_params: Vec<Value> = Vec::new();
     let mut reference_params: Vec<Value> = Vec::new();
     let mut uri_params: Vec<Value> = Vec::new();
-    let mut composite_params: Vec<Value> = Vec::new();
+    // Composite instances, keyed by (param name, group) so all components of one
+    // instance land in a single nested object with inline (array) component values.
+    let mut composite_groups: std::collections::BTreeMap<(String, u32), Value> =
+        std::collections::BTreeMap::new();
 
     for ev in extracted_values {
+        // Composite component values are accumulated into their instance object
+        // rather than the per-type arrays.
+        if let Some(group) = ev.composite_group {
+            let entry = composite_groups
+                .entry((ev.param_name.clone(), group))
+                .or_insert_with(|| json!({ "name": ev.param_name, "group_id": group }));
+            merge_composite_component(entry, &ev.value);
+            continue;
+        }
+
         match &ev.value {
             IndexValue::String(s) => {
                 string_params.push(json!({
@@ -217,14 +274,9 @@ pub(crate) fn build_es_document(
                 }));
             }
         }
-
-        if let Some(group) = ev.composite_group {
-            composite_params.push(json!({
-                "name": ev.param_name,
-                "group_id": group,
-            }));
-        }
     }
+
+    let composite_params: Vec<Value> = composite_groups.into_values().collect();
 
     json!({
         "resource_type": resource_type,

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -1120,6 +1120,77 @@ mod es_integration {
     }
 
     #[tokio::test]
+    async fn es_integration_search_composite_code_value_quantity() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            CompositeSearchComponent, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-bp",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6" }] },
+                    "valueQuantity": { "value": 107, "unit": "mmHg", "system": "http://unitsofmeasure.org" }
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        let query = |value: &str| {
+            SearchQuery::new("Observation").with_parameter(SearchParameter {
+                name: "code-value-quantity".to_string(),
+                param_type: SearchParamType::Composite,
+                modifier: None,
+                values: vec![SearchValue::eq(value)],
+                chain: vec![],
+                components: vec![
+                    CompositeSearchComponent {
+                        param_type: SearchParamType::Token,
+                        param_name: "code".to_string(),
+                    },
+                    CompositeSearchComponent {
+                        param_type: SearchParamType::Quantity,
+                        param_name: "value-quantity".to_string(),
+                    },
+                ],
+            })
+        };
+
+        // Both components match within the same instance.
+        let hit = backend
+            .search(&tenant, &query("8480-6$ge100"))
+            .await
+            .unwrap();
+        assert_eq!(hit.resources.items.len(), 1, "code + value match → 1 hit");
+        assert_eq!(hit.resources.items[0].id(), "obs-bp");
+
+        // Quantity component fails.
+        let miss = backend
+            .search(&tenant, &query("8480-6$ge200"))
+            .await
+            .unwrap();
+        assert!(miss.resources.items.is_empty(), "value too low → no hit");
+
+        // Token component fails.
+        let miss = backend
+            .search(&tenant, &query("9999-9$ge100"))
+            .await
+            .unwrap();
+        assert!(miss.resources.items.is_empty(), "code mismatch → no hit");
+    }
+
+    #[tokio::test]
     async fn es_integration_tenant_isolation_delete() {
         let backend = create_backend().await;
         let tenant_a = create_tenant("tenant-a");


### PR DESCRIPTION
Stacked on #122. Closes the "silently-wrong ES composite" gap.

## Problem
The ES composite handler matched only the composite parameter *name*, ignoring component values — so `code-value-quantity=8480-6$lt60` matched any Observation that had that composite indexed, regardless of the actual code/value.

## Approach (nested object per instance)
ES nested-object semantics enforce "all conditions match within the same object", which is exactly composite same-instance matching.
- **Index**: each composite instance is one nested object under `search_params.composite`, with component values stored inline as arrays (grouped by `composite_group` from the shared extractor). Schema extended with component fields (`token_system`/`token_code`, `string`, `number`, `quantity_value`/`unit`/`system`, `date`, `reference`, `uri`).
- **Query**: one nested query requiring the composite name plus one condition per component (term/range by component type). ES guarantees all match the same instance.

## Tests
- Unit: token+quantity condition generation, name-only fallback (no components), arity-mismatch never-match.
- End-to-end (testcontainers): `code-value-quantity` matches the right Observation; value-too-low and code-mismatch both correctly return nothing. Full ES suite (20 search/CRUD) + clippy clean.

## Chaining (the other half of the request)
While scoping ES chaining I found it's **not an ES-local gap**: chained/`_has` queries are parsed but the 2-arg `SearchProvider::search` that REST calls ignores `param.chain`/`reverse_chains` on *every* backend — the working logic lives in a separate `ChainedSearchProvider::resolve_chain` API that `search()` never invokes. `CompositeStorage` already drives `resolve_chain` via iterative plain searches (which work on ES). So the fix is a single cross-cutting dispatch change (route chained params through `resolve_chain` from `search()`), which I'll do in a follow-up PR — it fixes chaining end-to-end for ES **and** all backends. Documented in `docs/search-spec-assessment.md`.