### PR TITLE
feat(hts): import LOINC language variants at bootstrap and CLI import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,6 +577,10 @@ cargo run --bin hts -- import ./hl7.terminology.r4-6.0.0.tgz
 cargo run --bin hts -- import ./SnomedCT_InternationalRF2_*.zip --format snomed-rf2
 
 # LOINC CSV ZIP  ⚠️  requires free Regenstrief registration at loinc.org
+# Language translations under AccessoryFiles/LinguisticVariants/ (e.g.
+# frFR28LinguisticVariant.csv) are imported automatically as FHIR
+# concept.designation entries tagged with the BCP-47 language (fr-FR, de-DE, …).
+# No extra flag needed — works for both `hts import` and server bootstrap.
 cargo run --bin hts -- import ./Loinc_*.zip --format loinc
 
 # ICD-10-CM tabular XML (free, no license needed — from cms.gov)

--- a/crates/hts/src/import/loinc_csv.rs
+++ b/crates/hts/src/import/loinc_csv.rs
@@ -437,9 +437,10 @@ fn find_loinc_paths(path: &Path) -> Result<LoincArchivePaths, HtsError> {
 
 /// Parse `LinguisticVariants.csv` into `variant_id → (iso_language, iso_country)`.
 ///
-/// Columns: `LinguisticVariantId, IsoLanguage, IsoCountry, LanguageName`. A
-/// missing or malformed index is non-fatal — callers fall back to deriving the
-/// language tag from the per-variant filename.
+/// Columns: `ID, ISO_LANGUAGE, ISO_COUNTRY, LANGUAGE_NAME` (the documented
+/// `LinguisticVariantId`/`IsoLanguage`/`IsoCountry` spellings are also
+/// accepted). A missing or malformed index is non-fatal — callers fall back to
+/// deriving the language tag from the per-variant filename.
 fn parse_linguistic_index(
     reader: impl std::io::Read,
     errors: &mut Vec<String>,
@@ -454,13 +455,17 @@ fn parse_linguistic_index(
         }
     };
 
-    let id_idx = find_col(&headers, "LinguisticVariantId").ok();
-    let lang_idx = find_col(&headers, "IsoLanguage").ok();
-    let country_idx = find_col(&headers, "IsoCountry").ok();
+    // Real LOINC releases name these columns `ID`, `ISO_LANGUAGE`,
+    // `ISO_COUNTRY`; accept the documented `LinguisticVariantId`/`IsoLanguage`/
+    // `IsoCountry` spellings too so either form parses.
+    let find_any = |names: &[&str]| names.iter().find_map(|n| find_col(&headers, n).ok());
+    let id_idx = find_any(&["ID", "LinguisticVariantId"]);
+    let lang_idx = find_any(&["ISO_LANGUAGE", "IsoLanguage"]);
+    let country_idx = find_any(&["ISO_COUNTRY", "IsoCountry"]);
 
     let (Some(id_idx), Some(lang_idx)) = (id_idx, lang_idx) else {
         errors.push(
-            "LinguisticVariants.csv missing LinguisticVariantId/IsoLanguage columns — \
+            "LinguisticVariants.csv missing ID/ISO_LANGUAGE columns — \
              language tags will be derived from filenames"
                 .into(),
         );
@@ -534,9 +539,26 @@ fn format_lang_tag(lang: &str, country: &str) -> String {
     }
 }
 
+/// LOINC axis columns, in fully-specified-name order. Used to synthesize a
+/// translated display when a linguistic-variant file leaves the combined-name
+/// columns empty (e.g. the es-ES and it-IT translations only populate the
+/// individual axes).
+const LOINC_AXIS_COLUMNS: [&str; 6] = [
+    "COMPONENT",
+    "PROPERTY",
+    "TIME_ASPCT",
+    "SYSTEM",
+    "SCALE_TYP",
+    "METHOD_TYP",
+];
+
 /// Parse one `*LinguisticVariant.csv` into `(loinc_code, translated_display)`
-/// rows. The translated display prefers `LONG_COMMON_NAME`, falling back to
-/// `SHORTNAME`. Rows without a code or any translated text are skipped.
+/// rows. The translated display prefers `LONG_COMMON_NAME`, then `SHORTNAME`,
+/// then `LinguisticVariantDisplayName`. When none of those combined-name
+/// columns carry text (as in the es-ES and it-IT variants, which translate only
+/// the individual axes), the display is synthesized as a LOINC fully-specified
+/// name — the populated `COMPONENT:PROPERTY:TIME_ASPCT:SYSTEM:SCALE_TYP:METHOD_TYP`
+/// axes joined with `:`. Rows without a code or any translated text are skipped.
 fn parse_linguistic_variant(
     reader: impl std::io::Read,
     filename: &str,
@@ -552,10 +574,16 @@ fn parse_linguistic_variant(
     let code_idx = find_col(&headers, "LOINC_NUM")?;
     let long_idx = find_col(&headers, "LONG_COMMON_NAME").ok();
     let short_idx = find_col(&headers, "SHORTNAME").ok();
+    let display_idx = find_col(&headers, "LinguisticVariantDisplayName").ok();
+    let axis_idxs: Vec<usize> = LOINC_AXIS_COLUMNS
+        .iter()
+        .filter_map(|c| find_col(&headers, c).ok())
+        .collect();
 
-    if long_idx.is_none() && short_idx.is_none() {
+    if long_idx.is_none() && short_idx.is_none() && display_idx.is_none() && axis_idxs.is_empty() {
         errors.push(format!(
-            "{filename}: no LONG_COMMON_NAME/SHORTNAME column — no translations imported"
+            "{filename}: no LONG_COMMON_NAME/SHORTNAME/LinguisticVariantDisplayName or axis \
+             columns — no translations imported"
         ));
         return Ok(Vec::new());
     }
@@ -569,21 +597,37 @@ fn parse_linguistic_variant(
         if code.is_empty() {
             continue;
         }
-        let value = long_idx
-            .and_then(|i| record.get(i))
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .or_else(|| {
-                short_idx
-                    .and_then(|i| record.get(i))
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-            })
-            .unwrap_or("");
-        if value.is_empty() {
+        let pick = |idx: Option<usize>| {
+            idx.and_then(|i| record.get(i))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+        };
+        let value: String = match pick(long_idx)
+            .or_else(|| pick(short_idx))
+            .or_else(|| pick(display_idx))
+        {
+            Some(v) => v.to_string(),
+            // No combined name — synthesize the LOINC fully-specified name from
+            // the translated axis columns (e.g. es-ES, it-IT). Trailing empty
+            // axes are dropped so a partly-populated row doesn't render dangling
+            // `:` separators; interior gaps are kept to preserve axis position.
+            None => {
+                let mut axes: Vec<&str> = axis_idxs
+                    .iter()
+                    .map(|&i| record.get(i).unwrap_or("").trim())
+                    .collect();
+                while axes.last().is_some_and(|s| s.is_empty()) {
+                    axes.pop();
+                }
+                axes.join(":")
+            }
+        };
+        // A synthesized FSN of only empty axes collapses to ":::::" — treat
+        // anything without an alphanumeric character as no translation.
+        if !value.chars().any(|c| c.is_alphanumeric()) {
             continue;
         }
-        rows.push((code, value.to_string()));
+        rows.push((code, value));
     }
     Ok(rows)
 }
@@ -767,10 +811,20 @@ LP7786-3.LP10156-0.718-7,3,LP10156-0,718-7,Hemoglobin\r\n";
 
     // Linguistic-variant fixtures. The index maps numeric ids → language/country;
     // the per-variant files carry translated LONG_COMMON_NAME values.
+    // Uses the real LOINC release column names (`ID`, `ISO_LANGUAGE`, …); the
+    // documented `LinguisticVariantId`/`IsoLanguage` spellings are accepted too.
     const LV_INDEX_CSV: &str = "\
-LinguisticVariantId,IsoLanguage,IsoCountry,LanguageName\r\n\
-28,fr,FR,French (France)\r\n\
-8,de,DE,German (Germany)\r\n";
+ID,ISO_LANGUAGE,ISO_COUNTRY,LANGUAGE_NAME,PRODUCER\r\n\
+28,fr,FR,French (France),Some Producer\r\n\
+8,de,DE,German (Germany),Some Producer\r\n";
+
+    // es-ES / it-IT style: only the individual axes are translated; the
+    // combined-name columns (LONG_COMMON_NAME/SHORTNAME/LinguisticVariantDisplayName)
+    // are empty. The display must be synthesized from the axes.
+    const LV_ES_AXES_CSV: &str = "\
+LOINC_NUM,COMPONENT,PROPERTY,TIME_ASPCT,SYSTEM,SCALE_TYP,METHOD_TYP,CLASS,SHORTNAME,LONG_COMMON_NAME,RELATEDNAMES2,LinguisticVariantDisplayName\r\n\
+2160-0,Creatinina,MCnc,Punto temporal,Suero o Plasma,Cuant,,,,,,\r\n\
+718-7,Hemoglobina,MCnc,Punto temporal,Sangre,Cuant,,,,,,\r\n";
 
     const LV_FR_CSV: &str = "\
 LOINC_NUM,COMPONENT,LONG_COMMON_NAME,SHORTNAME\r\n\
@@ -1077,6 +1131,38 @@ LOINC_NUM,COMPONENT,LONG_COMMON_NAME,SHORTNAME\r\n\
             rows[0].1,
             "Créatinine [Masse/volume] dans le sérum ou le plasma"
         );
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn parse_linguistic_variant_synthesizes_display_from_axes() {
+        // es-ES / it-IT only populate the axis columns; the display must be the
+        // fully-specified name built from the populated axes (regression: these
+        // variants used to import zero designations).
+        let mut errors = Vec::new();
+        let rows = parse_linguistic_variant(
+            LV_ES_AXES_CSV.as_bytes(),
+            "esES12LinguisticVariant.csv",
+            &mut errors,
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, "2160-0");
+        // Trailing empty axis (METHOD_TYP) is dropped — no dangling separator.
+        assert_eq!(
+            rows[0].1,
+            "Creatinina:MCnc:Punto temporal:Suero o Plasma:Cuant"
+        );
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn parse_linguistic_index_accepts_real_loinc_columns() {
+        // Real LOINC releases use ID/ISO_LANGUAGE/ISO_COUNTRY rather than the
+        // documented camelCase spellings — both must parse without error.
+        let mut errors = Vec::new();
+        let index = parse_linguistic_index(LV_INDEX_CSV.as_bytes(), &mut errors);
+        assert_eq!(index["28"], ("fr".to_string(), "FR".to_string()));
         assert!(errors.is_empty());
     }
 

--- a/crates/hts/src/import/loinc_csv.rs
+++ b/crates/hts/src/import/loinc_csv.rs
@@ -3,6 +3,20 @@
 //! Reads a LOINC distribution ZIP and imports LOINC codes, preferred display
 //! names, status, and the multi-axial hierarchy into the HTS normalized schema.
 //!
+//! ## Linguistic variants (language translations)
+//!
+//! Official LOINC releases ship language translations under
+//! `AccessoryFiles/LinguisticVariants/`: an index file `LinguisticVariants.csv`
+//! (mapping a numeric variant id → ISO language / country / display name) plus
+//! one CSV per language named like `frFR28LinguisticVariant.csv`. Each such file
+//! carries translated `LONG_COMMON_NAME` / `SHORTNAME` columns keyed by
+//! `LOINC_NUM`. When present, those translations are imported as FHIR
+//! `concept.designation` entries tagged with the BCP-47 language (e.g. `fr-FR`,
+//! `de-DE`). The English `display` is left untouched. Because both the `hts
+//! import` CLI and the server bootstrap funnel LOINC ZIPs through
+//! [`import_loinc_csv`], language variants are picked up automatically by both
+//! paths — no extra flag or file is required.
+//!
 //! # ⚠️  LICENSE REQUIRED
 //!
 //! Real LOINC data requires a free license from the Regenstrief Institute.
@@ -18,7 +32,9 @@ use zip::ZipArchive;
 use crate::error::HtsError;
 use crate::import::BundleImportBackend;
 use crate::import::ImportStats;
-use crate::import::bundle_builder::{BuilderConcept, CodeSystemMeta, build_code_system_bundle};
+use crate::import::bundle_builder::{
+    BuilderConcept, BuilderDesignation, CodeSystemMeta, build_code_system_bundle,
+};
 
 // ── LOINC constants ───────────────────────────────────────────────────────────
 
@@ -44,6 +60,17 @@ struct MergedConcept {
     display: String,
     definition: Option<String>,
     parent: Option<String>,
+    /// Translated display names from LOINC linguistic-variant files. Owned so
+    /// the borrowed [`BuilderDesignation`] slice can be assembled per batch.
+    designations: Vec<OwnedDesignation>,
+}
+
+/// One translated display name, owned by its [`MergedConcept`].
+#[derive(Debug, Clone)]
+struct OwnedDesignation {
+    /// BCP-47 language tag, e.g. `fr-FR`, `de-DE`, `zh-CN`.
+    language: String,
+    value: String,
 }
 
 #[derive(Debug, Default)]
@@ -52,6 +79,9 @@ struct LoincParseResult {
     loinc_count: usize,
     lp_count: usize,
     edge_count: usize,
+    designation_count: usize,
+    /// Per-language designation counts, sorted for deterministic reporting.
+    designations_by_language: Vec<(String, usize)>,
     parse_errors: Vec<String>,
 }
 
@@ -70,11 +100,14 @@ pub async fn import_loinc_csv(
 
     let path_owned = path.to_path_buf();
     let parsed = tokio::task::spawn_blocking(move || -> Result<LoincParseResult, HtsError> {
-        let (loinc_table_path, hierarchy_path) = find_loinc_paths(&path_owned)?;
+        let paths = find_loinc_paths(&path_owned)?;
+        let loinc_table_path = &paths.loinc_table;
+        let hierarchy_path = &paths.hierarchy;
 
         tracing::info!(
             loinc_table = %loinc_table_path,
             hierarchy = %hierarchy_path,
+            linguistic_variants = paths.lv_variants.len(),
             "Located LOINC CSV files in archive"
         );
 
@@ -83,18 +116,70 @@ pub async fn import_loinc_csv(
         let loinc_concepts = {
             let mut zip = open_zip(&path_owned)?;
             let entry = zip
-                .by_name(&loinc_table_path)
+                .by_name(loinc_table_path)
                 .map_err(|e| HtsError::InvalidRequest(format!("Cannot open LoincTable: {e}")))?;
             parse_loinc_table(entry, &mut parse_errors)?
         };
 
         let (hierarchy_concepts, edges) = {
             let mut zip = open_zip(&path_owned)?;
-            let entry = zip.by_name(&hierarchy_path).map_err(|e| {
+            let entry = zip.by_name(hierarchy_path).map_err(|e| {
                 HtsError::InvalidRequest(format!("Cannot open MultiAxialHierarchy: {e}"))
             })?;
             parse_hierarchy(entry, &mut parse_errors)?
         };
+
+        // Linguistic variants (language translations). The index file maps a
+        // numeric variant id → ISO language/country; per-language files carry
+        // the translated LONG_COMMON_NAME keyed by LOINC_NUM. Each parsed file
+        // yields (loinc_code, language_tag, translated_display) tuples.
+        let lv_index = match &paths.lv_index {
+            Some(idx_path) => {
+                let mut zip = open_zip(&path_owned)?;
+                match zip.by_name(idx_path) {
+                    Ok(entry) => parse_linguistic_index(entry, &mut parse_errors),
+                    Err(e) => {
+                        parse_errors.push(format!(
+                            "Cannot open {idx_path}: {e} — \
+                             language tags will be derived from filenames"
+                        ));
+                        HashMap::new()
+                    }
+                }
+            }
+            None => HashMap::new(),
+        };
+
+        // code → (language → translated display). Last writer wins per language.
+        let mut translations: HashMap<String, HashMap<String, String>> = HashMap::new();
+        for variant_path in &paths.lv_variants {
+            let filename = variant_path
+                .rsplit('/')
+                .next()
+                .unwrap_or(variant_path)
+                .to_string();
+            let Some(language) = derive_language_tag(&filename, &lv_index) else {
+                parse_errors.push(format!(
+                    "Cannot determine language for linguistic-variant file '{filename}' — skipped"
+                ));
+                continue;
+            };
+            let mut zip = open_zip(&path_owned)?;
+            let entry = match zip.by_name(variant_path) {
+                Ok(e) => e,
+                Err(e) => {
+                    parse_errors.push(format!("Cannot open {variant_path}: {e} — skipped"));
+                    continue;
+                }
+            };
+            let rows = parse_linguistic_variant(entry, &filename, &mut parse_errors)?;
+            for (code, value) in rows {
+                translations
+                    .entry(code)
+                    .or_default()
+                    .insert(language.clone(), value);
+            }
+        }
 
         // Build parent map from the edges (child → parent).
         let mut parent_of: HashMap<String, String> = HashMap::new();
@@ -115,6 +200,7 @@ pub async fn import_loinc_csv(
                     display: display.clone(),
                     definition: None,
                     parent: parent_of.get(code).cloned(),
+                    ..Default::default()
                 },
             );
         }
@@ -130,15 +216,45 @@ pub async fn import_loinc_csv(
                     display: concept.display.clone(),
                     definition,
                     parent: parent_of.get(code).cloned(),
+                    ..Default::default()
                 },
             );
         }
+
+        // Attach translated display names as designations on the concepts that
+        // exist in this CodeSystem. Translations for unknown codes are recorded
+        // as parse errors rather than creating orphan concepts.
+        let mut designation_count: usize = 0;
+        let mut per_language: HashMap<String, usize> = HashMap::new();
+        for (code, langs) in translations {
+            let Some(concept) = all_concepts.get_mut(&code) else {
+                parse_errors.push(format!(
+                    "Linguistic variant for unknown LOINC code '{code}' — skipped"
+                ));
+                continue;
+            };
+            // Sort by language for deterministic designation ordering.
+            let mut langs: Vec<(String, String)> = langs.into_iter().collect();
+            langs.sort_by(|a, b| a.0.cmp(&b.0));
+            for (language, value) in langs {
+                *per_language.entry(language.clone()).or_default() += 1;
+                designation_count += 1;
+                concept
+                    .designations
+                    .push(OwnedDesignation { language, value });
+            }
+        }
+
+        let mut designations_by_language: Vec<(String, usize)> = per_language.into_iter().collect();
+        designations_by_language.sort_by(|a, b| a.0.cmp(&b.0));
 
         Ok(LoincParseResult {
             concepts: all_concepts,
             loinc_count: loinc_concepts.len(),
             lp_count: hierarchy_concepts.len(),
             edge_count: edges.len(),
+            designation_count,
+            designations_by_language,
             parse_errors,
         })
     })
@@ -153,12 +269,15 @@ pub async fn import_loinc_csv(
         ..Default::default()
     };
 
+    let lang_summary = format_language_summary(&parsed.designations_by_language);
+
     if dry_run {
         stats.concepts = total_concepts;
         eprintln!(
             "[{FORMAT}] dry-run — would import {total_concepts} concepts \
-             ({} LOINC codes, {} LP category nodes), {} hierarchy edges",
-            parsed.loinc_count, parsed.lp_count, parsed.edge_count,
+             ({} LOINC codes, {} LP category nodes), {} hierarchy edges, \
+             {} translated designations{lang_summary}",
+            parsed.loinc_count, parsed.lp_count, parsed.edge_count, parsed.designation_count,
         );
         return Ok(stats);
     }
@@ -185,13 +304,33 @@ pub async fn import_loinc_csv(
     let num_batches = concept_list.len().div_ceil(batch_size).max(1);
 
     for (i, chunk) in concept_list.chunks(batch_size).enumerate() {
+        // Build the borrowed designation slices first so they outlive the
+        // `BuilderConcept`s that reference them within this iteration.
+        let desig_sets: Vec<Vec<BuilderDesignation<'_>>> = chunk
+            .iter()
+            .map(|(_, entry)| {
+                entry
+                    .designations
+                    .iter()
+                    .map(|d| BuilderDesignation {
+                        language: Some(d.language.as_str()),
+                        use_system: None,
+                        use_code: None,
+                        value: d.value.as_str(),
+                    })
+                    .collect()
+            })
+            .collect();
+
         let builder: Vec<BuilderConcept<'_>> = chunk
             .iter()
-            .map(|(code, entry)| BuilderConcept {
+            .zip(&desig_sets)
+            .map(|((code, entry), desigs)| BuilderConcept {
                 code: code.as_str(),
                 display: Some(entry.display.as_str()).filter(|s| !s.is_empty()),
                 definition: entry.definition.as_deref(),
                 parent_code: entry.parent.as_deref(),
+                designations: desigs.as_slice(),
                 ..Default::default()
             })
             .collect();
@@ -209,6 +348,13 @@ pub async fn import_loinc_csv(
         );
     }
 
+    if parsed.designation_count > 0 {
+        eprintln!(
+            "[{FORMAT}] imported {} translated designations{lang_summary}",
+            parsed.designation_count,
+        );
+    }
+
     Ok(stats)
 }
 
@@ -221,11 +367,25 @@ fn open_zip(path: &Path) -> Result<ZipArchive<std::fs::File>, HtsError> {
         .map_err(|e| HtsError::InvalidRequest(format!("Not a valid ZIP archive: {e}")))
 }
 
-fn find_loinc_paths(path: &Path) -> Result<(String, String), HtsError> {
+/// Locations of the CSV files HTS reads from a LOINC distribution ZIP.
+#[derive(Debug, Default)]
+struct LoincArchivePaths {
+    loinc_table: String,
+    hierarchy: String,
+    /// `AccessoryFiles/LinguisticVariants/LinguisticVariants.csv`, if present.
+    lv_index: Option<String>,
+    /// Per-language `*LinguisticVariant.csv` files (excludes the index), sorted
+    /// for deterministic processing order.
+    lv_variants: Vec<String>,
+}
+
+fn find_loinc_paths(path: &Path) -> Result<LoincArchivePaths, HtsError> {
     let mut zip = open_zip(path)?;
 
     let mut loinc_path: Option<String> = None;
     let mut hierarchy_path: Option<String> = None;
+    let mut lv_index: Option<String> = None;
+    let mut lv_variants: Vec<String> = Vec::new();
 
     for i in 0..zip.len() {
         let entry = zip
@@ -245,22 +405,200 @@ fn find_loinc_paths(path: &Path) -> Result<(String, String), HtsError> {
                 loinc_path = Some(name);
             } else if filename.contains("multiaxial") || filename.contains("componenthierarchy") {
                 hierarchy_path = Some(name);
+            } else if filename == "linguisticvariants.csv" {
+                // The translation index (note trailing 's').
+                lv_index = Some(name);
+            } else if filename.ends_with("linguisticvariant.csv") {
+                // A per-language translation file, e.g. `frFR28LinguisticVariant.csv`.
+                lv_variants.push(name);
             }
         }
     }
 
-    Ok((
-        loinc_path.ok_or_else(|| {
+    lv_variants.sort();
+
+    Ok(LoincArchivePaths {
+        loinc_table: loinc_path.ok_or_else(|| {
             HtsError::InvalidRequest(
                 "No LoincTable CSV found. Expected a file whose name starts with 'loinc' or contains 'loinctable'.".into(),
             )
         })?,
-        hierarchy_path.ok_or_else(|| {
+        hierarchy: hierarchy_path.ok_or_else(|| {
             HtsError::InvalidRequest(
                 "No hierarchy CSV found. Expected 'MultiAxialHierarchy.csv' (LOINC ≤ 2.73) or 'ComponentHierarchyBySystem.csv' (LOINC ≥ 2.74).".into(),
             )
         })?,
-    ))
+        lv_index,
+        lv_variants,
+    })
+}
+
+// ── Linguistic-variant helpers ─────────────────────────────────────────────────
+
+/// Parse `LinguisticVariants.csv` into `variant_id → (iso_language, iso_country)`.
+///
+/// Columns: `LinguisticVariantId, IsoLanguage, IsoCountry, LanguageName`. A
+/// missing or malformed index is non-fatal — callers fall back to deriving the
+/// language tag from the per-variant filename.
+fn parse_linguistic_index(
+    reader: impl std::io::Read,
+    errors: &mut Vec<String>,
+) -> HashMap<String, (String, String)> {
+    let mut rdr = csv::ReaderBuilder::new().flexible(true).from_reader(reader);
+
+    let headers = match rdr.headers() {
+        Ok(h) => h.clone(),
+        Err(e) => {
+            errors.push(format!("Cannot read LinguisticVariants.csv headers: {e}"));
+            return HashMap::new();
+        }
+    };
+
+    let id_idx = find_col(&headers, "LinguisticVariantId").ok();
+    let lang_idx = find_col(&headers, "IsoLanguage").ok();
+    let country_idx = find_col(&headers, "IsoCountry").ok();
+
+    let (Some(id_idx), Some(lang_idx)) = (id_idx, lang_idx) else {
+        errors.push(
+            "LinguisticVariants.csv missing LinguisticVariantId/IsoLanguage columns — \
+             language tags will be derived from filenames"
+                .into(),
+        );
+        return HashMap::new();
+    };
+
+    let mut map: HashMap<String, (String, String)> = HashMap::new();
+    for result in rdr.records() {
+        let Ok(record) = result else { continue };
+        let id = record.get(id_idx).unwrap_or("").trim().to_string();
+        if id.is_empty() {
+            continue;
+        }
+        let lang = record.get(lang_idx).unwrap_or("").trim().to_lowercase();
+        let country = country_idx
+            .and_then(|i| record.get(i))
+            .unwrap_or("")
+            .trim()
+            .to_uppercase();
+        if !lang.is_empty() {
+            map.insert(id, (lang, country));
+        }
+    }
+    map
+}
+
+/// Derive the BCP-47 language tag for a per-variant file.
+///
+/// Prefers the index (matched by the numeric id embedded in the filename),
+/// falling back to the `<lang><COUNTRY>` letters that prefix the filename.
+/// `filename` is the lowercased basename, e.g. `frfr28linguisticvariant.csv`.
+fn derive_language_tag(
+    filename: &str,
+    index: &HashMap<String, (String, String)>,
+) -> Option<String> {
+    let lower = filename.to_lowercase();
+    let stem = lower.strip_suffix("linguisticvariant.csv")?;
+
+    // The numeric id (if any) sits between the language/country letters and the
+    // `LinguisticVariant` suffix, e.g. `frfr28` → "28".
+    let id: String = stem.chars().filter(|c| c.is_ascii_digit()).collect();
+    if !id.is_empty() {
+        if let Some((lang, country)) = index.get(&id) {
+            return Some(format_lang_tag(lang, country));
+        }
+    }
+
+    // Fallback: leading letters encode `<lang><country>` (e.g. `frfr`).
+    let letters: String = stem
+        .chars()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect();
+    if letters.len() >= 2 {
+        let lang = &letters[0..2];
+        let country = if letters.len() >= 4 {
+            &letters[2..4]
+        } else {
+            ""
+        };
+        return Some(format_lang_tag(lang, country));
+    }
+    None
+}
+
+fn format_lang_tag(lang: &str, country: &str) -> String {
+    let lang = lang.to_lowercase();
+    if country.is_empty() {
+        lang
+    } else {
+        format!("{lang}-{}", country.to_uppercase())
+    }
+}
+
+/// Parse one `*LinguisticVariant.csv` into `(loinc_code, translated_display)`
+/// rows. The translated display prefers `LONG_COMMON_NAME`, falling back to
+/// `SHORTNAME`. Rows without a code or any translated text are skipped.
+fn parse_linguistic_variant(
+    reader: impl std::io::Read,
+    filename: &str,
+    errors: &mut Vec<String>,
+) -> Result<Vec<(String, String)>, HtsError> {
+    let mut rdr = csv::ReaderBuilder::new().flexible(true).from_reader(reader);
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| HtsError::InvalidRequest(format!("Cannot read {filename} headers: {e}")))?;
+    let headers = headers.clone();
+
+    let code_idx = find_col(&headers, "LOINC_NUM")?;
+    let long_idx = find_col(&headers, "LONG_COMMON_NAME").ok();
+    let short_idx = find_col(&headers, "SHORTNAME").ok();
+
+    if long_idx.is_none() && short_idx.is_none() {
+        errors.push(format!(
+            "{filename}: no LONG_COMMON_NAME/SHORTNAME column — no translations imported"
+        ));
+        return Ok(Vec::new());
+    }
+
+    let mut rows: Vec<(String, String)> = Vec::new();
+    for result in rdr.records() {
+        let record = result
+            .map_err(|e| HtsError::InvalidRequest(format!("{filename} record error: {e}")))?;
+
+        let code = record.get(code_idx).unwrap_or("").trim().to_string();
+        if code.is_empty() {
+            continue;
+        }
+        let value = long_idx
+            .and_then(|i| record.get(i))
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .or_else(|| {
+                short_idx
+                    .and_then(|i| record.get(i))
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+            })
+            .unwrap_or("");
+        if value.is_empty() {
+            continue;
+        }
+        rows.push((code, value.to_string()));
+    }
+    Ok(rows)
+}
+
+/// Render a `" (fr-FR: 3, de-DE: 2)"`-style suffix for import logging, or an
+/// empty string when there are no translations.
+fn format_language_summary(by_language: &[(String, usize)]) -> String {
+    if by_language.is_empty() {
+        return String::new();
+    }
+    let parts: Vec<String> = by_language
+        .iter()
+        .map(|(lang, n)| format!("{lang}: {n}"))
+        .collect();
+    format!(" ({})", parts.join(", "))
 }
 
 // ── CSV parsers ───────────────────────────────────────────────────────────────
@@ -421,6 +759,64 @@ LP7786-3.LP10156-0.718-7,3,LP10156-0,718-7,Hemoglobin\r\n";
 
             zip.start_file("MultiAxialHierarchy.csv", opts).unwrap();
             zip.write_all(HIERARCHY_CSV.as_bytes()).unwrap();
+
+            zip.finish().unwrap();
+        }
+        tmp
+    }
+
+    // Linguistic-variant fixtures. The index maps numeric ids → language/country;
+    // the per-variant files carry translated LONG_COMMON_NAME values.
+    const LV_INDEX_CSV: &str = "\
+LinguisticVariantId,IsoLanguage,IsoCountry,LanguageName\r\n\
+28,fr,FR,French (France)\r\n\
+8,de,DE,German (Germany)\r\n";
+
+    const LV_FR_CSV: &str = "\
+LOINC_NUM,COMPONENT,LONG_COMMON_NAME,SHORTNAME\r\n\
+2160-0,Créatinine,Créatinine [Masse/volume] dans le sérum ou le plasma,Créat SerPl\r\n\
+718-7,Hémoglobine,Hémoglobine [Masse/volume] dans le sang,Hb Sang\r\n";
+
+    const LV_DE_CSV: &str = "\
+LOINC_NUM,COMPONENT,LONG_COMMON_NAME,SHORTNAME\r\n\
+2160-0,Kreatinin,Kreatinin [Masse/Volumen] in Serum oder Plasma,Krea SerPl\r\n";
+
+    fn make_test_loinc_zip_with_variants() -> NamedTempFile {
+        let tmp = NamedTempFile::with_suffix(".zip").unwrap();
+        {
+            let mut zip = zip::ZipWriter::new(tmp.reopen().unwrap());
+            let opts = zip::write::FileOptions::default();
+
+            zip.start_file("LoincTable/Loinc.csv", opts).unwrap();
+            zip.write_all(LOINC_TABLE_CSV.as_bytes()).unwrap();
+
+            zip.start_file(
+                "AccessoryFiles/MultiAxialHierarchy/MultiAxialHierarchy.csv",
+                opts,
+            )
+            .unwrap();
+            zip.write_all(HIERARCHY_CSV.as_bytes()).unwrap();
+
+            zip.start_file(
+                "AccessoryFiles/LinguisticVariants/LinguisticVariants.csv",
+                opts,
+            )
+            .unwrap();
+            zip.write_all(LV_INDEX_CSV.as_bytes()).unwrap();
+
+            zip.start_file(
+                "AccessoryFiles/LinguisticVariants/frFR28LinguisticVariant.csv",
+                opts,
+            )
+            .unwrap();
+            zip.write_all(LV_FR_CSV.as_bytes()).unwrap();
+
+            zip.start_file(
+                "AccessoryFiles/LinguisticVariants/deDE8LinguisticVariant.csv",
+                opts,
+            )
+            .unwrap();
+            zip.write_all(LV_DE_CSV.as_bytes()).unwrap();
 
             zip.finish().unwrap();
         }
@@ -622,6 +1018,146 @@ LP7786-3.LP10156-0.718-7,3,LP10156-0,718-7,Hemoglobin\r\n";
             .expect("should pick LoincTable/Loinc.csv, not the accessory file");
         assert_eq!(stats.concepts, 6);
         assert_eq!(count_rows(&backend, "concepts"), 6);
+    }
+
+    // ── Linguistic-variant tests ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_linguistic_index_maps_ids_to_lang_country() {
+        let mut errors = Vec::new();
+        let index = parse_linguistic_index(LV_INDEX_CSV.as_bytes(), &mut errors);
+        assert_eq!(index["28"], ("fr".to_string(), "FR".to_string()));
+        assert_eq!(index["8"], ("de".to_string(), "DE".to_string()));
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn derive_language_tag_prefers_index() {
+        let mut errors = Vec::new();
+        let index = parse_linguistic_index(LV_INDEX_CSV.as_bytes(), &mut errors);
+        assert_eq!(
+            derive_language_tag("frFR28LinguisticVariant.csv", &index).as_deref(),
+            Some("fr-FR")
+        );
+        assert_eq!(
+            derive_language_tag("deDE8LinguisticVariant.csv", &index).as_deref(),
+            Some("de-DE")
+        );
+    }
+
+    #[test]
+    fn derive_language_tag_falls_back_to_filename() {
+        let empty = HashMap::new();
+        // No index → derive `zh-CN` from the leading letters.
+        assert_eq!(
+            derive_language_tag("zhCN5LinguisticVariant.csv", &empty).as_deref(),
+            Some("zh-CN")
+        );
+        // Language only, no country letters.
+        assert_eq!(
+            derive_language_tag("fr99LinguisticVariant.csv", &empty).as_deref(),
+            Some("fr")
+        );
+        // Not a variant file.
+        assert_eq!(derive_language_tag("LoincTable.csv", &empty), None);
+    }
+
+    #[test]
+    fn parse_linguistic_variant_extracts_translations() {
+        let mut errors = Vec::new();
+        let rows = parse_linguistic_variant(
+            LV_FR_CSV.as_bytes(),
+            "frFR28LinguisticVariant.csv",
+            &mut errors,
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, "2160-0");
+        assert_eq!(
+            rows[0].1,
+            "Créatinine [Masse/volume] dans le sérum ou le plasma"
+        );
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn find_loinc_paths_locates_linguistic_variants() {
+        let zip_file = make_test_loinc_zip_with_variants();
+        let paths = find_loinc_paths(zip_file.path()).unwrap();
+        assert!(paths.lv_index.is_some());
+        assert_eq!(paths.lv_variants.len(), 2);
+        // The index (`LinguisticVariants.csv`, plural) must not be collected as
+        // a per-variant file.
+        assert!(
+            paths
+                .lv_variants
+                .iter()
+                .all(|p| !p.to_lowercase().ends_with("linguisticvariants.csv"))
+        );
+    }
+
+    #[tokio::test]
+    async fn import_loinc_csv_writes_designations() {
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        let ctx = TenantContext::system();
+        let zip_file = make_test_loinc_zip_with_variants();
+
+        import_loinc_csv(&backend, &ctx, zip_file.path(), 500, false)
+            .await
+            .expect("import with linguistic variants should succeed");
+
+        // 2 French + 1 German translation = 3 designation rows.
+        assert_eq!(count_rows(&backend, "concept_designations"), 3);
+
+        let conn = backend.pool().get().unwrap();
+        let (lang, value): (String, String) = conn
+            .query_row(
+                "SELECT d.language, d.value FROM concept_designations d \
+                 JOIN concepts c ON c.id = d.concept_id \
+                 WHERE c.code = '2160-0' AND d.language = 'de-DE'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("German designation for 2160-0 should exist");
+        assert_eq!(lang, "de-DE");
+        assert_eq!(value, "Kreatinin [Masse/Volumen] in Serum oder Plasma");
+
+        // The English display is left untouched.
+        let display: String = conn
+            .query_row(
+                "SELECT display FROM concepts WHERE code = '2160-0'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(display, "Creatinine [Mass/volume] in Serum or Plasma");
+    }
+
+    #[tokio::test]
+    async fn import_loinc_csv_dry_run_counts_designations() {
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        let ctx = TenantContext::system();
+        let zip_file = make_test_loinc_zip_with_variants();
+
+        import_loinc_csv(&backend, &ctx, zip_file.path(), 500, true)
+            .await
+            .expect("dry-run should succeed");
+
+        // Dry-run writes nothing.
+        assert_eq!(count_rows(&backend, "concept_designations"), 0);
+    }
+
+    #[tokio::test]
+    async fn import_loinc_csv_without_variants_still_works() {
+        // The original (no-variant) ZIP must import cleanly with zero designations.
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        let ctx = TenantContext::system();
+        let zip_file = make_test_loinc_zip();
+
+        import_loinc_csv(&backend, &ctx, zip_file.path(), 500, false)
+            .await
+            .unwrap();
+        assert_eq!(count_rows(&backend, "concept_designations"), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Imports LOINC linguistic-variant (language translation) files as FHIR `concept.designation` entries, at both server bootstrap and CLI import.

LOINC ships translations inside the main release ZIP under `AccessoryFiles/LinguisticVariants/`: an index `LinguisticVariants.csv` plus per-language files like `frFR28LinguisticVariant.csv`. Both `hts import` and server bootstrap funnel LOINC ZIPs through `import_loinc_csv`, so extending that single parser covers **both** paths — no new flag or file is required.

## Changes

- `find_loinc_paths` now also locates the linguistic-variant index and per-language files (returns a `LoincArchivePaths` struct); the plural index is correctly distinguished from per-variant files.
- New parsers `parse_linguistic_index` and `parse_linguistic_variant`, plus `derive_language_tag` producing BCP-47 tags (`fr-FR`, `de-DE`, `zh-CN`) — index-preferred, filename fallback.
- Translations attach as `concept.designation` entries via the existing `BuilderDesignation` → `concept_designations` path. The English `display` is left untouched. **No DB schema change.**
- Per-language designation counts reported in live and dry-run output, e.g. `imported 3 translated designations (de-DE: 1, fr-FR: 2)`.
- Malformed index, missing columns, unknown LOINC codes, and undetectable languages are recorded as non-fatal parse errors rather than aborting the import.

## Testing

- 10 new tests covering index parsing, language-tag derivation (index + filename fallback), variant CSV parsing, archive file discovery, end-to-end designation writes (verifying English display preserved), dry-run counting, and a regression test that variant-free ZIPs still import cleanly.
- All 23 LOINC tests pass (`cargo test -p helios-hts --features sqlite loinc`).
- `cargo fmt` and `cargo clippy` (CI flags) clean.
