### PR TITLE
feat(search): compartment search for ES/Mongo + all-types (/*) handler

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
@@ -5,8 +5,8 @@
 use serde_json::{Value, json};
 
 use crate::types::{
-    PageCursor, SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery,
-    SortDirection, SortDirective,
+    CompartmentMembership, PageCursor, SearchModifier, SearchParamType, SearchParameter,
+    SearchPrefix, SearchQuery, SortDirection, SortDirective, strip_reference_version,
 };
 
 use super::fts;
@@ -55,6 +55,16 @@ impl<'a> EsQueryBuilder<'a> {
             }
         }
 
+        // Compartment membership: a resource joins the compartment if it
+        // references `comp.reference` via ANY of the membership params (OR),
+        // per the FHIR CompartmentDefinition. Modeled as a single nested query
+        // over the stored reference search params.
+        if let Some(comp) = &query.compartment {
+            if let Some(clause) = Self::build_compartment_clause(comp) {
+                must_clauses.push(clause);
+            }
+        }
+
         // Build the bool query
         let mut bool_query = json!({
             "filter": filter_clauses,
@@ -92,6 +102,45 @@ impl<'a> EsQueryBuilder<'a> {
             body,
             index: self.index.clone(),
         }
+    }
+
+    /// Builds a nested clause matching resources that reference
+    /// `comp.reference` through ANY of the compartment membership params
+    /// (logical OR), which is how a resource joins a FHIR compartment.
+    ///
+    /// Reference matching is version-agnostic and mirrors the reference
+    /// parameter handler: the stored reference must equal the base reference or
+    /// carry a `/_history/<vid>` suffix. The membership params come from the
+    /// bundled FHIR `CompartmentDefinition`s. Returns `None` if there are no
+    /// membership params or no reference.
+    fn build_compartment_clause(comp: &CompartmentMembership) -> Option<Value> {
+        if comp.params.is_empty() || comp.reference.is_empty() {
+            return None;
+        }
+
+        let base = strip_reference_version(&comp.reference);
+
+        Some(json!({
+            "nested": {
+                "path": "search_params.reference",
+                "query": {
+                    "bool": {
+                        "must": [
+                            { "terms": { "search_params.reference.name": comp.params } },
+                            {
+                                "bool": {
+                                    "should": [
+                                        { "term": { "search_params.reference.reference": base } },
+                                        { "prefix": { "search_params.reference.reference": format!("{base}/_history/") } }
+                                    ],
+                                    "minimum_should_match": 1
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }))
     }
 
     /// Builds a clause for a single search parameter.

--- a/crates/persistence/src/backends/elasticsearch/search_impl.rs
+++ b/crates/persistence/src/backends/elasticsearch/search_impl.rs
@@ -163,18 +163,6 @@ impl SearchProvider for ElasticsearchBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
-        // Compartment membership (OR across reference params) is not yet wired
-        // into the ES query DSL. Fail loud rather than silently ignoring the
-        // membership filter and returning every resource of the target type.
-        if query.compartment.is_some() {
-            return Err(crate::error::StorageError::Backend(
-                crate::error::BackendError::UnsupportedCapability {
-                    backend_name: "elasticsearch".to_string(),
-                    capability: "compartment search".to_string(),
-                },
-            ));
-        }
-
         let tenant_id = tenant.tenant_id().as_str();
         let resource_type = &query.resource_type;
         let index = self.index_name(tenant_id, resource_type);

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -20,9 +20,9 @@ use crate::core::{
 use crate::error::{BackendError, SearchError, StorageError, StorageResult};
 use crate::tenant::TenantContext;
 use crate::types::{
-    CursorDirection, CursorValue, IncludeDirective, IncludeType, Page, PageCursor, PageInfo,
-    SearchModifier, SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
-    StoredResource,
+    CompartmentMembership, CursorDirection, CursorValue, IncludeDirective, IncludeType, Page,
+    PageCursor, PageInfo, SearchModifier, SearchParamType, SearchParameter, SearchPrefix,
+    SearchQuery, SearchValue, StoredResource, strip_reference_version,
 };
 
 use super::MongoBackend;
@@ -387,17 +387,6 @@ impl ConditionalStorage for MongoBackend {
 
 impl MongoBackend {
     fn validate_query_support(&self, query: &SearchQuery) -> StorageResult<()> {
-        // Compartment membership (OR across reference params) is not yet wired
-        // into the Mongo filter builder. Fail loud rather than ignoring it.
-        if query.compartment.is_some() {
-            return Err(StorageError::Backend(
-                crate::error::BackendError::UnsupportedCapability {
-                    backend_name: "mongodb".to_string(),
-                    capability: "compartment search".to_string(),
-                },
-            ));
-        }
-
         if query.parameters.iter().any(|param| !param.chain.is_empty()) {
             return Err(StorageError::Search(
                 SearchError::ChainedSearchNotSupported {
@@ -474,7 +463,72 @@ impl MongoBackend {
             }
         }
 
+        // Compartment membership: a resource joins the compartment if it
+        // references the compartment via ANY of the membership params (OR),
+        // per the FHIR CompartmentDefinition. Computed as a single OR query
+        // over the search_index and intersected with the parameter matches.
+        if let Some(comp) = &query.compartment {
+            if let Some(ids) = self
+                .compartment_resource_ids(&search_index, tenant_id, resource_type, comp)
+                .await?
+            {
+                if ids.is_empty() {
+                    return Ok(Some(HashSet::new()));
+                }
+                matched = Some(match matched {
+                    Some(current) => current
+                        .intersection(&ids)
+                        .cloned()
+                        .collect::<HashSet<String>>(),
+                    None => ids,
+                });
+            }
+        }
+
         Ok(matched)
+    }
+
+    /// Returns the resource IDs that are members of the compartment described by
+    /// `comp`: resources that reference `comp.reference` through ANY of the
+    /// membership params (logical OR). Reference matching is version-agnostic
+    /// (mirrors the reference handler): the stored reference must equal the base
+    /// reference or carry a `/_history/<vid>` suffix.
+    ///
+    /// Returns `Ok(None)` when `comp` carries no params or no reference (no
+    /// restriction to apply), otherwise `Ok(Some(ids))` (possibly empty).
+    async fn compartment_resource_ids(
+        &self,
+        search_index: &mongodb::Collection<Document>,
+        tenant_id: &str,
+        resource_type: &str,
+        comp: &CompartmentMembership,
+    ) -> StorageResult<Option<HashSet<String>>> {
+        if comp.params.is_empty() || comp.reference.is_empty() {
+            return Ok(None);
+        }
+
+        let base = strip_reference_version(&comp.reference);
+        let params: Vec<Bson> = comp.params.iter().cloned().map(Bson::String).collect();
+
+        let filter = doc! {
+            "tenant_id": tenant_id,
+            "resource_type": resource_type,
+            "param_name": { "$in": Bson::Array(params) },
+            "$or": [
+                { "value_reference": &base },
+                { "value_reference": { "$regex": format!("^{}/_history/", regex_escape(base)) } },
+            ],
+        };
+
+        let ids = search_index
+            .distinct("resource_id", filter)
+            .await
+            .map_err(|e| internal_error(format!("Failed to query search_index: {}", e)))?
+            .into_iter()
+            .filter_map(|value| value.as_str().map(ToString::to_string))
+            .collect::<HashSet<_>>();
+
+        Ok(Some(ids))
     }
 
     fn build_search_index_filter(

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -1475,6 +1475,100 @@ mod es_integration {
     }
 
     #[tokio::test]
+    async fn es_integration_compartment_search() {
+        // Compartment membership: a resource joins the Patient compartment if it
+        // references the patient via ANY of the membership params (here `subject`
+        // OR `performer`). Resources for another patient must be excluded.
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{CompartmentMembership, SearchQuery};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        // In the compartment via `subject`.
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-subject",
+                    "status": "final",
+                    "code": {"text": "hr"},
+                    "subject": {"reference": "Patient/p1"}
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        // In the compartment via the NON-first param `performer` only (subject
+        // points elsewhere). This verifies the OR across membership params.
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-performer",
+                    "status": "final",
+                    "code": {"text": "hr"},
+                    "subject": {"reference": "Patient/p2"},
+                    "performer": [{"reference": "Patient/p1"}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        // Not in the compartment (references another patient).
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-other",
+                    "status": "final",
+                    "code": {"text": "hr"},
+                    "subject": {"reference": "Patient/p2"}
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        let mut query = SearchQuery::new("Observation");
+        query.compartment = Some(CompartmentMembership {
+            params: vec!["subject".to_string(), "performer".to_string()],
+            reference: "Patient/p1".to_string(),
+        });
+
+        let result = backend.search(&tenant, &query).await.unwrap();
+        let ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+
+        assert!(
+            ids.contains(&"obs-subject".to_string()),
+            "compartment must include the resource linked via `subject`"
+        );
+        assert!(
+            ids.contains(&"obs-performer".to_string()),
+            "compartment must include the resource linked via `performer`"
+        );
+        assert!(
+            !ids.contains(&"obs-other".to_string()),
+            "compartment must exclude resources of another patient"
+        );
+    }
+
+    #[tokio::test]
     async fn es_integration_search_by_name_multiple() {
         use helios_persistence::core::SearchProvider;
         use helios_persistence::types::{

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -1335,6 +1335,100 @@ async fn mongodb_integration_search_quantity() {
 }
 
 #[tokio::test]
+async fn mongodb_integration_compartment_search() {
+    // Compartment membership: a resource joins the Patient compartment if it
+    // references the patient via ANY of the membership params (`subject` OR
+    // `performer`). Resources for another patient must be excluded.
+    use helios_persistence::types::CompartmentMembership;
+
+    let Some(backend) = create_backend_with_full_registry("compartment_search").await else {
+        eprintln!("Skipping mongodb_integration_compartment_search (set HFS_TEST_MONGODB_URL)");
+        return;
+    };
+
+    let tenant = create_tenant("tenant-compartment");
+
+    // In the compartment via `subject`.
+    backend
+        .create(
+            &tenant,
+            "Observation",
+            json!({
+                "resourceType": "Observation",
+                "id": "obs-subject",
+                "status": "final",
+                "code": {"text": "hr"},
+                "subject": {"reference": "Patient/p1"}
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    // In the compartment via the NON-first param `performer` only.
+    backend
+        .create(
+            &tenant,
+            "Observation",
+            json!({
+                "resourceType": "Observation",
+                "id": "obs-performer",
+                "status": "final",
+                "code": {"text": "hr"},
+                "subject": {"reference": "Patient/p2"},
+                "performer": [{"reference": "Patient/p1"}]
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    // Not in the compartment (references another patient).
+    backend
+        .create(
+            &tenant,
+            "Observation",
+            json!({
+                "resourceType": "Observation",
+                "id": "obs-other",
+                "status": "final",
+                "code": {"text": "hr"},
+                "subject": {"reference": "Patient/p2"}
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let mut query = SearchQuery::new("Observation");
+    query.compartment = Some(CompartmentMembership {
+        params: vec!["subject".to_string(), "performer".to_string()],
+        reference: "Patient/p1".to_string(),
+    });
+
+    let result = backend.search(&tenant, &query).await.unwrap();
+    let ids: Vec<String> = result
+        .resources
+        .items
+        .iter()
+        .map(|r| r.id().to_string())
+        .collect();
+
+    assert!(
+        ids.contains(&"obs-subject".to_string()),
+        "compartment must include the resource linked via `subject`"
+    );
+    assert!(
+        ids.contains(&"obs-performer".to_string()),
+        "compartment must include the resource linked via `performer`"
+    );
+    assert!(
+        !ids.contains(&"obs-other".to_string()),
+        "compartment must exclude resources of another patient"
+    );
+}
+
+#[tokio::test]
 async fn mongodb_integration_search_token_string_and_offset_pagination() {
     let Some(backend) = create_backend("search_token_string").await else {
         eprintln!(

--- a/crates/rest/src/handlers/compartment.rs
+++ b/crates/rest/src/handlers/compartment.rs
@@ -57,6 +57,20 @@ where
         "Processing compartment search request"
     );
 
+    // `GET [base]/[compartment]/[id]/*` searches every resource type that is a
+    // member of the compartment, rather than a single target type.
+    if target_type == "*" {
+        return compartment_search_all(
+            state,
+            compartment_type,
+            compartment_id,
+            tenant,
+            version,
+            pairs,
+        )
+        .await;
+    }
+
     // Get the reference parameters for this compartment/target combination
     let fhir_version = version.storage_version();
     let ref_params =
@@ -135,40 +149,133 @@ where
     Ok((StatusCode::OK, Json(bundle_to_json(bundle))).into_response())
 }
 
-/// Handler for compartment search across all types.
+/// Searches across all resource types in a compartment.
 ///
-/// Returns all resources in a compartment.
+/// Implements `GET [base]/[compartment-type]/[id]/*`: returns every resource
+/// that is a member of the compartment, regardless of type. Membership is
+/// resolved per type from the bundled FHIR `CompartmentDefinition`s (via
+/// [`helios_fhir::get_compartment_params`]) — the same source the single-type
+/// compartment search uses.
 ///
-/// # HTTP Request
+/// Each member type is searched independently and the matches are merged into a
+/// single `searchset` Bundle. Query parameters are applied per type on a
+/// best-effort basis: a type for which a parameter is not a valid search
+/// parameter is skipped (it cannot match that constraint anyway).
 ///
-/// `GET [base]/[compartment-type]/[id]/*`
+/// # Pagination
 ///
-/// Note: This is a less common operation and returns resources of various types.
-#[allow(dead_code)]
-pub async fn compartment_search_all_handler<S>(
-    State(_state): State<AppState<S>>,
-    Path((compartment_type, compartment_id)): Path<(String, String)>,
-    _tenant: TenantExtractor,
-    RawQuery(_raw_query): RawQuery,
+/// Cross-type keyset pagination is not supported. Results are capped at the
+/// effective page size (`_count`, clamped to the server maximum) and no
+/// `next`/`previous` links are emitted. `_count` therefore acts as an overall
+/// ceiling across all member types.
+async fn compartment_search_all<S>(
+    state: AppState<S>,
+    compartment_type: String,
+    compartment_id: String,
+    tenant: TenantExtractor,
+    version: FhirVersionExtractor,
+    pairs: Vec<(String, String)>,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + SearchProvider + Send + Sync,
 {
+    let fhir_version = version.storage_version();
+    let compartment_ref = format!("{}/{}", compartment_type, compartment_id);
+    let search_params = SearchParams::from_pairs(pairs.clone());
+
+    // Effective overall page size, clamped to the server maximum.
+    let count = search_params
+        .count()
+        .unwrap_or(state.default_page_size())
+        .min(state.max_page_size());
+
+    // Enumerate compartment member types and pre-build a SearchQuery for each,
+    // restricted to the compartment. Building happens under the registry read
+    // lock (no await); the lock is released before any search executes.
+    let queries: Vec<helios_persistence::types::SearchQuery> = {
+        let registry = state.storage().search_param_registry().read();
+        crate::fhir_types::get_resource_type_names_for_version(fhir_version)
+            .iter()
+            .filter_map(|target_type| {
+                let ref_params = helios_fhir::get_compartment_params(
+                    fhir_version,
+                    &compartment_type,
+                    target_type,
+                );
+                if ref_params.is_empty() {
+                    return None; // not a member of this compartment
+                }
+
+                // A parameter that is invalid for this member type means the type
+                // cannot satisfy it — skip the type rather than failing the request.
+                let mut query = match build_search_query(target_type, &search_params, &registry) {
+                    Ok(q) => q,
+                    Err(e) => {
+                        debug!(
+                            target_type = %target_type,
+                            error = %e,
+                            "Skipping compartment member type: query not applicable"
+                        );
+                        return None;
+                    }
+                };
+
+                query.compartment = Some(helios_persistence::types::CompartmentMembership {
+                    params: ref_params.iter().map(|s| s.to_string()).collect(),
+                    reference: compartment_ref.clone(),
+                });
+                // Cross-type paging is unsupported; cap each type at the overall
+                // ceiling and drop any client cursor/offset.
+                query.count = Some(count as u32);
+                query.cursor = None;
+                query.offset = None;
+                Some(query)
+            })
+            .collect()
+    };
+
+    // Run each member-type search, accumulating matches up to the page-size cap.
+    let mut collected: Vec<helios_persistence::types::StoredResource> = Vec::new();
+    for query in &queries {
+        if collected.len() >= count {
+            break;
+        }
+        match state.storage().search(tenant.context(), query).await {
+            Ok(result) => collected.extend(result.resources.items),
+            Err(e) => {
+                tracing::warn!(
+                    resource_type = %query.resource_type,
+                    error = %e,
+                    "Compartment all-types search failed for member type"
+                );
+                return Err(RestError::from(e));
+            }
+        }
+    }
+    collected.truncate(count);
+
+    // Merge into a single searchset Bundle (no cross-type paging links).
+    let page =
+        helios_persistence::types::Page::new(collected, helios_persistence::types::PageInfo::end());
+    let result = helios_persistence::core::SearchResult::new(page);
+
+    let self_link = build_compartment_search_url(
+        state.base_url(),
+        &compartment_type,
+        &compartment_id,
+        "*",
+        &search_params,
+    );
+    let bundle = result.to_bundle(state.base_url(), &self_link);
+
     debug!(
         compartment_type = %compartment_type,
         compartment_id = %compartment_id,
-        "Processing compartment search all request"
+        results = result.resources.len(),
+        "Compartment all-types search completed"
     );
 
-    // For now, return an error - full implementation would search multiple types
-    // and combine results
-    Err(RestError::BadRequest {
-        message: format!(
-            "Searching all types in compartment '{}' is not yet implemented. \
-             Please specify a resource type: GET /{}/{}/[type]",
-            compartment_type, compartment_type, compartment_id
-        ),
-    })
+    Ok((StatusCode::OK, Json(bundle_to_json(bundle))).into_response())
 }
 
 /// Builds a compartment search URL.

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -1394,6 +1394,44 @@ mod compartment_search {
         // Should return 400 Bad Request
         response.assert_status(StatusCode::BAD_REQUEST);
     }
+
+    #[tokio::test]
+    async fn test_patient_compartment_all_types() {
+        // `GET /Patient/{id}/*` returns every resource in the compartment,
+        // regardless of type. patient-1 has 2 Observations in the seed data,
+        // all of which must appear; nothing referencing another patient should.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient/patient-1/*")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        assert_eq!(body["resourceType"], "Bundle");
+        assert_eq!(body["type"], "searchset");
+
+        let entries = get_bundle_entries(&body);
+        // At least the 2 Observations for patient-1 should be present.
+        let observations = entries
+            .iter()
+            .filter(|e| e["resource"]["resourceType"] == "Observation")
+            .count();
+        assert_eq!(observations, 2, "expected both patient-1 observations");
+
+        // Every returned resource must actually belong to patient-1 (never
+        // patient-2). We can't assert a single reference field across types, so
+        // confirm patient-2 is not referenced anywhere in the matched set.
+        for entry in &entries {
+            let serialized = entry["resource"].to_string();
+            assert!(
+                !serialized.contains("patient-2"),
+                "compartment all-types must not include resources of another patient"
+            );
+        }
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Extends FHIR compartment search to all search-capable storage backends, reusing the codegen-backed `get_compartment_params()` (generated from the bundled FHIR `CompartmentDefinition` files) as the single source of membership rules — the same mechanism SQLite and PostgreSQL already used. S3 is intentionally left out, since S3-only backends have no search capability.

Previously only SQLite and PostgreSQL implemented compartment search; Elasticsearch and MongoDB returned `UnsupportedCapability`, and the `/[compartment]/[id]/*` all-types endpoint was a 400 stub.

## Changes

### Backends
- **Elasticsearch** (`backends/elasticsearch/search/query_builder.rs`): new `build_compartment_clause()` adds a nested query over `search_params.reference` (`terms` on `.name` + should/prefix on `.reference`). Covers both search and `_total` count (count reuses `build()`). Guard removed from `search_impl.rs`.
- **MongoDB** (`backends/mongodb/search_impl.rs`): new `compartment_resource_ids()` runs a single OR query over the `search_index` collection and intersects it with parameter matches in `matching_resource_ids()`. Guard removed from `validate_query_support`.
- Membership semantics match the SQL backends: a resource joins iff it references the compartment via **any** membership param (OR), with version-agnostic reference matching (`base` or `base/_history/<vid>`).
- **Composite** (`sqlite-es`, `postgres-es`) works automatically — the query (incl. compartment) passes straight through to the search provider.

### REST
- `/[compartment]/[id]/*` all-types handler implemented in `handlers/compartment.rs`. Detected via `target_type == "*"` and dispatched to `compartment_search_all()`, which enumerates compartment member types (`get_resource_type_names_for_version` + `get_compartment_params`), searches each, and merges into one `searchset` Bundle.
- **Documented limitation:** cross-type keyset pagination is not supported — `_count` acts as an overall ceiling and no `next`/`previous` links are emitted. Per-type query-build failures are skipped best-effort.

## Testing
- `cargo fmt` + clippy (CI flags): clean
- REST `search_integration`: 86 pass (added `test_patient_compartment_all_types`, runs on SQLite)
- Persistence lib: 688 pass
- `es_integration_compartment_search`: **passed against a real Elasticsearch testcontainer**
- `mongodb_integration_compartment_search`: **passed against a real MongoDB container** — covers inclusion via the first membership param (`subject`), inclusion via a non-first param (`performer`), and exclusion of another patient's resources