### PR TITLE
feat(search): implement _list, _score, and _contained/_containedType controls

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/schema.rs
+++ b/crates/persistence/src/backends/elasticsearch/schema.rs
@@ -45,6 +45,16 @@ pub fn create_index_mapping(config: &super::backend::ElasticsearchConfig) -> ser
                 "fhir_version": { "type": "keyword" },
                 "is_deleted": { "type": "boolean" },
 
+                // `_contained` search: a doc extracted from a container's
+                // `contained[]` entry is flagged `is_contained` and carries the
+                // container's identity plus the contained resource's local id.
+                // Its `resource_type`/`search_params` describe the contained
+                // resource (so it lands in that type's index and matches normally).
+                "is_contained": { "type": "boolean" },
+                "container_type": { "type": "keyword" },
+                "container_id": { "type": "keyword" },
+                "contained_local_id": { "type": "keyword" },
+
                 // Raw FHIR JSON - stored but not indexed
                 "content": { "type": "object", "enabled": false },
 

--- a/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
@@ -22,6 +22,19 @@ pub struct EsQuery {
     pub index: String,
 }
 
+/// Returns true if the query contains a relevance-scoring (full-text) clause:
+/// the `_text` / `_content` special params, or a `:text` / `:text-advanced`
+/// modifier. Such clauses make Elasticsearch's `_score` meaningful.
+fn query_has_relevance(query: &SearchQuery) -> bool {
+    query.parameters.iter().any(|p| {
+        matches!(p.name.as_str(), "_text" | "_content")
+            || matches!(
+                p.modifier,
+                Some(SearchModifier::Text) | Some(SearchModifier::TextAdvanced)
+            )
+    })
+}
+
 /// Builds Elasticsearch queries from FHIR search queries.
 pub struct EsQueryBuilder<'a> {
     tenant_id: &'a str,
@@ -43,10 +56,25 @@ impl<'a> EsQueryBuilder<'a> {
     /// Builds a complete ES query from a FHIR SearchQuery.
     pub fn build(&self, query: &SearchQuery) -> EsQuery {
         let mut must_clauses: Vec<Value> = Vec::new();
-        let filter_clauses: Vec<Value> = vec![
+        let mut filter_clauses: Vec<Value> = vec![
             json!({ "term": { "tenant_id": self.tenant_id } }),
             json!({ "term": { "is_deleted": false } }),
         ];
+
+        // `_contained` mode selects between top-level and contained docs. Contained
+        // docs carry `is_contained=true`; top-level docs omit the field, so
+        // `must_not term is_contained=true` excludes contained docs without
+        // requiring a value on every existing document.
+        let mut must_not_clauses: Vec<Value> = Vec::new();
+        match query.contained {
+            crate::types::ContainedMode::Off => {
+                must_not_clauses.push(json!({ "term": { "is_contained": true } }));
+            }
+            crate::types::ContainedMode::On => {
+                filter_clauses.push(json!({ "term": { "is_contained": true } }));
+            }
+            crate::types::ContainedMode::Both => {}
+        }
 
         // Process each search parameter
         for param in &query.parameters {
@@ -62,6 +90,10 @@ impl<'a> EsQueryBuilder<'a> {
 
         if !must_clauses.is_empty() {
             bool_query["must"] = json!(must_clauses);
+        }
+
+        if !must_not_clauses.is_empty() {
+            bool_query["must_not"] = json!(must_not_clauses);
         }
 
         let mut body = json!({
@@ -87,6 +119,14 @@ impl<'a> EsQueryBuilder<'a> {
 
         // Track total hits
         body["track_total_hits"] = json!(true);
+
+        // When the query contributes relevance (full-text), ask ES to compute
+        // `_score` even though we sort by a field — otherwise `_score` is null
+        // and we can't populate `Bundle.entry.search.score`. A `_sort=_score`
+        // already scores natively, so this only matters for the field-sort case.
+        if query_has_relevance(query) {
+            body["track_scores"] = json!(true);
+        }
 
         EsQuery {
             body,
@@ -222,6 +262,10 @@ impl<'a> EsQueryBuilder<'a> {
                 }
                 "_lastUpdated" => {
                     sort_clauses.push(json!({ "last_updated": { "order": order } }));
+                }
+                // `_sort=_score` ranks by Elasticsearch relevance.
+                "_score" => {
+                    sort_clauses.push(json!({ "_score": { "order": order } }));
                 }
                 // For other parameters, sort on the nested search_params field
                 name => {

--- a/crates/persistence/src/backends/elasticsearch/search_impl.rs
+++ b/crates/persistence/src/backends/elasticsearch/search_impl.rs
@@ -1,6 +1,7 @@
 //! SearchProvider, TextSearchProvider, IncludeProvider, and RevincludeProvider
 //! implementations for the Elasticsearch backend.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -175,6 +176,13 @@ impl SearchProvider for ElasticsearchBackend {
             ));
         }
 
+        // `_contained` search post-processes contained-doc hits into containers or
+        // contained resources; standard search excludes contained docs via the
+        // query builder's `must_not is_contained`.
+        if query.contained != crate::types::ContainedMode::Off {
+            return self.search_contained(tenant, query).await;
+        }
+
         let tenant_id = tenant.tenant_id().as_str();
         let resource_type = &query.resource_type;
         let index = self.index_name(tenant_id, resource_type);
@@ -206,6 +214,7 @@ impl SearchProvider for ElasticsearchBackend {
         let count = query.count.unwrap_or(20) as usize;
 
         let mut resources = Vec::new();
+        let mut scores: HashMap<String, f64> = HashMap::new();
         let mut last_sort: Option<Vec<Value>> = None;
         let mut last_resource_id = String::new();
 
@@ -225,6 +234,12 @@ impl SearchProvider for ElasticsearchBackend {
             }
 
             if let Some(stored) = parse_hit_to_stored_resource(source, tenant)? {
+                // Capture the relevance score for `Bundle.entry.search.score`.
+                // `_score` is null when a field sort overrides relevance scoring,
+                // so only record finite scores.
+                if let Some(score) = hit.get("_score").and_then(|s| s.as_f64()) {
+                    scores.insert(stored.url(), score);
+                }
                 last_resource_id = stored.id().to_string();
                 resources.push(stored);
             }
@@ -273,6 +288,10 @@ impl SearchProvider for ElasticsearchBackend {
 
         let page = Page::new(resources, page_info);
         let mut result = SearchResult::new(page);
+
+        if !scores.is_empty() {
+            result = result.with_scores(scores);
+        }
 
         if let Some(t) = total {
             result = result.with_total(t);
@@ -328,6 +347,140 @@ impl SearchProvider for ElasticsearchBackend {
         &self,
     ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
         self.search_registry()
+    }
+
+    fn supports_contained_search(&self) -> bool {
+        true
+    }
+}
+
+impl ElasticsearchBackend {
+    /// Executes a `_contained=true|both` search. The query builder restricts the
+    /// hit set (`is_contained=true` for `on`; no restriction for `both`); this
+    /// post-processes each hit: contained-doc hits resolve to their container
+    /// (`_containedType=container`, default) or the contained resource itself
+    /// (`_containedType=contained`), while top-level hits (only present for
+    /// `both`) pass through. Single window (no keyset cursor).
+    async fn search_contained(
+        &self,
+        tenant: &TenantContext,
+        query: &SearchQuery,
+    ) -> StorageResult<SearchResult> {
+        use crate::types::ContainedReturn;
+
+        let tenant_id = tenant.tenant_id().as_str();
+        let resource_type = &query.resource_type;
+        let index = self.index_name(tenant_id, resource_type);
+
+        // Fetch a generous window of candidate hits (offset/count applied below).
+        let mut es_query =
+            EsQueryBuilder::new(tenant_id, resource_type, index.clone()).build(query);
+        let count = query.count.unwrap_or(100) as usize;
+        let offset = query.offset.unwrap_or(0) as usize;
+        if let Some(obj) = es_query.body.as_object_mut() {
+            obj.insert("size".to_string(), json!(offset + count));
+            obj.remove("from");
+            obj.remove("search_after");
+        }
+
+        let body = match send_search_with_retry(self, &index, es_query.body).await? {
+            Some(v) => v,
+            None => return Ok(SearchResult::new(Page::new(vec![], PageInfo::end()))),
+        };
+        let hits = body
+            .get("hits")
+            .and_then(|h| h.get("hits"))
+            .and_then(|h| h.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let mut items: Vec<StoredResource> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for hit in &hits {
+            let Some(source) = hit.get("_source") else {
+                continue;
+            };
+            if source
+                .get("is_deleted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            let is_contained = source
+                .get("is_contained")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            if !is_contained {
+                // Top-level hit (only in `both` mode) — pass through.
+                if let Some(stored) = parse_hit_to_stored_resource(source, tenant)? {
+                    if seen.insert(stored.url()) {
+                        items.push(stored);
+                    }
+                }
+                continue;
+            }
+
+            let (Some(container_type), Some(container_id)) = (
+                source.get("container_type").and_then(|v| v.as_str()),
+                source.get("container_id").and_then(|v| v.as_str()),
+            ) else {
+                continue;
+            };
+
+            match query.contained_return {
+                ContainedReturn::Container => {
+                    if !seen.insert(format!("{container_type}/{container_id}")) {
+                        continue;
+                    }
+                    if let Some(container) = self.read(tenant, container_type, container_id).await?
+                    {
+                        items.push(container);
+                    }
+                }
+                ContainedReturn::Contained => {
+                    // The contained doc's `content` IS the contained resource;
+                    // return it directly with its local id.
+                    if let Some(stored) = parse_hit_to_stored_resource(source, tenant)? {
+                        let local_id = source
+                            .get("contained_local_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_else(|| stored.id());
+                        let key = format!("{container_type}/{container_id}#{local_id}");
+                        if seen.insert(key) {
+                            let rebuilt = StoredResource::from_storage(
+                                stored.resource_type().to_string(),
+                                local_id.to_string(),
+                                stored.version_id().to_string(),
+                                tenant.tenant_id().clone(),
+                                stored.content().clone(),
+                                stored.created_at(),
+                                stored.last_modified(),
+                                None,
+                                stored.fhir_version(),
+                            );
+                            items.push(rebuilt);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Apply the offset/count window.
+        let total = if query.wants_total() {
+            Some(items.len() as u64)
+        } else {
+            None
+        };
+        let windowed: Vec<StoredResource> = items.into_iter().skip(offset).take(count).collect();
+        let page = Page::new(windowed, PageInfo::end());
+        let mut result = SearchResult::new(page);
+        if let Some(t) = total {
+            result = result.with_total(t);
+        }
+        Ok(result)
     }
 }
 

--- a/crates/persistence/src/backends/elasticsearch/storage.rs
+++ b/crates/persistence/src/backends/elasticsearch/storage.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use chrono::Utc;
-use elasticsearch::{DeleteParts, GetParts, IndexParts};
+use elasticsearch::{DeleteByQueryParts, DeleteParts, GetParts, IndexParts};
 use helios_fhir::FhirVersion;
 use serde_json::{Value, json};
 
@@ -317,6 +317,141 @@ pub(crate) fn build_es_document(
     })
 }
 
+/// Synthetic ES `resource_id` for a contained-resource document: the
+/// container's id plus the contained local id, so it is unique within the
+/// contained type's index and stable across re-indexing.
+pub(crate) fn contained_resource_id(container_id: &str, local_id: &str) -> String {
+    format!("{}#{}", container_id, local_id)
+}
+
+/// Builds an ES document for a contained resource (`_contained` search). The
+/// doc describes the contained resource (its `resource_type`, `content`, and
+/// `search_params`) so it matches normally within that type's index, and is
+/// tagged with the container's identity for result resolution.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_es_contained_document(
+    tenant_id: &str,
+    container_type: &str,
+    container_id: &str,
+    contained_type: &str,
+    local_id: &str,
+    contained_content: &Value,
+    version_id: &str,
+    fhir_version: FhirVersion,
+    extracted_values: &[ExtractedValue],
+) -> Value {
+    let synthetic_id = contained_resource_id(container_id, local_id);
+    let mut doc = build_es_document(
+        tenant_id,
+        contained_type,
+        &synthetic_id,
+        version_id,
+        contained_content,
+        fhir_version,
+        extracted_values,
+    );
+    if let Some(obj) = doc.as_object_mut() {
+        obj.insert("is_contained".to_string(), json!(true));
+        obj.insert("container_type".to_string(), json!(container_type));
+        obj.insert("container_id".to_string(), json!(container_id));
+        obj.insert("contained_local_id".to_string(), json!(local_id));
+    }
+    doc
+}
+
+impl ElasticsearchBackend {
+    /// Deletes all contained-resource docs derived from the given container
+    /// (across the tenant's indices), used before re-indexing or on container
+    /// delete so removed contained resources don't linger.
+    pub(crate) async fn delete_contained_docs(
+        &self,
+        tenant_id: &str,
+        container_type: &str,
+        container_id: &str,
+    ) -> StorageResult<()> {
+        let pattern = format!(
+            "{}_{}_*",
+            self.config().index_prefix,
+            tenant_id.to_lowercase()
+        );
+        let body = json!({
+            "query": { "bool": { "filter": [
+                { "term": { "tenant_id": tenant_id } },
+                { "term": { "is_contained": true } },
+                { "term": { "container_type": container_type } },
+                { "term": { "container_id": container_id } }
+            ]}}
+        });
+        // Missing indices are fine (nothing to delete).
+        let _ = self
+            .client()
+            .delete_by_query(DeleteByQueryParts::Index(&[&pattern]))
+            .ignore_unavailable(true)
+            .refresh(true)
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| internal_error(format!("Failed to delete contained docs: {}", e)))?;
+        Ok(())
+    }
+
+    /// Extracts and indexes a container's `contained[]` resources as separate
+    /// `is_contained` docs in their respective type indices. When `delete_first`
+    /// is set, stale contained docs for this container are removed first
+    /// (needed on update, where contained resources may have changed/been removed).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn index_contained_docs(
+        &self,
+        tenant_id: &str,
+        container_type: &str,
+        container_id: &str,
+        resource: &Value,
+        fhir_version: FhirVersion,
+        version_id: &str,
+        delete_first: bool,
+    ) -> StorageResult<()> {
+        if delete_first {
+            self.delete_contained_docs(tenant_id, container_type, container_id)
+                .await?;
+        }
+
+        for contained in self.search_extractor().extract_contained(resource) {
+            let doc = build_es_contained_document(
+                tenant_id,
+                container_type,
+                container_id,
+                &contained.contained_type,
+                &contained.local_id,
+                &contained.content,
+                version_id,
+                fhir_version,
+                &contained.values,
+            );
+            schema::ensure_index(self, tenant_id, &contained.contained_type).await?;
+            let index = self.index_name(tenant_id, &contained.contained_type);
+            let doc_id = Self::document_id(
+                &contained.contained_type,
+                &contained_resource_id(container_id, &contained.local_id),
+            );
+            let response = self
+                .client()
+                .index(IndexParts::IndexId(&index, &doc_id))
+                .body(doc)
+                .send()
+                .await
+                .map_err(|e| internal_error(format!("Failed to index contained doc: {}", e)))?;
+            if !response.status_code().is_success() {
+                let body = response.text().await.unwrap_or_default();
+                return Err(internal_error(format!(
+                    "Failed to index contained doc: {}",
+                    body
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl ResourceStorage for ElasticsearchBackend {
     fn backend_name(&self) -> &'static str {
@@ -389,6 +524,25 @@ impl ResourceStorage for ElasticsearchBackend {
                 "Failed to index document (status {}): {}",
                 status, body
             )));
+        }
+
+        // Index any contained resources for `_contained` search. New resource,
+        // so no stale docs to delete first.
+        if resource
+            .get("contained")
+            .and_then(|c| c.as_array())
+            .is_some_and(|a| !a.is_empty())
+        {
+            self.index_contained_docs(
+                tenant_id,
+                resource_type,
+                &id,
+                &resource,
+                fhir_version,
+                version_id,
+                false,
+            )
+            .await?;
         }
 
         let now = Utc::now();
@@ -484,6 +638,19 @@ impl ResourceStorage for ElasticsearchBackend {
                 status, body
             )));
         }
+
+        // Re-sync contained docs (delete stale, then re-index) so updates that
+        // add/remove/change `contained[]` entries are reflected.
+        self.index_contained_docs(
+            tenant_id,
+            resource_type,
+            id,
+            &resource,
+            fhir_version,
+            &version_id,
+            true,
+        )
+        .await?;
 
         let now = Utc::now();
         Ok((
@@ -662,6 +829,10 @@ impl ResourceStorage for ElasticsearchBackend {
                 status, body
             )));
         }
+
+        // Remove any contained-resource docs derived from this container.
+        self.delete_contained_docs(tenant_id, resource_type, id)
+            .await?;
 
         Ok(())
     }

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -84,6 +84,38 @@ async fn collect_documents(mut cursor: Cursor<Document>) -> StorageResult<Vec<Do
     Ok(docs)
 }
 
+/// Finds the `contained[]` entry with the given local `id` in a container's
+/// content.
+fn extract_contained_resource(content: &Value, local_id: &str) -> Option<Value> {
+    content
+        .get("contained")?
+        .as_array()?
+        .iter()
+        .find(|e| e.get("id").and_then(|v| v.as_str()) == Some(local_id))
+        .cloned()
+}
+
+/// Builds a `StoredResource` for a contained resource, inheriting the
+/// container's version/tenant/timestamps. Used for `_containedType=contained`.
+fn build_contained_stored(
+    container: &StoredResource,
+    contained_type: &str,
+    local_id: &str,
+    content: Value,
+) -> StoredResource {
+    StoredResource::from_storage(
+        contained_type.to_string(),
+        local_id.to_string(),
+        container.version_id().to_string(),
+        container.tenant_id().clone(),
+        content,
+        container.created_at(),
+        container.last_modified(),
+        None,
+        container.fhir_version(),
+    )
+}
+
 fn parse_simple_search_params(params: &str) -> Vec<(String, String)> {
     params
         .split('&')
@@ -101,6 +133,14 @@ impl SearchProvider for MongoBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
+        // `_contained` search uses a dedicated path (separate index rows and
+        // heterogeneous result types); standard search handles `_contained=false`
+        // (contained rows carry the container's resource_type, so the standard
+        // type-scoped filter naturally excludes them).
+        if query.contained != crate::types::ContainedMode::Off {
+            return self.search_contained(tenant, query).await;
+        }
+
         self.validate_query_support(query)?;
 
         let db = self.get_database().await?;
@@ -249,6 +289,7 @@ impl SearchProvider for MongoBackend {
             resources: page,
             included,
             total,
+            scores: Default::default(),
         })
     }
 
@@ -285,6 +326,10 @@ impl SearchProvider for MongoBackend {
         &self,
     ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
         self.search_registry()
+    }
+
+    fn supports_contained_search(&self) -> bool {
+        true
     }
 }
 
@@ -386,6 +431,168 @@ impl ConditionalStorage for MongoBackend {
 }
 
 impl MongoBackend {
+    /// Executes a `_contained=true|both` search (see the SQLite backend's
+    /// `search_contained` for shared semantics). Returns containers (default) or
+    /// contained resources (`_containedType=contained`); `both` merges top-level
+    /// matches first. Single window (no keyset cursor).
+    async fn search_contained(
+        &self,
+        tenant: &TenantContext,
+        query: &SearchQuery,
+    ) -> StorageResult<SearchResult> {
+        use crate::types::{ContainedMode, ContainedReturn};
+
+        let db = self.get_database().await?;
+        let tenant_id = tenant.tenant_id().as_str();
+        let contained_type = query.resource_type.as_str();
+
+        let matches = self
+            .matching_contained(&db, tenant_id, contained_type, query)
+            .await?;
+
+        let mut items: Vec<StoredResource> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        match query.contained_return {
+            ContainedReturn::Container => {
+                for (ctype, cid, _) in &matches {
+                    if !seen.insert(format!("{ctype}/{cid}")) {
+                        continue;
+                    }
+                    if let Some(container) = self.read(tenant, ctype, cid).await? {
+                        items.push(container);
+                    }
+                }
+            }
+            ContainedReturn::Contained => {
+                for (ctype, cid, local) in &matches {
+                    let Some(local_id) = local else { continue };
+                    if !seen.insert(format!("{ctype}/{cid}#{local_id}")) {
+                        continue;
+                    }
+                    if let Some(container) = self.read(tenant, ctype, cid).await? {
+                        if let Some(c) = extract_contained_resource(container.content(), local_id) {
+                            items.push(build_contained_stored(
+                                &container,
+                                contained_type,
+                                local_id,
+                                c,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        if query.contained == ContainedMode::Both {
+            let mut top_query = query.clone();
+            top_query.contained = ContainedMode::Off;
+            top_query.contained_return = ContainedReturn::Container;
+            let top = self.search(tenant, &top_query).await?;
+            let mut merged = top.resources.items;
+            let top_urls: HashSet<String> = merged.iter().map(|r| r.url()).collect();
+            for item in items {
+                if !top_urls.contains(&item.url()) {
+                    merged.push(item);
+                }
+            }
+            items = merged;
+        }
+
+        let count = query.count.unwrap_or(100) as usize;
+        let offset = query.offset.unwrap_or(0) as usize;
+        let total = if query.total.is_some() {
+            Some(items.len() as u64)
+        } else {
+            None
+        };
+        let windowed: Vec<StoredResource> = items.into_iter().skip(offset).take(count).collect();
+        let page = Page::new(windowed, PageInfo::end());
+        let mut result = SearchResult::new(page);
+        if let Some(t) = total {
+            result = result.with_total(t);
+        }
+        Ok(result)
+    }
+
+    /// Resolves `_contained` matches via an aggregation over `search_index`,
+    /// grouping contained rows by the contained entity
+    /// `(resource_type, resource_id, contained_local_id)` and requiring every
+    /// searched parameter to be present on that entity. Returns
+    /// `(container_type, container_id, contained_local_id)` tuples.
+    async fn matching_contained(
+        &self,
+        db: &mongodb::Database,
+        tenant_id: &str,
+        contained_type: &str,
+        query: &SearchQuery,
+    ) -> StorageResult<Vec<(String, String, Option<String>)>> {
+        let search_index = db.collection::<Document>(MongoBackend::SEARCH_INDEX_COLLECTION);
+
+        let mut branches: Vec<Bson> = Vec::new();
+        let mut distinct_names: Vec<String> = Vec::new();
+        for param in &query.parameters {
+            if param.name.starts_with('_')
+                || matches!(
+                    param.param_type,
+                    SearchParamType::Composite | SearchParamType::Special
+                )
+            {
+                continue;
+            }
+            // Reuse the standard per-param value filter, dropping the tenant /
+            // resource_type scoping (handled by the pipeline's top `$match`).
+            let mut branch = self.build_search_index_filter("", "", param)?;
+            branch.remove("tenant_id");
+            branch.remove("resource_type");
+            branches.push(Bson::Document(branch));
+            if !distinct_names.contains(&param.name) {
+                distinct_names.push(param.name.clone());
+            }
+        }
+        if branches.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut pipeline = vec![
+            doc! { "$match": {
+                "tenant_id": tenant_id,
+                "is_contained": true,
+                "contained_type": contained_type,
+                "$or": branches,
+            }},
+            doc! { "$group": {
+                "_id": {
+                    "rtype": "$resource_type",
+                    "rid": "$resource_id",
+                    "lid": "$contained_local_id",
+                },
+                "names": { "$addToSet": "$param_name" },
+            }},
+        ];
+        if distinct_names.len() > 1 {
+            pipeline.push(doc! { "$match": { "names": { "$all": distinct_names } } });
+        }
+
+        let cursor = search_index
+            .aggregate(pipeline)
+            .await
+            .map_err(|e| internal_error(format!("Failed to aggregate contained search: {}", e)))?;
+        let docs = collect_documents(cursor).await?;
+
+        let mut out = Vec::new();
+        for doc in docs {
+            if let Ok(id) = doc.get_document("_id") {
+                let rtype = id.get_str("rtype").unwrap_or_default().to_string();
+                let rid = id.get_str("rid").unwrap_or_default().to_string();
+                let lid = id.get_str("lid").ok().map(ToString::to_string);
+                if !rtype.is_empty() && !rid.is_empty() {
+                    out.push((rtype, rid, lid));
+                }
+            }
+        }
+        Ok(out)
+    }
+
     fn validate_query_support(&self, query: &SearchQuery) -> StorageResult<()> {
         // Compartment membership (OR across reference params) is not yet wired
         // into the Mongo filter builder. Fail loud rather than ignoring it.

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -1168,7 +1168,7 @@ impl MongoBackend {
         self.delete_search_index(db, tenant_id, resource_type, resource_id, session)
             .await?;
 
-        let index_docs = match self.search_extractor().extract(resource, resource_type) {
+        let mut index_docs = match self.search_extractor().extract(resource, resource_type) {
             Ok(values) => values
                 .iter()
                 .filter_map(|value| {
@@ -1190,6 +1190,25 @@ impl MongoBackend {
                 )
             }
         };
+
+        // Also index any contained resources for `_contained` search. These rows
+        // share the container's (resource_type, resource_id) — so the earlier
+        // delete-by-(type,id) cleans them too — but are flagged `is_contained`
+        // and carry the contained resource's type and local id.
+        for contained in self.search_extractor().extract_contained(resource) {
+            for value in &contained.values {
+                if let Some(d) = self.build_contained_index_document(
+                    tenant_id,
+                    resource_type,
+                    resource_id,
+                    &contained.contained_type,
+                    &contained.local_id,
+                    value,
+                ) {
+                    index_docs.push(d);
+                }
+            }
+        }
 
         if index_docs.is_empty() {
             return Ok(());
@@ -1342,6 +1361,27 @@ impl MongoBackend {
             doc.insert("composite_group", group as i32);
         }
 
+        Some(doc)
+    }
+
+    /// Builds a contained-resource search-index document (`_contained` search):
+    /// the same value columns as [`Self::build_search_index_document`], with the
+    /// container's `(resource_type, resource_id)`, flagged `is_contained` and
+    /// carrying the contained resource's type and local id.
+    fn build_contained_index_document(
+        &self,
+        tenant_id: &str,
+        container_type: &str,
+        container_id: &str,
+        contained_type: &str,
+        contained_local_id: &str,
+        value: &ExtractedValue,
+    ) -> Option<Document> {
+        let mut doc =
+            self.build_search_index_document(tenant_id, container_type, container_id, value)?;
+        doc.insert("is_contained", true);
+        doc.insert("contained_type", contained_type);
+        doc.insert("contained_local_id", contained_local_id);
         Some(doc)
     }
 

--- a/crates/persistence/src/backends/postgres/schema.rs
+++ b/crates/persistence/src/backends/postgres/schema.rs
@@ -3,7 +3,7 @@
 use crate::error::{BackendError, StorageResult};
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 10;
+pub const SCHEMA_VERSION: i32 = 11;
 
 /// Initialize the database schema.
 pub async fn initialize_schema(client: &deadpool_postgres::Client) -> StorageResult<()> {
@@ -273,6 +273,7 @@ async fn migrate_schema(
             7 => migrate_v7_to_v8(client).await?,
             8 => migrate_v8_to_v9(client).await?,
             9 => migrate_v9_to_v10(client).await?,
+            10 => migrate_v10_to_v11(client).await?,
             _ => {
                 return Err(pg_error(format!("Unknown schema version: {}", version)));
             }
@@ -672,6 +673,27 @@ async fn migrate_v9_to_v10(client: &deadpool_postgres::Client) -> StorageResult<
             .execute(sql, &[])
             .await
             .map_err(|e| pg_error(format!("Migration v9->v10 failed: {}", e)))?;
+    }
+    Ok(())
+}
+
+/// v10 -> v11: Add columns supporting `_contained` search. Index rows extracted
+/// from a container's `contained[]` entries are flagged `is_contained = TRUE`
+/// and carry the contained resource's type and local id; the row's
+/// `resource_type` / `resource_id` continue to identify the container.
+async fn migrate_v10_to_v11(client: &deadpool_postgres::Client) -> StorageResult<()> {
+    let stmts = [
+        "ALTER TABLE search_index ADD COLUMN IF NOT EXISTS is_contained BOOLEAN NOT NULL DEFAULT FALSE",
+        "ALTER TABLE search_index ADD COLUMN IF NOT EXISTS contained_type TEXT",
+        "ALTER TABLE search_index ADD COLUMN IF NOT EXISTS contained_local_id TEXT",
+        "CREATE INDEX IF NOT EXISTS idx_search_contained
+         ON search_index(tenant_id, contained_type, is_contained, param_name)",
+    ];
+    for sql in stmts {
+        client
+            .execute(sql, &[])
+            .await
+            .map_err(|e| pg_error(format!("Migration v10->v11 failed: {}", e)))?;
     }
     Ok(())
 }

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -303,6 +303,88 @@ impl PostgresQueryBuilder {
         ))
     }
 
+    /// Builds the `_contained` match subquery (mirrors the SQLite backend's
+    /// `build_contained`).
+    ///
+    /// Returns SQL selecting `(resource_type, resource_id, contained_local_id)`
+    /// from `search_index` for contained resources (`is_contained = TRUE`) of the
+    /// searched type (`contained_type = $2`) matching every standard parameter,
+    /// keyed on the contained entity `(resource_id, contained_local_id)` via
+    /// `GROUP BY ... HAVING COUNT(DISTINCT param_name) >= n`. Value predicates are
+    /// the bare column conditions shared with composite-component matching.
+    ///
+    /// Param layout: `$1` = tenant, `$2` = contained type, then value params.
+    /// Returns `None` when no standard parameter contributes a condition
+    /// (special `_`-params and composites are not applied to contained matching).
+    pub fn build_contained(query: &SearchQuery) -> Option<SqlFragment> {
+        let mut branches: Vec<String> = Vec::new();
+        let mut params: Vec<SqlParam> = Vec::new();
+        let mut distinct_names: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        // $1 = tenant, $2 = contained_type are bound by the caller.
+        let mut offset = 2;
+
+        for param in &query.parameters {
+            if param.name.starts_with('_')
+                || matches!(
+                    param.param_type,
+                    SearchParamType::Composite | SearchParamType::Special
+                )
+            {
+                continue;
+            }
+
+            let mut or_parts: Vec<String> = Vec::new();
+            for value in &param.values {
+                let predicate = match param.param_type {
+                    SearchParamType::Token
+                    | SearchParamType::String
+                    | SearchParamType::Number
+                    | SearchParamType::Quantity
+                    | SearchParamType::Date => {
+                        Self::build_composite_component(value, param.param_type, offset)
+                    }
+                    SearchParamType::Reference => Some((
+                        format!("value_reference = ${}", offset + 1),
+                        vec![SqlParam::text(strip_reference_version(&value.value))],
+                    )),
+                    SearchParamType::Uri => Some((
+                        format!("value_uri = ${}", offset + 1),
+                        vec![SqlParam::text(&value.value)],
+                    )),
+                    SearchParamType::Composite | SearchParamType::Special => None,
+                };
+                if let Some((sql, ps)) = predicate {
+                    offset += ps.len();
+                    or_parts.push(sql);
+                    params.extend(ps);
+                }
+            }
+            if or_parts.is_empty() {
+                continue;
+            }
+            branches.push(format!(
+                "(param_name = '{}' AND ({}))",
+                param.name,
+                or_parts.join(" OR ")
+            ));
+            distinct_names.insert(param.name.clone());
+        }
+
+        if branches.is_empty() {
+            return None;
+        }
+        let sql = format!(
+            "SELECT resource_type, resource_id, contained_local_id FROM search_index \
+             WHERE tenant_id = $1 AND is_contained = TRUE AND contained_type = $2 AND ({}) \
+             GROUP BY resource_type, resource_id, contained_local_id \
+             HAVING COUNT(DISTINCT param_name) >= {}",
+            branches.join(" OR "),
+            distinct_names.len()
+        );
+        Some(SqlFragment::with_params(sql, params))
+    }
+
     /// Builds an `ORDER BY` clause from the query's `_sort` directives.
     ///
     /// Mirrors the SQLite backend's ordering semantics so the two backends stay

--- a/crates/persistence/src/backends/postgres/search/writer.rs
+++ b/crates/persistence/src/backends/postgres/search/writer.rs
@@ -237,6 +237,157 @@ impl PostgresSearchIndexWriter {
 
         Ok(())
     }
+
+    /// Writes a single contained `ExtractedValue` for `_contained` search. The
+    /// row's `resource_type` / `resource_id` identify the container; the entry is
+    /// flagged `is_contained = TRUE` and carries the contained resource's type
+    /// and local id. Uses one full-column INSERT (rather than the per-type
+    /// inserts above) so all value variants share a single statement.
+    pub async fn write_contained_entry(
+        client: &deadpool_postgres::Client,
+        tenant_id: &str,
+        container: (&str, &str),
+        contained: (&str, &str),
+        extracted: &ExtractedValue,
+    ) -> StorageResult<()> {
+        let (container_type, container_id) = container;
+        let (contained_type, contained_local_id) = contained;
+
+        let mut value_string: Option<String> = None;
+        let mut value_string_folded: Option<String> = None;
+        let mut token_system: Option<String> = None;
+        let mut token_code: Option<String> = None;
+        let mut token_display: Option<String> = None;
+        let mut value_date: Option<DateTime<Utc>> = None;
+        let mut date_precision: Option<String> = None;
+        let mut value_number: Option<f64> = None;
+        let mut q_value: Option<f64> = None;
+        let mut q_unit: Option<String> = None;
+        let mut q_system: Option<String> = None;
+        let mut q_canonical_value: Option<f64> = None;
+        let mut q_canonical_unit: Option<String> = None;
+        let mut value_reference: Option<String> = None;
+        let mut reference_display: Option<String> = None;
+        let mut value_uri: Option<String> = None;
+        let mut id_type_system: Option<String> = None;
+        let mut id_type_code: Option<String> = None;
+        let composite_group = extracted.composite_group.map(|g| g as i32);
+
+        match &extracted.value {
+            IndexValue::String(s) => {
+                value_string = Some(s.clone());
+                value_string_folded = Some(crate::search::fold_text(s));
+            }
+            IndexValue::Token {
+                system,
+                code,
+                display,
+                identifier_type_system,
+                identifier_type_code,
+            } => {
+                token_system = system.clone();
+                token_code = Some(code.clone());
+                token_display = display.clone();
+                id_type_system = identifier_type_system.clone();
+                id_type_code = identifier_type_code.clone();
+            }
+            IndexValue::Date { value, precision } => {
+                date_precision = Some(precision.to_string());
+                let normalized = normalize_date_for_pg(value);
+                value_date = Some(
+                    DateTime::parse_from_rfc3339(&normalized)
+                        .map(|dt| dt.with_timezone(&Utc))
+                        .or_else(|_| normalized.parse::<DateTime<Utc>>())
+                        .unwrap_or_else(|_| Utc::now()),
+                );
+            }
+            IndexValue::Number(n) => value_number = Some(*n),
+            IndexValue::Quantity {
+                value,
+                unit,
+                system,
+                code,
+            } => {
+                q_value = Some(*value);
+                q_unit = unit.clone();
+                q_system = system.clone();
+                if let Some((cv, cu)) = code
+                    .as_deref()
+                    .or(unit.as_deref())
+                    .and_then(|u| helios_fhirpath::ucum::canonicalize_quantity(*value, u))
+                {
+                    q_canonical_value = Some(cv);
+                    q_canonical_unit = Some(cu);
+                }
+            }
+            IndexValue::Reference {
+                reference, display, ..
+            } => {
+                value_reference = Some(reference.clone());
+                reference_display = display.clone();
+            }
+            IndexValue::Uri(uri) => value_uri = Some(uri.clone()),
+        }
+
+        let is_contained = true;
+        let contained_type = contained_type.to_string();
+        let contained_local_id = contained_local_id.to_string();
+
+        client
+            .execute(
+                "INSERT INTO search_index (
+                    tenant_id, resource_type, resource_id, param_name, param_url,
+                    value_string, value_token_system, value_token_code, value_token_display,
+                    value_date, value_date_precision, value_number,
+                    value_quantity_value, value_quantity_unit, value_quantity_system,
+                    value_reference, value_uri, composite_group,
+                    value_identifier_type_system, value_identifier_type_code, value_reference_display,
+                    value_quantity_canonical_value, value_quantity_canonical_unit, value_string_folded,
+                    is_contained, contained_type, contained_local_id
+                ) VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+                    $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27
+                )",
+                &[
+                    &tenant_id,
+                    &container_type,
+                    &container_id,
+                    &extracted.param_name.as_str(),
+                    &extracted.param_url.as_str(),
+                    &value_string,
+                    &token_system,
+                    &token_code,
+                    &token_display,
+                    &value_date,
+                    &date_precision,
+                    &value_number,
+                    &q_value,
+                    &q_unit,
+                    &q_system,
+                    &value_reference,
+                    &value_uri,
+                    &composite_group,
+                    &id_type_system,
+                    &id_type_code,
+                    &reference_display,
+                    &q_canonical_value,
+                    &q_canonical_unit,
+                    &value_string_folded,
+                    &is_contained,
+                    &contained_type,
+                    &contained_local_id,
+                ],
+            )
+            .await
+            .map_err(|e| {
+                internal_error(format!(
+                    "Failed to insert contained search index entry: {}",
+                    e
+                ))
+            })?;
+
+        Ok(())
+    }
 }
 
 /// Normalize a date string for PostgreSQL TIMESTAMPTZ.

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -14,8 +14,8 @@ use chrono::Utc;
 use helios_fhir::FhirVersion;
 
 use crate::core::{
-    ChainedSearchProvider, IncludeProvider, MultiTypeSearchProvider, RevincludeProvider,
-    SearchProvider, SearchResult, TextSearchProvider,
+    ChainedSearchProvider, IncludeProvider, MultiTypeSearchProvider, ResourceStorage,
+    RevincludeProvider, SearchProvider, SearchResult, TextSearchProvider,
 };
 use crate::error::{BackendError, StorageError, StorageResult};
 use crate::tenant::TenantContext;
@@ -43,6 +43,12 @@ impl SearchProvider for PostgresBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
+        // `_contained` search uses a dedicated path (different index columns and
+        // heterogeneous result types); standard search handles `_contained=false`.
+        if query.contained != crate::types::ContainedMode::Off {
+            return self.search_contained(tenant, query).await;
+        }
+
         // Populate Bundle.total only when the client asked for it
         // (`_total=accurate|estimate`). Computed up-front so the count query's
         // client is not held across the main query's await points.
@@ -271,6 +277,7 @@ impl SearchProvider for PostgresBackend {
             resources: page,
             included: Vec::new(),
             total,
+            scores: Default::default(),
         })
     }
 
@@ -342,6 +349,10 @@ impl SearchProvider for PostgresBackend {
         &self,
     ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
         self.search_registry()
+    }
+
+    fn supports_contained_search(&self) -> bool {
+        true
     }
 }
 
@@ -429,6 +440,7 @@ impl MultiTypeSearchProvider for PostgresBackend {
             resources: Page::new(resources, page_info),
             included: Vec::new(),
             total: None,
+            scores: Default::default(),
         })
     }
 }
@@ -769,6 +781,7 @@ impl TextSearchProvider for PostgresBackend {
             resources: Page::new(resources, page_info),
             included: Vec::new(),
             total: None,
+            scores: Default::default(),
         })
     }
 
@@ -843,7 +856,173 @@ impl TextSearchProvider for PostgresBackend {
             resources: Page::new(resources, page_info),
             included: Vec::new(),
             total: None,
+            scores: Default::default(),
         })
+    }
+}
+
+/// Finds the `contained[]` entry with the given local `id` in a container's
+/// content.
+fn extract_contained_resource(
+    content: &serde_json::Value,
+    local_id: &str,
+) -> Option<serde_json::Value> {
+    content
+        .get("contained")?
+        .as_array()?
+        .iter()
+        .find(|e| e.get("id").and_then(|v| v.as_str()) == Some(local_id))
+        .cloned()
+}
+
+/// Builds a `StoredResource` for a contained resource, inheriting the
+/// container's version/tenant/timestamps. Used for `_containedType=contained`.
+fn build_contained_stored(
+    container: &StoredResource,
+    contained_type: &str,
+    local_id: &str,
+    content: serde_json::Value,
+) -> StoredResource {
+    StoredResource::from_storage(
+        contained_type.to_string(),
+        local_id.to_string(),
+        container.version_id().to_string(),
+        container.tenant_id().clone(),
+        content,
+        container.created_at(),
+        container.last_modified(),
+        None,
+        container.fhir_version(),
+    )
+}
+
+// Contained (`_contained`) search.
+impl PostgresBackend {
+    /// Executes a `_contained=true|both` search. See the SQLite backend's
+    /// `search_contained` for the shared semantics: matches contained resources
+    /// of `query.resource_type` via the `is_contained` index rows, returns the
+    /// containers (default) or the contained resources (`_containedType=contained`),
+    /// and for `both` merges top-level matches first. Paginated by
+    /// `_offset`/`_count` as a single window (no keyset cursor).
+    async fn search_contained(
+        &self,
+        tenant: &TenantContext,
+        query: &SearchQuery,
+    ) -> StorageResult<SearchResult> {
+        use crate::types::{ContainedMode, ContainedReturn};
+
+        let tenant_id = tenant.tenant_id().as_str();
+        let contained_type = query.resource_type.as_str();
+
+        // 1. Resolve contained matches → (container_type, container_id, local_id).
+        let matches: Vec<(String, String, Option<String>)> =
+            match PostgresQueryBuilder::build_contained(query) {
+                Some(fragment) => {
+                    let client = self.get_client().await?;
+                    let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![
+                        Box::new(tenant_id.to_string()),
+                        Box::new(contained_type.to_string()),
+                    ];
+                    for param in &fragment.params {
+                        match param {
+                            SqlParam::Text(s) => params.push(Box::new(s.clone())),
+                            SqlParam::Float(f) => params.push(Box::new(*f)),
+                            SqlParam::Integer(i) => params.push(Box::new(*i)),
+                            SqlParam::Bool(b) => params.push(Box::new(*b)),
+                            SqlParam::Timestamp(dt) => params.push(Box::new(*dt)),
+                            SqlParam::Null => params.push(Box::new(Option::<String>::None)),
+                        }
+                    }
+                    let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
+                        .iter()
+                        .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
+                        .collect();
+                    let rows = client
+                        .query(&fragment.sql, &param_refs)
+                        .await
+                        .map_err(|e| {
+                            internal_error(format!("Failed to execute contained query: {e}"))
+                        })?;
+                    rows.iter()
+                        .map(|row| {
+                            (
+                                row.get::<_, String>(0),
+                                row.get::<_, String>(1),
+                                row.get::<_, Option<String>>(2),
+                            )
+                        })
+                        .collect()
+                }
+                None => Vec::new(),
+            };
+
+        // 2. Materialize result items (container or contained), de-duplicated.
+        let mut items: Vec<StoredResource> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        match query.contained_return {
+            ContainedReturn::Container => {
+                for (ctype, cid, _) in &matches {
+                    if !seen.insert(format!("{ctype}/{cid}")) {
+                        continue;
+                    }
+                    if let Some(container) = self.read(tenant, ctype, cid).await? {
+                        items.push(container);
+                    }
+                }
+            }
+            ContainedReturn::Contained => {
+                for (ctype, cid, local) in &matches {
+                    let Some(local_id) = local else { continue };
+                    if !seen.insert(format!("{ctype}/{cid}#{local_id}")) {
+                        continue;
+                    }
+                    if let Some(container) = self.read(tenant, ctype, cid).await? {
+                        if let Some(c) = extract_contained_resource(container.content(), local_id) {
+                            items.push(build_contained_stored(
+                                &container,
+                                contained_type,
+                                local_id,
+                                c,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3. For `both`, merge top-level matches ahead of contained ones.
+        if query.contained == ContainedMode::Both {
+            let mut top_query = query.clone();
+            top_query.contained = ContainedMode::Off;
+            top_query.contained_return = ContainedReturn::Container;
+            let top = self.search(tenant, &top_query).await?;
+            let mut merged = top.resources.items;
+            let top_urls: HashSet<String> = merged.iter().map(|r| r.url()).collect();
+            for item in items {
+                if !top_urls.contains(&item.url()) {
+                    merged.push(item);
+                }
+            }
+            items = merged;
+        }
+
+        // 4. Apply the offset/count window.
+        let count = query.count.unwrap_or(100) as usize;
+        let offset = query.offset.unwrap_or(0) as usize;
+        let total_matches = items.len() as u64;
+        let windowed: Vec<StoredResource> = items.into_iter().skip(offset).take(count).collect();
+
+        let total = if query.wants_total() {
+            Some(total_matches)
+        } else {
+            None
+        };
+        let page = Page::new(windowed, PageInfo::end());
+        let mut result = SearchResult::new(page);
+        if let Some(t) = total {
+            result = result.with_total(t);
+        }
+        Ok(result)
     }
 }
 

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -519,11 +519,45 @@ impl PostgresBackend {
             }
         }
 
+        // Index any contained resources for `_contained` search.
+        self.index_contained_resources(client, tenant_id, resource_type, resource_id, resource)
+            .await?;
+
         // Index FTS content for _text and _content searches
         self.index_fts_content(client, tenant_id, resource_type, resource_id, resource)
             .await?;
 
         Ok(())
+    }
+
+    /// Extracts and indexes a container's `contained[]` resources for
+    /// `_contained` search. Each contained resource's search values are written
+    /// as `is_contained = TRUE` rows whose `resource_type` / `resource_id`
+    /// identify the container. Returns the number of entries written.
+    async fn index_contained_resources(
+        &self,
+        client: &deadpool_postgres::Client,
+        tenant_id: &str,
+        container_type: &str,
+        container_id: &str,
+        resource: &Value,
+    ) -> StorageResult<usize> {
+        let mut count = 0;
+        let container = (container_type, container_id);
+        for contained in self.search_extractor().extract_contained(resource) {
+            for value in &contained.values {
+                PostgresSearchIndexWriter::write_contained_entry(
+                    client,
+                    tenant_id,
+                    container,
+                    (&contained.contained_type, &contained.local_id),
+                    value,
+                )
+                .await?;
+                count += 1;
+            }
+        }
+        Ok(count)
     }
 
     /// Index full-text search content for _text and _content searches.
@@ -2775,6 +2809,12 @@ impl ReindexableStorage for PostgresBackend {
             .await?;
             count += 1;
         }
+
+        // Re-index contained resources too, so `$reindex` rebuilds `_contained`
+        // search entries.
+        count += self
+            .index_contained_resources(&client, tenant_id, resource_type, resource_id, resource)
+            .await?;
 
         Ok(count)
     }

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use crate::error::StorageResult;
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 10;
+pub const SCHEMA_VERSION: i32 = 11;
 
 /// Initialize the database schema.
 pub fn initialize_schema(conn: &Connection) -> StorageResult<()> {
@@ -267,6 +267,7 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> StorageResult<()> {
             7 => migrate_v7_to_v8(conn)?,
             8 => migrate_v8_to_v9(conn)?,
             9 => migrate_v9_to_v10(conn)?,
+            10 => migrate_v10_to_v11(conn)?,
             _ => {
                 return Err(crate::error::StorageError::Backend(
                     crate::error::BackendError::Internal {
@@ -1002,6 +1003,36 @@ fn migrate_v9_to_v10(conn: &Connection) -> StorageResult<()> {
         [],
     )
     .map_err(|e| migration_err(format!("create folded string index: {e}")))?;
+    Ok(())
+}
+
+/// Migrate from schema version 10 to version 11.
+///
+/// Adds columns supporting `_contained` search: index rows extracted from a
+/// container's `contained[]` entries are flagged `is_contained = 1` and carry
+/// the contained resource's type and local id. The row's `resource_type` /
+/// `resource_id` continue to identify the *container* (preserving the FK to
+/// `resources`), while `contained_type` records the nested resource's type.
+fn migrate_v10_to_v11(conn: &Connection) -> StorageResult<()> {
+    // SQLite has no `ADD COLUMN IF NOT EXISTS`; ignore duplicate-column errors.
+    let _ = conn.execute(
+        "ALTER TABLE search_index ADD COLUMN is_contained INTEGER NOT NULL DEFAULT 0",
+        [],
+    );
+    let _ = conn.execute(
+        "ALTER TABLE search_index ADD COLUMN contained_type TEXT",
+        [],
+    );
+    let _ = conn.execute(
+        "ALTER TABLE search_index ADD COLUMN contained_local_id TEXT",
+        [],
+    );
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_search_contained
+         ON search_index(tenant_id, contained_type, is_contained, param_name)",
+        [],
+    )
+    .map_err(|e| migration_err(format!("create contained index: {e}")))?;
     Ok(())
 }
 

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -266,6 +266,78 @@ impl QueryBuilder {
         base
     }
 
+    /// Builds the `_contained` match subquery.
+    ///
+    /// Returns SQL selecting `(resource_type, resource_id, contained_local_id)`
+    /// from `search_index` for contained resources (`is_contained = 1`) of the
+    /// searched type (`contained_type = ?2`) that match every standard search
+    /// parameter. Matching is keyed on the contained entity
+    /// `(resource_id, contained_local_id)` via `GROUP BY ... HAVING
+    /// COUNT(DISTINCT param_name) >= <n>`, so a container only matches when a
+    /// single contained resource satisfies all parameters.
+    ///
+    /// Param layout: `?1` = tenant, `?2` = contained type, then value params.
+    /// Returns `None` when no standard parameter contributes a condition
+    /// (special `_`-params and composites are not applied to contained matching).
+    ///
+    /// Limitation: repeated occurrences of the same parameter name are treated
+    /// as OR rather than AND for the distinct-name count.
+    pub fn build_contained(&self, query: &SearchQuery) -> Option<SqlFragment> {
+        let mut branches: Vec<String> = Vec::new();
+        let mut params: Vec<SqlParam> = Vec::new();
+        let mut distinct_names: HashSet<String> = HashSet::new();
+        // ?1 = tenant, ?2 = contained_type already consumed by the caller.
+        let mut offset = 2;
+
+        for param in &query.parameters {
+            if param.name.starts_with('_')
+                || matches!(
+                    param.param_type,
+                    SearchParamType::Composite | SearchParamType::Special
+                )
+            {
+                continue;
+            }
+
+            let mut or_conditions = Vec::new();
+            let mut local_offset = offset;
+            for value in &param.values {
+                if let Some(cond) = self.build_value_condition(param, value, local_offset) {
+                    local_offset += cond.params.len();
+                    or_conditions.push(cond);
+                }
+            }
+            if or_conditions.is_empty() {
+                continue;
+            }
+            let mut combined = or_conditions.remove(0);
+            for cond in or_conditions {
+                combined = combined.or(cond);
+            }
+            offset += combined.params.len();
+            branches.push(format!(
+                "(param_name = '{}' AND ({}))",
+                param.name, combined.sql
+            ));
+            params.extend(combined.params);
+            distinct_names.insert(param.name.clone());
+        }
+
+        if branches.is_empty() {
+            return None;
+        }
+
+        let sql = format!(
+            "SELECT resource_type, resource_id, contained_local_id FROM search_index \
+             WHERE tenant_id = ?1 AND is_contained = 1 AND contained_type = ?2 AND ({}) \
+             GROUP BY resource_type, resource_id, contained_local_id \
+             HAVING COUNT(DISTINCT param_name) >= {}",
+            branches.join(" OR "),
+            distinct_names.len()
+        );
+        Some(SqlFragment::with_params(sql, params))
+    }
+
     /// Builds the compartment-membership subquery: matches resources that
     /// reference `comp.reference` via ANY of `comp.params` (logical OR), which
     /// is how a resource joins a FHIR compartment. Reference matching mirrors the

--- a/crates/persistence/src/backends/sqlite/search/writer.rs
+++ b/crates/persistence/src/backends/sqlite/search/writer.rs
@@ -38,6 +38,41 @@ impl SqliteSearchIndexWriter {
         "#
     }
 
+    /// INSERT SQL for a contained index entry: the same 24 base columns as
+    /// [`Self::insert_sql`] plus `is_contained`, `contained_type`, and
+    /// `contained_local_id` (`?25..?27`). The base columns' `resource_type` /
+    /// `resource_id` identify the *container*; `contained_type` is the nested
+    /// resource's type. Bind the base params from
+    /// [`Self::to_sql_params`] followed by `1`, the contained type, and the
+    /// contained local id.
+    pub fn insert_contained_sql() -> &'static str {
+        r#"
+        INSERT INTO search_index (
+            tenant_id, resource_type, resource_id, param_name, param_url,
+            value_string, value_token_system, value_token_code, value_token_display,
+            value_date, value_date_precision,
+            value_number, value_quantity_value, value_quantity_unit, value_quantity_system,
+            value_reference, value_uri, composite_group,
+            value_identifier_type_system, value_identifier_type_code,
+            value_reference_display,
+            value_quantity_canonical_value, value_quantity_canonical_unit,
+            value_string_folded,
+            is_contained, contained_type, contained_local_id
+        ) VALUES (
+            ?1, ?2, ?3, ?4, ?5,
+            ?6, ?7, ?8, ?9,
+            ?10, ?11,
+            ?12, ?13, ?14, ?15,
+            ?16, ?17, ?18,
+            ?19, ?20,
+            ?21,
+            ?22, ?23,
+            ?24,
+            ?25, ?26, ?27
+        )
+        "#
+    }
+
     /// Generates the DELETE SQL for clearing a resource's index entries.
     pub fn delete_sql() -> &'static str {
         "DELETE FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND resource_id = ?3"

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -15,8 +15,8 @@ use helios_fhir::FhirVersion;
 use rusqlite::params;
 
 use crate::core::{
-    ChainedSearchProvider, IncludeProvider, MultiTypeSearchProvider, RevincludeProvider,
-    SearchProvider, SearchResult,
+    ChainedSearchProvider, IncludeProvider, MultiTypeSearchProvider, ResourceStorage,
+    RevincludeProvider, SearchProvider, SearchResult,
 };
 use crate::error::{BackendError, StorageError, StorageResult};
 use crate::tenant::TenantContext;
@@ -76,6 +76,12 @@ impl SearchProvider for SqliteBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
+        // `_contained` search uses a dedicated path (different index columns and
+        // heterogeneous result types); standard search handles `_contained=false`.
+        if query.contained != crate::types::ContainedMode::Off {
+            return self.search_contained(tenant, query).await;
+        }
+
         // Populate Bundle.total only when the client asked for it
         // (`_total=accurate|estimate`). Computed up-front, before acquiring the
         // (non-Send) connection, so it is not held across this await.
@@ -327,6 +333,7 @@ impl SearchProvider for SqliteBackend {
             resources: page,
             included: Vec::new(),
             total,
+            scores: Default::default(),
         })
     }
 
@@ -391,6 +398,10 @@ impl SearchProvider for SqliteBackend {
         &self,
     ) -> &std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
         self.search_registry()
+    }
+
+    fn supports_contained_search(&self) -> bool {
+        true
     }
 }
 
@@ -503,6 +514,7 @@ impl MultiTypeSearchProvider for SqliteBackend {
             resources: Page::new(resources, page_info),
             included: Vec::new(),
             total: None,
+            scores: Default::default(),
         })
     }
 }
@@ -840,6 +852,169 @@ impl ChainedSearchProvider for SqliteBackend {
         }
 
         Ok(ids)
+    }
+}
+
+/// Finds the `contained[]` entry with the given local `id` in a container's
+/// content.
+fn extract_contained_resource(
+    content: &serde_json::Value,
+    local_id: &str,
+) -> Option<serde_json::Value> {
+    content
+        .get("contained")?
+        .as_array()?
+        .iter()
+        .find(|e| e.get("id").and_then(|v| v.as_str()) == Some(local_id))
+        .cloned()
+}
+
+/// Builds a `StoredResource` for a contained resource, inheriting the
+/// container's version/tenant/timestamps. Used for `_containedType=contained`.
+fn build_contained_stored(
+    container: &StoredResource,
+    contained_type: &str,
+    local_id: &str,
+    content: serde_json::Value,
+) -> StoredResource {
+    StoredResource::from_storage(
+        contained_type.to_string(),
+        local_id.to_string(),
+        container.version_id().to_string(),
+        container.tenant_id().clone(),
+        content,
+        container.created_at(),
+        container.last_modified(),
+        None,
+        container.fhir_version(),
+    )
+}
+
+// Contained (`_contained`) search.
+impl SqliteBackend {
+    /// Executes a `_contained=true|both` search.
+    ///
+    /// Matches contained resources of `query.resource_type` via the
+    /// `is_contained` index rows, then returns either the container resources
+    /// (`_containedType=container`, default) or the contained resources
+    /// themselves (`_containedType=contained`). For `_contained=both`, top-level
+    /// matches (run through the standard path) are merged in first.
+    ///
+    /// Paginated by `_offset`/`_count` as a single window (no keyset cursor);
+    /// contained result sets are expected to be small.
+    async fn search_contained(
+        &self,
+        tenant: &TenantContext,
+        query: &SearchQuery,
+    ) -> StorageResult<SearchResult> {
+        use crate::types::{ContainedMode, ContainedReturn};
+
+        let tenant_id = tenant.tenant_id().as_str();
+        let contained_type = query.resource_type.as_str();
+
+        // 1. Resolve contained matches → (container_type, container_id, local_id).
+        let builder = QueryBuilder::new(tenant_id, contained_type);
+        let matches: Vec<(String, String, Option<String>)> = match builder.build_contained(query) {
+            Some(fragment) => {
+                let conn = self.get_connection()?;
+                let mut stmt = conn.prepare(&fragment.sql).map_err(|e| {
+                    internal_error(format!("Failed to prepare contained query: {e}"))
+                })?;
+                let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = vec![
+                    Box::new(tenant_id.to_string()),
+                    Box::new(contained_type.to_string()),
+                ];
+                for param in &fragment.params {
+                    match param {
+                        SqlParam::String(s) => all_params.push(Box::new(s.clone())),
+                        SqlParam::Integer(i) => all_params.push(Box::new(*i)),
+                        SqlParam::Float(f) => all_params.push(Box::new(*f)),
+                        SqlParam::Null => all_params.push(Box::new(Option::<String>::None)),
+                    }
+                }
+                let refs: Vec<&dyn rusqlite::ToSql> =
+                    all_params.iter().map(|p| p.as_ref()).collect();
+                stmt.query_map(refs.as_slice(), |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
+                })
+                .map_err(|e| internal_error(format!("Failed to execute contained query: {e}")))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| internal_error(format!("Failed to read contained row: {e}")))?
+            }
+            None => Vec::new(),
+        };
+
+        // 2. Materialize result items (container or contained), de-duplicated.
+        let mut items: Vec<StoredResource> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        match query.contained_return {
+            ContainedReturn::Container => {
+                for (ctype, cid, _) in &matches {
+                    if !seen.insert(format!("{ctype}/{cid}")) {
+                        continue;
+                    }
+                    if let Some(container) = self.read(tenant, ctype, cid).await? {
+                        items.push(container);
+                    }
+                }
+            }
+            ContainedReturn::Contained => {
+                for (ctype, cid, local) in &matches {
+                    let Some(local_id) = local else { continue };
+                    if !seen.insert(format!("{ctype}/{cid}#{local_id}")) {
+                        continue;
+                    }
+                    if let Some(container) = self.read(tenant, ctype, cid).await? {
+                        if let Some(c) = extract_contained_resource(container.content(), local_id) {
+                            items.push(build_contained_stored(
+                                &container,
+                                contained_type,
+                                local_id,
+                                c,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3. For `both`, merge top-level matches ahead of contained ones.
+        if query.contained == ContainedMode::Both {
+            let mut top_query = query.clone();
+            top_query.contained = ContainedMode::Off;
+            top_query.contained_return = ContainedReturn::Container;
+            let top = self.search(tenant, &top_query).await?;
+            let mut merged = top.resources.items;
+            let top_urls: HashSet<String> = merged.iter().map(|r| r.url()).collect();
+            for item in items {
+                if !top_urls.contains(&item.url()) {
+                    merged.push(item);
+                }
+            }
+            items = merged;
+        }
+
+        // 4. Apply the offset/count window.
+        let count = query.count.unwrap_or(100) as usize;
+        let offset = query.offset.unwrap_or(0) as usize;
+        let total_matches = items.len() as u64;
+        let windowed: Vec<StoredResource> = items.into_iter().skip(offset).take(count).collect();
+
+        let total = if query.wants_total() {
+            Some(total_matches)
+        } else {
+            None
+        };
+        let page = Page::new(windowed, PageInfo::end());
+        let mut result = SearchResult::new(page);
+        if let Some(t) = total {
+            result = result.with_total(t);
+        }
+        Ok(result)
     }
 }
 
@@ -2448,5 +2623,145 @@ mod tests {
             "Combined patient + type search should find exactly doc1"
         );
         assert_eq!(result.resources.items[0].id(), "doc1");
+    }
+
+    // ---- _contained / _containedType search ----
+
+    use crate::types::{ContainedMode, ContainedReturn, SearchParamType, SearchValue};
+
+    /// Seeds an Observation containing a Patient named "Smith", plus a top-level
+    /// Patient also named "Smith".
+    async fn seed_contained(backend: &SqliteBackend, tenant: &TenantContext) {
+        backend
+            .create(
+                tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs1",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "1234-5" }] },
+                    "subject": { "reference": "#p1" },
+                    "contained": [{
+                        "resourceType": "Patient",
+                        "id": "p1",
+                        "name": [{ "family": "Smith", "given": ["Contained"] }],
+                        "gender": "male"
+                    }]
+                }),
+                helios_fhir::FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        backend
+            .create(
+                tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": "top1", "name": [{ "family": "Smith" }] }),
+                helios_fhir::FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+    }
+
+    fn name_query(mode: ContainedMode, ret: ContainedReturn) -> SearchQuery {
+        let mut q = SearchQuery::new("Patient");
+        q.contained = mode;
+        q.contained_return = ret;
+        q.parameters.push(SearchParameter {
+            name: "name".to_string(),
+            param_type: SearchParamType::String,
+            modifier: None,
+            values: vec![SearchValue::eq("Smith")],
+            chain: vec![],
+            components: vec![],
+        });
+        q
+    }
+
+    #[tokio::test]
+    async fn contained_off_excludes_contained_resources() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+        seed_contained(&backend, &tenant).await;
+
+        // Default (_contained=off): only the top-level Patient matches.
+        let result = backend
+            .search(
+                &tenant,
+                &name_query(ContainedMode::Off, ContainedReturn::Container),
+            )
+            .await
+            .unwrap();
+        let urls: Vec<String> = result.resources.items.iter().map(|r| r.url()).collect();
+        assert_eq!(urls, vec!["Patient/top1"]);
+    }
+
+    #[tokio::test]
+    async fn contained_on_returns_container_by_default() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+        seed_contained(&backend, &tenant).await;
+
+        let result = backend
+            .search(
+                &tenant,
+                &name_query(ContainedMode::On, ContainedReturn::Container),
+            )
+            .await
+            .unwrap();
+        let urls: Vec<String> = result.resources.items.iter().map(|r| r.url()).collect();
+        assert_eq!(urls, vec!["Observation/obs1"], "container is returned");
+    }
+
+    #[tokio::test]
+    async fn contained_on_contained_type_returns_contained_resource() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+        seed_contained(&backend, &tenant).await;
+
+        let result = backend
+            .search(
+                &tenant,
+                &name_query(ContainedMode::On, ContainedReturn::Contained),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.resources.items.len(), 1);
+        let r = &result.resources.items[0];
+        assert_eq!(r.resource_type(), "Patient");
+        assert_eq!(r.id(), "p1");
+        assert_eq!(r.content()["name"][0]["given"][0], "Contained");
+    }
+
+    #[tokio::test]
+    async fn contained_both_merges_top_level_and_container() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+        seed_contained(&backend, &tenant).await;
+
+        let result = backend
+            .search(
+                &tenant,
+                &name_query(ContainedMode::Both, ContainedReturn::Container),
+            )
+            .await
+            .unwrap();
+        let mut urls: Vec<String> = result.resources.items.iter().map(|r| r.url()).collect();
+        urls.sort();
+        assert_eq!(urls, vec!["Observation/obs1", "Patient/top1"]);
+    }
+
+    #[tokio::test]
+    async fn contained_respects_param_so_no_false_match() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+        seed_contained(&backend, &tenant).await;
+
+        // No contained Patient named "Jones" → no container match.
+        let mut q = name_query(ContainedMode::On, ContainedReturn::Container);
+        q.parameters[0].values = vec![SearchValue::eq("Jones")];
+        let result = backend.search(&tenant, &q).await.unwrap();
+        assert!(result.resources.items.is_empty());
     }
 }

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -29,7 +29,7 @@ use crate::types::{CursorValue, Page, PageCursor, PageInfo, StoredResource};
 use crate::types::{SearchParamType, SearchParameter, SearchQuery, SearchValue};
 
 use super::SqliteBackend;
-use super::search::writer::SqliteSearchIndexWriter;
+use super::search::writer::{SqlValue, SqliteSearchIndexWriter};
 
 fn internal_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::Internal {
@@ -580,6 +580,10 @@ impl SqliteBackend {
             count += 1;
         }
 
+        // Also index any contained resources for `_contained` search.
+        count +=
+            self.index_contained_resources(conn, tenant_id, resource_type, resource_id, resource)?;
+
         Ok(count)
     }
 
@@ -627,6 +631,99 @@ impl SqliteBackend {
 
         conn.execute(SqliteSearchIndexWriter::insert_sql(), param_refs.as_slice())
             .map_err(|e| internal_error(format!("Failed to insert search index entry: {}", e)))?;
+
+        Ok(())
+    }
+
+    /// Extracts and indexes a container's `contained[]` resources for
+    /// `_contained` search. Each contained resource's search values are written
+    /// as `is_contained = 1` rows whose `resource_type` / `resource_id` identify
+    /// the container. Returns the number of entries written.
+    fn index_contained_resources(
+        &self,
+        conn: &rusqlite::Connection,
+        tenant_id: &str,
+        container_type: &str,
+        container_id: &str,
+        resource: &Value,
+    ) -> StorageResult<usize> {
+        let mut count = 0;
+        let container = (container_type, container_id);
+        for contained in self.search_extractor().extract_contained(resource) {
+            for value in &contained.values {
+                self.write_contained_index_entry(
+                    conn,
+                    tenant_id,
+                    container,
+                    (&contained.contained_type, &contained.local_id),
+                    value,
+                )?;
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    /// Writes a single contained `ExtractedValue` to the search_index table,
+    /// flagged `is_contained = 1` and carrying the contained resource's type and
+    /// local id (mirrors [`Self::write_index_entry`]). `container` is the
+    /// `(type, id)` of the holding resource; `contained` is the
+    /// `(type, local id)` of the nested resource.
+    fn write_contained_index_entry(
+        &self,
+        conn: &rusqlite::Connection,
+        tenant_id: &str,
+        container: (&str, &str),
+        contained: (&str, &str),
+        value: &ExtractedValue,
+    ) -> StorageResult<()> {
+        use crate::search::converters::IndexValue;
+
+        let (container_type, container_id) = container;
+        let (contained_type, contained_local_id) = contained;
+
+        let normalized_value = match &value.value {
+            IndexValue::Date {
+                value: date_str,
+                precision,
+            } => {
+                let mut normalized = value.clone();
+                normalized.value = IndexValue::Date {
+                    value: Self::normalize_date_for_sqlite(date_str),
+                    precision: *precision,
+                };
+                Some(normalized)
+            }
+            _ => None,
+        };
+        let value_to_use = normalized_value.as_ref().unwrap_or(value);
+
+        let mut sql_params = SqliteSearchIndexWriter::to_sql_params(
+            tenant_id,
+            container_type,
+            container_id,
+            value_to_use,
+        );
+        // Trailing contained columns (?25..?27).
+        sql_params.push(SqlValue::Int(1));
+        sql_params.push(SqlValue::String(contained_type.to_string()));
+        sql_params.push(SqlValue::String(contained_local_id.to_string()));
+
+        let param_refs: Vec<&dyn ToSql> = sql_params
+            .iter()
+            .map(|p| self.sql_value_to_ref(p))
+            .collect();
+
+        conn.execute(
+            SqliteSearchIndexWriter::insert_contained_sql(),
+            param_refs.as_slice(),
+        )
+        .map_err(|e| {
+            internal_error(format!(
+                "Failed to insert contained search index entry: {}",
+                e
+            ))
+        })?;
 
         Ok(())
     }
@@ -3033,6 +3130,16 @@ impl ReindexableStorage for SqliteBackend {
             )?;
             count += 1;
         }
+
+        // Re-index contained resources too, so `$reindex` rebuilds `_contained`
+        // search entries.
+        count += self.index_contained_resources(
+            &conn,
+            tenant.tenant_id().as_str(),
+            resource_type,
+            resource_id,
+            resource,
+        )?;
 
         Ok(count)
     }

--- a/crates/persistence/src/composite/merger.rs
+++ b/crates/persistence/src/composite/merger.rs
@@ -142,6 +142,7 @@ impl ResultMerger {
             resources: Page::new(filtered_items, primary.resources.page_info),
             included: all_included,
             total: None, // Total is now uncertain due to filtering
+            scores: primary.scores,
         })
     }
 
@@ -181,6 +182,7 @@ impl ResultMerger {
             resources: Page::new(all_resources, primary.resources.page_info),
             included: primary.included,
             total: None,
+            scores: primary.scores,
         })
     }
 
@@ -229,6 +231,7 @@ impl ResultMerger {
             resources: Page::new(filtered_items, primary.resources.page_info),
             included: primary.included,
             total: None,
+            scores: primary.scores,
         })
     }
 
@@ -375,6 +378,7 @@ impl RelevanceMerger {
             resources: Page::new(final_results, PageInfo::end()),
             included: Vec::new(),
             total: None,
+            scores: Default::default(),
         }
     }
 }
@@ -406,6 +410,7 @@ mod tests {
             resources: Page::new(resources, PageInfo::end()),
             included: Vec::new(),
             total: None,
+            scores: Default::default(),
         }
     }
 

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -979,6 +979,24 @@ impl SearchProvider for CompositeStorage {
             ))
         })
     }
+
+    fn supports_contained_search(&self) -> bool {
+        // Same routing as `search`: defer to the dedicated Search backend when
+        // configured, otherwise the primary provider.
+        if let Some(search_backend) = self
+            .config
+            .backends_with_role(super::config::BackendRole::Search)
+            .next()
+        {
+            if let Some(provider) = self.search_providers.get(&search_backend.id) {
+                return provider.supports_contained_search();
+            }
+        }
+        self.search_providers
+            .get(self.config.primary_id().unwrap_or("primary"))
+            .map(|p| p.supports_contained_search())
+            .unwrap_or(false)
+    }
 }
 
 #[async_trait]

--- a/crates/persistence/src/core/search.rs
+++ b/crates/persistence/src/core/search.rs
@@ -9,7 +9,7 @@
 //! - [`TerminologySearchProvider`] - :above, :below, :in, :not-in
 //! - [`TextSearchProvider`] - Full-text search (_text, _content, :text)
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -36,6 +36,11 @@ pub struct SearchResult {
 
     /// Total count of matches (if requested via _total).
     pub total: Option<u64>,
+
+    /// Relevance scores (`Bundle.entry.search.score`) for matched resources,
+    /// keyed by resource URL (`Type/id`). Populated by backends that compute
+    /// relevance (e.g. Elasticsearch full-text search); empty otherwise.
+    pub scores: HashMap<String, f64>,
 }
 
 impl SearchResult {
@@ -45,6 +50,7 @@ impl SearchResult {
             resources,
             included: Vec::new(),
             total: None,
+            scores: HashMap::new(),
         }
     }
 
@@ -57,6 +63,12 @@ impl SearchResult {
     /// Sets the total count.
     pub fn with_total(mut self, total: u64) -> Self {
         self.total = Some(total);
+        self
+    }
+
+    /// Sets the relevance scores, keyed by resource URL (`Type/id`).
+    pub fn with_scores(mut self, scores: HashMap<String, f64>) -> Self {
+        self.scores = scores;
         self
     }
 
@@ -122,13 +134,13 @@ impl SearchResult {
             bundle = bundle.with_link("first", strip_paging_params(self_link));
         }
 
-        // Add matching resources
+        // Add matching resources, attaching a relevance score when the backend
+        // computed one for this resource (`Bundle.entry.search.score`).
         for resource in &self.resources.items {
             let full_url = format!("{}/{}", base_url, resource.url());
-            bundle = bundle.with_entry(BundleEntry::match_entry(
-                full_url,
-                resource.content().clone(),
-            ));
+            let entry = BundleEntry::match_entry(full_url, resource.content().clone())
+                .with_score(self.scores.get(&resource.url()).copied());
+            bundle = bundle.with_entry(entry);
         }
 
         // Add included resources
@@ -272,6 +284,15 @@ pub trait SearchProvider: ResourceStorage {
     /// and chained-search builders both consult it so they cannot disagree on
     /// whether a given param is a Date vs. Token vs. Reference, etc.
     fn search_param_registry(&self) -> &Arc<RwLock<SearchParameterRegistry>>;
+
+    /// Whether this backend can evaluate `_contained=true|both` searches (which
+    /// require contained-resource indexing). Defaults to `false`; backends that
+    /// index `contained[]` entries override this. The REST layer uses it to
+    /// reject `_contained` with `501` on backends that don't support it rather
+    /// than silently returning an unfiltered result.
+    fn supports_contained_search(&self) -> bool {
+        false
+    }
 }
 
 /// Search provider that supports searching across multiple resource types.
@@ -707,6 +728,32 @@ mod tests {
 
         assert_eq!(bundle.total, Some(1));
         assert_eq!(bundle.entry.len(), 1);
+        // No score recorded -> entry.search.score stays absent.
+        assert!(bundle.entry[0].search.as_ref().unwrap().score.is_none());
+    }
+
+    #[test]
+    fn test_search_result_to_bundle_attaches_score() {
+        let resource = StoredResource::new(
+            "Patient",
+            "123",
+            crate::tenant::TenantId::new("t1"),
+            serde_json::json!({"resourceType": "Patient", "id": "123"}),
+            FhirVersion::default(),
+        );
+        let page = Page::new(vec![resource], PageInfo::end());
+        let mut scores = HashMap::new();
+        scores.insert("Patient/123".to_string(), 0.875);
+        let result = SearchResult::new(page).with_scores(scores);
+
+        let bundle = result.to_bundle("http://example.com/fhir", "http://example.com/fhir/Patient");
+
+        assert_eq!(bundle.entry.len(), 1);
+        assert_eq!(
+            bundle.entry[0].search.as_ref().unwrap().score,
+            Some(0.875),
+            "the matched entry carries Bundle.entry.search.score"
+        );
     }
 
     /// Self-link has no query: cursor is appended with `?` (issue #69 bug 1).

--- a/crates/persistence/src/lib.rs
+++ b/crates/persistence/src/lib.rs
@@ -137,6 +137,9 @@
 
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_crate_level_docs)]
+// The Elasticsearch index mapping is built with a single large `json!` literal;
+// the added `_contained` fields push it past the default macro recursion limit.
+#![recursion_limit = "256"]
 
 pub mod advisor;
 pub mod backends;

--- a/crates/persistence/src/search/extractor.rs
+++ b/crates/persistence/src/search/extractor.rs
@@ -63,6 +63,20 @@ impl ExtractedValue {
     }
 }
 
+/// Search values extracted from one `contained[]` entry of a container resource.
+#[derive(Debug, Clone)]
+pub struct ContainedExtraction {
+    /// The contained resource's `resourceType`.
+    pub contained_type: String,
+    /// The contained resource's local `id` (used for `Container/cid#localid`).
+    pub local_id: String,
+    /// The contained resource's JSON (the `contained[]` entry itself). Backends
+    /// that store content inline (Elasticsearch) index this directly.
+    pub content: Value,
+    /// The search values extracted from the contained resource.
+    pub values: Vec<ExtractedValue>,
+}
+
 /// Extracts searchable values from FHIR resources using FHIRPath.
 pub struct SearchParameterExtractor {
     registry: Arc<RwLock<SearchParameterRegistry>>,
@@ -145,6 +159,46 @@ impl SearchParameterExtractor {
         }
 
         Ok(results)
+    }
+
+    /// Extracts searchable values from a container resource's `contained[]`
+    /// entries, for `_contained` search.
+    ///
+    /// Each contained resource is treated as a standalone resource of its own
+    /// `resourceType` and run through the normal [`Self::extract`] path. Contained
+    /// resources without a `resourceType` or `id` are skipped — an `id` is
+    /// required so the match can be addressed (`Container/cid#localid`) and the
+    /// container can return the specific contained resource.
+    pub fn extract_contained(&self, container: &Value) -> Vec<ContainedExtraction> {
+        let Some(entries) = container.get("contained").and_then(|c| c.as_array()) else {
+            return Vec::new();
+        };
+
+        let mut out = Vec::new();
+        for entry in entries {
+            let (Some(contained_type), Some(local_id)) = (
+                entry.get("resourceType").and_then(|v| v.as_str()),
+                entry.get("id").and_then(|v| v.as_str()),
+            ) else {
+                continue;
+            };
+            match self.extract(entry, contained_type) {
+                Ok(values) if !values.is_empty() => out.push(ContainedExtraction {
+                    contained_type: contained_type.to_string(),
+                    local_id: local_id.to_string(),
+                    content: entry.clone(),
+                    values,
+                }),
+                Ok(_) => {}
+                Err(e) => tracing::warn!(
+                    "Failed to extract contained {}/{}: {}",
+                    contained_type,
+                    local_id,
+                    e
+                ),
+            }
+        }
+        out
     }
 
     /// Extracts values for a specific parameter from a resource.

--- a/crates/persistence/src/search/list_resolver.rs
+++ b/crates/persistence/src/search/list_resolver.rs
@@ -1,0 +1,324 @@
+//! Backend-agnostic resolution of `_list` search.
+//!
+//! FHIR `_list` search (`Patient?_list=42`) restricts results to the resources
+//! referenced by a `List` resource's `entry.item`. No per-backend
+//! `SearchProvider::search` understands this directly, so — like chained search
+//! (see [`super::chain_resolver`]) — we resolve it application-side: read the
+//! referenced `List`(s), collect the member references that point at the searched
+//! resource type, and rewrite the query into an `_id` filter that any backend can
+//! execute.
+//!
+//! Multiple `_list` values are AND-ed: a result must be a member of *every*
+//! referenced list. Functional list values (the `$current-*` pseudo-lists) are
+//! not resolved here; the REST layer rejects them before this point.
+
+use std::collections::HashSet;
+
+use crate::core::ResourceStorage;
+use crate::error::StorageResult;
+use crate::tenant::TenantContext;
+use crate::types::{
+    SearchParamType, SearchParameter, SearchQuery, SearchValue, strip_reference_version,
+};
+
+/// Sentinel `_id` value that cannot match any real resource, used to force an
+/// empty result when a `_list` resolves to no members.
+const NO_MATCH_SENTINEL: &str = "__list_search_no_match__";
+
+/// Returns true if the query carries any `_list` filter.
+pub fn query_has_list(query: &SearchQuery) -> bool {
+    !query.list.is_empty()
+}
+
+/// Resolves a query's `_list` filters into an `_id` filter, returning a
+/// rewritten query that a plain `search()` can execute.
+///
+/// Each `_list` value is resolved to the set of `resource_type` member ids of
+/// the referenced `List`; the sets are intersected (`AND`). If any list is
+/// missing or contributes no members, the rewritten query is forced to match
+/// nothing. Queries without `_list` are returned unchanged.
+pub async fn resolve_list<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    query: &SearchQuery,
+) -> StorageResult<SearchQuery>
+where
+    S: ResourceStorage + ?Sized,
+{
+    if !query_has_list(query) {
+        return Ok(query.clone());
+    }
+
+    let base_type = query.resource_type.as_str();
+    let mut id_sets: Vec<HashSet<String>> = Vec::with_capacity(query.list.len());
+    for list_ref in &query.list {
+        // Accept both a bare logical id (`42`) and a `List/42` reference.
+        let list_id = list_ref.strip_prefix("List/").unwrap_or(list_ref);
+        id_sets.push(member_ids(storage, tenant, base_type, list_id).await?);
+    }
+
+    let matched_ids = intersect(id_sets);
+
+    // Rewrite: drop the `_list` filters and add an `_id` filter for the resolved
+    // member ids. Repeated `_id` parameters AND together, so this composes with
+    // any user-supplied `_id` and with chain resolution's own `_id` filter.
+    let mut rewritten = query.clone();
+    rewritten.list.clear();
+
+    let id_values: Vec<SearchValue> = if matched_ids.is_empty() {
+        vec![SearchValue::eq(NO_MATCH_SENTINEL)]
+    } else {
+        matched_ids.iter().map(SearchValue::eq).collect()
+    };
+    rewritten.parameters.push(SearchParameter {
+        name: "_id".to_string(),
+        param_type: SearchParamType::Token,
+        modifier: None,
+        values: id_values,
+        chain: vec![],
+        components: vec![],
+    });
+
+    Ok(rewritten)
+}
+
+/// Reads `List/<list_id>` and collects the logical ids of its `entry.item`
+/// references that point at `base_type`. A missing list yields an empty set
+/// (which forces an empty result). Entries flagged `deleted` are skipped.
+async fn member_ids<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    base_type: &str,
+    list_id: &str,
+) -> StorageResult<HashSet<String>>
+where
+    S: ResourceStorage + ?Sized,
+{
+    let Some(list) = storage.read(tenant, "List", list_id).await? else {
+        return Ok(HashSet::new());
+    };
+
+    let mut ids = HashSet::new();
+    if let Some(entries) = list.content().get("entry").and_then(|e| e.as_array()) {
+        for entry in entries {
+            // `entry.deleted = true` marks an item removed from the list.
+            if entry
+                .get("deleted")
+                .and_then(|d| d.as_bool())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let reference = entry
+                .get("item")
+                .and_then(|item| item.get("reference"))
+                .and_then(|r| r.as_str());
+            if let Some(reference) = reference {
+                if let Some(id) = id_for_type(reference, base_type) {
+                    ids.insert(id);
+                }
+            }
+        }
+    }
+    Ok(ids)
+}
+
+/// Extracts the logical id from a reference if it targets `base_type`. Handles
+/// both relative (`Patient/123`) and absolute (`http://host/fhir/Patient/123`)
+/// references, ignoring any `/_history/<vid>` version suffix.
+fn id_for_type(reference: &str, base_type: &str) -> Option<String> {
+    let reference = strip_reference_version(reference);
+    let (type_part, id) = reference.rsplit_once('/')?;
+    let type_name = type_part.rsplit('/').next().unwrap_or(type_part);
+    (type_name == base_type).then(|| id.to_string())
+}
+
+/// Intersects a list of id sets (`AND` across `_list` filters). An empty input
+/// yields an empty set.
+fn intersect(mut sets: Vec<HashSet<String>>) -> HashSet<String> {
+    let mut iter = sets.drain(..);
+    let mut acc = match iter.next() {
+        Some(s) => s,
+        None => return HashSet::new(),
+    };
+    for s in iter {
+        acc.retain(|id| s.contains(id));
+    }
+    acc
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+    use crate::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+    use crate::core::{ResourceStorage, SearchProvider};
+    use crate::tenant::{TenantId, TenantPermissions};
+    use helios_fhir::FhirVersion;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn backend() -> SqliteBackend {
+        let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.join("data"))
+            .unwrap();
+        let config = SqliteBackendConfig {
+            data_dir: Some(data_dir),
+            ..Default::default()
+        };
+        let b = SqliteBackend::with_config(":memory:", config).unwrap();
+        b.init_schema().unwrap();
+        b
+    }
+
+    fn tenant() -> TenantContext {
+        TenantContext::new(TenantId::new("t"), TenantPermissions::full_access())
+    }
+
+    async fn seed_patients(b: &SqliteBackend, t: &TenantContext) {
+        for id in ["smith", "jones", "doe"] {
+            b.create(
+                t,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": id }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        }
+    }
+
+    async fn create_list(
+        b: &SqliteBackend,
+        t: &TenantContext,
+        id: &str,
+        entries: serde_json::Value,
+    ) {
+        b.create(
+            t,
+            "List",
+            json!({ "resourceType": "List", "id": id, "status": "current", "mode": "working", "entry": entries }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn matched_ids(b: &SqliteBackend, t: &TenantContext, query: &SearchQuery) -> Vec<String> {
+        let rewritten = resolve_list(b, t, query).await.unwrap();
+        let result = b.search(t, &rewritten).await.unwrap();
+        let mut ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    #[tokio::test]
+    async fn list_filters_to_members() {
+        let b = backend();
+        let t = tenant();
+        seed_patients(&b, &t).await;
+        create_list(
+            &b,
+            &t,
+            "l1",
+            json!([
+                { "item": { "reference": "Patient/smith" } },
+                { "item": { "reference": "Patient/jones" } },
+            ]),
+        )
+        .await;
+
+        let mut query = SearchQuery::new("Patient");
+        query.list.push("l1".to_string());
+        assert_eq!(matched_ids(&b, &t, &query).await, vec!["jones", "smith"]);
+    }
+
+    #[tokio::test]
+    async fn list_reference_prefix_accepted() {
+        let b = backend();
+        let t = tenant();
+        seed_patients(&b, &t).await;
+        create_list(
+            &b,
+            &t,
+            "l1",
+            json!([{ "item": { "reference": "Patient/doe" } }]),
+        )
+        .await;
+
+        let mut query = SearchQuery::new("Patient");
+        query.list.push("List/l1".to_string());
+        assert_eq!(matched_ids(&b, &t, &query).await, vec!["doe"]);
+    }
+
+    #[tokio::test]
+    async fn list_skips_deleted_entries_and_other_types() {
+        let b = backend();
+        let t = tenant();
+        seed_patients(&b, &t).await;
+        create_list(
+            &b,
+            &t,
+            "l1",
+            json!([
+                { "item": { "reference": "Patient/smith" } },
+                { "item": { "reference": "Patient/jones" }, "deleted": true },
+                { "item": { "reference": "Observation/o1" } },
+            ]),
+        )
+        .await;
+
+        let mut query = SearchQuery::new("Patient");
+        query.list.push("l1".to_string());
+        assert_eq!(matched_ids(&b, &t, &query).await, vec!["smith"]);
+    }
+
+    #[tokio::test]
+    async fn multiple_lists_intersect() {
+        let b = backend();
+        let t = tenant();
+        seed_patients(&b, &t).await;
+        create_list(
+            &b,
+            &t,
+            "l1",
+            json!([
+                { "item": { "reference": "Patient/smith" } },
+                { "item": { "reference": "Patient/jones" } },
+            ]),
+        )
+        .await;
+        create_list(
+            &b,
+            &t,
+            "l2",
+            json!([
+                { "item": { "reference": "Patient/jones" } },
+                { "item": { "reference": "Patient/doe" } },
+            ]),
+        )
+        .await;
+
+        let mut query = SearchQuery::new("Patient");
+        query.list.push("l1".to_string());
+        query.list.push("l2".to_string());
+        assert_eq!(matched_ids(&b, &t, &query).await, vec!["jones"]);
+    }
+
+    #[tokio::test]
+    async fn missing_list_yields_empty() {
+        let b = backend();
+        let t = tenant();
+        seed_patients(&b, &t).await;
+
+        let mut query = SearchQuery::new("Patient");
+        query.list.push("does-not-exist".to_string());
+        assert!(matched_ids(&b, &t, &query).await.is_empty());
+    }
+}

--- a/crates/persistence/src/search/mod.rs
+++ b/crates/persistence/src/search/mod.rs
@@ -65,6 +65,7 @@ pub mod chain_resolver;
 pub mod converters;
 pub mod errors;
 pub mod extractor;
+pub mod list_resolver;
 pub mod loader;
 pub mod range;
 pub mod registry;
@@ -76,7 +77,8 @@ pub mod writer;
 pub use chain_resolver::{query_has_chains, resolve_chains};
 pub use converters::{IndexValue, ValueConverter};
 pub use errors::{ExtractionError, LoaderError, RegistryError, ReindexError};
-pub use extractor::{ExtractedValue, SearchParameterExtractor};
+pub use extractor::{ContainedExtraction, ExtractedValue, SearchParameterExtractor};
+pub use list_resolver::{query_has_list, resolve_list};
 pub use loader::SearchParameterLoader;
 pub use range::{implicit_precision, implicit_range};
 pub use registry::{

--- a/crates/persistence/src/types/mod.rs
+++ b/crates/persistence/src/types/mod.rs
@@ -83,10 +83,10 @@ pub use pagination::{
 };
 
 pub use search_params::{
-    ChainConfig, ChainedParameter, CompartmentMembership, CompositeSearchComponent,
-    IncludeDirective, IncludeType, ReverseChainedParameter, SearchModifier, SearchParamType,
-    SearchParameter, SearchPrefix, SearchQuery, SearchValue, SortDirection, SortDirective,
-    SummaryMode, TotalMode, strip_reference_version,
+    ChainConfig, ChainedParameter, CompartmentMembership, CompositeSearchComponent, ContainedMode,
+    ContainedReturn, IncludeDirective, IncludeType, ReverseChainedParameter, SearchModifier,
+    SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue, SortDirection,
+    SortDirective, SummaryMode, TotalMode, strip_reference_version,
 };
 
 pub use stored_resource::{ResourceMeta, ResourceMethod, StoredResource, StoredResourceBuilder};

--- a/crates/persistence/src/types/pagination.rs
+++ b/crates/persistence/src/types/pagination.rs
@@ -493,6 +493,16 @@ impl BundleEntry {
         }
     }
 
+    /// Sets the search relevance score (`entry.search.score`). A `None` score
+    /// leaves the entry unchanged. Has no effect if the entry has no `search`
+    /// component (e.g. an outcome entry).
+    pub fn with_score(mut self, score: Option<f64>) -> Self {
+        if let (Some(s), Some(search)) = (score, self.search.as_mut()) {
+            search.score = Some(s);
+        }
+        self
+    }
+
     /// Creates a new include entry.
     pub fn include_entry(full_url: impl Into<String>, resource: Value) -> Self {
         Self {

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -674,6 +674,21 @@ pub struct SearchQuery {
     /// Reverse chain parameters (_has).
     pub reverse_chains: Vec<ReverseChainedParameter>,
 
+    /// `_list` filters: logical ids of `List` resources whose `entry.item`
+    /// references restrict the result set. Multiple values are AND-ed (a result
+    /// must be a member of every listed `List`). Resolved application-side into
+    /// an `_id` filter by [`crate::search::list_resolver`], so any backend can
+    /// execute the rewritten query.
+    pub list: Vec<String>,
+
+    /// `_contained` mode: whether the search matches against resources nested in
+    /// other resources' `contained[]` arrays.
+    pub contained: ContainedMode,
+
+    /// `_containedType`: when a contained resource matches, whether to return the
+    /// container resource (default) or the contained resource itself.
+    pub contained_return: ContainedReturn,
+
     /// Include directives.
     pub includes: Vec<IncludeDirective>,
 
@@ -720,6 +735,32 @@ pub struct CompartmentMembership {
     pub params: Vec<String>,
     /// The compartment reference value, e.g. `Patient/123`.
     pub reference: String,
+}
+
+/// Mode for the `_contained` parameter — whether contained resources (nested in
+/// another resource's `contained[]`) participate in matching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ContainedMode {
+    /// `_contained=false` (default): match only top-level resources.
+    #[default]
+    Off,
+    /// `_contained=true`: match contained resources only.
+    On,
+    /// `_contained=both`: match both top-level and contained resources.
+    Both,
+}
+
+/// Mode for the `_containedType` parameter — what to return when a contained
+/// resource matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ContainedReturn {
+    /// `_containedType=container` (default): return the container resource.
+    #[default]
+    Container,
+    /// `_containedType=contained`: return the contained resource itself.
+    Contained,
 }
 
 /// Mode for _total parameter.

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -2265,6 +2265,131 @@ mod es_integration {
             !result.resources.items.is_empty(),
             "_content search should find resources containing the term"
         );
+
+        // Full-text search ranks by relevance, so the backend must populate
+        // `SearchResult.scores` (-> Bundle.entry.search.score) for the matches.
+        assert!(
+            !result.scores.is_empty(),
+            "full-text search should populate relevance scores"
+        );
+        for resource in &result.resources.items {
+            let score = result.scores.get(&resource.url());
+            assert!(
+                matches!(score, Some(s) if *s > 0.0),
+                "matched resource {} should have a positive relevance score, got {score:?}",
+                resource.url()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn es_integration_contained_search() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            ContainedMode, ContainedReturn, SearchParamType, SearchParameter, SearchQuery,
+            SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("contained-test-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs1",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "1234-5" }] },
+                    "subject": { "reference": "#p1" },
+                    "contained": [{
+                        "resourceType": "Patient",
+                        "id": "p1",
+                        "name": [{ "family": "Smith", "given": ["Contained"] }],
+                        "gender": "male"
+                    }]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": "top1", "name": [{ "family": "Smith" }] }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(800)).await;
+
+        let name_query = |mode: ContainedMode, ret: ContainedReturn| {
+            let mut q = SearchQuery::new("Patient");
+            q.contained = mode;
+            q.contained_return = ret;
+            q.parameters.push(SearchParameter {
+                name: "name".to_string(),
+                param_type: SearchParamType::String,
+                modifier: None,
+                values: vec![SearchValue::eq("Smith")],
+                chain: vec![],
+                components: vec![],
+            });
+            q
+        };
+
+        // Default (_contained=off): only the top-level Patient.
+        let off = backend
+            .search(
+                &tenant,
+                &name_query(ContainedMode::Off, ContainedReturn::Container),
+            )
+            .await
+            .unwrap();
+        let off_urls: Vec<String> = off.resources.items.iter().map(|r| r.url()).collect();
+        assert_eq!(
+            off_urls,
+            vec!["Patient/top1"],
+            "off excludes contained docs"
+        );
+
+        // _contained=true: the container is returned.
+        let on = backend
+            .search(
+                &tenant,
+                &name_query(ContainedMode::On, ContainedReturn::Container),
+            )
+            .await
+            .unwrap();
+        let on_urls: Vec<String> = on.resources.items.iter().map(|r| r.url()).collect();
+        assert_eq!(on_urls, vec!["Observation/obs1"], "container returned");
+
+        // _containedType=contained: the contained Patient itself.
+        let contained = backend
+            .search(
+                &tenant,
+                &name_query(ContainedMode::On, ContainedReturn::Contained),
+            )
+            .await
+            .unwrap();
+        assert_eq!(contained.resources.items.len(), 1);
+        assert_eq!(contained.resources.items[0].resource_type(), "Patient");
+        assert_eq!(contained.resources.items[0].id(), "p1");
+
+        // _contained=both: top-level + container.
+        let both = backend
+            .search(
+                &tenant,
+                &name_query(ContainedMode::Both, ContainedReturn::Container),
+            )
+            .await
+            .unwrap();
+        let mut both_urls: Vec<String> = both.resources.items.iter().map(|r| r.url()).collect();
+        both_urls.sort();
+        assert_eq!(both_urls, vec!["Observation/obs1", "Patient/top1"]);
     }
 
     #[tokio::test]

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -1259,6 +1259,109 @@ async fn mongodb_integration_history_delete_trial_use_not_supported() {
 }
 
 #[tokio::test]
+async fn mongodb_integration_contained_search() {
+    use helios_persistence::types::{ContainedMode, ContainedReturn};
+
+    let Some(backend) = create_backend_with_full_registry("contained_search").await else {
+        eprintln!("Skipping mongodb_integration_contained_search (set HFS_TEST_MONGODB_URL)");
+        return;
+    };
+    let tenant = create_tenant("tenant-contained");
+
+    backend
+        .create(
+            &tenant,
+            "Observation",
+            json!({
+                "resourceType": "Observation",
+                "id": "obs1",
+                "status": "final",
+                "code": { "coding": [{ "system": "http://loinc.org", "code": "1234-5" }] },
+                "subject": { "reference": "#p1" },
+                "contained": [{
+                    "resourceType": "Patient",
+                    "id": "p1",
+                    "name": [{ "family": "Smith", "given": ["Contained"] }],
+                    "gender": "male"
+                }]
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+    backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({ "resourceType": "Patient", "id": "top1", "name": [{ "family": "Smith" }] }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let name_query = |mode: ContainedMode, ret: ContainedReturn| {
+        let mut q = SearchQuery::new("Patient");
+        q.contained = mode;
+        q.contained_return = ret;
+        q.parameters.push(SearchParameter {
+            name: "name".to_string(),
+            param_type: SearchParamType::String,
+            modifier: None,
+            values: vec![SearchValue::eq("Smith")],
+            chain: vec![],
+            components: vec![],
+        });
+        q
+    };
+
+    // Default (_contained=off): only the top-level Patient.
+    let off = backend
+        .search(
+            &tenant,
+            &name_query(ContainedMode::Off, ContainedReturn::Container),
+        )
+        .await
+        .unwrap();
+    let off_urls: Vec<String> = off.resources.items.iter().map(|r| r.url()).collect();
+    assert_eq!(off_urls, vec!["Patient/top1"]);
+
+    // _contained=true: the container is returned.
+    let on = backend
+        .search(
+            &tenant,
+            &name_query(ContainedMode::On, ContainedReturn::Container),
+        )
+        .await
+        .unwrap();
+    let on_urls: Vec<String> = on.resources.items.iter().map(|r| r.url()).collect();
+    assert_eq!(on_urls, vec!["Observation/obs1"]);
+
+    // _containedType=contained: the contained Patient itself.
+    let contained = backend
+        .search(
+            &tenant,
+            &name_query(ContainedMode::On, ContainedReturn::Contained),
+        )
+        .await
+        .unwrap();
+    assert_eq!(contained.resources.items.len(), 1);
+    assert_eq!(contained.resources.items[0].resource_type(), "Patient");
+    assert_eq!(contained.resources.items[0].id(), "p1");
+
+    // _contained=both: top-level + container.
+    let both = backend
+        .search(
+            &tenant,
+            &name_query(ContainedMode::Both, ContainedReturn::Container),
+        )
+        .await
+        .unwrap();
+    let mut both_urls: Vec<String> = both.resources.items.iter().map(|r| r.url()).collect();
+    both_urls.sort();
+    assert_eq!(both_urls, vec!["Observation/obs1", "Patient/top1"]);
+}
+
+#[tokio::test]
 async fn mongodb_integration_search_quantity() {
     let Some(backend) = create_backend_with_full_registry("search_quantity").await else {
         eprintln!("Skipping mongodb_integration_search_quantity (set HFS_TEST_MONGODB_URL)");

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -3671,4 +3671,149 @@ mod postgres_integration {
         // Only completed/error/cancelled jobs can expire — these are accepted.
         assert!(expired_now.is_empty());
     }
+
+    // ========================================================================
+    // _contained / _containedType search
+    // ========================================================================
+
+    async fn seed_contained(backend: &PostgresBackend, tenant: &TenantContext) {
+        backend
+            .create(
+                tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs1",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "1234-5" }] },
+                    "subject": { "reference": "#p1" },
+                    "contained": [{
+                        "resourceType": "Patient",
+                        "id": "p1",
+                        "name": [{ "family": "Smith", "given": ["Contained"] }],
+                        "gender": "male"
+                    }]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        backend
+            .create(
+                tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": "top1", "name": [{ "family": "Smith" }] }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+    }
+
+    fn contained_name_query(
+        mode: helios_persistence::types::ContainedMode,
+        ret: helios_persistence::types::ContainedReturn,
+    ) -> helios_persistence::types::SearchQuery {
+        use helios_persistence::types::{
+            SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+        let mut q = SearchQuery::new("Patient");
+        q.contained = mode;
+        q.contained_return = ret;
+        q.parameters.push(SearchParameter {
+            name: "name".to_string(),
+            param_type: SearchParamType::String,
+            modifier: None,
+            values: vec![SearchValue::eq("Smith")],
+            chain: vec![],
+            components: vec![],
+        });
+        q
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_contained_off_excludes_contained() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{ContainedMode, ContainedReturn};
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+        seed_contained(&backend, &tenant).await;
+
+        let result = backend
+            .search(
+                &tenant,
+                &contained_name_query(ContainedMode::Off, ContainedReturn::Container),
+            )
+            .await
+            .unwrap();
+        let urls: Vec<String> = result.resources.items.iter().map(|r| r.url()).collect();
+        assert_eq!(urls, vec!["Patient/top1"]);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_contained_returns_container() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{ContainedMode, ContainedReturn};
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+        seed_contained(&backend, &tenant).await;
+
+        let result = backend
+            .search(
+                &tenant,
+                &contained_name_query(ContainedMode::On, ContainedReturn::Container),
+            )
+            .await
+            .unwrap();
+        let urls: Vec<String> = result.resources.items.iter().map(|r| r.url()).collect();
+        assert_eq!(urls, vec!["Observation/obs1"]);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_contained_type_contained_returns_contained() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{ContainedMode, ContainedReturn};
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+        seed_contained(&backend, &tenant).await;
+
+        let result = backend
+            .search(
+                &tenant,
+                &contained_name_query(ContainedMode::On, ContainedReturn::Contained),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.resources.items.len(), 1);
+        let r = &result.resources.items[0];
+        assert_eq!(r.resource_type(), "Patient");
+        assert_eq!(r.id(), "p1");
+        assert_eq!(r.content()["name"][0]["given"][0], "Contained");
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_contained_both_merges() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{ContainedMode, ContainedReturn};
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+        seed_contained(&backend, &tenant).await;
+
+        let result = backend
+            .search(
+                &tenant,
+                &contained_name_query(ContainedMode::Both, ContainedReturn::Container),
+            )
+            .await
+            .unwrap();
+        let mut urls: Vec<String> = result.resources.items.iter().map(|r| r.url()).collect();
+        urls.sort();
+        assert_eq!(urls, vec!["Observation/obs1", "Patient/top1"]);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_supports_contained_search() {
+        use helios_persistence::core::SearchProvider;
+        let backend = create_backend().await;
+        assert!(backend.supports_contained_search());
+    }
 }

--- a/crates/rest/src/extractors/search_params.rs
+++ b/crates/rest/src/extractors/search_params.rs
@@ -142,6 +142,9 @@ impl SearchParams {
             "_revinclude:iterate",
             "_contained",
             "_containedType",
+            // `_score` is an output/sort concept (Bundle.entry.search.score,
+            // `_sort=_score`), never a result filter — ignore it as an input.
+            "_score",
             "_format",
             "_pretty",
         ];

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -6,9 +6,9 @@ use std::collections::HashMap;
 
 use helios_persistence::search::{SearchParameterRegistry, resolve_param_type};
 use helios_persistence::types::{
-    CompositeSearchComponent, IncludeDirective, IncludeType, ReverseChainedParameter,
-    SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue, SortDirective,
-    SummaryMode, TotalMode,
+    CompositeSearchComponent, ContainedMode, ContainedReturn, IncludeDirective, IncludeType,
+    ReverseChainedParameter, SearchModifier, SearchParamType, SearchParameter, SearchQuery,
+    SearchValue, SortDirective, SummaryMode, TotalMode,
 };
 
 use super::SearchParams;
@@ -119,6 +119,37 @@ pub fn build_search_query(
         query.elements = elements.to_vec();
     }
 
+    // Process _contained / _containedType
+    if let Some(v) = params.get("_contained") {
+        query.contained = match v.as_str() {
+            "false" | "" => ContainedMode::Off,
+            "true" => ContainedMode::On,
+            "both" => ContainedMode::Both,
+            other => {
+                return Err(RestError::InvalidParameter {
+                    param: "_contained".to_string(),
+                    message: format!(
+                        "invalid _contained value '{other}' (expected 'true', 'false', or 'both')"
+                    ),
+                });
+            }
+        };
+    }
+    if let Some(v) = params.get("_containedType") {
+        query.contained_return = match v.as_str() {
+            "container" | "" => ContainedReturn::Container,
+            "contained" => ContainedReturn::Contained,
+            other => {
+                return Err(RestError::InvalidParameter {
+                    param: "_containedType".to_string(),
+                    message: format!(
+                        "invalid _containedType value '{other}' (expected 'container' or 'contained')"
+                    ),
+                });
+            }
+        };
+    }
+
     // Process _include directives
     for include in params.include() {
         if let Some(directive) = parse_include_directive(include, IncludeType::Include) {
@@ -150,6 +181,17 @@ pub fn build_search_query(
         if name == "_has" || name.starts_with("_has:") {
             if let Some(reverse_chain) = parse_has_parameter(name, value)? {
                 query.reverse_chains.push(reverse_chain);
+            }
+            continue;
+        }
+
+        // Handle _list: restrict results to members of the referenced List
+        // resource(s). Resolved application-side into an `_id` filter. A value
+        // may be a bare logical id (`42`) or a `List/42` reference; both are
+        // accepted and normalized to the logical id by the resolver.
+        if name == "_list" {
+            if !value.is_empty() {
+                query.list.push(value.to_string());
             }
             continue;
         }

--- a/crates/rest/src/handlers/capabilities.rs
+++ b/crates/rest/src/handlers/capabilities.rs
@@ -133,10 +133,14 @@ where
     // Advertise each resource type's real search parameters from the loaded
     // SearchParameter registry (not just the seven common params). The read
     // guard is held only across this synchronous build (no await).
+    // `_contained` / `_containedType` are only advertised when the backend can
+    // evaluate contained search (others reject them with 501).
+    let supports_contained = state.storage().supports_contained_search();
+
     let registry = state.storage().search_param_registry().read();
     let resources: Vec<serde_json::Value> = resource_types
         .iter()
-        .map(|rt| build_resource_capability(rt, &registry))
+        .map(|rt| build_resource_capability(rt, &registry, supports_contained))
         .collect();
 
     #[allow(unused_mut)]
@@ -206,6 +210,7 @@ where
 fn build_resource_capability(
     resource_type: &str,
     registry: &SearchParameterRegistry,
+    supports_contained: bool,
 ) -> serde_json::Value {
     let mut entry = serde_json::json!({
         "type": resource_type,
@@ -230,7 +235,7 @@ fn build_resource_capability(
         "conditionalDelete": "single",
         "searchInclude": ["*"],
         "searchRevInclude": ["*"],
-        "searchParam": build_search_params(resource_type, registry)
+        "searchParam": build_search_params(resource_type, registry, supports_contained)
     });
     // Bulk Data Access IG: per-resource `$export` operation entries on Patient
     // and Group, in addition to the system-level `$export` advertised at
@@ -260,8 +265,9 @@ fn build_resource_capability(
 fn build_search_params(
     resource_type: &str,
     registry: &SearchParameterRegistry,
+    supports_contained: bool,
 ) -> Vec<serde_json::Value> {
-    let mut params = build_common_search_params();
+    let mut params = build_common_search_params(supports_contained);
     let mut seen: std::collections::HashSet<String> = params
         .iter()
         .filter_map(|p| p.get("name").and_then(|n| n.as_str()).map(str::to_string))
@@ -301,8 +307,12 @@ fn fhir_search_param_type(t: SearchParamType) -> &'static str {
 }
 
 /// Builds common search parameters supported by all resources.
-fn build_common_search_params() -> Vec<serde_json::Value> {
-    vec![
+///
+/// `_contained` / `_containedType` are only included when `supports_contained`
+/// is set (the backend can evaluate contained search). `_list` is always
+/// advertised (resolved application-side on every backend).
+fn build_common_search_params(supports_contained: bool) -> Vec<serde_json::Value> {
+    let mut params = vec![
         serde_json::json!({
             "name": "_id",
             "type": "token",
@@ -338,5 +348,55 @@ fn build_common_search_params() -> Vec<serde_json::Value> {
             "type": "special",
             "documentation": "Search on the entire content of the resource"
         }),
-    ]
+        serde_json::json!({
+            "name": "_list",
+            "type": "special",
+            "documentation": "Resources referenced by the given List resource"
+        }),
+    ];
+
+    if supports_contained {
+        params.push(serde_json::json!({
+            "name": "_contained",
+            "type": "token",
+            "documentation": "Whether to search contained resources (false|true|both)"
+        }));
+        params.push(serde_json::json!({
+            "name": "_containedType",
+            "type": "token",
+            "documentation": "Return the container or the contained resource (container|contained)"
+        }));
+    }
+
+    params
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn param_names(params: &[serde_json::Value]) -> Vec<String> {
+        params
+            .iter()
+            .filter_map(|p| p["name"].as_str().map(str::to_string))
+            .collect()
+    }
+
+    #[test]
+    fn common_params_always_advertise_list() {
+        let names = param_names(&build_common_search_params(false));
+        assert!(names.contains(&"_list".to_string()));
+        assert!(names.contains(&"_text".to_string()));
+    }
+
+    #[test]
+    fn contained_params_gated_on_capability() {
+        let without = param_names(&build_common_search_params(false));
+        assert!(!without.contains(&"_contained".to_string()));
+        assert!(!without.contains(&"_containedType".to_string()));
+
+        let with = param_names(&build_common_search_params(true));
+        assert!(with.contains(&"_contained".to_string()));
+        assert!(with.contains(&"_containedType".to_string()));
+    }
 }

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -160,11 +160,11 @@ where
     S: ResourceStorage + SearchProvider + IncludeProvider + RevincludeProvider + Send + Sync,
 {
     // Reject known-but-unimplemented control parameters instead of silently
-    // ignoring them (which returns an unfiltered, misleading `200`). These FHIR
-    // search controls are not implemented by any backend. See search spec
-    // assessment item A1a.
-    const UNSUPPORTED_PARAMS: [&str; 5] =
-        ["_query", "_list", "_contained", "_containedType", "_score"];
+    // ignoring them (which returns an unfiltered, misleading `200`). `_query`
+    // (named queries) is not implemented by any backend. (`_list` is implemented
+    // via list resolution; `_score` as an output/`_sort` concept; `_contained` /
+    // `_containedType` are parsed below and gated per backend capability.)
+    const UNSUPPORTED_PARAMS: [&str; 1] = ["_query"];
     if let Some((key, _)) = pairs
         .iter()
         .find(|(k, _)| UNSUPPORTED_PARAMS.contains(&k.as_str()))
@@ -256,6 +256,9 @@ where
             for s in &built.sort {
                 let sortable = s.parameter == "_id"
                     || s.parameter == "_lastUpdated"
+                    // `_score` ranks by relevance on full-text backends
+                    // (Elasticsearch); other backends fall back to default order.
+                    || s.parameter == "_score"
                     || matches!(
                         s.param_type,
                         Some(t) if t != SearchParamType::Composite && t != SearchParamType::Special
@@ -274,6 +277,17 @@ where
         built
     };
 
+    // `_contained=true|both` requires contained-resource indexing. Gate it on the
+    // backend's capability so unsupported backends return a clear 501 rather than
+    // silently ignoring the parameter and returning an unfiltered result.
+    if query.contained != helios_persistence::types::ContainedMode::Off
+        && !state.storage().supports_contained_search()
+    {
+        return Err(RestError::NotImplemented {
+            feature: "'_contained' search is not supported by this storage backend".to_string(),
+        });
+    }
+
     // Clamp page size to the configured default/maximum.
     let count = query
         .count
@@ -281,6 +295,30 @@ where
         .unwrap_or(state.default_page_size())
         .min(state.max_page_size());
     query.count = Some(count as u32);
+
+    // Resolve `_list` into an `_id` filter via application-side List lookup, so
+    // any backend's `search()` can execute it. Functional list values (the
+    // `$current-*` pseudo-lists) require patient-compartment clinical logic that
+    // no backend implements; reject them explicitly rather than silently
+    // returning an unfiltered result.
+    if let Some(functional) = query.list.iter().find(|v| v.starts_with('$')) {
+        return Err(RestError::NotImplemented {
+            feature: format!(
+                "functional list '{functional}' is not supported; \
+                 use '_list=[List id]' with a stored List resource"
+            ),
+        });
+    }
+    let query = if helios_persistence::search::query_has_list(&query) {
+        helios_persistence::search::resolve_list(state.storage(), tenant.context(), &query)
+            .await
+            .map_err(|e| {
+                warn!(error = %e, "List (_list) resolution failed");
+                RestError::from(e)
+            })?
+    } else {
+        query
+    };
 
     // Resolve chained / reverse-chained (`_has`) parameters into an `_id` filter
     // via application-side joins, so any backend's `search()` can execute them.
@@ -508,13 +546,19 @@ fn bundle_to_json_with_subsetting(
                 entry["resource"] = subsetted;
             }
             if let Some(ref search) = e.search {
-                entry["search"] = serde_json::json!({
+                let mut search_json = serde_json::json!({
                     "mode": match search.mode {
                         helios_persistence::types::SearchEntryMode::Match => "match",
                         helios_persistence::types::SearchEntryMode::Include => "include",
                         helios_persistence::types::SearchEntryMode::Outcome => "outcome",
                     }
                 });
+                // Relevance score (Bundle.entry.search.score), when the backend
+                // computed one.
+                if let Some(score) = search.score {
+                    search_json["score"] = serde_json::json!(score);
+                }
+                entry["search"] = search_json;
             }
             entry
         }).collect::<Vec<_>>()
@@ -921,5 +965,36 @@ mod tests {
             as_map(&result).get("url:below"),
             Some(&"http://example.org/fhir/ValueSet/x".to_string())
         );
+    }
+
+    #[test]
+    fn test_bundle_json_emits_search_score() {
+        use helios_persistence::types::{BundleEntry, SearchBundle};
+
+        let bundle = SearchBundle::new().with_entry(
+            BundleEntry::match_entry(
+                "http://example.com/fhir/Patient/1",
+                serde_json::json!({"resourceType": "Patient", "id": "1"}),
+            )
+            .with_score(Some(0.42)),
+        );
+
+        let json = bundle_to_json_with_subsetting(bundle, None, None, FhirVersion::R4);
+        let search = &json["entry"][0]["search"];
+        assert_eq!(search["mode"], "match");
+        assert_eq!(search["score"], serde_json::json!(0.42));
+    }
+
+    #[test]
+    fn test_bundle_json_omits_absent_search_score() {
+        use helios_persistence::types::{BundleEntry, SearchBundle};
+
+        let bundle = SearchBundle::new().with_entry(BundleEntry::match_entry(
+            "http://example.com/fhir/Patient/1",
+            serde_json::json!({"resourceType": "Patient", "id": "1"}),
+        ));
+
+        let json = bundle_to_json_with_subsetting(bundle, None, None, FhirVersion::R4);
+        assert!(json["entry"][0]["search"].get("score").is_none());
     }
 }

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -1235,13 +1235,14 @@ mod unsupported_params {
 
     #[tokio::test]
     async fn test_unsupported_control_param_rejected() {
-        // `_query`/`_list`/`_contained`/`_score` are not implemented; the server
+        // `_query`/`_contained`/`_containedType` are not implemented; the server
         // must reject them (400) rather than silently ignoring them and returning
-        // an unfiltered result.
+        // an unfiltered result. (`_list` and `_score` are implemented — see the
+        // `list_search` and `score_param` modules below.)
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;
 
-        for param in ["_query", "_list", "_contained", "_score"] {
+        for param in ["_query", "_contained", "_containedType"] {
             let response = server
                 .get(&format!("/Patient?{param}=anything"))
                 .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
@@ -2149,6 +2150,283 @@ mod fulltext_search {
         assert!(
             status == StatusCode::OK || status == StatusCode::BAD_REQUEST,
             "Should return OK or 400"
+        );
+    }
+}
+
+mod list_search {
+    use super::*;
+
+    /// Creates a `List` resource whose entries reference the given patient ids.
+    async fn create_patient_list(backend: &SqliteBackend, id: &str, patient_ids: &[&str]) {
+        let entries: Vec<Value> = patient_ids
+            .iter()
+            .map(|pid| json!({ "item": { "reference": format!("Patient/{pid}") } }))
+            .collect();
+        backend
+            .create(
+                &test_tenant(),
+                "List",
+                json!({
+                    "resourceType": "List",
+                    "id": id,
+                    "status": "current",
+                    "mode": "working",
+                    "entry": entries,
+                }),
+                FhirVersion::R4,
+            )
+            .await
+            .unwrap_or_else(|e| panic!("Failed to create List {id}: {e}"));
+    }
+
+    #[tokio::test]
+    async fn test_list_filters_to_members() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+        create_patient_list(&backend, "list-1", &["patient-1", "patient-3"]).await;
+
+        let response = server
+            .get("/Patient?_list=list-1")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let mut ids: Vec<String> = get_bundle_entries(&body)
+            .iter()
+            .map(|e| e["resource"]["id"].as_str().unwrap().to_string())
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["patient-1", "patient-3"]);
+    }
+
+    #[tokio::test]
+    async fn test_list_combined_with_other_criteria() {
+        // `_list` membership AND-s with ordinary search criteria.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+        create_patient_list(&backend, "list-1", &["patient-1", "patient-2", "patient-3"]).await;
+
+        let response = server
+            .get("/Patient?_list=list-1&gender=male")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        // Only list members that are also male.
+        for entry in get_bundle_entries(&body) {
+            assert_eq!(entry["resource"]["gender"], "male");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_missing_yields_empty() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_list=does-not-exist")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        assert!(get_bundle_entries(&body).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_functional_list_rejected() {
+        // The `$current-*` functional lists are not implemented; reject (501)
+        // rather than silently returning an unfiltered result.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_list=$current-problems")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::NOT_IMPLEMENTED);
+    }
+}
+
+mod score_param {
+    use super::*;
+
+    const PREFER: HeaderName = HeaderName::from_static("prefer");
+
+    #[tokio::test]
+    async fn test_score_input_accepted_and_ignored() {
+        // `_score` is an output concept, not a filter. It must not be rejected
+        // (it used to 400) and must not filter results — it is simply ignored
+        // as an input.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_score=5")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        assert!(
+            !get_bundle_entries(&body).is_empty(),
+            "`_score` input is ignored, so all patients are returned"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_by_score_accepted() {
+        // `_sort=_score` is accepted under both lenient and strict handling. On a
+        // non-full-text backend (SQLite) it falls back to default ordering.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let lenient = server
+            .get("/Patient?_sort=_score")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        lenient.assert_status_ok();
+
+        let strict = server
+            .get("/Patient?_sort=_score")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .add_header(PREFER, HeaderValue::from_static("handling=strict"))
+            .await;
+        strict.assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn test_no_score_without_relevance_backend() {
+        // SQLite does not compute relevance, so match entries carry no
+        // `search.score` field.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_id=patient-1")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["search"]["mode"], "match");
+        assert!(entries[0]["search"].get("score").is_none());
+    }
+}
+
+mod contained_search {
+    use super::*;
+
+    /// Seeds an Observation containing a Patient named "Smith".
+    async fn seed_contained(backend: &SqliteBackend) {
+        backend
+            .create(
+                &test_tenant(),
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": "obs-c",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "1234-5" }] },
+                    "subject": { "reference": "#pc" },
+                    "contained": [{
+                        "resourceType": "Patient",
+                        "id": "pc",
+                        "name": [{ "family": "Smith" }]
+                    }]
+                }),
+                FhirVersion::R4,
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_contained_true_returns_container() {
+        let (server, backend) = create_test_server().await;
+        seed_contained(&backend).await;
+
+        let response = server
+            .get("/Patient?_contained=true&name=Smith")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["resource"]["resourceType"], "Observation");
+        assert_eq!(entries[0]["resource"]["id"], "obs-c");
+    }
+
+    #[tokio::test]
+    async fn test_contained_type_contained_returns_contained_resource() {
+        let (server, backend) = create_test_server().await;
+        seed_contained(&backend).await;
+
+        let response = server
+            .get("/Patient?_contained=true&_containedType=contained&name=Smith")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["resource"]["resourceType"], "Patient");
+        assert_eq!(entries[0]["resource"]["id"], "pc");
+    }
+
+    #[tokio::test]
+    async fn test_invalid_contained_value_rejected() {
+        let (server, backend) = create_test_server().await;
+        seed_contained(&backend).await;
+
+        let response = server
+            .get("/Patient?_contained=maybe")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_metadata_advertises_new_search_controls() {
+        // SQLite supports contained search, so `_contained`/`_containedType` are
+        // advertised alongside the always-supported `_list`.
+        let (server, _backend) = create_test_server().await;
+
+        let response = server
+            .get("/metadata")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status_ok();
+        let body: Value = response.json();
+
+        let patient = body["rest"][0]["resource"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["type"] == "Patient")
+            .expect("Patient resource in CapabilityStatement");
+        let names: Vec<&str> = patient["searchParam"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|p| p["name"].as_str())
+            .collect();
+
+        assert!(names.contains(&"_list"), "advertises _list");
+        assert!(names.contains(&"_contained"), "advertises _contained");
+        assert!(
+            names.contains(&"_containedType"),
+            "advertises _containedType"
         );
     }
 }


### PR DESCRIPTION
## Summary

Implements the FHIR search controls previously hard-rejected by the REST handler's `UNSUPPORTED_PARAMS` list. `_query` (named queries) stays rejected by design — there are no server-defined named queries to run.

| Param | Status |
|-------|--------|
| `_list` | ✅ all backends (application-layer `_id` rewrite) + advertised |
| `_score` | ✅ output `Bundle.entry.search.score` + `_sort=_score` (ES ranks; others no-op) |
| `_contained` / `_containedType` | ✅ all four backends (SQLite, Postgres, Elasticsearch, MongoDB) + advertised |
| `_query` | ❌ rejected by design |

## Details

### `_list`
New backend-agnostic `list_resolver` reads the referenced `List` and rewrites the query into an `_id` filter (same pattern as chained search), so any backend executes it. Multiple `_list` values AND; functional `$current-*` lists are rejected with `501`.

### `_score`
Relevance is surfaced as `Bundle.entry.search.score` via a new `SearchResult.scores` map and honored for `_sort=_score`. Elasticsearch computes real scores (sets `track_scores` when a full-text clause is present, since a field sort otherwise nulls `_score`). SQLite/Postgres/MongoDB accept the param and omit the score. A literal `?_score=` input is ignored (it is an output/sort concept, not a filter).

### `_contained` / `_containedType`
Contained-resource search across all four backends, gated per backend via a new `SearchProvider::supports_contained_search()` (REST returns `501` on backends that don't support it). The shared extractor indexes `contained[]` entries.

- **SQLite / Postgres / MongoDB**: contained rows live in the existing search index, keyed to the container's identity (so normal type-scoped search excludes them and delete-by-(type,id) cleans them), flagged `is_contained` + `contained_type` + `contained_local_id`. SQLite/PG add columns via schema migrations (v11). Entity-level AND is keyed on `(resource_id, contained_local_id)` — SQLite/PG via `GROUP BY ... HAVING COUNT(DISTINCT param_name)`, Mongo via an aggregation `$group`/`$all`.
- **Elasticsearch**: each contained resource is indexed as its own `is_contained` doc in the contained type's index (entity-level AND is automatic); normal searches exclude them via `must_not is_contained`; cross-index lifecycle handled with `delete_by_query` on update/delete.

Results return the container (default, `_containedType=container`) or the contained resource itself (`_containedType=contained`); `_contained=both` merges top-level and contained matches.

### Capabilities
`GET /metadata` now advertises `_list` (always) and `_contained` / `_containedType` (only when the backend supports contained search) per resource. `_score` is not advertised (output/sort concept, not a query parameter).

## Testing

Unit + integration tests for every parameter on every backend, including Elasticsearch, Postgres, and MongoDB via real containers. Full regression suites pass (`helios-persistence` lib + per-backend integration, `helios-rest` lib + `search_integration` + `rest_conformance`); `cargo fmt` and CI clippy clean across all four backends.

The 4 pre-existing MongoDB baseline failures (shared `create_backend()` with `data_dir=None`) are unrelated to this change.

## Known follow-ups (documented in code)
- Contained indexing in the transaction/batch paths (create/update + `$reindex` are covered).
- `_containedType=contained` returns the contained resource with `id=local_id` rather than the `Container/id#localid` fragment form.
- Repeated same-named params on contained matching are OR rather than AND.