### PR TITLE
FHIR search-modifier spec compliance across all backends

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/backend.rs
+++ b/crates/persistence/src/backends/elasticsearch/backend.rs
@@ -553,15 +553,10 @@ impl ElasticsearchBackend {
         match param_type {
             SearchParamType::String => vec!["exact", "contains", "text", "missing"],
             SearchParamType::Token => {
-                vec![
-                    "not",
-                    "text",
-                    "text-advanced",
-                    "in",
-                    "not-in",
-                    "of-type",
-                    "missing",
-                ]
+                // `not-in` is intentionally omitted: it returns 501 (negated
+                // value-set filtering is unimplemented), so it must not be
+                // advertised as supported.
+                vec!["not", "text", "text-advanced", "in", "of-type", "missing"]
             }
             SearchParamType::Reference => vec!["identifier", "missing"],
             SearchParamType::Date => vec!["missing"],

--- a/crates/persistence/src/backends/elasticsearch/backend.rs
+++ b/crates/persistence/src/backends/elasticsearch/backend.rs
@@ -566,9 +566,15 @@ impl ElasticsearchBackend {
                     "missing",
                 ]
             }
-            SearchParamType::Reference => {
-                vec!["identifier", "contains", "text", "code-text", "missing"]
-            }
+            SearchParamType::Reference => vec![
+                "identifier",
+                "contains",
+                "text",
+                "code-text",
+                "below",
+                "above",
+                "missing",
+            ],
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],

--- a/crates/persistence/src/backends/elasticsearch/backend.rs
+++ b/crates/persistence/src/backends/elasticsearch/backend.rs
@@ -556,7 +556,15 @@ impl ElasticsearchBackend {
                 // `not-in` is intentionally omitted: it returns 501 (negated
                 // value-set filtering is unimplemented), so it must not be
                 // advertised as supported.
-                vec!["not", "text", "text-advanced", "in", "of-type", "missing"]
+                vec![
+                    "not",
+                    "text",
+                    "text-advanced",
+                    "code-text",
+                    "in",
+                    "of-type",
+                    "missing",
+                ]
             }
             SearchParamType::Reference => vec!["identifier", "contains", "missing"],
             SearchParamType::Date => vec!["missing"],

--- a/crates/persistence/src/backends/elasticsearch/backend.rs
+++ b/crates/persistence/src/backends/elasticsearch/backend.rs
@@ -558,11 +558,11 @@ impl ElasticsearchBackend {
                 // advertised as supported.
                 vec!["not", "text", "text-advanced", "in", "of-type", "missing"]
             }
-            SearchParamType::Reference => vec!["identifier", "missing"],
+            SearchParamType::Reference => vec!["identifier", "contains", "missing"],
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],
-            SearchParamType::Uri => vec!["below", "above", "missing"],
+            SearchParamType::Uri => vec!["contains", "below", "above", "missing"],
             SearchParamType::Composite => vec!["missing"],
             SearchParamType::Special => vec![],
         }

--- a/crates/persistence/src/backends/elasticsearch/backend.rs
+++ b/crates/persistence/src/backends/elasticsearch/backend.rs
@@ -566,7 +566,9 @@ impl ElasticsearchBackend {
                     "missing",
                 ]
             }
-            SearchParamType::Reference => vec!["identifier", "contains", "missing"],
+            SearchParamType::Reference => {
+                vec!["identifier", "contains", "text", "code-text", "missing"]
+            }
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],

--- a/crates/persistence/src/backends/elasticsearch/schema.rs
+++ b/crates/persistence/src/backends/elasticsearch/schema.rs
@@ -131,7 +131,8 @@ pub fn create_index_mapping(config: &super::backend::ElasticsearchConfig) -> ser
                                 "name": { "type": "keyword" },
                                 "reference": { "type": "keyword" },
                                 "resource_type": { "type": "keyword" },
-                                "resource_id": { "type": "keyword" }
+                                "resource_id": { "type": "keyword" },
+                                "display": { "type": "text" }
                             }
                         },
                         "uri": {

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/reference.rs
@@ -12,6 +12,30 @@ pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
         return build_identifier_clause(name, value);
     }
 
+    // :contains - case-insensitive substring match on the stored reference.
+    if param.modifier == Some(SearchModifier::Contains) {
+        return Some(json!({
+            "nested": {
+                "path": "search_params.reference",
+                "query": {
+                    "bool": {
+                        "must": [
+                            { "term": { "search_params.reference.name": name } },
+                            {
+                                "wildcard": {
+                                    "search_params.reference.reference": {
+                                        "value": format!("*{}*", value),
+                                        "case_insensitive": true
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }));
+    }
+
     let mut must_conditions = vec![json!({ "term": { "search_params.reference.name": name } })];
 
     // Parse reference value

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/reference.rs
@@ -37,6 +37,48 @@ pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
         }));
     }
 
+    // :below / :above - URL/path-prefix hierarchy on the reference value
+    // (canonical |version comparison is not handled).
+    if param.modifier == Some(SearchModifier::Below) {
+        return Some(json!({
+            "nested": {
+                "path": "search_params.reference",
+                "query": {
+                    "bool": {
+                        "must": [
+                            { "term": { "search_params.reference.name": name } },
+                            {
+                                "bool": {
+                                    "should": [
+                                        { "term": { "search_params.reference.reference": value } },
+                                        { "prefix": { "search_params.reference.reference": format!("{}/", value.trim_end_matches('/')) } }
+                                    ],
+                                    "minimum_should_match": 1
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }));
+    }
+    if param.modifier == Some(SearchModifier::Above) {
+        let parents = super::uri::compute_parent_uris(value);
+        return Some(json!({
+            "nested": {
+                "path": "search_params.reference",
+                "query": {
+                    "bool": {
+                        "must": [
+                            { "term": { "search_params.reference.name": name } },
+                            { "terms": { "search_params.reference.reference": parents } }
+                        ]
+                    }
+                }
+            }
+        }));
+    }
+
     // :contains - case-insensitive substring match on the stored reference.
     if param.modifier == Some(SearchModifier::Contains) {
         return Some(json!({

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/reference.rs
@@ -12,6 +12,31 @@ pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
         return build_identifier_clause(name, value);
     }
 
+    // :text (full-text) and :code-text (starts-with) match Reference.display.
+    if matches!(
+        param.modifier,
+        Some(SearchModifier::Text | SearchModifier::CodeText)
+    ) {
+        let display_query = if param.modifier == Some(SearchModifier::CodeText) {
+            json!({ "match_phrase_prefix": { "search_params.reference.display": value } })
+        } else {
+            json!({ "match": { "search_params.reference.display": { "query": value } } })
+        };
+        return Some(json!({
+            "nested": {
+                "path": "search_params.reference",
+                "query": {
+                    "bool": {
+                        "must": [
+                            { "term": { "search_params.reference.name": name } },
+                            display_query
+                        ]
+                    }
+                }
+            }
+        }));
+    }
+
     // :contains - case-insensitive substring match on the stored reference.
     if param.modifier == Some(SearchModifier::Contains) {
         return Some(json!({

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/token.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/token.rs
@@ -25,6 +25,9 @@ pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
         Some(SearchModifier::TextAdvanced) => {
             return build_text_advanced_clause(name, value);
         }
+        Some(SearchModifier::CodeText) => {
+            return build_code_text_clause(name, value);
+        }
         Some(SearchModifier::OfType) => {
             return build_of_type_clause(name, value);
         }
@@ -117,6 +120,23 @@ fn build_text_advanced_clause(name: &str, value: &str) -> Option<Value> {
                                 "query": value
                             }
                         }
+                    ]
+                }
+            }
+        }
+    }))
+}
+
+/// Builds a :code-text modifier clause (case-insensitive starts-with on display).
+fn build_code_text_clause(name: &str, value: &str) -> Option<Value> {
+    Some(json!({
+        "nested": {
+            "path": "search_params.token",
+            "query": {
+                "bool": {
+                    "must": [
+                        { "term": { "search_params.token.name": name } },
+                        { "match_phrase_prefix": { "search_params.token.display": value } }
                     ]
                 }
             }

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/uri.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/uri.rs
@@ -64,14 +64,15 @@ pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
     }))
 }
 
-/// Computes all parent URIs for :above matching.
+/// Computes all parent URIs for :above matching (shared with the reference
+/// handler's URL/path-prefix `:above`).
 ///
 /// For "http://example.org/fhir/ValueSet/123", returns:
 /// - "http://example.org/fhir/ValueSet/123"
 /// - "http://example.org/fhir/ValueSet"
 /// - "http://example.org/fhir"
 /// - "http://example.org"
-fn compute_parent_uris(uri: &str) -> Vec<String> {
+pub(crate) fn compute_parent_uris(uri: &str) -> Vec<String> {
     let mut result = vec![uri.to_string()];
 
     // Strip query and fragment

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/uri.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/uri.rs
@@ -9,6 +9,17 @@ pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
     let name = &param.name;
 
     let condition = match param.modifier {
+        Some(SearchModifier::Contains) => {
+            // :contains - case-insensitive substring match on the URI.
+            json!({
+                "wildcard": {
+                    "search_params.uri.value": {
+                        "value": format!("*{}*", value),
+                        "case_insensitive": true
+                    }
+                }
+            })
+        }
         Some(SearchModifier::Below) => {
             // :below - Match URIs that start with the given value
             json!({

--- a/crates/persistence/src/backends/elasticsearch/storage.rs
+++ b/crates/persistence/src/backends/elasticsearch/storage.rs
@@ -254,6 +254,7 @@ pub(crate) fn build_es_document(
                 reference,
                 resource_type: ref_type,
                 resource_id: ref_id,
+                display,
             } => {
                 let mut ref_doc = json!({
                     "name": ev.param_name,
@@ -264,6 +265,9 @@ pub(crate) fn build_es_document(
                 }
                 if let Some(ri) = ref_id {
                     ref_doc["resource_id"] = json!(ri);
+                }
+                if let Some(d) = display {
+                    ref_doc["display"] = json!(d);
                 }
                 reference_params.push(ref_doc);
             }

--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -519,3 +519,129 @@ impl Backend for MongoBackend {
             })
     }
 }
+
+// ============================================================================
+// SearchCapabilityProvider Implementation
+// ============================================================================
+
+use crate::core::capabilities::{
+    GlobalSearchCapabilities, ResourceSearchCapabilities, SearchCapabilityProvider,
+};
+use crate::types::{
+    IncludeCapability, PaginationCapability, ResultModeCapability, SearchParamFullCapability,
+    SearchParamType, SpecialSearchParam,
+};
+
+impl MongoBackend {
+    /// Returns the search modifiers the MongoDB backend actually honors for a
+    /// parameter type. Unlike the SQL backends, the Mongo search implementation
+    /// does not implement `:missing`, token `:not`/`:of-type`, reference
+    /// `:identifier`, or uri `:above`/`:below`; advertising only what
+    /// `search_impl` accepts keeps the CapabilityStatement honest.
+    fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
+        match param_type {
+            SearchParamType::String => vec!["exact", "contains", "text"],
+            SearchParamType::Token => vec!["code", "text", "code-text"],
+            SearchParamType::Reference => vec!["contains", "text", "code-text"],
+            SearchParamType::Uri => vec!["exact", "contains"],
+            SearchParamType::Date
+            | SearchParamType::Number
+            | SearchParamType::Quantity
+            | SearchParamType::Composite
+            | SearchParamType::Special => vec![],
+        }
+    }
+}
+
+impl SearchCapabilityProvider for MongoBackend {
+    fn resource_search_capabilities(
+        &self,
+        resource_type: &str,
+    ) -> Option<ResourceSearchCapabilities> {
+        let params = {
+            let registry = self.search_registry.read();
+            registry.get_active_params(resource_type)
+        };
+        let common_params = {
+            let registry = self.search_registry.read();
+            registry.get_active_params("Resource")
+        };
+        if params.is_empty() && common_params.is_empty() {
+            return None;
+        }
+
+        let mut search_params = Vec::new();
+        for param in &params {
+            let mut cap = SearchParamFullCapability::new(&param.code, param.param_type)
+                .with_definition(&param.url)
+                .with_modifiers(Self::modifiers_for_type(param.param_type));
+            if let Some(ref targets) = param.target {
+                cap = cap.with_targets(targets.iter().map(|s| s.as_str()));
+            }
+            search_params.push(cap);
+        }
+        for param in &common_params {
+            if !search_params.iter().any(|p| p.name == param.code) {
+                search_params.push(
+                    SearchParamFullCapability::new(&param.code, param.param_type)
+                        .with_definition(&param.url)
+                        .with_modifiers(Self::modifiers_for_type(param.param_type)),
+                );
+            }
+        }
+
+        Some(
+            ResourceSearchCapabilities::new(resource_type)
+                .with_special_params(vec![SpecialSearchParam::Id])
+                .with_include_capabilities(vec![
+                    IncludeCapability::Include,
+                    IncludeCapability::Revinclude,
+                ])
+                .with_pagination_capabilities(vec![
+                    PaginationCapability::Count,
+                    PaginationCapability::Offset,
+                    PaginationCapability::MaxPageSize(1000),
+                    PaginationCapability::DefaultPageSize(20),
+                ])
+                .with_result_mode_capabilities(vec![ResultModeCapability::Total])
+                .with_param_list(search_params),
+        )
+    }
+
+    fn global_search_capabilities(&self) -> GlobalSearchCapabilities {
+        GlobalSearchCapabilities::new().with_special_params(vec![SpecialSearchParam::Id])
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::*;
+
+    #[test]
+    fn test_modifiers_for_type_reflects_mongo_support() {
+        // String honors exact/contains/text but not :missing.
+        let s = MongoBackend::modifiers_for_type(SearchParamType::String);
+        assert!(s.contains(&"exact"));
+        assert!(s.contains(&"text"));
+        assert!(!s.contains(&"missing"));
+
+        // Token honors code/text/code-text but not :not or :of-type.
+        let t = MongoBackend::modifiers_for_type(SearchParamType::Token);
+        assert!(t.contains(&"code"));
+        assert!(t.contains(&"code-text"));
+        assert!(!t.contains(&"not"));
+        assert!(!t.contains(&"of-type"));
+
+        // Reference honors contains/text/code-text but not :identifier.
+        let r = MongoBackend::modifiers_for_type(SearchParamType::Reference);
+        assert!(r.contains(&"contains"));
+        assert!(r.contains(&"text"));
+        assert!(!r.contains(&"identifier"));
+
+        // Uri honors exact/contains but not :above/:below.
+        let u = MongoBackend::modifiers_for_type(SearchParamType::Uri);
+        assert!(u.contains(&"contains"));
+        assert!(!u.contains(&"above"));
+        assert!(!u.contains(&"below"));
+    }
+}

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -575,7 +575,9 @@ impl MongoBackend {
                 }
             }),
             Some(SearchModifier::Exact) => Ok(doc! { "value_string": lowered }),
-            Some(SearchModifier::Contains) => Ok(doc! {
+            // `:text` on a string is a case-insensitive partial match,
+            // implemented here as a substring match (same as `:contains`).
+            Some(SearchModifier::Contains | SearchModifier::Text) => Ok(doc! {
                 "value_string": {
                     "$regex": regex_escape(&lowered)
                 }

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -605,6 +605,19 @@ impl MongoBackend {
 
         match param.modifier.as_ref() {
             None | Some(SearchModifier::CodeOnly) => {}
+            // `:text` (contains) and `:code-text` (starts-with) match the
+            // token's display text (Coding.display / CodeableConcept.text).
+            Some(m @ (SearchModifier::Text | SearchModifier::CodeText)) => {
+                let escaped = regex_escape(&value.value);
+                let regex = if *m == SearchModifier::CodeText {
+                    format!("^{}", escaped)
+                } else {
+                    escaped
+                };
+                return Ok(doc! {
+                    "value_token_display": { "$regex": regex, "$options": "i" }
+                });
+            }
             Some(other) => {
                 return Err(StorageError::Search(SearchError::UnsupportedModifier {
                     modifier: other.to_string(),

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -641,6 +641,16 @@ impl MongoBackend {
             }));
         }
 
+        // :contains - case-insensitive substring match on the stored reference.
+        if matches!(param.modifier.as_ref(), Some(SearchModifier::Contains)) {
+            return Ok(doc! {
+                "value_reference": {
+                    "$regex": regex_escape(&value.value),
+                    "$options": "i"
+                }
+            });
+        }
+
         if let Some(modifier) = &param.modifier {
             return Err(StorageError::Search(SearchError::UnsupportedModifier {
                 modifier: modifier.to_string(),

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -666,6 +666,22 @@ impl MongoBackend {
             });
         }
 
+        // :text (contains) / :code-text (starts-with) match Reference.display.
+        if matches!(
+            param.modifier.as_ref(),
+            Some(SearchModifier::Text | SearchModifier::CodeText)
+        ) {
+            let escaped = regex_escape(&value.value);
+            let regex = if matches!(param.modifier.as_ref(), Some(SearchModifier::CodeText)) {
+                format!("^{}", escaped)
+            } else {
+                escaped
+            };
+            return Ok(doc! {
+                "value_reference_display": { "$regex": regex, "$options": "i" }
+            });
+        }
+
         if let Some(modifier) = &param.modifier {
             return Err(StorageError::Search(SearchError::UnsupportedModifier {
                 modifier: modifier.to_string(),

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -1325,8 +1325,13 @@ impl MongoBackend {
                     doc.insert("value_quantity_system", system.clone());
                 }
             }
-            IndexValue::Reference { reference, .. } => {
+            IndexValue::Reference {
+                reference, display, ..
+            } => {
                 doc.insert("value_reference", reference.clone());
+                if let Some(d) = display {
+                    doc.insert("value_reference_display", d.clone());
+                }
             }
             IndexValue::Uri(uri) => {
                 doc.insert("value_uri", uri.clone());

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -745,7 +745,9 @@ impl PostgresBackend {
             // `not-in` is intentionally omitted: it returns 501 (negated
             // value-set filtering is unimplemented), so it must not be
             // advertised as supported.
-            SearchParamType::Token => vec!["not", "text", "in", "of-type", "missing"],
+            SearchParamType::Token => {
+                vec!["not", "text", "code-text", "in", "of-type", "missing"]
+            }
             SearchParamType::Reference => vec!["identifier", "contains", "missing"],
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -742,7 +742,10 @@ impl PostgresBackend {
     fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
             SearchParamType::String => vec!["exact", "contains", "missing"],
-            SearchParamType::Token => vec!["not", "text", "in", "not-in", "of-type", "missing"],
+            // `not-in` is intentionally omitted: it returns 501 (negated
+            // value-set filtering is unimplemented), so it must not be
+            // advertised as supported.
+            SearchParamType::Token => vec!["not", "text", "in", "of-type", "missing"],
             SearchParamType::Reference => vec!["identifier", "missing"],
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -748,9 +748,15 @@ impl PostgresBackend {
             SearchParamType::Token => {
                 vec!["not", "text", "code-text", "in", "of-type", "missing"]
             }
-            SearchParamType::Reference => {
-                vec!["identifier", "contains", "text", "code-text", "missing"]
-            }
+            SearchParamType::Reference => vec![
+                "identifier",
+                "contains",
+                "text",
+                "code-text",
+                "below",
+                "above",
+                "missing",
+            ],
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -748,7 +748,9 @@ impl PostgresBackend {
             SearchParamType::Token => {
                 vec!["not", "text", "code-text", "in", "of-type", "missing"]
             }
-            SearchParamType::Reference => vec!["identifier", "contains", "missing"],
+            SearchParamType::Reference => {
+                vec!["identifier", "contains", "text", "code-text", "missing"]
+            }
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -746,11 +746,11 @@ impl PostgresBackend {
             // value-set filtering is unimplemented), so it must not be
             // advertised as supported.
             SearchParamType::Token => vec!["not", "text", "in", "of-type", "missing"],
-            SearchParamType::Reference => vec!["identifier", "missing"],
+            SearchParamType::Reference => vec!["identifier", "contains", "missing"],
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],
-            SearchParamType::Uri => vec!["below", "above", "missing"],
+            SearchParamType::Uri => vec!["contains", "below", "above", "missing"],
             SearchParamType::Composite => vec!["missing"],
             SearchParamType::Special => vec![],
         }

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -741,7 +741,7 @@ impl PostgresBackend {
     /// Returns supported modifiers for a parameter type.
     fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
-            SearchParamType::String => vec!["exact", "contains", "missing"],
+            SearchParamType::String => vec!["exact", "contains", "text", "missing"],
             // `not-in` is intentionally omitted: it returns 501 (negated
             // value-set filtering is unimplemented), so it must not be
             // advertised as supported.

--- a/crates/persistence/src/backends/postgres/schema.rs
+++ b/crates/persistence/src/backends/postgres/schema.rs
@@ -3,7 +3,7 @@
 use crate::error::{BackendError, StorageResult};
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 8;
+pub const SCHEMA_VERSION: i32 = 9;
 
 /// Initialize the database schema.
 pub async fn initialize_schema(client: &deadpool_postgres::Client) -> StorageResult<()> {
@@ -122,6 +122,7 @@ async fn create_schema_v1(client: &deadpool_postgres::Client) -> StorageResult<(
                 composite_group INTEGER,
                 value_identifier_type_system TEXT,
                 value_identifier_type_code TEXT,
+                value_reference_display TEXT,
                 CONSTRAINT fk_search_resource FOREIGN KEY (tenant_id, resource_type, resource_id)
                     REFERENCES resources(tenant_id, resource_type, id) ON DELETE CASCADE
             )",
@@ -270,6 +271,7 @@ async fn migrate_schema(
             5 => migrate_v5_to_v6(client).await?,
             6 => migrate_v6_to_v7(client).await?,
             7 => migrate_v7_to_v8(client).await?,
+            8 => migrate_v8_to_v9(client).await?,
             _ => {
                 return Err(pg_error(format!("Unknown schema version: {}", version)));
             }
@@ -628,6 +630,28 @@ async fn migrate_v7_to_v8(client: &deadpool_postgres::Client) -> StorageResult<(
             .map_err(|e| pg_error(format!("Migration v7->v8 index failed: {}", e)))?;
     }
 
+    Ok(())
+}
+
+/// v8 -> v9: add `value_reference_display` for reference text modifiers
+/// (`:text`/`:code-text` on reference params). Additive and nullable; existing
+/// rows stay NULL until the resource is reindexed.
+async fn migrate_v8_to_v9(client: &deadpool_postgres::Client) -> StorageResult<()> {
+    client
+        .execute(
+            "ALTER TABLE search_index ADD COLUMN IF NOT EXISTS value_reference_display TEXT",
+            &[],
+        )
+        .await
+        .map_err(|e| pg_error(format!("Migration v8->v9 failed: {}", e)))?;
+    client
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_search_reference_display
+             ON search_index(tenant_id, resource_type, param_name, value_reference_display)",
+            &[],
+        )
+        .await
+        .map_err(|e| pg_error(format!("Migration v8->v9 index failed: {}", e)))?;
     Ok(())
 }
 

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -922,6 +922,8 @@ impl PostgresQueryBuilder {
         let is_contains = matches!(modifier, Some(SearchModifier::Contains));
         let is_text = matches!(modifier, Some(SearchModifier::Text));
         let is_code_text = matches!(modifier, Some(SearchModifier::CodeText));
+        let is_below = matches!(modifier, Some(SearchModifier::Below));
+        let is_above = matches!(modifier, Some(SearchModifier::Above));
 
         for (i, value) in param.values.iter().enumerate() {
             let param_num = offset + i + 1;
@@ -931,6 +933,17 @@ impl PostgresQueryBuilder {
                 format!("value_reference_display ILIKE ${} || '%'", param_num)
             } else if is_contains {
                 format!("value_reference ILIKE '%' || ${} || '%'", param_num)
+            } else if is_below {
+                // URL/path-prefix hierarchy (canonical |version not handled).
+                format!(
+                    "(value_reference = ${0} OR value_reference LIKE ${0} || '/%')",
+                    param_num
+                )
+            } else if is_above {
+                format!(
+                    "(${0} = value_reference OR ${0} LIKE value_reference || '/%')",
+                    param_num
+                )
             } else {
                 format!("value_reference = ${}", param_num)
             };

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -838,7 +838,82 @@ impl PostgresQueryBuilder {
         Some(combined)
     }
 
+    /// Builds the `:identifier` condition: match references whose target
+    /// resource has an identifier equal to the supplied `system|value`. Mirrors
+    /// the SQLite implementation using PG's `SUBSTRING`/`POSITION`.
+    fn build_reference_identifier_condition(
+        param: &SearchParameter,
+        offset: usize,
+    ) -> Option<SqlFragment> {
+        let mut conditions = Vec::new();
+        let mut next = offset; // running 0-based param offset
+
+        for value in &param.values {
+            // Correlate the target resource id (the part after '/') with an
+            // 'identifier' index row for that resource.
+            let target = "idx.resource_id = SUBSTRING(ref.value_reference FROM POSITION('/' IN ref.value_reference) + 1)";
+            let (filter, params): (String, Vec<SqlParam>) = match value.value.split_once('|') {
+                Some((system, code)) if system.is_empty() => {
+                    next += 1;
+                    (
+                        format!(
+                            "(idx.value_token_system IS NULL OR idx.value_token_system = '') AND idx.value_token_code = ${next}"
+                        ),
+                        vec![SqlParam::text(code)],
+                    )
+                }
+                Some((system, code)) if code.is_empty() => {
+                    next += 1;
+                    (
+                        format!("idx.value_token_system = ${next}"),
+                        vec![SqlParam::text(system)],
+                    )
+                }
+                Some((system, code)) => {
+                    let s = next + 1;
+                    let c = next + 2;
+                    next += 2;
+                    (
+                        format!("idx.value_token_system = ${s} AND idx.value_token_code = ${c}"),
+                        vec![SqlParam::text(system), SqlParam::text(code)],
+                    )
+                }
+                None => {
+                    next += 1;
+                    (
+                        format!("idx.value_token_code = ${next}"),
+                        vec![SqlParam::text(&value.value)],
+                    )
+                }
+            };
+            conditions.push(SqlFragment::with_params(
+                format!(
+                    "id IN (SELECT ref.resource_id FROM search_index ref \
+                     WHERE ref.tenant_id = $1 AND ref.resource_type = $2 AND ref.param_name = '{}' \
+                     AND EXISTS (SELECT 1 FROM search_index idx \
+                       WHERE idx.tenant_id = $1 AND idx.param_name = 'identifier' \
+                       AND {target} AND {filter}))",
+                    param.name
+                ),
+                params,
+            ));
+        }
+
+        if conditions.is_empty() {
+            return None;
+        }
+        let mut combined = conditions.remove(0);
+        for cond in conditions {
+            combined = combined.or(cond);
+        }
+        Some(combined)
+    }
+
     fn build_reference_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
+        if matches!(param.modifier.as_ref(), Some(SearchModifier::Identifier)) {
+            return Self::build_reference_identifier_condition(param, offset);
+        }
+
         let mut conditions = Vec::new();
         // :contains - case-insensitive substring on the stored reference.
         // :text (contains) / :code-text (starts-with) match the indexed

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -805,13 +805,20 @@ impl PostgresQueryBuilder {
 
     fn build_reference_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
         let mut conditions = Vec::new();
+        // :contains - case-insensitive substring match on the stored reference.
+        let is_contains = matches!(param.modifier.as_ref(), Some(SearchModifier::Contains));
 
         for (i, value) in param.values.iter().enumerate() {
             let param_num = offset + i + 1;
+            let predicate = if is_contains {
+                format!("value_reference ILIKE '%' || ${} || '%'", param_num)
+            } else {
+                format!("value_reference = ${}", param_num)
+            };
             conditions.push(SqlFragment::with_params(
                 format!(
-                    "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_reference = ${})",
-                    param.name, param_num
+                    "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
+                    param.name, predicate
                 ),
                 vec![SqlParam::text(&value.value)],
             ));
@@ -834,6 +841,13 @@ impl PostgresQueryBuilder {
         for (i, value) in param.values.iter().enumerate() {
             let param_num = offset + i + 1;
             let condition = match modifier {
+                Some(SearchModifier::Contains) => SqlFragment::with_params(
+                    format!(
+                        "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_uri ILIKE '%' || ${} || '%')",
+                        param.name, param_num
+                    ),
+                    vec![SqlParam::text(&value.value)],
+                ),
                 Some(SearchModifier::Below) => SqlFragment::with_params(
                     format!(
                         "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_uri LIKE ${} || '%')",

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -376,7 +376,9 @@ impl PostgresQueryBuilder {
                     ),
                     vec![SqlParam::text(&value.value)],
                 ),
-                Some(SearchModifier::Contains) => SqlFragment::with_params(
+                // `:text` on a string is a case-insensitive partial match,
+                // implemented here as a substring match (same as `:contains`).
+                Some(SearchModifier::Contains | SearchModifier::Text) => SqlFragment::with_params(
                     format!(
                         "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_string ILIKE ${})",
                         param.name, param_num

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -416,6 +416,39 @@ impl PostgresQueryBuilder {
             return Self::build_of_type_condition(param, offset);
         }
 
+        // `:text` (contains) and `:code-text` (starts-with) match the token's
+        // display text (Coding.display / CodeableConcept.text).
+        if matches!(
+            param.modifier,
+            Some(SearchModifier::Text | SearchModifier::CodeText)
+        ) {
+            let starts_with = matches!(param.modifier, Some(SearchModifier::CodeText));
+            let mut conditions = Vec::new();
+            for (i, value) in param.values.iter().enumerate() {
+                let param_num = offset + i + 1;
+                let pattern = if starts_with {
+                    format!("{}%", value.value)
+                } else {
+                    format!("%{}%", value.value)
+                };
+                conditions.push(SqlFragment::with_params(
+                    format!(
+                        "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_token_display ILIKE ${})",
+                        param.name, param_num
+                    ),
+                    vec![SqlParam::text(&pattern)],
+                ));
+            }
+            if conditions.is_empty() {
+                return None;
+            }
+            let mut combined = conditions.remove(0);
+            for cond in conditions {
+                combined = combined.or(cond);
+            }
+            return Some(combined);
+        }
+
         let mut conditions = Vec::new();
 
         for (i, value) in param.values.iter().enumerate() {

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -840,12 +840,21 @@ impl PostgresQueryBuilder {
 
     fn build_reference_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
         let mut conditions = Vec::new();
-        // :contains - case-insensitive substring match on the stored reference.
-        let is_contains = matches!(param.modifier.as_ref(), Some(SearchModifier::Contains));
+        // :contains - case-insensitive substring on the stored reference.
+        // :text (contains) / :code-text (starts-with) match the indexed
+        // Reference.display text.
+        let modifier = param.modifier.as_ref();
+        let is_contains = matches!(modifier, Some(SearchModifier::Contains));
+        let is_text = matches!(modifier, Some(SearchModifier::Text));
+        let is_code_text = matches!(modifier, Some(SearchModifier::CodeText));
 
         for (i, value) in param.values.iter().enumerate() {
             let param_num = offset + i + 1;
-            let predicate = if is_contains {
+            let predicate = if is_text {
+                format!("value_reference_display ILIKE '%' || ${} || '%'", param_num)
+            } else if is_code_text {
+                format!("value_reference_display ILIKE ${} || '%'", param_num)
+            } else if is_contains {
                 format!("value_reference ILIKE '%' || ${} || '%'", param_num)
             } else {
                 format!("value_reference = ${}", param_num)

--- a/crates/persistence/src/backends/postgres/search/writer.rs
+++ b/crates/persistence/src/backends/postgres/search/writer.rs
@@ -171,13 +171,14 @@ impl PostgresSearchIndexWriter {
                 reference,
                 resource_type: _,
                 resource_id: _,
+                display,
             } => {
                 client
                     .execute(
                         "INSERT INTO search_index (
                             tenant_id, resource_type, resource_id, param_name, param_url,
-                            value_reference, composite_group
-                        ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                            value_reference, composite_group, value_reference_display
+                        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                         &[
                             &tenant_id,
                             &resource_type,
@@ -186,6 +187,7 @@ impl PostgresSearchIndexWriter {
                             &extracted.param_url.as_str(),
                             &reference.as_str(),
                             &extracted.composite_group.map(|g| g as i32),
+                            &display.as_deref(),
                         ],
                     )
                     .await

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -707,11 +707,11 @@ impl SqliteBackend {
                 "text-advanced",
                 "missing",
             ],
-            SearchParamType::Reference => vec!["identifier", "missing"],
+            SearchParamType::Reference => vec!["identifier", "contains", "missing"],
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],
-            SearchParamType::Uri => vec!["below", "above", "missing"],
+            SearchParamType::Uri => vec!["contains", "below", "above", "missing"],
             SearchParamType::Composite => vec!["missing"],
             SearchParamType::Special => vec![],
         }

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -694,7 +694,19 @@ impl SqliteBackend {
     fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
             SearchParamType::String => vec!["exact", "contains", "missing"],
-            SearchParamType::Token => vec!["not", "text", "in", "not-in", "of-type", "missing"],
+            // `not-in` is intentionally omitted: the SQLite backend returns 501
+            // for it (negated value-set filtering is unimplemented), so it must
+            // not be advertised. `code`/`text-advanced` are implemented by the
+            // token handler and were previously under-advertised.
+            SearchParamType::Token => vec![
+                "not",
+                "text",
+                "in",
+                "of-type",
+                "code",
+                "text-advanced",
+                "missing",
+            ],
             SearchParamType::Reference => vec!["identifier", "missing"],
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
@@ -813,6 +825,11 @@ mod tests {
         let token_mods = SqliteBackend::modifiers_for_type(SearchParamType::Token);
         assert!(token_mods.contains(&"not"));
         assert!(token_mods.contains(&"text"));
+        assert!(token_mods.contains(&"of-type"));
+        assert!(token_mods.contains(&"code"));
+        assert!(token_mods.contains(&"text-advanced"));
+        // `not-in` returns 501, so it must not be advertised as supported.
+        assert!(!token_mods.contains(&"not-in"));
 
         // Reference modifiers
         let ref_mods = SqliteBackend::modifiers_for_type(SearchParamType::Reference);

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -708,7 +708,9 @@ impl SqliteBackend {
                 "text-advanced",
                 "missing",
             ],
-            SearchParamType::Reference => vec!["identifier", "contains", "missing"],
+            SearchParamType::Reference => {
+                vec!["identifier", "contains", "text", "code-text", "missing"]
+            }
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -693,7 +693,7 @@ impl SqliteBackend {
     /// Returns supported modifiers for a parameter type.
     fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
-            SearchParamType::String => vec!["exact", "contains", "missing"],
+            SearchParamType::String => vec!["exact", "contains", "text", "missing"],
             // `not-in` is intentionally omitted: the SQLite backend returns 501
             // for it (negated value-set filtering is unimplemented), so it must
             // not be advertised. `code`/`text-advanced` are implemented by the
@@ -819,6 +819,7 @@ mod tests {
         let string_mods = SqliteBackend::modifiers_for_type(SearchParamType::String);
         assert!(string_mods.contains(&"exact"));
         assert!(string_mods.contains(&"contains"));
+        assert!(string_mods.contains(&"text"));
         assert!(string_mods.contains(&"missing"));
 
         // Token modifiers

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -708,9 +708,15 @@ impl SqliteBackend {
                 "text-advanced",
                 "missing",
             ],
-            SearchParamType::Reference => {
-                vec!["identifier", "contains", "text", "code-text", "missing"]
-            }
+            SearchParamType::Reference => vec![
+                "identifier",
+                "contains",
+                "text",
+                "code-text",
+                "below",
+                "above",
+                "missing",
+            ],
             SearchParamType::Date => vec!["missing"],
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -704,6 +704,7 @@ impl SqliteBackend {
                 "in",
                 "of-type",
                 "code",
+                "code-text",
                 "text-advanced",
                 "missing",
             ],

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use crate::error::StorageResult;
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 8;
+pub const SCHEMA_VERSION: i32 = 9;
 
 /// Initialize the database schema.
 pub fn initialize_schema(conn: &Connection) -> StorageResult<()> {
@@ -148,6 +148,7 @@ fn create_schema_v1(conn: &Connection) -> StorageResult<()> {
             composite_group INTEGER,
             value_identifier_type_system TEXT,
             value_identifier_type_code TEXT,
+            value_reference_display TEXT,
             FOREIGN KEY (tenant_id, resource_type, resource_id)
                 REFERENCES resources(tenant_id, resource_type, id) ON DELETE CASCADE
         )",
@@ -264,6 +265,7 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> StorageResult<()> {
             5 => migrate_v5_to_v6(conn)?,
             6 => migrate_v6_to_v7(conn)?,
             7 => migrate_v7_to_v8(conn)?,
+            8 => migrate_v8_to_v9(conn)?,
             _ => {
                 return Err(crate::error::StorageError::Backend(
                     crate::error::BackendError::Internal {
@@ -941,6 +943,25 @@ fn migrate_v7_to_v8(conn: &Connection) -> StorageResult<()> {
             .map_err(|e| migration_err(format!("create index: {e}")))?;
     }
 
+    Ok(())
+}
+
+/// v8 → v9: add `value_reference_display` for reference text modifiers
+/// (`:text`/`:code-text`/`:text-advanced` on reference params). Additive and
+/// nullable; existing rows stay NULL until the resource is reindexed.
+fn migrate_v8_to_v9(conn: &Connection) -> StorageResult<()> {
+    // SQLite has no `ADD COLUMN IF NOT EXISTS`; the column may already exist if
+    // the table was created fresh at v9, so ignore a duplicate-column error.
+    let _ = conn.execute(
+        "ALTER TABLE search_index ADD COLUMN value_reference_display TEXT",
+        [],
+    );
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_search_reference_display
+         ON search_index(tenant_id, resource_type, param_name, value_reference_display)",
+        [],
+    )
+    .map_err(|e| migration_err(format!("create reference_display index: {e}")))?;
     Ok(())
 }
 

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
@@ -40,6 +40,27 @@ impl ReferenceHandler {
             );
         }
 
+        // Handle :text (contains) and :code-text (starts-with) on the indexed
+        // Reference.display text.
+        if matches!(modifier, Some(SearchModifier::Text)) {
+            return SqlFragment::with_params(
+                format!(
+                    "value_reference_display COLLATE NOCASE LIKE '%' || ?{} || '%'",
+                    param_num
+                ),
+                vec![SqlParam::string(value.value.to_lowercase())],
+            );
+        }
+        if matches!(modifier, Some(SearchModifier::CodeText)) {
+            return SqlFragment::with_params(
+                format!(
+                    "value_reference_display COLLATE NOCASE LIKE ?{} || '%'",
+                    param_num
+                ),
+                vec![SqlParam::string(value.value.to_lowercase())],
+            );
+        }
+
         // Handle :Type modifier (restrict to specific resource type)
         if let Some(SearchModifier::Type(type_name)) = modifier {
             // The reference must be to the specified type
@@ -187,6 +208,23 @@ mod tests {
         assert!(frag.sql.contains("value_reference LIKE '%' ||"));
         assert!(frag.sql.contains("|| '%'"));
         assert_eq!(frag.params.len(), 1);
+    }
+
+    #[test]
+    fn test_reference_text_modifier() {
+        let value = SearchValue::new(SearchPrefix::Eq, "John");
+        let frag = ReferenceHandler::build_sql(&value, Some(&SearchModifier::Text), 0);
+        assert!(frag.sql.contains("value_reference_display"));
+        assert!(frag.sql.contains("'%' || ?1 || '%'"));
+    }
+
+    #[test]
+    fn test_reference_code_text_modifier() {
+        let value = SearchValue::new(SearchPrefix::Eq, "John");
+        let frag = ReferenceHandler::build_sql(&value, Some(&SearchModifier::CodeText), 0);
+        assert!(frag.sql.contains("value_reference_display"));
+        // starts-with: no leading '%'
+        assert!(frag.sql.contains("LIKE ?1 || '%'"));
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
@@ -61,6 +61,31 @@ impl ReferenceHandler {
             );
         }
 
+        // :below / :above - URL/path-prefix hierarchy on the reference value
+        // (e.g. an absolute/canonical reference URL). Mirrors uri :below/:above
+        // (two placeholders, two bound params). Note: canonical `|version`
+        // comparison is not implemented.
+        if matches!(modifier, Some(SearchModifier::Below)) {
+            return SqlFragment::with_params(
+                format!(
+                    "(value_reference = ?{} OR value_reference LIKE ?{} || '/%')",
+                    param_num,
+                    param_num + 1
+                ),
+                vec![SqlParam::string(ref_value), SqlParam::string(ref_value)],
+            );
+        }
+        if matches!(modifier, Some(SearchModifier::Above)) {
+            return SqlFragment::with_params(
+                format!(
+                    "(?{} = value_reference OR ?{} LIKE value_reference || '/%')",
+                    param_num,
+                    param_num + 1
+                ),
+                vec![SqlParam::string(ref_value), SqlParam::string(ref_value)],
+            );
+        }
+
         // Handle :Type modifier (restrict to specific resource type)
         if let Some(SearchModifier::Type(type_name)) = modifier {
             // The reference must be to the specified type
@@ -225,6 +250,24 @@ mod tests {
         assert!(frag.sql.contains("value_reference_display"));
         // starts-with: no leading '%'
         assert!(frag.sql.contains("LIKE ?1 || '%'"));
+    }
+
+    #[test]
+    fn test_reference_below_modifier() {
+        let value = SearchValue::new(SearchPrefix::Eq, "http://x.org/Questionnaire/q");
+        let frag = ReferenceHandler::build_sql(&value, Some(&SearchModifier::Below), 0);
+        assert!(frag.sql.contains("value_reference = ?1"));
+        assert!(frag.sql.contains("LIKE ?2 || '/%'"));
+        assert_eq!(frag.params.len(), 2);
+    }
+
+    #[test]
+    fn test_reference_above_modifier() {
+        let value = SearchValue::new(SearchPrefix::Eq, "http://x.org/Questionnaire/q");
+        let frag = ReferenceHandler::build_sql(&value, Some(&SearchModifier::Above), 0);
+        assert!(frag.sql.contains("?1 = value_reference"));
+        assert!(frag.sql.contains("?2 LIKE value_reference || '/%'"));
+        assert_eq!(frag.params.len(), 2);
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
@@ -31,6 +31,15 @@ impl ReferenceHandler {
             return Self::build_identifier_condition(ref_value, param_num);
         }
 
+        // Handle :contains modifier - case-insensitive substring match on the
+        // stored reference string (e.g. "Patient/123" contains "23").
+        if matches!(modifier, Some(SearchModifier::Contains)) {
+            return SqlFragment::with_params(
+                format!("value_reference LIKE '%' || ?{} || '%'", param_num),
+                vec![SqlParam::string(ref_value)],
+            );
+        }
+
         // Handle :Type modifier (restrict to specific resource type)
         if let Some(SearchModifier::Type(type_name)) = modifier {
             // The reference must be to the specified type
@@ -168,6 +177,16 @@ mod tests {
 
         assert!(frag.sql.contains("value_reference = ?1"));
         // The param should be "Patient/123"
+    }
+
+    #[test]
+    fn test_reference_contains_modifier() {
+        let value = SearchValue::new(SearchPrefix::Eq, "123");
+        let frag = ReferenceHandler::build_sql(&value, Some(&SearchModifier::Contains), 0);
+
+        assert!(frag.sql.contains("value_reference LIKE '%' ||"));
+        assert!(frag.sql.contains("|| '%'"));
+        assert_eq!(frag.params.len(), 1);
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/token.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/token.rs
@@ -43,6 +43,19 @@ impl TokenHandler {
             );
         }
 
+        // Handle :code-text modifier - case-insensitive starts-with match on the
+        // display text (Coding.display, CodeableConcept.text). Distinct from
+        // :text, which is a substring/contains match.
+        if matches!(modifier, Some(SearchModifier::CodeText)) {
+            return SqlFragment::with_params(
+                format!(
+                    "value_token_display COLLATE NOCASE LIKE ?{} || '%'",
+                    param_num
+                ),
+                vec![SqlParam::string(value.value.to_lowercase())],
+            );
+        }
+
         // Handle :text-advanced modifier - FTS5-based advanced text search
         // Supports boolean operators (AND, OR, NOT), phrase matching, prefix search, and NEAR
         if matches!(modifier, Some(SearchModifier::TextAdvanced)) {
@@ -266,6 +279,21 @@ mod tests {
         let frag = TokenHandler::build_sql(&value, Some(&SearchModifier::Not), 0);
 
         assert!(frag.sql.starts_with("NOT ("));
+    }
+
+    #[test]
+    fn test_code_text_starts_with_display() {
+        // :code-text is a case-insensitive starts-with match on the display.
+        let value = SearchValue::new(SearchPrefix::Eq, "Heart");
+        let frag = TokenHandler::build_sql(&value, Some(&SearchModifier::CodeText), 0);
+
+        assert!(
+            frag.sql
+                .contains("value_token_display COLLATE NOCASE LIKE ?1 || '%'")
+        );
+        // No leading '%': starts-with, not contains.
+        assert!(!frag.sql.contains("'%' || ?1"));
+        assert_eq!(frag.params.len(), 1);
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/uri.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/uri.rs
@@ -24,6 +24,13 @@ impl UriHandler {
         let uri_value = &value.value;
 
         match modifier {
+            Some(SearchModifier::Contains) => {
+                // :contains - case-insensitive substring match on the URI.
+                SqlFragment::with_params(
+                    format!("value_uri LIKE '%' || ?{} || '%'", param_num),
+                    vec![SqlParam::string(uri_value)],
+                )
+            }
             Some(SearchModifier::Below) => {
                 // Below: match the URI or any URI that starts with it
                 // For "http://example.org", matches "http://example.org" and "http://example.org/foo"
@@ -70,6 +77,16 @@ mod tests {
         let frag = UriHandler::build_sql(&value, None, 0);
 
         assert!(frag.sql.contains("value_uri = ?1"));
+        assert_eq!(frag.params.len(), 1);
+    }
+
+    #[test]
+    fn test_uri_contains() {
+        let value = SearchValue::new(SearchPrefix::Eq, "example.org");
+        let frag = UriHandler::build_sql(&value, Some(&SearchModifier::Contains), 0);
+
+        assert!(frag.sql.contains("LIKE '%' ||"));
+        assert!(frag.sql.contains("|| '%'"));
         assert_eq!(frag.params.len(), 1);
     }
 

--- a/crates/persistence/src/backends/sqlite/search/writer.rs
+++ b/crates/persistence/src/backends/sqlite/search/writer.rs
@@ -266,7 +266,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Patient", "123", &extracted);
 
-        assert_eq!(params.len(), 20); // Updated for new columns
+        assert_eq!(params.len(), 21); // Updated for new columns
         assert!(matches!(&params[0], SqlValue::String(s) if s == "tenant1"));
         assert!(matches!(&params[5], SqlValue::OptString(Some(s)) if s == "Smith"));
     }
@@ -290,7 +290,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Patient", "123", &extracted);
 
-        assert_eq!(params.len(), 20); // Updated for new columns
+        assert_eq!(params.len(), 21); // Updated for new columns
         assert!(matches!(&params[6], SqlValue::OptString(Some(s)) if s == "http://example.org"));
         assert!(matches!(&params[7], SqlValue::String(s) if s == "12345"));
     }
@@ -314,7 +314,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Observation", "123", &extracted);
 
-        assert_eq!(params.len(), 20);
+        assert_eq!(params.len(), 21);
         assert!(matches!(&params[8], SqlValue::OptString(Some(s)) if s == "Test Display")); // value_token_display
     }
 
@@ -339,7 +339,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Patient", "123", &extracted);
 
-        assert_eq!(params.len(), 20);
+        assert_eq!(params.len(), 21);
         // value_identifier_type_system is at index 18
         assert!(
             matches!(&params[18], SqlValue::OptString(Some(s)) if s == "http://terminology.hl7.org/CodeSystem/v2-0203")

--- a/crates/persistence/src/backends/sqlite/search/writer.rs
+++ b/crates/persistence/src/backends/sqlite/search/writer.rs
@@ -20,14 +20,16 @@ impl SqliteSearchIndexWriter {
             value_date, value_date_precision,
             value_number, value_quantity_value, value_quantity_unit, value_quantity_system,
             value_reference, value_uri, composite_group,
-            value_identifier_type_system, value_identifier_type_code
+            value_identifier_type_system, value_identifier_type_code,
+            value_reference_display
         ) VALUES (
             ?1, ?2, ?3, ?4, ?5,
             ?6, ?7, ?8, ?9,
             ?10, ?11,
             ?12, ?13, ?14, ?15,
             ?16, ?17, ?18,
-            ?19, ?20
+            ?19, ?20,
+            ?21
         )
         "#
     }
@@ -58,6 +60,10 @@ impl SqliteSearchIndexWriter {
             SqlValue::String(extracted.param_name.clone()),
             SqlValue::String(extracted.param_url.clone()),
         ];
+
+        // `value_reference_display` is appended as the final column; capture it
+        // here so the common tail (and the Token early-return) can emit it.
+        let mut reference_display: Option<String> = None;
 
         // Add value columns based on the IndexValue type
         match &extracted.value {
@@ -99,6 +105,7 @@ impl SqliteSearchIndexWriter {
                 )); // composite_group
                 params.push(SqlValue::OptString(identifier_type_system.clone())); // value_identifier_type_system
                 params.push(SqlValue::OptString(identifier_type_code.clone())); // value_identifier_type_code
+                params.push(SqlValue::Null); // value_reference_display
                 return params;
             }
             IndexValue::Date { value, precision } => {
@@ -152,7 +159,9 @@ impl SqliteSearchIndexWriter {
                 reference,
                 resource_type: _,
                 resource_id: _,
+                display,
             } => {
+                reference_display = display.clone();
                 params.push(SqlValue::Null); // value_string
                 params.push(SqlValue::Null); // value_token_system
                 params.push(SqlValue::Null); // value_token_code
@@ -188,6 +197,7 @@ impl SqliteSearchIndexWriter {
         )); // composite_group
         params.push(SqlValue::Null); // value_identifier_type_system
         params.push(SqlValue::Null); // value_identifier_type_code
+        params.push(SqlValue::OptString(reference_display)); // value_reference_display
 
         params
     }

--- a/crates/persistence/src/search/converters.rs
+++ b/crates/persistence/src/search/converters.rs
@@ -61,6 +61,9 @@ pub enum IndexValue {
         resource_type: Option<String>,
         /// Resource ID if extractable.
         resource_id: Option<String>,
+        /// Display text (`Reference.display`), for the `:text`/`:code-text`/
+        /// `:text-advanced` modifiers on reference parameters.
+        display: Option<String>,
     },
 
     /// URI value.
@@ -160,8 +163,13 @@ impl IndexValue {
         }
     }
 
-    /// Creates a reference index value.
+    /// Creates a reference index value (no display text).
     pub fn reference(reference: impl Into<String>) -> Self {
+        Self::reference_with_display(reference, None)
+    }
+
+    /// Creates a reference index value with optional `Reference.display` text.
+    pub fn reference_with_display(reference: impl Into<String>, display: Option<String>) -> Self {
         let reference = reference.into();
         let (resource_type, resource_id) = parse_reference(&reference);
 
@@ -169,6 +177,7 @@ impl IndexValue {
             reference,
             resource_type,
             resource_id,
+            display,
         }
     }
 
@@ -534,7 +543,11 @@ impl ValueConverter {
             }
             Value::Object(obj) => {
                 if let Some(reference) = obj.get("reference").and_then(|v| v.as_str()) {
-                    results.push(IndexValue::reference(reference));
+                    let display = obj
+                        .get("display")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    results.push(IndexValue::reference_with_display(reference, display));
                 }
             }
             _ => {}
@@ -732,7 +745,8 @@ mod tests {
     #[test]
     fn test_convert_reference_object() {
         let value = json!({
-            "reference": "Patient/123"
+            "reference": "Patient/123",
+            "display": "John Smith"
         });
         let results =
             ValueConverter::convert(&value, SearchParamType::Reference, "subject").unwrap();
@@ -742,11 +756,13 @@ mod tests {
             reference,
             resource_type,
             resource_id,
+            display,
         } = &results[0]
         {
             assert_eq!(reference, "Patient/123");
             assert_eq!(resource_type.as_ref().unwrap(), "Patient");
             assert_eq!(resource_id.as_ref().unwrap(), "123");
+            assert_eq!(display.as_ref().unwrap(), "John Smith");
         }
     }
 

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -198,12 +198,16 @@ impl SearchModifier {
             // token; advertising it for other types was incorrect.
             SearchModifier::Not => param_type == SearchParamType::Token,
             SearchModifier::Missing => true, // Valid for all types
-            SearchModifier::Above
-            | SearchModifier::Below
-            | SearchModifier::In
-            | SearchModifier::NotIn => {
-                param_type == SearchParamType::Token || param_type == SearchParamType::Uri
+            // `:above`/`:below` are defined for token and uri (the spec also
+            // lists reference, a niche canonical-hierarchy case not yet
+            // implemented).
+            SearchModifier::Above | SearchModifier::Below => {
+                matches!(param_type, SearchParamType::Token | SearchParamType::Uri)
             }
+            // `:in`/`:not-in` are token-only per the FHIR spec. (`:not-in`
+            // itself returns 501 at the REST layer — negated value-set
+            // filtering is unimplemented.)
+            SearchModifier::In | SearchModifier::NotIn => param_type == SearchParamType::Token,
             SearchModifier::Identifier | SearchModifier::Type(_) => {
                 param_type == SearchParamType::Reference
             }
@@ -859,6 +863,14 @@ mod tests {
         // `:missing` is valid for every parameter type.
         assert!(SearchModifier::Missing.is_valid_for(SearchParamType::String));
         assert!(SearchModifier::Missing.is_valid_for(SearchParamType::Reference));
+        // `:in`/`:not-in` are token-only per the FHIR spec (not uri).
+        assert!(SearchModifier::In.is_valid_for(SearchParamType::Token));
+        assert!(!SearchModifier::In.is_valid_for(SearchParamType::Uri));
+        assert!(SearchModifier::NotIn.is_valid_for(SearchParamType::Token));
+        assert!(!SearchModifier::NotIn.is_valid_for(SearchParamType::Uri));
+        // `:above`/`:below` remain valid for token and uri.
+        assert!(SearchModifier::Above.is_valid_for(SearchParamType::Uri));
+        assert!(SearchModifier::Below.is_valid_for(SearchParamType::Token));
     }
 
     #[test]

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -180,9 +180,13 @@ impl SearchModifier {
     /// Returns true if this modifier is valid for the given parameter type.
     pub fn is_valid_for(&self, param_type: SearchParamType) -> bool {
         match self {
-            SearchModifier::Exact | SearchModifier::Contains => {
-                param_type == SearchParamType::String
-            }
+            SearchModifier::Exact => param_type == SearchParamType::String,
+            // Per the FHIR spec, `:contains` is defined for string, reference,
+            // and uri parameters (substring/containment match).
+            SearchModifier::Contains => matches!(
+                param_type,
+                SearchParamType::String | SearchParamType::Reference | SearchParamType::Uri
+            ),
             SearchModifier::Text => param_type == SearchParamType::Token,
             // Per the FHIR spec, `:not` is only defined for token parameters
             // (it negates a code match). Our backends only implement it for
@@ -830,6 +834,11 @@ mod tests {
     fn test_search_modifier_validity() {
         assert!(SearchModifier::Exact.is_valid_for(SearchParamType::String));
         assert!(!SearchModifier::Exact.is_valid_for(SearchParamType::Token));
+        // `:contains` is valid for string, reference, and uri (FHIR spec).
+        assert!(SearchModifier::Contains.is_valid_for(SearchParamType::String));
+        assert!(SearchModifier::Contains.is_valid_for(SearchParamType::Reference));
+        assert!(SearchModifier::Contains.is_valid_for(SearchParamType::Uri));
+        assert!(!SearchModifier::Contains.is_valid_for(SearchParamType::Token));
         assert!(SearchModifier::Text.is_valid_for(SearchParamType::Token));
         // `:not` is token-only per the FHIR spec.
         assert!(SearchModifier::Not.is_valid_for(SearchParamType::Token));

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -198,12 +198,13 @@ impl SearchModifier {
             // token; advertising it for other types was incorrect.
             SearchModifier::Not => param_type == SearchParamType::Token,
             SearchModifier::Missing => true, // Valid for all types
-            // `:above`/`:below` are defined for token and uri (the spec also
-            // lists reference, a niche canonical-hierarchy case not yet
-            // implemented).
-            SearchModifier::Above | SearchModifier::Below => {
-                matches!(param_type, SearchParamType::Token | SearchParamType::Uri)
-            }
+            // `:above`/`:below` are defined for token, uri, and reference.
+            // Reference uses URL/path-prefix hierarchy (canonical `|version`
+            // comparison is not implemented).
+            SearchModifier::Above | SearchModifier::Below => matches!(
+                param_type,
+                SearchParamType::Token | SearchParamType::Uri | SearchParamType::Reference
+            ),
             // `:in`/`:not-in` are token-only per the FHIR spec. (`:not-in`
             // itself returns 501 at the REST layer — negated value-set
             // filtering is unimplemented.)
@@ -868,9 +869,12 @@ mod tests {
         assert!(!SearchModifier::In.is_valid_for(SearchParamType::Uri));
         assert!(SearchModifier::NotIn.is_valid_for(SearchParamType::Token));
         assert!(!SearchModifier::NotIn.is_valid_for(SearchParamType::Uri));
-        // `:above`/`:below` remain valid for token and uri.
+        // `:above`/`:below` are valid for token, uri, and reference.
         assert!(SearchModifier::Above.is_valid_for(SearchParamType::Uri));
         assert!(SearchModifier::Below.is_valid_for(SearchParamType::Token));
+        assert!(SearchModifier::Above.is_valid_for(SearchParamType::Reference));
+        assert!(SearchModifier::Below.is_valid_for(SearchParamType::Reference));
+        assert!(!SearchModifier::Above.is_valid_for(SearchParamType::String));
     }
 
     #[test]

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -187,7 +187,12 @@ impl SearchModifier {
                 param_type,
                 SearchParamType::String | SearchParamType::Reference | SearchParamType::Uri
             ),
-            SearchModifier::Text => param_type == SearchParamType::Token,
+            // Per the FHIR spec, `:text` is defined for string, token, and
+            // reference params. Reference `:text` (matching `Reference.display`)
+            // is not yet implemented; string and token are.
+            SearchModifier::Text => {
+                matches!(param_type, SearchParamType::String | SearchParamType::Token)
+            }
             // Per the FHIR spec, `:not` is only defined for token parameters
             // (it negates a code match). Our backends only implement it for
             // token; advertising it for other types was incorrect.
@@ -840,6 +845,9 @@ mod tests {
         assert!(SearchModifier::Contains.is_valid_for(SearchParamType::Uri));
         assert!(!SearchModifier::Contains.is_valid_for(SearchParamType::Token));
         assert!(SearchModifier::Text.is_valid_for(SearchParamType::Token));
+        // `:text` is valid for string and token (FHIR spec).
+        assert!(SearchModifier::Text.is_valid_for(SearchParamType::String));
+        assert!(!SearchModifier::Text.is_valid_for(SearchParamType::Uri));
         // `:not` is token-only per the FHIR spec.
         assert!(SearchModifier::Not.is_valid_for(SearchParamType::Token));
         assert!(!SearchModifier::Not.is_valid_for(SearchParamType::String));

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -158,7 +158,10 @@ impl SearchModifier {
             "in" => Some(SearchModifier::In),
             "not-in" => Some(SearchModifier::NotIn),
             "identifier" => Some(SearchModifier::Identifier),
-            "oftype" => Some(SearchModifier::OfType),
+            // The FHIR spec (build.fhir.org) spells this `of-type`, and that is
+            // the form advertised in our CapabilityStatement; accept the legacy
+            // camelCase `ofType` too so older clients keep working.
+            "of-type" | "oftype" => Some(SearchModifier::OfType),
             "code" => Some(SearchModifier::CodeOnly),
             "iterate" => Some(SearchModifier::Iterate),
             "text-advanced" => Some(SearchModifier::TextAdvanced),
@@ -806,6 +809,16 @@ mod tests {
         assert_eq!(
             SearchModifier::parse("Patient"),
             Some(SearchModifier::Type("Patient".to_string()))
+        );
+        // Both the spec/CapabilityStatement spelling (`of-type`) and the legacy
+        // camelCase (`ofType`) must parse to the same modifier.
+        assert_eq!(
+            SearchModifier::parse("of-type"),
+            Some(SearchModifier::OfType)
+        );
+        assert_eq!(
+            SearchModifier::parse("ofType"),
+            Some(SearchModifier::OfType)
         );
         assert_eq!(SearchModifier::parse("unknown"), None);
     }

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -188,11 +188,11 @@ impl SearchModifier {
                 SearchParamType::String | SearchParamType::Reference | SearchParamType::Uri
             ),
             // Per the FHIR spec, `:text` is defined for string, token, and
-            // reference params. Reference `:text` (matching `Reference.display`)
-            // is not yet implemented; string and token are.
-            SearchModifier::Text => {
-                matches!(param_type, SearchParamType::String | SearchParamType::Token)
-            }
+            // reference params (reference matches the indexed `Reference.display`).
+            SearchModifier::Text => matches!(
+                param_type,
+                SearchParamType::String | SearchParamType::Token | SearchParamType::Reference
+            ),
             // Per the FHIR spec, `:not` is only defined for token parameters
             // (it negates a code match). Our backends only implement it for
             // token; advertising it for other types was incorrect.
@@ -213,7 +213,12 @@ impl SearchModifier {
             SearchModifier::TextAdvanced => {
                 param_type == SearchParamType::String || param_type == SearchParamType::Token
             }
-            SearchModifier::CodeText => param_type == SearchParamType::Token,
+            // `:code-text` is defined for token and reference params (matches a
+            // code's display, or the indexed `Reference.display`).
+            SearchModifier::CodeText => matches!(
+                param_type,
+                SearchParamType::Token | SearchParamType::Reference
+            ),
         }
     }
 }

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -184,7 +184,10 @@ impl SearchModifier {
                 param_type == SearchParamType::String
             }
             SearchModifier::Text => param_type == SearchParamType::Token,
-            SearchModifier::Not => true,     // Valid for all types
+            // Per the FHIR spec, `:not` is only defined for token parameters
+            // (it negates a code match). Our backends only implement it for
+            // token; advertising it for other types was incorrect.
+            SearchModifier::Not => param_type == SearchParamType::Token,
             SearchModifier::Missing => true, // Valid for all types
             SearchModifier::Above
             | SearchModifier::Below
@@ -828,8 +831,12 @@ mod tests {
         assert!(SearchModifier::Exact.is_valid_for(SearchParamType::String));
         assert!(!SearchModifier::Exact.is_valid_for(SearchParamType::Token));
         assert!(SearchModifier::Text.is_valid_for(SearchParamType::Token));
-        assert!(SearchModifier::Not.is_valid_for(SearchParamType::String));
+        // `:not` is token-only per the FHIR spec.
         assert!(SearchModifier::Not.is_valid_for(SearchParamType::Token));
+        assert!(!SearchModifier::Not.is_valid_for(SearchParamType::String));
+        // `:missing` is valid for every parameter type.
+        assert!(SearchModifier::Missing.is_valid_for(SearchParamType::String));
+        assert!(SearchModifier::Missing.is_valid_for(SearchParamType::Reference));
     }
 
     #[test]

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -206,6 +206,60 @@ mod query_builder_tests {
     }
 
     #[test]
+    fn test_token_parameter_code_text() {
+        use helios_persistence::types::SearchModifier;
+
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "code".to_string(),
+            param_type: SearchParamType::Token,
+            modifier: Some(SearchModifier::CodeText),
+            values: vec![SearchValue::eq("Heart")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = PostgresQueryBuilder::build_search_query(&query, 2);
+        assert!(result.is_some());
+        let fragment = result.unwrap();
+        assert!(fragment.sql.contains("value_token_display ILIKE"));
+        // starts-with: param is "Heart%"
+        match &fragment.params[0] {
+            SqlParam::Text(s) => {
+                assert!(!s.starts_with('%'));
+                assert!(s.ends_with('%'));
+            }
+            _ => panic!("Expected Text param"),
+        }
+    }
+
+    #[test]
+    fn test_token_parameter_text_contains() {
+        use helios_persistence::types::SearchModifier;
+
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "code".to_string(),
+            param_type: SearchParamType::Token,
+            modifier: Some(SearchModifier::Text),
+            values: vec![SearchValue::eq("Heart")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = PostgresQueryBuilder::build_search_query(&query, 2);
+        assert!(result.is_some());
+        let fragment = result.unwrap();
+        assert!(fragment.sql.contains("value_token_display ILIKE"));
+        // contains: param is "%Heart%"
+        match &fragment.params[0] {
+            SqlParam::Text(s) => {
+                assert!(s.starts_with('%'));
+                assert!(s.ends_with('%'));
+            }
+            _ => panic!("Expected Text param"),
+        }
+    }
+
+    #[test]
     fn test_string_parameter_text() {
         use helios_persistence::types::SearchModifier;
 

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -287,6 +287,25 @@ mod query_builder_tests {
     }
 
     #[test]
+    fn test_reference_parameter_below_above() {
+        use helios_persistence::types::SearchModifier;
+
+        for modifier in [SearchModifier::Below, SearchModifier::Above] {
+            let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+                name: "subject".to_string(),
+                param_type: SearchParamType::Reference,
+                modifier: Some(modifier),
+                values: vec![SearchValue::eq("http://x.org/Questionnaire/q")],
+                chain: vec![],
+                components: vec![],
+            });
+            let fragment = PostgresQueryBuilder::build_search_query(&query, 2).unwrap();
+            assert!(fragment.sql.contains("value_reference"));
+            assert!(fragment.sql.contains("|| '/%'"));
+        }
+    }
+
+    #[test]
     fn test_reference_parameter_identifier() {
         use helios_persistence::types::SearchModifier;
 

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -287,6 +287,26 @@ mod query_builder_tests {
     }
 
     #[test]
+    fn test_reference_parameter_identifier() {
+        use helios_persistence::types::SearchModifier;
+
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: Some(SearchModifier::Identifier),
+            values: vec![SearchValue::eq("http://hospital.org|12345")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let fragment = PostgresQueryBuilder::build_search_query(&query, 2).unwrap();
+        // Correlated subquery against the target's 'identifier' index rows.
+        assert!(fragment.sql.contains("param_name = 'identifier'"));
+        assert!(fragment.sql.contains("idx.value_token_system"));
+        assert!(fragment.sql.contains("idx.value_token_code"));
+    }
+
+    #[test]
     fn test_uri_parameter_contains() {
         use helios_persistence::types::SearchModifier;
 
@@ -2601,6 +2621,77 @@ mod postgres_integration {
         let ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
         assert!(ids.contains(&"obs-1"));
         assert!(ids.contains(&"obs-2"));
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_search_reference_identifier() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        // Patient with a known identifier, plus a decoy patient.
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "p-ident-1",
+                    "identifier": [{"system": "http://hospital.org", "value": "MRN-42"}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "p-ident-2",
+                    "identifier": [{"system": "http://hospital.org", "value": "MRN-99"}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        for (oid, pid) in [("obs-i1", "p-ident-1"), ("obs-i2", "p-ident-2")] {
+            backend
+                .create(
+                    &tenant,
+                    "Observation",
+                    json!({
+                        "resourceType": "Observation",
+                        "id": oid,
+                        "subject": {"reference": format!("Patient/{pid}")},
+                        "status": "final"
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+
+        // subject:identifier matches the observation whose subject patient has
+        // the given identifier.
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: Some(SearchModifier::Identifier),
+            values: vec![SearchValue::eq("http://hospital.org|MRN-42")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = backend.search(&tenant, &query).await.unwrap();
+        let ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+        assert_eq!(ids, vec!["obs-i1"]);
     }
 
     #[tokio::test]

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -306,6 +306,33 @@ mod query_builder_tests {
     }
 
     #[test]
+    fn test_reference_parameter_text_and_code_text() {
+        use helios_persistence::types::SearchModifier;
+
+        for (modifier, expect_leading_pct) in [
+            (SearchModifier::Text, true),
+            (SearchModifier::CodeText, false),
+        ] {
+            let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+                name: "subject".to_string(),
+                param_type: SearchParamType::Reference,
+                modifier: Some(modifier),
+                values: vec![SearchValue::eq("John")],
+                chain: vec![],
+                components: vec![],
+            });
+
+            let fragment = PostgresQueryBuilder::build_search_query(&query, 2).unwrap();
+            assert!(fragment.sql.contains("value_reference_display ILIKE"));
+            // :text wraps as %John%; :code-text is starts-with John%
+            assert_eq!(
+                fragment.sql.contains("'%' || $3 || '%'"),
+                expect_leading_pct
+            );
+        }
+    }
+
+    #[test]
     fn test_reference_parameter_contains() {
         use helios_persistence::types::SearchModifier;
 

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -206,6 +206,33 @@ mod query_builder_tests {
     }
 
     #[test]
+    fn test_string_parameter_text() {
+        use helios_persistence::types::SearchModifier;
+
+        let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "name".to_string(),
+            param_type: SearchParamType::String,
+            modifier: Some(SearchModifier::Text),
+            values: vec![SearchValue::eq("mit")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = PostgresQueryBuilder::build_search_query(&query, 2);
+        assert!(result.is_some());
+        let fragment = result.unwrap();
+        assert!(fragment.sql.contains("value_string ILIKE"));
+        // Substring match: param wrapped as %mit%
+        match &fragment.params[0] {
+            SqlParam::Text(s) => {
+                assert!(s.starts_with('%'));
+                assert!(s.ends_with('%'));
+            }
+            _ => panic!("Expected Text param"),
+        }
+    }
+
+    #[test]
     fn test_uri_parameter_contains() {
         use helios_persistence::types::SearchModifier;
 

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -206,6 +206,44 @@ mod query_builder_tests {
     }
 
     #[test]
+    fn test_uri_parameter_contains() {
+        use helios_persistence::types::SearchModifier;
+
+        let query = SearchQuery::new("ValueSet").with_parameter(SearchParameter {
+            name: "url".to_string(),
+            param_type: SearchParamType::Uri,
+            modifier: Some(SearchModifier::Contains),
+            values: vec![SearchValue::eq("example.org")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = PostgresQueryBuilder::build_search_query(&query, 2);
+        assert!(result.is_some());
+        let fragment = result.unwrap();
+        assert!(fragment.sql.contains("value_uri ILIKE"));
+    }
+
+    #[test]
+    fn test_reference_parameter_contains() {
+        use helios_persistence::types::SearchModifier;
+
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: Some(SearchModifier::Contains),
+            values: vec![SearchValue::eq("patient-1")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = PostgresQueryBuilder::build_search_query(&query, 2);
+        assert!(result.is_some());
+        let fragment = result.unwrap();
+        assert!(fragment.sql.contains("value_reference ILIKE"));
+    }
+
+    #[test]
     fn test_token_system_and_code() {
         let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
             name: "code".to_string(),

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -159,6 +159,29 @@ fn parse_search_parameter(
     // custom params. See `helios_persistence::search::resolve_param_type`.
     let param_type = resolve_param_type(registry, resource_type, base_name, &tentative_values);
 
+    // FHIR-spec modifier validation: reject a modifier that is not defined for
+    // this parameter's type (e.g. `:exact` on a token, `:contains` on a date)
+    // with a 400, rather than silently ignoring it. Scoped to registry-known,
+    // non-special params:
+    //   * unregistered custom params get a value-shape heuristic type, so
+    //     gating them could falsely reject a legitimate custom modifier;
+    //   * the `special` full-text params (`_text`, `_content`, …) carry
+    //     server-specific modifier semantics outside the typed modifier table.
+    // `is_valid_for` reflects what this server honors; combinations that are
+    // spec-valid but not yet implemented are enabled as their phase lands.
+    if let Some(m) = &modifier {
+        let registered = registry.get_param(resource_type, base_name).is_some()
+            || registry.get_param("Resource", base_name).is_some();
+        if registered && param_type != SearchParamType::Special && !m.is_valid_for(param_type) {
+            return Err(RestError::InvalidParameter {
+                param: name.to_string(),
+                message: format!(
+                    "search modifier ':{m}' is not supported for {param_type} parameter '{base_name}'"
+                ),
+            });
+        }
+    }
+
     let values: Vec<SearchValue> = if matches!(
         param_type,
         SearchParamType::Date | SearchParamType::Number | SearchParamType::Quantity

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -179,6 +179,19 @@ where
         state.max_page_size(),
     );
 
+    // `:not-in` requires negated value-set filtering, which no backend
+    // implements. Reject it explicitly (501) regardless of whether a terminology
+    // server is configured, rather than silently ignoring it (which would return
+    // a superset of the intended results).
+    if let Some(key) = params.keys().find(|k| k.ends_with(":not-in")) {
+        return Err(RestError::NotImplemented {
+            feature: format!(
+                "search modifier ':not-in' is not supported ({key}); \
+                 use ':in' or remove this modifier"
+            ),
+        });
+    }
+
     // Pre-process :in / :not-in modifiers via the terminology server (if configured).
     if let Some(ts_url) = state.terminology_server_url() {
         params = expand_terminology_params(params, ts_url).await?;

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -465,6 +465,25 @@ mod string_search {
     }
 
     #[tokio::test]
+    async fn test_string_search_text_modifier() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        // `:text` on a string is a case-insensitive partial match (FHIR spec
+        // allows :text on string). Previously the gate rejected it as
+        // token-only; now it matches "Smith" via the substring "mit".
+        let response = server
+            .get("/Patient?name:text=mit")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        assert!(!entries.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_modifier_invalid_for_param_type_returns_400() {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -595,6 +595,30 @@ mod reference_search {
         let entries = get_bundle_entries(&body);
         assert_eq!(entries.len(), 2);
     }
+
+    #[tokio::test]
+    async fn test_reference_search_contains_modifier() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        // `:contains` is spec-valid for reference params (substring match on the
+        // stored reference). Previously the validation gate rejected it as
+        // string-only; now it resolves and matches "Patient/patient-1".
+        let response = server
+            .get("/Observation?subject:contains=patient-1")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+
+        let entries = get_bundle_entries(&body);
+        assert!(!entries.is_empty());
+        for entry in &entries {
+            let subject = entry["resource"]["subject"]["reference"].as_str().unwrap();
+            assert!(subject.contains("patient-1"));
+        }
+    }
 }
 
 // =============================================================================

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -656,6 +656,28 @@ mod reference_search {
     }
 
     #[tokio::test]
+    async fn test_reference_search_below_modifier() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        // :below does URL/path-prefix hierarchy on the reference. "Patient"
+        // matches "Patient/patient-1" etc. (the seeded observation subjects).
+        let response = server
+            .get("/Observation?subject:below=Patient")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        assert!(!entries.is_empty());
+        for entry in &entries {
+            let subject = entry["resource"]["subject"]["reference"].as_str().unwrap();
+            assert!(subject.starts_with("Patient/"));
+        }
+    }
+
+    #[tokio::test]
     async fn test_reference_search_text_modifier_on_display() {
         let (server, backend) = create_test_server().await;
         let tenant = test_tenant();

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -638,6 +638,59 @@ mod reference_search {
             assert!(subject.contains("patient-1"));
         }
     }
+
+    #[tokio::test]
+    async fn test_reference_search_text_modifier_on_display() {
+        let (server, backend) = create_test_server().await;
+        let tenant = test_tenant();
+
+        // An Observation whose subject reference carries a display string. The
+        // extractor indexes Reference.display so :text (contains) and :code-text
+        // (starts-with) can match it.
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-display-1",
+                    "status": "final",
+                    "code": {"coding": [{"system": "http://loinc.org", "code": "8867-4"}]},
+                    "subject": {"reference": "Patient/p-xyz", "display": "Johnny Appleseed"}
+                }),
+                FhirVersion::R4,
+            )
+            .await
+            .unwrap();
+
+        // :text matches a substring of the display.
+        let response = server
+            .get("/Observation?subject:text=Appleseed")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["resource"]["id"], "obs-display-1");
+
+        // :code-text matches a prefix of the display, but not a mid-string token.
+        let prefix = server
+            .get("/Observation?subject:code-text=Johnny")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        prefix.assert_status_ok();
+        let prefix_body: Value = prefix.json();
+        assert_eq!(get_bundle_entries(&prefix_body).len(), 1);
+
+        let mid = server
+            .get("/Observation?subject:code-text=Appleseed")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        mid.assert_status_ok();
+        let mid_body: Value = mid.json();
+        assert_eq!(get_bundle_entries(&mid_body).len(), 0);
+    }
 }
 
 // =============================================================================

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -484,6 +484,22 @@ mod string_search {
     }
 
     #[tokio::test]
+    async fn test_not_in_modifier_returns_501_without_terminology_server() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        // :not-in needs negated value-set filtering, which is unimplemented; it
+        // must return 501 rather than silently returning a superset, even when
+        // no terminology server is configured.
+        let response = server
+            .get("/Observation?code:not-in=http://example.org/vs")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status(StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
     async fn test_modifier_invalid_for_param_type_returns_400() {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -463,6 +463,32 @@ mod string_search {
         let entries = get_bundle_entries(&body);
         assert!(!entries.is_empty());
     }
+
+    #[tokio::test]
+    async fn test_modifier_invalid_for_param_type_returns_400() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        // `:above` is only defined for token/uri/reference params; applying it
+        // to the string param `name` must be rejected with a 400 + invalid
+        // OperationOutcome rather than silently ignored.
+        let response = server
+            .get("/Patient?name:above=Smith")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let body: Value = response.json();
+        assert_eq!(body["resourceType"], "OperationOutcome");
+        assert_eq!(body["issue"][0]["severity"], "error");
+        assert_eq!(body["issue"][0]["code"], "invalid");
+        assert!(
+            body["issue"][0]["details"]["text"]
+                .as_str()
+                .unwrap()
+                .contains("above")
+        );
+    }
 }
 
 // =============================================================================

--- a/docs/search-modifier-spec-compliance-plan.md
+++ b/docs/search-modifier-spec-compliance-plan.md
@@ -1,0 +1,69 @@
+# Search-modifier FHIR spec-compliance plan
+
+**Branch:** `fix/search-modifier-spec-compliance`
+**Goal:** Bring `hfs` search-modifier handling into compliance with the FHIR
+search spec (https://build.fhir.org/search.html), across all search-capable
+backends (SQLite, PostgreSQL, Elasticsearch, MongoDB).
+
+This addresses the deviations documented in `docs/ui-requirements.md` §7.2.
+
+## Background / key finding
+
+`SearchModifier::is_valid_for(param_type)` in
+`crates/persistence/src/types/search_params.rs` is **not enforced at runtime** —
+it has no production call sites. Request handling is done by per-**type**
+parameter handlers (`crates/persistence/src/backends/*/search/...`), and each
+backend rejects unsupported combinations ad hoc. Values are indexed by the
+extractor into typed columns (`value_string`, `value_token_*`, `value_reference`,
+`value_uri`, …), so a modifier can only act on data the extractor actually
+indexed. Some spec widenings therefore require extractor/schema changes, not
+just handler tweaks.
+
+## Authoritative target (FHIR build spec) — modifier → allowed param types
+
+| Modifier | Allowed types (spec) | Current `hfs` | Gap |
+|----------|----------------------|---------------|-----|
+| `:missing` | all | all | none |
+| `:exact` | string | string | none |
+| `:contains` | string, reference, uri | string | + reference, uri |
+| `:text` | string, token, reference | token (string on ES only) | + string (all), + reference |
+| `:in` | token | token, uri | narrow to token |
+| `:not-in` | token | token, uri (returns 501) | narrow to token; decide semantics |
+| `:not` | token | "all" (impl token-only) | narrow table to token |
+| `:above` / `:below` | reference, token, uri | token, uri | + reference |
+| `:of-type` | token | token (✅ `of-type` + `ofType`) | done |
+| `:code-text` | reference, token | unimplemented | implement token + reference |
+| `:text-advanced` | reference, token | string, token | + reference; reconcile string |
+| `:identifier` | reference | reference | none |
+| `:[type]` | reference | reference | none |
+| `:iterate` | `_include`/`_revinclude` | same | none |
+
+## Phasing (each phase = its own commit(s), tests included)
+
+Each phase keeps the validation gate and the actual implementation **consistent**
+— a `(modifier, type)` combination is only marked valid once a backend honors it.
+
+- **Phase 0** — Make `is_valid_for` spec-accurate for already-implemented combos
+  (fix `:not` "all" → token-only overclaim; keep `:missing` = all). Wire it as a
+  single 400 gate in the REST search pipeline; align CapabilityStatement
+  per-type modifier advertisements. No new search behavior.
+- **Phase 1** — `:contains` on uri + reference (handler-only; substring match).
+- **Phase 2** — `:text` on string across all backends (currently ES-only).
+- **Phase 3** — `:code-text` (token first; then reference) — currently a no-op.
+- **Phase 4** — reference-typed text/hierarchy modifiers (`:text`/`:text-advanced`
+  on reference need `Reference.display` indexed; `:above`/`:below` on reference
+  need canonical/hierarchical handling). **Requires extractor + schema changes.**
+- **Phase 5** — narrow `:in`/`:not-in` to token-only; decide `:not-in`
+  (negated ValueSet expansion vs documented 501).
+
+## Per-phase backend checklist
+
+For each behavior change, touch: SQLite handler, Postgres handler, Elasticsearch
+handler, MongoDB handler, the backend `capabilities()` modifier lists, the
+`is_valid_for` arm, and tests (unit per handler + integration in
+`crates/rest/tests/search_integration.rs` / `crates/persistence/tests/`).
+
+## Status
+
+- [x] `:of-type` spelling alias (`of-type` + `ofType`) — committed.
+- [ ] Phase 0 … Phase 5 (see task list).

--- a/docs/search-modifier-spec-compliance-plan.md
+++ b/docs/search-modifier-spec-compliance-plan.md
@@ -77,15 +77,20 @@ handler, MongoDB handler, the backend `capabilities()` modifier lists, the
   unconditionally.
 - [x] **Postgres `:identifier`** — implemented (was advertised but broken).
 
-### Remaining (tracked as tasks, not blocking)
+- [x] **MongoDB `SearchCapabilityProvider`** — Mongo now advertises exactly the
+  modifiers it honors.
+- [x] **Reference `:above`/`:below`** — URL/path-prefix hierarchy (SQLite/PG/ES;
+  Mongo honestly 400s).
 
-- [ ] Reference `:text-advanced` (FTS over display) and `:above`/`:below`
-  (canonical version hierarchy). `is_valid_for` keeps them strict (gate 400s
-  them) until implemented.
-- [ ] MongoDB has no `SearchCapabilityProvider`, so it advertises no modifiers
-  while honoring several (string exact/contains/text, token code/text/code-text,
-  reference contains/text/code-text, uri exact/contains). Advertising-only gap;
-  no correctness impact.
+### Remaining (deferred by design decision)
+
+- [ ] Reference `:text-advanced` — needs FTS over `Reference.display` across
+  backends; disproportionate for a doubly-niche modifier. `is_valid_for` keeps
+  it strict, so the gate returns an honest 400 rather than a degraded result.
+- [ ] Canonical `|version` comparison for reference `:above`/`:below` — current
+  implementation is URL/path-prefix only.
+- [ ] `:text-advanced` is implemented for token on SQLite (FTS5) and ES only;
+  PG/Mongo don't advertise it.
 
 Validation: SQLite (full REST + unit) and Postgres (Docker integration) suites
 green on every commit; Elasticsearch and MongoDB compile-checked with logic

--- a/docs/search-modifier-spec-compliance-plan.md
+++ b/docs/search-modifier-spec-compliance-plan.md
@@ -65,5 +65,28 @@ handler, MongoDB handler, the backend `capabilities()` modifier lists, the
 
 ## Status
 
-- [x] `:of-type` spelling alias (`of-type` + `ofType`) — committed.
-- [ ] Phase 0 … Phase 5 (see task list).
+- [x] `:of-type` spelling alias (`of-type` + `ofType`).
+- [x] **Phase 0** — `:not` token-only; central 400 validation gate; capability
+  audit (drop `:not-in` 501-advertisement) across all 4 backends.
+- [x] **Phase 1** — `:contains` on uri + reference (all backends).
+- [x] **Phase 2** — `:text` on string (all backends).
+- [x] **Phase 3** — `:code-text` on token (all backends); also filled PG token `:text`.
+- [x] **Phase 4** — `Reference.display` indexed (SQLite/PG v8→v9 migrations, ES
+  mapping, Mongo); reference `:text`/`:code-text` (all backends).
+- [x] **Phase 5** — `:in`/`:not-in` token-only; `:not-in` returns 501
+  unconditionally.
+- [x] **Postgres `:identifier`** — implemented (was advertised but broken).
+
+### Remaining (tracked as tasks, not blocking)
+
+- [ ] Reference `:text-advanced` (FTS over display) and `:above`/`:below`
+  (canonical version hierarchy). `is_valid_for` keeps them strict (gate 400s
+  them) until implemented.
+- [ ] MongoDB has no `SearchCapabilityProvider`, so it advertises no modifiers
+  while honoring several (string exact/contains/text, token code/text/code-text,
+  reference contains/text/code-text, uri exact/contains). Advertising-only gap;
+  no correctness impact.
+
+Validation: SQLite (full REST + unit) and Postgres (Docker integration) suites
+green on every commit; Elasticsearch and MongoDB compile-checked with logic
+mirroring the validated backends (CI runs their Docker matrix).


### PR DESCRIPTION
## Summary

Brings `hfs` search-modifier handling into compliance with the [FHIR search spec](https://build.fhir.org/search.html) across all four search-capable backends (SQLite, PostgreSQL, Elasticsearch, MongoDB). This started as a doc-accuracy check of `docs/ui-requirements.md` §7 and grew into fixing the underlying code.

A key early finding: `SearchModifier::is_valid_for` was effectively **dead code** (no runtime enforcement) — capabilities came from per-backend hardcoded lists and behavior from per-type handlers, and the three sources disagreed. Phase 0 makes `is_valid_for` the single source of truth and wires it into a central validation gate.

## What changed (by phase)

- **`:of-type` spelling** — parser now accepts the spec/CapabilityStatement spelling `of-type` (was `oftype`-only, so the advertised modifier was silently dropped).
- **Phase 0** — `:not` restricted to token; **central 400 validation gate** in the REST search pipeline (rejects nonsensical modifier/type combos with an `OperationOutcome` instead of silently ignoring them); capability audit dropped `:not-in` (returns 501) from all backends' advertised lists.
- **Phase 1** — `:contains` on **uri + reference** (all backends).
- **Phase 2** — `:text` on **string** (added to PG/Mongo; gate had been blocking it).
- **Phase 3** — `:code-text` on **token** (starts-with on display) all backends; also filled the PG token `:text` gap.
- **Phase 4** — **`Reference.display` indexed end-to-end** (additive `v8→v9` migrations on SQLite/PG, ES mapping, Mongo) → reference `:text`/`:code-text`. Migration strategy: additive nullable columns + lazy reindex.
- **Phase 5** — `:in`/`:not-in` restricted to token; `:not-in` now returns **501 unconditionally** (was a silent no-op without a terminology server).
- **Postgres `:identifier`** — implemented (it was advertised but matched the identifier as a literal reference → wrong results).
- **MongoDB `SearchCapabilityProvider`** — Mongo now advertises exactly the modifiers it honors.
- **Reference `:above`/`:below`** — URL/path-prefix hierarchy (SQLite/PG/ES; Mongo honestly returns 400).

## Deliberately deferred (documented, tracked)

- **Reference `:text-advanced`** — needs FTS over `Reference.display` across backends; disproportionate for a doubly-niche modifier. The gate returns an honest **400** rather than a degraded result.
- **Canonical `|version` comparison** for reference `:above`/`:below` — current impl is URL/path-prefix only.

See `docs/search-modifier-spec-compliance-plan.md` for the full plan and status.

## Validation

- persistence lib **629** ✓ · full helios-rest suite **426** ✓ · Postgres Docker integration **91+** ✓ · clippy clean across all backend feature combinations.
- Every commit validated on SQLite (end-to-end) and Postgres (Docker); Elasticsearch/MongoDB compile-checked with logic mirroring the validated backends (CI runs their Docker matrix).
- Migrations are additive + nullable; existing rows stay `NULL` until reindexed via the existing `ReindexableStorage` path.

## Notes for reviewers

- The schema change adds a single nullable `value_reference_display` column (SQLite/PG migrations `v8→v9`); no backfill is forced.
- `docs/ui-requirements.md` §7 was also corrected as part of this work to match actual `hfs` behavior, including a "deviations from the FHIR spec" note.