### PR TITLE
fix(search): version-agnostic reference matching (follow-up to #131)

### DIFF
--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -213,10 +213,14 @@ Ordered roughly by impact:
    `1000|mg`. (UCUM logic exists in `helios-fhirpath` but is not wired into the search index.)
 8. **Accent-insensitive string search** — string search is case-insensitive and prefix-based, but
    not accent/diacritic-insensitive for ordinary string parameters (only the FTS `_text`/`_content`
-   path folds diacritics). The spec calls for accent-insensitive string matching.
-9. **Versioned / canonical references** — a versioned reference (`Patient/1/_history/2`) is matched
-   as a literal string, and canonical `url|version` hierarchy for reference `:above`/`:below` is not
-   implemented; `:identifier` assumes a `Type/id` reference shape.
+   path folds diacritics). This is **migration-class**, not a handler tweak: SQLite has no native
+   `unaccent` (needs a folded index column + reindex, or a custom connection-registered function),
+   Postgres needs the `unaccent` extension, and Elasticsearch needs an `asciifolding` analyzer +
+   reindex. Best done alongside the UCUM index migration (item 7).
+9. **Canonical `url|version` references** — versioned reference matching is now version-agnostic
+   (`Patient/1/_history/2` ⇄ `Patient/1`, via `strip_reference_version`, on SQLite/PG/ES). The
+   remaining gap is canonical `url|version` hierarchy for reference `:above`/`:below`; `:identifier`
+   also assumes a `Type/id` reference shape.
 10. **Ordered-value boundary semantics** — `gt`/`lt` (and SQLite `sa`/`eb`) compare against the
     scalar value rather than the precision-range boundary the spec defines; `eq`/`ne`/`ap` already
     use implicit-precision ranges. Edge-case-only.

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/reference.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{Value, json};
 
-use crate::types::{SearchModifier, SearchParameter};
+use crate::types::{SearchModifier, SearchParameter, strip_reference_version};
 
 /// Builds an ES query clause for a reference search parameter.
 pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
@@ -105,17 +105,27 @@ pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
 
     let mut must_conditions = vec![json!({ "term": { "search_params.reference.name": name } })];
 
-    // Parse reference value
-    if value.contains('/') {
+    // Reference matching is version-agnostic: strip any `/_history/<vid>` and
+    // match the base reference or the same reference carrying a version.
+    let base = strip_reference_version(value);
+    if base.contains('/') {
         // Type/id format (e.g., "Patient/123") or full URL
-        must_conditions.push(json!({ "term": { "search_params.reference.reference": value } }));
+        must_conditions.push(json!({
+            "bool": {
+                "should": [
+                    { "term": { "search_params.reference.reference": base } },
+                    { "prefix": { "search_params.reference.reference": format!("{}/_history/", base) } }
+                ],
+                "minimum_should_match": 1
+            }
+        }));
     } else {
         // Just an ID - match either resource_id or reference ending with /id
         must_conditions.push(json!({
             "bool": {
                 "should": [
-                    { "term": { "search_params.reference.resource_id": value } },
-                    { "term": { "search_params.reference.reference": value } }
+                    { "term": { "search_params.reference.resource_id": base } },
+                    { "term": { "search_params.reference.reference": base } }
                 ],
                 "minimum_should_match": 1
             }

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 
 use crate::types::{
     SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
+    strip_reference_version,
 };
 
 /// How a sort key's value is typed for cursor (keyset) binding and comparison.
@@ -945,14 +946,27 @@ impl PostgresQueryBuilder {
                     param_num
                 )
             } else {
-                format!("value_reference = ${}", param_num)
+                // Plain reference match, version-agnostic: the bound value is
+                // the version-stripped base; match it exactly or carrying any
+                // `_history` version.
+                format!(
+                    "(value_reference = ${0} OR value_reference LIKE ${0} || '/_history/%')",
+                    param_num
+                )
+            };
+            // For the plain match the bound value is version-stripped; modifiers
+            // keep the literal value.
+            let bound = if is_text || is_code_text || is_contains || is_below || is_above {
+                value.value.clone()
+            } else {
+                strip_reference_version(&value.value).to_string()
             };
             conditions.push(SqlFragment::with_params(
                 format!(
                     "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
                     param.name, predicate
                 ),
-                vec![SqlParam::text(&value.value)],
+                vec![SqlParam::text(&bound)],
             ));
         }
 

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
@@ -1,6 +1,6 @@
 //! Reference parameter SQL handler.
 
-use crate::types::{SearchModifier, SearchValue};
+use crate::types::{SearchModifier, SearchValue, strip_reference_version};
 
 use super::super::query_builder::{SqlFragment, SqlParam};
 
@@ -88,25 +88,13 @@ impl ReferenceHandler {
 
         // Handle :Type modifier (restrict to specific resource type)
         if let Some(SearchModifier::Type(type_name)) = modifier {
-            // The reference must be to the specified type
-            let expected_prefix = format!("{}/", type_name);
-
-            if ref_value.contains('/') {
-                // Value already has type - just match it
-                SqlFragment::with_params(
-                    format!("value_reference = ?{}", param_num),
-                    vec![SqlParam::string(ref_value)],
-                )
+            // Normalize to a `Type/id` reference, then match version-agnostically.
+            let full = if ref_value.contains('/') {
+                ref_value.to_string()
             } else {
-                // Value is just an ID - prepend the type
-                SqlFragment::with_params(
-                    format!("value_reference = ?{}", param_num),
-                    vec![SqlParam::string(format!(
-                        "{}{}",
-                        expected_prefix, ref_value
-                    ))],
-                )
-            }
+                format!("{}/{}", type_name, ref_value)
+            };
+            Self::build_reference_condition(&full, param_num)
         } else {
             // No modifier - match the reference as given
             Self::build_reference_condition(ref_value, param_num)
@@ -114,24 +102,42 @@ impl ReferenceHandler {
     }
 
     /// Builds a condition for a standard reference value.
+    ///
+    /// Reference matching is **version-agnostic** per the FHIR spec: a versioned
+    /// reference (`Patient/123/_history/2`) is normalized by stripping the
+    /// version, and a stored versioned reference still matches an unversioned
+    /// search (and vice versa).
     fn build_reference_condition(ref_value: &str, param_num: usize) -> SqlFragment {
-        if ref_value.contains('/') {
-            // Type/id or full URL - exact match
-            SqlFragment::with_params(
-                format!("value_reference = ?{}", param_num),
-                vec![SqlParam::string(ref_value)],
-            )
-        } else {
-            // Just an ID - match any reference ending with this ID
-            // This handles cases where the stored reference might be "Patient/123" but
-            // the search is just "123"
+        let base = strip_reference_version(ref_value);
+
+        if base.contains('/') {
+            // Type/id (or absolute URL): match the base reference, or the same
+            // reference carrying any `_history` version.
             SqlFragment::with_params(
                 format!(
-                    "(value_reference = ?{} OR value_reference LIKE '%/' || ?{})",
+                    "(value_reference = ?{} OR value_reference LIKE ?{} || '/_history/%')",
                     param_num,
                     param_num + 1
                 ),
-                vec![SqlParam::string(ref_value), SqlParam::string(ref_value)],
+                vec![SqlParam::string(base), SqlParam::string(base)],
+            )
+        } else {
+            // Just an ID - match any reference ending with this ID, with or
+            // without a trailing `_history` version.
+            SqlFragment::with_params(
+                format!(
+                    "(value_reference = ?{} \
+                      OR value_reference LIKE '%/' || ?{} \
+                      OR value_reference LIKE '%/' || ?{} || '/_history/%')",
+                    param_num,
+                    param_num + 1,
+                    param_num + 2
+                ),
+                vec![
+                    SqlParam::string(base),
+                    SqlParam::string(base),
+                    SqlParam::string(base),
+                ],
             )
         }
     }
@@ -198,8 +204,33 @@ mod tests {
         let value = SearchValue::new(SearchPrefix::Eq, "Patient/123");
         let frag = ReferenceHandler::build_sql(&value, None, 0);
 
+        // Version-agnostic: exact match or any `_history` version.
         assert!(frag.sql.contains("value_reference = ?1"));
-        assert_eq!(frag.params.len(), 1);
+        assert!(frag.sql.contains("'/_history/%'"));
+        assert_eq!(frag.params.len(), 2);
+    }
+
+    #[test]
+    fn test_reference_versioned_search_strips_version() {
+        // Searching a versioned reference matches the version-stripped base.
+        let value = SearchValue::new(SearchPrefix::Eq, "Patient/123/_history/2");
+        let frag = ReferenceHandler::build_sql(&value, None, 0);
+        assert_eq!(frag.params.len(), 2);
+        // Both bound params are the stripped base "Patient/123".
+        // (SqlParam compares via its Debug/string form.)
+        let dbg = format!("{:?}", frag.params);
+        assert!(dbg.contains("Patient/123"));
+        assert!(!dbg.contains("_history"));
+    }
+
+    #[test]
+    fn test_strip_reference_version() {
+        assert_eq!(
+            strip_reference_version("Patient/123/_history/2"),
+            "Patient/123"
+        );
+        assert_eq!(strip_reference_version("Patient/123"), "Patient/123");
+        assert_eq!(strip_reference_version("123"), "123");
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -875,12 +875,14 @@ mod tests {
 
         let fragment = builder.build(&query);
 
-        // Should use ?3 and ?4 for the two params in ID-only reference search
-        // (after ?1 tenant and ?2 resource_type)
+        // ID-only reference search is version-agnostic: exact, `%/id`, and
+        // `%/id/_history/%`, so three params (?3, ?4, ?5) after ?1 tenant / ?2
+        // resource_type.
         assert!(fragment.sql.contains("?3"));
         assert!(fragment.sql.contains("?4"));
-        // Should have 4 total params: tenant, resource_type, ref_value, ref_value
-        assert_eq!(fragment.params.len(), 4);
+        assert!(fragment.sql.contains("?5"));
+        // tenant, resource_type, + 3 ref_value bindings
+        assert_eq!(fragment.params.len(), 5);
     }
 
     #[test]
@@ -900,13 +902,12 @@ mod tests {
 
         let fragment = builder.build(&query);
 
-        // First value uses ?3 and ?4 (2 params for ID-only)
-        // Second value uses ?5 and ?6 (2 more params for ID-only)
-        assert!(fragment.sql.contains("?3"));
-        assert!(fragment.sql.contains("?4"));
-        assert!(fragment.sql.contains("?5"));
-        assert!(fragment.sql.contains("?6"));
-        // Should have 6 total params: tenant, resource_type, + 4 for 2 ID-only refs
-        assert_eq!(fragment.params.len(), 6);
+        // Each ID-only value now binds 3 params (exact, `%/id`, `%/id/_history/%`):
+        // first value ?3..?5, second value ?6..?8.
+        for p in ["?3", "?4", "?5", "?6", "?7", "?8"] {
+            assert!(fragment.sql.contains(p), "missing placeholder {p}");
+        }
+        // tenant, resource_type, + 3 per ID-only ref × 2 values
+        assert_eq!(fragment.params.len(), 8);
     }
 }

--- a/crates/persistence/src/types/mod.rs
+++ b/crates/persistence/src/types/mod.rs
@@ -86,6 +86,7 @@ pub use search_params::{
     ChainConfig, ChainedParameter, CompositeSearchComponent, IncludeDirective, IncludeType,
     ReverseChainedParameter, SearchModifier, SearchParamType, SearchParameter, SearchPrefix,
     SearchQuery, SearchValue, SortDirection, SortDirective, SummaryMode, TotalMode,
+    strip_reference_version,
 };
 
 pub use stored_resource::{ResourceMeta, ResourceMethod, StoredResource, StoredResourceBuilder};

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -725,6 +725,17 @@ pub enum SummaryMode {
     Count,
 }
 
+/// Strips a `/_history/<vid>` version suffix from a FHIR reference, returning
+/// the version-agnostic base. References without a version are returned
+/// unchanged. Used so reference search matches regardless of version, per the
+/// FHIR spec.
+pub fn strip_reference_version(reference: &str) -> &str {
+    match reference.find("/_history/") {
+        Some(i) => &reference[..i],
+        None => reference,
+    }
+}
+
 impl SearchQuery {
     /// Creates a new search query for the given resource type.
     pub fn new(resource_type: impl Into<String>) -> Self {

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -407,6 +407,29 @@ mod basic_search {
     }
 
     #[tokio::test]
+    async fn test_reference_search_is_version_agnostic() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        // obs-1 stores an unversioned subject (Patient/patient-1). A versioned
+        // reference search must still match it (version is not considered).
+        let response = server
+            .get("/Observation?subject=Patient/patient-1/_history/5")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let ids: Vec<&str> = get_bundle_entries(&body)
+            .iter()
+            .filter_map(|e| e["resource"]["id"].as_str())
+            .collect();
+        assert!(
+            ids.contains(&"obs-1"),
+            "versioned reference search should match the unversioned stored reference"
+        );
+    }
+
+    #[tokio::test]
     async fn test_search_by_id() {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;


### PR DESCRIPTION
Follow-up to #131. Stacked on `fix/search-spec-conformance` (retarget to `main` once #131 merges).

## What's in this PR — WS10 (versioned references)

Reference search is now **version-agnostic** per the FHIR spec, on **SQLite, Postgres, and Elasticsearch**:
- A versioned search value (`Patient/123/_history/2`) matches an unversioned stored reference.
- A stored versioned reference matches an unversioned search.
- Bare-id and `:Type`-modified reference searches are handled too.

Implemented via a shared `types::strip_reference_version` used by all three reference handlers (match the base reference exactly, or the base carrying any `/_history/` version).

Tested: SQLite reference unit tests + an end-to-end test (versioned `subject=Patient/patient-1/_history/5` matches the unversioned stored reference); updated the query-builder param-offset tests for the new bare-id binding count.

## Scope changes vs. the original plan (honest accounting)

While picking up the deferred items I found two of them are **not** the contained handler edits the audit implied:

- **WS9 (accent-insensitive string search)** is **migration-class**, not a handler tweak: SQLite has no native `unaccent` (needs a folded index column + reindex, or a custom connection-registered function), Postgres needs the `unaccent` extension, and ES needs an `asciifolding` analyzer + reindex. It belongs with the **WS8 UCUM** index migration in a dedicated PR.
- **WS7 (gt/lt/sa/eb precision-range boundary semantics)** is pure handler logic but genuinely subtle under FHIR's implicit-precision rules; the current scalar comparison is a defensible common choice. I left it rather than risk a wrong boundary interpretation; it's documented as edge-case.

Both, plus canonical `url|version` `:above/:below`, are documented as known gaps in `crates/persistence/docs/search-spec-assessment.md` §7.

## Remaining roadmap
- **Dedicated migration PR**: WS8 (UCUM quantity canonicalization) + WS9 (accent-insensitive string) — both need a search-index schema migration + reindex per backend.
- Optional: WS7 boundary semantics; canonical `url|version` reference hierarchy.