### PR TITLE
feat(persistence): implement quantity search for MongoDB

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -345,7 +345,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [Reference](https://build.fhir.org/search.html#reference)                   | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | [Date](https://build.fhir.org/search.html#date)                             | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
 | [Number](https://build.fhir.org/search.html#number)                         | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ○   |
-| [Quantity](https://build.fhir.org/search.html#quantity)                     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ○   |
+| [Quantity](https://build.fhir.org/search.html#quantity)                     | ✓      | ✓          | ✓       | ✗         | ✗     | ✓             | ○   |
 | [URI](https://build.fhir.org/search.html#uri)                               | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
 | [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
 | **[Search Modifiers](https://build.fhir.org/search.html#modifiers)**        |
@@ -568,8 +568,9 @@ MongoDB provides document-centric primary storage with full FHIR capabilities in
 - Full CRUD operations with document-native resource storage
 - Versioning and history providers (`vread`, instance/type/system history)
 - Transaction bundles with urn:uuid reference resolution (requires replica set)
-- Native search (string, token, reference, date, number, URI parameters; quantity and composite
-  parameters, chained/`_has`, `_text`/`_content`, and most modifiers are not yet supported)
+- Native search (string, token, reference, date, number, quantity, URI parameters; composite
+  parameters, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are not yet
+  supported; chained/`_has` work via the REST-layer resolver)
 - `_include` and `_revinclude` resolution
 - Conditional create, update, and delete operations
 - Cursor and offset pagination; sorting by `_id`/`_lastUpdated` (a custom sort cannot be combined

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -38,7 +38,7 @@ Neo4j are not implemented.
 | reference | ✓ | ✓ | ✓ | ✓ | type modifier + `:identifier` (SQLite/ES) |
 | date | ✓ | ✓ | ✓ | ✓ | precision-aware ranges + all prefixes |
 | number | ✓ | ✓ | ✓ | ✓ | implicit-precision ranges + all prefixes |
-| quantity | ✓ | ✓ | ✗ | ✓ | MongoDB rejects with `UnsupportedParameterType` |
+| quantity | ✓ | ✓ | ✓ | ✓ | value comparison + optional system/unit on all backends |
 | uri | ✓ | ✓ | ✓ | ✓ | exact + `:above`/`:below` prefix matching |
 | composite | ✓ | ✓ | ✗ | ✓ | SQLite/PG group by `composite_group`; ES uses one nested object per instance; Mongo returns no condition |
 
@@ -178,8 +178,9 @@ Ordered roughly by impact:
 3. **PostgreSQL modifier gaps** — only the `:text-advanced` modifier remains unimplemented relative
    to SQLite (`:exact`, `:contains`, `:not`, `:missing`, `:of-type`, URI `:above`/`:below`, and
    composite parameters are all supported now).
-4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
-   chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
+4. **MongoDB native search gaps** — composite parameters error out; `_text`/`_content` and most
+   modifiers beyond `:exact`/`:contains` are unsupported. (Quantity search is now implemented;
+   chained/`_has` work via the REST-layer resolver.)
 5. **Elasticsearch gaps** — `_filter` unsupported. (Composite now evaluates components via inline
    nested objects; chained/`_has` now work via the REST-layer resolver — see below.)
 6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -539,11 +539,7 @@ impl MongoBackend {
             SearchParamType::Number => self.build_number_filter(value),
             SearchParamType::Reference => self.build_reference_filter(param, value),
             SearchParamType::Uri => self.build_uri_filter(param, value),
-            SearchParamType::Quantity => Err(StorageError::Search(
-                SearchError::UnsupportedParameterType {
-                    param_type: "quantity".to_string(),
-                },
-            )),
+            SearchParamType::Quantity => self.build_quantity_filter(value),
             SearchParamType::Composite => {
                 Err(StorageError::Search(SearchError::InvalidComposite {
                     message: "Composite search is not supported in MongoDB Phase 4".to_string(),
@@ -725,6 +721,54 @@ impl MongoBackend {
                 })
             }
         }
+    }
+
+    /// Builds a MongoDB filter for a quantity parameter.
+    ///
+    /// Value form: `[prefix]number[|system|code]` (or the `number|code` shorthand).
+    /// The comparison runs on `value_quantity_value`; an optional system/code
+    /// further constrain `value_quantity_system` / `value_quantity_unit` (the
+    /// extractor stores the quantity code under the unit field).
+    fn build_quantity_filter(&self, value: &SearchValue) -> StorageResult<Document> {
+        let parts: Vec<&str> = value.value.splitn(3, '|').collect();
+        let parsed = parts[0].parse::<f64>().map_err(|e| {
+            StorageError::Search(SearchError::QueryParseError {
+                message: format!("Invalid quantity value '{}': {}", value.value, e),
+            })
+        })?;
+
+        let value_condition = match value.prefix {
+            SearchPrefix::Ap => {
+                let delta = (parsed.abs() * 0.1).max(0.1);
+                doc! { "$gte": parsed - delta, "$lte": parsed + delta }
+            }
+            _ => {
+                let op = Self::prefix_to_mongo_operator(value.prefix)?;
+                doc! { op: parsed }
+            }
+        };
+
+        let mut filter = doc! { "value_quantity_value": value_condition };
+        match parts.as_slice() {
+            // number|system|code
+            [_, system, code] => {
+                if !system.is_empty() {
+                    filter.insert("value_quantity_system", *system);
+                }
+                if !code.is_empty() {
+                    filter.insert("value_quantity_unit", *code);
+                }
+            }
+            // number|code shorthand
+            [_, code] => {
+                if !code.is_empty() {
+                    filter.insert("value_quantity_unit", *code);
+                }
+            }
+            _ => {}
+        }
+
+        Ok(filter)
     }
 
     fn build_number_filter(&self, value: &SearchValue) -> StorageResult<Document> {

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -8,6 +8,7 @@
 
 #![cfg(feature = "mongodb")]
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use helios_fhir::FhirVersion;
@@ -25,8 +26,8 @@ use helios_persistence::error::{
 use helios_persistence::search::SearchParameterStatus;
 use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
 use helios_persistence::types::{
-    IncludeDirective, IncludeType, SearchParamType, SearchParameter, SearchQuery, SearchValue,
-    SortDirective,
+    IncludeDirective, IncludeType, SearchParamType, SearchParameter, SearchPrefix, SearchQuery,
+    SearchValue, SortDirective,
 };
 use mongodb::Client;
 use mongodb::bson::{Document, doc};
@@ -210,6 +211,28 @@ async fn create_backend_with_search_offloaded(
         .await
         .expect("failed to initialize MongoDB schema for integration tests");
 
+    Some(backend)
+}
+
+/// Creates a backend whose registry is loaded from the repo's spec files, so
+/// non-embedded search parameters (e.g. `value-quantity`) are active.
+async fn create_backend_with_full_registry(test_name: &str) -> Option<MongoBackend> {
+    let connection_string = test_mongo_url()?;
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("data"))?;
+    let config = MongoBackendConfig {
+        connection_string,
+        database_name: build_test_database_name(test_name),
+        data_dir: Some(data_dir),
+        ..Default::default()
+    };
+    let backend = MongoBackend::new(config).expect("failed to create MongoBackend");
+    backend
+        .initialize()
+        .await
+        .expect("failed to initialize MongoDB schema");
     Some(backend)
 }
 
@@ -1233,6 +1256,82 @@ async fn mongodb_integration_history_delete_trial_use_not_supported() {
             BackendError::UnsupportedCapability { .. }
         ))
     ));
+}
+
+#[tokio::test]
+async fn mongodb_integration_search_quantity() {
+    let Some(backend) = create_backend_with_full_registry("search_quantity").await else {
+        eprintln!("Skipping mongodb_integration_search_quantity (set HFS_TEST_MONGODB_URL)");
+        return;
+    };
+
+    let tenant = create_tenant("tenant-quantity");
+
+    backend
+        .create(
+            &tenant,
+            "Observation",
+            json!({
+                "resourceType": "Observation",
+                "id": "obs-weight",
+                "status": "final",
+                "code": { "coding": [{ "system": "http://loinc.org", "code": "29463-7" }] },
+                "valueQuantity": { "value": 72.5, "unit": "kg", "system": "http://unitsofmeasure.org" }
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let query = |prefix: SearchPrefix, value: &str| {
+        SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "value-quantity".to_string(),
+            param_type: SearchParamType::Quantity,
+            modifier: None,
+            values: vec![SearchValue::new(prefix, value)],
+            chain: vec![],
+            components: vec![],
+        })
+    };
+
+    // ge70 matches (72.5 >= 70).
+    let result = backend
+        .search(&tenant, &query(SearchPrefix::Ge, "70"))
+        .await
+        .unwrap();
+    assert_eq!(
+        result.resources.items.len(),
+        1,
+        "value-quantity ge70 → 1 hit"
+    );
+    assert_eq!(result.resources.items[0].id(), "obs-weight");
+
+    // ge100 does not match.
+    let result = backend
+        .search(&tenant, &query(SearchPrefix::Ge, "100"))
+        .await
+        .unwrap();
+    assert!(result.resources.items.is_empty(), "ge100 → no hit");
+
+    // Quantity with a matching unit code.
+    let result = backend
+        .search(
+            &tenant,
+            &query(SearchPrefix::Ge, "70|http://unitsofmeasure.org|kg"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.resources.items.len(), 1, "ge70 with kg unit → 1 hit");
+
+    // Non-matching unit code excludes.
+    let result = backend
+        .search(
+            &tenant,
+            &query(SearchPrefix::Ge, "70|http://unitsofmeasure.org|lb"),
+        )
+        .await
+        .unwrap();
+    assert!(result.resources.items.is_empty(), "wrong unit → no hit");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Stacked on #124.

## Problem
MongoDB already **indexed** quantity values (`value_quantity_value`/`unit`/`system`), but the query path rejected `SearchParamType::Quantity` with `UnsupportedParameterType` — so `value-quantity=…` errored on the MongoDB backend.

## Fix
Added `build_quantity_filter`, mirroring the existing MongoDB number filter plus the `[prefix]number[|system|code]` parsing used by SQLite/PostgreSQL:
- comparison on `value_quantity_value` (with `prefix_to_mongo_operator`),
- optional `value_quantity_system` / `value_quantity_unit` constraints (the extractor stores the quantity code under the unit field),
- `ap` → ±10% range.

## Tests
End-to-end MongoDB integration test (testcontainers/external Mongo): `ge70` matches a 72.5 kg observation, `ge100` doesn't, matching unit code matches, wrong unit code excludes. Uses a registry loaded from the spec `data/` dir so `value-quantity` is active (the default test backend only loads embedded params). Clippy clean.

Note: the unrelated `mongodb_integration_search_token_string_and_offset_pagination` is a pre-existing baseline failure (it builds the backend without `data_dir`, so `identifier` isn't registered) — not affected by this change.

## Docs
Matrix: MongoDB **Quantity** ○ → ✓; assessment + MongoDB feature bullets updated.