### PR TITLE
feat(rest): resolve token :below / :above via terminology $expand

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -354,7 +354,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [:text](https://build.fhir.org/search.html#modifiers) (full-text)           | ✓      | ◐          | ○       | ✗         | ✗     | ✓             | ✗   |
 | [:not](https://build.fhir.org/search.html#modifiers)                        | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ○   |
 | [:missing](https://build.fhir.org/search.html#modifiers)                    | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ○   |
-| [:above / :below](https://build.fhir.org/search.html#modifiers)             | ◐      | ◐          | †○      | ✗         | ○     | ◐             | ✗   |
+| [:above / :below](https://build.fhir.org/search.html#modifiers)             | ◐      | ◐          | ◐       | ✗         | ○     | ◐             | ✗   |
 | [:in / :not-in](https://build.fhir.org/search.html#modifiers)               | ✗      | †○         | †○      | ✗         | ○     | †○            | ✗   |
 | [:of-type](https://build.fhir.org/search.html#modifiers)                    | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
 | [:text-advanced](https://build.fhir.org/search.html#modifiertextadvanced)   | ✓      | †○         | †○      | ✗         | ✗     | ✓             | ✗   |
@@ -387,9 +387,12 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
   paging preserves the sort order. A multi-field `_sort` returns a single page (no cursor). MongoDB
   sorts by `_id`/`_lastUpdated` only and cannot combine a custom sort with cursor pagination, hence
   ◐ for multiple fields.
-- **`:above` / `:below`** — SQLite, PostgreSQL, and Elasticsearch implement hierarchical URI
-  prefix matching (no external service needed), shown as ◐. Token/code hierarchy expansion
-  (which needs a terminology server) is not implemented natively.
+- **`:above` / `:below`** — two mechanisms (◐ = both, conditional on context): (1) hierarchical
+  **URI** prefix matching is native to SQLite, PostgreSQL, and Elasticsearch (no external service);
+  (2) **token/code** hierarchy (e.g. `code:below=http://snomed.info/sct|73211009`) is resolved at
+  the REST layer — the code and its descendants (`:below`, `is-a`) or ancestors (`:above`,
+  `generalizes`) are expanded via the terminology server's `$expand`, then matched as a plain token
+  OR list on any backend. Token hierarchy therefore requires `HFS_TERMINOLOGY_SERVER`.
 - **`:in` / `:not-in`** — handled at the REST layer: `:in` is expanded against a terminology
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -71,7 +71,7 @@ before evaluation. This fixed both composite value components and plain `value[x
 | `:of-type` | ✓ | ✓ | ✗ | ✓ |
 | `:text-advanced` | ✓ | ✗ | ✗ | ✓ |
 | `:above` / `:below` (URI) | ✓ | ✓ | ✗ | ✓ |
-| `:above` / `:below` (token hierarchy) | ✗ | ✗ | ✗ | ✗ |
+| `:above` / `:below` (token hierarchy) | †³ | †³ | †³ | †³ |
 | `:in` / `:not-in` | †² | †² | †² | †² |
 | `:identifier` (reference) | ✓ | ✗ | ✗ | ✓ |
 | `:[type]` (reference) | ✓ | ✗ | ✓ | ✓ |
@@ -82,6 +82,10 @@ before evaluation. This fixed both composite value components and plain `value[x
 ² `:in` is expanded by the REST layer against a configured terminology server before the query
   reaches the backend (`crates/rest/src/handlers/search.rs`); `:not-in` returns `501 Not
   Implemented`. No backend resolves either modifier natively.
+³ Token `:above`/`:below` (`code:below=system|code`) is resolved at the REST layer: the code and its
+  descendants (`is-a`, for `:below`) or ancestors (`generalizes`, for `:above`) are expanded via the
+  terminology server's `$expand`, then matched as a plain token OR list. Works on every backend when
+  `HFS_TERMINOLOGY_SERVER` is configured; URI `:above`/`:below` is separate and native (above).
 
 The REST layer parses **all** of these modifiers (`crates/rest/src/extractors/search_query_builder.rs`)
 regardless of backend; unsupported ones either no-op, error, or (for some ES/Mongo cases) return no
@@ -172,8 +176,10 @@ Ordered roughly by impact:
    correctly via the keyset cursor on SQLite/PG. A multi-field `_sort` currently returns a single
    page (no cursor); extending the keyset to a multi-key tuple is the remaining work. MongoDB still
    sorts by `_id`/`_lastUpdated` only.
-2. **Terminology-dependent modifiers** — token `:above`/`:below`, `:in`, `:not-in` need a
-   terminology server. `:in` is partially handled via REST-side expansion; the rest are not native.
+2. **Terminology-dependent modifiers** — `:in` and token `:above`/`:below` are resolved at the REST
+   layer via terminology `$expand` (functional when `HFS_TERMINOLOGY_SERVER` is set; no native
+   in-backend resolution). `:not-in` still returns `501` — negated value-set filtering is the
+   remaining gap.
    URI `:above`/`:below` (hierarchical prefix, no service needed) *is* implemented on SQLite/PG/ES.
 3. **PostgreSQL modifier gaps** — only the `:text-advanced` modifier remains unimplemented relative
    to SQLite (`:exact`, `:contains`, `:not`, `:missing`, `:of-type`, URI `:above`/`:below`, and

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -528,12 +528,92 @@ async fn expand_terminology_params(
                      ValueSet: {value}); use ':in' or remove this modifier"
                 ),
             });
+        } else if let Some((param_name, op)) = key
+            .strip_suffix(":below")
+            .map(|p| (p, "is-a"))
+            .or_else(|| key.strip_suffix(":above").map(|p| (p, "generalizes")))
+        {
+            // Token hierarchy: `code:below=system|code` expands to the code and
+            // its descendants (is-a) / ancestors (generalizes) via the
+            // terminology server. A bare value with no `system|code` is left
+            // untouched — that is the URI form, resolved natively by the backend.
+            if let Some((system, code)) = value.split_once('|') {
+                let modifier = if op == "is-a" { ":below" } else { ":above" };
+                expand_subsumption_into(
+                    &mut result,
+                    &client,
+                    param_name,
+                    &key,
+                    system,
+                    code,
+                    op,
+                    modifier,
+                )
+                .await;
+            } else {
+                result.insert(key, value);
+            }
         } else {
             result.insert(key, value);
         }
     }
 
     Ok(result)
+}
+
+/// Sentinel token that cannot match any indexed code, used to force an empty
+/// result when a terminology expansion legitimately yields no codes.
+const HTS_EMPTY_EXPANSION: &str = "__hts_empty_expansion__";
+
+/// Expands a token hierarchy modifier (`:below`/`:above`) and inserts the
+/// resulting comma-joined token list under `param_name`. Mirrors the `:in`
+/// policy: empty expansion → sentinel (match nothing); request error →
+/// fail-open (drop the filter).
+#[allow(clippy::too_many_arguments)]
+async fn expand_subsumption_into(
+    result: &mut HashMap<String, String>,
+    client: &TerminologyServiceClient,
+    param_name: &str,
+    key: &str,
+    system: &str,
+    code: &str,
+    op: &str,
+    modifier: &str,
+) {
+    match client.expand_subsumption(system, code, op).await {
+        Ok(codes) if !codes.is_empty() => {
+            let token_list = codes
+                .iter()
+                .map(|c| c.as_token())
+                .collect::<Vec<_>>()
+                .join(",");
+            debug!(
+                param = %param_name,
+                system = %system,
+                code = %code,
+                modifier = %modifier,
+                codes = codes.len(),
+                "Expanded token hierarchy modifier"
+            );
+            result.insert(param_name.to_string(), token_list);
+        }
+        Ok(_) => {
+            warn!(
+                param = %key,
+                modifier = %modifier,
+                "Token hierarchy expansion returned no codes; injecting sentinel so no resources match"
+            );
+            result.insert(param_name.to_string(), HTS_EMPTY_EXPANSION.to_string());
+        }
+        Err(e) => {
+            warn!(
+                param = %key,
+                modifier = %modifier,
+                error = %e,
+                "Token hierarchy expansion failed; skipping parameter (fail-open)"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -636,5 +716,84 @@ mod tests {
         // The :in key is gone; no code key was injected either (fail-open)
         assert!(!result.contains_key("code:in"));
         assert!(!result.contains_key("code"));
+    }
+
+    /// A token `:below` (`system|code`) is fail-open dropped on network error.
+    #[tokio::test]
+    async fn test_expand_terminology_params_below_token_dropped_on_network_error() {
+        let mut params = HashMap::new();
+        params.insert(
+            "code:below".to_string(),
+            "http://snomed.info/sct|73211009".to_string(),
+        );
+
+        let result = expand_terminology_params(params, "http://127.0.0.1:19999")
+            .await
+            .unwrap();
+
+        assert!(!result.contains_key("code:below"));
+        assert!(!result.contains_key("code"));
+    }
+
+    /// Happy path: a token `:below` expands to the code and its descendants via
+    /// a mock terminology server, rewriting to a comma-joined token list.
+    #[tokio::test]
+    async fn test_expand_terminology_params_below_success() {
+        use axum::{Json, Router, routing::post};
+        use serde_json::json;
+
+        let app = Router::new().route(
+            "/ValueSet/$expand",
+            post(|| async {
+                Json(json!({
+                    "resourceType": "ValueSet",
+                    "expansion": { "contains": [
+                        { "system": "http://snomed.info/sct", "code": "73211009" },
+                        { "system": "http://snomed.info/sct", "code": "44054006" },
+                        { "system": "http://snomed.info/sct", "code": "46635009" }
+                    ]}
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let mut params = HashMap::new();
+        params.insert(
+            "code:below".to_string(),
+            "http://snomed.info/sct|73211009".to_string(),
+        );
+        let result = expand_terminology_params(params, &format!("http://{addr}"))
+            .await
+            .unwrap();
+
+        // Modifier consumed; rewritten to a plain token OR list of descendants.
+        assert!(!result.contains_key("code:below"));
+        let codes = result.get("code").expect("code param injected");
+        assert!(codes.contains("http://snomed.info/sct|73211009"));
+        assert!(codes.contains("http://snomed.info/sct|44054006"));
+        assert!(codes.contains("http://snomed.info/sct|46635009"));
+    }
+
+    /// A `:below` value without a `system|code` (the URI form) is left untouched
+    /// so the backend can resolve URI hierarchy natively — no terminology call.
+    #[tokio::test]
+    async fn test_expand_terminology_params_below_uri_passthrough() {
+        let mut params = HashMap::new();
+        params.insert(
+            "url:below".to_string(),
+            "http://example.org/fhir/ValueSet/x".to_string(),
+        );
+
+        let result = expand_terminology_params(params, "http://127.0.0.1:19999")
+            .await
+            .unwrap();
+
+        // Unchanged — no `|`, so not treated as a token subsumption.
+        assert_eq!(
+            result.get("url:below"),
+            Some(&"http://example.org/fhir/ValueSet/x".to_string())
+        );
     }
 }

--- a/crates/rest/src/terminology.rs
+++ b/crates/rest/src/terminology.rs
@@ -165,6 +165,70 @@ impl TerminologyServiceClient {
 
         extract_expansion_codes(&value)
     }
+
+    /// Expands the concepts subsumed by (or subsuming) a code, via an inline
+    /// ValueSet `$expand` with a filter.
+    ///
+    /// - `op = "is-a"` returns the code and all its descendants (for `:below`).
+    /// - `op = "generalizes"` returns the code and all its ancestors (for `:above`).
+    ///
+    /// Both include the code itself, per FHIR subsumption-testing semantics.
+    pub async fn expand_subsumption(
+        &self,
+        system: &str,
+        code: &str,
+        op: &str,
+    ) -> Result<Vec<ExpandedCode>, TerminologyError> {
+        let endpoint = format!("{}/ValueSet/$expand", self.base_url);
+
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [{
+                "name": "valueSet",
+                "resource": {
+                    "resourceType": "ValueSet",
+                    "compose": {
+                        "include": [{
+                            "system": system,
+                            "filter": [{ "property": "concept", "op": op, "value": code }]
+                        }]
+                    }
+                }
+            }]
+        });
+
+        let response = self
+            .client
+            .post(&endpoint)
+            .json(&body)
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", "application/fhir+json")
+            .send()
+            .await
+            .map_err(|e| TerminologyError::Network(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body_text = response
+                .text()
+                .await
+                .unwrap_or_default()
+                .chars()
+                .take(512)
+                .collect::<String>();
+            return Err(TerminologyError::ServerError {
+                status,
+                body: body_text,
+            });
+        }
+
+        let value: Value = response
+            .json()
+            .await
+            .map_err(|e| TerminologyError::Parse(e.to_string()))?;
+
+        extract_expansion_codes(&value)
+    }
 }
 
 /// Extracts `ExpandedCode` entries from a FHIR ValueSet resource with expansion.


### PR DESCRIPTION
Stacked on #125. Closes the "silently-wrong" token hierarchy gap.

## Problem
`code:below=http://snomed.info/sct|73211009` (find a SNOMED code and all its descendants) was parsed but ignored by the backends' token handlers — silently returning only the exact code, missing the subtree. This is the most dangerous kind of gap: confident, clinically-incorrect results.

## Fix (REST-layer terminology expansion, mirroring `:in`)
- `TerminologyServiceClient::expand_subsumption` POSTs `ValueSet/$expand` with an inline ValueSet filter: `is-a` for `:below` (code + descendants), `generalizes` for `:above` (code + ancestors). Both include the code itself, per FHIR subsumption semantics.
- The search handler rewrites `param:below=system|code` → a plain token OR list of the expanded codes, so it works uniformly on **every backend** (SQLite, PG, Mongo, ES).
- Only token form (`system|code`) is intercepted; a bare value (no `|`) is left untouched so **native URI `:above`/`:below`** (no terminology server needed) is unaffected.
- Same robustness policy as `:in`: empty expansion → sentinel (match nothing); request error → fail-open (drop filter).

Requires `HFS_TERMINOLOGY_SERVER`.

## Tests
- **Happy path** against a mock terminology server (axum): `code:below=…|73211009` → the modifier is consumed and `code` is rewritten to the comma-joined descendants.
- Fail-open on network error (token `:below` dropped).
- URI-form pass-through (`url:below=http://…` left untouched — no terminology call).
All 6 terminology-expansion tests pass; clippy clean.

## Docs
Matrix `:above`/`:below`: Mongo `†○`→◐, note rewritten (URI native + token via REST `$expand`); assessment modifier table gets a `³` footnote and the roadmap item updated.