### PR TITLE
fix(search): address FHIR search spec-conformance gaps

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/search_impl.rs
+++ b/crates/persistence/src/backends/elasticsearch/search_impl.rs
@@ -163,6 +163,18 @@ impl SearchProvider for ElasticsearchBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
+        // Compartment membership (OR across reference params) is not yet wired
+        // into the ES query DSL. Fail loud rather than silently ignoring the
+        // membership filter and returning every resource of the target type.
+        if query.compartment.is_some() {
+            return Err(crate::error::StorageError::Backend(
+                crate::error::BackendError::UnsupportedCapability {
+                    backend_name: "elasticsearch".to_string(),
+                    capability: "compartment search".to_string(),
+                },
+            ));
+        }
+
         let tenant_id = tenant.tenant_id().as_str();
         let resource_type = &query.resource_type;
         let index = self.index_name(tenant_id, resource_type);

--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -541,7 +541,7 @@ impl MongoBackend {
     fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
             SearchParamType::String => vec!["exact", "contains", "text"],
-            SearchParamType::Token => vec!["code", "text", "code-text"],
+            SearchParamType::Token => vec!["text", "code-text"],
             SearchParamType::Reference => vec!["contains", "text", "code-text"],
             SearchParamType::Uri => vec!["exact", "contains"],
             SearchParamType::Date
@@ -625,9 +625,9 @@ mod capability_tests {
         assert!(s.contains(&"text"));
         assert!(!s.contains(&"missing"));
 
-        // Token honors code/text/code-text but not :not or :of-type.
+        // Token honors text/code-text but not the non-spec :code, nor :not / :of-type.
         let t = MongoBackend::modifiers_for_type(SearchParamType::Token);
-        assert!(t.contains(&"code"));
+        assert!(!t.contains(&"code"));
         assert!(t.contains(&"code-text"));
         assert!(!t.contains(&"not"));
         assert!(!t.contains(&"of-type"));

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -387,6 +387,17 @@ impl ConditionalStorage for MongoBackend {
 
 impl MongoBackend {
     fn validate_query_support(&self, query: &SearchQuery) -> StorageResult<()> {
+        // Compartment membership (OR across reference params) is not yet wired
+        // into the Mongo filter builder. Fail loud rather than ignoring it.
+        if query.compartment.is_some() {
+            return Err(StorageError::Backend(
+                crate::error::BackendError::UnsupportedCapability {
+                    backend_name: "mongodb".to_string(),
+                    capability: "compartment search".to_string(),
+                },
+            ));
+        }
+
         if query.parameters.iter().any(|param| !param.chain.is_empty()) {
             return Err(StorageError::Search(
                 SearchError::ChainedSearchNotSupported {

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -615,7 +615,7 @@ impl MongoBackend {
         }
 
         match param.modifier.as_ref() {
-            None | Some(SearchModifier::CodeOnly) => {}
+            None => {}
             // `:text` (contains) and `:code-text` (starts-with) match the
             // token's display text (Coding.display / CodeableConcept.text).
             Some(m @ (SearchModifier::Text | SearchModifier::CodeText)) => {

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -8,8 +8,8 @@ use chrono::{DateTime, Utc};
 
 use crate::search::fold_text;
 use crate::types::{
-    SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
-    strip_reference_version,
+    CompartmentMembership, SearchModifier, SearchParamType, SearchParameter, SearchPrefix,
+    SearchQuery, SearchValue, strip_reference_version,
 };
 
 /// Returns the implicit precision of a decimal search value from its string form
@@ -247,6 +247,15 @@ impl PostgresQueryBuilder {
             }
         }
 
+        // Compartment membership: match resources that reference the compartment
+        // through ANY of the membership params (OR), per the CompartmentDefinition.
+        if let Some(comp) = &query.compartment {
+            // Last condition appended, so no need to advance `current_offset`.
+            if let Some(condition) = Self::build_compartment_condition(comp, current_offset) {
+                conditions.push(condition);
+            }
+        }
+
         if conditions.is_empty() {
             return None;
         }
@@ -258,6 +267,40 @@ impl PostgresQueryBuilder {
         }
 
         Some(combined)
+    }
+
+    /// Builds the compartment-membership subquery: matches resources that
+    /// reference `comp.reference` via ANY of `comp.params` (logical OR), mirroring
+    /// the SQLite backend. Returns `None` when there are no params or reference.
+    fn build_compartment_condition(
+        comp: &CompartmentMembership,
+        param_offset: usize,
+    ) -> Option<SqlFragment> {
+        if comp.params.is_empty() || comp.reference.is_empty() {
+            return None;
+        }
+
+        // Membership params come from the bundled FHIR CompartmentDefinitions
+        // (trusted); escape single quotes defensively before inlining.
+        let in_list = comp
+            .params
+            .iter()
+            .map(|p| format!("'{}'", p.replace('\'', "''")))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let base = strip_reference_version(&comp.reference).to_string();
+        let p1 = param_offset + 1;
+        let p2 = param_offset + 2;
+
+        Some(SqlFragment::with_params(
+            format!(
+                "id IN (SELECT resource_id FROM search_index \
+                 WHERE tenant_id = $1 AND resource_type = $2 AND param_name IN ({in_list}) \
+                 AND (value_reference = ${p1} OR value_reference LIKE ${p2} || '/_history/%'))"
+            ),
+            vec![SqlParam::text(&base), SqlParam::text(&base)],
+        ))
     }
 
     /// Builds an `ORDER BY` clause from the query's `_sort` directives.

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -78,7 +78,7 @@ impl SearchProvider for PostgresBackend {
         // then the search-filter params.
         let param_offset = if cursor.is_some() { 4 } else { 2 };
 
-        let search_filter = if !query.parameters.is_empty() {
+        let search_filter = if !query.parameters.is_empty() || query.compartment.is_some() {
             PostgresQueryBuilder::build_search_query(query, param_offset)
         } else {
             None
@@ -286,7 +286,7 @@ impl SearchProvider for PostgresBackend {
         let (sql, params): (
             String,
             Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
-        ) = if !query.parameters.is_empty() {
+        ) = if !query.parameters.is_empty() || query.compartment.is_some() {
             let filter = PostgresQueryBuilder::build_search_query(query, 2);
 
             let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -696,14 +696,13 @@ impl SqliteBackend {
             SearchParamType::String => vec!["exact", "contains", "text", "missing"],
             // `not-in` is intentionally omitted: the SQLite backend returns 501
             // for it (negated value-set filtering is unimplemented), so it must
-            // not be advertised. `code`/`text-advanced` are implemented by the
-            // token handler and were previously under-advertised.
+            // not be advertised. `text-advanced` is implemented by the token
+            // handler and was previously under-advertised.
             SearchParamType::Token => vec![
                 "not",
                 "text",
                 "in",
                 "of-type",
-                "code",
                 "code-text",
                 "text-advanced",
                 "missing",
@@ -836,7 +835,8 @@ mod tests {
         assert!(token_mods.contains(&"not"));
         assert!(token_mods.contains(&"text"));
         assert!(token_mods.contains(&"of-type"));
-        assert!(token_mods.contains(&"code"));
+        // `:code` is a non-spec modifier and must not be advertised.
+        assert!(!token_mods.contains(&"code"));
         assert!(token_mods.contains(&"text-advanced"));
         // `not-in` returns 501, so it must not be advertised as supported.
         assert!(!token_mods.contains(&"not-in"));

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/token.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/token.rs
@@ -62,14 +62,6 @@ impl TokenHandler {
             return Self::build_text_advanced_sql(&value.value, param_offset);
         }
 
-        // Handle :code-only modifier
-        if matches!(modifier, Some(SearchModifier::CodeOnly)) {
-            return SqlFragment::with_params(
-                format!("value_token_code = ?{}", param_num),
-                vec![SqlParam::string(&value.value)],
-            );
-        }
-
         // Handle :of-type modifier (for identifier searches)
         if matches!(modifier, Some(SearchModifier::OfType)) {
             return Self::build_of_type_sql(&value.value, param_offset);

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -5,7 +5,10 @@
 
 use std::collections::HashSet;
 
-use crate::types::{SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue};
+use crate::types::{
+    CompartmentMembership, SearchModifier, SearchParamType, SearchParameter, SearchQuery,
+    SearchValue, strip_reference_version,
+};
 
 use super::parameter_handlers::{
     CompositeHandler, DateHandler, NumberHandler, QuantityHandler, ReferenceHandler, StringHandler,
@@ -239,6 +242,16 @@ impl QueryBuilder {
             }
         }
 
+        // Compartment membership: a resource is in the compartment if it
+        // references the compartment via ANY of the membership params (OR),
+        // per the FHIR CompartmentDefinition. Applied as a single subquery.
+        if let Some(comp) = &query.compartment {
+            // Last condition appended, so no need to advance `current_offset`.
+            if let Some(condition) = self.build_compartment_condition(comp, current_offset) {
+                conditions.push(condition);
+            }
+        }
+
         // Combine all conditions with AND
         if !conditions.is_empty() {
             let mut combined = conditions.remove(0);
@@ -251,6 +264,44 @@ impl QueryBuilder {
         }
 
         base
+    }
+
+    /// Builds the compartment-membership subquery: matches resources that
+    /// reference `comp.reference` via ANY of `comp.params` (logical OR), which
+    /// is how a resource joins a FHIR compartment. Reference matching mirrors the
+    /// standard reference handler (version-agnostic). Returns `None` if there are
+    /// no membership params or no reference.
+    fn build_compartment_condition(
+        &self,
+        comp: &CompartmentMembership,
+        param_offset: usize,
+    ) -> Option<SqlFragment> {
+        if comp.params.is_empty() || comp.reference.is_empty() {
+            return None;
+        }
+
+        // Membership params come from the bundled FHIR CompartmentDefinitions
+        // (trusted, e.g. "patient"), but bind nothing user-controlled here: build
+        // a safe `IN (...)` list by escaping any single quotes defensively.
+        let in_list = comp
+            .params
+            .iter()
+            .map(|p| format!("'{}'", p.replace('\'', "''")))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let base = strip_reference_version(&comp.reference);
+        let p1 = param_offset + 1;
+        let p2 = param_offset + 2;
+
+        Some(SqlFragment::with_params(
+            format!(
+                "resource_id IN (SELECT resource_id FROM search_index \
+                 WHERE tenant_id = ?1 AND resource_type = ?2 AND param_name IN ({in_list}) \
+                 AND (value_reference = ?{p1} OR value_reference LIKE ?{p2} || '/_history/%'))"
+            ),
+            vec![SqlParam::string(base), SqlParam::string(base)],
+        ))
     }
 
     /// Builds a condition for a single search parameter.
@@ -521,12 +572,16 @@ impl QueryBuilder {
                     conditions.push(sql);
                 }
                 Err(e) => {
-                    // Log parse error but continue with other filters
+                    // A malformed `_filter` must NOT be silently dropped — that
+                    // would return an unfiltered superset (everything matching
+                    // the other params). Fail closed: emit a match-nothing
+                    // condition so the client gets zero results, not wrong ones.
                     tracing::warn!(
-                        "Failed to parse _filter expression '{}': {}",
+                        "Failed to parse _filter expression '{}': {} — failing closed (no matches)",
                         value.value,
                         e
                     );
+                    conditions.push(SqlFragment::new("1 = 0"));
                 }
             }
         }

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -111,7 +111,7 @@ impl SearchProvider for SqliteBackend {
         // then the search-filter params.
         let param_offset = if cursor.is_some() { 4 } else { 2 };
 
-        let search_filter = if !query.parameters.is_empty() {
+        let search_filter = if !query.parameters.is_empty() || query.compartment.is_some() {
             let builder =
                 QueryBuilder::new(tenant_id, resource_type).with_param_offset(param_offset);
             let fragment = builder.build(query);
@@ -339,10 +339,11 @@ impl SearchProvider for SqliteBackend {
         let tenant_id = tenant.tenant_id().as_str();
         let resource_type = &query.resource_type;
 
-        // Build the search filter if there are search parameters
+        // Build the search filter if there are search parameters or a compartment.
         let (sql, all_params): (String, Vec<Box<dyn rusqlite::ToSql>>) = if !query
             .parameters
             .is_empty()
+            || query.compartment.is_some()
         {
             let builder = QueryBuilder::new(tenant_id, resource_type).with_param_offset(2);
             let fragment = builder.build(query);

--- a/crates/persistence/src/core/search.rs
+++ b/crates/persistence/src/core/search.rs
@@ -112,6 +112,16 @@ impl SearchResult {
             bundle = bundle.with_previous_link(replace_cursor_param(self_link, cursor));
         }
 
+        // First-page link: the self URL with paging params (`_cursor` / `_offset`)
+        // stripped. Emitted only for multi-page results (when a next/previous page
+        // exists). A `last` link is intentionally not emitted: under keyset
+        // (cursor) paging the final page is not cheaply computable.
+        if self.resources.page_info.next_cursor.is_some()
+            || self.resources.page_info.previous_cursor.is_some()
+        {
+            bundle = bundle.with_link("first", strip_paging_params(self_link));
+        }
+
         // Add matching resources
         for resource in &self.resources.items {
             let full_url = format!("{}/{}", base_url, resource.url());
@@ -152,6 +162,27 @@ impl SearchResult {
 /// ```text
 /// .../Patient?_count=3&_elements=id&_cursor=…
 /// ```
+/// Returns `url` with any `_cursor=…` and `_offset=…` query parameters removed,
+/// yielding the first-page URL for a paginated search.
+fn strip_paging_params(url: &str) -> String {
+    let (base, query) = match url.find('?') {
+        Some(pos) => (&url[..pos], &url[pos + 1..]),
+        None => return url.to_string(),
+    };
+
+    let parts: Vec<String> = query
+        .split('&')
+        .filter(|p| !p.is_empty() && !p.starts_with("_cursor=") && !p.starts_with("_offset="))
+        .map(str::to_string)
+        .collect();
+
+    if parts.is_empty() {
+        base.to_string()
+    } else {
+        format!("{}?{}", base, parts.join("&"))
+    }
+}
+
 fn replace_cursor_param(url: &str, cursor: &str) -> String {
     let (base, query) = match url.find('?') {
         Some(pos) => (&url[..pos], &url[pos + 1..]),

--- a/crates/persistence/src/search/chain_resolver.rs
+++ b/crates/persistence/src/search/chain_resolver.rs
@@ -46,9 +46,23 @@ where
     let base_type = query.resource_type.clone();
     let mut id_sets: Vec<HashSet<String>> = Vec::new();
 
+    let max_forward_depth = crate::types::ChainConfig::default().max_forward_depth;
     for param in &query.parameters {
         if param.chain.is_empty() {
             continue;
+        }
+        // Forward-chain depth = number of reference hops. Cap it (mirroring the
+        // reverse `_has` cap) so a pathological chain can't fan out unboundedly.
+        let depth = param.chain.len();
+        if depth > max_forward_depth {
+            return Err(crate::error::StorageError::Search(
+                crate::error::SearchError::QueryParseError {
+                    message: format!(
+                        "forward chain depth {} exceeds the maximum of {}",
+                        depth, max_forward_depth
+                    ),
+                },
+            ));
         }
         let chain = reconstruct_chain_string(param);
         let value = param

--- a/crates/persistence/src/types/mod.rs
+++ b/crates/persistence/src/types/mod.rs
@@ -83,10 +83,10 @@ pub use pagination::{
 };
 
 pub use search_params::{
-    ChainConfig, ChainedParameter, CompositeSearchComponent, IncludeDirective, IncludeType,
-    ReverseChainedParameter, SearchModifier, SearchParamType, SearchParameter, SearchPrefix,
-    SearchQuery, SearchValue, SortDirection, SortDirective, SummaryMode, TotalMode,
-    strip_reference_version,
+    ChainConfig, ChainedParameter, CompartmentMembership, CompositeSearchComponent,
+    IncludeDirective, IncludeType, ReverseChainedParameter, SearchModifier, SearchParamType,
+    SearchParameter, SearchPrefix, SearchQuery, SearchValue, SortDirection, SortDirective,
+    SummaryMode, TotalMode, strip_reference_version,
 };
 
 pub use stored_resource::{ResourceMeta, ResourceMethod, StoredResource, StoredResourceBuilder};

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -101,8 +101,6 @@ pub enum SearchModifier {
     Type(String),
     /// Match on type (token parameters for polymorphic elements).
     OfType,
-    /// Match on code only (token parameters).
-    CodeOnly,
     /// Iterate through results (_include modifier).
     Iterate,
     /// Advanced text search with synonyms and linguistic matching (FHIR v6.0.0).
@@ -136,7 +134,6 @@ impl fmt::Display for SearchModifier {
             SearchModifier::Identifier => write!(f, "identifier"),
             SearchModifier::Type(t) => write!(f, "{}", t),
             SearchModifier::OfType => write!(f, "ofType"),
-            SearchModifier::CodeOnly => write!(f, "code"),
             SearchModifier::Iterate => write!(f, "iterate"),
             SearchModifier::TextAdvanced => write!(f, "text-advanced"),
             SearchModifier::CodeText => write!(f, "code-text"),
@@ -162,7 +159,6 @@ impl SearchModifier {
             // the form advertised in our CapabilityStatement; accept the legacy
             // camelCase `ofType` too so older clients keep working.
             "of-type" | "oftype" => Some(SearchModifier::OfType),
-            "code" => Some(SearchModifier::CodeOnly),
             "iterate" => Some(SearchModifier::Iterate),
             "text-advanced" => Some(SearchModifier::TextAdvanced),
             "code-text" => Some(SearchModifier::CodeText),
@@ -213,7 +209,6 @@ impl SearchModifier {
                 param_type == SearchParamType::Reference
             }
             SearchModifier::OfType => param_type == SearchParamType::Token,
-            SearchModifier::CodeOnly => param_type == SearchParamType::Token,
             SearchModifier::Iterate => false, // Only for _include/_revinclude
             // Per the FHIR spec (build.fhir.org), `:text-advanced` is defined for
             // reference and token parameters (NOT string).

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -215,9 +215,12 @@ impl SearchModifier {
             SearchModifier::OfType => param_type == SearchParamType::Token,
             SearchModifier::CodeOnly => param_type == SearchParamType::Token,
             SearchModifier::Iterate => false, // Only for _include/_revinclude
-            SearchModifier::TextAdvanced => {
-                param_type == SearchParamType::String || param_type == SearchParamType::Token
-            }
+            // Per the FHIR spec (build.fhir.org), `:text-advanced` is defined for
+            // reference and token parameters (NOT string).
+            SearchModifier::TextAdvanced => matches!(
+                param_type,
+                SearchParamType::Token | SearchParamType::Reference
+            ),
             // `:code-text` is defined for token and reference params (matches a
             // code's display, or the indexed `Reference.display`).
             SearchModifier::CodeText => matches!(
@@ -316,7 +319,12 @@ impl SearchPrefix {
                     SearchParamType::Number | SearchParamType::Date | SearchParamType::Quantity
                 )
             }
-            SearchPrefix::Sa | SearchPrefix::Eb => param_type == SearchParamType::Date,
+            // Per the FHIR spec, `sa`/`eb` (starts-after / ends-before) apply to
+            // date and quantity ordered types (not number).
+            SearchPrefix::Sa | SearchPrefix::Eb => matches!(
+                param_type,
+                SearchParamType::Date | SearchParamType::Quantity
+            ),
             SearchPrefix::Ap => {
                 matches!(
                     param_type,
@@ -695,8 +703,28 @@ pub struct SearchQuery {
     /// Elements to include (_elements).
     pub elements: Vec<String>,
 
+    /// Compartment membership filter, when this is a compartment search
+    /// (`GET /{compartmentType}/{id}/{targetType}`). Restricts results to
+    /// resources that reference the compartment via *any* of the membership
+    /// params (OR), per the FHIR CompartmentDefinition.
+    pub compartment: Option<CompartmentMembership>,
+
     /// Raw query parameters for debugging.
     pub raw_params: HashMap<String, Vec<String>>,
+}
+
+/// Compartment membership constraint for a compartment search.
+///
+/// A resource is in the compartment if it references `reference` through *any*
+/// of the `params` reference search parameters (logical OR). See
+/// https://hl7.org/fhir/compartmentdefinition.html.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CompartmentMembership {
+    /// The membership reference search parameters (e.g. `patient`, `recorder`,
+    /// `asserter`). Matching ANY of these satisfies membership.
+    pub params: Vec<String>,
+    /// The compartment reference value, e.g. `Patient/123`.
+    pub reference: String,
 }
 
 /// Mode for _total parameter.
@@ -918,6 +946,9 @@ mod tests {
         assert!(SearchPrefix::Gt.is_valid_for(SearchParamType::Date));
         assert!(!SearchPrefix::Gt.is_valid_for(SearchParamType::String));
         assert!(SearchPrefix::Sa.is_valid_for(SearchParamType::Date));
+        // `sa`/`eb` apply to date and quantity, but not number, per the spec.
+        assert!(SearchPrefix::Sa.is_valid_for(SearchParamType::Quantity));
+        assert!(SearchPrefix::Eb.is_valid_for(SearchParamType::Quantity));
         assert!(!SearchPrefix::Sa.is_valid_for(SearchParamType::Number));
     }
 

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -14,6 +14,43 @@ use helios_persistence::types::{
 use super::SearchParams;
 use crate::error::RestError;
 
+/// Splits a FHIR search value into its comma-separated OR-alternatives,
+/// respecting backslash escaping.
+///
+/// Per the FHIR spec, the characters `, | $ \` are escaped with a leading
+/// backslash inside a value. Only the comma is the OR-list separator at this
+/// layer, so we split on *unescaped* commas and unescape `\,` and `\\` here.
+/// Other escapes (`\|`, `\$`) are left intact for the backend's token/composite
+/// parsing to interpret.
+fn split_unescaped_commas(value: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut chars = value.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => match chars.peek() {
+                Some(',') => {
+                    cur.push(',');
+                    chars.next();
+                }
+                Some('\\') => {
+                    cur.push('\\');
+                    chars.next();
+                }
+                // Preserve other escapes (e.g. `\|`, `\$`) for downstream parsing.
+                _ => cur.push('\\'),
+            },
+            ',' => {
+                out.push(cur.trim().to_string());
+                cur = String::new();
+            }
+            _ => cur.push(c),
+        }
+    }
+    out.push(cur.trim().to_string());
+    out
+}
+
 /// Builds a SearchQuery from REST parameters.
 ///
 /// This function converts HTTP query parameters into the persistence layer's
@@ -207,7 +244,10 @@ fn parse_search_parameter(
     // date/number/quantity types per FHIR. For tokens/strings/references/uris,
     // the raw value is the value — e.g. status code "appended" must not be
     // misread as Ap-prefix + "pended".
-    let raw_values: Vec<&str> = value.split(',').map(str::trim).collect();
+    // Split the OR-list on UNescaped commas and unescape `\,` / `\\`, per FHIR
+    // value escaping. A literal comma in a value is written `\,` and must not
+    // start a new OR-alternative.
+    let raw_values: Vec<String> = split_unescaped_commas(value);
     let tentative_values: Vec<SearchValue> =
         raw_values.iter().map(|v| SearchValue::parse(v)).collect();
 
@@ -246,7 +286,10 @@ fn parse_search_parameter(
     ) {
         tentative_values
     } else {
-        raw_values.iter().map(|v| SearchValue::eq(*v)).collect()
+        raw_values
+            .iter()
+            .map(|v| SearchValue::eq(v.clone()))
+            .collect()
     };
 
     let mut param = SearchParameter {
@@ -633,6 +676,22 @@ mod tests {
         let (name, modifier) = parse_parameter_name("name");
         assert_eq!(name, "name");
         assert!(modifier.is_none());
+    }
+
+    #[test]
+    fn test_split_unescaped_commas() {
+        // Plain OR-list splits on commas.
+        assert_eq!(split_unescaped_commas("a,b,c"), vec!["a", "b", "c"]);
+        // An escaped comma stays part of one value and is unescaped.
+        assert_eq!(
+            split_unescaped_commas("Smith\\, John,Doe"),
+            vec!["Smith, John", "Doe"]
+        );
+        // Escaped backslash is unescaped; other escapes (\|) are preserved.
+        assert_eq!(split_unescaped_commas("a\\\\b"), vec!["a\\b"]);
+        assert_eq!(split_unescaped_commas("sys\\|code"), vec!["sys\\|code"]);
+        // Surrounding whitespace is trimmed.
+        assert_eq!(split_unescaped_commas(" a , b "), vec!["a", "b"]);
     }
 
     #[test]

--- a/crates/rest/src/handlers/capabilities.rs
+++ b/crates/rest/src/handlers/capabilities.rs
@@ -20,7 +20,9 @@ use axum::{
     response::Response,
 };
 use helios_fhir::FhirVersion;
-use helios_persistence::core::ResourceStorage;
+use helios_persistence::core::{ResourceStorage, SearchProvider};
+use helios_persistence::search::SearchParameterRegistry;
+use helios_persistence::types::SearchParamType;
 use tracing::debug;
 
 use crate::error::{RestError, RestResult};
@@ -65,7 +67,7 @@ pub async fn capabilities_handler<S>(
     req_headers: HeaderMap,
 ) -> RestResult<Response>
 where
-    S: ResourceStorage + Send + Sync,
+    S: ResourceStorage + SearchProvider + Send + Sync,
 {
     // Determine which version to describe (from Accept header or default)
     let fhir_version = version
@@ -121,16 +123,20 @@ fn build_capability_statement<S>(
     base_url: &str,
 ) -> serde_json::Value
 where
-    S: ResourceStorage,
+    S: ResourceStorage + SearchProvider,
 {
     let backend_name = state.storage().backend_name();
 
     // Get resource types for the requested FHIR version
     let resource_types = get_resource_type_names_for_version(version);
 
+    // Advertise each resource type's real search parameters from the loaded
+    // SearchParameter registry (not just the seven common params). The read
+    // guard is held only across this synchronous build (no await).
+    let registry = state.storage().search_param_registry().read();
     let resources: Vec<serde_json::Value> = resource_types
         .iter()
-        .map(|rt| build_resource_capability(rt))
+        .map(|rt| build_resource_capability(rt, &registry))
         .collect();
 
     #[allow(unused_mut)]
@@ -197,7 +203,10 @@ where
 }
 
 /// Builds the capability entry for a resource type.
-fn build_resource_capability(resource_type: &str) -> serde_json::Value {
+fn build_resource_capability(
+    resource_type: &str,
+    registry: &SearchParameterRegistry,
+) -> serde_json::Value {
     let mut entry = serde_json::json!({
         "type": resource_type,
         "profile": format!("http://hl7.org/fhir/StructureDefinition/{}", resource_type),
@@ -221,7 +230,7 @@ fn build_resource_capability(resource_type: &str) -> serde_json::Value {
         "conditionalDelete": "single",
         "searchInclude": ["*"],
         "searchRevInclude": ["*"],
-        "searchParam": build_common_search_params()
+        "searchParam": build_search_params(resource_type, registry)
     });
     // Bulk Data Access IG: per-resource `$export` operation entries on Patient
     // and Group, in addition to the system-level `$export` advertised at
@@ -242,6 +251,53 @@ fn build_resource_capability(resource_type: &str) -> serde_json::Value {
         _ => {}
     }
     entry
+}
+
+/// Builds the full `searchParam` list for a resource type: the seven common
+/// params plus the resource-specific params from the loaded SearchParameter
+/// registry. Control/common params (those starting with `_`) and duplicates are
+/// skipped.
+fn build_search_params(
+    resource_type: &str,
+    registry: &SearchParameterRegistry,
+) -> Vec<serde_json::Value> {
+    let mut params = build_common_search_params();
+    let mut seen: std::collections::HashSet<String> = params
+        .iter()
+        .filter_map(|p| p.get("name").and_then(|n| n.as_str()).map(str::to_string))
+        .collect();
+
+    for def in registry.get_active_params(resource_type) {
+        if def.code.starts_with('_') || !seen.insert(def.code.clone()) {
+            continue;
+        }
+        let mut param = serde_json::json!({
+            "name": def.code,
+            "type": fhir_search_param_type(def.param_type),
+            "definition": def.url,
+        });
+        if let Some(doc) = &def.description {
+            param["documentation"] = serde_json::Value::String(doc.clone());
+        }
+        params.push(param);
+    }
+    params
+}
+
+/// Maps an internal search-parameter type to its FHIR CapabilityStatement
+/// `searchParam.type` code.
+fn fhir_search_param_type(t: SearchParamType) -> &'static str {
+    match t {
+        SearchParamType::Number => "number",
+        SearchParamType::Date => "date",
+        SearchParamType::String => "string",
+        SearchParamType::Token => "token",
+        SearchParamType::Reference => "reference",
+        SearchParamType::Composite => "composite",
+        SearchParamType::Quantity => "quantity",
+        SearchParamType::Uri => "uri",
+        SearchParamType::Special => "special",
+    }
 }
 
 /// Builds common search parameters supported by all resources.
@@ -274,12 +330,12 @@ fn build_common_search_params() -> Vec<serde_json::Value> {
         }),
         serde_json::json!({
             "name": "_text",
-            "type": "string",
+            "type": "special",
             "documentation": "Search on the narrative of the resource"
         }),
         serde_json::json!({
             "name": "_content",
-            "type": "string",
+            "type": "special",
             "documentation": "Search on the entire content of the resource"
         }),
     ]

--- a/crates/rest/src/handlers/compartment.rs
+++ b/crates/rest/src/handlers/compartment.rs
@@ -47,7 +47,7 @@ pub async fn compartment_search_handler<S>(
 where
     S: ResourceStorage + SearchProvider + Send + Sync,
 {
-    let mut pairs = parse_query_pairs(raw_query.as_deref());
+    let pairs = parse_query_pairs(raw_query.as_deref());
     debug!(
         compartment_type = %compartment_type,
         compartment_id = %compartment_id,
@@ -75,10 +75,6 @@ where
     // Build the compartment reference
     let compartment_ref = format!("{}/{}", compartment_type, compartment_id);
 
-    // Add the first compartment reference parameter to the search parameters
-    // (the first parameter is typically the most specific one)
-    pairs.push((ref_params[0].to_string(), compartment_ref));
-
     let search_params = SearchParams::from_pairs(pairs);
 
     // Convert REST params to persistence SearchQuery. Scope the registry read
@@ -87,6 +83,16 @@ where
         let registry = state.storage().search_param_registry().read();
         build_search_query(&target_type, &search_params, &registry)?
     };
+
+    // Restrict to compartment members. A resource joins a compartment if it
+    // references the compartment through ANY of the membership reference params
+    // (e.g. AllergyIntolerance via `patient`, `recorder`, OR `asserter`), so we
+    // pass all of them — not just the first — and the backend ORs them. This
+    // avoids the under-inclusive "first param only" behaviour.
+    query.compartment = Some(helios_persistence::types::CompartmentMembership {
+        params: ref_params.iter().map(|s| s.to_string()).collect(),
+        reference: compartment_ref,
+    });
 
     // Clamp page size to the configured default/maximum.
     let count = query

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -17,7 +17,7 @@ use helios_persistence::core::{
     IncludeProvider, MultiTypeSearchProvider, ResourceStorage, RevincludeProvider, SearchProvider,
     resolve_includes_iterative,
 };
-use helios_persistence::types::SearchBundle;
+use helios_persistence::types::{SearchBundle, SearchParamType};
 use tracing::{debug, warn};
 
 use helios_fhir::FhirVersion;
@@ -159,6 +159,22 @@ async fn execute_search<S>(
 where
     S: ResourceStorage + SearchProvider + IncludeProvider + RevincludeProvider + Send + Sync,
 {
+    // Reject known-but-unimplemented control parameters instead of silently
+    // ignoring them (which returns an unfiltered, misleading `200`). These FHIR
+    // search controls are not implemented by any backend. See search spec
+    // assessment item A1a.
+    const UNSUPPORTED_PARAMS: [&str; 5] =
+        ["_query", "_list", "_contained", "_containedType", "_score"];
+    if let Some((key, _)) = pairs
+        .iter()
+        .find(|(k, _)| UNSUPPORTED_PARAMS.contains(&k.as_str()))
+    {
+        return Err(RestError::InvalidParameter {
+            param: key.clone(),
+            message: format!("search parameter '{key}' is not supported by this server"),
+        });
+    }
+
     // `:not-in` requires negated value-set filtering, which no backend
     // implements. Reject it explicitly (501) regardless of whether a terminology
     // server is configured, rather than silently ignoring it (which would return
@@ -176,6 +192,37 @@ where
     let pairs = if let Some(ts_url) = state.terminology_server_url() {
         expand_terminology_params(pairs, ts_url).await?
     } else {
+        // No terminology server configured: token `:in` / `:above` / `:below`
+        // cannot be satisfied. Reject them with `501` rather than silently
+        // falling through to literal matching (which returns misleading results).
+        // `:in` is token-only, so it always needs terminology; `:above`/`:below`
+        // also apply to reference/uri, which resolve locally — only reject those
+        // when the parameter is a token. See assessment item A2c.
+        {
+            let registry = state.storage().search_param_registry().read();
+            for (key, _) in &pairs {
+                let Some((base, modifier)) = key.split_once(':') else {
+                    continue;
+                };
+                let needs_terminology = match modifier {
+                    "in" => true,
+                    "above" | "below" => registry
+                        .get_param(resource_type, base)
+                        .or_else(|| registry.get_param("Resource", base))
+                        .map(|p| p.param_type == SearchParamType::Token)
+                        .unwrap_or(false),
+                    _ => false,
+                };
+                if needs_terminology {
+                    return Err(RestError::NotImplemented {
+                        feature: format!(
+                            "search modifier ':{modifier}' on token parameter '{base}' requires a \
+                             configured terminology server (set HFS_TERMINOLOGY_SERVER)"
+                        ),
+                    });
+                }
+            }
+        }
         pairs
     };
 
@@ -200,7 +247,31 @@ where
                 });
             }
         }
-        build_search_query(resource_type, &search_params, &registry)?
+        let built = build_search_query(resource_type, &search_params, &registry)?;
+        // Under strict handling, reject a `_sort` on a field the server cannot
+        // actually sort by (it would otherwise silently fall back to `id`). Only
+        // `_id`, `_lastUpdated`, and registered indexed typed params sort
+        // reliably; composite/special/unknown fields do not. See item A4a.
+        if strict {
+            for s in &built.sort {
+                let sortable = s.parameter == "_id"
+                    || s.parameter == "_lastUpdated"
+                    || matches!(
+                        s.param_type,
+                        Some(t) if t != SearchParamType::Composite && t != SearchParamType::Special
+                    );
+                if !sortable {
+                    return Err(RestError::InvalidParameter {
+                        param: format!("_sort={}", s.parameter),
+                        message: format!(
+                            "cannot sort by '{}' (unsupported sort field) under Prefer: handling=strict",
+                            s.parameter
+                        ),
+                    });
+                }
+            }
+        }
+        built
     };
 
     // Clamp page size to the configured default/maximum.

--- a/crates/rest/src/routing/fhir_routes.rs
+++ b/crates/rest/src/routing/fhir_routes.rs
@@ -344,7 +344,7 @@ where
 /// of functionality.
 pub fn create_minimal_routes<S>(state: AppState<S>) -> Router
 where
-    S: ResourceStorage + Send + Sync + 'static,
+    S: ResourceStorage + SearchProvider + Send + Sync + 'static,
 {
     Router::new()
         .route("/health", get(handlers::health_handler::<S>))

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -1230,6 +1230,31 @@ mod subsetting {
 // Compartment Search Tests
 // =============================================================================
 
+mod unsupported_params {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_unsupported_control_param_rejected() {
+        // `_query`/`_list`/`_contained`/`_score` are not implemented; the server
+        // must reject them (400) rather than silently ignoring them and returning
+        // an unfiltered result.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        for param in ["_query", "_list", "_contained", "_score"] {
+            let response = server
+                .get(&format!("/Patient?{param}=anything"))
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .await;
+            assert_eq!(
+                response.status_code(),
+                StatusCode::BAD_REQUEST,
+                "expected 400 for unsupported param {param}"
+            );
+        }
+    }
+}
+
 mod compartment_search {
     use super::*;
 
@@ -1302,6 +1327,57 @@ mod compartment_search {
                 assert!(subject.contains("patient-1"));
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_compartment_membership_via_non_first_param() {
+        // A resource that belongs to the compartment via a NON-first membership
+        // param must still be found. AllergyIntolerance joins the Patient
+        // compartment via patient/recorder/asserter; here the resource is linked
+        // ONLY through `recorder` (its `patient` points elsewhere). The previous
+        // first-param-only behaviour would have missed it.
+        let (server, backend) = create_test_server().await;
+        let tenant = test_tenant();
+
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({"resourceType": "Patient", "id": "patient-1", "active": true}),
+                FhirVersion::R4,
+            )
+            .await
+            .expect("create patient-1");
+
+        backend
+            .create(
+                &tenant,
+                "AllergyIntolerance",
+                json!({
+                    "resourceType": "AllergyIntolerance",
+                    "id": "ai-1",
+                    "patient": {"reference": "Patient/patient-2"},
+                    "recorder": {"reference": "Patient/patient-1"}
+                }),
+                FhirVersion::R4,
+            )
+            .await
+            .expect("create allergy");
+
+        let response = server
+            .get("/Patient/patient-1/AllergyIntolerance")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        assert_eq!(
+            entries.len(),
+            1,
+            "AllergyIntolerance linked via `recorder` should be in the compartment"
+        );
+        assert_eq!(entries[0]["resource"]["id"], "ai-1");
     }
 
     #[tokio::test]

--- a/crates/rest/tests/terminology_integration.rs
+++ b/crates/rest/tests/terminology_integration.rs
@@ -157,10 +157,11 @@ async fn test_in_modifier_calls_hts_expand() {
     assert_eq!(url_param["valueUri"], "http://example.org/vs");
 }
 
-/// When no terminology server is configured, `:in` params pass through to the
-/// storage layer unchanged (no HTTP calls are made).
+/// When no terminology server is configured, a token `:in` modifier cannot be
+/// satisfied and must be rejected with `501` rather than silently falling
+/// through to literal matching (which would return misleading results).
 #[tokio::test]
-async fn test_in_modifier_passthrough_when_no_terminology_server() {
+async fn test_in_modifier_returns_not_implemented_without_terminology_server() {
     let backend = SqliteBackend::in_memory().expect("SQLite in-memory failed");
     backend.init_schema().expect("Schema init failed");
 
@@ -169,19 +170,17 @@ async fn test_in_modifier_passthrough_when_no_terminology_server() {
     let app = create_app_with_config(backend, config);
     let server = TestServer::new(app).expect("TestServer init failed");
 
-    // The search will reach the persistence layer with the raw :in param.
-    // SQLite will likely ignore or fail the modifier, but no HTTP call is made.
     let response = server
         .get("/Patient")
         .add_query_param("code:in", "http://example.org/vs")
         .await;
 
-    // We just assert the server doesn't panic and returns a Bundle (or error).
-    // The exact status depends on SQLite modifier handling.
-    let status = response.status_code().as_u16();
-    assert!(
-        status == 200 || status == 400,
-        "Expected 200 (empty bundle) or 400, got {status}"
+    // Fail loud: `:in` needs a terminology server, so it returns 501 (no HTTP
+    // call to an external server is made because none is configured).
+    assert_eq!(
+        response.status_code().as_u16(),
+        501,
+        "Expected 501 for :in without a configured terminology server"
     );
 }
 

--- a/docs/search-conformance-plan.md
+++ b/docs/search-conformance-plan.md
@@ -1,0 +1,107 @@
+# Search spec-conformance fixes — plan & status
+
+**Branch:** `fix/search-spec-conformance-fixes` (off `main`)
+**Source:** the Part-A findings from the search-conformance assessment of `hfs`
+against https://build.fhir.org/search.html. Part-B (doc-only) corrections live on
+the `docs/ui-requirements` branch.
+
+Each item notes the spec basis, the fix, the files touched, and backend coverage.
+"Default path" = SQLite, the zero-config default backend.
+
+## A1 — Parameter types & special params
+- **A1a — Reject unsupported `_query` / `_list` / `_contained` / `_containedType`
+  / `_score`.** Today they are silently ignored (HTTP 200, unfiltered). FHIR
+  servers must not silently drop a constraint the client asked for. Fix: reject
+  with `400` (these are known-but-unimplemented control params), in the REST
+  search handler, for all backends. Files: `crates/rest/src/handlers/search.rs`.
+- **A1b — Search-value escaping.** FHIR escapes `, | $ \` in values with `\`.
+  `hfs` did no unescaping, so a literal comma always split OR-values. Fix:
+  split the comma-separated value list on *unescaped* commas and unescape `\,`
+  and `\\` in each value. Files:
+  `crates/rest/src/extractors/search_query_builder.rs`. (Pipe/`$` escaping inside
+  token `system|code` and composite values remains a follow-up — tracked below.)
+- **A1c — `_filter` parse failure.** A malformed `_filter` was dropped with only a
+  logged warning, leaving an unfiltered superset. Implemented as **fail-closed**:
+  a malformed `_filter` now emits a match-nothing condition (`1 = 0`) so the
+  client gets zero results rather than wrong ones. (A true `400` would require
+  threading a `Result` through `QueryBuilder::build`, used by production + tests —
+  tracked as a follow-up.) Files:
+  `crates/persistence/src/backends/sqlite/search/query_builder.rs`.
+
+## A2 — Modifiers
+- **A2b — `:text-advanced` applicability.** Spec (build.fhir.org): **reference +
+  token**. `hfs` had **string + token** (wrong in both directions). Fix:
+  `SearchModifier::is_valid_for` → `Token | Reference`. Files:
+  `crates/persistence/src/types/search_params.rs`.
+- **A2c — Token `:in` / `:above` / `:below` with no terminology server.** Today
+  they silently fall through to literal/no-op matching and return 200 with wrong
+  results. Fix: when no `HFS_TERMINOLOGY_SERVER` is configured, reject these token
+  modifiers with `501` (fail loud), mirroring the existing `:not-in` handling.
+  Files: `crates/rest/src/handlers/search.rs`.
+- **A2d — `:code` cross-backend consistency.** *No change made.* `:code` is an
+  `hfs` extension; the Postgres token handler does **not** implement it, so
+  Postgres correctly does **not** advertise it. Advertising an unimplemented
+  modifier would be the real bug — so PG's behaviour is left as-is. Implementing
+  `:code` in PG (to match SQLite/ES) is an optional follow-up, not a conformance
+  fix.
+- *No change (verified conformant):* `:contains` (reference/string/uri) and
+  `:above`/`:below` (reference/token/uri) match build.fhir.org — the earlier
+  "deviation" reading was incorrect.
+
+## A3 — Prefixes
+- **`sa` / `eb` applicability.** Spec: **date + quantity** (not number). `hfs`'s
+  `SearchPrefix::is_valid_for` returned date-only. Fix: `Date | Quantity`. (The
+  request path performs no prefix/type validation, so this table is advisory
+  today; correcting it removes the latent inconsistency and is used by the
+  CapabilityStatement-adjacent logic.) Files:
+  `crates/persistence/src/types/search_params.rs`.
+
+## A4 — Result controls
+- **A4a — Unsupported `_sort` field.** Today an unknown/unsortable sort field
+  silently falls back to `id`. Fix: under `Prefer: handling=strict`, reject an
+  unknown sort field with `400`; under lenient, keep the fallback (spec-allowed)
+  but it is now visible via the validation path. Files:
+  `crates/rest/src/handlers/search.rs`.
+- **A4b — `first` pagination link.** Search Bundles emitted `self` + `next` /
+  `previous` but never `first` / `last`. Fix: add a `first` link (the self URL
+  with `_cursor` / `_offset` stripped). `last` is intentionally **not** added:
+  under keyset (cursor) paging — the default — the last page is not cheaply
+  computable, which is why it stays absent. Files:
+  `crates/persistence/src/core/search.rs`.
+
+## A5 — Includes, chaining, compartments
+- **A5a — Compartment multi-param membership (correctness bug).** For target
+  types that join a compartment via several reference params (e.g.
+  AllergyIntolerance via `patient` / `recorder` / `asserter`), `hfs` applied only
+  the **first** param, silently dropping legitimate members. Fix: a new
+  `SearchQuery.compartment` field carrying *all* membership params + the
+  reference, emitted as one OR'd subquery
+  (`… param_name IN (p1,p2,…) AND value_reference = ref`). Files:
+  `crates/persistence/src/types/search_params.rs` (model),
+  `crates/persistence/src/backends/sqlite/search/query_builder.rs` (default path),
+  `crates/rest/src/handlers/compartment.rs` (handler). **Backend coverage:**
+  SQLite (default) implemented; Postgres/ES/Mongo to follow the same field
+  (tracked as follow-up — they retain first-param behavior until wired).
+- **A5b — All-types compartment `/{type}/{id}/*`.** Returns `400` today. Plan:
+  iterate the compartment's member target types (bounded by the compartment
+  definition) and union per-type searches. Larger surface (routing + multi-type
+  bundle merge); tracked as follow-up, not in the first cut.
+- **A5c — Forward-chain depth cap.** The active application-side resolver has no
+  cap (reverse `_has` is capped at 4). Fix: apply the same `ChainConfig`
+  forward-depth cap in the application-side resolver. Files:
+  `crates/persistence/src/search/chain_resolver.rs`.
+
+## A6 — CapabilityStatement
+- **`_text` / `_content` type.** Advertised as `string`; spec type is `special`.
+  Fix → `special`. Files: `crates/rest/src/handlers/capabilities.rs`.
+- **Per-type search params.** `/metadata` advertised only the 7 common params for
+  every type. Fix: emit each resource type's real search params from the loaded
+  `SearchParameterRegistry` (already reachable from the handler via
+  `state.storage().search_param_registry()`). Files:
+  `crates/rest/src/handlers/capabilities.rs`.
+
+## Out of first cut (tracked follow-ups)
+- A5a for Postgres / Elasticsearch / MongoDB query builders.
+- A5b all-types compartment search.
+- A1b full `|` / `$` escaping inside token & composite value parsing.
+- Per-param `modifier` arrays in the CapabilityStatement.

--- a/docs/search-conformance-plan.md
+++ b/docs/search-conformance-plan.md
@@ -38,12 +38,18 @@ Each item notes the spec basis, the fix, the files touched, and backend coverage
   results. Fix: when no `HFS_TERMINOLOGY_SERVER` is configured, reject these token
   modifiers with `501` (fail loud), mirroring the existing `:not-in` handling.
   Files: `crates/rest/src/handlers/search.rs`.
-- **A2d — `:code` cross-backend consistency.** *No change made.* `:code` is an
-  `hfs` extension; the Postgres token handler does **not** implement it, so
-  Postgres correctly does **not** advertise it. Advertising an unimplemented
-  modifier would be the real bug — so PG's behaviour is left as-is. Implementing
-  `:code` in PG (to match SQLite/ES) is an optional follow-up, not a conformance
-  fix.
+- **A2d — `:code` token modifier removed entirely.** `:code` was a non-spec
+  `hfs` invention with no FHIR basis. Its SQL (`value_token_code = ?`) is
+  byte-for-byte identical to a plain code match (`code=X`), and it actively
+  *breaks* `system|code` values (it matches the literal `"system|code"` as a
+  code). Redundant at best, harmful at worst. Removed from the `SearchModifier`
+  enum, parser, validity table, the SQLite token handler, the Mongo no-op arm,
+  and the SQLite/Mongo `modifiers_for_type` advertisements (with regression-guard
+  tests asserting it stays gone). Files:
+  `crates/persistence/src/types/search_params.rs`,
+  `crates/persistence/src/backends/sqlite/search/parameter_handlers/token.rs`,
+  `crates/persistence/src/backends/{sqlite,mongodb}/backend.rs`,
+  `crates/persistence/src/backends/mongodb/search_impl.rs`.
 - *No change (verified conformant):* `:contains` (reference/string/uri) and
   `:above`/`:below` (reference/token/uri) match build.fhir.org — the earlier
   "deviation" reading was incorrect.


### PR DESCRIPTION
## Summary

Implements the code-side fixes from a search-conformance assessment of the `hfs`
server against https://build.fhir.org/search.html. Companion doc-only changes
(the UI-requirements corrections) live on the `docs/ui-requirements` branch; this
PR is the behavioral/code half.

Full scope, rationale, and tracked follow-ups: `docs/search-conformance-plan.md`.

## Fixes

| Item | Change |
|------|--------|
| **A5a** | Compartment search now ORs across **all** membership reference params (was first-param-only → silently under-inclusive). New `SearchQuery.compartment` field + SQLite/Postgres subquery; ES/Mongo fail loud (501) instead of returning everything. |
| **A1a** | Reject unsupported control params (`_query`/`_list`/`_contained`/`_containedType`/`_score`) with `400` instead of silently ignoring. |
| **A1b** | Search-value escaping: split OR-lists on **unescaped** commas; unescape `\,` and `\\`. |
| **A1c** | Malformed `_filter` now fails closed (matches nothing) instead of dropping the clause and returning an unfiltered superset. |
| **A2b / A3** | `:text-advanced` applicability → reference+token (was string+token); `sa`/`eb` prefixes → date+quantity (was date-only). |
| **A2c** | Token `:in`/`:above`/`:below` now return `501` when no terminology server is configured (was silent literal fallthrough). |
| **A2d** | Removed the non-spec `:code` token modifier entirely (redundant with a plain code match; broke `system\|code` values). |
| **A4a** | Strict handling rejects `_sort` on unsupported fields (was silent `id` fallback). |
| **A4b** | Search Bundles now emit a `first` pagination link for multi-page results. |
| **A5c** | Forward-chain depth is now capped (mirrors the reverse `_has` cap). |
| **A6** | CapabilityStatement: `_text`/`_content` advertised as `special` (was `string`); per-resource-type search params now sourced from the registry. |

Two items investigated and intentionally **not** changed (documented in the plan):
`:contains` (already conformant: reference/string/uri) and PG's omission of `:code`
(it correctly didn't advertise an unimplemented modifier — now moot since `:code`
is removed).

## Tracked follow-ups (out of first cut)

- A5a for the Elasticsearch / MongoDB query DSLs (they currently 501 on compartment search)
- All-types compartment form `/{type}/{id}/*`
- Full `|`/`$` escaping inside token & composite value parsing
- A true `400` for malformed `_filter` (needs `Result` threading through `QueryBuilder::build`)
- Per-param `modifier` arrays in the CapabilityStatement

## Testing

- Builds clean: default (R4/SQLite) and `--features postgres,elasticsearch,mongodb`
- Clippy clean with CI flags
- `helios-persistence` + `helios-rest` test suites pass
- New tests: compartment membership via a non-first param, unsupported-param rejection, value-escaping unit test; updated two tests that asserted the old behavior