### PR TITLE
feat: FHIR Search improvements — composite, chaining, cursor sort, value[x], terminology, MongoDB quantity (#119–#126 into main)

### DIFF
--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -363,8 +363,8 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [\_content](https://build.fhir.org/search.html#_content) (full content)     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ✗   |
 | [\_filter](https://build.fhir.org/search.html#_filter) (advanced filtering) | ✓      | ○          | ○       | ✗         | ○     | ○             | ✗   |
 | **Advanced Search**                                                         |
-| [Chained Parameters](https://build.fhir.org/search.html#chaining)           | ✓      | ✓          | ○       | ✗         | ○     | ✗             | ✗   |
-| [Reverse Chaining (\_has)](https://build.fhir.org/search.html#has)          | ✓      | ✓          | ○       | ✗         | ○     | ✗             | ✗   |
+| [Chained Parameters](https://build.fhir.org/search.html#chaining)           | ✓      | ✓          | ◐       | ✗         | ○     | ◐             | ✗   |
+| [Reverse Chaining (\_has)](https://build.fhir.org/search.html#has)          | ✓      | ✓          | ◐       | ✗         | ○     | ◐             | ✗   |
 | [\_include](https://build.fhir.org/search.html#include)                     | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | [\_revinclude](https://build.fhir.org/search.html#revinclude)               | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | **[Pagination](https://build.fhir.org/http.html#paging)**                   |
@@ -393,6 +393,12 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 - **`:in` / `:not-in`** — handled at the REST layer: `:in` is expanded against a terminology
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.
+- **Chained / `_has`** — SQLite and PostgreSQL resolve chains natively in-backend (✓). For every
+  other backend (◐), the REST layer resolves chained and reverse-chained parameters via
+  application-side joins (`search::resolve_chains`): each hop is one plain `search()` against the
+  backend, and the result is folded into an `_id` filter. So `GET /Observation?subject.name=Smith`
+  and `?_has:Observation:subject:code=…` work end-to-end on every searchable backend, including
+  Elasticsearch and MongoDB.
 - **Composite** — SQLite, PostgreSQL, and Elasticsearch evaluate composite component values
   (token, string, number, quantity, date) end-to-end (✓): the REST layer resolves component types
   from the registry and the extractor indexes each composite instance as a `composite_group`.

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -382,10 +382,11 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 - **Sorting** — SQLite and PostgreSQL sort by any indexed search parameter (string, token,
   date, number, quantity, reference, URI) via a correlated subquery into the search index, taking
   the min value ascending / max descending for multi-valued params; `_id`/`_lastUpdated` sort on
-  the resources table directly. Sort is applied on the first-page and offset paths; cursor
-  (keyset) pages always use the default `_lastUpdated` ordering. MongoDB sorts by `_id`/
-  `_lastUpdated` only and cannot combine a custom sort with cursor pagination, hence ◐ for
-  multiple fields.
+  the resources table directly. Cursor (keyset) pagination is consistent with the active sort: the
+  sort key value is encoded into the opaque cursor and the keyset comparison runs on it, so deep
+  paging preserves the sort order. A multi-field `_sort` returns a single page (no cursor). MongoDB
+  sorts by `_id`/`_lastUpdated` only and cannot combine a custom sort with cursor pagination, hence
+  ◐ for multiple fields.
 - **`:above` / `:below`** — SQLite, PostgreSQL, and Elasticsearch implement hierarchical URI
   prefix matching (no external service needed), shown as ◐. Token/code hierarchy expansion
   (which needs a terminology server) is not implemented natively.

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -354,7 +354,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [:text](https://build.fhir.org/search.html#modifiers) (full-text)           | ✓      | ◐          | ○       | ✗         | ✗     | ✓             | ✗   |
 | [:not](https://build.fhir.org/search.html#modifiers)                        | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ○   |
 | [:missing](https://build.fhir.org/search.html#modifiers)                    | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ○   |
-| [:above / :below](https://build.fhir.org/search.html#modifiers)             | ◐      | ◐          | †○      | ✗         | ○     | ◐             | ✗   |
+| [:above / :below](https://build.fhir.org/search.html#modifiers)             | ◐      | ◐          | ◐       | ✗         | ○     | ◐             | ✗   |
 | [:in / :not-in](https://build.fhir.org/search.html#modifiers)               | ✗      | †○         | †○      | ✗         | ○     | †○            | ✗   |
 | [:of-type](https://build.fhir.org/search.html#modifiers)                    | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
 | [:text-advanced](https://build.fhir.org/search.html#modifiertextadvanced)   | ✓      | †○         | †○      | ✗         | ✗     | ✓             | ✗   |
@@ -387,9 +387,12 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
   paging preserves the sort order. A multi-field `_sort` returns a single page (no cursor). MongoDB
   sorts by `_id`/`_lastUpdated` only and cannot combine a custom sort with cursor pagination, hence
   ◐ for multiple fields.
-- **`:above` / `:below`** — SQLite, PostgreSQL, and Elasticsearch implement hierarchical URI
-  prefix matching (no external service needed), shown as ◐. Token/code hierarchy expansion
-  (which needs a terminology server) is not implemented natively.
+- **`:above` / `:below`** — two mechanisms (◐ = both, conditional on context): (1) hierarchical
+  **URI** prefix matching is native to SQLite, PostgreSQL, and Elasticsearch (no external service);
+  (2) **token/code** hierarchy (e.g. `code:below=http://snomed.info/sct|73211009`) is resolved at
+  the REST layer — the code and its descendants (`:below`, `is-a`) or ancestors (`:above`,
+  `generalizes`) are expanded via the terminology server's `$expand`, then matched as a plain token
+  OR list on any backend. Token hierarchy therefore requires `HFS_TERMINOLOGY_SERVER`.
 - **`:in` / `:not-in`** — handled at the REST layer: `:in` is expanded against a terminology
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -345,7 +345,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [Reference](https://build.fhir.org/search.html#reference)                   | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
 | [Date](https://build.fhir.org/search.html#date)                             | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
 | [Number](https://build.fhir.org/search.html#number)                         | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ○   |
-| [Quantity](https://build.fhir.org/search.html#quantity)                     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ○   |
+| [Quantity](https://build.fhir.org/search.html#quantity)                     | ✓      | ✓          | ✓       | ✗         | ✗     | ✓             | ○   |
 | [URI](https://build.fhir.org/search.html#uri)                               | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
 | [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
 | **[Search Modifiers](https://build.fhir.org/search.html#modifiers)**        |
@@ -568,8 +568,9 @@ MongoDB provides document-centric primary storage with full FHIR capabilities in
 - Full CRUD operations with document-native resource storage
 - Versioning and history providers (`vread`, instance/type/system history)
 - Transaction bundles with urn:uuid reference resolution (requires replica set)
-- Native search (string, token, reference, date, number, URI parameters; quantity and composite
-  parameters, chained/`_has`, `_text`/`_content`, and most modifiers are not yet supported)
+- Native search (string, token, reference, date, number, quantity, URI parameters; composite
+  parameters, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are not yet
+  supported; chained/`_has` work via the REST-layer resolver)
 - `_include` and `_revinclude` resolution
 - Conditional create, update, and delete operations
 - Cursor and offset pagination; sorting by `_id`/`_lastUpdated` (a custom sort cannot be combined

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -379,11 +379,13 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 
 **Notes on partial cells:**
 
-- **Sorting** — "Single/Multiple field" covers `_id` and `_lastUpdated` only on every
-  backend; sorting by an arbitrary search parameter is not yet implemented (it would require a
-  join against the search index). Sort is applied on the first-page and offset paths; cursor
-  (keyset) pages always use the default `_lastUpdated` ordering. MongoDB cannot combine a custom
-  sort with cursor pagination, hence ◐ for multiple fields.
+- **Sorting** — SQLite and PostgreSQL sort by any indexed search parameter (string, token,
+  date, number, quantity, reference, URI) via a correlated subquery into the search index, taking
+  the min value ascending / max descending for multi-valued params; `_id`/`_lastUpdated` sort on
+  the resources table directly. Sort is applied on the first-page and offset paths; cursor
+  (keyset) pages always use the default `_lastUpdated` ordering. MongoDB sorts by `_id`/
+  `_lastUpdated` only and cannot combine a custom sort with cursor pagination, hence ◐ for
+  multiple fields.
 - **`:above` / `:below`** — SQLite, PostgreSQL, and Elasticsearch implement hierarchical URI
   prefix matching (no external service needed), shown as ◐. Token/code hierarchy expansion
   (which needs a terminology server) is not implemented natively.
@@ -1136,7 +1138,8 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
       search works end-to-end (REST → registry-resolved components → grouped index → query).
 - [x] ChainedSearchProvider and reverse chaining (\_has)
 - [x] Full-text search (tsvector/tsquery)
-- [x] `_sort` by `_id`/`_lastUpdated` (first-page and offset paths)
+- [x] `_sort` by `_id`/`_lastUpdated` and any indexed search parameter via a search_index
+      correlated subquery (first-page and offset paths)
 - [x] `_include` and `_revinclude` resolution
 - [x] BulkExportStorage and BulkSubmitProvider
 - [x] Search offloading support

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -347,7 +347,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [Number](https://build.fhir.org/search.html#number)                         | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ○   |
 | [Quantity](https://build.fhir.org/search.html#quantity)                     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ○   |
 | [URI](https://build.fhir.org/search.html#uri)                               | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
-| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ○          | ○       | ✗         | ○     | ◐             | ✗   |
+| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ✓          | ○       | ✗         | ○     | ◐             | ✗   |
 | **[Search Modifiers](https://build.fhir.org/search.html#modifiers)**        |
 | [:exact](https://build.fhir.org/search.html#modifiers)                      | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
 | [:contains](https://build.fhir.org/search.html#modifiers)                   | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
@@ -356,7 +356,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [:missing](https://build.fhir.org/search.html#modifiers)                    | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ○   |
 | [:above / :below](https://build.fhir.org/search.html#modifiers)             | ◐      | ◐          | †○      | ✗         | ○     | ◐             | ✗   |
 | [:in / :not-in](https://build.fhir.org/search.html#modifiers)               | ✗      | †○         | †○      | ✗         | ○     | †○            | ✗   |
-| [:of-type](https://build.fhir.org/search.html#modifiers)                    | ✓      | ○          | ○       | ✗         | ○     | ✓             | ✗   |
+| [:of-type](https://build.fhir.org/search.html#modifiers)                    | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
 | [:text-advanced](https://build.fhir.org/search.html#modifiertextadvanced)   | ✓      | †○         | †○      | ✗         | ✗     | ✓             | ✗   |
 | **[Special Parameters](https://build.fhir.org/search.html#all)**            |
 | [\_text](https://build.fhir.org/search.html#_text) (narrative search)       | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ✗   |
@@ -390,8 +390,11 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 - **`:in` / `:not-in`** — handled at the REST layer: `:in` is expanded against a terminology
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.
-- **Elasticsearch Composite** — matches on the composite parameter name only; individual
-  component values are not yet evaluated, hence ◐.
+- **Composite** — SQLite and PostgreSQL evaluate composite component values (token, string,
+  number, quantity, date) at the backend level (✓); Elasticsearch matches on the composite
+  parameter name only (◐). Note: the REST layer does not yet populate composite component
+  definitions from the registry, so composite search is currently reachable via the direct
+  backend API rather than over HTTP. See `docs/search-spec-assessment.md`.
 
 The S3 backend is intentionally storage-focused (CRUD/version/history/bulk submit) and does not act as a full FHIR search engine. For bulk export, S3 can feed system-level batches through `ExportDataProvider` and can store output files through `S3OutputStore`, but job state belongs to SQLite or PostgreSQL. Patient-level and Group-level export compartment enumeration are not supported by S3 as the resource store. For query-heavy deployments, use a DB/search backend as primary query engine and compose S3 as archive/history/output storage.
 
@@ -1127,10 +1130,10 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
 - [x] History providers (instance, type, system)
 - [x] TransactionProvider with configurable isolation levels
 - [x] Conditional operations (conditional create/update/delete)
-- [x] SearchProvider with all parameter types except composite (string, token, reference, date,
-      number, quantity, URI; supports `:exact`/`:contains`/`:not`/`:missing` and URI
-      `:above`/`:below`; composite and the `:of-type`/`:text-advanced` modifiers are not yet
-      implemented)
+- [x] SearchProvider with all parameter types including composite (string, token, reference, date,
+      number, quantity, URI, composite; supports `:exact`/`:contains`/`:not`/`:missing`/`:of-type`
+      and URI `:above`/`:below`; the `:text-advanced` modifier is not yet implemented). Composite
+      component definitions are not yet wired through the REST layer.
 - [x] ChainedSearchProvider and reverse chaining (\_has)
 - [x] Full-text search (tsvector/tsquery)
 - [x] `_sort` by `_id`/`_lastUpdated` (first-page and offset paths)

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -347,7 +347,7 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | [Number](https://build.fhir.org/search.html#number)                         | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ○   |
 | [Quantity](https://build.fhir.org/search.html#quantity)                     | ✓      | ✓          | ○       | ✗         | ✗     | ✓             | ○   |
 | [URI](https://build.fhir.org/search.html#uri)                               | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
-| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ✓          | ○       | ✗         | ○     | ◐             | ✗   |
+| [Composite](https://build.fhir.org/search.html#composite)                   | ✓      | ✓          | ○       | ✗         | ○     | ✓             | ✗   |
 | **[Search Modifiers](https://build.fhir.org/search.html#modifiers)**        |
 | [:exact](https://build.fhir.org/search.html#modifiers)                      | ✓      | ✓          | ✓       | ○         | ○     | ✓             | ○   |
 | [:contains](https://build.fhir.org/search.html#modifiers)                   | ✓      | ✓          | ✓       | ✗         | ○     | ✓             | ✗   |
@@ -393,11 +393,12 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 - **`:in` / `:not-in`** — handled at the REST layer: `:in` is expanded against a terminology
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.
-- **Composite** — SQLite and PostgreSQL evaluate composite component values (token, string,
-  number, quantity, date) end-to-end (✓): the REST layer resolves component types from the
-  registry, the extractor indexes each composite instance as a `composite_group`, and the backend
-  matches all components within one group. Elasticsearch matches on the composite parameter name
-  only (◐). See `docs/search-spec-assessment.md`.
+- **Composite** — SQLite, PostgreSQL, and Elasticsearch evaluate composite component values
+  (token, string, number, quantity, date) end-to-end (✓): the REST layer resolves component types
+  from the registry and the extractor indexes each composite instance as a `composite_group`.
+  SQLite/PG match all components within one group via `GROUP BY … HAVING`; Elasticsearch indexes
+  each instance as one nested object with inline component values and matches with a single nested
+  query. See `docs/search-spec-assessment.md`.
 
 The S3 backend is intentionally storage-focused (CRUD/version/history/bulk submit) and does not act as a full FHIR search engine. For bulk export, S3 can feed system-level batches through `ExportDataProvider` and can store output files through `S3OutputStore`, but job state belongs to SQLite or PostgreSQL. Patient-level and Group-level export compartment enumeration are not supported by S3 as the resource store. For query-heavy deployments, use a DB/search backend as primary query engine and compose S3 as archive/history/output storage.
 
@@ -1115,8 +1116,9 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
 - [x] Index schema and mappings (nested objects for multi-value search params)
 - [x] ResourceStorage implementation for composite sync support
 - [x] Search query translation (FHIR SearchQuery → ES Query DSL)
-- [x] Parameter type handlers (string, token, date, number, quantity, reference, URI; composite
-      matches on the parameter name only — component values are not yet evaluated)
+- [x] Parameter type handlers (string, token, date, number, quantity, reference, URI, composite —
+      each composite instance is one nested object with inline component values, matched by a
+      single nested query)
 - [x] Full-text search (`_text`, `_content`, `:text-advanced`)
 - [x] Modifier support (:exact, :contains, :text, :not, :missing, :above, :below, :of-type)
 - [x] `_include` and `_revinclude` resolution

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -391,10 +391,10 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
   server before the query reaches the backend; `:not-in` returns `501 Not Implemented`. No
   backend resolves these natively.
 - **Composite** — SQLite and PostgreSQL evaluate composite component values (token, string,
-  number, quantity, date) at the backend level (✓); Elasticsearch matches on the composite
-  parameter name only (◐). Note: the REST layer does not yet populate composite component
-  definitions from the registry, so composite search is currently reachable via the direct
-  backend API rather than over HTTP. See `docs/search-spec-assessment.md`.
+  number, quantity, date) end-to-end (✓): the REST layer resolves component types from the
+  registry, the extractor indexes each composite instance as a `composite_group`, and the backend
+  matches all components within one group. Elasticsearch matches on the composite parameter name
+  only (◐). See `docs/search-spec-assessment.md`.
 
 The S3 backend is intentionally storage-focused (CRUD/version/history/bulk submit) and does not act as a full FHIR search engine. For bulk export, S3 can feed system-level batches through `ExportDataProvider` and can store output files through `S3OutputStore`, but job state belongs to SQLite or PostgreSQL. Patient-level and Group-level export compartment enumeration are not supported by S3 as the resource store. For query-heavy deployments, use a DB/search backend as primary query engine and compose S3 as archive/history/output storage.
 
@@ -1133,7 +1133,7 @@ The SQLite backend includes a complete FHIR search implementation using pre-comp
 - [x] SearchProvider with all parameter types including composite (string, token, reference, date,
       number, quantity, URI, composite; supports `:exact`/`:contains`/`:not`/`:missing`/`:of-type`
       and URI `:above`/`:below`; the `:text-advanced` modifier is not yet implemented). Composite
-      component definitions are not yet wired through the REST layer.
+      search works end-to-end (REST → registry-resolved components → grouped index → query).
 - [x] ChainedSearchProvider and reverse chaining (\_has)
 - [x] Full-text search (tsvector/tsquery)
 - [x] `_sort` by `_id`/`_lastUpdated` (first-page and offset paths)

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -152,19 +152,21 @@ These are parsed and largely orchestrated by the REST layer.
 field's type from the registry (`SortDirective.param_type`). On SQLite and PostgreSQL, `_id` and
 `_lastUpdated` sort on the `resources` table, while any other indexed parameter sorts on a
 correlated subquery into `search_index` — `MIN(value_col)` for ascending, `MAX(value_col)` for
-descending (FHIR multi-value sort), with the value column chosen by the parameter type. Sort is
-applied on the first-page and offset query paths; cursor (keyset) pages always use the default
-`_lastUpdated, id` ordering because the keyset `WHERE` comparison depends on it. MongoDB sorts by
+descending (FHIR multi-value sort), with the value column chosen by the parameter type. Cursor
+(keyset) pagination is consistent with the sort: the boundary row's sort value is selected, encoded
+into the opaque `PageCursor` alongside the id, and the next/previous page applies a keyset `WHERE`
+`(sort_expr, id)` comparison on it — so deep paging preserves the order. A multi-field `_sort`
+returns a single page (no cursor) rather than risk an inconsistent keyset. MongoDB sorts by
 `_id`/`_lastUpdated` only and cannot combine a custom sort with cursor pagination; Elasticsearch
-sorts on its mapped fields.
+sorts on its mapped fields via `search_after`.
 
 ## 7. Known limitations & roadmap
 
 Ordered roughly by impact:
 
-1. **Cursor pagination + custom sort** — SQLite/PG now sort by any indexed parameter on the
-   first-page and offset paths, but cursor (keyset) pages still use the default `_lastUpdated`
-   ordering. Reconciling keyset pagination with arbitrary sort keys remains open. MongoDB still
+1. **Multi-field `_sort` + cursor** — single-field sorts (and the default `_lastUpdated`) page
+   correctly via the keyset cursor on SQLite/PG. A multi-field `_sort` currently returns a single
+   page (no cursor); extending the keyset to a multi-key tuple is the remaining work. MongoDB still
    sorts by `_id`/`_lastUpdated` only.
 2. **Terminology-dependent modifiers** — token `:above`/`:below`, `:in`, `:not-in` need a
    terminology server. `:in` is partially handled via REST-side expansion; the rest are not native.

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -40,7 +40,7 @@ Neo4j are not implemented.
 | number | ✓ | ✓ | ✓ | ✓ | implicit-precision ranges + all prefixes |
 | quantity | ✓ | ✓ | ✗ | ✓ | MongoDB rejects with `UnsupportedParameterType` |
 | uri | ✓ | ✓ | ✓ | ✓ | exact + `:above`/`:below` prefix matching |
-| composite | ✓ | ✓ | ✗ | ◐ | SQLite/PG evaluate components; ES matches name only; Mongo returns no condition |
+| composite | ✓ | ✓ | ✗ | ✓ | SQLite/PG group by `composite_group`; ES uses one nested object per instance; Mongo returns no condition |
 
 The `resource` and `special` parameter types from the spec are modeled in the `SearchParamType`
 enum but have no dedicated execution path beyond the special common parameters below.
@@ -176,11 +176,22 @@ Ordered roughly by impact:
    composite parameters are all supported now).
 4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
    chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
-5. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
-   forward chaining and `_has` silently return nothing rather than erroring; `_filter` unsupported.
+5. **Elasticsearch gaps** — forward chaining and `_has` silently return nothing rather than
+   erroring; `_filter` unsupported. (Composite now evaluates components via inline nested objects.)
+   See the chaining note below — chained search is a cross-cutting dispatch gap, not ES-specific.
 6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
    unsupported everywhere.
+
+**Chaining dispatch (cross-cutting).** Chained (`subject.name=Smith`) and reverse-chained
+(`_has:Observation:subject:code=1234`) searches are *parsed* into `SearchQuery` (`param.chain`,
+`reverse_chains`) but the 2-arg `SearchProvider::search` that the REST layer calls does not act on
+them on any backend — the working chain logic lives in the separate `ChainedSearchProvider::
+resolve_chain` API, which `search()` never invokes. `CompositeStorage` already implements
+`resolve_chain` via iterative plain `search()` calls (which work on every backend, including ES).
+So making chained/`_has` search work end-to-end over HTTP is a single dispatch change — detect
+chained params in the `search()` path and route them through `resolve_chain` — not an
+ES-specific fix.
 
 SQLite is the most complete backend and serves as the reference for the others; PostgreSQL is now
 at near-parity (only `:text-advanced` remains).

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -45,13 +45,19 @@ Neo4j are not implemented.
 The `resource` and `special` parameter types from the spec are modeled in the `SearchParamType`
 enum but have no dedicated execution path beyond the special common parameters below.
 
-**Composite caveat (all backends):** the SQLite and PostgreSQL composite handlers evaluate each
-component (token/string/number/quantity/date) against the columns of a single `search_index` row.
-However, the REST layer builds the outgoing `SearchParameter` with empty `components`
-(`crates/rest/src/extractors/search_query_builder.rs`), so composite search is currently exercised
-through the direct backend API (with components supplied), not over HTTP. Wiring component
-definitions from the registry into the REST query builder is a prerequisite for end-to-end
-composite search on any backend.
+**Composite (SQLite, PostgreSQL):** works end-to-end. The REST layer resolves each component's
+type and code from the registry (by the component `definition` URL); the extractor indexes every
+composite instance as a set of `search_index` rows sharing a `composite_group`; and the backend
+matches with `GROUP BY resource_id, composite_group HAVING <every component present>`, so all
+components must be satisfied within the same instance. Elasticsearch still matches the composite
+name only (◐).
+
+**Choice types (`value[x]`):** the extractor evaluates FHIRPath against schema-less JSON, where a
+cast such as `value as Quantity` / `value.ofType(Quantity)` cannot resolve to the stored
+`valueQuantity` field. `rewrite_choice_types` in `search/extractor.rs` rewrites these casts to the
+concrete element name (`valueQuantity`, `medicationCodeableConcept`, `occurrenceDateTime`, …)
+before evaluation. This fixed both composite value components and plain `value[x]` parameters
+(e.g. `value-quantity`), which previously indexed nothing.
 
 ## 2. Search modifiers
 
@@ -161,17 +167,14 @@ Ordered roughly by impact:
    URI `:above`/`:below` (hierarchical prefix, no service needed) *is* implemented on SQLite/PG/ES.
 3. **PostgreSQL modifier gaps** — only the `:text-advanced` modifier remains unimplemented relative
    to SQLite (`:exact`, `:contains`, `:not`, `:missing`, `:of-type`, URI `:above`/`:below`, and
-   composite parameters are all supported at the backend level now).
-4. **Composite REST wiring** — composite search works at the backend level (SQLite, PostgreSQL) but
-   the REST layer does not yet populate composite component definitions, so it is not reachable over
-   HTTP on any backend. See the composite caveat in §1.
-5. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
+   composite parameters are all supported now).
+4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
    chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
-6. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
+5. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
    forward chaining and `_has` silently return nothing rather than erroring; `_filter` unsupported.
-7. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
+6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
    unsupported everywhere.
 
 SQLite is the most complete backend and serves as the reference for the others; PostgreSQL is now
-at near-parity (only `:text-advanced` and REST-side composite wiring remain).
+at near-parity (only `:text-advanced` remains).

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -71,7 +71,7 @@ before evaluation. This fixed both composite value components and plain `value[x
 | `:of-type` | ✓ | ✓ | ✗ | ✓ |
 | `:text-advanced` | ✓ | ✗ | ✗ | ✓ |
 | `:above` / `:below` (URI) | ✓ | ✓ | ✗ | ✓ |
-| `:above` / `:below` (token hierarchy) | ✗ | ✗ | ✗ | ✗ |
+| `:above` / `:below` (token hierarchy) | †³ | †³ | †³ | †³ |
 | `:in` / `:not-in` | †² | †² | †² | †² |
 | `:identifier` (reference) | ✓ | ✗ | ✗ | ✓ |
 | `:[type]` (reference) | ✓ | ✗ | ✓ | ✓ |
@@ -82,6 +82,10 @@ before evaluation. This fixed both composite value components and plain `value[x
 ² `:in` is expanded by the REST layer against a configured terminology server before the query
   reaches the backend (`crates/rest/src/handlers/search.rs`); `:not-in` returns `501 Not
   Implemented`. No backend resolves either modifier natively.
+³ Token `:above`/`:below` (`code:below=system|code`) is resolved at the REST layer: the code and its
+  descendants (`is-a`, for `:below`) or ancestors (`generalizes`, for `:above`) are expanded via the
+  terminology server's `$expand`, then matched as a plain token OR list. Works on every backend when
+  `HFS_TERMINOLOGY_SERVER` is configured; URI `:above`/`:below` is separate and native (above).
 
 The REST layer parses **all** of these modifiers (`crates/rest/src/extractors/search_query_builder.rs`)
 regardless of backend; unsupported ones either no-op, error, or (for some ES/Mongo cases) return no
@@ -172,8 +176,10 @@ Ordered roughly by impact:
    correctly via the keyset cursor on SQLite/PG. A multi-field `_sort` currently returns a single
    page (no cursor); extending the keyset to a multi-key tuple is the remaining work. MongoDB still
    sorts by `_id`/`_lastUpdated` only.
-2. **Terminology-dependent modifiers** — token `:above`/`:below`, `:in`, `:not-in` need a
-   terminology server. `:in` is partially handled via REST-side expansion; the rest are not native.
+2. **Terminology-dependent modifiers** — `:in` and token `:above`/`:below` are resolved at the REST
+   layer via terminology `$expand` (functional when `HFS_TERMINOLOGY_SERVER` is set; no native
+   in-backend resolution). `:not-in` still returns `501` — negated value-set filtering is the
+   remaining gap.
    URI `:above`/`:below` (hierarchical prefix, no service needed) *is* implemented on SQLite/PG/ES.
 3. **PostgreSQL modifier gaps** — only the `:text-advanced` modifier remains unimplemented relative
    to SQLite (`:exact`, `:contains`, `:not`, `:missing`, `:of-type`, URI `:above`/`:below`, and

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -120,15 +120,19 @@ effectively a no-op.
 
 | Capability | SQLite | PostgreSQL | MongoDB | Elasticsearch |
 |------------|:------:|:----------:|:-------:|:-------------:|
-| Forward chained params (N-level) | ✓ | ✓ | ✗ | ✗ |
-| Reverse chaining (`_has`, nested) | ✓ | ✓ | ✗ | ✗ |
+| Forward chained params (N-level) | ✓ | ✓ | ◐ | ◐ |
+| Reverse chaining (`_has`) | ✓ | ✓ | ◐ | ◐ |
 | `_include` | ✓ | ✓ | ✓ | ✓ |
 | `_revinclude` | ✓ | ✓ | ✓ | ✓ |
 | `:iterate` on include | parsed | parsed | parsed | parsed |
 
-SQLite and PostgreSQL resolve chains via nested `search_index` subqueries with configurable depth
-limits. MongoDB returns `ChainedSearchNotSupported` / `ReverseChainNotSupported`; Elasticsearch
-silently returns no matches when `param.chain` or `reverse_chains` are present.
+SQLite and PostgreSQL resolve chains natively, via nested `search_index` subqueries with
+configurable depth limits (✓). For all other backends (◐), the REST layer resolves chained and
+reverse-chained parameters before the backend search runs: `search::resolve_chains` issues one
+plain `search()` per chain hop against the same backend and folds the result into an `_id`
+filter — application-side joins. So chained and `_has` queries work end-to-end over HTTP on every
+searchable backend, including Elasticsearch and MongoDB; the per-backend distinction is whether the
+join is pushed into the backend (SQLite/PG) or performed by the REST layer.
 
 ## 6. Result control (paging, sort, total, summary, elements)
 
@@ -176,22 +180,20 @@ Ordered roughly by impact:
    composite parameters are all supported now).
 4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
    chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
-5. **Elasticsearch gaps** — forward chaining and `_has` silently return nothing rather than
-   erroring; `_filter` unsupported. (Composite now evaluates components via inline nested objects.)
-   See the chaining note below — chained search is a cross-cutting dispatch gap, not ES-specific.
+5. **Elasticsearch gaps** — `_filter` unsupported. (Composite now evaluates components via inline
+   nested objects; chained/`_has` now work via the REST-layer resolver — see below.)
 6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
    unsupported everywhere.
 
-**Chaining dispatch (cross-cutting).** Chained (`subject.name=Smith`) and reverse-chained
-(`_has:Observation:subject:code=1234`) searches are *parsed* into `SearchQuery` (`param.chain`,
-`reverse_chains`) but the 2-arg `SearchProvider::search` that the REST layer calls does not act on
-them on any backend — the working chain logic lives in the separate `ChainedSearchProvider::
-resolve_chain` API, which `search()` never invokes. `CompositeStorage` already implements
-`resolve_chain` via iterative plain `search()` calls (which work on every backend, including ES).
-So making chained/`_has` search work end-to-end over HTTP is a single dispatch change — detect
-chained params in the `search()` path and route them through `resolve_chain` — not an
-ES-specific fix.
+**Chaining dispatch (resolved).** Chained (`subject.name=Smith`) and reverse-chained
+(`_has:Observation:subject:code=1234`) searches are parsed into `SearchQuery` (`param.chain`,
+`reverse_chains`), but the 2-arg `SearchProvider::search` does not act on them. The REST search
+handler now calls `search::resolve_chains` first: a backend-agnostic resolver that performs the
+chain as application-side joins (one plain `search()` per hop, results folded into an `_id`
+filter), then runs the rewritten query. This works for any `SearchProvider`, so chained and `_has`
+queries are functional end-to-end on SQLite, PostgreSQL, MongoDB, and Elasticsearch. SQLite and PG
+additionally resolve chains natively in-backend.
 
 SQLite is the most complete backend and serves as the reference for the others; PostgreSQL is now
 at near-parity (only `:text-advanced` remains).

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -38,7 +38,7 @@ Neo4j are not implemented.
 | reference | ✓ | ✓ | ✓ | ✓ | type modifier + `:identifier` (SQLite/ES) |
 | date | ✓ | ✓ | ✓ | ✓ | precision-aware ranges + all prefixes |
 | number | ✓ | ✓ | ✓ | ✓ | implicit-precision ranges + all prefixes |
-| quantity | ✓ | ✓ | ✗ | ✓ | MongoDB rejects with `UnsupportedParameterType` |
+| quantity | ✓ | ✓ | ✓ | ✓ | value comparison + optional system/unit on all backends |
 | uri | ✓ | ✓ | ✓ | ✓ | exact + `:above`/`:below` prefix matching |
 | composite | ✓ | ✓ | ✗ | ✓ | SQLite/PG group by `composite_group`; ES uses one nested object per instance; Mongo returns no condition |
 
@@ -178,8 +178,9 @@ Ordered roughly by impact:
 3. **PostgreSQL modifier gaps** — only the `:text-advanced` modifier remains unimplemented relative
    to SQLite (`:exact`, `:contains`, `:not`, `:missing`, `:of-type`, URI `:above`/`:below`, and
    composite parameters are all supported now).
-4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
-   chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
+4. **MongoDB native search gaps** — composite parameters error out; `_text`/`_content` and most
+   modifiers beyond `:exact`/`:contains` are unsupported. (Quantity search is now implemented;
+   chained/`_has` work via the REST-layer resolver.)
 5. **Elasticsearch gaps** — `_filter` unsupported. (Composite now evaluates components via inline
    nested objects; chained/`_has` now work via the REST-layer resolver — see below.)
 6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -40,10 +40,18 @@ Neo4j are not implemented.
 | number | ✓ | ✓ | ✓ | ✓ | implicit-precision ranges + all prefixes |
 | quantity | ✓ | ✓ | ✗ | ✓ | MongoDB rejects with `UnsupportedParameterType` |
 | uri | ✓ | ✓ | ✓ | ✓ | exact + `:above`/`:below` prefix matching |
-| composite | ✓ | ✗ | ✗ | ◐ | PG/Mongo return no condition; ES matches name only |
+| composite | ✓ | ✓ | ✗ | ◐ | SQLite/PG evaluate components; ES matches name only; Mongo returns no condition |
 
 The `resource` and `special` parameter types from the spec are modeled in the `SearchParamType`
 enum but have no dedicated execution path beyond the special common parameters below.
+
+**Composite caveat (all backends):** the SQLite and PostgreSQL composite handlers evaluate each
+component (token/string/number/quantity/date) against the columns of a single `search_index` row.
+However, the REST layer builds the outgoing `SearchParameter` with empty `components`
+(`crates/rest/src/extractors/search_query_builder.rs`), so composite search is currently exercised
+through the direct backend API (with components supplied), not over HTTP. Wiring component
+definitions from the registry into the REST query builder is a prerequisite for end-to-end
+composite search on any backend.
 
 ## 2. Search modifiers
 
@@ -54,7 +62,7 @@ enum but have no dedicated execution path beyond the special common parameters b
 | `:contains` | ✓ | ✓ | ✓ | ✓ |
 | `:text` | ✓ | ◐¹ | ✗ | ✓ |
 | `:not` | ✓ | ✓ | ✗ | ✓ |
-| `:of-type` | ✓ | ✗ | ✗ | ✓ |
+| `:of-type` | ✓ | ✓ | ✗ | ✓ |
 | `:text-advanced` | ✓ | ✗ | ✗ | ✓ |
 | `:above` / `:below` (URI) | ✓ | ✓ | ✗ | ✓ |
 | `:above` / `:below` (token hierarchy) | ✗ | ✗ | ✗ | ✗ |
@@ -151,16 +159,19 @@ Ordered roughly by impact:
 2. **Terminology-dependent modifiers** — token `:above`/`:below`, `:in`, `:not-in` need a
    terminology server. `:in` is partially handled via REST-side expansion; the rest are not native.
    URI `:above`/`:below` (hierarchical prefix, no service needed) *is* implemented on SQLite/PG/ES.
-3. **PostgreSQL modifier/param gaps** — composite parameters and the `:of-type` and
-   `:text-advanced` modifiers are not implemented (`:not` and `:missing` are now supported; SQLite
-   implements all of these).
-4. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
+3. **PostgreSQL modifier gaps** — only the `:text-advanced` modifier remains unimplemented relative
+   to SQLite (`:exact`, `:contains`, `:not`, `:missing`, `:of-type`, URI `:above`/`:below`, and
+   composite parameters are all supported at the backend level now).
+4. **Composite REST wiring** — composite search works at the backend level (SQLite, PostgreSQL) but
+   the REST layer does not yet populate composite component definitions, so it is not reachable over
+   HTTP on any backend. See the composite caveat in §1.
+5. **MongoDB native search gaps** — quantity and composite parameters error out; forward/reverse
    chaining, `_text`/`_content`, and most modifiers beyond `:exact`/`:contains` are unsupported.
-5. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
+6. **Elasticsearch gaps** — composite matches the parameter name only (components not evaluated);
    forward chaining and `_has` silently return nothing rather than erroring; `_filter` unsupported.
-6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
+7. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
    unsupported everywhere.
 
-SQLite is the most complete backend and serves as the reference for the others; closing the
-PostgreSQL gaps (composite, `:not`/`:missing`) to reach SQLite parity is the most direct next step.
+SQLite is the most complete backend and serves as the reference for the others; PostgreSQL is now
+at near-parity (only `:text-advanced` and REST-side composite wiring remain).

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -137,7 +137,7 @@ These are parsed and largely orchestrated by the REST layer.
 | Parameter | Status | Notes |
 |-----------|--------|-------|
 | `_count` | ✓ | page size; `_offset`/`_cursor` for paging |
-| `_sort` | ◐ | applied for `_id`/`_lastUpdated` only; see below |
+| `_sort` | ✓ | SQLite/PG sort by any indexed param; see below |
 | `_total` | ✓ | `none` / `estimate` / `accurate` parsed and applied |
 | `_summary` | ✓ | `true`/`text`/`data`/`count`/`false`, applied in `subsetting.rs` |
 | `_elements` | ✓ | applied post-search with nested-path support |
@@ -148,20 +148,24 @@ These are parsed and largely orchestrated by the REST layer.
 | `next` / `previous` links | ✓ | cursor-based |
 | `first` / `last` links | ✗ | not generated |
 
-**`_sort` detail.** `_sort` is parsed into `SearchQuery.sort` for every backend. The backends map
-sort fields to columns via a small allow-list — `_id` → `id`, `_lastUpdated` → `last_updated` —
-and fall back to `id` for anything else. So sorting by an arbitrary search parameter (e.g.
-`_sort=birthdate`) currently degrades to a stable-but-not-meaningful `id` ordering on all backends.
-Sort is applied on the first-page and offset query paths; cursor (keyset) pages always use the
-default `_lastUpdated, id` ordering because the keyset `WHERE` comparison depends on it. MongoDB
-additionally cannot combine a custom sort with cursor pagination.
+**`_sort` detail.** `_sort` is parsed into `SearchQuery.sort`; the REST layer resolves each sort
+field's type from the registry (`SortDirective.param_type`). On SQLite and PostgreSQL, `_id` and
+`_lastUpdated` sort on the `resources` table, while any other indexed parameter sorts on a
+correlated subquery into `search_index` — `MIN(value_col)` for ascending, `MAX(value_col)` for
+descending (FHIR multi-value sort), with the value column chosen by the parameter type. Sort is
+applied on the first-page and offset query paths; cursor (keyset) pages always use the default
+`_lastUpdated, id` ordering because the keyset `WHERE` comparison depends on it. MongoDB sorts by
+`_id`/`_lastUpdated` only and cannot combine a custom sort with cursor pagination; Elasticsearch
+sorts on its mapped fields.
 
 ## 7. Known limitations & roadmap
 
 Ordered roughly by impact:
 
-1. **Sort by arbitrary search parameter** — unsupported on all backends (only `_id`/`_lastUpdated`).
-   Would require sorting on `search_index` values via a join. Cursor pages ignore custom sort.
+1. **Cursor pagination + custom sort** — SQLite/PG now sort by any indexed parameter on the
+   first-page and offset paths, but cursor (keyset) pages still use the default `_lastUpdated`
+   ordering. Reconciling keyset pagination with arbitrary sort keys remains open. MongoDB still
+   sorts by `_id`/`_lastUpdated` only.
 2. **Terminology-dependent modifiers** — token `:above`/`:below`, `:in`, `:not-in` need a
    terminology server. `:in` is partially handled via REST-side expansion; the rest are not native.
    URI `:above`/`:below` (hierarchical prefix, no service needed) *is* implemented on SQLite/PG/ES.

--- a/crates/persistence/src/backends/elasticsearch/schema.rs
+++ b/crates/persistence/src/backends/elasticsearch/schema.rs
@@ -150,7 +150,31 @@ pub fn create_index_mapping(config: &super::backend::ElasticsearchConfig) -> ser
                             "type": "nested",
                             "properties": {
                                 "name": { "type": "keyword" },
-                                "group_id": { "type": "integer" }
+                                "group_id": { "type": "integer" },
+                                // Component values stored inline (as arrays) so a
+                                // single nested query matches all components of the
+                                // same composite instance.
+                                "token_system": { "type": "keyword" },
+                                "token_code": { "type": "keyword" },
+                                "string": {
+                                    "type": "keyword",
+                                    "fields": {
+                                        "lowercase": {
+                                            "type": "keyword",
+                                            "normalizer": "lowercase_normalizer"
+                                        }
+                                    }
+                                },
+                                "number": { "type": "double" },
+                                "quantity_value": { "type": "double" },
+                                "quantity_unit": { "type": "keyword" },
+                                "quantity_system": { "type": "keyword" },
+                                "date": {
+                                    "type": "date",
+                                    "format": "strict_date_optional_time||epoch_millis||yyyy||yyyy-MM||yyyy-MM-dd"
+                                },
+                                "reference": { "type": "keyword" },
+                                "uri": { "type": "keyword" }
                             }
                         }
                     }

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/composite.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/composite.rs
@@ -2,55 +2,193 @@
 
 use serde_json::{Value, json};
 
-use crate::types::SearchParameter;
+use crate::types::{SearchParamType, SearchParameter};
 
 /// Builds an ES query clause for a composite search parameter.
 ///
-/// Composite parameters combine two or more sub-parameters that must
-/// match on the same logical grouping. The value format is `value1$value2`.
+/// Composite parameters combine two or more components that must all match
+/// within the same composite instance. Each instance is indexed as one nested
+/// object under `search_params.composite` with the component values inline (as
+/// arrays), so a single nested query with one condition per component enforces
+/// same-instance matching. The value format is `value1$value2$...`.
 pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
     let name = &param.name;
-    let component_values: Vec<&str> = value.split('$').collect();
+    let parts: Vec<&str> = value.split('$').collect();
 
-    if component_values.is_empty() {
-        return None;
+    let mut must: Vec<Value> = vec![json!({ "term": { "search_params.composite.name": name } })];
+
+    if param.components.is_empty() {
+        // Component definitions not resolved (e.g. standalone ES registry) —
+        // fall back to matching the composite name only.
+        return Some(nested(must));
     }
 
-    // Build a nested query that matches on the composite group
-    // Each component must match within the same group_id
-    let must_conditions = vec![json!({ "term": { "search_params.composite.name": name } })];
+    if parts.len() != param.components.len() {
+        return Some(nested(never_match(must)));
+    }
 
-    // For now, composite matching is simplified:
-    // We match the composite name, and the actual component matching
-    // is handled by the individual parameter type handlers in the query
-    Some(json!({
+    for (part, component) in parts.iter().zip(param.components.iter()) {
+        match component_conditions(component.param_type, part) {
+            Some(conds) => must.extend(conds),
+            None => return Some(nested(never_match(must))),
+        }
+    }
+
+    Some(nested(must))
+}
+
+/// Wraps the must-conditions in a nested query on the composite path.
+fn nested(must: Vec<Value>) -> Value {
+    json!({
         "nested": {
             "path": "search_params.composite",
-            "query": {
-                "bool": {
-                    "must": must_conditions
+            "query": { "bool": { "must": must } }
+        }
+    })
+}
+
+/// Appends an impossible condition so the clause matches nothing.
+fn never_match(mut must: Vec<Value>) -> Vec<Value> {
+    must.push(json!({ "term": { "search_params.composite.group_id": -1 } }));
+    must
+}
+
+/// Builds the ES condition(s) for a single component value.
+fn component_conditions(param_type: SearchParamType, part: &str) -> Option<Vec<Value>> {
+    let field = |f: &str| format!("search_params.composite.{}", f);
+    match param_type {
+        SearchParamType::Token => {
+            let conds = if let Some((system, code)) = part.split_once('|') {
+                let mut v = Vec::new();
+                if !system.is_empty() {
+                    v.push(json!({ "term": { field("token_system"): system } }));
+                }
+                if !code.is_empty() {
+                    v.push(json!({ "term": { field("token_code"): code } }));
+                }
+                v
+            } else {
+                vec![json!({ "term": { field("token_code"): part } })]
+            };
+            Some(conds)
+        }
+        SearchParamType::String => Some(vec![json!({
+            "term": { field("string.lowercase"): part.to_lowercase() }
+        })]),
+        SearchParamType::Number => {
+            let (op, num) = parse_prefixed_number(part)?;
+            Some(vec![numeric_condition(&field("number"), op, num)])
+        }
+        SearchParamType::Quantity => {
+            let mut comps = part.splitn(3, '|');
+            let (op, num) = parse_prefixed_number(comps.next()?)?;
+            let mut v = vec![numeric_condition(&field("quantity_value"), op, num)];
+            let _system = comps.next();
+            if let Some(code) = comps.next() {
+                if !code.is_empty() {
+                    v.push(json!({ "term": { field("quantity_unit"): code } }));
                 }
             }
+            Some(v)
         }
-    }))
+        SearchParamType::Date => {
+            let (op, val) = split_prefix(part);
+            Some(vec![range_condition(&field("date"), op, json!(val))])
+        }
+        SearchParamType::Reference => Some(vec![json!({ "term": { field("reference"): part } })]),
+        SearchParamType::Uri => Some(vec![json!({ "term": { field("uri"): part } })]),
+        SearchParamType::Composite | SearchParamType::Special => None,
+    }
+}
+
+/// Splits a leading FHIR comparison prefix (`eq`/`gt`/…) from a value.
+fn split_prefix(part: &str) -> (&str, &str) {
+    for p in ["eq", "ne", "gt", "lt", "ge", "le", "sa", "eb", "ap"] {
+        if let Some(rest) = part.strip_prefix(p) {
+            return (p, rest);
+        }
+    }
+    ("eq", part)
+}
+
+fn parse_prefixed_number(part: &str) -> Option<(&str, f64)> {
+    let (op, rest) = split_prefix(part);
+    rest.parse::<f64>().ok().map(|n| (op, n))
+}
+
+/// Builds a numeric term/range condition honoring the comparison prefix.
+fn numeric_condition(field: &str, op: &str, num: f64) -> Value {
+    match op {
+        "gt" | "sa" => json!({ "range": { field: { "gt": num } } }),
+        "lt" | "eb" => json!({ "range": { field: { "lt": num } } }),
+        "ge" => json!({ "range": { field: { "gte": num } } }),
+        "le" => json!({ "range": { field: { "lte": num } } }),
+        _ => json!({ "term": { field: num } }),
+    }
+}
+
+/// Builds a date range condition honoring the comparison prefix.
+fn range_condition(field: &str, op: &str, val: Value) -> Value {
+    match op {
+        "gt" | "sa" => json!({ "range": { field: { "gt": val } } }),
+        "lt" | "eb" => json!({ "range": { field: { "lt": val } } }),
+        "ge" => json!({ "range": { field: { "gte": val } } }),
+        "le" => json!({ "range": { field: { "lte": val } } }),
+        _ => json!({ "range": { field: { "gte": val, "lte": val } } }),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{SearchParamType, SearchValue};
+    use crate::types::{CompositeSearchComponent, SearchValue};
 
-    #[test]
-    fn test_composite_clause() {
-        let param = SearchParameter {
+    fn composite_param(components: Vec<CompositeSearchComponent>) -> SearchParameter {
+        SearchParameter {
             name: "code-value-quantity".to_string(),
             param_type: SearchParamType::Composite,
             modifier: None,
             values: vec![SearchValue::eq("8867-4$120")],
             chain: vec![],
-            components: vec![],
-        };
-        let clause = build_clause(&param, "8867-4$120");
-        assert!(clause.is_some());
+            components,
+        }
+    }
+
+    #[test]
+    fn name_only_when_no_components() {
+        let clause = build_clause(&composite_param(vec![]), "8867-4$120").unwrap();
+        let s = clause.to_string();
+        assert!(s.contains("search_params.composite.name"));
+        assert!(!s.contains("token_code"));
+    }
+
+    #[test]
+    fn evaluates_token_and_quantity_components() {
+        let param = composite_param(vec![
+            CompositeSearchComponent {
+                param_type: SearchParamType::Token,
+                param_name: "code".to_string(),
+            },
+            CompositeSearchComponent {
+                param_type: SearchParamType::Quantity,
+                param_name: "value-quantity".to_string(),
+            },
+        ]);
+        let clause = build_clause(&param, "http://loinc.org|8480-6$ge100").unwrap();
+        let s = clause.to_string();
+        assert!(s.contains("token_system"));
+        assert!(s.contains("token_code"));
+        assert!(s.contains("quantity_value"));
+        assert!(s.contains("gte"));
+    }
+
+    #[test]
+    fn arity_mismatch_never_matches() {
+        let param = composite_param(vec![CompositeSearchComponent {
+            param_type: SearchParamType::Token,
+            param_name: "code".to_string(),
+        }]);
+        let clause = build_clause(&param, "a$b").unwrap();
+        assert!(clause.to_string().contains("group_id"));
     }
 }

--- a/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
@@ -336,6 +336,7 @@ mod tests {
         let query = SearchQuery::new("Patient").with_sort(SortDirective {
             parameter: "_id".to_string(),
             direction: SortDirection::Ascending,
+            param_type: None,
         });
 
         let builder = EsQueryBuilder::new("acme", "Patient", "hfs_acme_patient".to_string());

--- a/crates/persistence/src/backends/elasticsearch/storage.rs
+++ b/crates/persistence/src/backends/elasticsearch/storage.rs
@@ -106,6 +106,50 @@ fn collect_strings(value: &Value, parts: &mut Vec<String>) {
 }
 
 /// Builds an ES document from a FHIR resource and its extracted search values.
+/// Appends a value to a JSON array field on `obj`, creating the array if needed.
+fn push_array_field(obj: &mut Value, key: &str, val: Value) {
+    match obj.get_mut(key) {
+        Some(Value::Array(arr)) => arr.push(val),
+        _ => obj[key] = json!([val]),
+    }
+}
+
+/// Merges one composite component's value into the composite instance object,
+/// placing it in the array field matching the component's value type. All
+/// components of one instance share a nested object, so a single nested query
+/// can require every component to match within the same instance.
+fn merge_composite_component(entry: &mut Value, value: &IndexValue) {
+    match value {
+        IndexValue::String(s) => push_array_field(entry, "string", json!(s)),
+        IndexValue::Token { system, code, .. } => {
+            push_array_field(entry, "token_code", json!(code));
+            if let Some(sys) = system {
+                push_array_field(entry, "token_system", json!(sys));
+            }
+        }
+        IndexValue::Number(n) => push_array_field(entry, "number", json!(n)),
+        IndexValue::Quantity {
+            value,
+            unit,
+            system,
+            ..
+        } => {
+            push_array_field(entry, "quantity_value", json!(value));
+            if let Some(u) = unit {
+                push_array_field(entry, "quantity_unit", json!(u));
+            }
+            if let Some(s) = system {
+                push_array_field(entry, "quantity_system", json!(s));
+            }
+        }
+        IndexValue::Date { value, .. } => push_array_field(entry, "date", json!(value)),
+        IndexValue::Reference { reference, .. } => {
+            push_array_field(entry, "reference", json!(reference))
+        }
+        IndexValue::Uri(u) => push_array_field(entry, "uri", json!(u)),
+    }
+}
+
 pub(crate) fn build_es_document(
     tenant_id: &str,
     resource_type: &str,
@@ -124,9 +168,22 @@ pub(crate) fn build_es_document(
     let mut quantity_params: Vec<Value> = Vec::new();
     let mut reference_params: Vec<Value> = Vec::new();
     let mut uri_params: Vec<Value> = Vec::new();
-    let mut composite_params: Vec<Value> = Vec::new();
+    // Composite instances, keyed by (param name, group) so all components of one
+    // instance land in a single nested object with inline (array) component values.
+    let mut composite_groups: std::collections::BTreeMap<(String, u32), Value> =
+        std::collections::BTreeMap::new();
 
     for ev in extracted_values {
+        // Composite component values are accumulated into their instance object
+        // rather than the per-type arrays.
+        if let Some(group) = ev.composite_group {
+            let entry = composite_groups
+                .entry((ev.param_name.clone(), group))
+                .or_insert_with(|| json!({ "name": ev.param_name, "group_id": group }));
+            merge_composite_component(entry, &ev.value);
+            continue;
+        }
+
         match &ev.value {
             IndexValue::String(s) => {
                 string_params.push(json!({
@@ -217,14 +274,9 @@ pub(crate) fn build_es_document(
                 }));
             }
         }
-
-        if let Some(group) = ev.composite_group {
-            composite_params.push(json!({
-                "name": ev.param_name,
-                "group_id": group,
-            }));
-        }
     }
+
+    let composite_params: Vec<Value> = composite_groups.into_values().collect();
 
     json!({
         "resource_type": resource_type,

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -539,11 +539,7 @@ impl MongoBackend {
             SearchParamType::Number => self.build_number_filter(value),
             SearchParamType::Reference => self.build_reference_filter(param, value),
             SearchParamType::Uri => self.build_uri_filter(param, value),
-            SearchParamType::Quantity => Err(StorageError::Search(
-                SearchError::UnsupportedParameterType {
-                    param_type: "quantity".to_string(),
-                },
-            )),
+            SearchParamType::Quantity => self.build_quantity_filter(value),
             SearchParamType::Composite => {
                 Err(StorageError::Search(SearchError::InvalidComposite {
                     message: "Composite search is not supported in MongoDB Phase 4".to_string(),
@@ -725,6 +721,54 @@ impl MongoBackend {
                 })
             }
         }
+    }
+
+    /// Builds a MongoDB filter for a quantity parameter.
+    ///
+    /// Value form: `[prefix]number[|system|code]` (or the `number|code` shorthand).
+    /// The comparison runs on `value_quantity_value`; an optional system/code
+    /// further constrain `value_quantity_system` / `value_quantity_unit` (the
+    /// extractor stores the quantity code under the unit field).
+    fn build_quantity_filter(&self, value: &SearchValue) -> StorageResult<Document> {
+        let parts: Vec<&str> = value.value.splitn(3, '|').collect();
+        let parsed = parts[0].parse::<f64>().map_err(|e| {
+            StorageError::Search(SearchError::QueryParseError {
+                message: format!("Invalid quantity value '{}': {}", value.value, e),
+            })
+        })?;
+
+        let value_condition = match value.prefix {
+            SearchPrefix::Ap => {
+                let delta = (parsed.abs() * 0.1).max(0.1);
+                doc! { "$gte": parsed - delta, "$lte": parsed + delta }
+            }
+            _ => {
+                let op = Self::prefix_to_mongo_operator(value.prefix)?;
+                doc! { op: parsed }
+            }
+        };
+
+        let mut filter = doc! { "value_quantity_value": value_condition };
+        match parts.as_slice() {
+            // number|system|code
+            [_, system, code] => {
+                if !system.is_empty() {
+                    filter.insert("value_quantity_system", *system);
+                }
+                if !code.is_empty() {
+                    filter.insert("value_quantity_unit", *code);
+                }
+            }
+            // number|code shorthand
+            [_, code] => {
+                if !code.is_empty() {
+                    filter.insert("value_quantity_unit", *code);
+                }
+            }
+            _ => {}
+        }
+
+        Ok(filter)
     }
 
     fn build_number_filter(&self, value: &SearchValue) -> StorageResult<Document> {

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -444,12 +444,11 @@ impl PostgresQueryBuilder {
     /// Builds a composite-parameter condition.
     ///
     /// Composite values join their components with `$` (e.g.
-    /// `http://loinc.org|8480-6$lt60`). Each component is matched as a bare
-    /// predicate against the columns of a single `search_index` row scoped to
-    /// the composite parameter name — mirroring the SQLite backend. Requires
-    /// `param.components` to be populated (the REST layer does not yet wire
-    /// these from the registry, so this is reachable via the direct backend
-    /// API; see `docs/search-spec-assessment.md`).
+    /// `http://loinc.org|8480-6$lt60`). Each component of a composite instance
+    /// is indexed as its own `search_index` row sharing a `composite_group`, so
+    /// a resource matches when there is a group in which every component is
+    /// satisfied by some row. This is expressed with
+    /// `GROUP BY resource_id, composite_group HAVING <every component present>`.
     fn build_composite_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
         if param.components.is_empty() {
             return None;
@@ -461,35 +460,37 @@ impl PostgresQueryBuilder {
 
         for value in &param.values {
             let parts: Vec<&str> = value.value.split('$').collect();
-            let inner = if parts.len() != param.components.len() {
-                "1 = 0".to_string()
-            } else {
-                let mut comp_sqls = Vec::new();
-                let mut ok = true;
-                for (part, component) in parts.iter().zip(param.components.iter()) {
-                    let cv = Self::parse_component_value(part);
-                    match Self::build_composite_component(&cv, component.param_type, current) {
-                        Some((sql, params)) => {
-                            current += params.len();
-                            all_params.extend(params);
-                            comp_sqls.push(sql);
-                        }
-                        None => {
-                            ok = false;
-                            break;
-                        }
+            if parts.len() != param.components.len() {
+                value_conditions.push("1 = 0".to_string());
+                continue;
+            }
+
+            let mut havings = Vec::new();
+            let mut ok = true;
+            for (part, component) in parts.iter().zip(param.components.iter()) {
+                let cv = Self::parse_component_value(part);
+                match Self::build_composite_component(&cv, component.param_type, current) {
+                    Some((sql, params)) => {
+                        current += params.len();
+                        all_params.extend(params);
+                        havings.push(format!("MAX(CASE WHEN {} THEN 1 ELSE 0 END) = 1", sql));
+                    }
+                    None => {
+                        ok = false;
+                        break;
                     }
                 }
-                if ok && !comp_sqls.is_empty() {
-                    comp_sqls.join(" AND ")
-                } else {
-                    "1 = 0".to_string()
-                }
-            };
+            }
+
+            if !ok || havings.is_empty() {
+                value_conditions.push("1 = 0".to_string());
+                continue;
+            }
 
             value_conditions.push(format!(
-                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
-                param.name, inner
+                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' GROUP BY resource_id, composite_group HAVING {})",
+                param.name,
+                havings.join(" AND ")
             ));
         }
 

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -10,6 +10,47 @@ use crate::types::{
     SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
 };
 
+/// How a sort key's value is typed for cursor (keyset) binding and comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortValueKind {
+    /// Text column (string/token/uri/reference/`_id`).
+    Text,
+    /// Floating-point column (number/quantity).
+    Number,
+    /// Timestamp column (`_lastUpdated`, date).
+    Timestamp,
+}
+
+/// A single keyset sort key: the SQL value expression, its direction, and the
+/// value kind used to bind/read the cursor boundary value.
+#[derive(Debug, Clone)]
+pub struct KeysetKey {
+    /// SQL expression yielding the sort value (column or correlated subquery).
+    pub expr: String,
+    /// Sort direction.
+    pub direction: crate::types::SortDirection,
+    /// How the value is typed for binding/reading.
+    pub kind: SortValueKind,
+}
+
+/// Determines the value kind for a sort parameter.
+pub(crate) fn sort_value_kind(
+    parameter: &str,
+    param_type: Option<SearchParamType>,
+) -> SortValueKind {
+    match parameter {
+        "_id" => SortValueKind::Text,
+        "_lastUpdated" => SortValueKind::Timestamp,
+        _ => match param_type {
+            Some(SearchParamType::Number) | Some(SearchParamType::Quantity) => {
+                SortValueKind::Number
+            }
+            Some(SearchParamType::Date) => SortValueKind::Timestamp,
+            _ => SortValueKind::Text,
+        },
+    }
+}
+
 /// Maps a search-parameter type to the `search_index` value column used when
 /// sorting on that parameter. Returns `None` for types that are not sortable via
 /// a single value column (composite, special).
@@ -168,6 +209,28 @@ impl PostgresQueryBuilder {
         }
 
         format!("ORDER BY {}", clauses.join(", "))
+    }
+
+    /// Returns the keyset sort key for cursor pagination, or `None` when the
+    /// query has multiple sort fields (those are returned as a single page
+    /// rather than paged with a possibly-inconsistent keyset).
+    pub fn primary_keyset_key(query: &SearchQuery) -> Option<KeysetKey> {
+        match query.sort.len() {
+            0 => Some(KeysetKey {
+                expr: "last_updated".to_string(),
+                direction: crate::types::SortDirection::Descending,
+                kind: SortValueKind::Timestamp,
+            }),
+            1 => {
+                let directive = &query.sort[0];
+                Some(KeysetKey {
+                    expr: Self::sort_expression(directive),
+                    direction: directive.direction,
+                    kind: sort_value_kind(&directive.parameter, directive.param_type),
+                })
+            }
+            _ => None,
+        }
     }
 
     /// Builds the ORDER BY expression for a single sort directive.

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -10,6 +10,22 @@ use crate::types::{
     SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
 };
 
+/// Maps a search-parameter type to the `search_index` value column used when
+/// sorting on that parameter. Returns `None` for types that are not sortable via
+/// a single value column (composite, special).
+pub(crate) fn sort_value_column(param_type: SearchParamType) -> Option<&'static str> {
+    match param_type {
+        SearchParamType::String => Some("value_string"),
+        SearchParamType::Token => Some("value_token_code"),
+        SearchParamType::Date => Some("value_date"),
+        SearchParamType::Number => Some("value_number"),
+        SearchParamType::Quantity => Some("value_quantity_value"),
+        SearchParamType::Reference => Some("value_reference"),
+        SearchParamType::Uri => Some("value_uri"),
+        SearchParamType::Composite | SearchParamType::Special => None,
+    }
+}
+
 /// A SQL fragment with associated parameters.
 #[derive(Debug, Clone)]
 pub struct SqlFragment {
@@ -142,7 +158,7 @@ impl PostgresQueryBuilder {
                     crate::types::SortDirection::Ascending => "ASC",
                     crate::types::SortDirection::Descending => "DESC",
                 };
-                format!("{} {}", Self::sort_column(&s.parameter), dir)
+                format!("{} {}", Self::sort_expression(s), dir)
             })
             .collect();
 
@@ -154,14 +170,31 @@ impl PostgresQueryBuilder {
         format!("ORDER BY {}", clauses.join(", "))
     }
 
-    /// Maps a FHIR sort parameter name to a `resources` table column.
-    fn sort_column(parameter: &str) -> &'static str {
-        match parameter {
-            "_id" => "id",
-            "_lastUpdated" => "last_updated",
-            // Arbitrary search parameters are not yet sortable; fall back to a
-            // stable column.
-            _ => "id",
+    /// Builds the ORDER BY expression for a single sort directive.
+    ///
+    /// `_id`/`_lastUpdated` map to `resources` columns. Any other indexed search
+    /// parameter sorts on a correlated subquery into `search_index`, taking the
+    /// MIN value for ascending and MAX for descending (FHIR multi-value sort).
+    fn sort_expression(directive: &crate::types::SortDirective) -> String {
+        match directive.parameter.as_str() {
+            "_id" => return "id".to_string(),
+            "_lastUpdated" => return "last_updated".to_string(),
+            _ => {}
+        }
+
+        match directive.param_type.and_then(sort_value_column) {
+            Some(col) => {
+                let agg = match directive.direction {
+                    crate::types::SortDirection::Ascending => "MIN",
+                    crate::types::SortDirection::Descending => "MAX",
+                };
+                format!(
+                    "(SELECT {}({}) FROM search_index si WHERE si.tenant_id = $1 AND si.resource_type = $2 AND si.resource_id = resources.id AND si.param_name = '{}')",
+                    agg, col, directive.parameter
+                )
+            }
+            // Unsortable (composite/special/unresolved) — stable fallback.
+            None => "id".to_string(),
         }
     }
 

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -198,7 +198,7 @@ impl PostgresQueryBuilder {
             SearchParamType::Quantity => Self::build_quantity_condition(param, param_offset),
             SearchParamType::Reference => Self::build_reference_condition(param, param_offset),
             SearchParamType::Uri => Self::build_uri_condition(param, param_offset),
-            SearchParamType::Composite => None,
+            SearchParamType::Composite => Self::build_composite_condition(param, param_offset),
             SearchParamType::Special => None,
         }
     }
@@ -312,6 +312,12 @@ impl PostgresQueryBuilder {
     }
 
     fn build_token_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
+        // `:of-type` matches an Identifier by its type (system|code) and value,
+        // in the three-part form `type-system|type-code|identifier-value`.
+        if let Some(SearchModifier::OfType) = param.modifier {
+            return Self::build_of_type_condition(param, offset);
+        }
+
         let mut conditions = Vec::new();
 
         for (i, value) in param.values.iter().enumerate() {
@@ -380,6 +386,230 @@ impl PostgresQueryBuilder {
         }
 
         Some(combined)
+    }
+
+    /// Builds an `:of-type` identifier condition (token modifier).
+    ///
+    /// Value form: `type-system|type-code|identifier-value`. Empty parts are
+    /// dropped, so e.g. `||MR12345` matches by identifier value only.
+    fn build_of_type_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
+        let mut value_conditions = Vec::new();
+        let mut all_params: Vec<SqlParam> = Vec::new();
+        let mut current = offset;
+
+        for value in &param.values {
+            let parts: Vec<&str> = value.value.splitn(3, '|').collect();
+            if parts.len() != 3 {
+                continue;
+            }
+            let (type_system, type_code, identifier_value) = (parts[0], parts[1], parts[2]);
+
+            let mut conds = Vec::new();
+            // Identifier value (matched against the token code column).
+            if !identifier_value.is_empty() {
+                current += 1;
+                conds.push(format!("value_token_code = ${}", current));
+                all_params.push(SqlParam::text(identifier_value));
+            }
+            if !type_system.is_empty() {
+                current += 1;
+                conds.push(format!("value_identifier_type_system = ${}", current));
+                all_params.push(SqlParam::text(type_system));
+            }
+            if !type_code.is_empty() {
+                current += 1;
+                conds.push(format!("value_identifier_type_code = ${}", current));
+                all_params.push(SqlParam::text(type_code));
+            }
+            if conds.is_empty() {
+                continue;
+            }
+
+            value_conditions.push(format!(
+                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
+                param.name,
+                conds.join(" AND ")
+            ));
+        }
+
+        if value_conditions.is_empty() {
+            return None;
+        }
+        Some(SqlFragment::with_params(
+            value_conditions.join(" OR "),
+            all_params,
+        ))
+    }
+
+    /// Builds a composite-parameter condition.
+    ///
+    /// Composite values join their components with `$` (e.g.
+    /// `http://loinc.org|8480-6$lt60`). Each component is matched as a bare
+    /// predicate against the columns of a single `search_index` row scoped to
+    /// the composite parameter name — mirroring the SQLite backend. Requires
+    /// `param.components` to be populated (the REST layer does not yet wire
+    /// these from the registry, so this is reachable via the direct backend
+    /// API; see `docs/search-spec-assessment.md`).
+    fn build_composite_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
+        if param.components.is_empty() {
+            return None;
+        }
+
+        let mut value_conditions = Vec::new();
+        let mut all_params: Vec<SqlParam> = Vec::new();
+        let mut current = offset;
+
+        for value in &param.values {
+            let parts: Vec<&str> = value.value.split('$').collect();
+            let inner = if parts.len() != param.components.len() {
+                "1 = 0".to_string()
+            } else {
+                let mut comp_sqls = Vec::new();
+                let mut ok = true;
+                for (part, component) in parts.iter().zip(param.components.iter()) {
+                    let cv = Self::parse_component_value(part);
+                    match Self::build_composite_component(&cv, component.param_type, current) {
+                        Some((sql, params)) => {
+                            current += params.len();
+                            all_params.extend(params);
+                            comp_sqls.push(sql);
+                        }
+                        None => {
+                            ok = false;
+                            break;
+                        }
+                    }
+                }
+                if ok && !comp_sqls.is_empty() {
+                    comp_sqls.join(" AND ")
+                } else {
+                    "1 = 0".to_string()
+                }
+            };
+
+            value_conditions.push(format!(
+                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
+                param.name, inner
+            ));
+        }
+
+        if value_conditions.is_empty() {
+            return None;
+        }
+        Some(SqlFragment::with_params(
+            value_conditions.join(" OR "),
+            all_params,
+        ))
+    }
+
+    /// Parses a composite component value, stripping any comparison prefix.
+    fn parse_component_value(part: &str) -> SearchValue {
+        let prefixes = [
+            ("ne", SearchPrefix::Ne),
+            ("gt", SearchPrefix::Gt),
+            ("lt", SearchPrefix::Lt),
+            ("ge", SearchPrefix::Ge),
+            ("le", SearchPrefix::Le),
+            ("sa", SearchPrefix::Sa),
+            ("eb", SearchPrefix::Eb),
+            ("ap", SearchPrefix::Ap),
+            ("eq", SearchPrefix::Eq),
+        ];
+        for (prefix_str, prefix) in prefixes {
+            if let Some(stripped) = part.strip_prefix(prefix_str) {
+                return SearchValue {
+                    prefix,
+                    value: stripped.to_string(),
+                };
+            }
+        }
+        SearchValue {
+            prefix: SearchPrefix::Eq,
+            value: part.to_string(),
+        }
+    }
+
+    /// Builds a single composite component as a bare column predicate (no
+    /// `id IN (...)` wrapper — the caller scopes it to the composite row).
+    /// Returns `None` if the value cannot be parsed for the component type.
+    fn build_composite_component(
+        value: &SearchValue,
+        param_type: SearchParamType,
+        offset: usize,
+    ) -> Option<(String, Vec<SqlParam>)> {
+        match param_type {
+            SearchParamType::Token => {
+                if let Some((system, code)) = value.value.split_once('|') {
+                    if system.is_empty() {
+                        Some((
+                            format!("value_token_code = ${}", offset + 1),
+                            vec![SqlParam::text(code)],
+                        ))
+                    } else if code.is_empty() {
+                        Some((
+                            format!("value_token_system = ${}", offset + 1),
+                            vec![SqlParam::text(system)],
+                        ))
+                    } else {
+                        Some((
+                            format!(
+                                "value_token_system = ${} AND value_token_code = ${}",
+                                offset + 1,
+                                offset + 2
+                            ),
+                            vec![SqlParam::text(system), SqlParam::text(code)],
+                        ))
+                    }
+                } else {
+                    Some((
+                        format!("value_token_code = ${}", offset + 1),
+                        vec![SqlParam::text(&value.value)],
+                    ))
+                }
+            }
+            SearchParamType::String => Some((
+                format!("value_string ILIKE ${}", offset + 1),
+                vec![SqlParam::text(&format!("{}%", value.value))],
+            )),
+            SearchParamType::Number => {
+                let num = value.value.parse::<f64>().ok()?;
+                let op = Self::prefix_to_operator(&value.prefix);
+                Some((
+                    format!("value_number {} ${}", op, offset + 1),
+                    vec![SqlParam::Float(num)],
+                ))
+            }
+            SearchParamType::Quantity => {
+                let parts: Vec<&str> = value.value.splitn(3, '|').collect();
+                let num = parts.first().and_then(|s| s.parse::<f64>().ok())?;
+                let op = Self::prefix_to_operator(&value.prefix);
+                if parts.len() >= 3 {
+                    Some((
+                        format!(
+                            "value_quantity_value {} ${} AND value_quantity_unit = ${}",
+                            op,
+                            offset + 1,
+                            offset + 2
+                        ),
+                        vec![SqlParam::Float(num), SqlParam::text(parts[2])],
+                    ))
+                } else {
+                    Some((
+                        format!("value_quantity_value {} ${}", op, offset + 1),
+                        vec![SqlParam::Float(num)],
+                    ))
+                }
+            }
+            SearchParamType::Date => {
+                let op = Self::prefix_to_operator(&value.prefix);
+                let ts = Self::parse_date_value(&value.value);
+                Some((
+                    format!("value_date {} ${}", op, offset + 1),
+                    vec![SqlParam::Timestamp(ts)],
+                ))
+            }
+            _ => None,
+        }
     }
 
     fn build_date_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
@@ -581,5 +811,84 @@ impl PostgresQueryBuilder {
             .map(|dt| dt.with_timezone(&Utc))
             .or_else(|_| normalized.parse::<DateTime<Utc>>())
             .unwrap_or_else(|_| Utc::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{CompositeSearchComponent, SearchModifier, SearchQuery};
+
+    #[test]
+    fn composite_token_quantity_sql() {
+        let param = SearchParameter {
+            name: "code-value-quantity".to_string(),
+            param_type: SearchParamType::Composite,
+            modifier: None,
+            values: vec![SearchValue::new(
+                SearchPrefix::Eq,
+                "http://loinc.org|8480-6$lt60",
+            )],
+            chain: vec![],
+            components: vec![
+                CompositeSearchComponent {
+                    param_type: SearchParamType::Token,
+                    param_name: "code".to_string(),
+                },
+                CompositeSearchComponent {
+                    param_type: SearchParamType::Quantity,
+                    param_name: "value".to_string(),
+                },
+            ],
+        };
+        let query = SearchQuery::new("Observation").with_parameter(param);
+        // Non-cursor search binds $1=tenant, $2=type, so params start at $3.
+        let frag = PostgresQueryBuilder::build_search_query(&query, 2)
+            .expect("composite should produce a condition");
+
+        assert!(frag.sql.contains("param_name = 'code-value-quantity'"));
+        assert!(frag.sql.contains("value_token_system = $3"));
+        assert!(frag.sql.contains("value_token_code = $4"));
+        assert!(frag.sql.contains("value_quantity_value < $5"));
+        // token (system+code) = 2 params, quantity (no unit) = 1 param.
+        assert_eq!(frag.params.len(), 3);
+    }
+
+    #[test]
+    fn composite_returns_none_without_components() {
+        let param = SearchParameter {
+            name: "code-value-quantity".to_string(),
+            param_type: SearchParamType::Composite,
+            modifier: None,
+            values: vec![SearchValue::new(SearchPrefix::Eq, "a$b")],
+            chain: vec![],
+            components: vec![],
+        };
+        let query = SearchQuery::new("Observation").with_parameter(param);
+        assert!(PostgresQueryBuilder::build_search_query(&query, 2).is_none());
+    }
+
+    #[test]
+    fn of_type_identifier_sql() {
+        let param = SearchParameter {
+            name: "identifier".to_string(),
+            param_type: SearchParamType::Token,
+            modifier: Some(SearchModifier::OfType),
+            values: vec![SearchValue::new(
+                SearchPrefix::Eq,
+                "http://terminology.hl7.org/CodeSystem/v2-0203|MR|12345",
+            )],
+            chain: vec![],
+            components: vec![],
+        };
+        let query = SearchQuery::new("Patient").with_parameter(param);
+        let frag = PostgresQueryBuilder::build_search_query(&query, 2)
+            .expect(":of-type should produce a condition");
+
+        assert!(frag.sql.contains("param_name = 'identifier'"));
+        assert!(frag.sql.contains("value_token_code = $3"));
+        assert!(frag.sql.contains("value_identifier_type_system = $4"));
+        assert!(frag.sql.contains("value_identifier_type_code = $5"));
+        assert_eq!(frag.params.len(), 3);
     }
 }

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -26,7 +26,7 @@ use crate::types::{
 
 use super::PostgresBackend;
 use super::search::chain_builder::ChainQueryBuilder;
-use super::search::query_builder::{PostgresQueryBuilder, SqlParam};
+use super::search::query_builder::{PostgresQueryBuilder, SortValueKind, SqlParam};
 
 fn internal_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::Internal {
@@ -50,226 +50,156 @@ impl SearchProvider for PostgresBackend {
         // Get count with default
         let count = query.count.unwrap_or(100) as usize;
 
-        // Check for cursor-based pagination
-        let cursor = query
-            .cursor
-            .as_ref()
-            .and_then(|c| PageCursor::decode(c).ok());
+        // Keyset key for cursor pagination. `None` for multi-field sorts, which
+        // are returned as a single page rather than paged with an inconsistent
+        // keyset.
+        let keyset = PostgresQueryBuilder::primary_keyset_key(query);
 
-        // Determine param offset based on pagination mode
-        // Cursor pagination: $1=tenant, $2=type, $3=timestamp, $4=id -> offset=4
-        // Non-cursor: $1=tenant, $2=type -> offset=2
+        // Only honor an inbound cursor when we can build a keyset comparison.
+        let cursor = if keyset.is_some() {
+            query
+                .cursor
+                .as_ref()
+                .and_then(|c| PageCursor::decode(c).ok())
+        } else {
+            None
+        };
+
+        // Param layout: $1=tenant, $2=type, then (cursor) $3=sort value, $4=id,
+        // then the search-filter params.
         let param_offset = if cursor.is_some() { 4 } else { 2 };
 
-        // Build the search filter subquery if there are search parameters
         let search_filter = if !query.parameters.is_empty() {
             PostgresQueryBuilder::build_search_query(query, param_offset)
         } else {
             None
         };
+        let filter_clause = search_filter
+            .as_ref()
+            .map(|f| format!(" AND ({})", f.sql))
+            .unwrap_or_default();
+        let search_params = search_filter.map(|f| f.params).unwrap_or_default();
 
-        // ORDER BY derived from `_sort` (first-page and offset paths only).
-        // When no `_sort` is supplied we keep the original default ordering
-        // (`id DESC` tie-break) so cursor "next" paging stays consistent. The
-        // cursor/keyset paths always keep their `(last_updated, id)` ordering,
-        // which the keyset WHERE comparison depends on.
+        // SELECT the sort key alongside the row so the next cursor can be built.
+        let select_cols = match &keyset {
+            Some(k) => format!(
+                "id, version_id, data, last_updated, fhir_version, {} AS sort_key",
+                k.expr
+            ),
+            None => "id, version_id, data, last_updated, fhir_version".to_string(),
+        };
+
+        // ORDER BY for the first-page / offset paths.
         let order_by = if query.sort.is_empty() {
-            "ORDER BY last_updated DESC, id DESC".to_string()
+            "ORDER BY last_updated DESC, id ASC".to_string()
         } else {
             PostgresQueryBuilder::build_order_by(query)
         };
 
-        // Build query based on pagination mode
-        let (sql, has_previous, search_params) = if let Some(ref cursor) = cursor {
+        // Build query based on pagination mode.
+        let (sql, has_previous) = if let (Some(cursor), Some(k)) = (&cursor, &keyset) {
+            let e = &k.expr;
+            let asc = k.direction == crate::types::SortDirection::Ascending;
             match cursor.direction() {
                 CursorDirection::Next => {
-                    let sql = if let Some(ref filter) = search_filter {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                             AND ({})
-                             AND (last_updated < $3 OR (last_updated = $3 AND id < $4))
-                             ORDER BY last_updated DESC, id DESC
-                             LIMIT {}",
-                            filter.sql,
-                            count + 1
-                        )
-                    } else {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                             AND (last_updated < $3 OR (last_updated = $3 AND id < $4))
-                             ORDER BY last_updated DESC, id DESC
-                             LIMIT {}",
-                            count + 1
-                        )
-                    };
-                    (
-                        sql,
-                        true,
-                        search_filter.map(|f| f.params).unwrap_or_default(),
-                    )
+                    let e_op = if asc { ">" } else { "<" };
+                    let sql = format!(
+                        "SELECT {cols} FROM resources \
+                         WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE{filter} \
+                         AND ({e} {e_op} $3 OR ({e} = $3 AND id > $4)) \
+                         ORDER BY {e} {dir}, id ASC LIMIT {lim}",
+                        cols = select_cols,
+                        filter = filter_clause,
+                        e = e,
+                        e_op = e_op,
+                        dir = if asc { "ASC" } else { "DESC" },
+                        lim = count + 1,
+                    );
+                    (sql, true)
                 }
                 CursorDirection::Previous => {
-                    let sql = if let Some(ref filter) = search_filter {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                             AND ({})
-                             AND (last_updated > $3 OR (last_updated = $3 AND id > $4))
-                             ORDER BY last_updated ASC, id ASC
-                             LIMIT {}",
-                            filter.sql,
-                            count + 1
-                        )
-                    } else {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                             AND (last_updated > $3 OR (last_updated = $3 AND id > $4))
-                             ORDER BY last_updated ASC, id ASC
-                             LIMIT {}",
-                            count + 1
-                        )
-                    };
-                    (
-                        sql,
-                        false,
-                        search_filter.map(|f| f.params).unwrap_or_default(),
-                    )
+                    let e_op = if asc { "<" } else { ">" };
+                    let sql = format!(
+                        "SELECT {cols} FROM resources \
+                         WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE{filter} \
+                         AND ({e} {e_op} $3 OR ({e} = $3 AND id < $4)) \
+                         ORDER BY {e} {dir}, id DESC LIMIT {lim}",
+                        cols = select_cols,
+                        filter = filter_clause,
+                        e = e,
+                        e_op = e_op,
+                        dir = if asc { "DESC" } else { "ASC" },
+                        lim = count + 1,
+                    );
+                    (sql, false)
                 }
             }
         } else if let Some(offset) = query.offset {
-            // Offset-based pagination (legacy support)
-            let sql = if let Some(ref filter) = search_filter {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     AND ({})
-                     {}
-                     LIMIT {} OFFSET {}",
-                    filter.sql,
-                    order_by,
-                    count + 1,
-                    offset
-                )
-            } else {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     {}
-                     LIMIT {} OFFSET {}",
-                    order_by,
-                    count + 1,
-                    offset
-                )
-            };
-            (
-                sql,
-                offset > 0,
-                search_filter.map(|f| f.params).unwrap_or_default(),
-            )
+            let sql = format!(
+                "SELECT {cols} FROM resources \
+                 WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE{filter} \
+                 {order} LIMIT {lim} OFFSET {off}",
+                cols = select_cols,
+                filter = filter_clause,
+                order = order_by,
+                lim = count + 1,
+                off = offset,
+            );
+            (sql, offset > 0)
         } else {
-            // First page (no cursor, no offset)
-            let sql = if let Some(ref filter) = search_filter {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     AND ({})
-                     {}
-                     LIMIT {}",
-                    filter.sql,
-                    order_by,
-                    count + 1
-                )
-            } else {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE
-                     {}
-                     LIMIT {}",
-                    order_by,
-                    count + 1
-                )
-            };
-            (
-                sql,
-                false,
-                search_filter.map(|f| f.params).unwrap_or_default(),
-            )
+            let sql = format!(
+                "SELECT {cols} FROM resources \
+                 WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE{filter} \
+                 {order} LIMIT {lim}",
+                cols = select_cols,
+                filter = filter_clause,
+                order = order_by,
+                lim = count + 1,
+            );
+            (sql, false)
         };
 
-        // Build parameter list for binding
-        let rows = if let Some(ref cursor) = cursor {
-            let (cursor_timestamp, cursor_id) = Self::extract_cursor_values(cursor)?;
-
-            // Build params: [tenant_id, resource_type, cursor_timestamp, cursor_id, ...search_params]
-            let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![
-                Box::new(tenant_id.to_string()),
-                Box::new(resource_type.to_string()),
-                Box::new(cursor_timestamp),
-                Box::new(cursor_id),
-            ];
-
-            for param in &search_params {
-                match param {
-                    SqlParam::Text(s) => params.push(Box::new(s.clone())),
-                    SqlParam::Float(f) => params.push(Box::new(*f)),
-                    SqlParam::Integer(i) => params.push(Box::new(*i)),
-                    SqlParam::Bool(b) => params.push(Box::new(*b)),
-                    SqlParam::Timestamp(dt) => params.push(Box::new(*dt)),
-                    SqlParam::Null => params.push(Box::new(Option::<String>::None)),
-                }
+        // Build parameter list for binding.
+        let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![
+            Box::new(tenant_id.to_string()),
+            Box::new(resource_type.to_string()),
+        ];
+        if let (Some(cursor), Some(k)) = (&cursor, &keyset) {
+            Self::bind_cursor_value(&mut params, k.kind, cursor)?;
+            params.push(Box::new(cursor.resource_id().to_string()));
+        }
+        for param in &search_params {
+            match param {
+                SqlParam::Text(s) => params.push(Box::new(s.clone())),
+                SqlParam::Float(f) => params.push(Box::new(*f)),
+                SqlParam::Integer(i) => params.push(Box::new(*i)),
+                SqlParam::Bool(b) => params.push(Box::new(*b)),
+                SqlParam::Timestamp(dt) => params.push(Box::new(*dt)),
+                SqlParam::Null => params.push(Box::new(Option::<String>::None)),
             }
+        }
+        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
+            .iter()
+            .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
+        let rows = client
+            .query(&sql, &param_refs)
+            .await
+            .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?;
 
-            let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
-                .iter()
-                .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
-                .collect();
-
-            client
-                .query(&sql, &param_refs)
-                .await
-                .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?
-        } else {
-            // Build params: [tenant_id, resource_type, ...search_params]
-            let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![
-                Box::new(tenant_id.to_string()),
-                Box::new(resource_type.to_string()),
-            ];
-
-            for param in &search_params {
-                match param {
-                    SqlParam::Text(s) => params.push(Box::new(s.clone())),
-                    SqlParam::Float(f) => params.push(Box::new(*f)),
-                    SqlParam::Integer(i) => params.push(Box::new(*i)),
-                    SqlParam::Bool(b) => params.push(Box::new(*b)),
-                    SqlParam::Timestamp(dt) => params.push(Box::new(*dt)),
-                    SqlParam::Null => params.push(Box::new(Option::<String>::None)),
-                }
-            }
-
-            let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
-                .iter()
-                .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
-                .collect();
-
-            client
-                .query(&sql, &param_refs)
-                .await
-                .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?
-        };
-
-        let mut resources = Vec::new();
+        // Parse rows, capturing the sort key for cursor construction.
+        let mut parsed: Vec<(StoredResource, Option<CursorValue>)> = Vec::new();
         for row in &rows {
             let id: String = row.get(0);
             let version_id: String = row.get(1);
             let json_data: serde_json::Value = row.get(2);
             let last_updated: chrono::DateTime<Utc> = row.get(3);
             let fhir_version_str: String = row.get(4);
+            let sort_key = keyset
+                .as_ref()
+                .map(|k| Self::read_cursor_value(row, 5, k.kind));
 
             let fhir_version = FhirVersion::from_storage(&fhir_version_str).unwrap_or_default();
-
             let resource = StoredResource::from_storage(
                 resource_type.clone(),
                 id,
@@ -281,50 +211,40 @@ impl SearchProvider for PostgresBackend {
                 None,
                 fhir_version,
             );
-
-            resources.push(resource);
+            parsed.push((resource, sort_key));
         }
 
-        // For backward pagination, reverse the results to maintain DESC order
+        // Backward pagination fetched in reverse order — restore sort order.
         if cursor
             .as_ref()
             .map(|c| c.direction() == CursorDirection::Previous)
             .unwrap_or(false)
         {
-            resources.reverse();
+            parsed.reverse();
         }
 
-        // Check if there are more results (we fetched one extra)
-        let has_next = resources.len() > count;
+        // We fetched one extra to detect a further page.
+        let has_next = parsed.len() > count;
         if has_next {
-            resources.pop();
+            parsed.pop();
         }
 
-        // Generate cursors for pagination
         let next_cursor = if has_next {
-            resources.last().map(|r| {
-                let cursor = PageCursor::new(
-                    vec![CursorValue::String(r.last_modified().to_rfc3339())],
-                    r.id(),
-                );
-                cursor.encode()
+            parsed.last().map(|(r, sk)| {
+                PageCursor::new(vec![sk.clone().unwrap_or(CursorValue::Null)], r.id()).encode()
             })
         } else {
             None
         };
-
         let previous_cursor = if has_previous {
-            resources.first().map(|r| {
-                let cursor = PageCursor::previous(
-                    vec![CursorValue::String(r.last_modified().to_rfc3339())],
-                    r.id(),
-                );
-                cursor.encode()
+            parsed.first().map(|(r, sk)| {
+                PageCursor::previous(vec![sk.clone().unwrap_or(CursorValue::Null)], r.id()).encode()
             })
         } else {
             None
         };
 
+        let resources: Vec<StoredResource> = parsed.into_iter().map(|(r, _)| r).collect();
         let page_info = PageInfo {
             next_cursor,
             previous_cursor,
@@ -332,7 +252,6 @@ impl SearchProvider for PostgresBackend {
             has_next,
             has_previous,
         };
-
         let page = Page::new(resources, page_info);
 
         Ok(SearchResult {
@@ -914,18 +833,73 @@ impl TextSearchProvider for PostgresBackend {
 // Helper methods for search implementations
 impl PostgresBackend {
     /// Extract timestamp and ID from a cursor for keyset pagination.
-    fn extract_cursor_values(cursor: &PageCursor) -> StorageResult<(String, String)> {
-        let sort_values = cursor.sort_values();
-        let timestamp = match sort_values.first() {
-            Some(CursorValue::String(s)) => s.clone(),
-            _ => {
-                return Err(internal_error(
-                    "Invalid cursor: missing or invalid timestamp".to_string(),
-                ));
+    /// Binds the cursor's boundary sort value as `$3`, typed per the sort key
+    /// kind so PostgreSQL compares it correctly against the sort expression.
+    fn bind_cursor_value(
+        params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
+        kind: SortValueKind,
+        cursor: &PageCursor,
+    ) -> StorageResult<()> {
+        let value = cursor.sort_values().first();
+        match kind {
+            SortValueKind::Timestamp => {
+                let dt = match value {
+                    Some(CursorValue::String(s)) => chrono::DateTime::parse_from_rfc3339(s)
+                        .map(|d| d.with_timezone(&Utc))
+                        .map_err(|_| internal_error("Invalid cursor timestamp".to_string()))?,
+                    _ => {
+                        return Err(internal_error(
+                            "Invalid cursor: expected timestamp".to_string(),
+                        ));
+                    }
+                };
+                params.push(Box::new(dt));
             }
-        };
-        let id = cursor.resource_id().to_string();
-        Ok((timestamp, id))
+            SortValueKind::Number => {
+                let n = match value {
+                    Some(CursorValue::Decimal(f)) => *f,
+                    Some(CursorValue::Number(i)) => *i as f64,
+                    Some(CursorValue::String(s)) => s.parse().unwrap_or(0.0),
+                    _ => {
+                        return Err(internal_error(
+                            "Invalid cursor: expected number".to_string(),
+                        ));
+                    }
+                };
+                params.push(Box::new(n));
+            }
+            SortValueKind::Text => match value {
+                Some(CursorValue::String(s)) => params.push(Box::new(s.clone())),
+                Some(CursorValue::Null) | None => params.push(Box::new(Option::<String>::None)),
+                _ => {
+                    return Err(internal_error("Invalid cursor: expected text".to_string()));
+                }
+            },
+        }
+        Ok(())
+    }
+
+    /// Reads the `sort_key` column (index 5) as a `CursorValue` per the key kind.
+    fn read_cursor_value(
+        row: &tokio_postgres::Row,
+        idx: usize,
+        kind: SortValueKind,
+    ) -> CursorValue {
+        match kind {
+            SortValueKind::Timestamp => {
+                let v: Option<chrono::DateTime<Utc>> = row.try_get(idx).ok().flatten();
+                v.map(|d| CursorValue::String(d.to_rfc3339()))
+                    .unwrap_or(CursorValue::Null)
+            }
+            SortValueKind::Number => {
+                let v: Option<f64> = row.try_get(idx).ok().flatten();
+                v.map(CursorValue::Decimal).unwrap_or(CursorValue::Null)
+            }
+            SortValueKind::Text => {
+                let v: Option<String> = row.try_get(idx).ok().flatten();
+                v.map(CursorValue::String).unwrap_or(CursorValue::Null)
+            }
+        }
     }
 
     /// Extract references from a resource for a given search parameter.

--- a/crates/persistence/src/backends/sqlite/search/mod.rs
+++ b/crates/persistence/src/backends/sqlite/search/mod.rs
@@ -22,6 +22,6 @@ pub mod writer;
 pub use chain_builder::{ChainError, ChainLink, ChainQueryBuilder, ParsedChain};
 pub use filter_parser::{FilterExpr, FilterOp, FilterParseError, FilterParser, FilterSqlGenerator};
 pub use parameter_handlers::CompositeComponentDef;
-pub use query_builder::{QueryBuilder, SqlFragment, SqlParam};
+pub use query_builder::{KeysetKey, QueryBuilder, SortValueKind, SqlFragment, SqlParam};
 pub use strategy::{SearchStrategyCapability, SqliteSearchStrategy};
 pub use writer::{SqlValue, SqliteSearchIndexWriter};

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/composite.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/composite.rs
@@ -75,6 +75,41 @@ impl CompositeHandler {
         SqlFragment::with_params(format!("({})", conditions_sql), all_params)
     }
 
+    /// Builds one bare predicate fragment per component.
+    ///
+    /// Returns `None` if the value's part count does not match the component
+    /// count, or if any component value cannot be built. The caller wraps each
+    /// fragment in a `MAX(CASE WHEN ... THEN 1 ELSE 0 END) = 1` aggregate and
+    /// groups by `(resource_id, composite_group)` so that all components are
+    /// matched within the same composite instance.
+    pub fn build_component_fragments(
+        value: &SearchValue,
+        components: &[CompositeSearchComponent],
+        param_offset: usize,
+    ) -> Option<Vec<SqlFragment>> {
+        let parts: Vec<&str> = value.value.split('$').collect();
+        if parts.len() != components.len() || components.is_empty() {
+            return None;
+        }
+
+        let mut fragments = Vec::new();
+        let mut current_offset = param_offset;
+        for (part, component) in parts.iter().zip(components.iter()) {
+            let component_value = Self::parse_component_value(part);
+            let fragment = Self::build_component_sql_from_type(
+                &component_value,
+                component.param_type,
+                current_offset,
+            );
+            if fragment.sql == "1 = 0" {
+                return None;
+            }
+            current_offset += fragment.params.len();
+            fragments.push(fragment);
+        }
+        Some(fragments)
+    }
+
     /// Builds SQL for a composite parameter value.
     ///
     /// The value should be in the format "value1$value2$..." where each value

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -207,6 +207,11 @@ impl QueryBuilder {
             return self.build_special_parameter_condition(param, param_offset);
         }
 
+        // Composite parameters need a group-aware subquery (see below).
+        if matches!(param.param_type, SearchParamType::Composite) {
+            return self.build_composite_parameter_condition(param, param_offset);
+        }
+
         // Multiple values are ORed together
         let mut or_conditions = Vec::new();
         let mut total_params = 0usize;
@@ -237,6 +242,56 @@ impl QueryBuilder {
             ),
             combined.params,
         ))
+    }
+
+    /// Builds a condition for a composite parameter.
+    ///
+    /// Each composite instance is indexed as a set of `search_index` rows that
+    /// share a `composite_group`. A resource matches when there is a group in
+    /// which every component is satisfied by some row, expressed as
+    /// `GROUP BY resource_id, composite_group HAVING <every component present>`.
+    fn build_composite_parameter_condition(
+        &self,
+        param: &SearchParameter,
+        param_offset: usize,
+    ) -> Option<SqlFragment> {
+        if param.components.is_empty() {
+            return None;
+        }
+
+        let mut or_conditions = Vec::new();
+        let mut params = Vec::new();
+        let mut total_params = 0usize;
+
+        for value in &param.values {
+            match CompositeHandler::build_component_fragments(
+                value,
+                &param.components,
+                param_offset + total_params,
+            ) {
+                Some(fragments) if !fragments.is_empty() => {
+                    let havings: Vec<String> = fragments
+                        .iter()
+                        .map(|f| format!("MAX(CASE WHEN {} THEN 1 ELSE 0 END) = 1", f.sql))
+                        .collect();
+                    for f in fragments {
+                        total_params += f.params.len();
+                        params.extend(f.params);
+                    }
+                    or_conditions.push(format!(
+                        "resource_id IN (SELECT resource_id FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND param_name = '{}' GROUP BY resource_id, composite_group HAVING {})",
+                        param.name,
+                        havings.join(" AND ")
+                    ));
+                }
+                _ => or_conditions.push("0 = 1".to_string()),
+            }
+        }
+
+        if or_conditions.is_empty() {
+            return None;
+        }
+        Some(SqlFragment::with_params(or_conditions.join(" OR "), params))
     }
 
     /// Builds a condition for a special parameter (_id, _lastUpdated, etc.).

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -12,6 +12,47 @@ use super::parameter_handlers::{
     TokenHandler, UriHandler,
 };
 
+/// How a sort key's value is typed for cursor (keyset) binding and comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortValueKind {
+    /// Text column (string/token/uri/reference/`_id`).
+    Text,
+    /// Floating-point column (number/quantity).
+    Number,
+    /// Timestamp column, stored as RFC3339 text (`_lastUpdated`, date).
+    Timestamp,
+}
+
+/// A single keyset sort key: the SQL value expression, its direction, and the
+/// value kind used to bind/read the cursor boundary value.
+#[derive(Debug, Clone)]
+pub struct KeysetKey {
+    /// SQL expression yielding the sort value (column or correlated subquery).
+    pub expr: String,
+    /// Sort direction.
+    pub direction: crate::types::SortDirection,
+    /// How the value is typed for binding/reading.
+    pub kind: SortValueKind,
+}
+
+/// Determines the value kind for a sort parameter.
+pub(crate) fn sort_value_kind(
+    parameter: &str,
+    param_type: Option<SearchParamType>,
+) -> SortValueKind {
+    match parameter {
+        "_id" => SortValueKind::Text,
+        "_lastUpdated" => SortValueKind::Timestamp,
+        _ => match param_type {
+            Some(SearchParamType::Number) | Some(SearchParamType::Quantity) => {
+                SortValueKind::Number
+            }
+            Some(SearchParamType::Date) => SortValueKind::Timestamp,
+            _ => SortValueKind::Text,
+        },
+    }
+}
+
 /// Maps a search-parameter type to the `search_index` value column used when
 /// sorting on that parameter. Returns `None` for types that are not sortable via
 /// a single value column (composite, special).
@@ -619,6 +660,28 @@ impl QueryBuilder {
         }
 
         format!("ORDER BY {}", clauses.join(", "))
+    }
+
+    /// Returns the keyset sort key for cursor pagination, or `None` when the
+    /// query has multiple sort fields (those are returned as a single page
+    /// rather than paged with a possibly-inconsistent keyset).
+    pub fn primary_keyset_key(&self, query: &SearchQuery) -> Option<KeysetKey> {
+        match query.sort.len() {
+            0 => Some(KeysetKey {
+                expr: "last_updated".to_string(),
+                direction: crate::types::SortDirection::Descending,
+                kind: SortValueKind::Timestamp,
+            }),
+            1 => {
+                let directive = &query.sort[0];
+                Some(KeysetKey {
+                    expr: self.sort_expression(directive),
+                    direction: directive.direction,
+                    kind: sort_value_kind(&directive.parameter, directive.param_type),
+                })
+            }
+            _ => None,
+        }
     }
 
     /// Builds the ORDER BY expression for a single sort directive.

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -12,6 +12,22 @@ use super::parameter_handlers::{
     TokenHandler, UriHandler,
 };
 
+/// Maps a search-parameter type to the `search_index` value column used when
+/// sorting on that parameter. Returns `None` for types that are not sortable via
+/// a single value column (composite, special).
+pub(crate) fn sort_value_column(param_type: SearchParamType) -> Option<&'static str> {
+    match param_type {
+        SearchParamType::String => Some("value_string"),
+        SearchParamType::Token => Some("value_token_code"),
+        SearchParamType::Date => Some("value_date"),
+        SearchParamType::Number => Some("value_number"),
+        SearchParamType::Quantity => Some("value_quantity_value"),
+        SearchParamType::Reference => Some("value_reference"),
+        SearchParamType::Uri => Some("value_uri"),
+        SearchParamType::Composite | SearchParamType::Special => None,
+    }
+}
+
 /// A fragment of SQL with bound parameters.
 #[derive(Debug, Clone)]
 pub struct SqlFragment {
@@ -592,10 +608,7 @@ impl QueryBuilder {
                     crate::types::SortDirection::Ascending => "ASC",
                     crate::types::SortDirection::Descending => "DESC",
                 };
-
-                // Map sort parameters to SQL columns
-                let column = self.sort_column(&s.parameter);
-                format!("{} {}", column, dir)
+                format!("{} {}", self.sort_expression(s), dir)
             })
             .collect();
 
@@ -608,17 +621,32 @@ impl QueryBuilder {
         format!("ORDER BY {}", clauses.join(", "))
     }
 
-    /// Maps a sort parameter name to the corresponding SQL column.
+    /// Builds the ORDER BY expression for a single sort directive.
     ///
-    /// This is used by `build_order_by` to translate FHIR sort parameters
-    /// to SQLite column names.
-    fn sort_column(&self, parameter: &str) -> &'static str {
-        match parameter {
-            "_id" => "id",
-            "_lastUpdated" => "last_updated",
-            // Future: could support arbitrary parameters via search_index join
-            // For now, use id as a stable fallback
-            _ => "id",
+    /// `_id`/`_lastUpdated` map to `resources` columns. Any other indexed search
+    /// parameter sorts on a correlated subquery into `search_index`, taking the
+    /// MIN value for ascending and MAX for descending (FHIR multi-value sort).
+    fn sort_expression(&self, directive: &crate::types::SortDirective) -> String {
+        match directive.parameter.as_str() {
+            "_id" => return "id".to_string(),
+            "_lastUpdated" => return "last_updated".to_string(),
+            _ => {}
+        }
+
+        let column = directive.param_type.and_then(sort_value_column);
+        match column {
+            Some(col) => {
+                let agg = match directive.direction {
+                    crate::types::SortDirection::Ascending => "MIN",
+                    crate::types::SortDirection::Descending => "MAX",
+                };
+                format!(
+                    "(SELECT {}({}) FROM search_index si WHERE si.tenant_id = ?1 AND si.resource_type = ?2 AND si.resource_id = resources.id AND si.param_name = '{}')",
+                    agg, col, directive.parameter
+                )
+            }
+            // Unsortable (composite/special/unresolved) — stable fallback.
+            None => "id".to_string(),
         }
     }
 
@@ -725,10 +753,12 @@ mod tests {
             SortDirective {
                 parameter: "_lastUpdated".to_string(),
                 direction: SortDirection::Descending,
+                param_type: None,
             },
             SortDirective {
                 parameter: "_id".to_string(),
                 direction: SortDirection::Ascending,
+                param_type: None,
             },
         ];
 
@@ -745,6 +775,7 @@ mod tests {
         query.sort = vec![SortDirective {
             parameter: "_lastUpdated".to_string(),
             direction: SortDirection::Ascending,
+            param_type: None,
         }];
 
         let order_by = builder.build_order_by(&query);

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -26,7 +26,7 @@ use crate::types::{
 };
 
 use super::SqliteBackend;
-use super::search::{QueryBuilder, SqlParam};
+use super::search::{QueryBuilder, SortValueKind, SqlParam};
 
 fn internal_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::Internal {
@@ -34,6 +34,39 @@ fn internal_error(message: String) -> StorageError {
         message,
         source: None,
     })
+}
+
+/// Binds the cursor's boundary sort value as `?3`, typed per the sort key kind.
+/// Timestamps are stored as RFC3339 text, so they bind (and compare) as text.
+fn bind_cursor_value(
+    params: &mut Vec<Box<dyn rusqlite::ToSql>>,
+    kind: SortValueKind,
+    cursor: &PageCursor,
+) -> StorageResult<()> {
+    let value = cursor.sort_values().first();
+    match kind {
+        SortValueKind::Number => {
+            let n = match value {
+                Some(CursorValue::Decimal(f)) => *f,
+                Some(CursorValue::Number(i)) => *i as f64,
+                Some(CursorValue::String(s)) => s.parse().unwrap_or(0.0),
+                _ => {
+                    return Err(internal_error(
+                        "Invalid cursor: expected number".to_string(),
+                    ));
+                }
+            };
+            params.push(Box::new(n));
+        }
+        SortValueKind::Timestamp | SortValueKind::Text => match value {
+            Some(CursorValue::String(s)) => params.push(Box::new(s.clone())),
+            Some(CursorValue::Null) | None => params.push(Box::new(Option::<String>::None)),
+            _ => {
+                return Err(internal_error("Invalid cursor: expected text".to_string()));
+            }
+        },
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -50,25 +83,30 @@ impl SearchProvider for SqliteBackend {
         // Get count with default
         let count = query.count.unwrap_or(100) as usize;
 
-        // Check for cursor-based pagination
-        let cursor = query
-            .cursor
-            .as_ref()
-            .and_then(|c| PageCursor::decode(c).ok());
+        // Keyset key for cursor pagination. `None` for multi-field sorts, which
+        // are returned as a single page rather than paged with an inconsistent
+        // keyset.
+        let keyset = QueryBuilder::new(tenant_id, resource_type).primary_keyset_key(query);
 
-        // Determine param offset based on pagination mode
-        // Cursor pagination: ?1=tenant, ?2=type, ?3=timestamp, ?4=id -> offset=4
-        // Non-cursor: ?1=tenant, ?2=type -> offset=2
+        // Only honor an inbound cursor when we can build a keyset comparison.
+        let cursor = if keyset.is_some() {
+            query
+                .cursor
+                .as_ref()
+                .and_then(|c| PageCursor::decode(c).ok())
+        } else {
+            None
+        };
+
+        // Param layout: ?1=tenant, ?2=type, then (cursor) ?3=sort value, ?4=id,
+        // then the search-filter params.
         let param_offset = if cursor.is_some() { 4 } else { 2 };
 
-        // Build the search filter subquery if there are search parameters
         let search_filter = if !query.parameters.is_empty() {
             let builder =
                 QueryBuilder::new(tenant_id, resource_type).with_param_offset(param_offset);
             let fragment = builder.build(query);
             if !fragment.sql.is_empty() {
-                // The QueryBuilder returns a SELECT DISTINCT resource_id query
-                // We use this as a subquery to filter the resources table
                 Some(fragment)
             } else {
                 None
@@ -76,222 +114,140 @@ impl SearchProvider for SqliteBackend {
         } else {
             None
         };
+        let filter_clause = search_filter
+            .as_ref()
+            .map(|f| format!(" AND id IN ({})", f.sql))
+            .unwrap_or_default();
+        let search_params = search_filter.map(|f| f.params).unwrap_or_default();
 
-        // ORDER BY derived from `_sort` (first-page and offset paths only).
-        // When no `_sort` is supplied we keep the original default ordering
-        // (`id DESC` tie-break) so cursor "next" paging stays consistent. The
-        // cursor/keyset paths always keep their `(last_updated, id)` ordering,
-        // which the keyset WHERE comparison depends on.
+        // SELECT the sort key alongside the row so the next cursor can be built.
+        let select_cols = match &keyset {
+            Some(k) => format!(
+                "id, version_id, data, last_updated, fhir_version, {} AS sort_key",
+                k.expr
+            ),
+            None => "id, version_id, data, last_updated, fhir_version".to_string(),
+        };
+
+        // ORDER BY for the first-page / offset paths.
         let order_by = if query.sort.is_empty() {
-            "ORDER BY last_updated DESC, id DESC".to_string()
+            "ORDER BY last_updated DESC, id ASC".to_string()
         } else {
             QueryBuilder::new(tenant_id, resource_type).build_order_by(query)
         };
 
-        // Build query based on pagination mode
-        let (sql, has_previous, search_params) = if let Some(ref cursor) = cursor {
-            // Cursor-based pagination using keyset
+        // Build query based on pagination mode.
+        let (sql, has_previous) = if let (Some(cursor), Some(k)) = (&cursor, &keyset) {
+            let e = &k.expr;
+            let asc = k.direction == crate::types::SortDirection::Ascending;
             match cursor.direction() {
                 CursorDirection::Next => {
-                    let sql = if let Some(ref filter) = search_filter {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                             AND id IN ({})
-                             AND (last_updated < ?3 OR (last_updated = ?3 AND id < ?4))
-                             ORDER BY last_updated DESC, id DESC
-                             LIMIT {}",
-                            filter.sql,
-                            count + 1
-                        )
-                    } else {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                             AND (last_updated < ?3 OR (last_updated = ?3 AND id < ?4))
-                             ORDER BY last_updated DESC, id DESC
-                             LIMIT {}",
-                            count + 1
-                        )
-                    };
-                    (
-                        sql,
-                        true,
-                        search_filter.map(|f| f.params).unwrap_or_default(),
-                    )
+                    let e_op = if asc { ">" } else { "<" };
+                    let sql = format!(
+                        "SELECT {cols} FROM resources \
+                         WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0{filter} \
+                         AND ({e} {e_op} ?3 OR ({e} = ?3 AND id > ?4)) \
+                         ORDER BY {e} {dir}, id ASC LIMIT {lim}",
+                        cols = select_cols,
+                        filter = filter_clause,
+                        e = e,
+                        e_op = e_op,
+                        dir = if asc { "ASC" } else { "DESC" },
+                        lim = count + 1,
+                    );
+                    (sql, true)
                 }
                 CursorDirection::Previous => {
-                    let sql = if let Some(ref filter) = search_filter {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                             AND id IN ({})
-                             AND (last_updated > ?3 OR (last_updated = ?3 AND id > ?4))
-                             ORDER BY last_updated ASC, id ASC
-                             LIMIT {}",
-                            filter.sql,
-                            count + 1
-                        )
-                    } else {
-                        format!(
-                            "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                             WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                             AND (last_updated > ?3 OR (last_updated = ?3 AND id > ?4))
-                             ORDER BY last_updated ASC, id ASC
-                             LIMIT {}",
-                            count + 1
-                        )
-                    };
-                    (
-                        sql,
-                        false,
-                        search_filter.map(|f| f.params).unwrap_or_default(),
-                    )
+                    let e_op = if asc { "<" } else { ">" };
+                    let sql = format!(
+                        "SELECT {cols} FROM resources \
+                         WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0{filter} \
+                         AND ({e} {e_op} ?3 OR ({e} = ?3 AND id < ?4)) \
+                         ORDER BY {e} {dir}, id DESC LIMIT {lim}",
+                        cols = select_cols,
+                        filter = filter_clause,
+                        e = e,
+                        e_op = e_op,
+                        dir = if asc { "DESC" } else { "ASC" },
+                        lim = count + 1,
+                    );
+                    (sql, false)
                 }
             }
         } else if let Some(offset) = query.offset {
-            // Offset-based pagination (legacy support)
-            let sql = if let Some(ref filter) = search_filter {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     AND id IN ({})
-                     {}
-                     LIMIT {} OFFSET {}",
-                    filter.sql,
-                    order_by,
-                    count + 1,
-                    offset
-                )
-            } else {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     {}
-                     LIMIT {} OFFSET {}",
-                    order_by,
-                    count + 1,
-                    offset
-                )
-            };
-            (
-                sql,
-                offset > 0,
-                search_filter.map(|f| f.params).unwrap_or_default(),
-            )
+            let sql = format!(
+                "SELECT {cols} FROM resources \
+                 WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0{filter} \
+                 {order} LIMIT {lim} OFFSET {off}",
+                cols = select_cols,
+                filter = filter_clause,
+                order = order_by,
+                lim = count + 1,
+                off = offset,
+            );
+            (sql, offset > 0)
         } else {
-            // First page (no cursor, no offset)
-            let sql = if let Some(ref filter) = search_filter {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     AND id IN ({})
-                     {}
-                     LIMIT {}",
-                    filter.sql,
-                    order_by,
-                    count + 1
-                )
-            } else {
-                format!(
-                    "SELECT id, version_id, data, last_updated, fhir_version FROM resources
-                     WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0
-                     {}
-                     LIMIT {}",
-                    order_by,
-                    count + 1
-                )
-            };
-            (
-                sql,
-                false,
-                search_filter.map(|f| f.params).unwrap_or_default(),
-            )
+            let sql = format!(
+                "SELECT {cols} FROM resources \
+                 WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0{filter} \
+                 {order} LIMIT {lim}",
+                cols = select_cols,
+                filter = filter_clause,
+                order = order_by,
+                lim = count + 1,
+            );
+            (sql, false)
         };
 
         let mut stmt = conn
             .prepare(&sql)
             .map_err(|e| internal_error(format!("Failed to prepare search query: {}", e)))?;
 
-        // Build the parameter list for binding
-        // Base params are always tenant_id and resource_type
-        // For cursor pagination, add cursor_timestamp and cursor_id
-        // Then append any search params from the QueryBuilder
-        let raw_rows: Vec<(String, String, Vec<u8>, String, String)> =
-            if let Some(ref cursor) = cursor {
-                let (cursor_timestamp, cursor_id) = Self::extract_cursor_values(cursor)?;
+        // Bind params: tenant, type, then (cursor) sort value + id, then filter params.
+        let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = vec![
+            Box::new(tenant_id.to_string()),
+            Box::new(resource_type.to_string()),
+        ];
+        if let (Some(cursor), Some(k)) = (&cursor, &keyset) {
+            bind_cursor_value(&mut all_params, k.kind, cursor)?;
+            all_params.push(Box::new(cursor.resource_id().to_string()));
+        }
+        for param in &search_params {
+            match param {
+                SqlParam::String(s) => all_params.push(Box::new(s.clone())),
+                SqlParam::Integer(i) => all_params.push(Box::new(*i)),
+                SqlParam::Float(f) => all_params.push(Box::new(*f)),
+                SqlParam::Null => all_params.push(Box::new(Option::<String>::None)),
+            }
+        }
+        let param_refs: Vec<&dyn rusqlite::ToSql> = all_params.iter().map(|p| p.as_ref()).collect();
 
-                // Build params: [tenant_id, resource_type, cursor_timestamp, cursor_id, ...search_params]
-                let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = vec![
-                    Box::new(tenant_id.to_string()),
-                    Box::new(resource_type.to_string()),
-                    Box::new(cursor_timestamp),
-                    Box::new(cursor_id),
-                ];
-
-                // Add search params
-                for param in &search_params {
-                    match param {
-                        SqlParam::String(s) => all_params.push(Box::new(s.clone())),
-                        SqlParam::Integer(i) => all_params.push(Box::new(*i)),
-                        SqlParam::Float(f) => all_params.push(Box::new(*f)),
-                        SqlParam::Null => all_params.push(Box::new(Option::<String>::None)),
+        // The sort key (column 5) is selected only when keyset paging is active.
+        let sort_kind = keyset.as_ref().map(|k| k.kind);
+        let raw_rows: Vec<(String, String, Vec<u8>, String, String, Option<CursorValue>)> = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                let id: String = row.get(0)?;
+                let version_id: String = row.get(1)?;
+                let data: Vec<u8> = row.get(2)?;
+                let last_updated: String = row.get(3)?;
+                let fhir_version: String = row.get(4)?;
+                let sort_key = match sort_kind {
+                    Some(SortValueKind::Number) => {
+                        row.get::<_, Option<f64>>(5)?.map(CursorValue::Decimal)
                     }
-                }
+                    // Timestamps are stored as RFC3339 text, so read text.
+                    Some(_) => row.get::<_, Option<String>>(5)?.map(CursorValue::String),
+                    None => None,
+                };
+                Ok((id, version_id, data, last_updated, fhir_version, sort_key))
+            })
+            .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| internal_error(format!("Failed to read row: {}", e)))?;
 
-                let param_refs: Vec<&dyn rusqlite::ToSql> =
-                    all_params.iter().map(|p| p.as_ref()).collect();
-
-                let rows = stmt
-                    .query_map(param_refs.as_slice(), |row| {
-                        let id: String = row.get(0)?;
-                        let version_id: String = row.get(1)?;
-                        let data: Vec<u8> = row.get(2)?;
-                        let last_updated: String = row.get(3)?;
-                        let fhir_version: String = row.get(4)?;
-                        Ok((id, version_id, data, last_updated, fhir_version))
-                    })
-                    .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?;
-
-                rows.collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| internal_error(format!("Failed to read row: {}", e)))?
-            } else {
-                // Build params: [tenant_id, resource_type, ...search_params]
-                let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = vec![
-                    Box::new(tenant_id.to_string()),
-                    Box::new(resource_type.to_string()),
-                ];
-
-                // Add search params
-                for param in &search_params {
-                    match param {
-                        SqlParam::String(s) => all_params.push(Box::new(s.clone())),
-                        SqlParam::Integer(i) => all_params.push(Box::new(*i)),
-                        SqlParam::Float(f) => all_params.push(Box::new(*f)),
-                        SqlParam::Null => all_params.push(Box::new(Option::<String>::None)),
-                    }
-                }
-
-                let param_refs: Vec<&dyn rusqlite::ToSql> =
-                    all_params.iter().map(|p| p.as_ref()).collect();
-
-                let rows = stmt
-                    .query_map(param_refs.as_slice(), |row| {
-                        let id: String = row.get(0)?;
-                        let version_id: String = row.get(1)?;
-                        let data: Vec<u8> = row.get(2)?;
-                        let last_updated: String = row.get(3)?;
-                        let fhir_version: String = row.get(4)?;
-                        Ok((id, version_id, data, last_updated, fhir_version))
-                    })
-                    .map_err(|e| internal_error(format!("Failed to execute search: {}", e)))?;
-
-                rows.collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| internal_error(format!("Failed to read row: {}", e)))?
-            };
-
-        let mut resources = Vec::new();
-        for (id, version_id, data, last_updated_str, fhir_version_str) in raw_rows {
+        // Parse rows, carrying the sort key for cursor construction.
+        let mut parsed: Vec<(StoredResource, Option<CursorValue>)> = Vec::new();
+        for (id, version_id, data, last_updated_str, fhir_version_str, sort_key) in raw_rows {
             let json_data: serde_json::Value = serde_json::from_slice(&data)
                 .map_err(|e| internal_error(format!("Failed to deserialize resource: {}", e)))?;
 
@@ -313,49 +269,40 @@ impl SearchProvider for SqliteBackend {
                 fhir_version,
             );
 
-            resources.push(resource);
+            parsed.push((resource, sort_key));
         }
 
-        // For backward pagination, reverse the results to maintain DESC order
+        // Backward pagination fetched in reverse order — restore sort order.
         if cursor
             .as_ref()
             .map(|c| c.direction() == CursorDirection::Previous)
             .unwrap_or(false)
         {
-            resources.reverse();
+            parsed.reverse();
         }
 
-        // Check if there are more results (we fetched one extra)
-        let has_next = resources.len() > count;
+        // We fetched one extra to detect a further page.
+        let has_next = parsed.len() > count;
         if has_next {
-            resources.pop(); // Remove the extra one
+            parsed.pop();
         }
 
-        // Generate cursors for pagination
         let next_cursor = if has_next {
-            resources.last().map(|r| {
-                let cursor = PageCursor::new(
-                    vec![CursorValue::String(r.last_modified().to_rfc3339())],
-                    r.id(),
-                );
-                cursor.encode()
+            parsed.last().map(|(r, sk)| {
+                PageCursor::new(vec![sk.clone().unwrap_or(CursorValue::Null)], r.id()).encode()
             })
         } else {
             None
         };
-
         let previous_cursor = if has_previous {
-            resources.first().map(|r| {
-                let cursor = PageCursor::previous(
-                    vec![CursorValue::String(r.last_modified().to_rfc3339())],
-                    r.id(),
-                );
-                cursor.encode()
+            parsed.first().map(|(r, sk)| {
+                PageCursor::previous(vec![sk.clone().unwrap_or(CursorValue::Null)], r.id()).encode()
             })
         } else {
             None
         };
 
+        let resources: Vec<StoredResource> = parsed.into_iter().map(|(r, _)| r).collect();
         let page_info = PageInfo {
             next_cursor,
             previous_cursor,
@@ -885,21 +832,6 @@ impl ChainedSearchProvider for SqliteBackend {
 
 // Helper methods for search implementations
 impl SqliteBackend {
-    /// Extract timestamp and ID from a cursor for keyset pagination.
-    fn extract_cursor_values(cursor: &PageCursor) -> StorageResult<(String, String)> {
-        let sort_values = cursor.sort_values();
-        let timestamp = match sort_values.first() {
-            Some(CursorValue::String(s)) => s.clone(),
-            _ => {
-                return Err(internal_error(
-                    "Invalid cursor: missing or invalid timestamp".to_string(),
-                ));
-            }
-        };
-        let id = cursor.resource_id().to_string();
-        Ok((timestamp, id))
-    }
-
     /// Extract references from a resource for a given search parameter.
     fn extract_references(&self, content: &serde_json::Value, search_param: &str) -> Vec<String> {
         let mut refs = Vec::new();

--- a/crates/persistence/src/search/chain_resolver.rs
+++ b/crates/persistence/src/search/chain_resolver.rs
@@ -1,0 +1,489 @@
+//! Backend-agnostic resolution of chained and reverse-chained search.
+//!
+//! FHIR chained search (`Observation?subject.name=Smith`) and reverse chaining
+//! (`Patient?_has:Observation:subject:code=1234-5`) require joins that the
+//! per-backend `SearchProvider::search` does not perform. This module resolves
+//! them by issuing iterative *plain* searches against any `SearchProvider` —
+//! application-side joins — and rewrites the query into an `_id` filter that any
+//! backend can execute. The cost is proportional to the chain depth, not the
+//! intermediate fan-out (each hop is one search whose multi-value `OR` is
+//! applied natively by the backend).
+
+use std::collections::HashSet;
+
+use crate::core::SearchProvider;
+use crate::error::StorageResult;
+use crate::tenant::TenantContext;
+use crate::types::{
+    ReverseChainedParameter, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+};
+
+use super::{IndexValue, SearchParameterExtractor, resolve_param_type};
+
+/// Returns true if the query contains any chained or reverse-chained parameter.
+pub fn query_has_chains(query: &SearchQuery) -> bool {
+    !query.reverse_chains.is_empty() || query.parameters.iter().any(|p| !p.chain.is_empty())
+}
+
+/// Resolves a query's chained and reverse-chained parameters into an `_id`
+/// filter, returning a rewritten query that a plain `search()` can execute.
+///
+/// Multiple chains are intersected (`AND`). If any chain resolves to no
+/// resources the rewritten query is forced to match nothing. Queries without
+/// chains are returned unchanged.
+pub async fn resolve_chains<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    query: &SearchQuery,
+) -> StorageResult<SearchQuery>
+where
+    S: SearchProvider + ?Sized,
+{
+    if !query_has_chains(query) {
+        return Ok(query.clone());
+    }
+
+    let base_type = query.resource_type.clone();
+    let mut id_sets: Vec<HashSet<String>> = Vec::new();
+
+    for param in &query.parameters {
+        if param.chain.is_empty() {
+            continue;
+        }
+        let chain = reconstruct_chain_string(param);
+        let value = param
+            .values
+            .first()
+            .map(|v| v.value.clone())
+            .unwrap_or_default();
+        let ids = resolve_forward_chain(storage, tenant, &base_type, &chain, &value).await?;
+        id_sets.push(ids.into_iter().collect());
+    }
+
+    for reverse_chain in &query.reverse_chains {
+        let ids = resolve_reverse_chain(storage, tenant, &base_type, reverse_chain).await?;
+        id_sets.push(ids.into_iter().collect());
+    }
+
+    let matched_ids = intersect(id_sets);
+
+    // Rewrite: keep non-chained params, drop chained params + reverse chains,
+    // and add an `_id` filter for the resolved base-resource ids.
+    let mut rewritten = query.clone();
+    rewritten.parameters.retain(|p| p.chain.is_empty());
+    rewritten.reverse_chains.clear();
+
+    let id_values: Vec<SearchValue> = if matched_ids.is_empty() {
+        // Sentinel that cannot match a real id, forcing an empty result.
+        vec![SearchValue::eq("__chained_search_no_match__")]
+    } else {
+        matched_ids.iter().map(SearchValue::eq).collect()
+    };
+    rewritten.parameters.push(SearchParameter {
+        name: "_id".to_string(),
+        param_type: SearchParamType::Token,
+        modifier: None,
+        values: id_values,
+        chain: vec![],
+        components: vec![],
+    });
+
+    Ok(rewritten)
+}
+
+/// Reconstructs the dotted chain string (`subject.organization.name`) from a
+/// parameter's structured chain links.
+fn reconstruct_chain_string(param: &SearchParameter) -> String {
+    let mut parts = vec![param.name.clone()];
+    for link in &param.chain {
+        parts.push(link.target_param.clone());
+    }
+    parts.join(".")
+}
+
+/// Intersects a list of id sets (`AND` across chains). An empty input means no
+/// chains contributed, which should not happen here, but yields an empty set.
+fn intersect(mut sets: Vec<HashSet<String>>) -> HashSet<String> {
+    let mut iter = sets.drain(..);
+    let mut acc = match iter.next() {
+        Some(s) => s,
+        None => return HashSet::new(),
+    };
+    for s in iter {
+        acc.retain(|id| s.contains(id));
+    }
+    acc
+}
+
+/// Resolves a forward chain (e.g. `subject.organization.name=Hospital`) to a
+/// set of `base_type` resource ids, walking from the deepest target back out.
+async fn resolve_forward_chain<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    base_type: &str,
+    chain: &str,
+    value: &str,
+) -> StorageResult<Vec<String>>
+where
+    S: SearchProvider + ?Sized,
+{
+    let parts: Vec<&str> = chain.split('.').collect();
+    if parts.len() < 2 {
+        return Ok(Vec::new());
+    }
+
+    // Per-link target types, resolved from the registry (single-target params)
+    // with a heuristic fallback for ambiguous references.
+    let target_types: Vec<String> = {
+        let registry = storage.search_param_registry().read();
+        let mut types = Vec::with_capacity(parts.len() - 1);
+        let mut current = base_type.to_string();
+        for ref_param in parts.iter().take(parts.len() - 1) {
+            let next = registry
+                .get_param(&current, ref_param)
+                .and_then(|def| {
+                    def.target.as_ref().and_then(|t| {
+                        if t.len() == 1 {
+                            Some(t[0].clone())
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .unwrap_or_else(|| infer_target_type(ref_param));
+            types.push(next.clone());
+            current = next;
+        }
+        types
+    };
+
+    // Deepest hop: search the terminal target type for the terminal param.
+    let terminal_param = parts[parts.len() - 1];
+    let deepest_type = target_types.last().map(String::as_str).unwrap_or(base_type);
+    let terminal_type = {
+        let registry = storage.search_param_registry().read();
+        resolve_param_type(
+            &registry,
+            deepest_type,
+            terminal_param,
+            &[SearchValue::eq(value)],
+        )
+    };
+    let terminal_query = SearchQuery::new(deepest_type).with_parameter(SearchParameter {
+        name: terminal_param.to_string(),
+        param_type: terminal_type,
+        modifier: None,
+        values: vec![SearchValue::eq(value)],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = storage.search(tenant, &terminal_query).await?;
+    let mut current_refs: Vec<String> = result
+        .resources
+        .items
+        .into_iter()
+        .map(|r| format!("{}/{}", r.resource_type(), r.id()))
+        .collect();
+    if current_refs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Walk back out: for each reference hop, find parents pointing at the refs.
+    for i in (0..parts.len() - 1).rev() {
+        let ref_param = parts[i];
+        let parent_type = if i == 0 {
+            base_type
+        } else {
+            &target_types[i - 1]
+        };
+        let values: Vec<SearchValue> = current_refs.iter().map(SearchValue::eq).collect();
+        let query = SearchQuery::new(parent_type).with_parameter(SearchParameter {
+            name: ref_param.to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values,
+            chain: vec![],
+            components: vec![],
+        });
+        let r = storage.search(tenant, &query).await?;
+        current_refs = r
+            .resources
+            .items
+            .into_iter()
+            .map(|res| {
+                if i == 0 {
+                    res.id().to_string()
+                } else {
+                    format!("{}/{}", res.resource_type(), res.id())
+                }
+            })
+            .collect();
+        if current_refs.is_empty() {
+            return Ok(Vec::new());
+        }
+    }
+
+    Ok(current_refs)
+}
+
+/// Resolves a reverse chain (`_has:Source:refParam:searchParam=value`) to a set
+/// of `base_type` ids by finding matching source resources and collecting the
+/// references they make to `base_type`.
+async fn resolve_reverse_chain<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    base_type: &str,
+    reverse_chain: &ReverseChainedParameter,
+) -> StorageResult<Vec<String>>
+where
+    S: SearchProvider + ?Sized,
+{
+    let values = match &reverse_chain.value {
+        Some(v) => vec![v.clone()],
+        None => vec![],
+    };
+    let search_param_type = {
+        let registry = storage.search_param_registry().read();
+        resolve_param_type(
+            &registry,
+            &reverse_chain.source_type,
+            &reverse_chain.search_param,
+            &values,
+        )
+    };
+    let query = SearchQuery::new(&reverse_chain.source_type).with_parameter(SearchParameter {
+        name: reverse_chain.search_param.clone(),
+        param_type: search_param_type,
+        modifier: None,
+        values,
+        chain: vec![],
+        components: vec![],
+    });
+
+    let result = storage.search(tenant, &query).await?;
+
+    let extractor = SearchParameterExtractor::new(storage.search_param_registry().clone());
+    let mut ids = Vec::new();
+    for resource in result.resources.items {
+        let refs = extract_references(
+            &extractor,
+            storage,
+            &resource,
+            &reverse_chain.reference_param,
+        );
+        for reference in refs {
+            if let Some((ref_type, ref_id)) = reference.split_once('/') {
+                if ref_type == base_type {
+                    ids.push(ref_id.to_string());
+                }
+            }
+        }
+    }
+    Ok(ids)
+}
+
+/// Extracts reference values for `search_param` from a resource, using the
+/// registry's FHIRPath expression when the parameter is registered.
+fn extract_references<S>(
+    extractor: &SearchParameterExtractor,
+    storage: &S,
+    resource: &crate::types::StoredResource,
+    search_param: &str,
+) -> Vec<String>
+where
+    S: SearchProvider + ?Sized,
+{
+    let content = resource.content();
+    let resource_type = resource.resource_type();
+
+    let registered = {
+        let registry = storage.search_param_registry().read();
+        registry
+            .get_param(resource_type, search_param)
+            .or_else(|| registry.get_param("Resource", search_param))
+    };
+
+    if let Some(param_def) = registered {
+        if let Ok(values) = extractor.extract_for_param(content, &param_def) {
+            return values
+                .into_iter()
+                .filter_map(|v| match v.value {
+                    IndexValue::Reference { reference, .. } => Some(reference),
+                    _ => None,
+                })
+                .collect();
+        }
+    }
+    Vec::new()
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+    use crate::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+    use crate::core::ResourceStorage;
+    use crate::tenant::{TenantId, TenantPermissions};
+    use crate::types::ChainedParameter;
+    use helios_fhir::FhirVersion;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn backend() -> SqliteBackend {
+        let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.join("data"))
+            .unwrap();
+        let config = SqliteBackendConfig {
+            data_dir: Some(data_dir),
+            ..Default::default()
+        };
+        let b = SqliteBackend::with_config(":memory:", config).unwrap();
+        b.init_schema().unwrap();
+        b
+    }
+
+    async fn seed(b: &SqliteBackend, tenant: &TenantContext) {
+        for (id, family) in [("smith", "Smith"), ("jones", "Jones")] {
+            b.create(
+                tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": id, "name": [{ "family": family }] }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        }
+        b.create(
+            tenant,
+            "Observation",
+            json!({ "resourceType": "Observation", "id": "o1", "status": "final",
+                    "subject": { "reference": "Patient/smith" },
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "8867-4" }] } }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+        b.create(
+            tenant,
+            "Observation",
+            json!({ "resourceType": "Observation", "id": "o2", "status": "final",
+                    "subject": { "reference": "Patient/jones" } }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+    }
+
+    fn tenant() -> TenantContext {
+        TenantContext::new(TenantId::new("t"), TenantPermissions::full_access())
+    }
+
+    #[tokio::test]
+    async fn forward_chain_subject_name() {
+        let b = backend();
+        let t = tenant();
+        seed(&b, &t).await;
+
+        // Observation?subject.name=Smith
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::eq("Smith")],
+            chain: vec![ChainedParameter {
+                reference_param: "subject".to_string(),
+                target_type: Some("Patient".to_string()),
+                target_param: "name".to_string(),
+            }],
+            components: vec![],
+        });
+
+        let rewritten = resolve_chains(&b, &t, &query).await.unwrap();
+        let result = b.search(&t, &rewritten).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        assert_eq!(ids, vec!["o1"], "only Smith's observation matches");
+    }
+
+    #[tokio::test]
+    async fn reverse_chain_has() {
+        let b = backend();
+        let t = tenant();
+        seed(&b, &t).await;
+
+        // Patient?_has:Observation:subject:code=8867-4
+        let mut query = SearchQuery::new("Patient");
+        query.reverse_chains.push(ReverseChainedParameter {
+            source_type: "Observation".to_string(),
+            reference_param: "subject".to_string(),
+            search_param: "code".to_string(),
+            value: Some(SearchValue::eq("8867-4")),
+            nested: None,
+        });
+
+        let rewritten = resolve_chains(&b, &t, &query).await.unwrap();
+        let result = b.search(&t, &rewritten).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["smith"],
+            "only Smith is referenced by a matching obs"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_match_chain_yields_empty() {
+        let b = backend();
+        let t = tenant();
+        seed(&b, &t).await;
+
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::eq("Nobody")],
+            chain: vec![ChainedParameter {
+                reference_param: "subject".to_string(),
+                target_type: Some("Patient".to_string()),
+                target_param: "name".to_string(),
+            }],
+            components: vec![],
+        });
+        let rewritten = resolve_chains(&b, &t, &query).await.unwrap();
+        let result = b.search(&t, &rewritten).await.unwrap();
+        assert!(result.resources.items.is_empty(), "no patient named Nobody");
+    }
+}
+
+/// Heuristic fallback for ambiguous reference targets, matching the SQLite /
+/// PostgreSQL chain builders so all backends agree.
+fn infer_target_type(ref_param: &str) -> String {
+    match ref_param {
+        "patient" | "subject" => "Patient".to_string(),
+        "practitioner" | "performer" | "requester" | "author" => "Practitioner".to_string(),
+        "organization" | "managingOrganization" | "custodian" => "Organization".to_string(),
+        "encounter" | "context" => "Encounter".to_string(),
+        "location" => "Location".to_string(),
+        "device" => "Device".to_string(),
+        "specimen" => "Specimen".to_string(),
+        "medication" => "Medication".to_string(),
+        "condition" => "Condition".to_string(),
+        _ => {
+            let mut chars = ref_param.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().chain(chars).collect(),
+                None => ref_param.to_string(),
+            }
+        }
+    }
+}

--- a/crates/persistence/src/search/extractor.rs
+++ b/crates/persistence/src/search/extractor.rs
@@ -3,11 +3,12 @@
 //! Uses FHIRPath expressions to extract searchable values from FHIR resources.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use helios_fhirpath::EvaluationContext;
 use helios_fhirpath_support::EvaluationResult;
 use parking_lot::RwLock;
+use regex::Regex;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -152,6 +153,12 @@ impl SearchParameterExtractor {
         resource: &Value,
         param: &SearchParameterDefinition,
     ) -> Result<Vec<ExtractedValue>, ExtractionError> {
+        // Composite parameters are indexed component-by-component, with all the
+        // components of one composite instance sharing a `composite_group`.
+        if matches!(param.param_type, SearchParamType::Composite) {
+            return self.extract_composite(resource, param);
+        }
+
         if param.expression.is_empty() {
             return Ok(Vec::new());
         }
@@ -162,8 +169,10 @@ impl SearchParameterExtractor {
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        // Filter the expression to only include parts relevant to this resource type
-        let filtered_expr = self.filter_expression_for_resource(&param.expression, resource_type);
+        // Rewrite choice-type casts (`value as Quantity` → `valueQuantity`) so they
+        // resolve against schema-less JSON, then filter to this resource type.
+        let rewritten = rewrite_choice_types(&param.expression);
+        let filtered_expr = self.filter_expression_for_resource(&rewritten, resource_type);
 
         if filtered_expr.is_empty() {
             return Ok(Vec::new());
@@ -182,6 +191,75 @@ impl SearchParameterExtractor {
                     param.param_type,
                     idx_value,
                 ));
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Extracts index rows for a composite search parameter.
+    ///
+    /// The composite's `expression` (e.g. `Observation` or
+    /// `Observation.component`) selects the base instances. Each instance gets a
+    /// `composite_group` id, and every component sub-expression is evaluated
+    /// relative to that instance and stored as its own row under the composite
+    /// parameter's code. Component value types are resolved from the registry by
+    /// the component `definition` URL.
+    fn extract_composite(
+        &self,
+        resource: &Value,
+        param: &SearchParameterDefinition,
+    ) -> Result<Vec<ExtractedValue>, ExtractionError> {
+        let components = match &param.component {
+            Some(c) if !c.is_empty() => c,
+            _ => return Ok(Vec::new()),
+        };
+
+        let resource_type = resource
+            .get("resourceType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let rewritten_base = rewrite_choice_types(&param.expression);
+        let base_expr = self.filter_expression_for_resource(&rewritten_base, resource_type);
+        if base_expr.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Resolve each component's value type from the registry (by definition URL).
+        let component_types: Vec<Option<SearchParamType>> = {
+            let registry = self.registry.read();
+            components
+                .iter()
+                .map(|c| registry.get_by_url(&c.definition).map(|d| d.param_type))
+                .collect()
+        };
+
+        // Each base instance becomes a composite group.
+        let base_nodes = self.evaluate_fhirpath(resource, &base_expr)?;
+
+        let mut results = Vec::new();
+        for (group_idx, node) in base_nodes.iter().enumerate() {
+            let group = group_idx as u32;
+            for (component, sub_type) in components.iter().zip(component_types.iter()) {
+                let sub_type = match sub_type {
+                    Some(t) => *t,
+                    None => continue, // unknown component definition — skip
+                };
+                if component.expression.is_empty() {
+                    continue;
+                }
+                let comp_expr = rewrite_choice_types(&component.expression);
+                let values = self.evaluate_fhirpath(node, &comp_expr)?;
+                for value in values {
+                    let converted = ValueConverter::convert(&value, sub_type, &param.code)?;
+                    for idx_value in converted {
+                        results.push(
+                            ExtractedValue::new(&param.code, &param.url, sub_type, idx_value)
+                                .with_composite_group(group),
+                        );
+                    }
+                }
             }
         }
 
@@ -264,6 +342,61 @@ impl SearchParameterExtractor {
         // Convert EvaluationResult back to JSON values
         evaluation_result_to_json_values(&result)
     }
+}
+
+/// Rewrites FHIRPath choice-type casts to concrete element names.
+///
+/// The extractor evaluates expressions against schema-less JSON, where a cast
+/// like `value as Quantity` cannot resolve `value` to the stored `valueQuantity`
+/// field. FHIR choice elements are serialized as `<element><Type>` (e.g.
+/// `valueQuantity`, `medicationCodeableConcept`, `occurrenceDateTime`), so we
+/// rewrite the three cast forms used in SearchParameter expressions to that
+/// concrete name:
+///
+/// - `(Observation.value as Quantity)` → `Observation.valueQuantity`
+/// - `value.as(Quantity)`              → `valueQuantity`
+/// - `Observation.value.ofType(Quantity)` → `Observation.valueQuantity`
+/// - `Observation.value as Quantity`   → `Observation.valueQuantity`
+///
+/// (The loader normalizes the `X as Type` form to `X.ofType(Type)`, so that
+/// form is what usually reaches the extractor.)
+///
+/// Stripping the parentheses in the `(... as Type)` form is intentional: it also
+/// lets `filter_expression_for_resource` recognize the `ResourceType.` prefix,
+/// which it otherwise drops for parenthesized union members.
+fn rewrite_choice_types(expression: &str) -> String {
+    static AS_FN: OnceLock<Regex> = OnceLock::new();
+    static OF_TYPE: OnceLock<Regex> = OnceLock::new();
+    static PAREN_AS: OnceLock<Regex> = OnceLock::new();
+    static BARE_AS: OnceLock<Regex> = OnceLock::new();
+
+    let path = r"[A-Za-z_][A-Za-z0-9_.]*";
+    let ty = r"[A-Za-z][A-Za-z0-9]*";
+    let as_fn =
+        AS_FN.get_or_init(|| Regex::new(&format!(r"({path})\.as\(\s*({ty})\s*\)")).unwrap());
+    let of_type =
+        OF_TYPE.get_or_init(|| Regex::new(&format!(r"({path})\.ofType\(\s*({ty})\s*\)")).unwrap());
+    let paren_as =
+        PAREN_AS.get_or_init(|| Regex::new(&format!(r"\(\s*({path})\s+as\s+({ty})\s*\)")).unwrap());
+    let bare_as = BARE_AS.get_or_init(|| Regex::new(&format!(r"({path})\s+as\s+({ty})")).unwrap());
+
+    let concrete = |caps: &regex::Captures| -> String {
+        let base = &caps[1];
+        let type_name = &caps[2];
+        let mut chars = type_name.chars();
+        let capitalized = match chars.next() {
+            Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+            None => String::new(),
+        };
+        format!("{}{}", base, capitalized)
+    };
+
+    // `.as(Type)` / `.ofType(Type)` and `(path as Type)` first (the latter also
+    // drops parens), then any remaining bare `path as Type`.
+    let step1 = as_fn.replace_all(expression, &concrete);
+    let step2 = of_type.replace_all(&step1, &concrete);
+    let step3 = paren_as.replace_all(&step2, &concrete);
+    bare_as.replace_all(&step3, &concrete).into_owned()
 }
 
 /// Converts a serde_json::Value to an EvaluationResult.
@@ -375,6 +508,33 @@ mod tests {
     use helios_fhir::FhirVersion;
     use serde_json::json;
     use std::path::PathBuf;
+
+    #[test]
+    fn rewrite_choice_types_handles_all_forms() {
+        // `.as(Type)` form.
+        assert_eq!(rewrite_choice_types("value.as(Quantity)"), "valueQuantity");
+        // `.ofType(Type)` form (what the loader normalizes `as` to).
+        assert_eq!(
+            rewrite_choice_types("(Observation.value.ofType(Quantity))"),
+            "(Observation.valueQuantity)"
+        );
+        // Parenthesized `as` form drops the parens.
+        assert_eq!(
+            rewrite_choice_types("(Observation.value as Quantity)"),
+            "Observation.valueQuantity"
+        );
+        // Lower-case primitive type names are capitalized.
+        assert_eq!(
+            rewrite_choice_types("(RiskAssessment.occurrence as dateTime)"),
+            "RiskAssessment.occurrenceDateTime"
+        );
+        // Unions are rewritten member-by-member; non-cast parts are untouched.
+        assert_eq!(
+            rewrite_choice_types("value.as(Quantity) | value.as(Range)"),
+            "valueQuantity | valueRange"
+        );
+        assert_eq!(rewrite_choice_types("Observation.code"), "Observation.code");
+    }
 
     fn create_test_extractor() -> SearchParameterExtractor {
         let loader = SearchParameterLoader::new(FhirVersion::R4);

--- a/crates/persistence/src/search/mod.rs
+++ b/crates/persistence/src/search/mod.rs
@@ -61,6 +61,7 @@
 //! }
 //! ```
 
+pub mod chain_resolver;
 pub mod converters;
 pub mod errors;
 pub mod extractor;
@@ -70,6 +71,7 @@ pub mod reindex;
 pub mod writer;
 
 // Re-export main types
+pub use chain_resolver::{query_has_chains, resolve_chains};
 pub use converters::{IndexValue, ValueConverter};
 pub use errors::{ExtractionError, LoaderError, RegistryError, ReindexError};
 pub use extractor::{ExtractedValue, SearchParameterExtractor};

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -599,6 +599,12 @@ pub struct SortDirective {
     pub parameter: String,
     /// The sort direction.
     pub direction: SortDirection,
+    /// The resolved search-parameter type, when the sort is on an indexed
+    /// search parameter (rather than `_id` / `_lastUpdated`). Lets backends pick
+    /// the correct `search_index` value column. `None` for `_id`/`_lastUpdated`
+    /// or unresolved parameters.
+    #[serde(default)]
+    pub param_type: Option<SearchParamType>,
 }
 
 impl SortDirective {
@@ -608,13 +614,21 @@ impl SortDirective {
             Self {
                 parameter: stripped.to_string(),
                 direction: SortDirection::Descending,
+                param_type: None,
             }
         } else {
             Self {
                 parameter: s.to_string(),
                 direction: SortDirection::Ascending,
+                param_type: None,
             }
         }
+    }
+
+    /// Sets the resolved search-parameter type for this sort directive.
+    pub fn with_param_type(mut self, param_type: Option<SearchParamType>) -> Self {
+        self.param_type = param_type;
+        self
     }
 }
 

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -252,6 +252,7 @@ mod query_builder_tests {
         let query = SearchQuery::new("Patient").with_sort(SortDirective {
             parameter: "_id".to_string(),
             direction: SortDirection::Ascending,
+            param_type: None,
         });
 
         let es_query = builder.build(&query);

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -1120,6 +1120,77 @@ mod es_integration {
     }
 
     #[tokio::test]
+    async fn es_integration_search_composite_code_value_quantity() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            CompositeSearchComponent, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-bp",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6" }] },
+                    "valueQuantity": { "value": 107, "unit": "mmHg", "system": "http://unitsofmeasure.org" }
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        let query = |value: &str| {
+            SearchQuery::new("Observation").with_parameter(SearchParameter {
+                name: "code-value-quantity".to_string(),
+                param_type: SearchParamType::Composite,
+                modifier: None,
+                values: vec![SearchValue::eq(value)],
+                chain: vec![],
+                components: vec![
+                    CompositeSearchComponent {
+                        param_type: SearchParamType::Token,
+                        param_name: "code".to_string(),
+                    },
+                    CompositeSearchComponent {
+                        param_type: SearchParamType::Quantity,
+                        param_name: "value-quantity".to_string(),
+                    },
+                ],
+            })
+        };
+
+        // Both components match within the same instance.
+        let hit = backend
+            .search(&tenant, &query("8480-6$ge100"))
+            .await
+            .unwrap();
+        assert_eq!(hit.resources.items.len(), 1, "code + value match → 1 hit");
+        assert_eq!(hit.resources.items[0].id(), "obs-bp");
+
+        // Quantity component fails.
+        let miss = backend
+            .search(&tenant, &query("8480-6$ge200"))
+            .await
+            .unwrap();
+        assert!(miss.resources.items.is_empty(), "value too low → no hit");
+
+        // Token component fails.
+        let miss = backend
+            .search(&tenant, &query("9999-9$ge100"))
+            .await
+            .unwrap();
+        assert!(miss.resources.items.is_empty(), "code mismatch → no hit");
+    }
+
+    #[tokio::test]
     async fn es_integration_tenant_isolation_delete() {
         let backend = create_backend().await;
         let tenant_a = create_tenant("tenant-a");

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -8,6 +8,7 @@
 
 #![cfg(feature = "mongodb")]
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use helios_fhir::FhirVersion;
@@ -25,8 +26,8 @@ use helios_persistence::error::{
 use helios_persistence::search::SearchParameterStatus;
 use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
 use helios_persistence::types::{
-    IncludeDirective, IncludeType, SearchParamType, SearchParameter, SearchQuery, SearchValue,
-    SortDirective,
+    IncludeDirective, IncludeType, SearchParamType, SearchParameter, SearchPrefix, SearchQuery,
+    SearchValue, SortDirective,
 };
 use mongodb::Client;
 use mongodb::bson::{Document, doc};
@@ -210,6 +211,28 @@ async fn create_backend_with_search_offloaded(
         .await
         .expect("failed to initialize MongoDB schema for integration tests");
 
+    Some(backend)
+}
+
+/// Creates a backend whose registry is loaded from the repo's spec files, so
+/// non-embedded search parameters (e.g. `value-quantity`) are active.
+async fn create_backend_with_full_registry(test_name: &str) -> Option<MongoBackend> {
+    let connection_string = test_mongo_url()?;
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("data"))?;
+    let config = MongoBackendConfig {
+        connection_string,
+        database_name: build_test_database_name(test_name),
+        data_dir: Some(data_dir),
+        ..Default::default()
+    };
+    let backend = MongoBackend::new(config).expect("failed to create MongoBackend");
+    backend
+        .initialize()
+        .await
+        .expect("failed to initialize MongoDB schema");
     Some(backend)
 }
 
@@ -1233,6 +1256,82 @@ async fn mongodb_integration_history_delete_trial_use_not_supported() {
             BackendError::UnsupportedCapability { .. }
         ))
     ));
+}
+
+#[tokio::test]
+async fn mongodb_integration_search_quantity() {
+    let Some(backend) = create_backend_with_full_registry("search_quantity").await else {
+        eprintln!("Skipping mongodb_integration_search_quantity (set HFS_TEST_MONGODB_URL)");
+        return;
+    };
+
+    let tenant = create_tenant("tenant-quantity");
+
+    backend
+        .create(
+            &tenant,
+            "Observation",
+            json!({
+                "resourceType": "Observation",
+                "id": "obs-weight",
+                "status": "final",
+                "code": { "coding": [{ "system": "http://loinc.org", "code": "29463-7" }] },
+                "valueQuantity": { "value": 72.5, "unit": "kg", "system": "http://unitsofmeasure.org" }
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let query = |prefix: SearchPrefix, value: &str| {
+        SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "value-quantity".to_string(),
+            param_type: SearchParamType::Quantity,
+            modifier: None,
+            values: vec![SearchValue::new(prefix, value)],
+            chain: vec![],
+            components: vec![],
+        })
+    };
+
+    // ge70 matches (72.5 >= 70).
+    let result = backend
+        .search(&tenant, &query(SearchPrefix::Ge, "70"))
+        .await
+        .unwrap();
+    assert_eq!(
+        result.resources.items.len(),
+        1,
+        "value-quantity ge70 → 1 hit"
+    );
+    assert_eq!(result.resources.items[0].id(), "obs-weight");
+
+    // ge100 does not match.
+    let result = backend
+        .search(&tenant, &query(SearchPrefix::Ge, "100"))
+        .await
+        .unwrap();
+    assert!(result.resources.items.is_empty(), "ge100 → no hit");
+
+    // Quantity with a matching unit code.
+    let result = backend
+        .search(
+            &tenant,
+            &query(SearchPrefix::Ge, "70|http://unitsofmeasure.org|kg"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.resources.items.len(), 1, "ge70 with kg unit → 1 hit");
+
+    // Non-matching unit code excludes.
+    let result = backend
+        .search(
+            &tenant,
+            &query(SearchPrefix::Ge, "70|http://unitsofmeasure.org|lb"),
+        )
+        .await
+        .unwrap();
+    assert!(result.resources.items.is_empty(), "wrong unit → no hit");
 }
 
 #[tokio::test]

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -1355,6 +1355,72 @@ mod postgres_integration {
         );
     }
 
+    #[tokio::test]
+    async fn postgres_integration_search_composite_code_value_quantity() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            CompositeSearchComponent, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        let observation = json!({
+            "resourceType": "Observation",
+            "id": "obs-bp",
+            "status": "final",
+            "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6" }] },
+            "valueQuantity": { "value": 107, "unit": "mmHg", "system": "http://unitsofmeasure.org" }
+        });
+        backend
+            .create(&tenant, "Observation", observation, FhirVersion::default())
+            .await
+            .unwrap();
+
+        let query = |value: &str| {
+            SearchQuery::new("Observation").with_parameter(SearchParameter {
+                name: "code-value-quantity".to_string(),
+                param_type: SearchParamType::Composite,
+                modifier: None,
+                values: vec![SearchValue::eq(value)],
+                chain: vec![],
+                components: vec![
+                    CompositeSearchComponent {
+                        param_type: SearchParamType::Token,
+                        param_name: "code".to_string(),
+                    },
+                    CompositeSearchComponent {
+                        param_type: SearchParamType::Quantity,
+                        param_name: "value-quantity".to_string(),
+                    },
+                ],
+            })
+        };
+
+        let result = backend
+            .search(&tenant, &query("8480-6$ge100"))
+            .await
+            .unwrap();
+        assert_eq!(
+            result.resources.items.len(),
+            1,
+            "code + value match → 1 hit"
+        );
+        assert_eq!(result.resources.items[0].id(), "obs-bp");
+
+        let result = backend
+            .search(&tenant, &query("8480-6$ge200"))
+            .await
+            .unwrap();
+        assert!(result.resources.items.is_empty(), "value too low → no hit");
+
+        let result = backend
+            .search(&tenant, &query("9999-9$ge100"))
+            .await
+            .unwrap();
+        assert!(result.resources.items.is_empty(), "code mismatch → no hit");
+    }
+
     // ========================================================================
     // Backend Health Check Tests
     // ========================================================================

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -1238,6 +1238,58 @@ mod postgres_integration {
     }
 
     #[tokio::test]
+    async fn postgres_integration_search_cursor_with_custom_sort() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{SearchParamType, SearchQuery, SortDirective};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        // Insert out of order; page size 1 to force keyset paging across pages.
+        for (id, family) in [
+            ("p-charlie", "Charlie"),
+            ("p-alice", "Alice"),
+            ("p-bob", "Bob"),
+        ] {
+            backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({ "resourceType": "Patient", "id": id, "name": [{ "family": family }] }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let mut collected = Vec::new();
+        let mut cursor: Option<String> = None;
+        for _ in 0..5 {
+            let mut q = SearchQuery::new("Patient")
+                .with_sort(
+                    SortDirective::parse("family").with_param_type(Some(SearchParamType::String)),
+                )
+                .with_count(1);
+            q.cursor = cursor.clone();
+            let result = backend.search(&tenant, &q).await.unwrap();
+            for r in &result.resources.items {
+                collected.push(r.id().to_string());
+            }
+            match result.resources.page_info.next_cursor {
+                Some(c) => cursor = Some(c),
+                None => break,
+            }
+        }
+
+        // Keyset paging must yield the full set in family order, no dups/gaps.
+        assert_eq!(
+            collected,
+            vec!["p-alice", "p-bob", "p-charlie"],
+            "cursor paging with custom sort must preserve global order"
+        );
+    }
+
+    #[tokio::test]
     async fn postgres_integration_search_sort_by_indexed_param() {
         use helios_persistence::core::SearchProvider;
         use helios_persistence::types::{SearchParamType, SearchQuery, SortDirective};

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -1238,6 +1238,60 @@ mod postgres_integration {
     }
 
     #[tokio::test]
+    async fn postgres_integration_search_sort_by_indexed_param() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{SearchParamType, SearchQuery, SortDirective};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        for (id, family) in [
+            ("p-charlie", "Charlie"),
+            ("p-alice", "Alice"),
+            ("p-bob", "Bob"),
+        ] {
+            let patient = json!({
+                "resourceType": "Patient",
+                "id": id,
+                "name": [{ "family": family }],
+            });
+            backend
+                .create(&tenant, "Patient", patient, FhirVersion::default())
+                .await
+                .unwrap();
+        }
+
+        let collect_ids = |result: helios_persistence::core::SearchResult| {
+            result
+                .resources
+                .items
+                .iter()
+                .map(|r| r.id().to_string())
+                .collect::<Vec<_>>()
+        };
+
+        let asc = SearchQuery::new("Patient").with_sort(
+            SortDirective::parse("family").with_param_type(Some(SearchParamType::String)),
+        );
+        let ids = collect_ids(backend.search(&tenant, &asc).await.unwrap());
+        assert_eq!(
+            ids,
+            vec!["p-alice", "p-bob", "p-charlie"],
+            "sort by family asc"
+        );
+
+        let desc = SearchQuery::new("Patient").with_sort(
+            SortDirective::parse("-family").with_param_type(Some(SearchParamType::String)),
+        );
+        let ids = collect_ids(backend.search(&tenant, &desc).await.unwrap());
+        assert_eq!(
+            ids,
+            vec!["p-charlie", "p-bob", "p-alice"],
+            "sort by family desc"
+        );
+    }
+
+    #[tokio::test]
     async fn postgres_integration_search_missing_modifier() {
         use helios_persistence::core::SearchProvider;
         use helios_persistence::types::{

--- a/crates/persistence/tests/sqlite_tests.rs
+++ b/crates/persistence/tests/sqlite_tests.rs
@@ -1146,7 +1146,114 @@ async fn test_history_system_tenant_isolation() {
 // ============================================================================
 
 use helios_persistence::core::SearchProvider;
-use helios_persistence::types::{SearchParamType, SearchParameter, SearchQuery, SearchValue};
+use helios_persistence::types::{
+    CompositeSearchComponent, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+};
+
+/// Builds the `code-value-quantity` composite query with the component types
+/// the registry would supply, mirroring what the REST layer now wires up.
+fn code_value_quantity_query(value: &str) -> SearchQuery {
+    SearchQuery::new("Observation").with_parameter(SearchParameter {
+        name: "code-value-quantity".to_string(),
+        param_type: SearchParamType::Composite,
+        modifier: None,
+        values: vec![SearchValue::eq(value)],
+        chain: vec![],
+        components: vec![
+            CompositeSearchComponent {
+                param_type: SearchParamType::Token,
+                param_name: "code".to_string(),
+            },
+            CompositeSearchComponent {
+                param_type: SearchParamType::Quantity,
+                param_name: "value-quantity".to_string(),
+            },
+        ],
+    })
+}
+
+#[tokio::test]
+async fn test_search_value_quantity_choice_type() {
+    // Regression: choice-type elements (`value[x]`) must be indexed. The
+    // `value-quantity` expression is `(Observation.value as Quantity)`.
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    let observation = json!({
+        "resourceType": "Observation",
+        "id": "obs-q",
+        "status": "final",
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "29463-7" }] },
+        "valueQuantity": { "value": 72.5, "unit": "kg", "system": "http://unitsofmeasure.org" }
+    });
+    backend
+        .create(&tenant, "Observation", observation, FhirVersion::default())
+        .await
+        .unwrap();
+
+    let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+        name: "value-quantity".to_string(),
+        param_type: SearchParamType::Quantity,
+        modifier: None,
+        values: vec![SearchValue::new(
+            helios_persistence::types::SearchPrefix::Ge,
+            "70",
+        )],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = backend.search(&tenant, &query).await.unwrap();
+    assert_eq!(
+        result.resources.items.len(),
+        1,
+        "value-quantity ge70 → 1 hit"
+    );
+    assert_eq!(result.resources.items[0].id(), "obs-q");
+}
+
+#[tokio::test]
+async fn test_search_composite_code_value_quantity() {
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    let observation = json!({
+        "resourceType": "Observation",
+        "id": "obs-bp",
+        "status": "final",
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6" }] },
+        "valueQuantity": { "value": 107, "unit": "mmHg", "system": "http://unitsofmeasure.org" }
+    });
+    backend
+        .create(&tenant, "Observation", observation, FhirVersion::default())
+        .await
+        .unwrap();
+
+    // Matches: correct code AND value satisfies the quantity comparison.
+    let result = backend
+        .search(&tenant, &code_value_quantity_query("8480-6$ge100"))
+        .await
+        .unwrap();
+    assert_eq!(
+        result.resources.items.len(),
+        1,
+        "code + value both match → 1 hit"
+    );
+    assert_eq!(result.resources.items[0].id(), "obs-bp");
+
+    // Value component fails (107 is not >= 200).
+    let result = backend
+        .search(&tenant, &code_value_quantity_query("8480-6$ge200"))
+        .await
+        .unwrap();
+    assert!(result.resources.items.is_empty(), "value too low → no hit");
+
+    // Code component fails.
+    let result = backend
+        .search(&tenant, &code_value_quantity_query("9999-9$ge100"))
+        .await
+        .unwrap();
+    assert!(result.resources.items.is_empty(), "code mismatch → no hit");
+}
 
 // Note: These tests verify that search indexing infrastructure is integrated into
 // storage operations. Full end-to-end search filtering requires updating search_impl.rs
@@ -2814,7 +2921,7 @@ async fn test_fts_delete_does_not_fail() {
 // _content Parameter Tests (Full Content Search)
 // ============================================================================
 
-use helios_persistence::types::{CompositeSearchComponent, SearchModifier};
+use helios_persistence::types::SearchModifier;
 
 #[tokio::test]
 async fn test_content_search_basic() {

--- a/crates/persistence/tests/sqlite_tests.rs
+++ b/crates/persistence/tests/sqlite_tests.rs
@@ -1168,6 +1168,87 @@ async fn search_ids(
 }
 
 #[tokio::test]
+async fn test_search_cursor_with_custom_sort() {
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    // Insert out of order; page size 1 to force keyset paging across pages.
+    for (id, family) in [
+        ("p-charlie", "Charlie"),
+        ("p-alice", "Alice"),
+        ("p-bob", "Bob"),
+    ] {
+        let patient =
+            json!({ "resourceType": "Patient", "id": id, "name": [{ "family": family }] });
+        backend
+            .create(&tenant, "Patient", patient, FhirVersion::default())
+            .await
+            .unwrap();
+    }
+
+    let mut collected = Vec::new();
+    let mut cursor: Option<String> = None;
+    for _ in 0..5 {
+        let mut q = SearchQuery::new("Patient")
+            .with_sort(
+                SortDirective::parse("family").with_param_type(Some(SearchParamType::String)),
+            )
+            .with_count(1);
+        q.cursor = cursor.clone();
+        let result = backend.search(&tenant, &q).await.unwrap();
+        for r in &result.resources.items {
+            collected.push(r.id().to_string());
+        }
+        match result.resources.page_info.next_cursor {
+            Some(c) => cursor = Some(c),
+            None => break,
+        }
+    }
+
+    assert_eq!(
+        collected,
+        vec!["p-alice", "p-bob", "p-charlie"],
+        "cursor paging with custom sort must preserve global order"
+    );
+}
+
+#[tokio::test]
+async fn test_search_cursor_default_sort_paging() {
+    // The default (no _sort) keyset still pages correctly across pages.
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    for id in ["a", "b", "c", "d"] {
+        let patient = json!({ "resourceType": "Patient", "id": id });
+        backend
+            .create(&tenant, "Patient", patient, FhirVersion::default())
+            .await
+            .unwrap();
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut total = 0;
+    let mut cursor: Option<String> = None;
+    for _ in 0..10 {
+        let mut q = SearchQuery::new("Patient").with_count(2);
+        q.cursor = cursor.clone();
+        let result = backend.search(&tenant, &q).await.unwrap();
+        for r in &result.resources.items {
+            assert!(
+                seen.insert(r.id().to_string()),
+                "no duplicate ids across pages"
+            );
+            total += 1;
+        }
+        match result.resources.page_info.next_cursor {
+            Some(c) => cursor = Some(c),
+            None => break,
+        }
+    }
+    assert_eq!(total, 4, "all four resources returned exactly once");
+}
+
+#[tokio::test]
 async fn test_search_sort_by_indexed_param() {
     let backend = create_backend();
     let tenant = create_tenant("test-tenant");

--- a/crates/persistence/tests/sqlite_tests.rs
+++ b/crates/persistence/tests/sqlite_tests.rs
@@ -1148,7 +1148,70 @@ async fn test_history_system_tenant_isolation() {
 use helios_persistence::core::SearchProvider;
 use helios_persistence::types::{
     CompositeSearchComponent, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+    SortDirective,
 };
+
+async fn search_ids(
+    backend: &SqliteBackend,
+    tenant: &TenantContext,
+    query: &SearchQuery,
+) -> Vec<String> {
+    backend
+        .search(tenant, query)
+        .await
+        .unwrap()
+        .resources
+        .items
+        .iter()
+        .map(|r| r.id().to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn test_search_sort_by_indexed_param() {
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    for (id, family, birth) in [
+        ("p-charlie", "Charlie", "1990-01-01"),
+        ("p-alice", "Alice", "1985-01-01"),
+        ("p-bob", "Bob", "2000-01-01"),
+    ] {
+        let patient = json!({
+            "resourceType": "Patient",
+            "id": id,
+            "name": [{ "family": family }],
+            "birthDate": birth,
+        });
+        backend
+            .create(&tenant, "Patient", patient, FhirVersion::default())
+            .await
+            .unwrap();
+    }
+
+    // Sort by family (string), ascending then descending.
+    let asc = SearchQuery::new("Patient")
+        .with_sort(SortDirective::parse("family").with_param_type(Some(SearchParamType::String)));
+    assert_eq!(
+        search_ids(&backend, &tenant, &asc).await,
+        vec!["p-alice", "p-bob", "p-charlie"]
+    );
+
+    let desc = SearchQuery::new("Patient")
+        .with_sort(SortDirective::parse("-family").with_param_type(Some(SearchParamType::String)));
+    assert_eq!(
+        search_ids(&backend, &tenant, &desc).await,
+        vec!["p-charlie", "p-bob", "p-alice"]
+    );
+
+    // Sort by birthdate (date), ascending.
+    let by_birth = SearchQuery::new("Patient")
+        .with_sort(SortDirective::parse("birthdate").with_param_type(Some(SearchParamType::Date)));
+    assert_eq!(
+        search_ids(&backend, &tenant, &by_birth).await,
+        vec!["p-alice", "p-charlie", "p-bob"]
+    );
+}
 
 /// Builds the `code-value-quantity` composite query with the component types
 /// the registry would supply, mirroring what the REST layer now wires up.

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -53,7 +53,17 @@ pub fn build_search_query(
             } else {
                 SortDirective::parse(&format!("-{}", sort.field))
             };
-            query.sort.push(directive);
+            // Resolve the search-parameter type so backends can sort by the
+            // indexed value column. `_id`/`_lastUpdated` are columns on the
+            // resources table and need no type.
+            let param_type = if directive.parameter.starts_with('_') {
+                None
+            } else {
+                registry
+                    .get_param(resource_type, &directive.parameter)
+                    .map(|d| d.param_type)
+            };
+            query.sort.push(directive.with_param_type(param_type));
         }
     }
 

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -6,8 +6,9 @@ use std::collections::HashMap;
 
 use helios_persistence::search::{SearchParameterRegistry, resolve_param_type};
 use helios_persistence::types::{
-    IncludeDirective, IncludeType, ReverseChainedParameter, SearchModifier, SearchParamType,
-    SearchParameter, SearchQuery, SearchValue, SortDirective, SummaryMode, TotalMode,
+    CompositeSearchComponent, IncludeDirective, IncludeType, ReverseChainedParameter,
+    SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue, SortDirective,
+    SummaryMode, TotalMode,
 };
 
 use super::SearchParams;
@@ -165,6 +166,27 @@ fn parse_search_parameter(
         chain,
         components: vec![],
     };
+
+    // For composite parameters, resolve the component sub-parameters from the
+    // registry (type + code), so the backend can match each component within
+    // the same composite instance.
+    if matches!(param_type, SearchParamType::Composite) {
+        if let Some(def) = registry.get_param(resource_type, base_name) {
+            if let Some(comps) = def.component.as_ref() {
+                param.components = comps
+                    .iter()
+                    .filter_map(|c| {
+                        registry
+                            .get_by_url(&c.definition)
+                            .map(|sub| CompositeSearchComponent {
+                                param_type: sub.param_type,
+                                param_name: sub.code.clone(),
+                            })
+                    })
+                    .collect();
+            }
+        }
+    }
 
     // Handle :missing modifier specially
     if param

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -528,12 +528,92 @@ async fn expand_terminology_params(
                      ValueSet: {value}); use ':in' or remove this modifier"
                 ),
             });
+        } else if let Some((param_name, op)) = key
+            .strip_suffix(":below")
+            .map(|p| (p, "is-a"))
+            .or_else(|| key.strip_suffix(":above").map(|p| (p, "generalizes")))
+        {
+            // Token hierarchy: `code:below=system|code` expands to the code and
+            // its descendants (is-a) / ancestors (generalizes) via the
+            // terminology server. A bare value with no `system|code` is left
+            // untouched — that is the URI form, resolved natively by the backend.
+            if let Some((system, code)) = value.split_once('|') {
+                let modifier = if op == "is-a" { ":below" } else { ":above" };
+                expand_subsumption_into(
+                    &mut result,
+                    &client,
+                    param_name,
+                    &key,
+                    system,
+                    code,
+                    op,
+                    modifier,
+                )
+                .await;
+            } else {
+                result.insert(key, value);
+            }
         } else {
             result.insert(key, value);
         }
     }
 
     Ok(result)
+}
+
+/// Sentinel token that cannot match any indexed code, used to force an empty
+/// result when a terminology expansion legitimately yields no codes.
+const HTS_EMPTY_EXPANSION: &str = "__hts_empty_expansion__";
+
+/// Expands a token hierarchy modifier (`:below`/`:above`) and inserts the
+/// resulting comma-joined token list under `param_name`. Mirrors the `:in`
+/// policy: empty expansion → sentinel (match nothing); request error →
+/// fail-open (drop the filter).
+#[allow(clippy::too_many_arguments)]
+async fn expand_subsumption_into(
+    result: &mut HashMap<String, String>,
+    client: &TerminologyServiceClient,
+    param_name: &str,
+    key: &str,
+    system: &str,
+    code: &str,
+    op: &str,
+    modifier: &str,
+) {
+    match client.expand_subsumption(system, code, op).await {
+        Ok(codes) if !codes.is_empty() => {
+            let token_list = codes
+                .iter()
+                .map(|c| c.as_token())
+                .collect::<Vec<_>>()
+                .join(",");
+            debug!(
+                param = %param_name,
+                system = %system,
+                code = %code,
+                modifier = %modifier,
+                codes = codes.len(),
+                "Expanded token hierarchy modifier"
+            );
+            result.insert(param_name.to_string(), token_list);
+        }
+        Ok(_) => {
+            warn!(
+                param = %key,
+                modifier = %modifier,
+                "Token hierarchy expansion returned no codes; injecting sentinel so no resources match"
+            );
+            result.insert(param_name.to_string(), HTS_EMPTY_EXPANSION.to_string());
+        }
+        Err(e) => {
+            warn!(
+                param = %key,
+                modifier = %modifier,
+                error = %e,
+                "Token hierarchy expansion failed; skipping parameter (fail-open)"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -636,5 +716,84 @@ mod tests {
         // The :in key is gone; no code key was injected either (fail-open)
         assert!(!result.contains_key("code:in"));
         assert!(!result.contains_key("code"));
+    }
+
+    /// A token `:below` (`system|code`) is fail-open dropped on network error.
+    #[tokio::test]
+    async fn test_expand_terminology_params_below_token_dropped_on_network_error() {
+        let mut params = HashMap::new();
+        params.insert(
+            "code:below".to_string(),
+            "http://snomed.info/sct|73211009".to_string(),
+        );
+
+        let result = expand_terminology_params(params, "http://127.0.0.1:19999")
+            .await
+            .unwrap();
+
+        assert!(!result.contains_key("code:below"));
+        assert!(!result.contains_key("code"));
+    }
+
+    /// Happy path: a token `:below` expands to the code and its descendants via
+    /// a mock terminology server, rewriting to a comma-joined token list.
+    #[tokio::test]
+    async fn test_expand_terminology_params_below_success() {
+        use axum::{Json, Router, routing::post};
+        use serde_json::json;
+
+        let app = Router::new().route(
+            "/ValueSet/$expand",
+            post(|| async {
+                Json(json!({
+                    "resourceType": "ValueSet",
+                    "expansion": { "contains": [
+                        { "system": "http://snomed.info/sct", "code": "73211009" },
+                        { "system": "http://snomed.info/sct", "code": "44054006" },
+                        { "system": "http://snomed.info/sct", "code": "46635009" }
+                    ]}
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let mut params = HashMap::new();
+        params.insert(
+            "code:below".to_string(),
+            "http://snomed.info/sct|73211009".to_string(),
+        );
+        let result = expand_terminology_params(params, &format!("http://{addr}"))
+            .await
+            .unwrap();
+
+        // Modifier consumed; rewritten to a plain token OR list of descendants.
+        assert!(!result.contains_key("code:below"));
+        let codes = result.get("code").expect("code param injected");
+        assert!(codes.contains("http://snomed.info/sct|73211009"));
+        assert!(codes.contains("http://snomed.info/sct|44054006"));
+        assert!(codes.contains("http://snomed.info/sct|46635009"));
+    }
+
+    /// A `:below` value without a `system|code` (the URI form) is left untouched
+    /// so the backend can resolve URI hierarchy natively — no terminology call.
+    #[tokio::test]
+    async fn test_expand_terminology_params_below_uri_passthrough() {
+        let mut params = HashMap::new();
+        params.insert(
+            "url:below".to_string(),
+            "http://example.org/fhir/ValueSet/x".to_string(),
+        );
+
+        let result = expand_terminology_params(params, "http://127.0.0.1:19999")
+            .await
+            .unwrap();
+
+        // Unchanged — no `|`, so not treated as a token subsumption.
+        assert_eq!(
+            result.get("url:below"),
+            Some(&"http://example.org/fhir/ValueSet/x".to_string())
+        );
     }
 }

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -192,6 +192,19 @@ where
         build_search_query_from_map(resource_type, &params, &registry)?
     };
 
+    // Resolve chained / reverse-chained (`_has`) parameters into an `_id` filter
+    // via application-side joins, so any backend's `search()` can execute them.
+    let query = if helios_persistence::search::query_has_chains(&query) {
+        helios_persistence::search::resolve_chains(state.storage(), tenant.context(), &query)
+            .await
+            .map_err(|e| {
+                warn!(error = %e, "Chained search resolution failed");
+                RestError::from(e)
+            })?
+    } else {
+        query
+    };
+
     // Execute the search
     // Note: The search provider is responsible for resolving _include/_revinclude
     // directives that are part of the query. The result already contains included resources.

--- a/crates/rest/src/terminology.rs
+++ b/crates/rest/src/terminology.rs
@@ -165,6 +165,70 @@ impl TerminologyServiceClient {
 
         extract_expansion_codes(&value)
     }
+
+    /// Expands the concepts subsumed by (or subsuming) a code, via an inline
+    /// ValueSet `$expand` with a filter.
+    ///
+    /// - `op = "is-a"` returns the code and all its descendants (for `:below`).
+    /// - `op = "generalizes"` returns the code and all its ancestors (for `:above`).
+    ///
+    /// Both include the code itself, per FHIR subsumption-testing semantics.
+    pub async fn expand_subsumption(
+        &self,
+        system: &str,
+        code: &str,
+        op: &str,
+    ) -> Result<Vec<ExpandedCode>, TerminologyError> {
+        let endpoint = format!("{}/ValueSet/$expand", self.base_url);
+
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [{
+                "name": "valueSet",
+                "resource": {
+                    "resourceType": "ValueSet",
+                    "compose": {
+                        "include": [{
+                            "system": system,
+                            "filter": [{ "property": "concept", "op": op, "value": code }]
+                        }]
+                    }
+                }
+            }]
+        });
+
+        let response = self
+            .client
+            .post(&endpoint)
+            .json(&body)
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", "application/fhir+json")
+            .send()
+            .await
+            .map_err(|e| TerminologyError::Network(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body_text = response
+                .text()
+                .await
+                .unwrap_or_default()
+                .chars()
+                .take(512)
+                .collect::<String>();
+            return Err(TerminologyError::ServerError {
+                status,
+                body: body_text,
+            });
+        }
+
+        let value: Value = response
+            .json()
+            .await
+            .map_err(|e| TerminologyError::Parse(e.to_string()))?;
+
+        extract_expansion_codes(&value)
+    }
 }
 
 /// Extracts `ExpandedCode` entries from a FHIR ValueSet resource with expansion.


### PR DESCRIPTION
## Why this PR exists
PRs #119–#126 were a stack and each was (correctly) based on the **previous** feature branch. When #118 was squash-merged to `main`, GitHub did **not** retarget the rest, so #119–#126 each merged into their stale base branch — their content never reached `main`. Only #118 landed.

This branch is the stack tip rebased onto `main`: the duplicate #118 commit drops out (patch-id match), leaving exactly the 8 missing commits. Diff vs `main` = the same ~2,930-line search body that was reviewed across #119–#126. Merging this brings all of it into `main` in one shot.

## What's included (the already-reviewed #119–#126)
- **#119** PostgreSQL composite params + `:of-type`
- **#120** Composite end-to-end + `value[x]` choice-type extraction fix
- **#121** Sort by any indexed search parameter (SQLite + PostgreSQL)
- **#122** Stateless keyset cursor pagination consistent with `_sort`
- **#123** Elasticsearch composite component evaluation
- **#124** Chained & `_has` search dispatch (all backends)
- **#125** MongoDB quantity search
- **#126** Token `:below`/`:above` via terminology `$expand`

## Verification
Rebased cleanly (no conflicts); `helios-persistence` and `helios-rest` compile on default features. All the per-PR tests (unit + testcontainers for Postgres/Elasticsearch/MongoDB) are part of the commits.

## Recommended merge
**Rebase-merge** (or merge-commit) to preserve the 8 commits — avoid squash so history stays granular. After merge, the now-redundant intermediate branches (`feat/pg-search-sort-modifiers` … `feat/token-hierarchy-modifiers`) can be deleted.