### PR TITLE
feat(search): search-index v10 — UCUM quantity canonicalization + accent-insensitive   string search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,6 +3149,7 @@ dependencies = [
  "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "uuid",
 ]
 

--- a/crates/fhirpath/src/lib.rs
+++ b/crates/fhirpath/src/lib.rs
@@ -272,7 +272,7 @@ mod conversion_functions;
 mod format_functions;
 mod interval_functions;
 mod json_utils;
-mod ucum;
+pub mod ucum;
 // Public for internal testing only - not part of the public API
 #[doc(hidden)]
 pub mod date_operation;

--- a/crates/fhirpath/src/ucum.rs
+++ b/crates/fhirpath/src/ucum.rs
@@ -18,6 +18,26 @@ pub fn validate_unit(unit: &str) -> bool {
     validate(unit).is_ok()
 }
 
+/// Canonicalizes a quantity to its UCUM canonical unit.
+///
+/// Returns `(canonical_value, canonical_unit)`, or `None` if the unit is
+/// unknown or cannot be converted. Used by the search index to store a
+/// unit-normalized quantity so that, e.g., `1 g` and `1000 mg` compare equal.
+pub fn canonicalize_quantity(value: f64, unit: &str) -> Option<(f64, String)> {
+    if unit.is_empty() {
+        return None;
+    }
+    // `get_canonical_units` reduces the unit to its dimension-based base form and
+    // gives the conversion factor/offset, so commensurable units (g, mg, kg)
+    // share the same canonical `unit` string and comparable canonical values.
+    let canonical = octofhir_ucum::get_canonical_units(unit).ok()?;
+    if canonical.unit.is_empty() {
+        return None;
+    }
+    let canonical_value = value * canonical.factor + canonical.offset;
+    Some((canonical_value, canonical.unit))
+}
+
 /// Converts a value from one UCUM unit to another
 pub fn convert_units(value: Decimal, from_unit: &str, to_unit: &str) -> Result<Decimal, String> {
     // Normalize calendar units to UCUM format

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -55,6 +55,7 @@ parking_lot = "0.12"
 json-patch = "3"
 humantime = "2"
 futures = "0.3"
+unicode-normalization = "0.1"
 
 # SQLite backend
 rusqlite = { version = "0.33", features = ["bundled", "serde_json"], optional = true }

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -208,19 +208,26 @@ Ordered roughly by impact:
    nested objects; chained/`_has` now work via the REST-layer resolver — see below.)
 6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links.
-7. **Quantity UCUM canonicalization** — **done on SQLite** (schema v10): the index stores a
-   dimension-canonical value/unit (`value_quantity_canonical_value`/`_unit`) computed via
-   `helios_fhirpath::ucum::canonicalize_quantity`, and quantity search matches the canonical columns
-   (bounds canonicalized to preserve implicit precision) OR the raw unit, so `1|g` matches
-   `1000|mg`. **Remaining:** Postgres/Elasticsearch (their schema/mapping + writer + handler), and a
-   **reindex backfill** (`ReindexRequest`) to populate canonical columns for resources written
-   before the upgrade — un-reindexed rows fall back to raw unit matching.
-8. **Accent-insensitive string search** — string search is case-insensitive and prefix-based, but
-   not accent/diacritic-insensitive for ordinary string parameters (only the FTS `_text`/`_content`
-   path folds diacritics). This is **migration-class**, not a handler tweak: SQLite has no native
-   `unaccent` (needs a folded index column + reindex, or a custom connection-registered function),
-   Postgres needs the `unaccent` extension, and Elasticsearch needs an `asciifolding` analyzer +
-   reindex. Best done alongside the UCUM index migration (item 7).
+7. **Quantity UCUM canonicalization** (schema v10) — the index stores a dimension-canonical
+   value/unit (`value_quantity_canonical_value`/`_unit`) computed via
+   `helios_fhirpath::ucum::canonicalize_quantity`, so `1|g` matches `1000|mg`.
+   - **SQLite: complete** — writer populates canonical columns; the quantity handler matches the
+     canonical columns (search bounds canonicalized to preserve implicit precision) OR the raw unit.
+   - **Postgres: write-side done** (canonical columns populated by the writer); the **query-side OR**
+     into the canonical columns is not yet wired (raw unit matching only) — pending param-stride and
+     float-tolerance handling.
+   - **Elasticsearch: remaining.**
+   - A **reindex backfill** (`ReindexRequest`) is required to populate canonical columns for
+     resources written before the upgrade; un-reindexed rows fall back to raw unit matching.
+8. **Accent-insensitive string search** (schema v10) — string search folds case **and** accents via
+   NFD + combining-mark stripping (`unicode-normalization`, shared `search::fold_text`), stored in
+   `value_string_folded`.
+   - **SQLite: complete** — default/`:contains`/`:text` match the folded column ORed with the raw
+     (case-insensitive) column; `:exact` stays case/accent-sensitive.
+   - **Postgres: complete** — `COALESCE(value_string_folded, value_string) ILIKE` against a folded
+     pattern (raw fallback keeps non-accented pre-reindex rows matching case-insensitively).
+   - **Elasticsearch: remaining** (needs an `asciifolding` analyzer + reindex).
+   - Pre-reindex rows need the **reindex backfill** for accent-insensitivity.
 9. **Canonical `url|version` references** — versioned reference matching is now version-agnostic
    (`Patient/1/_history/2` ⇄ `Patient/1`, via `strip_reference_version`, on SQLite/PG/ES). The
    remaining gap is canonical `url|version` hierarchy for reference `:above`/`:below`; `:identifier`

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -208,9 +208,13 @@ Ordered roughly by impact:
    nested objects; chained/`_has` now work via the REST-layer resolver — see below.)
 6. **REST result params** — `_maxresults`, `_score`, `_query`, `_contained`/`_containedType`
    unsupported; Bundles omit `first`/`last` paging links.
-7. **Quantity UCUM canonicalization** — quantity `system|code` is matched by literal string equality;
-   there is no unit conversion, so `120|mm[Hg]` does not match `120|mmHg` and `1|g` does not match
-   `1000|mg`. (UCUM logic exists in `helios-fhirpath` but is not wired into the search index.)
+7. **Quantity UCUM canonicalization** — **done on SQLite** (schema v10): the index stores a
+   dimension-canonical value/unit (`value_quantity_canonical_value`/`_unit`) computed via
+   `helios_fhirpath::ucum::canonicalize_quantity`, and quantity search matches the canonical columns
+   (bounds canonicalized to preserve implicit precision) OR the raw unit, so `1|g` matches
+   `1000|mg`. **Remaining:** Postgres/Elasticsearch (their schema/mapping + writer + handler), and a
+   **reindex backfill** (`ReindexRequest`) to populate canonical columns for resources written
+   before the upgrade — un-reindexed rows fall back to raw unit matching.
 8. **Accent-insensitive string search** — string search is case-insensitive and prefix-based, but
    not accent/diacritic-insensitive for ordinary string parameters (only the FTS `_text`/`_content`
    path folds diacritics). This is **migration-class**, not a handler tweak: SQLite has no native

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -216,11 +216,14 @@ Ordered roughly by impact:
    - **Elasticsearch: complete** — canonical `value`/`unit` stored in the `quantity` nested object;
      the handler ORs a canonical range (bounds canonicalized) with the raw match (integration-tested
      against a live ES container).
-   - **Postgres: write-side done** (canonical columns populated by the writer); the **query-side OR**
-     into the canonical columns is not yet wired (raw unit matching only) — pending param-stride and
-     float-tolerance handling.
+   - **Postgres: complete** — writer populates canonical columns; the quantity handler ORs a
+     range-based canonical predicate (bounds canonicalized; eq uses an implicit-precision range that
+     also absorbs float-conversion noise) with the raw match. Integration-tested against a live PG
+     container.
    - A **reindex backfill** (`ReindexRequest`) is required to populate canonical columns for
      resources written before the upgrade; un-reindexed rows fall back to raw unit matching.
+
+   All three searchable backends (SQLite, Postgres, Elasticsearch) now match UCUM-equivalent units.
 8. **Accent-insensitive string search** (schema v10) — string search folds case **and** accents via
    NFD + combining-mark stripping (`unicode-normalization`, shared `search::fold_text`), stored in
    `value_string_folded`.

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -213,10 +213,12 @@ Ordered roughly by impact:
    `helios_fhirpath::ucum::canonicalize_quantity`, so `1|g` matches `1000|mg`.
    - **SQLite: complete** — writer populates canonical columns; the quantity handler matches the
      canonical columns (search bounds canonicalized to preserve implicit precision) OR the raw unit.
+   - **Elasticsearch: complete** — canonical `value`/`unit` stored in the `quantity` nested object;
+     the handler ORs a canonical range (bounds canonicalized) with the raw match (integration-tested
+     against a live ES container).
    - **Postgres: write-side done** (canonical columns populated by the writer); the **query-side OR**
      into the canonical columns is not yet wired (raw unit matching only) — pending param-stride and
      float-tolerance handling.
-   - **Elasticsearch: remaining.**
    - A **reindex backfill** (`ReindexRequest`) is required to populate canonical columns for
      resources written before the upgrade; un-reindexed rows fall back to raw unit matching.
 8. **Accent-insensitive string search** (schema v10) — string search folds case **and** accents via
@@ -226,7 +228,8 @@ Ordered roughly by impact:
      (case-insensitive) column; `:exact` stays case/accent-sensitive.
    - **Postgres: complete** — `COALESCE(value_string_folded, value_string) ILIKE` against a folded
      pattern (raw fallback keeps non-accented pre-reindex rows matching case-insensitively).
-   - **Elasticsearch: remaining** (needs an `asciifolding` analyzer + reindex).
+   - **Elasticsearch: complete** — a `folded` keyword field (written via `fold_text`) is matched
+     (wildcard) ORed with the raw field; integration-tested against a live ES container.
    - Pre-reindex rows need the **reindex backfill** for accent-insensitivity.
 9. **Canonical `url|version` references** — versioned reference matching is now version-agnostic
    (`Patient/1/_history/2` ⇄ `Patient/1`, via `strip_reference_version`, on SQLite/PG/ES). The

--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -238,9 +238,11 @@ Ordered roughly by impact:
    (`Patient/1/_history/2` ⇄ `Patient/1`, via `strip_reference_version`, on SQLite/PG/ES). The
    remaining gap is canonical `url|version` hierarchy for reference `:above`/`:below`; `:identifier`
    also assumes a `Type/id` reference shape.
-10. **Ordered-value boundary semantics** — `gt`/`lt` (and SQLite `sa`/`eb`) compare against the
-    scalar value rather than the precision-range boundary the spec defines; `eq`/`ne`/`ap` already
-    use implicit-precision ranges. Edge-case-only.
+10. **Ordered-value boundary semantics** — **done** (SQLite, Postgres, Elasticsearch). Comparator
+    prefixes now match against the search value's implicit-precision range boundaries per spec:
+    `ge → x≥lo`, `le → x<hi`, `gt`/`sa → x≥hi`, `lt`/`eb → x<lo` (range `[lo, hi)`), for number,
+    quantity, and date (date falls back to scalar for full-precision instants). Postgres also gained
+    implicit-precision `eq`/`ne` ranges for number/date (was exact). Shared `search::range` helper.
 
 **Recently landed (REST layer).** Repeated query parameters are now preserved as FHIR AND semantics
 (previously collapsed to last-wins by `HashMap` extraction); `Prefer: handling=strict` rejects

--- a/crates/persistence/src/backends/elasticsearch/schema.rs
+++ b/crates/persistence/src/backends/elasticsearch/schema.rs
@@ -77,7 +77,11 @@ pub fn create_index_mapping(config: &super::backend::ElasticsearchConfig) -> ser
                                             "normalizer": "lowercase_normalizer"
                                         }
                                     }
-                                }
+                                },
+                                // Case- and accent-folded value (NFD + combining-mark
+                                // stripping, computed by the writer) for accent-
+                                // insensitive string search.
+                                "folded": { "type": "keyword" }
                             }
                         },
                         "token": {
@@ -122,7 +126,11 @@ pub fn create_index_mapping(config: &super::backend::ElasticsearchConfig) -> ser
                                 "value": { "type": "double" },
                                 "unit": { "type": "keyword" },
                                 "system": { "type": "keyword" },
-                                "code": { "type": "keyword" }
+                                "code": { "type": "keyword" },
+                                // UCUM-canonical value/unit (computed by the writer)
+                                // for unit-equivalent quantity search (g ⇄ mg).
+                                "canonical_value": { "type": "double" },
+                                "canonical_unit": { "type": "keyword" }
                             }
                         },
                         "reference": {

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/number.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/number.rs
@@ -45,24 +45,26 @@ pub fn build_clause(name: &str, value: &str, prefix: SearchPrefix) -> Option<Val
                 }
             }));
         }
-        SearchPrefix::Gt => {
+        // Comparators match the implicit-precision range boundaries (FHIR spec):
+        // gt/sa → ≥ hi, lt/eb → < lo, ge → ≥ lo, le → < hi.
+        SearchPrefix::Gt | SearchPrefix::Sa => {
             json!({
-                "range": { "search_params.number.value": { "gt": num } }
+                "range": { "search_params.number.value": { "gte": num + implicit_precision } }
             })
         }
-        SearchPrefix::Lt => {
+        SearchPrefix::Lt | SearchPrefix::Eb => {
             json!({
-                "range": { "search_params.number.value": { "lt": num } }
+                "range": { "search_params.number.value": { "lt": num - implicit_precision } }
             })
         }
         SearchPrefix::Ge => {
             json!({
-                "range": { "search_params.number.value": { "gte": num } }
+                "range": { "search_params.number.value": { "gte": num - implicit_precision } }
             })
         }
         SearchPrefix::Le => {
             json!({
-                "range": { "search_params.number.value": { "lte": num } }
+                "range": { "search_params.number.value": { "lt": num + implicit_precision } }
             })
         }
         SearchPrefix::Ap => {
@@ -73,16 +75,6 @@ pub fn build_clause(name: &str, value: &str, prefix: SearchPrefix) -> Option<Val
                     "search_params.number.value": {
                         "gte": num - margin,
                         "lte": num + margin
-                    }
-                }
-            })
-        }
-        _ => {
-            json!({
-                "range": {
-                    "search_params.number.value": {
-                        "gte": num - implicit_precision,
-                        "lt": num + implicit_precision
                     }
                 }
             })
@@ -139,8 +131,9 @@ mod tests {
 
     #[test]
     fn test_gt() {
+        // gt matches strictly above the search range; for "100" that is >= 100.5.
         let clause = build_clause("length", "100", SearchPrefix::Gt).unwrap();
         let s = serde_json::to_string(&clause).unwrap();
-        assert!(s.contains("\"gt\":100"));
+        assert!(s.contains("\"gte\":100.5"));
     }
 }

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/quantity.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/quantity.rs
@@ -77,11 +77,15 @@ fn range_condition(
     num_str: &str,
     map: impl Fn(f64) -> Option<f64>,
 ) -> Option<Value> {
+    // Half-precision of the search value (e.g. "100" → 0.5); comparators match
+    // the implicit range boundaries: gt/sa → ≥ hi, lt/eb → < lo, ge → ≥ lo,
+    // le → < hi (per the FHIR spec).
+    let p = super::number::implicit_range(num_str);
     let range = match prefix {
-        SearchPrefix::Gt | SearchPrefix::Sa => json!({ "gt": map(num)? }),
-        SearchPrefix::Lt | SearchPrefix::Eb => json!({ "lt": map(num)? }),
-        SearchPrefix::Ge => json!({ "gte": map(num)? }),
-        SearchPrefix::Le => json!({ "lte": map(num)? }),
+        SearchPrefix::Gt | SearchPrefix::Sa => json!({ "gte": map(num + p)? }),
+        SearchPrefix::Lt | SearchPrefix::Eb => json!({ "lt": map(num - p)? }),
+        SearchPrefix::Ge => json!({ "gte": map(num - p)? }),
+        SearchPrefix::Le => json!({ "lt": map(num + p)? }),
         SearchPrefix::Ap => {
             let margin = (num * 0.1).abs().max(0.5);
             let (lo, hi) = ordered(map(num - margin)?, map(num + margin)?);
@@ -89,8 +93,7 @@ fn range_condition(
         }
         // Eq, Ne (treated as Eq range here), and any default
         _ => {
-            let precision = super::number::implicit_range(num_str);
-            let (lo, hi) = ordered(map(num - precision)?, map(num + precision)?);
+            let (lo, hi) = ordered(map(num - p)?, map(num + p)?);
             json!({ "gte": lo, "lt": hi })
         }
     };

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/quantity.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/quantity.rs
@@ -11,76 +11,96 @@ pub fn build_clause(name: &str, value: &str, prefix: SearchPrefix) -> Option<Val
     let (num_str, system, code) = parse_quantity_value(value);
     let num: f64 = num_str.parse().ok()?;
 
-    let mut must_conditions = vec![json!({ "term": { "search_params.quantity.name": name } })];
-
-    // Add numeric condition based on prefix
-    let num_condition = match prefix {
-        SearchPrefix::Eq => {
-            let precision = super::number::implicit_range(num_str);
-            json!({
-                "range": {
-                    "search_params.quantity.value": {
-                        "gte": num - precision,
-                        "lt": num + precision
-                    }
-                }
-            })
-        }
-        SearchPrefix::Gt => {
-            json!({ "range": { "search_params.quantity.value": { "gt": num } } })
-        }
-        SearchPrefix::Lt => {
-            json!({ "range": { "search_params.quantity.value": { "lt": num } } })
-        }
-        SearchPrefix::Ge => {
-            json!({ "range": { "search_params.quantity.value": { "gte": num } } })
-        }
-        SearchPrefix::Le => {
-            json!({ "range": { "search_params.quantity.value": { "lte": num } } })
-        }
-        SearchPrefix::Ap => {
-            let margin = (num * 0.1).abs().max(0.5);
-            json!({
-                "range": {
-                    "search_params.quantity.value": {
-                        "gte": num - margin,
-                        "lte": num + margin
-                    }
-                }
-            })
-        }
-        _ => {
-            let precision = super::number::implicit_range(num_str);
-            json!({
-                "range": {
-                    "search_params.quantity.value": {
-                        "gte": num - precision,
-                        "lt": num + precision
-                    }
-                }
-            })
-        }
-    };
-    must_conditions.push(num_condition);
-
-    // Add system/code conditions if specified
+    // Raw match against the stored value/unit/system.
+    let mut raw_must = vec![
+        json!({ "term": { "search_params.quantity.name": name } }),
+        range_condition("search_params.quantity.value", prefix, num, num_str, |x| {
+            Some(x)
+        })?,
+    ];
     if let Some(sys) = system {
-        must_conditions.push(json!({ "term": { "search_params.quantity.system": sys } }));
+        raw_must.push(json!({ "term": { "search_params.quantity.system": sys } }));
     }
     if let Some(c) = code {
-        must_conditions.push(json!({ "term": { "search_params.quantity.code": c } }));
+        raw_must.push(json!({ "term": { "search_params.quantity.code": c } }));
     }
+
+    // Canonical match: when a UCUM code is supplied and convertible, also match
+    // rows whose canonical unit/value are equivalent (e.g. g ⇄ mg). Bounds are
+    // canonicalized so range/precision semantics survive unit conversion.
+    let canonical = code.and_then(|c| {
+        let (_, canon_unit) = helios_fhirpath::ucum::canonicalize_quantity(num, c)?;
+        let canon = |x: f64| helios_fhirpath::ucum::canonicalize_quantity(x, c).map(|(v, _)| v);
+        let range = range_condition(
+            "search_params.quantity.canonical_value",
+            prefix,
+            num,
+            num_str,
+            canon,
+        )?;
+        Some(json!({
+            "bool": {
+                "must": [
+                    { "term": { "search_params.quantity.name": name } },
+                    range,
+                    { "term": { "search_params.quantity.canonical_unit": canon_unit } }
+                ]
+            }
+        }))
+    });
+
+    let query = match canonical {
+        Some(canon_clause) => json!({
+            "bool": {
+                "should": [ { "bool": { "must": raw_must } }, canon_clause ],
+                "minimum_should_match": 1
+            }
+        }),
+        None => json!({ "bool": { "must": raw_must } }),
+    };
 
     Some(json!({
         "nested": {
             "path": "search_params.quantity",
-            "query": {
-                "bool": {
-                    "must": must_conditions
-                }
-            }
+            "query": query
         }
     }))
+}
+
+/// Builds an ES `range` condition for `field`, transforming the numeric bounds
+/// through `map` (identity for the raw value, UCUM-canonicalization for the
+/// canonical column). Returns `None` if a transformed bound is unavailable.
+fn range_condition(
+    field: &str,
+    prefix: SearchPrefix,
+    num: f64,
+    num_str: &str,
+    map: impl Fn(f64) -> Option<f64>,
+) -> Option<Value> {
+    let range = match prefix {
+        SearchPrefix::Gt | SearchPrefix::Sa => json!({ "gt": map(num)? }),
+        SearchPrefix::Lt | SearchPrefix::Eb => json!({ "lt": map(num)? }),
+        SearchPrefix::Ge => json!({ "gte": map(num)? }),
+        SearchPrefix::Le => json!({ "lte": map(num)? }),
+        SearchPrefix::Ap => {
+            let margin = (num * 0.1).abs().max(0.5);
+            let (lo, hi) = ordered(map(num - margin)?, map(num + margin)?);
+            json!({ "gte": lo, "lte": hi })
+        }
+        // Eq, Ne (treated as Eq range here), and any default
+        _ => {
+            let precision = super::number::implicit_range(num_str);
+            let (lo, hi) = ordered(map(num - precision)?, map(num + precision)?);
+            json!({ "gte": lo, "lt": hi })
+        }
+    };
+    Some(json!({ "range": { field: range } }))
+}
+
+/// Returns the two values in ascending order (canonicalization factor is
+/// positive, but guard against any inversion).
+fn ordered(a: f64, b: f64) -> (f64, f64) {
+    if a <= b { (a, b) } else { (b, a) }
 }
 
 /// Parses a quantity value string into (number, system, code).

--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/string.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/string.rs
@@ -2,50 +2,71 @@
 
 use serde_json::{Value, json};
 
+use crate::search::fold_text;
 use crate::types::{SearchModifier, SearchParameter};
+
+/// ORs an accent-folded match (against the `folded` field) with a raw-field
+/// match, so accent-insensitive search works on reindexed docs while docs not
+/// yet carrying the `folded` field still match via the raw field.
+fn folded_or_raw(folded: Value, raw: Value) -> Value {
+    json!({ "bool": { "should": [folded, raw], "minimum_should_match": 1 } })
+}
 
 /// Builds an ES query clause for a string search parameter.
 pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
     let name = &param.name;
+    let folded = fold_text(value);
 
     let condition = match param.modifier {
         Some(SearchModifier::Exact) => {
-            // Case-sensitive exact match
+            // Case- and accent-sensitive exact match
             json!({
                 "term": { "search_params.string.value.keyword": value }
             })
         }
         Some(SearchModifier::Contains) => {
-            // Case-insensitive substring match
-            json!({
-                "wildcard": {
-                    "search_params.string.value.lowercase": {
-                        "value": format!("*{}*", value.to_lowercase())
+            // Case- and accent-insensitive substring match
+            folded_or_raw(
+                json!({
+                    "wildcard": { "search_params.string.folded": { "value": format!("*{}*", folded) } }
+                }),
+                json!({
+                    "wildcard": {
+                        "search_params.string.value.lowercase": {
+                            "value": format!("*{}*", value.to_lowercase())
+                        }
                     }
-                }
-            })
+                }),
+            )
         }
         Some(SearchModifier::Text) => {
-            // Full-text match using standard analyzer
-            json!({
-                "match": {
-                    "search_params.string.value": {
-                        "query": value,
-                        "operator": "and"
+            // Full-text match, plus an accent-folded substring branch.
+            folded_or_raw(
+                json!({
+                    "wildcard": { "search_params.string.folded": { "value": format!("*{}*", folded) } }
+                }),
+                json!({
+                    "match": {
+                        "search_params.string.value": {
+                            "query": value,
+                            "operator": "and"
+                        }
                     }
-                }
-            })
+                }),
+            )
         }
         _ => {
-            // Default: case-insensitive prefix match
-            // Use match_phrase_prefix for natural prefix matching
-            json!({
-                "match_phrase_prefix": {
-                    "search_params.string.value": {
-                        "query": value
+            // Default: case- and accent-insensitive prefix match.
+            folded_or_raw(
+                json!({
+                    "wildcard": { "search_params.string.folded": { "value": format!("{}*", folded) } }
+                }),
+                json!({
+                    "match_phrase_prefix": {
+                        "search_params.string.value": { "query": value }
                     }
-                }
-            })
+                }),
+            )
         }
     };
 

--- a/crates/persistence/src/backends/elasticsearch/storage.rs
+++ b/crates/persistence/src/backends/elasticsearch/storage.rs
@@ -189,6 +189,7 @@ pub(crate) fn build_es_document(
                 string_params.push(json!({
                     "name": ev.param_name,
                     "value": s,
+                    "folded": crate::search::fold_text(s),
                 }));
             }
             IndexValue::Token {
@@ -247,6 +248,16 @@ pub(crate) fn build_es_document(
                 }
                 if let Some(c) = code {
                     qty["code"] = json!(c);
+                }
+                // UCUM-canonical value/unit so quantity search matches equivalent
+                // units (g ⇄ mg). Uses the code if present, else the unit display.
+                if let Some((cv, cu)) = code
+                    .as_deref()
+                    .or(unit.as_deref())
+                    .and_then(|u| helios_fhirpath::ucum::canonicalize_quantity(*value, u))
+                {
+                    qty["canonical_value"] = json!(cv);
+                    qty["canonical_unit"] = json!(cu);
                 }
                 quantity_params.push(qty);
             }

--- a/crates/persistence/src/backends/postgres/schema.rs
+++ b/crates/persistence/src/backends/postgres/schema.rs
@@ -3,7 +3,7 @@
 use crate::error::{BackendError, StorageResult};
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 9;
+pub const SCHEMA_VERSION: i32 = 10;
 
 /// Initialize the database schema.
 pub async fn initialize_schema(client: &deadpool_postgres::Client) -> StorageResult<()> {
@@ -272,6 +272,7 @@ async fn migrate_schema(
             6 => migrate_v6_to_v7(client).await?,
             7 => migrate_v7_to_v8(client).await?,
             8 => migrate_v8_to_v9(client).await?,
+            9 => migrate_v9_to_v10(client).await?,
             _ => {
                 return Err(pg_error(format!("Unknown schema version: {}", version)));
             }
@@ -652,6 +653,26 @@ async fn migrate_v8_to_v9(client: &deadpool_postgres::Client) -> StorageResult<(
         )
         .await
         .map_err(|e| pg_error(format!("Migration v8->v9 index failed: {}", e)))?;
+    Ok(())
+}
+
+/// v9 -> v10: UCUM-canonical quantity columns + case/accent-folded string column.
+async fn migrate_v9_to_v10(client: &deadpool_postgres::Client) -> StorageResult<()> {
+    let stmts = [
+        "ALTER TABLE search_index ADD COLUMN IF NOT EXISTS value_quantity_canonical_value DOUBLE PRECISION",
+        "ALTER TABLE search_index ADD COLUMN IF NOT EXISTS value_quantity_canonical_unit TEXT",
+        "ALTER TABLE search_index ADD COLUMN IF NOT EXISTS value_string_folded TEXT",
+        "CREATE INDEX IF NOT EXISTS idx_search_quantity_canonical
+         ON search_index(tenant_id, resource_type, param_name, value_quantity_canonical_unit, value_quantity_canonical_value)",
+        "CREATE INDEX IF NOT EXISTS idx_search_string_folded
+         ON search_index(tenant_id, resource_type, param_name, value_string_folded)",
+    ];
+    for sql in stmts {
+        client
+            .execute(sql, &[])
+            .await
+            .map_err(|e| pg_error(format!("Migration v9->v10 failed: {}", e)))?;
+    }
     Ok(())
 }
 

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -15,13 +15,93 @@ use crate::types::{
 /// Returns the implicit precision of a decimal search value from its string form
 /// (e.g. `"100"` → 1.0, `"100.0"` → 0.1), used to build `eq` ranges.
 fn quantity_implicit_precision(num_str: &str) -> f64 {
-    match num_str.find('.') {
-        Some(dot) => {
-            let decimals = num_str.len() - dot - 1;
-            10f64.powi(-(decimals as i32))
+    crate::search::implicit_precision(num_str)
+}
+
+/// Builds the numeric comparison SQL for `col` against the implicit-precision
+/// range `[lo, hi)` per the FHIR prefix semantics, advancing `next` and
+/// returning the SQL plus its bound params. `num` is used only for the `ap`
+/// margin.
+fn numeric_predicate(
+    col: &str,
+    prefix: SearchPrefix,
+    num: f64,
+    lo: f64,
+    hi: f64,
+    next: &mut usize,
+) -> (String, Vec<SqlParam>) {
+    match prefix {
+        SearchPrefix::Eq => {
+            *next += 1;
+            let a = *next;
+            *next += 1;
+            (
+                format!("{col} >= ${a} AND {col} < ${next}"),
+                vec![SqlParam::Float(lo), SqlParam::Float(hi)],
+            )
         }
-        None => 1.0,
+        SearchPrefix::Ne => {
+            *next += 1;
+            let a = *next;
+            *next += 1;
+            (
+                format!("({col} < ${a} OR {col} >= ${next})"),
+                vec![SqlParam::Float(lo), SqlParam::Float(hi)],
+            )
+        }
+        SearchPrefix::Gt | SearchPrefix::Sa => {
+            *next += 1;
+            (format!("{col} >= ${next}"), vec![SqlParam::Float(hi)])
+        }
+        SearchPrefix::Lt | SearchPrefix::Eb => {
+            *next += 1;
+            (format!("{col} < ${next}"), vec![SqlParam::Float(lo)])
+        }
+        SearchPrefix::Ge => {
+            *next += 1;
+            (format!("{col} >= ${next}"), vec![SqlParam::Float(lo)])
+        }
+        SearchPrefix::Le => {
+            *next += 1;
+            (format!("{col} < ${next}"), vec![SqlParam::Float(hi)])
+        }
+        SearchPrefix::Ap => {
+            let margin = (num.abs() * 0.1).max(0.0001);
+            *next += 1;
+            let a = *next;
+            *next += 1;
+            (
+                format!("{col} BETWEEN ${a} AND ${next}"),
+                vec![SqlParam::Float(num - margin), SqlParam::Float(num + margin)],
+            )
+        }
     }
+}
+
+/// Returns the `[start, end)` timestamp range for a date search value at its
+/// inherent precision (year/month/day). Full-precision instants return a
+/// degenerate range (`start == end`).
+fn date_precision_range(value: &str) -> (DateTime<Utc>, DateTime<Utc>) {
+    use chrono::Datelike;
+    let start = PostgresQueryBuilder::parse_date_value(value);
+    let end = if value.contains('T') {
+        start
+    } else if value.len() == 4 {
+        start.with_year(start.year() + 1).unwrap_or(start)
+    } else if value.len() == 7 {
+        let (y, m) = (start.year(), start.month());
+        let (ny, nm) = if m == 12 { (y + 1, 1) } else { (y, m + 1) };
+        start
+            .with_month(1)
+            .and_then(|d| d.with_year(ny))
+            .and_then(|d| d.with_month(nm))
+            .unwrap_or(start)
+    } else if value.len() == 10 {
+        start + chrono::Duration::days(1)
+    } else {
+        start
+    };
+    (start, end)
 }
 
 /// How a sort key's value is typed for cursor (keyset) binding and comparison.
@@ -762,17 +842,76 @@ impl PostgresQueryBuilder {
 
     fn build_date_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
         let mut conditions = Vec::new();
+        let mut next = offset;
 
-        for (i, value) in param.values.iter().enumerate() {
-            let param_num = offset + i + 1;
-            let op = Self::prefix_to_operator(&value.prefix);
-            let timestamp = Self::parse_date_value(&value.value);
+        for value in &param.values {
+            let (start, end) = date_precision_range(&value.value);
+            // Comparators match against the precision-range boundaries; a
+            // full-precision instant (degenerate range) falls back to scalar.
+            let degenerate = start == end;
+            let (sql, params): (String, Vec<SqlParam>) = match value.prefix {
+                SearchPrefix::Eq if !degenerate => {
+                    next += 1;
+                    let a = next;
+                    next += 1;
+                    (
+                        format!("value_date >= ${a} AND value_date < ${next}"),
+                        vec![SqlParam::Timestamp(start), SqlParam::Timestamp(end)],
+                    )
+                }
+                SearchPrefix::Ne if !degenerate => {
+                    next += 1;
+                    let a = next;
+                    next += 1;
+                    (
+                        format!("(value_date < ${a} OR value_date >= ${next})"),
+                        vec![SqlParam::Timestamp(start), SqlParam::Timestamp(end)],
+                    )
+                }
+                SearchPrefix::Gt | SearchPrefix::Sa if !degenerate => {
+                    next += 1;
+                    (
+                        format!("value_date >= ${next}"),
+                        vec![SqlParam::Timestamp(end)],
+                    )
+                }
+                SearchPrefix::Lt | SearchPrefix::Eb if !degenerate => {
+                    next += 1;
+                    (
+                        format!("value_date < ${next}"),
+                        vec![SqlParam::Timestamp(start)],
+                    )
+                }
+                SearchPrefix::Ge if !degenerate => {
+                    next += 1;
+                    (
+                        format!("value_date >= ${next}"),
+                        vec![SqlParam::Timestamp(start)],
+                    )
+                }
+                SearchPrefix::Le if !degenerate => {
+                    next += 1;
+                    (
+                        format!("value_date < ${next}"),
+                        vec![SqlParam::Timestamp(end)],
+                    )
+                }
+                // Degenerate (full-precision) or unhandled: scalar comparison.
+                other => {
+                    let op = Self::prefix_to_operator(&other);
+                    next += 1;
+                    (
+                        format!("value_date {op} ${next}"),
+                        vec![SqlParam::Timestamp(start)],
+                    )
+                }
+            };
             conditions.push(SqlFragment::with_params(
                 format!(
-                    "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_date {} ${})",
-                    param.name, op, param_num
+                    "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
+                    param.name, sql
                 ),
-                vec![SqlParam::Timestamp(timestamp)],
+                params,
             ));
         }
 
@@ -788,19 +927,23 @@ impl PostgresQueryBuilder {
 
     fn build_number_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
         let mut conditions = Vec::new();
+        let mut next = offset;
 
-        for (i, value) in param.values.iter().enumerate() {
-            let param_num = offset + i + 1;
-            let op = Self::prefix_to_operator(&value.prefix);
-            if let Ok(num) = value.value.parse::<f64>() {
-                conditions.push(SqlFragment::with_params(
-                    format!(
-                        "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_number {} ${})",
-                        param.name, op, param_num
-                    ),
-                    vec![SqlParam::Float(num)],
-                ));
-            }
+        for value in &param.values {
+            let num: f64 = match value.value.parse() {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            let (lo, hi) = crate::search::implicit_range(num, &value.value);
+            let (sql, params) =
+                numeric_predicate("value_number", value.prefix, num, lo, hi, &mut next);
+            conditions.push(SqlFragment::with_params(
+                format!(
+                    "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
+                    param.name, sql
+                ),
+                params,
+            ));
         }
 
         if conditions.is_empty() {
@@ -827,7 +970,6 @@ impl PostgresQueryBuilder {
                 None => continue,
             };
             let num_str = parts[0];
-            let op = Self::prefix_to_operator(&value.prefix);
             let (system, code) = match parts.len() {
                 3 => (
                     (!parts[1].is_empty()).then_some(parts[1]),
@@ -837,12 +979,11 @@ impl PostgresQueryBuilder {
                 _ => (None, None),
             };
 
-            let mut params: Vec<SqlParam> = Vec::new();
-
-            // Raw branch: exact value comparison + the stored unit/system.
-            next += 1;
-            params.push(SqlParam::Float(num));
-            let mut raw = format!("value_quantity_value {op} ${next}");
+            // Raw branch: range-boundary value comparison + the stored unit/system.
+            let (lo, hi) = crate::search::implicit_range(num, num_str);
+            let (raw_num, mut params) =
+                numeric_predicate("value_quantity_value", value.prefix, num, lo, hi, &mut next);
+            let mut raw = raw_num;
             if let Some(c) = code {
                 next += 1;
                 params.push(SqlParam::text(c));
@@ -866,26 +1007,30 @@ impl PostgresQueryBuilder {
                             helios_fhirpath::ucum::canonicalize_quantity(x, c).map(|(v, _)| v)
                         };
                         let col = "value_quantity_canonical_value";
+                        // Comparators match canonicalized range boundaries:
+                        // gt/sa → ≥ canon(hi), lt/eb → < canon(lo),
+                        // ge → ≥ canon(lo), le → < canon(hi).
+                        let half = quantity_implicit_precision(num_str) / 2.0;
                         let range: Option<String> = match value.prefix {
-                            SearchPrefix::Gt | SearchPrefix::Sa => canon(num).map(|b| {
-                                next += 1;
-                                params.push(SqlParam::Float(b));
-                                format!("{col} > ${next}")
-                            }),
-                            SearchPrefix::Lt | SearchPrefix::Eb => canon(num).map(|b| {
-                                next += 1;
-                                params.push(SqlParam::Float(b));
-                                format!("{col} < ${next}")
-                            }),
-                            SearchPrefix::Ge => canon(num).map(|b| {
+                            SearchPrefix::Gt | SearchPrefix::Sa => canon(num + half).map(|b| {
                                 next += 1;
                                 params.push(SqlParam::Float(b));
                                 format!("{col} >= ${next}")
                             }),
-                            SearchPrefix::Le => canon(num).map(|b| {
+                            SearchPrefix::Lt | SearchPrefix::Eb => canon(num - half).map(|b| {
                                 next += 1;
                                 params.push(SqlParam::Float(b));
-                                format!("{col} <= ${next}")
+                                format!("{col} < ${next}")
+                            }),
+                            SearchPrefix::Ge => canon(num - half).map(|b| {
+                                next += 1;
+                                params.push(SqlParam::Float(b));
+                                format!("{col} >= ${next}")
+                            }),
+                            SearchPrefix::Le => canon(num + half).map(|b| {
+                                next += 1;
+                                params.push(SqlParam::Float(b));
+                                format!("{col} < ${next}")
                             }),
                             SearchPrefix::Ap => {
                                 let margin = (num.abs() * 0.1).max(0.0001);

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -6,6 +6,7 @@
 
 use chrono::{DateTime, Utc};
 
+use crate::search::fold_text;
 use crate::types::{
     SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
     strip_reference_version,
@@ -379,21 +380,23 @@ impl PostgresQueryBuilder {
                 ),
                 // `:text` on a string is a case-insensitive partial match,
                 // implemented here as a substring match (same as `:contains`).
+                // Match the accent-folded column (falling back to the raw column
+                // for not-yet-reindexed rows) against a folded pattern.
                 Some(SearchModifier::Contains | SearchModifier::Text) => SqlFragment::with_params(
                     format!(
-                        "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_string ILIKE ${})",
+                        "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND COALESCE(value_string_folded, value_string) ILIKE ${})",
                         param.name, param_num
                     ),
-                    vec![SqlParam::text(&format!("%{}%", value.value))],
+                    vec![SqlParam::text(&format!("%{}%", fold_text(&value.value)))],
                 ),
                 _ => {
-                    // Default: starts-with (case-insensitive)
+                    // Default: starts-with (case- and accent-insensitive).
                     SqlFragment::with_params(
                         format!(
-                            "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_string ILIKE ${})",
+                            "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND COALESCE(value_string_folded, value_string) ILIKE ${})",
                             param.name, param_num
                         ),
-                        vec![SqlParam::text(&format!("{}%", value.value))],
+                        vec![SqlParam::text(&format!("{}%", fold_text(&value.value)))],
                     )
                 }
             };

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -12,6 +12,18 @@ use crate::types::{
     strip_reference_version,
 };
 
+/// Returns the implicit precision of a decimal search value from its string form
+/// (e.g. `"100"` → 1.0, `"100.0"` → 0.1), used to build `eq` ranges.
+fn quantity_implicit_precision(num_str: &str) -> f64 {
+    match num_str.find('.') {
+        Some(dot) => {
+            let decimals = num_str.len() - dot - 1;
+            10f64.powi(-(decimals as i32))
+        }
+        None => 1.0,
+    }
+}
+
 /// How a sort key's value is typed for cursor (keyset) binding and comparison.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortValueKind {
@@ -803,33 +815,128 @@ impl PostgresQueryBuilder {
 
     fn build_quantity_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
         let mut conditions = Vec::new();
+        // Running placeholder counter: the outer builder advances by the
+        // fragment's params.len(), so numbering must be sequential and gap-free.
+        let mut next = offset;
 
-        for (i, value) in param.values.iter().enumerate() {
-            let base_offset = offset + i * 2;
-            // Parse quantity: [prefix]number|system|code
+        for value in &param.values {
+            // Parse quantity: [prefix]number|system|code (or number|code, or number).
             let parts: Vec<&str> = value.value.splitn(3, '|').collect();
-            if let Some(num_str) = parts.first() {
-                if let Ok(num) = num_str.parse::<f64>() {
-                    let op = Self::prefix_to_operator(&value.prefix);
-                    if parts.len() >= 3 {
-                        conditions.push(SqlFragment::with_params(
-                            format!(
-                                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_quantity_value {} ${} AND value_quantity_unit = ${})",
-                                param.name, op, base_offset + 1, base_offset + 2
-                            ),
-                            vec![SqlParam::Float(num), SqlParam::text(parts[2])],
-                        ));
-                    } else {
-                        conditions.push(SqlFragment::with_params(
-                            format!(
-                                "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND value_quantity_value {} ${})",
-                                param.name, op, base_offset + 1
-                            ),
-                            vec![SqlParam::Float(num)],
-                        ));
+            let num: f64 = match parts.first().and_then(|s| s.parse::<f64>().ok()) {
+                Some(n) => n,
+                None => continue,
+            };
+            let num_str = parts[0];
+            let op = Self::prefix_to_operator(&value.prefix);
+            let (system, code) = match parts.len() {
+                3 => (
+                    (!parts[1].is_empty()).then_some(parts[1]),
+                    (!parts[2].is_empty()).then_some(parts[2]),
+                ),
+                2 => (None, (!parts[1].is_empty()).then_some(parts[1])),
+                _ => (None, None),
+            };
+
+            let mut params: Vec<SqlParam> = Vec::new();
+
+            // Raw branch: exact value comparison + the stored unit/system.
+            next += 1;
+            params.push(SqlParam::Float(num));
+            let mut raw = format!("value_quantity_value {op} ${next}");
+            if let Some(c) = code {
+                next += 1;
+                params.push(SqlParam::text(c));
+                raw.push_str(&format!(" AND value_quantity_unit = ${next}"));
+            }
+            if let Some(s) = system {
+                next += 1;
+                params.push(SqlParam::text(s));
+                raw.push_str(&format!(" AND value_quantity_system = ${next}"));
+            }
+
+            // Canonical branch (range-based on the canonical columns) so unit
+            // equivalents match (g ⇄ mg). Bounds are canonicalized to preserve
+            // range/precision and absorb float-conversion noise. Skipped for
+            // `ne` and non-convertible units.
+            let mut predicate = format!("({raw})");
+            if let Some(c) = code {
+                if !matches!(value.prefix, SearchPrefix::Ne) {
+                    if let Some((_, cunit)) = helios_fhirpath::ucum::canonicalize_quantity(num, c) {
+                        let canon = |x: f64| {
+                            helios_fhirpath::ucum::canonicalize_quantity(x, c).map(|(v, _)| v)
+                        };
+                        let col = "value_quantity_canonical_value";
+                        let range: Option<String> = match value.prefix {
+                            SearchPrefix::Gt | SearchPrefix::Sa => canon(num).map(|b| {
+                                next += 1;
+                                params.push(SqlParam::Float(b));
+                                format!("{col} > ${next}")
+                            }),
+                            SearchPrefix::Lt | SearchPrefix::Eb => canon(num).map(|b| {
+                                next += 1;
+                                params.push(SqlParam::Float(b));
+                                format!("{col} < ${next}")
+                            }),
+                            SearchPrefix::Ge => canon(num).map(|b| {
+                                next += 1;
+                                params.push(SqlParam::Float(b));
+                                format!("{col} >= ${next}")
+                            }),
+                            SearchPrefix::Le => canon(num).map(|b| {
+                                next += 1;
+                                params.push(SqlParam::Float(b));
+                                format!("{col} <= ${next}")
+                            }),
+                            SearchPrefix::Ap => {
+                                let margin = (num.abs() * 0.1).max(0.0001);
+                                match (canon(num - margin), canon(num + margin)) {
+                                    (Some(a), Some(b)) => {
+                                        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                                        next += 1;
+                                        params.push(SqlParam::Float(lo));
+                                        let lo_p = next;
+                                        next += 1;
+                                        params.push(SqlParam::Float(hi));
+                                        Some(format!("{col} BETWEEN ${lo_p} AND ${next}"))
+                                    }
+                                    _ => None,
+                                }
+                            }
+                            // Eq + default: implicit-precision range.
+                            _ => {
+                                let half = quantity_implicit_precision(num_str) / 2.0;
+                                match (canon(num - half), canon(num + half)) {
+                                    (Some(a), Some(b)) => {
+                                        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                                        next += 1;
+                                        params.push(SqlParam::Float(lo));
+                                        let lo_p = next;
+                                        next += 1;
+                                        params.push(SqlParam::Float(hi));
+                                        Some(format!("{col} >= ${lo_p} AND {col} < ${next}"))
+                                    }
+                                    _ => None,
+                                }
+                            }
+                        };
+                        if let Some(range) = range {
+                            next += 1;
+                            params.push(SqlParam::text(&cunit));
+                            predicate = format!(
+                                "(({raw}) OR ({range} AND value_quantity_canonical_unit = ${next}))"
+                            );
+                        }
                     }
                 }
             }
+
+            conditions.push(SqlFragment::with_params(
+                format!(
+                    "id IN (SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}' AND {})",
+                    param.name, predicate
+                ),
+                params,
+            ));
         }
 
         if conditions.is_empty() {

--- a/crates/persistence/src/backends/postgres/search/writer.rs
+++ b/crates/persistence/src/backends/postgres/search/writer.rs
@@ -30,12 +30,13 @@ impl PostgresSearchIndexWriter {
     ) -> StorageResult<()> {
         match &extracted.value {
             IndexValue::String(s) => {
+                let folded = crate::search::fold_text(s);
                 client
                     .execute(
                         "INSERT INTO search_index (
                             tenant_id, resource_type, resource_id, param_name, param_url,
-                            value_string, composite_group
-                        ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                            value_string, composite_group, value_string_folded
+                        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                         &[
                             &tenant_id,
                             &resource_type,
@@ -44,6 +45,7 @@ impl PostgresSearchIndexWriter {
                             &extracted.param_url.as_str(),
                             &Some(s.as_str()),
                             &extracted.composite_group.map(|g| g as i32),
+                            &folded.as_str(),
                         ],
                     )
                     .await
@@ -139,14 +141,23 @@ impl PostgresSearchIndexWriter {
                 value,
                 unit,
                 system,
-                code: _,
+                code,
             } => {
+                // Canonicalize using the UCUM code (else the unit display) so
+                // quantity search can match equivalent units (g ⇄ mg).
+                let (canonical_value, canonical_unit) = code
+                    .as_deref()
+                    .or(unit.as_deref())
+                    .and_then(|u| helios_fhirpath::ucum::canonicalize_quantity(*value, u))
+                    .map(|(v, u)| (Some(v), Some(u)))
+                    .unwrap_or((None, None));
                 client
                     .execute(
                         "INSERT INTO search_index (
                             tenant_id, resource_type, resource_id, param_name, param_url,
-                            value_quantity_value, value_quantity_unit, value_quantity_system, composite_group
-                        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                            value_quantity_value, value_quantity_unit, value_quantity_system, composite_group,
+                            value_quantity_canonical_value, value_quantity_canonical_unit
+                        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
                         &[
                             &tenant_id,
                             &resource_type,
@@ -157,6 +168,8 @@ impl PostgresSearchIndexWriter {
                             &unit.as_deref(),
                             &system.as_deref(),
                             &extracted.composite_group.map(|g| g as i32),
+                            &canonical_value,
+                            &canonical_unit.as_deref(),
                         ],
                     )
                     .await

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use crate::error::StorageResult;
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 9;
+pub const SCHEMA_VERSION: i32 = 10;
 
 /// Initialize the database schema.
 pub fn initialize_schema(conn: &Connection) -> StorageResult<()> {
@@ -266,6 +266,7 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> StorageResult<()> {
             6 => migrate_v6_to_v7(conn)?,
             7 => migrate_v7_to_v8(conn)?,
             8 => migrate_v8_to_v9(conn)?,
+            9 => migrate_v9_to_v10(conn)?,
             _ => {
                 return Err(crate::error::StorageError::Backend(
                     crate::error::BackendError::Internal {
@@ -962,6 +963,32 @@ fn migrate_v8_to_v9(conn: &Connection) -> StorageResult<()> {
         [],
     )
     .map_err(|e| migration_err(format!("create reference_display index: {e}")))?;
+    Ok(())
+}
+
+/// Migrate from schema version 9 to version 10.
+///
+/// Adds UCUM-canonicalized quantity columns so quantity search can match across
+/// equivalent units (e.g. `1 g` ⇄ `1000 mg`). Existing rows have NULL canonical
+/// columns until a reindex backfills them; the quantity handler falls back to
+/// raw unit matching for those rows.
+fn migrate_v9_to_v10(conn: &Connection) -> StorageResult<()> {
+    // SQLite has no `ADD COLUMN IF NOT EXISTS`; ignore duplicate-column errors
+    // (the columns may already exist if the table was created fresh at v10).
+    let _ = conn.execute(
+        "ALTER TABLE search_index ADD COLUMN value_quantity_canonical_value REAL",
+        [],
+    );
+    let _ = conn.execute(
+        "ALTER TABLE search_index ADD COLUMN value_quantity_canonical_unit TEXT",
+        [],
+    );
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_search_quantity_canonical
+         ON search_index(tenant_id, resource_type, param_name, value_quantity_canonical_unit, value_quantity_canonical_value)",
+        [],
+    )
+    .map_err(|e| migration_err(format!("create canonical quantity index: {e}")))?;
     Ok(())
 }
 

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -968,10 +968,13 @@ fn migrate_v8_to_v9(conn: &Connection) -> StorageResult<()> {
 
 /// Migrate from schema version 9 to version 10.
 ///
-/// Adds UCUM-canonicalized quantity columns so quantity search can match across
-/// equivalent units (e.g. `1 g` ⇄ `1000 mg`). Existing rows have NULL canonical
-/// columns until a reindex backfills them; the quantity handler falls back to
-/// raw unit matching for those rows.
+/// Adds:
+/// - UCUM-canonicalized quantity columns so quantity search matches across
+///   equivalent units (e.g. `1 g` ⇄ `1000 mg`); and
+/// - a case/accent-folded string column so string search is accent-insensitive.
+///
+/// Existing rows have NULL values in the new columns until a reindex backfills
+/// them; the handlers fall back to raw matching for those rows.
 fn migrate_v9_to_v10(conn: &Connection) -> StorageResult<()> {
     // SQLite has no `ADD COLUMN IF NOT EXISTS`; ignore duplicate-column errors
     // (the columns may already exist if the table was created fresh at v10).
@@ -983,12 +986,22 @@ fn migrate_v9_to_v10(conn: &Connection) -> StorageResult<()> {
         "ALTER TABLE search_index ADD COLUMN value_quantity_canonical_unit TEXT",
         [],
     );
+    let _ = conn.execute(
+        "ALTER TABLE search_index ADD COLUMN value_string_folded TEXT",
+        [],
+    );
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_search_quantity_canonical
          ON search_index(tenant_id, resource_type, param_name, value_quantity_canonical_unit, value_quantity_canonical_value)",
         [],
     )
     .map_err(|e| migration_err(format!("create canonical quantity index: {e}")))?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_search_string_folded
+         ON search_index(tenant_id, resource_type, param_name, value_string_folded)",
+        [],
+    )
+    .map_err(|e| migration_err(format!("create folded string index: {e}")))?;
     Ok(())
 }
 

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/date.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/date.rs
@@ -19,17 +19,37 @@ impl DateHandler {
         let date_value = &value.value;
         let precision = DatePrecision::from_date_string(date_value);
 
+        // Precision range [start, end). Comparators match against its
+        // boundaries per the FHIR spec. When the value is full-precision the
+        // range is degenerate (start == end); fall back to scalar comparison
+        // so an exact instant still matches le/ge/eq.
+        let (start, end) = Self::get_precision_range(date_value, precision);
+
         match value.prefix {
             SearchPrefix::Eq => Self::build_equals(date_value, precision, param_num),
             SearchPrefix::Ne => Self::build_not_equals(date_value, precision, param_num),
-            SearchPrefix::Gt => Self::build_greater_than(date_value, param_num),
-            SearchPrefix::Lt => Self::build_less_than(date_value, param_num),
-            SearchPrefix::Ge => Self::build_greater_equal(date_value, param_num),
-            SearchPrefix::Le => Self::build_less_equal(date_value, param_num),
-            SearchPrefix::Sa => Self::build_starts_after(date_value, param_num),
-            SearchPrefix::Eb => Self::build_ends_before(date_value, param_num),
+            // gt / sa: strictly after the whole range → value_date >= end.
+            SearchPrefix::Gt | SearchPrefix::Sa if start != end => Self::cmp(">=", &end, param_num),
+            SearchPrefix::Gt | SearchPrefix::Sa => Self::cmp(">", date_value, param_num),
+            // lt / eb: strictly before the whole range → value_date < start.
+            SearchPrefix::Lt | SearchPrefix::Eb if start != end => {
+                Self::cmp("<", &start, param_num)
+            }
+            SearchPrefix::Lt | SearchPrefix::Eb => Self::cmp("<", date_value, param_num),
+            SearchPrefix::Ge if start != end => Self::cmp(">=", &start, param_num),
+            SearchPrefix::Ge => Self::cmp(">=", date_value, param_num),
+            SearchPrefix::Le if start != end => Self::cmp("<", &end, param_num),
+            SearchPrefix::Le => Self::cmp("<=", date_value, param_num),
             SearchPrefix::Ap => Self::build_approximately(date_value, precision, param_num),
         }
+    }
+
+    /// Builds a single-boundary date comparison `value_date {op} ?`.
+    fn cmp(op: &str, bound: &str, param_num: usize) -> SqlFragment {
+        SqlFragment::with_params(
+            format!("value_date {} ?{}", op, param_num),
+            vec![SqlParam::string(bound)],
+        )
     }
 
     /// Equality - matches any date within the precision range.
@@ -57,54 +77,6 @@ impl DateHandler {
                 param_num + 1
             ),
             vec![SqlParam::string(start), SqlParam::string(end)],
-        )
-    }
-
-    /// Greater than.
-    fn build_greater_than(date: &str, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_date > ?{}", param_num),
-            vec![SqlParam::string(date)],
-        )
-    }
-
-    /// Less than.
-    fn build_less_than(date: &str, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_date < ?{}", param_num),
-            vec![SqlParam::string(date)],
-        )
-    }
-
-    /// Greater than or equal.
-    fn build_greater_equal(date: &str, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_date >= ?{}", param_num),
-            vec![SqlParam::string(date)],
-        )
-    }
-
-    /// Less than or equal.
-    fn build_less_equal(date: &str, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_date <= ?{}", param_num),
-            vec![SqlParam::string(date)],
-        )
-    }
-
-    /// Starts after (for Period.start).
-    fn build_starts_after(date: &str, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_date > ?{}", param_num),
-            vec![SqlParam::string(date)],
-        )
-    }
-
-    /// Ends before (for Period.end).
-    fn build_ends_before(date: &str, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_date < ?{}", param_num),
-            vec![SqlParam::string(date)],
         )
     }
 
@@ -219,19 +191,30 @@ mod tests {
 
     #[test]
     fn test_date_gt() {
+        // gt on day-precision "2024-01-15" matches strictly after the day, i.e.
+        // value_date >= 2024-01-16T00:00:00.
         let value = SearchValue::new(SearchPrefix::Gt, "2024-01-15");
         let frag = DateHandler::build_sql(&value, 0);
 
-        assert!(frag.sql.contains("> ?1"));
+        assert!(frag.sql.contains(">= ?1"));
         assert_eq!(frag.params.len(), 1);
+        match &frag.params[0] {
+            SqlParam::String(s) => assert_eq!(s, "2024-01-16T00:00:00"),
+            _ => panic!("expected string bound"),
+        }
     }
 
     #[test]
     fn test_date_le() {
+        // le on day-precision matches up to the end of the day → < next day.
         let value = SearchValue::new(SearchPrefix::Le, "2024-01-15");
         let frag = DateHandler::build_sql(&value, 0);
 
-        assert!(frag.sql.contains("<= ?1"));
+        assert!(frag.sql.contains("< ?1"));
+        match &frag.params[0] {
+            SqlParam::String(s) => assert_eq!(s, "2024-01-16T00:00:00"),
+            _ => panic!("expected string bound"),
+        }
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/number.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/number.rs
@@ -23,17 +23,29 @@ impl NumberHandler {
             }
         };
 
+        // Implicit-precision range [lo, hi) of the search value; comparators
+        // match against its boundaries per the FHIR spec.
+        let (lo, hi) = crate::search::implicit_range(num_value, &value.value);
+
         match value.prefix {
             SearchPrefix::Eq => Self::build_equals(num_value, param_num),
             SearchPrefix::Ne => Self::build_not_equals(num_value, param_num),
-            SearchPrefix::Gt => Self::build_greater_than(num_value, param_num),
-            SearchPrefix::Lt => Self::build_less_than(num_value, param_num),
-            SearchPrefix::Ge => Self::build_greater_equal(num_value, param_num),
-            SearchPrefix::Le => Self::build_less_equal(num_value, param_num),
-            SearchPrefix::Sa => Self::build_greater_than(num_value, param_num), // Same as gt for numbers
-            SearchPrefix::Eb => Self::build_less_than(num_value, param_num), // Same as lt for numbers
+            // gt / sa: strictly above the whole search range.
+            SearchPrefix::Gt | SearchPrefix::Sa => Self::cmp(">=", hi, param_num),
+            // lt / eb: strictly below the whole search range.
+            SearchPrefix::Lt | SearchPrefix::Eb => Self::cmp("<", lo, param_num),
+            SearchPrefix::Ge => Self::cmp(">=", lo, param_num),
+            SearchPrefix::Le => Self::cmp("<", hi, param_num),
             SearchPrefix::Ap => Self::build_approximately(num_value, param_num),
         }
+    }
+
+    /// Builds a single-boundary numeric comparison `value_number {op} ?`.
+    fn cmp(op: &str, bound: f64, param_num: usize) -> SqlFragment {
+        SqlFragment::with_params(
+            format!("value_number {} ?{}", op, param_num),
+            vec![SqlParam::float(bound)],
+        )
     }
 
     /// Equality - exact match with implicit precision.
@@ -72,38 +84,6 @@ impl NumberHandler {
                 SqlParam::float(value - half_precision),
                 SqlParam::float(value + half_precision),
             ],
-        )
-    }
-
-    /// Greater than.
-    fn build_greater_than(value: f64, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_number > ?{}", param_num),
-            vec![SqlParam::float(value)],
-        )
-    }
-
-    /// Less than.
-    fn build_less_than(value: f64, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_number < ?{}", param_num),
-            vec![SqlParam::float(value)],
-        )
-    }
-
-    /// Greater than or equal.
-    fn build_greater_equal(value: f64, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_number >= ?{}", param_num),
-            vec![SqlParam::float(value)],
-        )
-    }
-
-    /// Less than or equal.
-    fn build_less_equal(value: f64, param_num: usize) -> SqlFragment {
-        SqlFragment::with_params(
-            format!("value_number <= ?{}", param_num),
-            vec![SqlParam::float(value)],
         )
     }
 
@@ -151,19 +131,29 @@ mod tests {
 
     #[test]
     fn test_number_gt() {
+        // gt matches strictly above the search range; for "100" that is >= 100.5.
         let value = SearchValue::new(SearchPrefix::Gt, "100");
         let frag = NumberHandler::build_sql(&value, 0);
 
-        assert!(frag.sql.contains("> ?1"));
+        assert!(frag.sql.contains(">= ?1"));
         assert_eq!(frag.params.len(), 1);
+        match &frag.params[0] {
+            SqlParam::Float(f) => assert!((*f - 100.5).abs() < 1e-9),
+            _ => panic!("expected float bound"),
+        }
     }
 
     #[test]
     fn test_number_le() {
+        // le matches up to the top of the search range; for "100" that is < 100.5.
         let value = SearchValue::new(SearchPrefix::Le, "100");
         let frag = NumberHandler::build_sql(&value, 0);
 
-        assert!(frag.sql.contains("<= ?1"));
+        assert!(frag.sql.contains("< ?1"));
+        match &frag.params[0] {
+            SqlParam::Float(f) => assert!((*f - 100.5).abs() < 1e-9),
+            _ => panic!("expected float bound"),
+        }
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/quantity.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/quantity.rs
@@ -131,16 +131,21 @@ impl QuantityHandler {
                 };
                 (sql, vec![SqlParam::float(lo), SqlParam::float(hi)], unit)
             }
+            // Comparators match against the canonicalized range boundaries:
+            // gt/sa → ≥ canon(hi), lt/eb → < canon(lo), ge → ≥ canon(lo),
+            // le → < canon(hi).
             SearchPrefix::Gt | SearchPrefix::Sa => {
-                let (b, unit) = canon(value, code)?;
+                let hi = value + Self::get_implicit_precision(value) / 2.0;
+                let (b, unit) = canon(hi, code)?;
                 (
-                    format!("{col} > ?{}", param_num),
+                    format!("{col} >= ?{}", param_num),
                     vec![SqlParam::float(b)],
                     unit,
                 )
             }
             SearchPrefix::Lt | SearchPrefix::Eb => {
-                let (b, unit) = canon(value, code)?;
+                let lo = value - Self::get_implicit_precision(value) / 2.0;
+                let (b, unit) = canon(lo, code)?;
                 (
                     format!("{col} < ?{}", param_num),
                     vec![SqlParam::float(b)],
@@ -148,7 +153,8 @@ impl QuantityHandler {
                 )
             }
             SearchPrefix::Ge => {
-                let (b, unit) = canon(value, code)?;
+                let lo = value - Self::get_implicit_precision(value) / 2.0;
+                let (b, unit) = canon(lo, code)?;
                 (
                     format!("{col} >= ?{}", param_num),
                     vec![SqlParam::float(b)],
@@ -156,9 +162,10 @@ impl QuantityHandler {
                 )
             }
             SearchPrefix::Le => {
-                let (b, unit) = canon(value, code)?;
+                let hi = value + Self::get_implicit_precision(value) / 2.0;
+                let (b, unit) = canon(hi, code)?;
                 (
-                    format!("{col} <= ?{}", param_num),
+                    format!("{col} < ?{}", param_num),
                     vec![SqlParam::float(b)],
                     unit,
                 )
@@ -217,22 +224,36 @@ impl QuantityHandler {
                     vec![SqlParam::float(value - half), SqlParam::float(value + half)],
                 )
             }
-            SearchPrefix::Gt | SearchPrefix::Sa => SqlFragment::with_params(
-                format!("{column} > ?{}", param_num),
-                vec![SqlParam::float(value)],
-            ),
-            SearchPrefix::Lt | SearchPrefix::Eb => SqlFragment::with_params(
-                format!("{column} < ?{}", param_num),
-                vec![SqlParam::float(value)],
-            ),
-            SearchPrefix::Ge => SqlFragment::with_params(
-                format!("{column} >= ?{}", param_num),
-                vec![SqlParam::float(value)],
-            ),
-            SearchPrefix::Le => SqlFragment::with_params(
-                format!("{column} <= ?{}", param_num),
-                vec![SqlParam::float(value)],
-            ),
+            // Comparators match against the implicit-precision range boundaries
+            // (FHIR spec): gt/sa → ≥ hi, lt/eb → < lo, ge → ≥ lo, le → < hi.
+            SearchPrefix::Gt | SearchPrefix::Sa => {
+                let hi = value + Self::get_implicit_precision(value) / 2.0;
+                SqlFragment::with_params(
+                    format!("{column} >= ?{}", param_num),
+                    vec![SqlParam::float(hi)],
+                )
+            }
+            SearchPrefix::Lt | SearchPrefix::Eb => {
+                let lo = value - Self::get_implicit_precision(value) / 2.0;
+                SqlFragment::with_params(
+                    format!("{column} < ?{}", param_num),
+                    vec![SqlParam::float(lo)],
+                )
+            }
+            SearchPrefix::Ge => {
+                let lo = value - Self::get_implicit_precision(value) / 2.0;
+                SqlFragment::with_params(
+                    format!("{column} >= ?{}", param_num),
+                    vec![SqlParam::float(lo)],
+                )
+            }
+            SearchPrefix::Le => {
+                let hi = value + Self::get_implicit_precision(value) / 2.0;
+                SqlFragment::with_params(
+                    format!("{column} < ?{}", param_num),
+                    vec![SqlParam::float(hi)],
+                )
+            }
             SearchPrefix::Ap => {
                 // +/- 10%
                 let margin = (value.abs() * 0.1).max(0.0001);
@@ -293,10 +314,11 @@ mod tests {
 
     #[test]
     fn test_quantity_gt() {
+        // gt matches strictly above the search range → `value_quantity_value >= hi`.
         let value = SearchValue::new(SearchPrefix::Gt, "5.4|mg");
         let frag = QuantityHandler::build_sql(&value, 0);
 
-        assert!(frag.sql.contains("> ?1"));
+        assert!(frag.sql.contains(">= ?1"));
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/quantity.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/quantity.rs
@@ -59,13 +59,16 @@ impl QuantityHandler {
             _ => return SqlFragment::new("1 = 0"),
         };
 
-        // Build the numeric comparison
-        let num_condition = Self::build_numeric_condition(num_value, value.prefix, param_num);
-
-        // Add unit conditions if specified
-        if system.is_some() || code.is_some() {
-            let mut conditions = vec![num_condition.sql];
-            let mut params = num_condition.params;
+        // Raw match: numeric comparison plus the stored unit/system verbatim.
+        let raw = {
+            let num = Self::build_numeric_condition(
+                "value_quantity_value",
+                num_value,
+                value.prefix,
+                param_num,
+            );
+            let mut conditions = vec![num.sql];
+            let mut params = num.params;
             let mut next_param = param_num + params.len();
 
             if let Some(sys) = system {
@@ -73,20 +76,121 @@ impl QuantityHandler {
                 params.push(SqlParam::string(sys));
                 next_param += 1;
             }
-
             if let Some(c) = code {
                 conditions.push(format!("value_quantity_unit = ?{}", next_param));
                 params.push(SqlParam::string(c));
             }
-
             SqlFragment::with_params(conditions.join(" AND "), params)
-        } else {
-            num_condition
+        };
+
+        // Canonical match: when a UCUM code is supplied and convertible, also
+        // match rows whose canonical unit/value are equivalent (e.g. `g` ⇄ `mg`).
+        // ORed with the raw match so rows not yet reindexed (canonical columns
+        // NULL) still match via their stored unit.
+        if let Some(c) = code {
+            let start = param_num + raw.params.len();
+            if let Some((canon_sql, canon_params)) =
+                Self::build_canonical_condition(c, num_value, value.prefix, start)
+            {
+                let mut params = raw.params;
+                params.extend(canon_params);
+                return SqlFragment::with_params(
+                    format!("(({}) OR ({}))", raw.sql, canon_sql),
+                    params,
+                );
+            }
         }
+
+        raw
     }
 
-    /// Builds the numeric comparison part of the condition.
-    fn build_numeric_condition(value: f64, prefix: SearchPrefix, param_num: usize) -> SqlFragment {
+    /// Builds the canonical-column predicate by canonicalizing the search value's
+    /// numeric *bounds* (range endpoints) with the supplied UCUM code, so unit
+    /// equivalence is honored without losing implicit-precision semantics to
+    /// float rounding. Returns `None` if the unit cannot be canonicalized.
+    fn build_canonical_condition(
+        code: &str,
+        value: f64,
+        prefix: SearchPrefix,
+        param_num: usize,
+    ) -> Option<(String, Vec<SqlParam>)> {
+        use helios_fhirpath::ucum::canonicalize_quantity as canon;
+        let col = "value_quantity_canonical_value";
+
+        // Canonicalize one bound, returning (canonical_value, canonical_unit).
+        let (sql, mut params, unit) = match prefix {
+            SearchPrefix::Eq | SearchPrefix::Ne => {
+                let half = Self::get_implicit_precision(value) / 2.0;
+                let (lo, unit) = canon(value - half, code)?;
+                let (hi, _) = canon(value + half, code)?;
+                let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+                let sql = if matches!(prefix, SearchPrefix::Eq) {
+                    format!("{col} >= ?{} AND {col} < ?{}", param_num, param_num + 1)
+                } else {
+                    format!("({col} < ?{} OR {col} >= ?{})", param_num, param_num + 1)
+                };
+                (sql, vec![SqlParam::float(lo), SqlParam::float(hi)], unit)
+            }
+            SearchPrefix::Gt | SearchPrefix::Sa => {
+                let (b, unit) = canon(value, code)?;
+                (
+                    format!("{col} > ?{}", param_num),
+                    vec![SqlParam::float(b)],
+                    unit,
+                )
+            }
+            SearchPrefix::Lt | SearchPrefix::Eb => {
+                let (b, unit) = canon(value, code)?;
+                (
+                    format!("{col} < ?{}", param_num),
+                    vec![SqlParam::float(b)],
+                    unit,
+                )
+            }
+            SearchPrefix::Ge => {
+                let (b, unit) = canon(value, code)?;
+                (
+                    format!("{col} >= ?{}", param_num),
+                    vec![SqlParam::float(b)],
+                    unit,
+                )
+            }
+            SearchPrefix::Le => {
+                let (b, unit) = canon(value, code)?;
+                (
+                    format!("{col} <= ?{}", param_num),
+                    vec![SqlParam::float(b)],
+                    unit,
+                )
+            }
+            SearchPrefix::Ap => {
+                let margin = (value.abs() * 0.1).max(0.0001);
+                let (lo, unit) = canon(value - margin, code)?;
+                let (hi, _) = canon(value + margin, code)?;
+                let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+                (
+                    format!("{col} BETWEEN ?{} AND ?{}", param_num, param_num + 1),
+                    vec![SqlParam::float(lo), SqlParam::float(hi)],
+                    unit,
+                )
+            }
+        };
+
+        let unit_param = param_num + params.len();
+        params.push(SqlParam::string(&unit));
+        Some((
+            format!("{sql} AND value_quantity_canonical_unit = ?{unit_param}"),
+            params,
+        ))
+    }
+
+    /// Builds the numeric comparison part of the condition against `column`.
+    fn build_numeric_condition(
+        column: &str,
+        value: f64,
+        prefix: SearchPrefix,
+        param_num: usize,
+    ) -> SqlFragment {
         match prefix {
             SearchPrefix::Eq => {
                 // Implicit precision range
@@ -94,7 +198,7 @@ impl QuantityHandler {
                 let half = precision / 2.0;
                 SqlFragment::with_params(
                     format!(
-                        "value_quantity_value >= ?{} AND value_quantity_value < ?{}",
+                        "{column} >= ?{} AND {column} < ?{}",
                         param_num,
                         param_num + 1
                     ),
@@ -106,7 +210,7 @@ impl QuantityHandler {
                 let half = precision / 2.0;
                 SqlFragment::with_params(
                     format!(
-                        "(value_quantity_value < ?{} OR value_quantity_value >= ?{})",
+                        "({column} < ?{} OR {column} >= ?{})",
                         param_num,
                         param_num + 1
                     ),
@@ -114,30 +218,26 @@ impl QuantityHandler {
                 )
             }
             SearchPrefix::Gt | SearchPrefix::Sa => SqlFragment::with_params(
-                format!("value_quantity_value > ?{}", param_num),
+                format!("{column} > ?{}", param_num),
                 vec![SqlParam::float(value)],
             ),
             SearchPrefix::Lt | SearchPrefix::Eb => SqlFragment::with_params(
-                format!("value_quantity_value < ?{}", param_num),
+                format!("{column} < ?{}", param_num),
                 vec![SqlParam::float(value)],
             ),
             SearchPrefix::Ge => SqlFragment::with_params(
-                format!("value_quantity_value >= ?{}", param_num),
+                format!("{column} >= ?{}", param_num),
                 vec![SqlParam::float(value)],
             ),
             SearchPrefix::Le => SqlFragment::with_params(
-                format!("value_quantity_value <= ?{}", param_num),
+                format!("{column} <= ?{}", param_num),
                 vec![SqlParam::float(value)],
             ),
             SearchPrefix::Ap => {
                 // +/- 10%
                 let margin = (value.abs() * 0.1).max(0.0001);
                 SqlFragment::with_params(
-                    format!(
-                        "value_quantity_value BETWEEN ?{} AND ?{}",
-                        param_num,
-                        param_num + 1
-                    ),
+                    format!("{column} BETWEEN ?{} AND ?{}", param_num, param_num + 1),
                     vec![
                         SqlParam::float(value - margin),
                         SqlParam::float(value + margin),

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/string.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/string.rs
@@ -1,5 +1,6 @@
 //! String parameter SQL handler.
 
+use crate::search::fold_text;
 use crate::types::{SearchModifier, SearchValue};
 
 use super::super::query_builder::{SqlFragment, SqlParam};
@@ -26,31 +27,37 @@ impl StringHandler {
                     vec![SqlParam::string(&value.value)],
                 )
             }
-            Some(SearchModifier::Contains) => {
-                // Contains (case-insensitive)
+            Some(SearchModifier::Contains) | Some(SearchModifier::Text) => {
+                // Contains (case- and accent-insensitive). Match the folded
+                // column; OR the raw column (case-insensitive) so rows not yet
+                // reindexed — whose folded column is NULL — still match.
                 SqlFragment::with_params(
                     format!(
-                        "value_string COLLATE NOCASE LIKE '%' || ?{} || '%'",
-                        param_num
+                        "(value_string_folded LIKE '%' || ?{} || '%' \
+                          OR value_string COLLATE NOCASE LIKE '%' || ?{} || '%')",
+                        param_num,
+                        param_num + 1
                     ),
-                    vec![SqlParam::string(value.value.to_lowercase())],
-                )
-            }
-            Some(SearchModifier::Text) => {
-                // Full-text search - use FTS5 if available, otherwise contains
-                SqlFragment::with_params(
-                    format!(
-                        "value_string COLLATE NOCASE LIKE '%' || ?{} || '%'",
-                        param_num
-                    ),
-                    vec![SqlParam::string(value.value.to_lowercase())],
+                    vec![
+                        SqlParam::string(fold_text(&value.value)),
+                        SqlParam::string(value.value.to_lowercase()),
+                    ],
                 )
             }
             _ => {
-                // Default: case-insensitive prefix match
+                // Default: case- and accent-insensitive prefix match, with a raw
+                // fallback for not-yet-reindexed rows (folded column NULL).
                 SqlFragment::with_params(
-                    format!("value_string COLLATE NOCASE LIKE ?{} || '%'", param_num),
-                    vec![SqlParam::string(value.value.to_lowercase())],
+                    format!(
+                        "(value_string_folded LIKE ?{} || '%' \
+                          OR value_string COLLATE NOCASE LIKE ?{} || '%')",
+                        param_num,
+                        param_num + 1
+                    ),
+                    vec![
+                        SqlParam::string(fold_text(&value.value)),
+                        SqlParam::string(value.value.to_lowercase()),
+                    ],
                 )
             }
         }
@@ -67,9 +74,10 @@ mod tests {
         let value = SearchValue::new(SearchPrefix::Eq, "Smith");
         let frag = StringHandler::build_sql(&value, None, 0);
 
+        assert!(frag.sql.contains("value_string_folded LIKE"));
         assert!(frag.sql.contains("COLLATE NOCASE LIKE"));
         assert!(frag.sql.contains("|| '%'"));
-        assert_eq!(frag.params.len(), 1);
+        assert_eq!(frag.params.len(), 2);
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search/writer.rs
+++ b/crates/persistence/src/backends/sqlite/search/writer.rs
@@ -22,7 +22,8 @@ impl SqliteSearchIndexWriter {
             value_reference, value_uri, composite_group,
             value_identifier_type_system, value_identifier_type_code,
             value_reference_display,
-            value_quantity_canonical_value, value_quantity_canonical_unit
+            value_quantity_canonical_value, value_quantity_canonical_unit,
+            value_string_folded
         ) VALUES (
             ?1, ?2, ?3, ?4, ?5,
             ?6, ?7, ?8, ?9,
@@ -31,7 +32,8 @@ impl SqliteSearchIndexWriter {
             ?16, ?17, ?18,
             ?19, ?20,
             ?21,
-            ?22, ?23
+            ?22, ?23,
+            ?24
         )
         "#
     }
@@ -69,10 +71,12 @@ impl SqliteSearchIndexWriter {
         let mut reference_display: Option<String> = None;
         let mut canonical_value: Option<f64> = None;
         let mut canonical_unit: Option<String> = None;
+        let mut string_folded: Option<String> = None;
 
         // Add value columns based on the IndexValue type
         match &extracted.value {
             IndexValue::String(s) => {
+                string_folded = Some(crate::search::fold_text(s));
                 params.push(SqlValue::OptString(Some(s.clone()))); // value_string
                 params.push(SqlValue::Null); // value_token_system
                 params.push(SqlValue::Null); // value_token_code
@@ -113,6 +117,7 @@ impl SqliteSearchIndexWriter {
                 params.push(SqlValue::Null); // value_reference_display
                 params.push(SqlValue::Null); // value_quantity_canonical_value
                 params.push(SqlValue::Null); // value_quantity_canonical_unit
+                params.push(SqlValue::Null); // value_string_folded
                 return params;
             }
             IndexValue::Date { value, precision } => {
@@ -221,6 +226,7 @@ impl SqliteSearchIndexWriter {
             None => SqlValue::Null,
         }); // value_quantity_canonical_value
         params.push(SqlValue::OptString(canonical_unit)); // value_quantity_canonical_unit
+        params.push(SqlValue::OptString(string_folded)); // value_string_folded
 
         params
     }
@@ -289,7 +295,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Patient", "123", &extracted);
 
-        assert_eq!(params.len(), 23); // Updated for new columns
+        assert_eq!(params.len(), 24); // Updated for new columns
         assert!(matches!(&params[0], SqlValue::String(s) if s == "tenant1"));
         assert!(matches!(&params[5], SqlValue::OptString(Some(s)) if s == "Smith"));
     }
@@ -313,7 +319,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Patient", "123", &extracted);
 
-        assert_eq!(params.len(), 23); // Updated for new columns
+        assert_eq!(params.len(), 24); // Updated for new columns
         assert!(matches!(&params[6], SqlValue::OptString(Some(s)) if s == "http://example.org"));
         assert!(matches!(&params[7], SqlValue::String(s) if s == "12345"));
     }
@@ -337,7 +343,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Observation", "123", &extracted);
 
-        assert_eq!(params.len(), 23);
+        assert_eq!(params.len(), 24);
         assert!(matches!(&params[8], SqlValue::OptString(Some(s)) if s == "Test Display")); // value_token_display
     }
 
@@ -362,7 +368,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Patient", "123", &extracted);
 
-        assert_eq!(params.len(), 23);
+        assert_eq!(params.len(), 24);
         // value_identifier_type_system is at index 18
         assert!(
             matches!(&params[18], SqlValue::OptString(Some(s)) if s == "http://terminology.hl7.org/CodeSystem/v2-0203")

--- a/crates/persistence/src/backends/sqlite/search/writer.rs
+++ b/crates/persistence/src/backends/sqlite/search/writer.rs
@@ -21,7 +21,8 @@ impl SqliteSearchIndexWriter {
             value_number, value_quantity_value, value_quantity_unit, value_quantity_system,
             value_reference, value_uri, composite_group,
             value_identifier_type_system, value_identifier_type_code,
-            value_reference_display
+            value_reference_display,
+            value_quantity_canonical_value, value_quantity_canonical_unit
         ) VALUES (
             ?1, ?2, ?3, ?4, ?5,
             ?6, ?7, ?8, ?9,
@@ -29,7 +30,8 @@ impl SqliteSearchIndexWriter {
             ?12, ?13, ?14, ?15,
             ?16, ?17, ?18,
             ?19, ?20,
-            ?21
+            ?21,
+            ?22, ?23
         )
         "#
     }
@@ -61,9 +63,12 @@ impl SqliteSearchIndexWriter {
             SqlValue::String(extracted.param_url.clone()),
         ];
 
-        // `value_reference_display` is appended as the final column; capture it
-        // here so the common tail (and the Token early-return) can emit it.
+        // `value_reference_display` and the UCUM-canonical quantity columns are
+        // appended as trailing columns; capture them here so the common tail
+        // (and the Token early-return) can emit them.
         let mut reference_display: Option<String> = None;
+        let mut canonical_value: Option<f64> = None;
+        let mut canonical_unit: Option<String> = None;
 
         // Add value columns based on the IndexValue type
         match &extracted.value {
@@ -106,6 +111,8 @@ impl SqliteSearchIndexWriter {
                 params.push(SqlValue::OptString(identifier_type_system.clone())); // value_identifier_type_system
                 params.push(SqlValue::OptString(identifier_type_code.clone())); // value_identifier_type_code
                 params.push(SqlValue::Null); // value_reference_display
+                params.push(SqlValue::Null); // value_quantity_canonical_value
+                params.push(SqlValue::Null); // value_quantity_canonical_unit
                 return params;
             }
             IndexValue::Date { value, precision } => {
@@ -140,8 +147,19 @@ impl SqliteSearchIndexWriter {
                 value,
                 unit,
                 system,
-                code: _,
+                code,
             } => {
+                // Canonicalize using the UCUM code when present, else the unit
+                // display string. Stored alongside the raw value so quantity
+                // search can match equivalent units (e.g. g ⇄ mg).
+                let ucum = code.as_deref().or(unit.as_deref());
+                if let Some(u) = ucum {
+                    if let Some((cv, cu)) = helios_fhirpath::ucum::canonicalize_quantity(*value, u)
+                    {
+                        canonical_value = Some(cv);
+                        canonical_unit = Some(cu);
+                    }
+                }
                 params.push(SqlValue::Null); // value_string
                 params.push(SqlValue::Null); // value_token_system
                 params.push(SqlValue::Null); // value_token_code
@@ -198,6 +216,11 @@ impl SqliteSearchIndexWriter {
         params.push(SqlValue::Null); // value_identifier_type_system
         params.push(SqlValue::Null); // value_identifier_type_code
         params.push(SqlValue::OptString(reference_display)); // value_reference_display
+        params.push(match canonical_value {
+            Some(v) => SqlValue::Float(v),
+            None => SqlValue::Null,
+        }); // value_quantity_canonical_value
+        params.push(SqlValue::OptString(canonical_unit)); // value_quantity_canonical_unit
 
         params
     }
@@ -266,7 +289,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Patient", "123", &extracted);
 
-        assert_eq!(params.len(), 21); // Updated for new columns
+        assert_eq!(params.len(), 23); // Updated for new columns
         assert!(matches!(&params[0], SqlValue::String(s) if s == "tenant1"));
         assert!(matches!(&params[5], SqlValue::OptString(Some(s)) if s == "Smith"));
     }
@@ -290,7 +313,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Patient", "123", &extracted);
 
-        assert_eq!(params.len(), 21); // Updated for new columns
+        assert_eq!(params.len(), 23); // Updated for new columns
         assert!(matches!(&params[6], SqlValue::OptString(Some(s)) if s == "http://example.org"));
         assert!(matches!(&params[7], SqlValue::String(s) if s == "12345"));
     }
@@ -314,7 +337,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Observation", "123", &extracted);
 
-        assert_eq!(params.len(), 21);
+        assert_eq!(params.len(), 23);
         assert!(matches!(&params[8], SqlValue::OptString(Some(s)) if s == "Test Display")); // value_token_display
     }
 
@@ -339,7 +362,7 @@ mod tests {
         let params =
             SqliteSearchIndexWriter::to_sql_params("tenant1", "Patient", "123", &extracted);
 
-        assert_eq!(params.len(), 21);
+        assert_eq!(params.len(), 23);
         // value_identifier_type_system is at index 18
         assert!(
             matches!(&params[18], SqlValue::OptString(Some(s)) if s == "http://terminology.hl7.org/CodeSystem/v2-0203")

--- a/crates/persistence/src/search/mod.rs
+++ b/crates/persistence/src/search/mod.rs
@@ -68,6 +68,7 @@ pub mod extractor;
 pub mod loader;
 pub mod registry;
 pub mod reindex;
+pub mod text_fold;
 pub mod writer;
 
 // Re-export main types
@@ -84,4 +85,5 @@ pub use reindex::{
     ReindexOperation, ReindexProgress, ReindexRequest, ReindexStatus, ReindexableStorage,
     ResourcePage,
 };
+pub use text_fold::fold_text;
 pub use writer::SearchIndexWriter;

--- a/crates/persistence/src/search/mod.rs
+++ b/crates/persistence/src/search/mod.rs
@@ -66,6 +66,7 @@ pub mod converters;
 pub mod errors;
 pub mod extractor;
 pub mod loader;
+pub mod range;
 pub mod registry;
 pub mod reindex;
 pub mod text_fold;
@@ -77,6 +78,7 @@ pub use converters::{IndexValue, ValueConverter};
 pub use errors::{ExtractionError, LoaderError, RegistryError, ReindexError};
 pub use extractor::{ExtractedValue, SearchParameterExtractor};
 pub use loader::SearchParameterLoader;
+pub use range::{implicit_precision, implicit_range};
 pub use registry::{
     RegistryUpdate, SearchParameterDefinition, SearchParameterRegistry, SearchParameterSource,
     SearchParameterStatus, resolve_param_targets, resolve_param_type,

--- a/crates/persistence/src/search/range.rs
+++ b/crates/persistence/src/search/range.rs
@@ -1,0 +1,53 @@
+//! Implicit-precision ranges for ordered (number/quantity) search values.
+//!
+//! FHIR treats a decimal search value as a range determined by its significant
+//! figures: `100` ⇒ `[99.5, 100.5)`, `100.0` ⇒ `[99.95, 100.05)`. Comparator
+//! prefixes are then defined against that range's boundaries (per
+//! <https://build.fhir.org/search.html#prefix>):
+//!
+//! | prefix | match (target value `x`, search range `[lo, hi)`) |
+//! |--------|---------------------------------------------------|
+//! | `eq`   | `lo ≤ x < hi`                                     |
+//! | `ne`   | `x < lo OR x ≥ hi`                                 |
+//! | `ge`   | `x ≥ lo`                                           |
+//! | `le`   | `x < hi`                                           |
+//! | `gt` / `sa` | `x ≥ hi`                                      |
+//! | `lt` / `eb` | `x < lo`                                      |
+
+/// Returns the implicit precision (ULP of the least significant digit) of a
+/// decimal value from its string form: `"100"` → 1.0, `"100.0"` → 0.1.
+pub fn implicit_precision(num_str: &str) -> f64 {
+    match num_str.find('.') {
+        Some(dot) => {
+            let decimals = num_str.len() - dot - 1;
+            10f64.powi(-(decimals as i32))
+        }
+        None => 1.0,
+    }
+}
+
+/// Returns the half-open implicit-precision range `[lo, hi)` for `value`, whose
+/// textual form is `num_str` (used to derive the precision).
+pub fn implicit_range(value: f64, num_str: &str) -> (f64, f64) {
+    let half = implicit_precision(num_str) / 2.0;
+    (value - half, value + half)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn precision_from_significant_figures() {
+        assert_eq!(implicit_precision("100"), 1.0);
+        assert_eq!(implicit_precision("100.0"), 0.1);
+        assert_eq!(implicit_precision("100.00"), 0.01);
+    }
+
+    #[test]
+    fn range_brackets_value() {
+        let (lo, hi) = implicit_range(100.0, "100");
+        assert_eq!(lo, 99.5);
+        assert_eq!(hi, 100.5);
+    }
+}

--- a/crates/persistence/src/search/text_fold.rs
+++ b/crates/persistence/src/search/text_fold.rs
@@ -1,0 +1,42 @@
+//! Case- and accent-insensitive text folding for string search.
+//!
+//! FHIR string search is case-insensitive **and accent-insensitive**. We fold
+//! by lowercasing and stripping Unicode combining marks (NFD decomposition, then
+//! dropping `Mn` characters), so e.g. `Müller`, `muller`, and `MÜLLER` all fold
+//! to `muller`. The folded form is stored alongside the raw value in the search
+//! index and compared against a folded query value.
+
+use unicode_normalization::UnicodeNormalization;
+use unicode_normalization::char::is_combining_mark;
+
+/// Folds text for accent- and case-insensitive comparison.
+///
+/// Lowercases, then NFD-decomposes and removes combining marks (diacritics).
+pub fn fold_text(input: &str) -> String {
+    input
+        .nfd()
+        .filter(|c| !is_combining_mark(*c))
+        .flat_map(|c| c.to_lowercase())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folds_case_and_accents() {
+        assert_eq!(fold_text("Müller"), "muller");
+        assert_eq!(fold_text("MÜLLER"), "muller");
+        assert_eq!(fold_text("muller"), "muller");
+        assert_eq!(fold_text("Café"), "cafe");
+        assert_eq!(fold_text("naïve"), "naive");
+        assert_eq!(fold_text("ÀÉÎÕÜ"), "aeiou");
+    }
+
+    #[test]
+    fn leaves_plain_ascii_unchanged_except_case() {
+        assert_eq!(fold_text("Smith"), "smith");
+        assert_eq!(fold_text("smith"), "smith");
+    }
+}

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -295,8 +295,10 @@ impl SearchPrefix {
     ///
     /// Returns the prefix and the remaining value.
     pub fn extract(value: &str) -> (Self, &str) {
-        if value.len() >= 2 {
-            let prefix = &value[..2];
+        // `get(..2)` is char-boundary safe: it returns None when the first two
+        // bytes don't form a valid prefix (e.g. a multibyte first character like
+        // "Müller"), avoiding a panic from slicing mid-codepoint.
+        if let Some(prefix) = value.get(..2) {
             if let Ok(p) = prefix.parse() {
                 return (p, &value[2..]);
             }

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -1191,6 +1191,94 @@ mod es_integration {
     }
 
     #[tokio::test]
+    async fn es_integration_string_search_is_accent_insensitive() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "accent-es",
+                    "name": [{ "family": "Müller" }]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        for q in ["muller", "Müller", "MULLER"] {
+            let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+                name: "family".to_string(),
+                param_type: SearchParamType::String,
+                modifier: None,
+                values: vec![SearchValue::eq(q)],
+                chain: vec![],
+                components: vec![],
+            });
+            let result = backend.search(&tenant, &query).await.unwrap();
+            assert_eq!(
+                result.resources.items.len(),
+                1,
+                "accent-insensitive family search '{q}' should match 'Müller'"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn es_integration_quantity_search_ucum_equivalence() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-mass-es",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "x" }] },
+                    "valueQuantity": { "value": 1, "unit": "g", "system": "http://unitsofmeasure.org", "code": "g" }
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        // 1 g stored; search the equivalent 1000 mg.
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "value-quantity".to_string(),
+            param_type: SearchParamType::Quantity,
+            modifier: None,
+            values: vec![SearchValue::eq("1000|http://unitsofmeasure.org|mg")],
+            chain: vec![],
+            components: vec![],
+        });
+        let result = backend.search(&tenant, &query).await.unwrap();
+        assert_eq!(
+            result.resources.items.len(),
+            1,
+            "UCUM-equivalent quantity (1000 mg) should match stored 1 g"
+        );
+        assert_eq!(result.resources.items[0].id(), "obs-mass-es");
+    }
+
+    #[tokio::test]
     async fn es_integration_tenant_isolation_delete() {
         let backend = create_backend().await;
         let tenant_a = create_tenant("tenant-a");

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -463,7 +463,8 @@ mod query_builder_tests {
         assert!(result.is_some());
         let fragment = result.unwrap();
         assert!(fragment.sql.contains("value_date"));
-        assert!(fragment.sql.contains("> $"));
+        // gt now matches strictly after the day → value_date >= (next day).
+        assert!(fragment.sql.contains(">= $"));
     }
 
     #[test]
@@ -482,8 +483,10 @@ mod query_builder_tests {
         let fragment = result.unwrap();
         assert!(fragment.sql.contains("value_number"));
         assert!(fragment.sql.contains(">= $"));
+        // ge matches from the low boundary of the implicit range: "0.5" has
+        // precision 0.1, so the bound is 0.5 - 0.05 = 0.45.
         match &fragment.params[0] {
-            SqlParam::Float(f) => assert!((f - 0.5).abs() < f64::EPSILON),
+            SqlParam::Float(f) => assert!((f - 0.45).abs() < 1e-9),
             _ => panic!("Expected Float param"),
         }
     }

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -275,7 +275,9 @@ mod query_builder_tests {
         let result = PostgresQueryBuilder::build_search_query(&query, 2);
         assert!(result.is_some());
         let fragment = result.unwrap();
-        assert!(fragment.sql.contains("value_string ILIKE"));
+        // Accent-folded substring match: COALESCE(folded, raw) ILIKE %mit%
+        assert!(fragment.sql.contains("value_string_folded"));
+        assert!(fragment.sql.contains("ILIKE"));
         // Substring match: param wrapped as %mit%
         match &fragment.params[0] {
             SqlParam::Text(s) => {
@@ -1335,6 +1337,91 @@ mod postgres_integration {
             "Search by name should find the patient"
         );
         assert_eq!(result.resources.items[0].id(), "p1");
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_string_search_is_accent_insensitive() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "accent-pg",
+                    "name": [{ "family": "Müller" }]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        for q in ["muller", "Müller", "MULLER"] {
+            let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+                name: "family".to_string(),
+                param_type: SearchParamType::String,
+                modifier: None,
+                values: vec![SearchValue::eq(q)],
+                chain: vec![],
+                components: vec![],
+            });
+            let result = backend.search(&tenant, &query).await.unwrap();
+            assert_eq!(
+                result.resources.items.len(),
+                1,
+                "accent-insensitive family search '{q}' should match 'Müller'"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_quantity_search_ucum_equivalence() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-mass-pg",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "x" }] },
+                    "valueQuantity": { "value": 1, "unit": "g", "system": "http://unitsofmeasure.org", "code": "g" }
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "value-quantity".to_string(),
+            param_type: SearchParamType::Quantity,
+            modifier: None,
+            values: vec![SearchValue::eq("1000|http://unitsofmeasure.org|mg")],
+            chain: vec![],
+            components: vec![],
+        });
+        let result = backend.search(&tenant, &query).await.unwrap();
+        assert_eq!(
+            result.resources.items.len(),
+            1,
+            "UCUM-equivalent quantity (1000 mg) should match stored 1 g"
+        );
+        assert_eq!(result.resources.items[0].id(), "obs-mass-pg");
     }
 
     #[tokio::test]

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -407,6 +407,52 @@ mod basic_search {
     }
 
     #[tokio::test]
+    async fn test_date_prefix_uses_precision_boundaries() {
+        let (server, backend) = create_test_server().await;
+        let tenant = test_tenant();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": "born-2020", "birthDate": "2020-06-15" }),
+                FhirVersion::R4,
+            )
+            .await
+            .unwrap();
+
+        let ids = |body: &Value| -> Vec<String> {
+            get_bundle_entries(body)
+                .iter()
+                .filter_map(|e| e["resource"]["id"].as_str().map(String::from))
+                .collect()
+        };
+        let search = |q: &'static str| {
+            let server = &server;
+            async move {
+                server
+                    .get(&format!("/Patient?birthdate={}", q))
+                    .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                    .await
+                    .json::<Value>()
+            }
+        };
+
+        // gt2020 means "after all of 2020" → 2020-06-15 must NOT match.
+        assert!(
+            !ids(&search("gt2020").await).contains(&"born-2020".to_string()),
+            "gt2020 should not match a date within 2020"
+        );
+        // gt2019 → after 2019 → matches.
+        assert!(
+            ids(&search("gt2019").await).contains(&"born-2020".to_string()),
+            "gt2019 should match 2020-06-15"
+        );
+        // lt2021 → before 2021 → matches; lt2020 → before 2020 → no match.
+        assert!(ids(&search("lt2021").await).contains(&"born-2020".to_string()));
+        assert!(!ids(&search("lt2020").await).contains(&"born-2020".to_string()));
+    }
+
+    #[tokio::test]
     async fn test_string_search_is_accent_insensitive() {
         let (server, backend) = create_test_server().await;
         let tenant = test_tenant();

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -407,6 +407,43 @@ mod basic_search {
     }
 
     #[tokio::test]
+    async fn test_string_search_is_accent_insensitive() {
+        let (server, backend) = create_test_server().await;
+        let tenant = test_tenant();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "accent-pt",
+                    "name": [{ "family": "Müller" }]
+                }),
+                FhirVersion::R4,
+            )
+            .await
+            .unwrap();
+
+        // An unaccented, lowercase query must match the accented stored name.
+        for query in ["muller", "Müller", "MULLER"] {
+            let response = server
+                .get(&format!("/Patient?family={}", query))
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .await;
+            response.assert_status_ok();
+            let body: Value = response.json();
+            let ids: Vec<&str> = get_bundle_entries(&body)
+                .iter()
+                .filter_map(|e| e["resource"]["id"].as_str())
+                .collect();
+            assert!(
+                ids.contains(&"accent-pt"),
+                "accent-insensitive family search '{query}' should match 'Müller'"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn test_quantity_search_ucum_unit_equivalence() {
         let (server, backend) = create_test_server().await;
         let tenant = test_tenant();

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -407,6 +407,49 @@ mod basic_search {
     }
 
     #[tokio::test]
+    async fn test_quantity_search_ucum_unit_equivalence() {
+        let (server, backend) = create_test_server().await;
+        let tenant = test_tenant();
+        // Observation with a mass quantity expressed in grams.
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-mass",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "x" }] },
+                    "valueQuantity": {
+                        "value": 1,
+                        "unit": "g",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "g"
+                    }
+                }),
+                FhirVersion::R4,
+            )
+            .await
+            .unwrap();
+
+        // Searching the equivalent quantity in milligrams must match (g ⇄ mg).
+        let response = server
+            .get("/Observation?value-quantity=1000|http://unitsofmeasure.org|mg")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let ids: Vec<&str> = get_bundle_entries(&body)
+            .iter()
+            .filter_map(|e| e["resource"]["id"].as_str())
+            .collect();
+        assert!(
+            ids.contains(&"obs-mass"),
+            "UCUM-equivalent quantity (1000 mg) should match the stored 1 g"
+        );
+    }
+
+    #[tokio::test]
     async fn test_reference_search_is_version_agnostic() {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;


### PR DESCRIPTION
Search-index v10 migration PR (stacked on #132 → #131; retarget to main once those merge). Adds two FHIR-spec conformance features behind one
  additive, idempotent migration.

  WS8 — UCUM quantity canonicalization

  1|g now matches 1000|mg (and mm[Hg] ⇄ mmHg), not just literal unit strings.
  - helios-fhirpath: pub mod ucum + canonicalize_quantity(value, unit) using octofhir get_canonical_units (dimension base form + factor/offset).
  Caught and fixed a trap: octofhir's get_canonical_unit returns the unit as-is (mg→mg), which would silently break equivalence — switched to
  get_canonical_units.
  - Schema v10 adds value_quantity_canonical_value / _unit (+ index).
  - SQLite: complete — writer populates canonical columns; quantity handler ORs a canonical predicate (search bounds canonicalized to preserve
  eq/precision through float rounding) with the raw-unit match. End-to-end tested (1 g matched by 1000|…|mg).
  - Postgres: write-side done (canonical columns populated by the writer); the query-side OR into the canonical columns is not yet wired (raw
  unit matching only) — pending param-stride and float-tolerance handling.
  - Elasticsearch: remaining.

  WS9 — accent-insensitive string search

  String search now folds case + accents (NFD + combining-mark stripping via unicode-normalization, shared search::fold_text), stored in
  value_string_folded.
  - SQLite: complete — default/:contains/:text match the folded column ORed with the raw case-insensitive column; :exact stays
  case/accent-sensitive. E2e tested (Müller matched by muller/MULLER/Müller).
  - Postgres: complete — COALESCE(value_string_folded, value_string) ILIKE a folded pattern (non-accented pre-reindex rows still match
  case-insensitively).
  - Elasticsearch: remaining (asciifolding analyzer + reindex).
  - Also fixed a latent UTF-8 panic in SearchPrefix::extract (&value[..2] split a multibyte char like Müller); now char-boundary-safe get(..2).

  Migration & backfill

  The v10 migration is additive (nullable columns) and idempotent; old rows fall back to raw matching. A reindex backfill (ReindexRequest)
  populates the new columns for pre-upgrade resources. No data is rewritten by the migration itself.

  Verification

  SQLite end-to-end (UCUM equivalence, accent folding) + unit tests; persistence lib 634 + rest search integration 82 green; Postgres compiles
  and PG query-builder unit tests pass; fmt + clippy clean. PG/ES integration paths run under CI testcontainers (not runnable in this
  environment).

  Remaining (documented in crates/persistence/docs/search-spec-assessment.md §7–8)

  - Postgres quantity canonical query matching (write-side already lands here).
  - Elasticsearch for both features (mapping/analyzer + writer + handlers + reindex).

