### PR TITLE
fix(search): FHIR search conformance — repeated params, includes/iterate, nested _has, total, SUBSETTED, strict handling

### DIFF
--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -125,10 +125,10 @@ effectively a no-op.
 | Capability | SQLite | PostgreSQL | MongoDB | Elasticsearch |
 |------------|:------:|:----------:|:-------:|:-------------:|
 | Forward chained params (N-level) | ✓ | ✓ | ◐ | ◐ |
-| Reverse chaining (`_has`) | ✓ | ✓ | ◐ | ◐ |
-| `_include` | ✓ | ✓ | ✓ | ✓ |
-| `_revinclude` | ✓ | ✓ | ✓ | ✓ |
-| `:iterate` on include | parsed | parsed | parsed | parsed |
+| Reverse chaining (`_has`), incl. **nested** | ✓ | ✓ | ◐ | ◐ |
+| `_include` / `_revinclude` | ✓ | ✓ | ✓ | ✓ |
+| `:iterate` on include | ✓¹ | ✓¹ | parsed | ✓ (inline) |
+| `_include=Type:*` wildcard | ✓ | ✓ | ✓ | ✓ |
 
 SQLite and PostgreSQL resolve chains natively, via nested `search_index` subqueries with
 configurable depth limits (✓). For all other backends (◐), the REST layer resolves chained and
@@ -138,6 +138,23 @@ filter — application-side joins. So chained and `_has` queries work end-to-end
 searchable backend, including Elasticsearch and MongoDB; the per-backend distinction is whether the
 join is pushed into the backend (SQLite/PG) or performed by the REST layer.
 
+**Nested `_has`** (`_has:Observation:subject:_has:Provenance:target:agent=X`) is resolved
+recursively by `resolve_reverse_chain`: the inner chain selects the qualifying source resources by
+id, then the outer level collects their references to the base type. A reverse-depth cap
+(`ChainConfig::max_reverse_depth`, default 4) is enforced.
+
+**Include resolution (`_include`/`_revinclude`).** Elasticsearch and MongoDB populate `included`
+inside their own `search()`. SQLite and Postgres do not — so the REST handler resolves includes via
+the backend-agnostic `core::resolve_includes_iterative` whenever the backend left `included` empty.
+References are extracted through the search-parameter registry's FHIRPath expression (so a parameter
+whose name differs from its JSON field — e.g. Patient `organization` → `managingOrganization` —
+resolves correctly), and the referenced/referencing resources are fetched with `search()`.
+
+¹ `:iterate` transitively follows includes of already-included resources (depth-capped, deduped) via
+  `resolve_includes_iterative`. Both spellings are accepted: `_include=Obs:subject:iterate` and the
+  spec's `_include:iterate=Obs:subject`. `_include=Type:*` expands at query-build time to one
+  directive per reference search parameter of `Type`.
+
 ## 6. Result control (paging, sort, total, summary, elements)
 
 These are parsed and largely orchestrated by the REST layer.
@@ -146,9 +163,9 @@ These are parsed and largely orchestrated by the REST layer.
 |-----------|--------|-------|
 | `_count` | ✓ | page size; `_offset`/`_cursor` for paging |
 | `_sort` | ✓ | SQLite/PG sort by any indexed param; see below |
-| `_total` | ✓ | `none` / `estimate` / `accurate` parsed and applied |
-| `_summary` | ✓ | `true`/`text`/`data`/`count`/`false`, applied in `subsetting.rs` |
-| `_elements` | ✓ | applied post-search with nested-path support |
+| `_total` | ✓ | `accurate`/`estimate` populate `Bundle.total` (incl. SQLite/PG via `search_count`); `none`/absent omit it |
+| `_summary` | ✓ | `true`/`text`/`data`/`count`/`false`, applied in `subsetting.rs`; adds `SUBSETTED` `meta.tag` |
+| `_elements` | ✓ | applied post-search with nested-path support; adds `SUBSETTED` `meta.tag` |
 | `_include` / `_revinclude` | ✓ | see §5 |
 | `_maxresults` | ✗ | not handled |
 | `_score` | ✗ | bundle field exists but is never populated |
@@ -190,8 +207,26 @@ Ordered roughly by impact:
 5. **Elasticsearch gaps** — `_filter` unsupported. (Composite now evaluates components via inline
    nested objects; chained/`_has` now work via the REST-layer resolver — see below.)
 6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
-   unsupported; Bundles omit `first`/`last` paging links. `:code-text` (newer spec modifier) is
-   unsupported everywhere.
+   unsupported; Bundles omit `first`/`last` paging links.
+7. **Quantity UCUM canonicalization** — quantity `system|code` is matched by literal string equality;
+   there is no unit conversion, so `120|mm[Hg]` does not match `120|mmHg` and `1|g` does not match
+   `1000|mg`. (UCUM logic exists in `helios-fhirpath` but is not wired into the search index.)
+8. **Accent-insensitive string search** — string search is case-insensitive and prefix-based, but
+   not accent/diacritic-insensitive for ordinary string parameters (only the FTS `_text`/`_content`
+   path folds diacritics). The spec calls for accent-insensitive string matching.
+9. **Versioned / canonical references** — a versioned reference (`Patient/1/_history/2`) is matched
+   as a literal string, and canonical `url|version` hierarchy for reference `:above`/`:below` is not
+   implemented; `:identifier` assumes a `Type/id` reference shape.
+10. **Ordered-value boundary semantics** — `gt`/`lt` (and SQLite `sa`/`eb`) compare against the
+    scalar value rather than the precision-range boundary the spec defines; `eq`/`ne`/`ap` already
+    use implicit-precision ranges. Edge-case-only.
+
+**Recently landed (REST layer).** Repeated query parameters are now preserved as FHIR AND semantics
+(previously collapsed to last-wins by `HashMap` extraction); `Prefer: handling=strict` rejects
+unknown search parameters with `400` on type-level search (lenient default still ignores them);
+`_include`/`_revinclude` (with `:iterate` and `Type:*` wildcard) resolve on SQLite/Postgres;
+nested `_has` resolves; `Bundle.total` populates on SQLite/Postgres; and `_summary`/`_elements`
+responses carry the `SUBSETTED` tag.
 
 **Chaining dispatch (resolved).** Chained (`subject.name=Smith`) and reverse-chained
 (`_has:Observation:subject:code=1234`) searches are parsed into `SearchQuery` (`param.chain`,

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -853,7 +853,7 @@ impl PostgresQueryBuilder {
             // 'identifier' index row for that resource.
             let target = "idx.resource_id = SUBSTRING(ref.value_reference FROM POSITION('/' IN ref.value_reference) + 1)";
             let (filter, params): (String, Vec<SqlParam>) = match value.value.split_once('|') {
-                Some((system, code)) if system.is_empty() => {
+                Some(("", code)) => {
                     next += 1;
                     (
                         format!(
@@ -862,7 +862,7 @@ impl PostgresQueryBuilder {
                         vec![SqlParam::text(code)],
                     )
                 }
-                Some((system, code)) if code.is_empty() => {
+                Some((system, "")) => {
                     next += 1;
                     (
                         format!("idx.value_token_system = ${next}"),

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -43,6 +43,15 @@ impl SearchProvider for PostgresBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
+        // Populate Bundle.total only when the client asked for it
+        // (`_total=accurate|estimate`). Computed up-front so the count query's
+        // client is not held across the main query's await points.
+        let total = if query.wants_total() {
+            Some(self.search_count(tenant, query).await?)
+        } else {
+            None
+        };
+
         let client = self.get_client().await?;
         let tenant_id = tenant.tenant_id().as_str();
         let resource_type = &query.resource_type;
@@ -245,10 +254,19 @@ impl SearchProvider for PostgresBackend {
         };
 
         let resources: Vec<StoredResource> = parsed.into_iter().map(|(r, _)| r).collect();
+
+        // Populate Bundle.total only when the client asked for it
+        // (`_total=accurate|estimate`); otherwise skip the extra COUNT query.
+        let total = if query.wants_total() {
+            Some(self.search_count(tenant, query).await?)
+        } else {
+            None
+        };
+
         let page_info = PageInfo {
             next_cursor,
             previous_cursor,
-            total: None,
+            total,
             has_next,
             has_previous,
         };
@@ -257,7 +275,7 @@ impl SearchProvider for PostgresBackend {
         Ok(SearchResult {
             resources: page,
             included: Vec::new(),
-            total: None,
+            total,
         })
     }
 

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -255,14 +255,8 @@ impl SearchProvider for PostgresBackend {
 
         let resources: Vec<StoredResource> = parsed.into_iter().map(|(r, _)| r).collect();
 
-        // Populate Bundle.total only when the client asked for it
-        // (`_total=accurate|estimate`); otherwise skip the extra COUNT query.
-        let total = if query.wants_total() {
-            Some(self.search_count(tenant, query).await?)
-        } else {
-            None
-        };
-
+        // `total` was computed up-front (before acquiring `client`) to avoid
+        // holding a non-Send guard across the count query's await.
         let page_info = PageInfo {
             next_cursor,
             previous_cursor,

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -76,6 +76,15 @@ impl SearchProvider for SqliteBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
+        // Populate Bundle.total only when the client asked for it
+        // (`_total=accurate|estimate`). Computed up-front, before acquiring the
+        // (non-Send) connection, so it is not held across this await.
+        let total = if query.wants_total() {
+            Some(self.search_count(tenant, query).await?)
+        } else {
+            None
+        };
+
         let conn = self.get_connection()?;
         let tenant_id = tenant.tenant_id().as_str();
         let resource_type = &query.resource_type;
@@ -306,7 +315,7 @@ impl SearchProvider for SqliteBackend {
         let page_info = PageInfo {
             next_cursor,
             previous_cursor,
-            total: None,
+            total,
             has_next,
             has_previous,
         };
@@ -316,7 +325,7 @@ impl SearchProvider for SqliteBackend {
         Ok(SearchResult {
             resources: page,
             included: Vec::new(),
-            total: None,
+            total,
         })
     }
 

--- a/crates/persistence/src/core/mod.rs
+++ b/crates/persistence/src/core/mod.rs
@@ -134,7 +134,7 @@ pub use history::{
 pub use search::{
     ChainedSearchProvider, FullSearchProvider, IncludeProvider, MultiTypeSearchProvider,
     RevincludeProvider, SearchProvider, SearchResult, TerminologySearchProvider,
-    TextSearchProvider,
+    TextSearchProvider, resolve_includes_iterative,
 };
 pub use storage::{
     ConditionalCreateResult, ConditionalDeleteResult, ConditionalPatchResult, ConditionalStorage,

--- a/crates/persistence/src/core/search.rs
+++ b/crates/persistence/src/core/search.rs
@@ -9,16 +9,18 @@
 //! - [`TerminologySearchProvider`] - :above, :below, :in, :not-in
 //! - [`TextSearchProvider`] - Full-text search (_text, _content, :text)
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use parking_lot::RwLock;
 
 use crate::error::StorageResult;
-use crate::search::SearchParameterRegistry;
+use crate::search::{IndexValue, SearchParameterExtractor, SearchParameterRegistry};
 use crate::tenant::TenantContext;
 use crate::types::{
-    IncludeDirective, Page, ReverseChainedParameter, SearchBundle, SearchQuery, StoredResource,
+    IncludeDirective, IncludeType, Page, ReverseChainedParameter, SearchBundle, SearchParamType,
+    SearchParameter, SearchQuery, SearchValue, StoredResource,
 };
 
 use super::storage::ResourceStorage;
@@ -312,6 +314,152 @@ pub trait RevincludeProvider: SearchProvider {
         resources: &[StoredResource],
         revincludes: &[IncludeDirective],
     ) -> StorageResult<Vec<StoredResource>>;
+}
+
+/// Maximum number of `:iterate` hops when transitively following includes,
+/// guarding against reference cycles.
+const MAX_INCLUDE_ITERATE_DEPTH: usize = 5;
+
+/// Upper bound on resources fetched per internal include/revinclude query, to
+/// avoid the default page size silently truncating included resources.
+const INCLUDE_FETCH_LIMIT: u32 = 10_000;
+
+/// Resolves `_include`/`_revinclude` directives for a set of primary matches,
+/// following `:iterate` directives transitively until no new resources are
+/// found (bounded by [`MAX_INCLUDE_ITERATE_DEPTH`]). Included resources are
+/// deduplicated by `type/id` and never include a primary match.
+///
+/// This is the single, backend-agnostic include-resolution path used by the
+/// REST layer for backends whose `search()` does not resolve includes inline
+/// (SQLite, Postgres). References are extracted via the search-parameter
+/// registry's FHIRPath expression — so parameters whose name differs from the
+/// JSON field (e.g. Patient `organization` → `managingOrganization`) resolve
+/// correctly — and the referenced resources are fetched with `search()`.
+pub async fn resolve_includes_iterative<S>(
+    provider: &S,
+    tenant: &TenantContext,
+    matches: &[StoredResource],
+    includes: &[IncludeDirective],
+) -> StorageResult<Vec<StoredResource>>
+where
+    S: SearchProvider + ?Sized,
+{
+    if matches.is_empty() || includes.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let extractor = SearchParameterExtractor::new(provider.search_param_registry().clone());
+    let key = |r: &StoredResource| format!("{}/{}", r.resource_type(), r.id());
+
+    // Don't re-include primary matches.
+    let mut seen: HashSet<String> = matches.iter().map(&key).collect();
+    let mut included: Vec<StoredResource> = Vec::new();
+
+    let mut frontier: Vec<StoredResource> = matches.to_vec();
+    let mut first_hop = true;
+    let mut depth = 0;
+
+    loop {
+        // First hop applies all directives; later hops only `:iterate` ones.
+        let active: Vec<&IncludeDirective> =
+            includes.iter().filter(|d| first_hop || d.iterate).collect();
+        if active.is_empty() {
+            break;
+        }
+
+        let mut fetched: Vec<StoredResource> = Vec::new();
+        for directive in active {
+            match directive.include_type {
+                IncludeType::Include => {
+                    // Forward: collect references from the frontier resources,
+                    // then fetch the referenced resources by id.
+                    let mut wanted: Vec<(String, String)> = Vec::new();
+                    for res in &frontier {
+                        if res.resource_type() != directive.source_type {
+                            continue;
+                        }
+                        let def = provider
+                            .search_param_registry()
+                            .read()
+                            .get_param(res.resource_type(), &directive.search_param);
+                        let Some(def) = def else { continue };
+                        if let Ok(values) = extractor.extract_for_param(res.content(), &def) {
+                            for v in values {
+                                if let IndexValue::Reference { reference, .. } = v.value {
+                                    if let Some((t, i)) = reference.split_once('/') {
+                                        if let Some(target) = &directive.target_type {
+                                            if t != target {
+                                                continue;
+                                            }
+                                        }
+                                        wanted.push((t.to_string(), i.to_string()));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    // Group ids by type and fetch each group.
+                    let mut by_type: std::collections::HashMap<String, Vec<String>> =
+                        std::collections::HashMap::new();
+                    for (t, i) in wanted {
+                        by_type.entry(t).or_default().push(i);
+                    }
+                    for (rtype, ids) in by_type {
+                        let mut q = SearchQuery::new(&rtype).with_parameter(SearchParameter {
+                            name: "_id".to_string(),
+                            param_type: SearchParamType::Token,
+                            modifier: None,
+                            values: ids.iter().map(SearchValue::eq).collect(),
+                            chain: vec![],
+                            components: vec![],
+                        });
+                        q.count = Some(INCLUDE_FETCH_LIMIT);
+                        let result = provider.search(tenant, &q).await?;
+                        fetched.extend(result.resources.items);
+                    }
+                }
+                IncludeType::Revinclude => {
+                    // Reverse: find source resources that reference any frontier
+                    // resource via the directive's reference parameter.
+                    let refs: Vec<SearchValue> =
+                        frontier.iter().map(|r| SearchValue::eq(key(r))).collect();
+                    if refs.is_empty() {
+                        continue;
+                    }
+                    let mut q =
+                        SearchQuery::new(&directive.source_type).with_parameter(SearchParameter {
+                            name: directive.search_param.clone(),
+                            param_type: SearchParamType::Reference,
+                            modifier: None,
+                            values: refs,
+                            chain: vec![],
+                            components: vec![],
+                        });
+                    q.count = Some(INCLUDE_FETCH_LIMIT);
+                    let result = provider.search(tenant, &q).await?;
+                    fetched.extend(result.resources.items);
+                }
+            }
+        }
+
+        // Dedup against everything seen so far; newly-added become next frontier.
+        let mut next = Vec::new();
+        for r in fetched {
+            if seen.insert(key(&r)) {
+                next.push(r.clone());
+                included.push(r);
+            }
+        }
+
+        first_hop = false;
+        depth += 1;
+        frontier = next;
+        if frontier.is_empty() || depth >= MAX_INCLUDE_ITERATE_DEPTH {
+            break;
+        }
+    }
+
+    Ok(included)
 }
 
 /// Search provider that supports chained parameters and _has.

--- a/crates/persistence/src/search/chain_resolver.rs
+++ b/crates/persistence/src/search/chain_resolver.rs
@@ -60,7 +60,19 @@ where
         id_sets.push(ids.into_iter().collect());
     }
 
+    let max_reverse_depth = crate::types::ChainConfig::default().max_reverse_depth;
     for reverse_chain in &query.reverse_chains {
+        if reverse_chain.depth() > max_reverse_depth {
+            return Err(crate::error::StorageError::Search(
+                crate::error::SearchError::QueryParseError {
+                    message: format!(
+                        "_has nesting depth {} exceeds the maximum of {}",
+                        reverse_chain.depth(),
+                        max_reverse_depth
+                    ),
+                },
+            ));
+        }
         let ids = resolve_reverse_chain(storage, tenant, &base_type, reverse_chain).await?;
         id_sets.push(ids.into_iter().collect());
     }
@@ -229,6 +241,10 @@ where
 /// Resolves a reverse chain (`_has:Source:refParam:searchParam=value`) to a set
 /// of `base_type` ids by finding matching source resources and collecting the
 /// references they make to `base_type`.
+///
+/// Nested `_has` (`_has:Source:refParam:_has:...`) is resolved recursively: the
+/// inner chain selects the qualifying `Source` resources by id, then this level
+/// collects the references those resources make to `base_type`.
 async fn resolve_reverse_chain<S>(
     storage: &S,
     tenant: &TenantContext,
@@ -238,29 +254,54 @@ async fn resolve_reverse_chain<S>(
 where
     S: SearchProvider + ?Sized,
 {
-    let values = match &reverse_chain.value {
-        Some(v) => vec![v.clone()],
-        None => vec![],
-    };
-    let search_param_type = {
-        let registry = storage.search_param_registry().read();
-        resolve_param_type(
-            &registry,
+    // Build a query selecting the matching `source_type` resources.
+    let source_query = if let Some(inner) = &reverse_chain.nested {
+        // Nested: the inner chain decides which source resources qualify. Its
+        // base type is *this* level's source type.
+        let inner_ids = Box::pin(resolve_reverse_chain(
+            storage,
+            tenant,
             &reverse_chain.source_type,
-            &reverse_chain.search_param,
-            &values,
-        )
+            inner,
+        ))
+        .await?;
+        if inner_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        SearchQuery::new(&reverse_chain.source_type).with_parameter(SearchParameter {
+            name: "_id".to_string(),
+            param_type: SearchParamType::Token,
+            modifier: None,
+            values: inner_ids.iter().map(SearchValue::eq).collect(),
+            chain: vec![],
+            components: vec![],
+        })
+    } else {
+        // Terminal: match source resources by `search_param=value`.
+        let values = match &reverse_chain.value {
+            Some(v) => vec![v.clone()],
+            None => vec![],
+        };
+        let search_param_type = {
+            let registry = storage.search_param_registry().read();
+            resolve_param_type(
+                &registry,
+                &reverse_chain.source_type,
+                &reverse_chain.search_param,
+                &values,
+            )
+        };
+        SearchQuery::new(&reverse_chain.source_type).with_parameter(SearchParameter {
+            name: reverse_chain.search_param.clone(),
+            param_type: search_param_type,
+            modifier: None,
+            values,
+            chain: vec![],
+            components: vec![],
+        })
     };
-    let query = SearchQuery::new(&reverse_chain.source_type).with_parameter(SearchParameter {
-        name: reverse_chain.search_param.clone(),
-        param_type: search_param_type,
-        modifier: None,
-        values,
-        chain: vec![],
-        components: vec![],
-    });
 
-    let result = storage.search(tenant, &query).await?;
+    let result = storage.search(tenant, &source_query).await?;
 
     let extractor = SearchParameterExtractor::new(storage.search_param_registry().clone());
     let mut ids = Vec::new();
@@ -438,6 +479,55 @@ mod tests {
             ids,
             vec!["smith"],
             "only Smith is referenced by a matching obs"
+        );
+    }
+
+    #[tokio::test]
+    async fn nested_reverse_chain_has() {
+        let b = backend();
+        let t = tenant();
+        seed(&b, &t).await;
+
+        // A Provenance targets Smith's observation (o1) with a known agent.
+        b.create(
+            &t,
+            "Provenance",
+            json!({ "resourceType": "Provenance", "id": "prov1",
+                    "target": [{ "reference": "Observation/o1" }],
+                    "recorded": "2020-01-01T00:00:00Z",
+                    "agent": [{ "who": { "reference": "Practitioner/prac-1" } }] }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+        // Patient?_has:Observation:subject:_has:Provenance:target:agent=Practitioner/prac-1
+        // -> patients whose observation is the target of a provenance with that agent.
+        let inner = ReverseChainedParameter::terminal(
+            "Provenance",
+            "target",
+            "agent",
+            SearchValue::eq("Practitioner/prac-1"),
+        );
+        let mut query = SearchQuery::new("Patient");
+        query.reverse_chains.push(ReverseChainedParameter::nested(
+            "Observation",
+            "subject",
+            inner,
+        ));
+
+        let rewritten = resolve_chains(&b, &t, &query).await.unwrap();
+        let result = b.search(&t, &rewritten).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["smith"],
+            "only Smith's observation is targeted by the matching provenance"
         );
     }
 

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -734,6 +734,15 @@ impl SearchQuery {
         }
     }
 
+    /// Returns true if the client requested a total count via
+    /// `_total=accurate` or `_total=estimate`.
+    ///
+    /// `_total=none` or an unspecified `_total` returns `false`, so backends
+    /// skip the extra count query (FHIR allows omitting `Bundle.total`).
+    pub fn wants_total(&self) -> bool {
+        matches!(self.total, Some(TotalMode::Estimate | TotalMode::Accurate))
+    }
+
     /// Adds a search parameter.
     pub fn with_parameter(mut self, param: SearchParameter) -> Self {
         self.parameters.push(param);

--- a/crates/rest/src/extractors/mod.rs
+++ b/crates/rest/src/extractors/mod.rs
@@ -12,6 +12,7 @@
 mod fhir_resource;
 mod fhir_version;
 mod pagination;
+pub(crate) mod query_pairs;
 mod search_params;
 pub mod search_query_builder;
 mod tenant;
@@ -20,5 +21,7 @@ pub use fhir_resource::FhirResource;
 pub use fhir_version::FhirVersionExtractor;
 pub use pagination::Pagination;
 pub use search_params::SearchParams;
-pub use search_query_builder::{build_search_query, build_search_query_from_map};
+pub use search_query_builder::{
+    build_search_query, build_search_query_from_map, build_search_query_from_pairs,
+};
 pub use tenant::TenantExtractor;

--- a/crates/rest/src/extractors/mod.rs
+++ b/crates/rest/src/extractors/mod.rs
@@ -23,5 +23,6 @@ pub use pagination::Pagination;
 pub use search_params::SearchParams;
 pub use search_query_builder::{
     build_search_query, build_search_query_from_map, build_search_query_from_pairs,
+    unknown_search_params,
 };
 pub use tenant::TenantExtractor;

--- a/crates/rest/src/extractors/query_pairs.rs
+++ b/crates/rest/src/extractors/query_pairs.rs
@@ -1,0 +1,49 @@
+//! Shared helpers for parsing query/form parameters while preserving repeated
+//! keys.
+//!
+//! FHIR search uses repeated parameters for AND semantics (e.g.
+//! `?language=en&language=fr` means *both*, and `?_include=A&_include=B` requests
+//! two includes). Extracting parameters into a `HashMap<String, String>` would
+//! collapse duplicate keys to a single (last-wins) value, silently dropping the
+//! others. These helpers parse into an ordered `Vec<(String, String)>` that keeps
+//! every occurrence.
+
+/// Parses a raw query string into ordered key/value pairs (repeated keys kept).
+pub(crate) fn parse_query_pairs(raw: Option<&str>) -> Vec<(String, String)> {
+    match raw {
+        None => Vec::new(),
+        Some(q) => url::form_urlencoded::parse(q.as_bytes())
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect(),
+    }
+}
+
+/// Collects all values for `key`, splitting each on `,`.
+///
+/// Handles both FHIR multi-value forms: comma-separated (`?_include=A,B`) and
+/// repeated keys (`?_include=A&_include=B`).
+pub(crate) fn collect_multi(pairs: &[(String, String)], key: &str) -> Vec<String> {
+    pairs
+        .iter()
+        .filter(|(k, _)| k == key)
+        .flat_map(|(_, v)| v.split(',').map(|s| s.trim().to_string()))
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Returns the first value for `key`, if any.
+pub(crate) fn first_value(pairs: &[(String, String)], key: &str) -> Option<String> {
+    pairs.iter().find(|(k, _)| k == key).map(|(_, v)| v.clone())
+}
+
+/// Returns the last value for `key`, if any.
+///
+/// Use for genuinely single-valued control params (`_format`, `_count`,
+/// `_summary`, …) where HTTP "last wins" is the conventional behavior.
+pub(crate) fn last_value(pairs: &[(String, String)], key: &str) -> Option<String> {
+    pairs
+        .iter()
+        .rev()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.clone())
+}

--- a/crates/rest/src/extractors/search_params.rs
+++ b/crates/rest/src/extractors/search_params.rs
@@ -104,8 +104,8 @@ impl SearchParams {
         if !sort_specs.is_empty() {
             result.sort = Some(sort_specs.iter().map(|s| parse_one_sort(s)).collect());
         }
-        result.include = collect_multi(&pairs, "_include");
-        result.revinclude = collect_multi(&pairs, "_revinclude");
+        result.include = collect_includes(&pairs, "_include");
+        result.revinclude = collect_includes(&pairs, "_revinclude");
         let elements = collect_multi(&pairs, "_elements");
         if !elements.is_empty() {
             result.elements = Some(elements);
@@ -137,7 +137,9 @@ impl SearchParams {
             "_summary",
             "_elements",
             "_include",
+            "_include:iterate",
             "_revinclude",
+            "_revinclude:iterate",
             "_contained",
             "_containedType",
             "_format",
@@ -202,6 +204,23 @@ impl SearchParams {
     pub fn contains(&self, name: &str) -> bool {
         self.pairs.iter().any(|(k, _)| k == name)
     }
+}
+
+/// Collects `_include`/`_revinclude` directives, supporting both the value-suffix
+/// iterate form (`_include=Obs:subject:iterate`) and the spec's key-modifier form
+/// (`_include:iterate=Obs:subject`). For the key-modifier form an `:iterate`
+/// suffix is appended so directive parsing flags it consistently.
+fn collect_includes(pairs: &[(String, String)], base: &str) -> Vec<String> {
+    let mut out = collect_multi(pairs, base);
+    let iterate_key = format!("{base}:iterate");
+    for v in collect_multi(pairs, &iterate_key) {
+        if v.ends_with(":iterate") {
+            out.push(v);
+        } else {
+            out.push(format!("{v}:iterate"));
+        }
+    }
+    out
 }
 
 /// Parses a single sort token into a structured param (`-field` = descending).

--- a/crates/rest/src/extractors/search_params.rs
+++ b/crates/rest/src/extractors/search_params.rs
@@ -2,11 +2,11 @@
 //!
 //! Extracts and parses FHIR search parameters from query strings.
 
-use axum::{
-    extract::{FromRequestParts, Query},
-    http::{StatusCode, request::Parts},
-};
+use axum::{extract::FromRequestParts, http::request::Parts};
 use std::collections::HashMap;
+use std::convert::Infallible;
+
+use super::query_pairs::{collect_multi, parse_query_pairs};
 
 /// Axum extractor for FHIR search parameters.
 ///
@@ -26,8 +26,8 @@ use std::collections::HashMap;
 /// ```
 #[derive(Debug, Default)]
 pub struct SearchParams {
-    /// Raw query parameters.
-    params: HashMap<String, String>,
+    /// Raw query parameters in request order, with repeated keys preserved.
+    pairs: Vec<(String, String)>,
 
     /// Page size (_count).
     count: Option<usize>,
@@ -70,51 +70,54 @@ impl SearchParams {
     }
 
     /// Creates search params from a HashMap.
+    ///
+    /// Convenience for callers that already hold a single-valued map (e.g.
+    /// conditional-operation `If-None-Exist` queries). Prefer [`from_pairs`] for
+    /// HTTP search requests so repeated parameters are preserved.
+    ///
+    /// [`from_pairs`]: SearchParams::from_pairs
     pub fn from_map(params: HashMap<String, String>) -> Self {
-        let mut result = Self {
-            params: params.clone(),
-            ..Default::default()
+        Self::from_pairs(params.into_iter().collect())
+    }
+
+    /// Creates search params from ordered key/value pairs, preserving every
+    /// occurrence of a repeated key (FHIR AND semantics).
+    pub fn from_pairs(pairs: Vec<(String, String)>) -> Self {
+        let last = |key: &str| {
+            pairs
+                .iter()
+                .rev()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.clone())
         };
 
-        // Extract system parameters
-        if let Some(count) = params.get("_count") {
-            result.count = count.parse().ok();
+        let mut result = Self::default();
+
+        // Single-valued control parameters: last occurrence wins.
+        result.count = last("_count").and_then(|v| v.parse().ok());
+        result.offset = last("_offset").and_then(|v| v.parse().ok());
+        result.summary = last("_summary");
+        result.total = last("_total");
+
+        // Multi-valued: collected across all occurrences and comma-splits.
+        let sort_specs = collect_multi(&pairs, "_sort");
+        if !sort_specs.is_empty() {
+            result.sort = Some(sort_specs.iter().map(|s| parse_one_sort(s)).collect());
+        }
+        result.include = collect_multi(&pairs, "_include");
+        result.revinclude = collect_multi(&pairs, "_revinclude");
+        let elements = collect_multi(&pairs, "_elements");
+        if !elements.is_empty() {
+            result.elements = Some(elements);
         }
 
-        if let Some(offset) = params.get("_offset") {
-            result.offset = offset.parse().ok();
-        }
-
-        if let Some(sort) = params.get("_sort") {
-            result.sort = Some(parse_sort_params(sort));
-        }
-
-        if let Some(include) = params.get("_include") {
-            result.include = include.split(',').map(String::from).collect();
-        }
-
-        if let Some(revinclude) = params.get("_revinclude") {
-            result.revinclude = revinclude.split(',').map(String::from).collect();
-        }
-
-        if let Some(summary) = params.get("_summary") {
-            result.summary = Some(summary.clone());
-        }
-
-        if let Some(elements) = params.get("_elements") {
-            result.elements = Some(elements.split(',').map(String::from).collect());
-        }
-
-        if let Some(total) = params.get("_total") {
-            result.total = Some(total.clone());
-        }
-
+        result.pairs = pairs;
         result
     }
 
-    /// Returns an iterator over all parameters.
+    /// Returns an iterator over all parameters (repeated keys included).
     pub fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
-        self.params.iter()
+        self.pairs.iter().map(|(k, v)| (k, v))
     }
 
     /// Returns an iterator over search parameters (excluding result format/pagination params).
@@ -140,8 +143,9 @@ impl SearchParams {
             "_format",
             "_pretty",
         ];
-        self.params
+        self.pairs
             .iter()
+            .map(|(k, v)| (k, v))
             .filter(|(k, _)| !EXCLUDED_PARAMS.contains(&k.as_str()))
     }
 
@@ -185,54 +189,47 @@ impl SearchParams {
         self.total.as_deref()
     }
 
-    /// Returns a specific parameter value.
+    /// Returns the last value for `name`, if present.
     pub fn get(&self, name: &str) -> Option<&String> {
-        self.params.get(name)
+        self.pairs
+            .iter()
+            .rev()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v)
     }
 
     /// Checks if a parameter is present.
     pub fn contains(&self, name: &str) -> bool {
-        self.params.contains_key(name)
-    }
-
-    /// Returns the raw parameter map.
-    pub fn raw_params(&self) -> &HashMap<String, String> {
-        &self.params
+        self.pairs.iter().any(|(k, _)| k == name)
     }
 }
 
-/// Parses sort parameter string into structured params.
-fn parse_sort_params(sort: &str) -> Vec<SortParam> {
-    sort.split(',')
-        .map(|s| {
-            let s = s.trim();
-            if let Some(field) = s.strip_prefix('-') {
-                SortParam {
-                    field: field.to_string(),
-                    ascending: false,
-                }
-            } else {
-                SortParam {
-                    field: s.to_string(),
-                    ascending: true,
-                }
-            }
-        })
-        .collect()
+/// Parses a single sort token into a structured param (`-field` = descending).
+fn parse_one_sort(s: &str) -> SortParam {
+    let s = s.trim();
+    if let Some(field) = s.strip_prefix('-') {
+        SortParam {
+            field: field.to_string(),
+            ascending: false,
+        }
+    } else {
+        SortParam {
+            field: s.to_string(),
+            ascending: true,
+        }
+    }
 }
 
 impl<S> FromRequestParts<S> for SearchParams
 where
     S: Send + Sync,
 {
-    type Rejection = (StatusCode, &'static str);
+    type Rejection = Infallible;
 
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let Query(params) = Query::<HashMap<String, String>>::from_request_parts(parts, state)
-            .await
-            .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid query parameters"))?;
-
-        Ok(SearchParams::from_map(params))
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(SearchParams::from_pairs(parse_query_pairs(
+            parts.uri.query(),
+        )))
     }
 }
 

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -133,6 +133,46 @@ pub fn build_search_query_from_map(
     build_search_query(resource_type, &search_params, registry)
 }
 
+/// Returns the names of search parameters that are not recognized for the given
+/// resource type (used to enforce `Prefer: handling=strict`).
+///
+/// A parameter is "unknown" when its base name (after stripping any modifier and
+/// chain) is not registered for `resource_type` or for `Resource`, and is not a
+/// global parameter (those start with `_`, e.g. `_id`, `_text`, `_has`). Under
+/// lenient handling the server ignores such parameters; under strict handling
+/// the caller turns this list into a `400`.
+pub fn unknown_search_params(
+    resource_type: &str,
+    params: &SearchParams,
+    registry: &SearchParameterRegistry,
+) -> Vec<String> {
+    let mut unknown = Vec::new();
+    for (name, _) in params.search_params() {
+        // Reverse chaining is validated when parsed; skip here.
+        if name == "_has" || name.starts_with("_has:") {
+            continue;
+        }
+        // Strip modifier (`name:exact`, `subject:Patient`) then chain (`a.b`).
+        let base = name
+            .split(':')
+            .next()
+            .unwrap_or(name)
+            .split('.')
+            .next()
+            .unwrap_or(name);
+        // Global/result parameters (`_id`, `_text`, `_type`, …) are always allowed.
+        if base.starts_with('_') {
+            continue;
+        }
+        let known = registry.get_param(resource_type, base).is_some()
+            || registry.get_param("Resource", base).is_some();
+        if !known {
+            unknown.push(name.clone());
+        }
+    }
+    unknown
+}
+
 /// Builds a SearchQuery from ordered key/value pairs.
 ///
 /// Unlike [`build_search_query_from_map`], this preserves repeated parameters

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -96,6 +96,10 @@ pub fn build_search_query(
         }
     }
 
+    // Expand wildcard includes (_include=Type:*) into one directive per
+    // reference search parameter of the source type.
+    expand_wildcard_includes(&mut query.includes, registry);
+
     // Store raw parameters for debugging, grouping repeated keys.
     let mut raw_params: HashMap<String, Vec<String>> = HashMap::new();
     for (k, v) in params.iter() {
@@ -513,6 +517,35 @@ fn parse_include_directive(directive: &str, include_type: IncludeType) -> Option
         target_type,
         iterate,
     })
+}
+
+/// Expands wildcard include directives (`_include=Type:*`) into a concrete
+/// directive for each reference-typed search parameter of the source type,
+/// preserving the original `iterate` / `target_type` flags. Non-wildcard
+/// directives pass through unchanged.
+fn expand_wildcard_includes(
+    includes: &mut Vec<IncludeDirective>,
+    registry: &SearchParameterRegistry,
+) {
+    if !includes.iter().any(|d| d.search_param == "*") {
+        return;
+    }
+    let mut expanded = Vec::with_capacity(includes.len());
+    for directive in includes.drain(..) {
+        if directive.search_param == "*" {
+            for def in registry.get_active_params(&directive.source_type) {
+                if def.param_type == SearchParamType::Reference {
+                    expanded.push(IncludeDirective {
+                        search_param: def.code.clone(),
+                        ..directive.clone()
+                    });
+                }
+            }
+        } else {
+            expanded.push(directive);
+        }
+    }
+    *includes = expanded;
 }
 
 /// Parses _total parameter value.

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -96,11 +96,12 @@ pub fn build_search_query(
         }
     }
 
-    // Store raw parameters for debugging
-    query.raw_params = params
-        .iter()
-        .map(|(k, v)| (k.clone(), vec![v.clone()]))
-        .collect();
+    // Store raw parameters for debugging, grouping repeated keys.
+    let mut raw_params: HashMap<String, Vec<String>> = HashMap::new();
+    for (k, v) in params.iter() {
+        raw_params.entry(k.clone()).or_default().push(v.clone());
+    }
+    query.raw_params = raw_params;
 
     // Process search parameters (non-system params)
     for (name, value) in params.search_params() {
@@ -129,6 +130,19 @@ pub fn build_search_query_from_map(
     registry: &SearchParameterRegistry,
 ) -> Result<SearchQuery, RestError> {
     let search_params = SearchParams::from_map(params.clone());
+    build_search_query(resource_type, &search_params, registry)
+}
+
+/// Builds a SearchQuery from ordered key/value pairs.
+///
+/// Unlike [`build_search_query_from_map`], this preserves repeated parameters
+/// (FHIR AND semantics) and multiple `_include`/`_revinclude`/`_has` directives.
+pub fn build_search_query_from_pairs(
+    resource_type: &str,
+    pairs: &[(String, String)],
+    registry: &SearchParameterRegistry,
+) -> Result<SearchQuery, RestError> {
+    let search_params = SearchParams::from_pairs(pairs.to_vec());
     build_search_query(resource_type, &search_params, registry)
 }
 
@@ -746,6 +760,81 @@ mod tests {
         assert_eq!(query.includes.len(), 1);
         assert_eq!(query.includes[0].source_type, "Observation");
         assert_eq!(query.includes[0].search_param, "patient");
+    }
+
+    #[test]
+    fn test_repeated_search_params_are_anded() {
+        // `?name=Smith&name=Jones` -> two ANDed parameters, both preserved.
+        let pairs = vec![
+            ("name".to_string(), "Smith".to_string()),
+            ("name".to_string(), "Jones".to_string()),
+        ];
+        let sp = SearchParams::from_pairs(pairs);
+        let query = build_search_query("Patient", &sp, &test_registry()).unwrap();
+
+        let name_values: Vec<&str> = query
+            .parameters
+            .iter()
+            .filter(|p| p.name == "name")
+            .flat_map(|p| p.values.iter().map(|v| v.value.as_str()))
+            .collect();
+        assert_eq!(query.parameters.len(), 2, "both name params preserved");
+        assert!(name_values.contains(&"Smith"));
+        assert!(name_values.contains(&"Jones"));
+    }
+
+    #[test]
+    fn test_repeated_include_directives_preserved() {
+        // `?_include=A&_include=B` -> two include directives (was last-wins before).
+        let pairs = vec![
+            ("_include".to_string(), "Observation:subject".to_string()),
+            ("_include".to_string(), "Observation:encounter".to_string()),
+        ];
+        let sp = SearchParams::from_pairs(pairs);
+        let query = build_search_query("Observation", &sp, &test_registry()).unwrap();
+
+        assert_eq!(query.includes.len(), 2);
+        let params: Vec<&str> = query
+            .includes
+            .iter()
+            .map(|d| d.search_param.as_str())
+            .collect();
+        assert!(params.contains(&"subject"));
+        assert!(params.contains(&"encounter"));
+    }
+
+    #[test]
+    fn test_repeated_has_chains_preserved() {
+        // Repeated `_has` -> multiple reverse chains, all preserved.
+        let pairs = vec![
+            (
+                "_has:Observation:patient:code".to_string(),
+                "1234-5".to_string(),
+            ),
+            (
+                "_has:Observation:patient:status".to_string(),
+                "final".to_string(),
+            ),
+        ];
+        let sp = SearchParams::from_pairs(pairs);
+        let query = build_search_query("Patient", &sp, &test_registry()).unwrap();
+
+        assert_eq!(query.reverse_chains.len(), 2);
+    }
+
+    #[test]
+    fn test_mixed_comma_and_repeat_include() {
+        // Comma and repeat combine: `?_include=A,B&_include=C` -> three directives.
+        let pairs = vec![
+            (
+                "_include".to_string(),
+                "Observation:subject,Observation:encounter".to_string(),
+            ),
+            ("_include".to_string(), "Observation:patient".to_string()),
+        ];
+        let sp = SearchParams::from_pairs(pairs);
+        let query = build_search_query("Observation", &sp, &test_registry()).unwrap();
+        assert_eq!(query.includes.len(), 3);
     }
 
     #[test]

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -410,14 +410,13 @@ fn parse_has_parameter(
         SearchValue::eq(value)
     };
 
-    // Check for nested _has
-    if search_param == "_has" || search_param.starts_with("_has:") {
-        // Nested reverse chain - this is complex and requires recursion
-        // For now, return a basic structure; the backend can handle it
-        let nested = parse_has_parameter(
-            &format!("_has:{}", &chain_str[parts[0].len() + parts[1].len() + 2..]),
-            value,
-        )?;
+    // Check for nested _has, e.g.
+    // `_has:Observation:subject:_has:Provenance:target:agent`.
+    // Everything after `source_type:reference_param:` is itself a `_has:...`
+    // expression, which we parse recursively.
+    if search_param == "_has" {
+        let inner = &chain_str[parts[0].len() + parts[1].len() + 2..];
+        let nested = parse_has_parameter(inner, value)?;
         if let Some(nested_chain) = nested {
             return Ok(Some(ReverseChainedParameter::nested(
                 source_type,
@@ -646,6 +645,34 @@ mod tests {
         assert_eq!(chain.source_type, "Observation");
         assert_eq!(chain.reference_param, "patient");
         assert_eq!(chain.search_param, "code");
+    }
+
+    #[test]
+    fn test_parse_nested_has_parameter() {
+        // _has:Observation:subject:_has:Provenance:target:agent=prac-1
+        let result = parse_has_parameter(
+            "_has:Observation:subject:_has:Provenance:target:agent",
+            "prac-1",
+        )
+        .unwrap()
+        .expect("nested chain parsed");
+
+        // Outer level.
+        assert_eq!(result.source_type, "Observation");
+        assert_eq!(result.reference_param, "subject");
+        assert!(result.value.is_none(), "outer level carries no value");
+        assert_eq!(result.depth(), 2);
+
+        // Inner (terminal) level.
+        let inner = result.nested.expect("inner chain present");
+        assert_eq!(inner.source_type, "Provenance");
+        assert_eq!(inner.reference_param, "target");
+        assert_eq!(inner.search_param, "agent");
+        assert_eq!(
+            inner.value.as_ref().map(|v| v.value.as_str()),
+            Some("prac-1")
+        );
+        assert!(inner.is_terminal());
     }
 
     #[test]

--- a/crates/rest/src/handlers/bulk_export.rs
+++ b/crates/rest/src/handlers/bulk_export.rs
@@ -51,30 +51,7 @@ fn bad_request(msg: impl Into<String>) -> RestError {
     }
 }
 
-/// Parses a raw query string into ordered key/value pairs (repeated keys kept).
-fn parse_query_pairs(raw: Option<&str>) -> Vec<(String, String)> {
-    match raw {
-        None => Vec::new(),
-        Some(q) => url::form_urlencoded::parse(q.as_bytes())
-            .map(|(k, v)| (k.into_owned(), v.into_owned()))
-            .collect(),
-    }
-}
-
-/// Collects all values for `key`, splitting each on `,`.
-fn collect_multi(pairs: &[(String, String)], key: &str) -> Vec<String> {
-    pairs
-        .iter()
-        .filter(|(k, _)| k == key)
-        .flat_map(|(_, v)| v.split(',').map(|s| s.trim().to_string()))
-        .filter(|s| !s.is_empty())
-        .collect()
-}
-
-/// Returns the first value for `key`, if any.
-fn first_value(pairs: &[(String, String)], key: &str) -> Option<String> {
-    pairs.iter().find(|(k, _)| k == key).map(|(_, v)| v.clone())
-}
+use crate::extractors::query_pairs::{collect_multi, first_value, parse_query_pairs};
 
 /// Parses a FHIR `instant` into a UTC datetime.
 fn parse_instant(s: &str) -> Result<chrono::DateTime<Utc>, RestError> {

--- a/crates/rest/src/handlers/compartment.rs
+++ b/crates/rest/src/handlers/compartment.rs
@@ -6,11 +6,9 @@
 //! Compartment search allows finding all resources related to a specific resource,
 //! such as all Observations for a specific Patient.
 
-use std::collections::HashMap;
-
 use axum::{
     Json,
-    extract::{Path, Query, State},
+    extract::{Path, RawQuery, State},
     http::StatusCode,
     response::{IntoResponse, Response},
 };
@@ -18,7 +16,8 @@ use helios_persistence::core::{ResourceStorage, SearchProvider};
 use tracing::debug;
 
 use crate::error::{RestError, RestResult};
-use crate::extractors::{FhirVersionExtractor, TenantExtractor, build_search_query_from_map};
+use crate::extractors::query_pairs::parse_query_pairs;
+use crate::extractors::{FhirVersionExtractor, SearchParams, TenantExtractor, build_search_query};
 use crate::state::AppState;
 
 /// Handler for compartment search.
@@ -43,17 +42,18 @@ pub async fn compartment_search_handler<S>(
     Path((compartment_type, compartment_id, target_type)): Path<(String, String, String)>,
     tenant: TenantExtractor,
     version: FhirVersionExtractor,
-    Query(mut params): Query<HashMap<String, String>>,
+    RawQuery(raw_query): RawQuery,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + SearchProvider + Send + Sync,
 {
+    let mut pairs = parse_query_pairs(raw_query.as_deref());
     debug!(
         compartment_type = %compartment_type,
         compartment_id = %compartment_id,
         target_type = %target_type,
         tenant = %tenant.tenant_id(),
-        params = ?params,
+        params = ?pairs,
         "Processing compartment search request"
     );
 
@@ -77,21 +77,24 @@ where
 
     // Add the first compartment reference parameter to the search parameters
     // (the first parameter is typically the most specific one)
-    params.insert(ref_params[0].to_string(), compartment_ref);
+    pairs.push((ref_params[0].to_string(), compartment_ref));
 
-    // Apply pagination limits
-    apply_pagination_limits(
-        &mut params,
-        state.default_page_size(),
-        state.max_page_size(),
-    );
+    let search_params = SearchParams::from_pairs(pairs);
 
     // Convert REST params to persistence SearchQuery. Scope the registry read
     // guard tightly so it doesn't span any await.
-    let query = {
+    let mut query = {
         let registry = state.storage().search_param_registry().read();
-        build_search_query_from_map(&target_type, &params, &registry)?
+        build_search_query(&target_type, &search_params, &registry)?
     };
+
+    // Clamp page size to the configured default/maximum.
+    let count = query
+        .count
+        .map(|c| c as usize)
+        .unwrap_or(state.default_page_size())
+        .min(state.max_page_size());
+    query.count = Some(count as u32);
 
     // Execute the search
     let result = state
@@ -109,7 +112,7 @@ where
         &compartment_type,
         &compartment_id,
         &target_type,
-        &params,
+        &search_params,
     );
 
     // Convert result to FHIR Bundle
@@ -140,7 +143,7 @@ pub async fn compartment_search_all_handler<S>(
     State(_state): State<AppState<S>>,
     Path((compartment_type, compartment_id)): Path<(String, String)>,
     _tenant: TenantExtractor,
-    Query(_params): Query<HashMap<String, String>>,
+    RawQuery(_raw_query): RawQuery,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + SearchProvider + Send + Sync,
@@ -162,42 +165,27 @@ where
     })
 }
 
-/// Applies pagination limits from configuration to the params.
-fn apply_pagination_limits(
-    params: &mut HashMap<String, String>,
-    default_page_size: usize,
-    max_page_size: usize,
-) {
-    let count = params
-        .get("_count")
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(default_page_size)
-        .min(max_page_size);
-
-    params.insert("_count".to_string(), count.to_string());
-}
-
 /// Builds a compartment search URL.
 fn build_compartment_search_url(
     base_url: &str,
     compartment_type: &str,
     compartment_id: &str,
     target_type: &str,
-    params: &HashMap<String, String>,
+    params: &SearchParams,
 ) -> String {
     let path = format!(
         "{}/{}/{}/{}",
         base_url, compartment_type, compartment_id, target_type
     );
 
-    if params.is_empty() {
+    let query: String = params
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+    if query.is_empty() {
         path
     } else {
-        let query: String = params
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
-            .collect::<Vec<_>>()
-            .join("&");
         format!("{}?{}", path, query)
     }
 }
@@ -306,15 +294,14 @@ mod tests {
             "Patient",
             "123",
             "Observation",
-            &HashMap::new(),
+            &SearchParams::from_pairs(vec![]),
         );
         assert_eq!(url, "http://example.com/fhir/Patient/123/Observation");
     }
 
     #[test]
     fn test_build_compartment_search_url_with_params() {
-        let mut params = HashMap::new();
-        params.insert("code".to_string(), "8867-4".to_string());
+        let params = SearchParams::from_pairs(vec![("code".to_string(), "8867-4".to_string())]);
 
         let url = build_compartment_search_url(
             "http://example.com/fhir",

--- a/crates/rest/src/handlers/read.rs
+++ b/crates/rest/src/handlers/read.rs
@@ -130,12 +130,24 @@ where
                 .map(|v| v.split(',').map(|s| s.trim()).collect());
 
             let mut content = stored.content().clone();
+            let mut subsetted = false;
 
             if let Some(mode) = summary_mode {
                 content = apply_summary(&content, mode, stored.fhir_version());
+                if mode != SummaryMode::False {
+                    subsetted = true;
+                }
             }
             if let Some(ref elem_list) = elements {
-                content = apply_elements(&content, elem_list);
+                if !elem_list.is_empty() {
+                    content = apply_elements(&content, elem_list);
+                    subsetted = true;
+                }
+            }
+
+            // Flag incomplete representations with the SUBSETTED tag (FHIR spec).
+            if subsetted {
+                crate::responses::subsetting::add_subsetted_tag(&mut content);
             }
 
             // Return the resource

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -21,8 +21,9 @@ use helios_fhir::FhirVersion;
 
 use crate::error::{RestError, RestResult};
 use crate::extractors::query_pairs::{last_value, parse_query_pairs};
-use crate::extractors::{SearchParams, TenantExtractor, build_search_query};
+use crate::extractors::{SearchParams, TenantExtractor, build_search_query, unknown_search_params};
 use crate::middleware::content_type::{FhirFormat, negotiate_format};
+use crate::middleware::prefer::PreferHeader;
 use crate::responses::format_resource_response;
 use crate::responses::subsetting::{SummaryMode, apply_elements, apply_summary};
 use crate::state::AppState;
@@ -59,8 +60,17 @@ where
 
     let format_param = last_value(&pairs, "_format");
     let negotiated = negotiate_format(&req_headers, format_param.as_deref());
+    let strict = PreferHeader::from_headers(&req_headers).is_strict();
 
-    execute_search(&state, tenant, &resource_type, pairs, negotiated.format).await
+    execute_search(
+        &state,
+        tenant,
+        &resource_type,
+        pairs,
+        negotiated.format,
+        strict,
+    )
+    .await
 }
 
 /// Handler for POST search.
@@ -92,8 +102,17 @@ where
     );
 
     let negotiated = negotiate_format(&req_headers, None);
+    let strict = PreferHeader::from_headers(&req_headers).is_strict();
 
-    execute_search(&state, tenant, &resource_type, pairs, negotiated.format).await
+    execute_search(
+        &state,
+        tenant,
+        &resource_type,
+        pairs,
+        negotiated.format,
+        strict,
+    )
+    .await
 }
 
 /// Handler for system-level search.
@@ -132,6 +151,7 @@ async fn execute_search<S>(
     resource_type: &str,
     pairs: Vec<(String, String)>,
     format: FhirFormat,
+    strict: bool,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + SearchProvider + Send + Sync,
@@ -163,6 +183,20 @@ where
     // Send by default, which would make this async fn !Send.
     let mut query = {
         let registry = state.storage().search_param_registry().read();
+        // Under `Prefer: handling=strict`, reject unknown search parameters
+        // (the lenient default ignores them).
+        if strict {
+            let unknown = unknown_search_params(resource_type, &search_params, &registry);
+            if !unknown.is_empty() {
+                return Err(RestError::InvalidParameter {
+                    param: unknown.join(", "),
+                    message: format!(
+                        "unknown search parameter(s) rejected under Prefer: handling=strict: {}",
+                        unknown.join(", ")
+                    ),
+                });
+            }
+        }
         build_search_query(resource_type, &search_params, &registry)?
     };
 
@@ -257,6 +291,9 @@ where
 
     // Build a search query (resource type doesn't matter much for system search).
     // Scope the registry read guard tightly so it doesn't span any await.
+    // Note: strict unknown-parameter validation is intentionally skipped for
+    // system search — parameters there are interpreted across many resource
+    // types, so a per-"Resource" registry check would false-positive.
     let mut query = {
         let registry = state.storage().search_param_registry().read();
         build_search_query("Resource", &search_params, &registry)?

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -13,7 +13,10 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::Response,
 };
-use helios_persistence::core::{MultiTypeSearchProvider, ResourceStorage, SearchProvider};
+use helios_persistence::core::{
+    IncludeProvider, MultiTypeSearchProvider, ResourceStorage, RevincludeProvider, SearchProvider,
+    resolve_includes_iterative,
+};
 use helios_persistence::types::SearchBundle;
 use tracing::{debug, warn};
 
@@ -48,7 +51,7 @@ pub async fn search_get_handler<S>(
     RawQuery(raw_query): RawQuery,
 ) -> RestResult<Response>
 where
-    S: ResourceStorage + SearchProvider + Send + Sync,
+    S: ResourceStorage + SearchProvider + IncludeProvider + RevincludeProvider + Send + Sync,
 {
     let pairs = parse_query_pairs(raw_query.as_deref());
     debug!(
@@ -90,7 +93,7 @@ pub async fn search_post_handler<S>(
     RawForm(form): RawForm,
 ) -> RestResult<Response>
 where
-    S: ResourceStorage + SearchProvider + Send + Sync,
+    S: ResourceStorage + SearchProvider + IncludeProvider + RevincludeProvider + Send + Sync,
 {
     let body = String::from_utf8_lossy(form.as_ref());
     let pairs = parse_query_pairs(Some(&body));
@@ -154,7 +157,7 @@ async fn execute_search<S>(
     strict: bool,
 ) -> RestResult<Response>
 where
-    S: ResourceStorage + SearchProvider + Send + Sync,
+    S: ResourceStorage + SearchProvider + IncludeProvider + RevincludeProvider + Send + Sync,
 {
     // `:not-in` requires negated value-set filtering, which no backend
     // implements. Reject it explicitly (501) regardless of whether a terminology
@@ -222,9 +225,7 @@ where
     };
 
     // Execute the search
-    // Note: The search provider is responsible for resolving _include/_revinclude
-    // directives that are part of the query. The result already contains included resources.
-    let result = state
+    let mut result = state
         .storage()
         .search(tenant.context(), &query)
         .await
@@ -232,6 +233,25 @@ where
             warn!(error = %e, "Search failed");
             RestError::from(e)
         })?;
+
+    // Resolve _include/_revinclude (with :iterate) for backends whose search()
+    // does not populate includes inline (SQLite, Postgres). Backends that
+    // resolve inline (Elasticsearch, MongoDB) return a non-empty `included` and
+    // are left as-is.
+    if !query.includes.is_empty() && result.included.is_empty() {
+        let included = resolve_includes_iterative(
+            state.storage(),
+            tenant.context(),
+            &result.resources.items,
+            &query.includes,
+        )
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "Include resolution failed");
+            RestError::from(e)
+        })?;
+        result.included = included;
+    }
 
     // Build the self link URL
     let self_link = build_search_url(state.base_url(), resource_type, &search_params);

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -401,15 +401,27 @@ fn apply_subsetting(
     fhir_version: FhirVersion,
 ) -> serde_json::Value {
     let mut result = resource.clone();
+    let mut subsetted = false;
 
     // Apply _summary if specified
     if let Some(mode) = summary_mode {
         result = apply_summary(&result, mode, fhir_version);
+        if mode != SummaryMode::False {
+            subsetted = true;
+        }
     }
 
     // Apply _elements if specified (takes precedence over _summary for element selection)
     if let Some(elem_list) = elements {
-        result = apply_elements(&result, elem_list);
+        if !elem_list.is_empty() {
+            result = apply_elements(&result, elem_list);
+            subsetted = true;
+        }
+    }
+
+    // Flag incomplete representations with the SUBSETTED tag (FHIR spec).
+    if subsetted {
+        crate::responses::subsetting::add_subsetted_tag(&mut result);
     }
 
     result

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -9,63 +9,24 @@
 //! to execute searches against the storage backend.
 
 use axum::{
-    Form,
-    extract::{Path, Query, State},
+    extract::{Path, RawForm, RawQuery, State},
     http::{HeaderMap, StatusCode},
     response::Response,
 };
 use helios_persistence::core::{MultiTypeSearchProvider, ResourceStorage, SearchProvider};
 use helios_persistence::types::SearchBundle;
-use serde::Deserialize;
-use std::collections::HashMap;
 use tracing::{debug, warn};
 
 use helios_fhir::FhirVersion;
 
 use crate::error::{RestError, RestResult};
-use crate::extractors::{TenantExtractor, build_search_query_from_map};
+use crate::extractors::query_pairs::{last_value, parse_query_pairs};
+use crate::extractors::{SearchParams, TenantExtractor, build_search_query};
 use crate::middleware::content_type::{FhirFormat, negotiate_format};
 use crate::responses::format_resource_response;
 use crate::responses::subsetting::{SummaryMode, apply_elements, apply_summary};
 use crate::state::AppState;
 use crate::terminology::TerminologyServiceClient;
-
-/// Query parameters for search (used in the SearchQuery struct in handlers).
-#[derive(Debug, Deserialize, Default)]
-#[allow(dead_code)]
-pub struct SearchQueryParams {
-    /// The page size (_count parameter).
-    #[serde(rename = "_count")]
-    pub count: Option<usize>,
-
-    /// The page offset for pagination.
-    #[serde(rename = "_offset")]
-    pub offset: Option<usize>,
-
-    /// Include total count in response.
-    #[serde(rename = "_total")]
-    pub total: Option<String>,
-
-    /// Sort order.
-    #[serde(rename = "_sort")]
-    pub sort: Option<String>,
-
-    /// Summary mode (_summary parameter).
-    #[serde(rename = "_summary")]
-    pub summary: Option<String>,
-
-    /// Elements to include (_elements parameter).
-    #[serde(rename = "_elements")]
-    pub elements: Option<String>,
-
-    /// Resources to include (_include parameter).
-    #[serde(rename = "_include")]
-    pub include: Option<Vec<String>>,
-
-    /// Resources to reverse include (_revinclude parameter).
-    #[serde(rename = "_revinclude")]
-    pub revinclude: Option<Vec<String>>,
-}
 
 /// Handler for GET search.
 ///
@@ -83,22 +44,23 @@ pub async fn search_get_handler<S>(
     Path(resource_type): Path<String>,
     tenant: TenantExtractor,
     req_headers: HeaderMap,
-    Query(params): Query<HashMap<String, String>>,
+    RawQuery(raw_query): RawQuery,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + SearchProvider + Send + Sync,
 {
+    let pairs = parse_query_pairs(raw_query.as_deref());
     debug!(
         resource_type = %resource_type,
         tenant = %tenant.tenant_id(),
-        params = ?params,
+        params = ?pairs,
         "Processing search GET request"
     );
 
-    let format_param = params.get("_format").map(|s| s.as_str());
-    let negotiated = negotiate_format(&req_headers, format_param);
+    let format_param = last_value(&pairs, "_format");
+    let negotiated = negotiate_format(&req_headers, format_param.as_deref());
 
-    execute_search(&state, tenant, &resource_type, params, negotiated.format).await
+    execute_search(&state, tenant, &resource_type, pairs, negotiated.format).await
 }
 
 /// Handler for POST search.
@@ -115,21 +77,23 @@ pub async fn search_post_handler<S>(
     Path(resource_type): Path<String>,
     tenant: TenantExtractor,
     req_headers: HeaderMap,
-    Form(params): Form<HashMap<String, String>>,
+    RawForm(form): RawForm,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + SearchProvider + Send + Sync,
 {
+    let body = String::from_utf8_lossy(form.as_ref());
+    let pairs = parse_query_pairs(Some(&body));
     debug!(
         resource_type = %resource_type,
         tenant = %tenant.tenant_id(),
-        params = ?params,
+        params = ?pairs,
         "Processing search POST request"
     );
 
     let negotiated = negotiate_format(&req_headers, None);
 
-    execute_search(&state, tenant, &resource_type, params, negotiated.format).await
+    execute_search(&state, tenant, &resource_type, pairs, negotiated.format).await
 }
 
 /// Handler for system-level search.
@@ -143,21 +107,22 @@ pub async fn search_system_handler<S>(
     State(state): State<AppState<S>>,
     tenant: TenantExtractor,
     req_headers: HeaderMap,
-    Query(params): Query<HashMap<String, String>>,
+    RawQuery(raw_query): RawQuery,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + MultiTypeSearchProvider + Send + Sync,
 {
+    let pairs = parse_query_pairs(raw_query.as_deref());
     debug!(
         tenant = %tenant.tenant_id(),
-        params = ?params,
+        params = ?pairs,
         "Processing system-level search request"
     );
 
-    let format_param = params.get("_format").map(|s| s.as_str());
-    let negotiated = negotiate_format(&req_headers, format_param);
+    let format_param = last_value(&pairs, "_format");
+    let negotiated = negotiate_format(&req_headers, format_param.as_deref());
 
-    execute_system_search(&state, tenant, params, negotiated.format).await
+    execute_system_search(&state, tenant, pairs, negotiated.format).await
 }
 
 /// Executes a type-level search and returns a Bundle response.
@@ -165,25 +130,17 @@ async fn execute_search<S>(
     state: &AppState<S>,
     tenant: TenantExtractor,
     resource_type: &str,
-    params: HashMap<String, String>,
+    pairs: Vec<(String, String)>,
     format: FhirFormat,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + SearchProvider + Send + Sync,
 {
-    // Apply pagination limits from config
-    let mut params = params;
-    apply_pagination_limits(
-        &mut params,
-        state.default_page_size(),
-        state.max_page_size(),
-    );
-
     // `:not-in` requires negated value-set filtering, which no backend
     // implements. Reject it explicitly (501) regardless of whether a terminology
     // server is configured, rather than silently ignoring it (which would return
     // a superset of the intended results).
-    if let Some(key) = params.keys().find(|k| k.ends_with(":not-in")) {
+    if let Some((key, _)) = pairs.iter().find(|(k, _)| k.ends_with(":not-in")) {
         return Err(RestError::NotImplemented {
             feature: format!(
                 "search modifier ':not-in' is not supported ({key}); \
@@ -192,18 +149,30 @@ where
         });
     }
 
-    // Pre-process :in / :not-in modifiers via the terminology server (if configured).
-    if let Some(ts_url) = state.terminology_server_url() {
-        params = expand_terminology_params(params, ts_url).await?;
-    }
+    // Pre-process :in / :above / :below modifiers via the terminology server.
+    let pairs = if let Some(ts_url) = state.terminology_server_url() {
+        expand_terminology_params(pairs, ts_url).await?
+    } else {
+        pairs
+    };
+
+    let search_params = SearchParams::from_pairs(pairs);
 
     // Convert REST params to persistence SearchQuery. Scope the registry read
     // guard tightly so it doesn't span any await — parking_lot guards aren't
     // Send by default, which would make this async fn !Send.
-    let query = {
+    let mut query = {
         let registry = state.storage().search_param_registry().read();
-        build_search_query_from_map(resource_type, &params, &registry)?
+        build_search_query(resource_type, &search_params, &registry)?
     };
+
+    // Clamp page size to the configured default/maximum.
+    let count = query
+        .count
+        .map(|c| c as usize)
+        .unwrap_or(state.default_page_size())
+        .min(state.max_page_size());
+    query.count = Some(count as u32);
 
     // Resolve chained / reverse-chained (`_has`) parameters into an `_id` filter
     // via application-side joins, so any backend's `search()` can execute them.
@@ -231,16 +200,18 @@ where
         })?;
 
     // Build the self link URL
-    let self_link = build_search_url(state.base_url(), resource_type, &params);
+    let self_link = build_search_url(state.base_url(), resource_type, &search_params);
 
     // Convert result to FHIR Bundle
     let bundle = result.to_bundle(state.base_url(), &self_link);
 
     // Parse subsetting parameters
-    let summary_mode = params.get("_summary").and_then(|v| SummaryMode::parse(v));
-    let elements: Option<Vec<&str>> = params
-        .get("_elements")
-        .map(|v| v.split(',').map(|s| s.trim()).collect());
+    let summary_mode = search_params
+        .get("_summary")
+        .and_then(|v| SummaryMode::parse(v));
+    let elements: Option<Vec<&str>> = search_params
+        .elements()
+        .map(|e| e.iter().map(|s| s.as_str()).collect());
 
     debug!(
         resource_type = %resource_type,
@@ -269,32 +240,35 @@ where
 async fn execute_system_search<S>(
     state: &AppState<S>,
     tenant: TenantExtractor,
-    params: HashMap<String, String>,
+    pairs: Vec<(String, String)>,
     format: FhirFormat,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + MultiTypeSearchProvider + Send + Sync,
 {
-    // Apply pagination limits from config
-    let mut params = params;
-    apply_pagination_limits(
-        &mut params,
-        state.default_page_size(),
-        state.max_page_size(),
-    );
+    let search_params = SearchParams::from_pairs(pairs);
 
     // Get resource types from _type parameter (if specified)
-    let resource_types: Vec<&str> = params
-        .get("_type")
-        .map(|t| t.split(',').collect())
+    let type_param = search_params.get("_type").cloned();
+    let resource_types: Vec<&str> = type_param
+        .as_deref()
+        .map(|t| t.split(',').map(|s| s.trim()).collect())
         .unwrap_or_default();
 
     // Build a search query (resource type doesn't matter much for system search).
     // Scope the registry read guard tightly so it doesn't span any await.
-    let query = {
+    let mut query = {
         let registry = state.storage().search_param_registry().read();
-        build_search_query_from_map("Resource", &params, &registry)?
+        build_search_query("Resource", &search_params, &registry)?
     };
+
+    // Clamp page size to the configured default/maximum.
+    let count = query
+        .count
+        .map(|c| c as usize)
+        .unwrap_or(state.default_page_size())
+        .min(state.max_page_size());
+    query.count = Some(count as u32);
 
     // Execute the multi-type search
     let result = state
@@ -307,16 +281,18 @@ where
         })?;
 
     // Build the self link URL
-    let self_link = build_system_search_url(state.base_url(), &params);
+    let self_link = build_system_search_url(state.base_url(), &search_params);
 
     // Convert result to FHIR Bundle
     let bundle = result.to_bundle(state.base_url(), &self_link);
 
     // Parse subsetting parameters
-    let summary_mode = params.get("_summary").and_then(|v| SummaryMode::parse(v));
-    let elements: Option<Vec<&str>> = params
-        .get("_elements")
-        .map(|v| v.split(',').map(|s| s.trim()).collect());
+    let summary_mode = search_params
+        .get("_summary")
+        .and_then(|v| SummaryMode::parse(v));
+    let elements: Option<Vec<&str>> = search_params
+        .elements()
+        .map(|e| e.iter().map(|s| s.as_str()).collect());
 
     debug!(
         results = result.resources.len(),
@@ -338,52 +314,33 @@ where
     })
 }
 
-/// Applies pagination limits from configuration to the params.
-fn apply_pagination_limits(
-    params: &mut HashMap<String, String>,
-    default_page_size: usize,
-    max_page_size: usize,
-) {
-    // Parse and limit _count
-    let count = params
-        .get("_count")
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(default_page_size)
-        .min(max_page_size);
-
-    params.insert("_count".to_string(), count.to_string());
-}
-
 /// Builds a type-level search URL from base URL and parameters.
-fn build_search_url(
-    base_url: &str,
-    resource_type: &str,
-    params: &HashMap<String, String>,
-) -> String {
-    if params.is_empty() {
+fn build_search_url(base_url: &str, resource_type: &str, params: &SearchParams) -> String {
+    let query = encode_query(params);
+    if query.is_empty() {
         format!("{}/{}", base_url, resource_type)
     } else {
-        let query: String = params
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
-            .collect::<Vec<_>>()
-            .join("&");
         format!("{}/{}?{}", base_url, resource_type, query)
     }
 }
 
 /// Builds a system-level search URL from base URL and parameters.
-fn build_system_search_url(base_url: &str, params: &HashMap<String, String>) -> String {
-    if params.is_empty() {
+fn build_system_search_url(base_url: &str, params: &SearchParams) -> String {
+    let query = encode_query(params);
+    if query.is_empty() {
         base_url.to_string()
     } else {
-        let query: String = params
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
-            .collect::<Vec<_>>()
-            .join("&");
         format!("{}?{}", base_url, query)
     }
+}
+
+/// Encodes search params back into a query string, preserving repeated keys.
+fn encode_query(params: &SearchParams) -> String {
+    params
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+        .collect::<Vec<_>>()
+        .join("&")
 }
 
 /// Converts a SearchBundle to a serde_json::Value for response with optional subsetting.
@@ -482,13 +439,13 @@ mod urlencoding {
 /// failures the problematic parameter is skipped with a warning so a single
 /// bad ValueSet URL does not abort the entire search.
 async fn expand_terminology_params(
-    params: HashMap<String, String>,
+    pairs: Vec<(String, String)>,
     ts_url: &str,
-) -> Result<HashMap<String, String>, RestError> {
+) -> Result<Vec<(String, String)>, RestError> {
     let client = TerminologyServiceClient::new(ts_url.to_string());
-    let mut result: HashMap<String, String> = HashMap::with_capacity(params.len());
+    let mut result: Vec<(String, String)> = Vec::with_capacity(pairs.len());
 
-    for (key, value) in params {
+    for (key, value) in pairs {
         if let Some(param_name) = key.strip_suffix(":in") {
             // Expand the ValueSet and join codes with commas for OR token search.
             match client.expand_value_set(&value).await {
@@ -504,7 +461,7 @@ async fn expand_terminology_params(
                         codes = %codes.len(),
                         "Expanded ValueSet for :in modifier"
                     );
-                    result.insert(param_name.to_string(), token_list);
+                    result.push((param_name.to_string(), token_list));
                 }
                 Ok(_) => {
                     // Empty expansion — no code can match; use a sentinel value
@@ -515,10 +472,7 @@ async fn expand_terminology_params(
                         "ValueSet $expand returned empty expansion for :in modifier; \
                          injecting sentinel value so no resources match"
                     );
-                    result.insert(
-                        param_name.to_string(),
-                        "__hts_empty_expansion__".to_string(),
-                    );
+                    result.push((param_name.to_string(), HTS_EMPTY_EXPANSION.to_string()));
                 }
                 Err(e) => {
                     warn!(
@@ -564,10 +518,10 @@ async fn expand_terminology_params(
                 )
                 .await;
             } else {
-                result.insert(key, value);
+                result.push((key, value));
             }
         } else {
-            result.insert(key, value);
+            result.push((key, value));
         }
     }
 
@@ -584,7 +538,7 @@ const HTS_EMPTY_EXPANSION: &str = "__hts_empty_expansion__";
 /// fail-open (drop the filter).
 #[allow(clippy::too_many_arguments)]
 async fn expand_subsumption_into(
-    result: &mut HashMap<String, String>,
+    result: &mut Vec<(String, String)>,
     client: &TerminologyServiceClient,
     param_name: &str,
     key: &str,
@@ -608,7 +562,7 @@ async fn expand_subsumption_into(
                 codes = codes.len(),
                 "Expanded token hierarchy modifier"
             );
-            result.insert(param_name.to_string(), token_list);
+            result.push((param_name.to_string(), token_list));
         }
         Ok(_) => {
             warn!(
@@ -616,7 +570,7 @@ async fn expand_subsumption_into(
                 modifier = %modifier,
                 "Token hierarchy expansion returned no codes; injecting sentinel so no resources match"
             );
-            result.insert(param_name.to_string(), HTS_EMPTY_EXPANSION.to_string());
+            result.push((param_name.to_string(), HTS_EMPTY_EXPANSION.to_string()));
         }
         Err(e) => {
             warn!(
@@ -632,70 +586,89 @@ async fn expand_subsumption_into(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    /// Collapses result pairs into a last-wins map for assertions.
+    fn as_map(pairs: &[(String, String)]) -> HashMap<String, String> {
+        pairs.iter().cloned().collect()
+    }
+
+    fn sp(pairs: &[(&str, &str)]) -> SearchParams {
+        SearchParams::from_pairs(
+            pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        )
+    }
 
     #[test]
     fn test_build_search_url_no_params() {
-        let url = build_search_url("http://example.com/fhir", "Patient", &HashMap::new());
+        let url = build_search_url("http://example.com/fhir", "Patient", &sp(&[]));
         assert_eq!(url, "http://example.com/fhir/Patient");
     }
 
     #[test]
     fn test_build_search_url_with_params() {
-        let mut params = HashMap::new();
-        params.insert("name".to_string(), "Smith".to_string());
-        params.insert("_count".to_string(), "10".to_string());
-
-        let url = build_search_url("http://example.com/fhir", "Patient", &params);
+        let url = build_search_url(
+            "http://example.com/fhir",
+            "Patient",
+            &sp(&[("name", "Smith"), ("_count", "10")]),
+        );
         assert!(url.starts_with("http://example.com/fhir/Patient?"));
         assert!(url.contains("name=Smith"));
         assert!(url.contains("_count=10"));
     }
 
     #[test]
-    fn test_build_system_search_url() {
-        let mut params = HashMap::new();
-        params.insert("_type".to_string(), "Patient,Observation".to_string());
+    fn test_build_search_url_preserves_repeated_keys() {
+        let url = build_search_url(
+            "http://example.com/fhir",
+            "Observation",
+            &sp(&[
+                ("_include", "Observation:subject"),
+                ("_include", "Observation:encounter"),
+            ]),
+        );
+        assert!(url.contains("_include=Observation%3Asubject"));
+        assert!(url.contains("_include=Observation%3Aencounter"));
+    }
 
-        let url = build_system_search_url("http://example.com/fhir", &params);
+    #[test]
+    fn test_build_system_search_url() {
+        let url = build_system_search_url(
+            "http://example.com/fhir",
+            &sp(&[("_type", "Patient,Observation")]),
+        );
         assert!(url.starts_with("http://example.com/fhir?"));
         assert!(url.contains("_type="));
     }
 
-    #[test]
-    fn test_apply_pagination_limits() {
-        let mut params = HashMap::new();
-        params.insert("_count".to_string(), "1000".to_string());
-
-        apply_pagination_limits(&mut params, 20, 100);
-
-        assert_eq!(params.get("_count"), Some(&"100".to_string()));
-    }
-
-    #[test]
-    fn test_apply_pagination_limits_default() {
-        let mut params = HashMap::new();
-
-        apply_pagination_limits(&mut params, 20, 100);
-
-        assert_eq!(params.get("_count"), Some(&"20".to_string()));
-    }
-
     // ─── expand_terminology_params ───────────────────────────────────────────
 
-    /// Verifies that non-terminology params pass through unchanged.
+    /// Verifies that non-terminology params pass through unchanged, including
+    /// repeated keys.
     #[tokio::test]
     async fn test_expand_terminology_params_passthrough() {
-        let mut params = HashMap::new();
-        params.insert("name".to_string(), "Smith".to_string());
-        params.insert("_count".to_string(), "10".to_string());
+        let params = vec![
+            ("name".to_string(), "Smith".to_string()),
+            ("name".to_string(), "Jones".to_string()),
+            ("_count".to_string(), "10".to_string()),
+        ];
 
-        // Use a URL that won't be reachable — but only :in/:not-in keys trigger calls.
-        let result = expand_terminology_params(params.clone(), "http://localhost:9999")
+        // Use a URL that won't be reachable — but only :in/:above/:below keys trigger calls.
+        let result = expand_terminology_params(params, "http://localhost:9999")
             .await
             .unwrap();
 
-        assert_eq!(result.get("name"), Some(&"Smith".to_string()));
-        assert_eq!(result.get("_count"), Some(&"10".to_string()));
+        // Both repeated `name` values survive (FHIR AND semantics).
+        let names: Vec<&str> = result
+            .iter()
+            .filter(|(k, _)| k == "name")
+            .map(|(_, v)| v.as_str())
+            .collect();
+        assert_eq!(names, vec!["Smith", "Jones"]);
+        assert_eq!(as_map(&result).get("_count"), Some(&"10".to_string()));
     }
 
     /// Verifies that a `:not-in` parameter returns `NotImplemented` rather than
@@ -703,12 +676,13 @@ mod tests {
     #[tokio::test]
     async fn test_expand_terminology_params_not_in_returns_not_implemented() {
         use crate::error::RestError;
-        let mut params = HashMap::new();
-        params.insert(
-            "code:not-in".to_string(),
-            "http://example.org/vs".to_string(),
-        );
-        params.insert("name".to_string(), "Smith".to_string());
+        let params = vec![
+            (
+                "code:not-in".to_string(),
+                "http://example.org/vs".to_string(),
+            ),
+            ("name".to_string(), "Smith".to_string()),
+        ];
 
         let result = expand_terminology_params(params, "http://127.0.0.1:19999").await;
 
@@ -719,33 +693,33 @@ mod tests {
     /// Verifies that a :in param is dropped on network error (fail-open).
     #[tokio::test]
     async fn test_expand_terminology_params_in_dropped_on_network_error() {
-        let mut params = HashMap::new();
-        params.insert("code:in".to_string(), "http://example.org/vs".to_string());
+        let params = vec![("code:in".to_string(), "http://example.org/vs".to_string())];
 
         let result = expand_terminology_params(params, "http://127.0.0.1:19999")
             .await
             .unwrap();
 
         // The :in key is gone; no code key was injected either (fail-open)
-        assert!(!result.contains_key("code:in"));
-        assert!(!result.contains_key("code"));
+        let map = as_map(&result);
+        assert!(!map.contains_key("code:in"));
+        assert!(!map.contains_key("code"));
     }
 
     /// A token `:below` (`system|code`) is fail-open dropped on network error.
     #[tokio::test]
     async fn test_expand_terminology_params_below_token_dropped_on_network_error() {
-        let mut params = HashMap::new();
-        params.insert(
+        let params = vec![(
             "code:below".to_string(),
             "http://snomed.info/sct|73211009".to_string(),
-        );
+        )];
 
         let result = expand_terminology_params(params, "http://127.0.0.1:19999")
             .await
             .unwrap();
 
-        assert!(!result.contains_key("code:below"));
-        assert!(!result.contains_key("code"));
+        let map = as_map(&result);
+        assert!(!map.contains_key("code:below"));
+        assert!(!map.contains_key("code"));
     }
 
     /// Happy path: a token `:below` expands to the code and its descendants via
@@ -772,18 +746,18 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-        let mut params = HashMap::new();
-        params.insert(
+        let params = vec![(
             "code:below".to_string(),
             "http://snomed.info/sct|73211009".to_string(),
-        );
+        )];
         let result = expand_terminology_params(params, &format!("http://{addr}"))
             .await
             .unwrap();
 
         // Modifier consumed; rewritten to a plain token OR list of descendants.
-        assert!(!result.contains_key("code:below"));
-        let codes = result.get("code").expect("code param injected");
+        let map = as_map(&result);
+        assert!(!map.contains_key("code:below"));
+        let codes = map.get("code").expect("code param injected");
         assert!(codes.contains("http://snomed.info/sct|73211009"));
         assert!(codes.contains("http://snomed.info/sct|44054006"));
         assert!(codes.contains("http://snomed.info/sct|46635009"));
@@ -793,11 +767,10 @@ mod tests {
     /// so the backend can resolve URI hierarchy natively — no terminology call.
     #[tokio::test]
     async fn test_expand_terminology_params_below_uri_passthrough() {
-        let mut params = HashMap::new();
-        params.insert(
+        let params = vec![(
             "url:below".to_string(),
             "http://example.org/fhir/ValueSet/x".to_string(),
-        );
+        )];
 
         let result = expand_terminology_params(params, "http://127.0.0.1:19999")
             .await
@@ -805,7 +778,7 @@ mod tests {
 
         // Unchanged — no `|`, so not treated as a token subsumption.
         assert_eq!(
-            result.get("url:below"),
+            as_map(&result).get("url:below"),
             Some(&"http://example.org/fhir/ValueSet/x".to_string())
         );
     }

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -162,8 +162,8 @@ use std::sync::Arc;
 
 use axum::{Router, extract::DefaultBodyLimit};
 use helios_persistence::core::{
-    BundleProvider, ConditionalStorage, InstanceHistoryProvider, ResourceStorage, SearchProvider,
-    SystemHistoryProvider, TypeHistoryProvider,
+    BundleProvider, ConditionalStorage, IncludeProvider, InstanceHistoryProvider, ResourceStorage,
+    RevincludeProvider, SearchProvider, SystemHistoryProvider, TypeHistoryProvider,
 };
 use tower::ServiceBuilder;
 use tower_http::{
@@ -196,6 +196,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider
@@ -239,6 +241,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider
@@ -288,6 +292,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider
@@ -323,6 +329,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider
@@ -358,6 +366,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider

--- a/crates/rest/src/responses/subsetting.rs
+++ b/crates/rest/src/responses/subsetting.rs
@@ -41,6 +41,43 @@ impl SummaryMode {
 /// Elements that are always included regardless of subsetting.
 const ALWAYS_INCLUDED: &[&str] = &["resourceType", "id", "meta"];
 
+/// CodeSystem for the `SUBSETTED` tag added to incomplete representations.
+const SUBSETTED_SYSTEM: &str = "http://terminology.hl7.org/CodeSystem/v3-ObservationValue";
+
+/// Adds a `SUBSETTED` `meta.tag` to a resource, flagging that the returned
+/// representation is incomplete (per `_summary`/`_elements`), as required by the
+/// FHIR spec. Idempotent; a no-op for non-object JSON values.
+pub fn add_subsetted_tag(resource: &mut Value) {
+    let Value::Object(obj) = resource else {
+        return;
+    };
+    let meta = obj
+        .entry("meta")
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Value::Object(meta_obj) = meta else {
+        return;
+    };
+    let tags = meta_obj
+        .entry("tag")
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let Value::Array(arr) = tags else {
+        return;
+    };
+    let already_tagged = arr.iter().any(|t| {
+        t.get("system").and_then(|s| s.as_str()) == Some(SUBSETTED_SYSTEM)
+            && t.get("code").and_then(|c| c.as_str()) == Some("SUBSETTED")
+    });
+    if !already_tagged {
+        let mut tag = Map::new();
+        tag.insert(
+            "system".to_string(),
+            Value::String(SUBSETTED_SYSTEM.to_string()),
+        );
+        tag.insert("code".to_string(), Value::String("SUBSETTED".to_string()));
+        arr.push(Value::Object(tag));
+    }
+}
+
 /// Converts a Rust snake_case field name to JSON camelCase.
 ///
 /// The generated FHIR types use snake_case for Rust field names, but the
@@ -439,6 +476,32 @@ mod tests {
             assert!(first.get("family").is_some());
             // given should not be included as we only requested name.family
         }
+    }
+
+    #[test]
+    fn test_add_subsetted_tag_is_idempotent() {
+        let mut resource = json!({ "resourceType": "Patient", "id": "1" });
+        add_subsetted_tag(&mut resource);
+        add_subsetted_tag(&mut resource);
+
+        let tags = resource["meta"]["tag"].as_array().expect("tag array");
+        let subsetted: Vec<_> = tags
+            .iter()
+            .filter(|t| t["code"] == "SUBSETTED" && t["system"] == SUBSETTED_SYSTEM)
+            .collect();
+        assert_eq!(subsetted.len(), 1, "SUBSETTED tag added exactly once");
+    }
+
+    #[test]
+    fn test_add_subsetted_tag_preserves_existing_tags() {
+        let mut resource = json!({
+            "resourceType": "Patient",
+            "id": "1",
+            "meta": { "tag": [{ "system": "http://example.org", "code": "x" }] }
+        });
+        add_subsetted_tag(&mut resource);
+        let tags = resource["meta"]["tag"].as_array().unwrap();
+        assert_eq!(tags.len(), 2, "existing tag preserved + SUBSETTED added");
     }
 
     #[test]

--- a/crates/rest/src/routing/fhir_routes.rs
+++ b/crates/rest/src/routing/fhir_routes.rs
@@ -11,8 +11,8 @@ use axum::{
 };
 use helios_fhir::FhirVersion;
 use helios_persistence::core::{
-    BundleProvider, ConditionalStorage, InstanceHistoryProvider, ResourceStorage, SearchProvider,
-    SystemHistoryProvider, TypeHistoryProvider,
+    BundleProvider, ConditionalStorage, IncludeProvider, InstanceHistoryProvider, ResourceStorage,
+    RevincludeProvider, SearchProvider, SystemHistoryProvider, TypeHistoryProvider,
 };
 use tower::ServiceExt;
 
@@ -58,6 +58,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider
@@ -82,6 +84,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider
@@ -105,6 +109,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider
@@ -133,6 +139,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider
@@ -200,6 +208,8 @@ where
     S: ResourceStorage
         + ConditionalStorage
         + SearchProvider
+        + IncludeProvider
+        + RevincludeProvider
         + InstanceHistoryProvider
         + TypeHistoryProvider
         + SystemHistoryProvider

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -1538,12 +1538,20 @@ mod includes {
 
         assert!(obs_count >= 1, "Should have at least 1 observation");
 
-        // If includes are working, we should have a patient too
-        // Check if any entry has search.mode = "include"
-        let has_include = entries.iter().any(|e| e["search"]["mode"] == "include");
-        if has_include {
-            assert!(patient_count >= 1, "Should include the patient");
-        }
+        // The referenced Patient must be included, tagged search.mode=include.
+        assert!(patient_count >= 1, "Should include the referenced patient");
+        let included_patient = entries.iter().find(|e| {
+            e["resource"]["resourceType"] == "Patient" && e["search"]["mode"] == "include"
+        });
+        assert!(
+            included_patient.is_some(),
+            "Patient should be present as an include entry"
+        );
+        assert_eq!(
+            included_patient.unwrap()["resource"]["id"],
+            "patient-1",
+            "the subject of obs-1 is patient-1"
+        );
     }
 
     #[tokio::test]
@@ -1590,7 +1598,13 @@ mod includes {
             resource_types.contains(&"Observation"),
             "Should have observation"
         );
-        // Included resources depend on implementation
+        // Repeated _include keys are both honored (AND). obs-1's subject is
+        // Patient/patient-1; it has no encounter, so only the Patient is added —
+        // but crucially the subject include is NOT lost to the encounter one.
+        assert!(
+            resource_types.contains(&"Patient"),
+            "subject include must survive alongside the encounter include"
+        );
     }
 
     #[tokio::test]
@@ -1622,11 +1636,15 @@ mod includes {
             .filter(|e| e["resource"]["resourceType"] == "Observation")
             .count();
 
-        // If revinclude is working, we should have observations
-        let has_include = entries.iter().any(|e| e["search"]["mode"] == "include");
-        if has_include {
-            assert!(obs_count >= 1, "Should revinclude observations");
-        }
+        // Observations referencing patient-1 must be reverse-included.
+        assert!(obs_count >= 1, "Should revinclude observations");
+        assert!(
+            entries
+                .iter()
+                .any(|e| e["resource"]["resourceType"] == "Observation"
+                    && e["search"]["mode"] == "include"),
+            "revincluded observations must be tagged search.mode=include"
+        );
     }
 
     #[tokio::test]
@@ -1652,17 +1670,26 @@ mod includes {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;
 
-        // Use _include:iterate to follow references from included resources
+        // _include:iterate follows references from included resources:
+        // obs-1 -> subject Patient/patient-1 -> organization Organization/org-1.
         let response = server
             .get("/Observation?_id=obs-1&_include=Observation:subject&_include:iterate=Patient:organization")
             .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
             .await;
 
-        // May or may not be supported
-        let status = response.status_code();
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        let types: Vec<&str> = entries
+            .iter()
+            .filter_map(|e| e["resource"]["resourceType"].as_str())
+            .collect();
+
+        // First-hop include (Patient) and the transitively-included Organization.
+        assert!(types.contains(&"Patient"), "subject Patient included");
         assert!(
-            status == StatusCode::OK || status == StatusCode::BAD_REQUEST,
-            "Should return OK or indicate unsupported"
+            types.contains(&"Organization"),
+            ":iterate should transitively include the Patient's managingOrganization"
         );
     }
 
@@ -1671,17 +1698,28 @@ mod includes {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;
 
-        // Use * to include all references
+        // _include=Observation:* expands to every reference search param of
+        // Observation; obs-1 references subject (Patient) and performer
+        // (Practitioner), both of which should be included.
         let response = server
             .get("/Observation?_id=obs-1&_include=Observation:*")
             .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
             .await;
 
-        // May or may not be supported
-        let status = response.status_code();
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        let types: Vec<&str> = entries
+            .iter()
+            .filter_map(|e| e["resource"]["resourceType"].as_str())
+            .collect();
         assert!(
-            status == StatusCode::OK || status == StatusCode::BAD_REQUEST,
-            "Should return OK or indicate unsupported"
+            types.contains(&"Patient"),
+            "wildcard include resolves subject"
+        );
+        assert!(
+            types.contains(&"Practitioner"),
+            "wildcard include resolves performer"
         );
     }
 

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -372,6 +372,41 @@ mod basic_search {
     }
 
     #[tokio::test]
+    async fn test_unknown_param_lenient_ignored_strict_rejected() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        // Lenient (default): unknown parameter is ignored, search succeeds.
+        let lenient = server
+            .get("/Patient?nonsense-param=foo")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        lenient.assert_status_ok();
+
+        // Strict: unknown parameter is rejected with 400.
+        let strict = server
+            .get("/Patient?nonsense-param=foo")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .add_header(
+                HeaderName::from_static("prefer"),
+                HeaderValue::from_static("handling=strict"),
+            )
+            .await;
+        assert_eq!(strict.status_code(), StatusCode::BAD_REQUEST);
+
+        // A known parameter is accepted even under strict handling.
+        let ok = server
+            .get("/Patient?name=Smith")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .add_header(
+                HeaderName::from_static("prefer"),
+                HeaderValue::from_static("handling=strict"),
+            )
+            .await;
+        ok.assert_status_ok();
+    }
+
+    #[tokio::test]
     async fn test_search_by_id() {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -1005,6 +1005,39 @@ mod subsetting {
             // Should not include unrequested elements
             assert!(resource["gender"].is_null());
             assert!(resource["birthDate"].is_null());
+            // Subset responses must carry the SUBSETTED meta.tag (FHIR spec).
+            let tags = resource["meta"]["tag"]
+                .as_array()
+                .expect("meta.tag present");
+            assert!(
+                tags.iter().any(|t| t["code"] == "SUBSETTED"
+                    && t["system"] == "http://terminology.hl7.org/CodeSystem/v3-ObservationValue"),
+                "subsetted entry should be tagged SUBSETTED"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_no_subsetted_tag_without_subsetting() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_count=1")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        if let Some(entry) = entries.first() {
+            let tags = entry["resource"]["meta"]["tag"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+            assert!(
+                !tags.iter().any(|t| t["code"] == "SUBSETTED"),
+                "full representation must not be tagged SUBSETTED"
+            );
         }
     }
 }

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -340,6 +340,38 @@ mod basic_search {
     }
 
     #[tokio::test]
+    async fn test_total_accurate_populates_bundle_total() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        // Baseline count of all patients (no _total -> total omitted).
+        let baseline: Value = server
+            .get("/Patient")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await
+            .json();
+        let patient_count = get_bundle_entries(&baseline).len() as i64;
+        assert!(patient_count > 0, "fixture should seed patients");
+        assert!(
+            baseline["total"].is_null(),
+            "Bundle.total should be absent without _total"
+        );
+
+        // _total=accurate -> Bundle.total present and equal to the match count.
+        let response = server
+            .get("/Patient?_total=accurate")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status_ok();
+        let body: Value = response.json();
+        assert_eq!(
+            body["total"].as_i64(),
+            Some(patient_count),
+            "Bundle.total must equal the number of matches"
+        );
+    }
+
+    #[tokio::test]
     async fn test_search_by_id() {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;


### PR DESCRIPTION
## Summary

Fixes a set of FHIR search conformance gaps found by auditing the implementation against the [FHIR search spec](https://build.fhir.org/search.html). Each fix is an independent commit; all are committed, tested, and clippy-clean.

## What's fixed

| Area | Before | After |
|------|--------|-------|
| **Repeated query params** | `?_include=A&_include=B`, repeated `_has`, and repeated filter params collapsed to last-wins (`HashMap` extraction) | Preserved as FHIR AND semantics via duplicate-preserving extraction threaded through the search pipeline |
| **`_include` / `_revinclude`** | Resolved **only** on Elasticsearch/MongoDB; SQLite & Postgres returned **no** included resources | Resolved on all backends via one registry-based central resolver (`core::resolve_includes_iterative`) called from the REST handler when the backend left includes empty |
| **`:iterate` + `Type:*` wildcard** | parsed but not executed; wildcard unsupported | `:iterate` transitively follows includes (depth-capped, deduped); `_include=Type:*` expands to every reference param of the type. Both iterate spellings accepted (`_include=Obs:subject:iterate` and `_include:iterate=Obs:subject`) |
| **Nested `_has`** | parsed but ignored (wrong results); parser double-prefixed `_has:` | Resolved recursively with a reverse-depth cap |
| **`Bundle.total`** | always `None` on SQLite/Postgres | Populated for `_total=accurate\|estimate` via the existing `search_count` |
| **`SUBSETTED` tag** | only bulk export tagged subsets | `_summary`/`_elements` search & read responses now carry the `SUBSETTED` `meta.tag` |
| **`Prefer: handling=strict`** | never consulted by search | Unknown params rejected with `400` on type-level search; lenient default still ignores them |

References are extracted through the search-parameter registry's FHIRPath expression, so params whose name differs from the JSON field (e.g. Patient `organization` → `managingOrganization`) now resolve correctly.

## Audit corrections
Two originally-suspected gaps turned out **not** to be gaps and were intentionally left alone: SQLite already implements `_text`/`_content` (FTS5), and terminology `:in`/`:above`/`:below` fail-open is a deliberate, tested design.

## Verification
- `cargo fmt --all --check` clean
- clippy clean (`-p helios-rest -p helios-persistence --features postgres`, CI flag set)
- persistence lib: 630 pass · rest: ~436 pass · `hfs` + postgres builds succeed
- New/strengthened tests for every workstream (repeated params, multi/iterate/wildcard includes, revinclude, nested `_has`, `Bundle.total`, SUBSETTED present/absent, strict 400)

## Not in this PR (documented as known gaps in `crates/persistence/docs/search-spec-assessment.md` §7)
Deferred to focused follow-ups due to scope/risk:
- Quantity **UCUM canonicalization** (needs a search-index schema migration + reindex)
- **Accent-insensitive** string search (3 backends)
- **Versioned / canonical references** (3 backends)
- `gt`/`lt` precision-range **boundary** semantics (edge-case; 3 backends)

MongoDB search feature parity (composite, native chaining) remains out of scope per design.

## Docs
`crates/persistence/docs/search-spec-assessment.md` updated to reflect landed behavior and the remaining gaps. Note: `docs/ui-requirements.md` lives on the `docs/ui-requirements` branch (not on main), so its corresponding §7 updates should be applied there separately.