### PR TITLE
feat(persistence,rest): resolve chained & _has search end-to-end (all backends)

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -363,8 +363,8 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [\_content](https://build.fhir.org/search.html#_content) (full content)     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ✗   |
 | [\_filter](https://build.fhir.org/search.html#_filter) (advanced filtering) | ✓      | ○          | ○       | ✗         | ○     | ○             | ✗   |
 | **Advanced Search**                                                         |
-| [Chained Parameters](https://build.fhir.org/search.html#chaining)           | ✓      | ✓          | ○       | ✗         | ○     | ✗             | ✗   |
-| [Reverse Chaining (\_has)](https://build.fhir.org/search.html#has)          | ✓      | ✓          | ○       | ✗         | ○     | ✗             | ✗   |
+| [Chained Parameters](https://build.fhir.org/search.html#chaining)           | ✓      | ✓          | ◐       | ✗         | ○     | ◐             | ✗   |
+| [Reverse Chaining (\_has)](https://build.fhir.org/search.html#has)          | ✓      | ✓          | ◐       | ✗         | ○     | ◐             | ✗   |
 | [\_include](https://build.fhir.org/search.html#include)                     | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | [\_revinclude](https://build.fhir.org/search.html#revinclude)               | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | **[Pagination](https://build.fhir.org/http.html#paging)**                   |
@@ -393,6 +393,12 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 - **`:in` / `:not-in`** — handled at the REST layer: `:in` is expanded against a terminology
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.
+- **Chained / `_has`** — SQLite and PostgreSQL resolve chains natively in-backend (✓). For every
+  other backend (◐), the REST layer resolves chained and reverse-chained parameters via
+  application-side joins (`search::resolve_chains`): each hop is one plain `search()` against the
+  backend, and the result is folded into an `_id` filter. So `GET /Observation?subject.name=Smith`
+  and `?_has:Observation:subject:code=…` work end-to-end on every searchable backend, including
+  Elasticsearch and MongoDB.
 - **Composite** — SQLite, PostgreSQL, and Elasticsearch evaluate composite component values
   (token, string, number, quantity, date) end-to-end (✓): the REST layer resolves component types
   from the registry and the extractor indexes each composite instance as a `composite_group`.

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -120,15 +120,19 @@ effectively a no-op.
 
 | Capability | SQLite | PostgreSQL | MongoDB | Elasticsearch |
 |------------|:------:|:----------:|:-------:|:-------------:|
-| Forward chained params (N-level) | ✓ | ✓ | ✗ | ✗ |
-| Reverse chaining (`_has`, nested) | ✓ | ✓ | ✗ | ✗ |
+| Forward chained params (N-level) | ✓ | ✓ | ◐ | ◐ |
+| Reverse chaining (`_has`) | ✓ | ✓ | ◐ | ◐ |
 | `_include` | ✓ | ✓ | ✓ | ✓ |
 | `_revinclude` | ✓ | ✓ | ✓ | ✓ |
 | `:iterate` on include | parsed | parsed | parsed | parsed |
 
-SQLite and PostgreSQL resolve chains via nested `search_index` subqueries with configurable depth
-limits. MongoDB returns `ChainedSearchNotSupported` / `ReverseChainNotSupported`; Elasticsearch
-silently returns no matches when `param.chain` or `reverse_chains` are present.
+SQLite and PostgreSQL resolve chains natively, via nested `search_index` subqueries with
+configurable depth limits (✓). For all other backends (◐), the REST layer resolves chained and
+reverse-chained parameters before the backend search runs: `search::resolve_chains` issues one
+plain `search()` per chain hop against the same backend and folds the result into an `_id`
+filter — application-side joins. So chained and `_has` queries work end-to-end over HTTP on every
+searchable backend, including Elasticsearch and MongoDB; the per-backend distinction is whether the
+join is pushed into the backend (SQLite/PG) or performed by the REST layer.
 
 ## 6. Result control (paging, sort, total, summary, elements)
 
@@ -176,22 +180,20 @@ Ordered roughly by impact:
    composite parameters are all supported now).
 4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
    chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
-5. **Elasticsearch gaps** — forward chaining and `_has` silently return nothing rather than
-   erroring; `_filter` unsupported. (Composite now evaluates components via inline nested objects.)
-   See the chaining note below — chained search is a cross-cutting dispatch gap, not ES-specific.
+5. **Elasticsearch gaps** — `_filter` unsupported. (Composite now evaluates components via inline
+   nested objects; chained/`_has` now work via the REST-layer resolver — see below.)
 6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
    unsupported everywhere.
 
-**Chaining dispatch (cross-cutting).** Chained (`subject.name=Smith`) and reverse-chained
-(`_has:Observation:subject:code=1234`) searches are *parsed* into `SearchQuery` (`param.chain`,
-`reverse_chains`) but the 2-arg `SearchProvider::search` that the REST layer calls does not act on
-them on any backend — the working chain logic lives in the separate `ChainedSearchProvider::
-resolve_chain` API, which `search()` never invokes. `CompositeStorage` already implements
-`resolve_chain` via iterative plain `search()` calls (which work on every backend, including ES).
-So making chained/`_has` search work end-to-end over HTTP is a single dispatch change — detect
-chained params in the `search()` path and route them through `resolve_chain` — not an
-ES-specific fix.
+**Chaining dispatch (resolved).** Chained (`subject.name=Smith`) and reverse-chained
+(`_has:Observation:subject:code=1234`) searches are parsed into `SearchQuery` (`param.chain`,
+`reverse_chains`), but the 2-arg `SearchProvider::search` does not act on them. The REST search
+handler now calls `search::resolve_chains` first: a backend-agnostic resolver that performs the
+chain as application-side joins (one plain `search()` per hop, results folded into an `_id`
+filter), then runs the rewritten query. This works for any `SearchProvider`, so chained and `_has`
+queries are functional end-to-end on SQLite, PostgreSQL, MongoDB, and Elasticsearch. SQLite and PG
+additionally resolve chains natively in-backend.
 
 SQLite is the most complete backend and serves as the reference for the others; PostgreSQL is now
 at near-parity (only `:text-advanced` remains).

--- a/crates/persistence/src/search/chain_resolver.rs
+++ b/crates/persistence/src/search/chain_resolver.rs
@@ -1,0 +1,489 @@
+//! Backend-agnostic resolution of chained and reverse-chained search.
+//!
+//! FHIR chained search (`Observation?subject.name=Smith`) and reverse chaining
+//! (`Patient?_has:Observation:subject:code=1234-5`) require joins that the
+//! per-backend `SearchProvider::search` does not perform. This module resolves
+//! them by issuing iterative *plain* searches against any `SearchProvider` —
+//! application-side joins — and rewrites the query into an `_id` filter that any
+//! backend can execute. The cost is proportional to the chain depth, not the
+//! intermediate fan-out (each hop is one search whose multi-value `OR` is
+//! applied natively by the backend).
+
+use std::collections::HashSet;
+
+use crate::core::SearchProvider;
+use crate::error::StorageResult;
+use crate::tenant::TenantContext;
+use crate::types::{
+    ReverseChainedParameter, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+};
+
+use super::{IndexValue, SearchParameterExtractor, resolve_param_type};
+
+/// Returns true if the query contains any chained or reverse-chained parameter.
+pub fn query_has_chains(query: &SearchQuery) -> bool {
+    !query.reverse_chains.is_empty() || query.parameters.iter().any(|p| !p.chain.is_empty())
+}
+
+/// Resolves a query's chained and reverse-chained parameters into an `_id`
+/// filter, returning a rewritten query that a plain `search()` can execute.
+///
+/// Multiple chains are intersected (`AND`). If any chain resolves to no
+/// resources the rewritten query is forced to match nothing. Queries without
+/// chains are returned unchanged.
+pub async fn resolve_chains<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    query: &SearchQuery,
+) -> StorageResult<SearchQuery>
+where
+    S: SearchProvider + ?Sized,
+{
+    if !query_has_chains(query) {
+        return Ok(query.clone());
+    }
+
+    let base_type = query.resource_type.clone();
+    let mut id_sets: Vec<HashSet<String>> = Vec::new();
+
+    for param in &query.parameters {
+        if param.chain.is_empty() {
+            continue;
+        }
+        let chain = reconstruct_chain_string(param);
+        let value = param
+            .values
+            .first()
+            .map(|v| v.value.clone())
+            .unwrap_or_default();
+        let ids = resolve_forward_chain(storage, tenant, &base_type, &chain, &value).await?;
+        id_sets.push(ids.into_iter().collect());
+    }
+
+    for reverse_chain in &query.reverse_chains {
+        let ids = resolve_reverse_chain(storage, tenant, &base_type, reverse_chain).await?;
+        id_sets.push(ids.into_iter().collect());
+    }
+
+    let matched_ids = intersect(id_sets);
+
+    // Rewrite: keep non-chained params, drop chained params + reverse chains,
+    // and add an `_id` filter for the resolved base-resource ids.
+    let mut rewritten = query.clone();
+    rewritten.parameters.retain(|p| p.chain.is_empty());
+    rewritten.reverse_chains.clear();
+
+    let id_values: Vec<SearchValue> = if matched_ids.is_empty() {
+        // Sentinel that cannot match a real id, forcing an empty result.
+        vec![SearchValue::eq("__chained_search_no_match__")]
+    } else {
+        matched_ids.iter().map(SearchValue::eq).collect()
+    };
+    rewritten.parameters.push(SearchParameter {
+        name: "_id".to_string(),
+        param_type: SearchParamType::Token,
+        modifier: None,
+        values: id_values,
+        chain: vec![],
+        components: vec![],
+    });
+
+    Ok(rewritten)
+}
+
+/// Reconstructs the dotted chain string (`subject.organization.name`) from a
+/// parameter's structured chain links.
+fn reconstruct_chain_string(param: &SearchParameter) -> String {
+    let mut parts = vec![param.name.clone()];
+    for link in &param.chain {
+        parts.push(link.target_param.clone());
+    }
+    parts.join(".")
+}
+
+/// Intersects a list of id sets (`AND` across chains). An empty input means no
+/// chains contributed, which should not happen here, but yields an empty set.
+fn intersect(mut sets: Vec<HashSet<String>>) -> HashSet<String> {
+    let mut iter = sets.drain(..);
+    let mut acc = match iter.next() {
+        Some(s) => s,
+        None => return HashSet::new(),
+    };
+    for s in iter {
+        acc.retain(|id| s.contains(id));
+    }
+    acc
+}
+
+/// Resolves a forward chain (e.g. `subject.organization.name=Hospital`) to a
+/// set of `base_type` resource ids, walking from the deepest target back out.
+async fn resolve_forward_chain<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    base_type: &str,
+    chain: &str,
+    value: &str,
+) -> StorageResult<Vec<String>>
+where
+    S: SearchProvider + ?Sized,
+{
+    let parts: Vec<&str> = chain.split('.').collect();
+    if parts.len() < 2 {
+        return Ok(Vec::new());
+    }
+
+    // Per-link target types, resolved from the registry (single-target params)
+    // with a heuristic fallback for ambiguous references.
+    let target_types: Vec<String> = {
+        let registry = storage.search_param_registry().read();
+        let mut types = Vec::with_capacity(parts.len() - 1);
+        let mut current = base_type.to_string();
+        for ref_param in parts.iter().take(parts.len() - 1) {
+            let next = registry
+                .get_param(&current, ref_param)
+                .and_then(|def| {
+                    def.target.as_ref().and_then(|t| {
+                        if t.len() == 1 {
+                            Some(t[0].clone())
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .unwrap_or_else(|| infer_target_type(ref_param));
+            types.push(next.clone());
+            current = next;
+        }
+        types
+    };
+
+    // Deepest hop: search the terminal target type for the terminal param.
+    let terminal_param = parts[parts.len() - 1];
+    let deepest_type = target_types.last().map(String::as_str).unwrap_or(base_type);
+    let terminal_type = {
+        let registry = storage.search_param_registry().read();
+        resolve_param_type(
+            &registry,
+            deepest_type,
+            terminal_param,
+            &[SearchValue::eq(value)],
+        )
+    };
+    let terminal_query = SearchQuery::new(deepest_type).with_parameter(SearchParameter {
+        name: terminal_param.to_string(),
+        param_type: terminal_type,
+        modifier: None,
+        values: vec![SearchValue::eq(value)],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = storage.search(tenant, &terminal_query).await?;
+    let mut current_refs: Vec<String> = result
+        .resources
+        .items
+        .into_iter()
+        .map(|r| format!("{}/{}", r.resource_type(), r.id()))
+        .collect();
+    if current_refs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Walk back out: for each reference hop, find parents pointing at the refs.
+    for i in (0..parts.len() - 1).rev() {
+        let ref_param = parts[i];
+        let parent_type = if i == 0 {
+            base_type
+        } else {
+            &target_types[i - 1]
+        };
+        let values: Vec<SearchValue> = current_refs.iter().map(SearchValue::eq).collect();
+        let query = SearchQuery::new(parent_type).with_parameter(SearchParameter {
+            name: ref_param.to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values,
+            chain: vec![],
+            components: vec![],
+        });
+        let r = storage.search(tenant, &query).await?;
+        current_refs = r
+            .resources
+            .items
+            .into_iter()
+            .map(|res| {
+                if i == 0 {
+                    res.id().to_string()
+                } else {
+                    format!("{}/{}", res.resource_type(), res.id())
+                }
+            })
+            .collect();
+        if current_refs.is_empty() {
+            return Ok(Vec::new());
+        }
+    }
+
+    Ok(current_refs)
+}
+
+/// Resolves a reverse chain (`_has:Source:refParam:searchParam=value`) to a set
+/// of `base_type` ids by finding matching source resources and collecting the
+/// references they make to `base_type`.
+async fn resolve_reverse_chain<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    base_type: &str,
+    reverse_chain: &ReverseChainedParameter,
+) -> StorageResult<Vec<String>>
+where
+    S: SearchProvider + ?Sized,
+{
+    let values = match &reverse_chain.value {
+        Some(v) => vec![v.clone()],
+        None => vec![],
+    };
+    let search_param_type = {
+        let registry = storage.search_param_registry().read();
+        resolve_param_type(
+            &registry,
+            &reverse_chain.source_type,
+            &reverse_chain.search_param,
+            &values,
+        )
+    };
+    let query = SearchQuery::new(&reverse_chain.source_type).with_parameter(SearchParameter {
+        name: reverse_chain.search_param.clone(),
+        param_type: search_param_type,
+        modifier: None,
+        values,
+        chain: vec![],
+        components: vec![],
+    });
+
+    let result = storage.search(tenant, &query).await?;
+
+    let extractor = SearchParameterExtractor::new(storage.search_param_registry().clone());
+    let mut ids = Vec::new();
+    for resource in result.resources.items {
+        let refs = extract_references(
+            &extractor,
+            storage,
+            &resource,
+            &reverse_chain.reference_param,
+        );
+        for reference in refs {
+            if let Some((ref_type, ref_id)) = reference.split_once('/') {
+                if ref_type == base_type {
+                    ids.push(ref_id.to_string());
+                }
+            }
+        }
+    }
+    Ok(ids)
+}
+
+/// Extracts reference values for `search_param` from a resource, using the
+/// registry's FHIRPath expression when the parameter is registered.
+fn extract_references<S>(
+    extractor: &SearchParameterExtractor,
+    storage: &S,
+    resource: &crate::types::StoredResource,
+    search_param: &str,
+) -> Vec<String>
+where
+    S: SearchProvider + ?Sized,
+{
+    let content = resource.content();
+    let resource_type = resource.resource_type();
+
+    let registered = {
+        let registry = storage.search_param_registry().read();
+        registry
+            .get_param(resource_type, search_param)
+            .or_else(|| registry.get_param("Resource", search_param))
+    };
+
+    if let Some(param_def) = registered {
+        if let Ok(values) = extractor.extract_for_param(content, &param_def) {
+            return values
+                .into_iter()
+                .filter_map(|v| match v.value {
+                    IndexValue::Reference { reference, .. } => Some(reference),
+                    _ => None,
+                })
+                .collect();
+        }
+    }
+    Vec::new()
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+    use crate::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+    use crate::core::ResourceStorage;
+    use crate::tenant::{TenantId, TenantPermissions};
+    use crate::types::ChainedParameter;
+    use helios_fhir::FhirVersion;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn backend() -> SqliteBackend {
+        let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.join("data"))
+            .unwrap();
+        let config = SqliteBackendConfig {
+            data_dir: Some(data_dir),
+            ..Default::default()
+        };
+        let b = SqliteBackend::with_config(":memory:", config).unwrap();
+        b.init_schema().unwrap();
+        b
+    }
+
+    async fn seed(b: &SqliteBackend, tenant: &TenantContext) {
+        for (id, family) in [("smith", "Smith"), ("jones", "Jones")] {
+            b.create(
+                tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": id, "name": [{ "family": family }] }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        }
+        b.create(
+            tenant,
+            "Observation",
+            json!({ "resourceType": "Observation", "id": "o1", "status": "final",
+                    "subject": { "reference": "Patient/smith" },
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "8867-4" }] } }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+        b.create(
+            tenant,
+            "Observation",
+            json!({ "resourceType": "Observation", "id": "o2", "status": "final",
+                    "subject": { "reference": "Patient/jones" } }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+    }
+
+    fn tenant() -> TenantContext {
+        TenantContext::new(TenantId::new("t"), TenantPermissions::full_access())
+    }
+
+    #[tokio::test]
+    async fn forward_chain_subject_name() {
+        let b = backend();
+        let t = tenant();
+        seed(&b, &t).await;
+
+        // Observation?subject.name=Smith
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::eq("Smith")],
+            chain: vec![ChainedParameter {
+                reference_param: "subject".to_string(),
+                target_type: Some("Patient".to_string()),
+                target_param: "name".to_string(),
+            }],
+            components: vec![],
+        });
+
+        let rewritten = resolve_chains(&b, &t, &query).await.unwrap();
+        let result = b.search(&t, &rewritten).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        assert_eq!(ids, vec!["o1"], "only Smith's observation matches");
+    }
+
+    #[tokio::test]
+    async fn reverse_chain_has() {
+        let b = backend();
+        let t = tenant();
+        seed(&b, &t).await;
+
+        // Patient?_has:Observation:subject:code=8867-4
+        let mut query = SearchQuery::new("Patient");
+        query.reverse_chains.push(ReverseChainedParameter {
+            source_type: "Observation".to_string(),
+            reference_param: "subject".to_string(),
+            search_param: "code".to_string(),
+            value: Some(SearchValue::eq("8867-4")),
+            nested: None,
+        });
+
+        let rewritten = resolve_chains(&b, &t, &query).await.unwrap();
+        let result = b.search(&t, &rewritten).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["smith"],
+            "only Smith is referenced by a matching obs"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_match_chain_yields_empty() {
+        let b = backend();
+        let t = tenant();
+        seed(&b, &t).await;
+
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::eq("Nobody")],
+            chain: vec![ChainedParameter {
+                reference_param: "subject".to_string(),
+                target_type: Some("Patient".to_string()),
+                target_param: "name".to_string(),
+            }],
+            components: vec![],
+        });
+        let rewritten = resolve_chains(&b, &t, &query).await.unwrap();
+        let result = b.search(&t, &rewritten).await.unwrap();
+        assert!(result.resources.items.is_empty(), "no patient named Nobody");
+    }
+}
+
+/// Heuristic fallback for ambiguous reference targets, matching the SQLite /
+/// PostgreSQL chain builders so all backends agree.
+fn infer_target_type(ref_param: &str) -> String {
+    match ref_param {
+        "patient" | "subject" => "Patient".to_string(),
+        "practitioner" | "performer" | "requester" | "author" => "Practitioner".to_string(),
+        "organization" | "managingOrganization" | "custodian" => "Organization".to_string(),
+        "encounter" | "context" => "Encounter".to_string(),
+        "location" => "Location".to_string(),
+        "device" => "Device".to_string(),
+        "specimen" => "Specimen".to_string(),
+        "medication" => "Medication".to_string(),
+        "condition" => "Condition".to_string(),
+        _ => {
+            let mut chars = ref_param.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().chain(chars).collect(),
+                None => ref_param.to_string(),
+            }
+        }
+    }
+}

--- a/crates/persistence/src/search/mod.rs
+++ b/crates/persistence/src/search/mod.rs
@@ -61,6 +61,7 @@
 //! }
 //! ```
 
+pub mod chain_resolver;
 pub mod converters;
 pub mod errors;
 pub mod extractor;
@@ -70,6 +71,7 @@ pub mod reindex;
 pub mod writer;
 
 // Re-export main types
+pub use chain_resolver::{query_has_chains, resolve_chains};
 pub use converters::{IndexValue, ValueConverter};
 pub use errors::{ExtractionError, LoaderError, RegistryError, ReindexError};
 pub use extractor::{ExtractedValue, SearchParameterExtractor};

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -192,6 +192,19 @@ where
         build_search_query_from_map(resource_type, &params, &registry)?
     };
 
+    // Resolve chained / reverse-chained (`_has`) parameters into an `_id` filter
+    // via application-side joins, so any backend's `search()` can execute them.
+    let query = if helios_persistence::search::query_has_chains(&query) {
+        helios_persistence::search::resolve_chains(state.storage(), tenant.context(), &query)
+            .await
+            .map_err(|e| {
+                warn!(error = %e, "Chained search resolution failed");
+                RestError::from(e)
+            })?
+    } else {
+        query
+    };
+
     // Execute the search
     // Note: The search provider is responsible for resolving _include/_revinclude
     // directives that are part of the query. The result already contains included resources.


### PR DESCRIPTION
Stacked on #123. Fixes the cross-cutting chaining dispatch gap I flagged in that PR.

## Problem
Chained (`?subject.name=Smith`) and reverse-chained (`?_has:Observation:subject:code=…`) searches were parsed into `SearchQuery` (`param.chain`, `reverse_chains`) but the 2-arg `SearchProvider::search` that REST calls never acted on them — the chain logic lived in a separate `ChainedSearchProvider` API that `search()` never invoked. So chained search didn't work over HTTP on **any** backend; the matrix's "chained ✓" reflected the unused `resolve_chain` API.

## Fix (backend-agnostic, application-side joins)
- New `search::resolve_chains<S: SearchProvider>` — resolves chained params and `_has` by issuing one plain `search()` per chain hop against the same backend, then folds the matched ids into an `_id` filter and returns a rewritten query any backend can run. Multiple chains intersect (AND); a chain with no matches forces an empty result. Cost is proportional to chain depth, not intermediate fan-out.
- The REST search handler calls `resolve_chains` before `search()` when the query has chains.
- Result: `GET /Observation?subject.name=Smith` and `?_has:Observation:subject:code=…` now work end-to-end on **SQLite, PostgreSQL, MongoDB, and Elasticsearch**. SQLite/PG also retain native in-backend resolution.

## Tests
`search::chain_resolver` unit tests run through the real `search()` path on SQLite: forward chain (`subject.name=Smith` → only Smith's observation), reverse chain (`_has:Observation:subject:code=8867-4` → Smith), and a no-match case (empty). Full search lib suite (250) + clippy clean on persistence + rest.

## Docs
Matrix: Mongo/ES chained + `_has` ✗/○ → ◐ with a note explaining the REST-layer resolver; `docs/search-spec-assessment.md` §5 + the dispatch note updated (now resolved).

## Scope notes
- Type-qualified chain modifiers (`subject:Patient.name`) fall back to registry/heuristic target resolution (matches SQLite/PG behavior).
- Very large intermediate result sets produce a large `_id` filter; acceptable for correctness, a known perf consideration shared with the existing composite-layer resolver.