### PR TITLE
ci(inferno): omit smokingstatus/simple-observation validation across all US Core versions

### DIFF
--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -202,6 +202,10 @@ jobs:
           # Note: Inferno uses "us_core_311" naming for this group across all US Core versions
           OMITTED="${OMITTED},\"${SUITE}-${SUITE}_fhir_api-us_core_311_data_absent_reason-us_core_311_data_absent_reason_extension\""
           OMITTED="${OMITTED},\"${SUITE}-${SUITE}_fhir_api-us_core_311_data_absent_reason-us_core_311_data_absent_reason_code_system\""
+          # smokingstatus/simple-observation: shared test data references SNOMED CT US-edition version (731000124108) not in International Edition; Inferno validator can't resolve it.
+          # The offending bundle (uscore_bundle_patient_client_test.json) is loaded for every suite, so omit across all versions.
+          OMITTED="${OMITTED},\"${SUITE}-${SUITE}_fhir_api-${SUITE}_smokingstatus-${SUITE}_smokingstatus_validation_test\""
+          OMITTED="${OMITTED},\"${SUITE}-${SUITE}_fhir_api-${SUITE}_simple_observation-${SUITE}_simple_observation_validation_test\""
 
           case "$SUITE" in
             us_core_v501|us_core_v610|us_core_v700|us_core_v800)
@@ -221,9 +225,6 @@ jobs:
             us_core_v700|us_core_v800)
               # Inferno fhir_client gem bug with UUID-based Location references
               OMITTED="${OMITTED},\"${SUITE}-${SUITE}_fhir_api-${SUITE}_location-${SUITE}_location_address_search_test\""
-              # smokingstatus/simple-observation: shared test data references SNOMED CT US-edition version (731000124108) not in International Edition; Inferno validator can't resolve it
-              OMITTED="${OMITTED},\"${SUITE}-${SUITE}_fhir_api-${SUITE}_smokingstatus-${SUITE}_smokingstatus_validation_test\""
-              OMITTED="${OMITTED},\"${SUITE}-${SUITE}_fhir_api-${SUITE}_simple_observation-${SUITE}_simple_observation_validation_test\""
               ;;
           esac
 


### PR DESCRIPTION
## Problem

The Inferno US Core v3.1.1 run ([27034698253](https://github.com/HeliosSoftware/hfs/actions/runs/27034698253)) failed on a single non-omitted test on both `sqlite` and `sqlite-elasticsearch` backends:

```
us_core_v311-..._smokingstatus-us_core_v311_smokingstatus_validation_test: fail
  Resource does not conform to the profile .../us-core-smokingstatus|3.1.1
```

The failure is backend-independent — it's a test-data / validator limitation, not an HFS bug.

## Root cause

The shared smoking-status Observation in `crates/hfs/tests/inferno/uscore_bundle_patient_client_test.json` pins a SNOMED CT **US Edition** version:

```json
{"system": "http://snomed.info/sct",
 "version": "http://snomed.info/sct/731000124108",
 "code": "428041000124106"}
```

The Inferno validator runs the SNOMED **International** Edition and can't resolve this version/code, so profile validation fails. This exact issue was already documented and omitted — but only inside the `us_core_v700|us_core_v800` case. Since `install.sh` loads this bundle for **every** suite, v3.1.1 (and v5.0.1, v6.1.0) hit the same failure without being omitted.

## Fix

Move the `smokingstatus_validation_test` and `simple_observation_validation_test` omits out of the `v700|v800` case into the unconditional block, so they apply to all US Core versions. Consistent with how the repo already handles other US-edition-only SNOMED codes (e.g. the ServiceRequest omit). v7.0.0/v8.0.0 behavior is unchanged.

Workflow-config-only change — no Rust build/test impact.