### PR TITLE
feat(http): compressed request/response support and uniform body-size limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,10 +216,21 @@ HFS_SERVER_PORT=3000 HFS_LOG_LEVEL=debug cargo run --bin hfs
 #### Limits
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `HFS_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes) |
+| `HFS_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes; applies to the decompressed body for compressed requests) |
 | `HFS_REQUEST_TIMEOUT` | 30 | Request timeout (seconds) |
 | `HFS_DEFAULT_PAGE_SIZE` | 20 | Default search result page size |
 | `HFS_MAX_PAGE_SIZE` | 1000 | Maximum search result page size |
+
+#### HTTP compression
+
+All three HTTP servers (`hfs`, `sof-server`, `hts`) accept request bodies sent
+with `Content-Encoding: gzip` (also `deflate`, `br`, `zstd`); unsupported
+encodings are rejected with `415`. Responses are compressed when the client
+sends `Accept-Encoding` (with `Content-Encoding` and `Vary: Accept-Encoding`
+set). SOF never re-compresses `application/parquet` / `application/zip`
+output. Body-size limits (`HFS_MAX_BODY_SIZE`, `SOF_MAX_BODY_SIZE`,
+`HTS_MAX_BODY_SIZE`) are enforced on the *decompressed* body, so highly
+compressed payloads cannot bypass them.
 
 #### CORS
 | Variable | Default | Description |
@@ -373,7 +384,7 @@ FHIRPATH_SERVER_PORT=8080 FHIRPATH_SERVER_HOST=0.0.0.0 cargo run --bin fhirpath-
 | `SOF_SERVER_PORT` | 8080 | Server port |
 | `SOF_SERVER_HOST` | 127.0.0.1 | Host to bind |
 | `SOF_LOG_LEVEL` | info | Log level |
-| `SOF_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes) |
+| `SOF_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes; applies to the decompressed body for compressed requests) |
 | `SOF_REQUEST_TIMEOUT` | 30 | Request timeout (seconds) |
 | `SOF_ENABLE_CORS` | true | Enable CORS |
 | `SOF_CORS_ORIGINS` | * | Allowed origins |
@@ -524,6 +535,7 @@ HTS_DATABASE_URL=./my-terminology.db HTS_SERVER_PORT=9090 cargo run --bin hts
 | `HTS_DATABASE_URL` | ./data/hts.db | Database location — SQLite file path, or `postgresql://user:pass@host/db` for Postgres |
 | `HTS_STORAGE_BACKEND` | sqlite | Storage backend (`sqlite` default; `postgres` when built with `--features postgres`) |
 | `HTS_BOOTSTRAP_DIR` | (none) | Directory of terminology files imported on startup. The Docker image sets this to `/app/terminology-data`. See bootstrap sync below. |
+| `HTS_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes; applies to the decompressed body for compressed requests) |
 | `HTS_ENABLE_CORS` | true | Enable CORS |
 | `HTS_CORS_ORIGINS` | * | Allowed CORS origins |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,7 +1278,18 @@ checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 4.0.3",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 5.0.1",
 ]
 
 [[package]]
@@ -1286,6 +1297,16 @@ name = "brotli-decompressor"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1690,9 +1711,12 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
+ "brotli 8.0.3",
  "compression-core",
  "flate2",
  "memchr",
+ "zstd 0.13.3",
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -3164,6 +3188,7 @@ dependencies = [
  "axum-test",
  "chrono",
  "clap",
+ "flate2",
  "helios-audit",
  "helios-auth",
  "helios-fhir",
@@ -3229,6 +3254,7 @@ dependencies = [
  "clap",
  "criterion",
  "csv",
+ "flate2",
  "futures",
  "helios-fhir",
  "helios-fhirpath",
@@ -4749,7 +4775,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64 0.22.1",
- "brotli",
+ "brotli 7.0.0",
  "bytes",
  "chrono",
  "flate2",

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ AWS_REGION=us-east-1 \
 
 | Variable | Default | Description |
 |---|---|---|
-| `HFS_MAX_BODY_SIZE` | `10485760` | Max request body size (bytes) |
+| `HFS_MAX_BODY_SIZE` | `10485760` | Max request body size (bytes; applies to the decompressed body for compressed requests) |
 | `HFS_REQUEST_TIMEOUT` | `30` | Request timeout (seconds) |
 | `HFS_DEFAULT_PAGE_SIZE` | `20` | Default search result page size |
 | `HFS_MAX_PAGE_SIZE` | `1000` | Maximum search result page size |
@@ -251,6 +251,10 @@ AWS_REGION=us-east-1 \
 | `HFS_ENABLE_VERSIONING` | `true` | Enable ETag versioning |
 | `HFS_RETURN_GONE` | `true` | Return `410 Gone` for deleted resources (vs `404`) |
 | `HFS_REQUIRE_IF_MATCH` | `false` | Require `If-Match` header for updates |
+
+Request bodies may be sent compressed (`Content-Encoding: gzip`, `deflate`,
+`br`, or `zstd`); unsupported encodings are rejected with `415`. Responses are
+compressed when the client sends `Accept-Encoding`.
 
 **CORS**
 

--- a/book/src/appendix-a-cli.md
+++ b/book/src/appendix-a-cli.md
@@ -158,7 +158,7 @@ No command-line flags. All configuration is via environment variables.
 | `SOF_SERVER_PORT` | `8080` | Port to listen on |
 | `SOF_SERVER_HOST` | `127.0.0.1` | Host to bind |
 | `SOF_LOG_LEVEL` | `info` | Log level |
-| `SOF_MAX_BODY_SIZE` | `10485760` | Max request body (bytes) |
+| `SOF_MAX_BODY_SIZE` | `10485760` | Max request body (bytes; applies to the decompressed body for compressed requests) |
 | `SOF_REQUEST_TIMEOUT` | `30` | Request timeout (seconds) |
 | `SOF_ENABLE_CORS` | `true` | Enable CORS |
 | `SOF_CORS_ORIGINS` | `*` | Allowed CORS origins |

--- a/book/src/ch06-sql-on-fhir.md
+++ b/book/src/ch06-sql-on-fhir.md
@@ -211,7 +211,7 @@ curl -X POST http://localhost:8080/ViewDefinition/\$viewdefinition-run \
 | `SOF_SERVER_PORT` | `8080` | Server port |
 | `SOF_SERVER_HOST` | `127.0.0.1` | Host to bind |
 | `SOF_LOG_LEVEL` | `info` | Log level |
-| `SOF_MAX_BODY_SIZE` | `10485760` | Max request body (bytes) |
+| `SOF_MAX_BODY_SIZE` | `10485760` | Max request body (bytes; applies to the decompressed body for compressed requests) |
 | `SOF_REQUEST_TIMEOUT` | `30` | Request timeout (seconds) |
 | `SOF_ENABLE_CORS` | `true` | Enable CORS |
 | `SOF_CORS_ORIGINS` | `*` | Allowed CORS origins |

--- a/book/src/components/sql-on-fhir.md
+++ b/book/src/components/sql-on-fhir.md
@@ -50,7 +50,7 @@ Parameter precedence: request body > query params > `Accept` header.
 | `SOF_SERVER_PORT` | 8080 | Server port |
 | `SOF_SERVER_HOST` | 127.0.0.1 | Host to bind |
 | `SOF_LOG_LEVEL` | info | Log level |
-| `SOF_MAX_BODY_SIZE` | 10485760 | Max request body (bytes) |
+| `SOF_MAX_BODY_SIZE` | 10485760 | Max request body (bytes; applies to the decompressed body for compressed requests) |
 | `SOF_REQUEST_TIMEOUT` | 30 | Request timeout (seconds) |
 | `SOF_ENABLE_CORS` | true | Enable CORS |
 | `SOF_CORS_ORIGINS` | `*` | Allowed origins |

--- a/book/src/configuration/environment-variables.md
+++ b/book/src/configuration/environment-variables.md
@@ -16,10 +16,14 @@ All server behavior is controlled through environment variables. No configuratio
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `HFS_MAX_BODY_SIZE` | `10485760` | Max request body size (bytes) |
+| `HFS_MAX_BODY_SIZE` | `10485760` | Max request body size (bytes; applies to the decompressed body for compressed requests) |
 | `HFS_REQUEST_TIMEOUT` | `30` | Request timeout (seconds) |
 | `HFS_DEFAULT_PAGE_SIZE` | `20` | Default search result page size |
 | `HFS_MAX_PAGE_SIZE` | `1000` | Maximum search result page size |
+
+Request bodies may be sent compressed (`Content-Encoding: gzip`, `deflate`,
+`br`, or `zstd`); unsupported encodings are rejected with `415`. Responses
+are compressed when the client sends `Accept-Encoding`.
 
 ## CORS
 

--- a/crates/hfs/README.md
+++ b/crates/hfs/README.md
@@ -82,7 +82,7 @@ Options:
 | `HFS_LOG_LEVEL` | info | Log level (error, warn, info, debug, trace) |
 | `DATABASE_URL` | fhir.db | Database connection string |
 | `HFS_DATA_DIR` | ./data | Path to FHIR data directory (search parameters) |
-| `HFS_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes) |
+| `HFS_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes; applies to the decompressed body for compressed requests) |
 | `HFS_REQUEST_TIMEOUT` | 30 | Request timeout (seconds) |
 | `HFS_ENABLE_CORS` | true | Enable CORS |
 | `HFS_CORS_ORIGINS` | * | Allowed CORS origins |

--- a/crates/hts/Cargo.toml
+++ b/crates/hts/Cargo.toml
@@ -37,7 +37,7 @@ axum = { version = "0.8", features = ["json", "query"] }
 futures = "0.3"
 bytes = "1"
 tower = { version = "0.5" }
-tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "timeout", "compression-full", "decompression-full"] }
 tokio = { version = "1", features = ["full"] }
 chrono = { workspace = true }
 serde = { workspace = true }

--- a/crates/hts/README.md
+++ b/crates/hts/README.md
@@ -350,6 +350,8 @@ Options:
       --storage-backend <BACKEND>  Storage backend [env: HTS_STORAGE_BACKEND=] [default: sqlite]
       --enable-cors                Enable CORS [env: HTS_ENABLE_CORS=] [default: true]
       --cors-origins <ORIGINS>     Allowed CORS origins [env: HTS_CORS_ORIGINS=] [default: *]
+      --max-body-size <BYTES>      Maximum request body size in bytes [env: HTS_MAX_BODY_SIZE=]
+                                   [default: 10485760]
       --max-expansion-size <N>     Max codes in a ValueSet expansion [env: HTS_MAX_EXPANSION_SIZE=]
                                    [default: 3500]
   -h, --help                       Print help
@@ -368,7 +370,12 @@ Options:
 | `HTS_STORAGE_BACKEND` | sqlite | Storage backend (`sqlite` or `postgres`) |
 | `HTS_ENABLE_CORS` | true | Enable CORS |
 | `HTS_CORS_ORIGINS` | * | Allowed CORS origins |
+| `HTS_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes; applies to the decompressed body for compressed requests) |
 | `HTS_MAX_EXPANSION_SIZE` | 3500 | Maximum codes in a single ValueSet `$expand` response. Requests exceeding this limit return HTTP 422 with issue code `too-costly`. |
+
+Request bodies sent with `Content-Encoding: gzip` (also `deflate`, `br`,
+`zstd`) are decompressed transparently; unsupported encodings are rejected
+with `415`. Responses are compressed when the client sends `Accept-Encoding`.
 
 ## Storage Backends
 

--- a/crates/hts/src/config.rs
+++ b/crates/hts/src/config.rs
@@ -71,6 +71,14 @@ pub struct HtsConfig {
     #[arg(long, env = "HTS_CORS_ORIGINS", default_value = "*")]
     pub cors_origins: String,
 
+    /// Maximum request body size in bytes.
+    ///
+    /// For requests sent with `Content-Encoding`, the limit applies to the
+    /// *decompressed* body, so a small highly-compressed payload cannot
+    /// bypass it. Mirrors `HFS_MAX_BODY_SIZE` / `SOF_MAX_BODY_SIZE`.
+    #[arg(long, env = "HTS_MAX_BODY_SIZE", default_value = "10485760")]
+    pub max_body_size: usize,
+
     /// Maximum number of codes allowed in a single ValueSet expansion.
     /// Requests that would exceed this limit receive HTTP 422 with issue
     /// code `too-costly`.
@@ -105,6 +113,7 @@ impl Default for HtsConfig {
             storage_backend: "sqlite".into(),
             enable_cors: true,
             cors_origins: "*".into(),
+            max_body_size: 10 * 1024 * 1024, // 10MB
             max_expansion_size: 10_000,
             bootstrap_dir: String::new(),
         }

--- a/crates/hts/src/server.rs
+++ b/crates/hts/src/server.rs
@@ -6,9 +6,15 @@
 //!
 //! ## Middleware stack (outermost → innermost)
 //!
-//! 1. **CORS** — configurable allowed origins; enabled by default with `*`.
-//! 2. **Tracing** — emits `tracing` spans for every request/response pair.
-//! 3. **Timeout** — hard 30-second request deadline (non-configurable).
+//! 1. **Tracing** — emits `tracing` spans for every request/response pair.
+//! 2. **Timeout** — hard 30-second request deadline (non-configurable).
+//! 3. **CORS** — configurable allowed origins; enabled by default with `*`.
+//! 4. **Response compression** — gzip/deflate/br/zstd when the client sends
+//!    `Accept-Encoding` (adds `Content-Encoding` + `Vary: Accept-Encoding`).
+//! 5. **Request decompression** — bodies sent with `Content-Encoding` are
+//!    decompressed before parsing; unsupported encodings get `415`.
+//! 6. **Body-size limit** — `HTS_MAX_BODY_SIZE` (default 10 MiB), measured on
+//!    the decompressed body.
 //!
 //! ## Route registration order
 //!
@@ -19,12 +25,16 @@
 
 use crate::operations::batch::batch_handler;
 use crate::operations::batch_validate::vs_batch_validate_handler;
+use axum::extract::DefaultBodyLimit;
 use axum::{
     Router,
     routing::{get, post},
 };
 use std::time::Duration;
-use tower_http::{cors::CorsLayer, timeout::TimeoutLayer, trace::TraceLayer};
+use tower_http::{
+    compression::CompressionLayer, cors::CorsLayer, decompression::RequestDecompressionLayer,
+    timeout::TimeoutLayer, trace::TraceLayer,
+};
 
 use crate::config::HtsConfig;
 use crate::import::BundleImportBackend;
@@ -167,6 +177,17 @@ where
                 .delete(delete_concept_map::<B>),
         )
         .with_state(state)
+        // Raise the body-size limit from axum's 2 MiB default to the
+        // configured ceiling. The decompression layer below replaces the
+        // request body before extractors read it, so this limit applies to
+        // the *decompressed* bytes — a small highly-compressed payload
+        // cannot bypass `HTS_MAX_BODY_SIZE`.
+        .layer(DefaultBodyLimit::max(config.max_body_size))
+        // Decompress request bodies sent with `Content-Encoding` (gzip,
+        // deflate, br, zstd); unsupported encodings get 415. Compress
+        // responses when the client sends `Accept-Encoding`.
+        .layer(RequestDecompressionLayer::new())
+        .layer(CompressionLayer::new())
         .layer(cors)
         .layer(TimeoutLayer::with_status_code(
             axum::http::StatusCode::REQUEST_TIMEOUT,
@@ -183,12 +204,30 @@ fn build_cors(config: &HtsConfig) -> CorsLayer {
     if config.cors_origins.trim() == "*" {
         CorsLayer::permissive()
     } else {
+        use axum::http::{Method, header};
+
         let origins: Vec<axum::http::HeaderValue> = config
             .cors_origins
             .split(',')
             .filter_map(|s| s.trim().parse().ok())
             .collect();
 
-        CorsLayer::new().allow_origin(origins)
+        // With explicit origins the browser enforces the allow-lists below;
+        // include `Content-Encoding` so clients can send compressed bodies.
+        CorsLayer::new()
+            .allow_origin(origins)
+            .allow_methods([
+                Method::GET,
+                Method::POST,
+                Method::PUT,
+                Method::DELETE,
+                Method::OPTIONS,
+            ])
+            .allow_headers([
+                header::CONTENT_TYPE,
+                header::ACCEPT,
+                header::AUTHORIZATION,
+                header::CONTENT_ENCODING,
+            ])
     }
 }

--- a/crates/hts/tests/http_compression.rs
+++ b/crates/hts/tests/http_compression.rs
@@ -1,0 +1,299 @@
+//! HTTP compression tests for the HTS server.
+//!
+//! Verifies the middleware stack assembled in `create_app`:
+//!
+//! - Request bodies sent with `Content-Encoding: gzip` are decompressed
+//!   before parsing.
+//! - Invalid compressed bodies produce a 4xx, unsupported encodings a 415.
+//! - `HTS_MAX_BODY_SIZE` applies to the *decompressed* body, so a small
+//!   highly-compressed payload cannot bypass the limit.
+//! - Responses are gzip-compressed when the client sends
+//!   `Accept-Encoding: gzip` (with `Content-Encoding` and
+//!   `Vary: Accept-Encoding` set) and left identity-encoded otherwise.
+
+#![cfg(feature = "sqlite")]
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, Response, StatusCode},
+};
+use helios_hts::{backends::SqliteTerminologyBackend, config::HtsConfig, state::AppState};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+fn app_with_config(config: HtsConfig) -> Router {
+    let backend =
+        SqliteTerminologyBackend::in_memory().expect("failed to create in-memory HTS backend");
+    let state = AppState::new(backend);
+    helios_hts::server::create_app(&config, state)
+}
+
+fn test_app() -> Router {
+    app_with_config(HtsConfig::default())
+}
+
+fn code_system_json() -> Value {
+    json!({
+        "resourceType": "CodeSystem",
+        "url": "http://hts.test/compression-cs",
+        "status": "active",
+        "content": "complete",
+        "concept": [
+            {"code": "A", "display": "Alpha"},
+            {"code": "B", "display": "Beta"}
+        ]
+    })
+}
+
+/// A minimal import Bundle wrapping the test CodeSystem.
+fn import_bundle_json() -> Value {
+    json!({
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [{"resource": code_system_json()}]
+    })
+}
+
+fn gzip_bytes(input: &[u8]) -> Vec<u8> {
+    use flate2::{Compression, write::GzEncoder};
+    use std::io::Write;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(input).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn gunzip_bytes(input: &[u8]) -> Vec<u8> {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+
+    let mut decoder = GzDecoder::new(input);
+    let mut output = Vec::new();
+    decoder.read_to_end(&mut output).unwrap();
+    output
+}
+
+async fn body_bytes(response: Response<Body>) -> Vec<u8> {
+    axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap()
+        .to_vec()
+}
+
+// =============================================================================
+// Request decompression
+// =============================================================================
+
+#[tokio::test]
+async fn gzip_request_body_is_decompressed() {
+    let app = test_app();
+    let body = serde_json::to_vec(&import_bundle_json()).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/import")
+                .header("content-type", "application/fhir+json")
+                .header("content-encoding", "gzip")
+                .body(Body::from(gzip_bytes(&body)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response.status().is_success(),
+        "gzip import failed: {}",
+        response.status()
+    );
+    let json: Value = serde_json::from_slice(&body_bytes(response).await).unwrap();
+    assert_eq!(json["code_systems"], 1, "import stats were: {json}");
+}
+
+#[tokio::test]
+async fn uncompressed_request_still_works() {
+    let app = test_app();
+    let body = serde_json::to_vec(&import_bundle_json()).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/import")
+                .header("content-type", "application/fhir+json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response.status().is_success(),
+        "plain import failed: {}",
+        response.status()
+    );
+}
+
+#[tokio::test]
+async fn invalid_gzip_request_body_is_client_error() {
+    let app = test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/import")
+                .header("content-type", "application/fhir+json")
+                .header("content-encoding", "gzip")
+                .body(Body::from("this is not gzip"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response.status().is_client_error(),
+        "invalid gzip body must produce a 4xx, got {}",
+        response.status()
+    );
+}
+
+#[tokio::test]
+async fn unsupported_content_encoding_is_rejected() {
+    let app = test_app();
+    let body = serde_json::to_vec(&import_bundle_json()).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/import")
+                .header("content-type", "application/fhir+json")
+                .header("content-encoding", "compress")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn body_limit_applies_to_decompressed_size() {
+    let app = app_with_config(HtsConfig {
+        max_body_size: 1024,
+        ..HtsConfig::default()
+    });
+
+    // ~64 KiB of repeated text compresses to well under the 1 KiB limit,
+    // but the decompressed body must still be rejected with 413.
+    let mut bundle = import_bundle_json();
+    bundle["entry"][0]["resource"]["description"] = json!("a".repeat(64 * 1024));
+    let raw = serde_json::to_vec(&bundle).unwrap();
+    let compressed = gzip_bytes(&raw);
+    assert!(
+        compressed.len() < 1024,
+        "test payload must compress below the limit"
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/import")
+                .header("content-type", "application/fhir+json")
+                .header("content-encoding", "gzip")
+                .body(Body::from(compressed))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn body_limit_applies_to_plain_requests() {
+    let app = app_with_config(HtsConfig {
+        max_body_size: 1024,
+        ..HtsConfig::default()
+    });
+
+    let mut bundle = import_bundle_json();
+    bundle["entry"][0]["resource"]["description"] = json!("a".repeat(64 * 1024));
+    let raw = serde_json::to_vec(&bundle).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/import")
+                .header("content-type", "application/fhir+json")
+                .body(Body::from(raw))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+// =============================================================================
+// Response compression
+// =============================================================================
+
+#[tokio::test]
+async fn response_is_gzip_compressed_on_accept_encoding() {
+    let app = test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/metadata")
+                .header("accept-encoding", "gzip")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
+    let vary = response
+        .headers()
+        .get_all("vary")
+        .iter()
+        .map(|v| v.to_str().unwrap().to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join(",");
+    assert!(vary.contains("accept-encoding"), "Vary was: {vary}");
+
+    let decompressed = gunzip_bytes(&body_bytes(response).await);
+    let json: Value = serde_json::from_slice(&decompressed).unwrap();
+    assert_eq!(json["resourceType"], "CapabilityStatement");
+}
+
+#[tokio::test]
+async fn response_is_not_compressed_without_accept_encoding() {
+    let app = test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/metadata")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response.headers().get("content-encoding").is_none());
+    let json: Value = serde_json::from_slice(&body_bytes(response).await).unwrap();
+    assert_eq!(json["resourceType"], "CapabilityStatement");
+}

--- a/crates/rest/Cargo.toml
+++ b/crates/rest/Cargo.toml
@@ -52,7 +52,7 @@ async-trait = "0.1"
 # Web framework
 axum = { version = "0.8", features = ["json", "query", "matched-path", "ws"] }
 tower = { version = "0.5", features = ["full"] }
-tower-http = { version = "0.6", features = ["cors", "trace", "timeout", "request-id"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "timeout", "request-id", "compression-full", "decompression-full"] }
 http = "1.0"
 mime = "0.3"
 
@@ -85,6 +85,9 @@ reqwest = { version = "0.12", features = ["json"] }
 [dev-dependencies]
 # HTTP testing
 axum-test = "18.0"
+
+# gzip test payloads for HTTP compression tests
+flate2 = "1"
 
 # Temp files
 tempfile = "3"

--- a/crates/rest/README.md
+++ b/crates/rest/README.md
@@ -91,7 +91,7 @@ The server is configured via environment variables:
 | `HFS_SERVER_PORT` | 8080 | Server port |
 | `HFS_SERVER_HOST` | 127.0.0.1 | Host to bind |
 | `HFS_LOG_LEVEL` | info | Log level |
-| `HFS_MAX_BODY_SIZE` | 10485760 | Max request body (bytes) |
+| `HFS_MAX_BODY_SIZE` | 10485760 | Max request body (bytes; applies to the decompressed body for compressed requests) |
 | `HFS_REQUEST_TIMEOUT` | 30 | Request timeout (seconds) |
 | `HFS_ENABLE_CORS` | true | Enable CORS |
 | `HFS_DEFAULT_TENANT` | default | Default tenant ID |
@@ -99,6 +99,14 @@ The server is configured via environment variables:
 | `HFS_TENANT_ROUTING_MODE` | header_only | Tenant routing mode |
 | `HFS_TENANT_STRICT_VALIDATION` | false | Error on tenant mismatch |
 | `HFS_JWT_TENANT_CLAIM` | tenant_id | JWT claim name (future) |
+
+### HTTP Compression
+
+Request bodies sent with `Content-Encoding: gzip` (also `deflate`, `br`,
+`zstd`) are decompressed transparently before parsing; unsupported encodings
+are rejected with `415 Unsupported Media Type`. Responses are compressed when
+the client advertises support via `Accept-Encoding`, with `Content-Encoding`
+and `Vary: Accept-Encoding` set accordingly.
 
 ### Bulk Data Export
 

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -10,12 +10,12 @@
 //! | `HFS_SERVER_PORT` | 8080 | Server port |
 //! | `HFS_SERVER_HOST` | 127.0.0.1 | Host to bind |
 //! | `HFS_LOG_LEVEL` | info | Log level |
-//! | `HFS_MAX_BODY_SIZE` | 10485760 | Max request body (bytes) |
+//! | `HFS_MAX_BODY_SIZE` | 10485760 | Max request body (bytes; applies to the decompressed body for compressed requests) |
 //! | `HFS_REQUEST_TIMEOUT` | 30 | Request timeout (seconds) |
 //! | `HFS_ENABLE_CORS` | true | Enable CORS |
 //! | `HFS_CORS_ORIGINS` | * | Allowed origins |
 //! | `HFS_CORS_METHODS` | GET,POST,PUT,PATCH,DELETE,OPTIONS | Allowed methods |
-//! | `HFS_CORS_HEADERS` | Content-Type,Authorization,Accept,If-Match,If-None-Match,Prefer | Allowed headers |
+//! | `HFS_CORS_HEADERS` | Content-Type,Authorization,Accept,If-Match,If-None-Match,Prefer,Content-Encoding | Allowed headers |
 //! | `HFS_DEFAULT_TENANT` | default | Default tenant ID |
 //! | `HFS_BASE_URL` | http://localhost:8080 | Server base URL |
 //! | `HFS_DEFAULT_FHIR_VERSION` | R4 | Default FHIR version (R4, R4B, R5, R6) |
@@ -447,6 +447,10 @@ pub struct ServerConfig {
     pub log_level: String,
 
     /// Maximum request body size in bytes.
+    ///
+    /// For requests sent with `Content-Encoding`, the limit applies to the
+    /// *decompressed* body, so a small highly-compressed payload cannot
+    /// bypass it.
     #[arg(long, env = "HFS_MAX_BODY_SIZE", default_value = "10485760")]
     pub max_body_size: usize,
 
@@ -474,7 +478,7 @@ pub struct ServerConfig {
     #[arg(
         long,
         env = "HFS_CORS_HEADERS",
-        default_value = "Content-Type,Authorization,Accept,If-Match,If-None-Match,If-None-Exist,If-Modified-Since,Prefer,X-Tenant-ID"
+        default_value = "Content-Type,Authorization,Accept,If-Match,If-None-Match,If-None-Exist,If-Modified-Since,Prefer,X-Tenant-ID,Content-Encoding"
     )]
     pub cors_headers: String,
 
@@ -596,7 +600,7 @@ impl Default for ServerConfig {
             enable_cors: true,
             cors_origins: "*".to_string(),
             cors_methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS".to_string(),
-            cors_headers: "Content-Type,Authorization,Accept,If-Match,If-None-Match,If-None-Exist,If-Modified-Since,Prefer,X-Tenant-ID".to_string(),
+            cors_headers: "Content-Type,Authorization,Accept,If-Match,If-None-Match,If-None-Exist,If-Modified-Since,Prefer,X-Tenant-ID,Content-Encoding".to_string(),
             default_tenant: "default".to_string(),
             base_url: "http://localhost:8080".to_string(),
             database_url: None,

--- a/crates/rest/src/error.rs
+++ b/crates/rest/src/error.rs
@@ -99,6 +99,12 @@ pub enum RestError {
         content_type: String,
     },
 
+    /// Request body exceeds the configured size limit (HTTP 413).
+    PayloadTooLarge {
+        /// Error message.
+        message: String,
+    },
+
     /// Unprocessable entity - semantic error (HTTP 422).
     UnprocessableEntity {
         /// Error message.
@@ -191,6 +197,9 @@ impl fmt::Display for RestError {
             RestError::UnsupportedMediaType { content_type } => {
                 write!(f, "Unsupported media type: {}", content_type)
             }
+            RestError::PayloadTooLarge { message } => {
+                write!(f, "Payload too large: {}", message)
+            }
             RestError::UnprocessableEntity { message } => {
                 write!(f, "Unprocessable entity: {}", message)
             }
@@ -271,6 +280,9 @@ impl IntoResponse for RestError {
                 "not-supported",
                 format!("Content type '{}' is not supported", content_type),
             ),
+            RestError::PayloadTooLarge { message } => {
+                (StatusCode::PAYLOAD_TOO_LARGE, "too-long", message.clone())
+            }
             RestError::UnprocessableEntity { message } => (
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "processing",

--- a/crates/rest/src/extractors/fhir_resource.rs
+++ b/crates/rest/src/extractors/fhir_resource.rs
@@ -57,6 +57,8 @@ impl FhirResource {
 pub enum FhirResourceRejection {
     /// JSON parsing failed.
     InvalidJson(String),
+    /// Request body exceeds the configured size limit.
+    PayloadTooLarge(String),
     /// Missing resourceType field.
     MissingResourceType,
     /// Unsupported content type.
@@ -71,6 +73,9 @@ impl IntoResponse for FhirResourceRejection {
             FhirResourceRejection::InvalidJson(msg) => RestError::BadRequest {
                 message: format!("Invalid JSON: {}", msg),
             },
+            FhirResourceRejection::PayloadTooLarge(msg) => {
+                RestError::PayloadTooLarge { message: msg }
+            }
             FhirResourceRejection::MissingResourceType => RestError::BadRequest {
                 message: "Resource must contain resourceType".to_string(),
             },
@@ -100,10 +105,15 @@ where
             .unwrap_or("application/json")
             .to_string();
 
-        // Extract body bytes
-        let bytes = Bytes::from_request(req, state)
-            .await
-            .map_err(|e| FhirResourceRejection::InvalidJson(e.to_string()))?;
+        // Extract body bytes. A length-limit rejection must keep its 413
+        // status instead of collapsing into a generic 400 "invalid JSON".
+        let bytes = Bytes::from_request(req, state).await.map_err(|e| {
+            if e.status() == axum::http::StatusCode::PAYLOAD_TOO_LARGE {
+                FhirResourceRejection::PayloadTooLarge(e.body_text())
+            } else {
+                FhirResourceRejection::InvalidJson(e.body_text())
+            }
+        })?;
 
         // Parse body based on content type
         let value: Value = if content_type.contains("xml") {

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -115,11 +115,19 @@
 //! | `HFS_SERVER_PORT` | 8080 | Server port |
 //! | `HFS_SERVER_HOST` | 127.0.0.1 | Host to bind |
 //! | `HFS_LOG_LEVEL` | info | Log level (error, warn, info, debug, trace) |
-//! | `HFS_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes) |
+//! | `HFS_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes; measured after decompression for compressed requests) |
 //! | `HFS_REQUEST_TIMEOUT` | 30 | Request timeout (seconds) |
 //! | `HFS_ENABLE_CORS` | true | Enable CORS |
 //! | `HFS_CORS_ORIGINS` | * | Allowed CORS origins |
 //! | `HFS_DEFAULT_TENANT` | default | Default tenant ID |
+//!
+//! ## HTTP Compression
+//!
+//! Request bodies sent with `Content-Encoding: gzip` (or `deflate`, `br`,
+//! `zstd`) are decompressed transparently before parsing; unsupported
+//! encodings are rejected with `415 Unsupported Media Type`. Responses are
+//! compressed when the client advertises support via `Accept-Encoding`, with
+//! `Content-Encoding` and `Vary: Accept-Encoding` set accordingly.
 //!
 //! ## Architecture
 //!
@@ -167,7 +175,9 @@ use helios_persistence::core::{
 };
 use tower::ServiceBuilder;
 use tower_http::{
+    compression::CompressionLayer,
     cors::{Any, CorsLayer},
+    decompression::RequestDecompressionLayer,
     timeout::TimeoutLayer,
     trace::TraceLayer,
 };
@@ -509,6 +519,18 @@ where
             axum::http::StatusCode::REQUEST_TIMEOUT,
             std::time::Duration::from_secs(config.request_timeout),
         ));
+
+    // Transparently decompress request bodies sent with `Content-Encoding`
+    // (gzip, deflate, br, zstd) and compress responses when the client sends
+    // `Accept-Encoding`. Unsupported request encodings get 415. Because the
+    // decompression layer replaces the request body before any extractor or
+    // handler reads it, the body-size limit below applies to the
+    // *decompressed* bytes — a small highly-compressed payload cannot bypass
+    // `HFS_MAX_BODY_SIZE`. Kept inside the CORS layer so 415/413 error
+    // responses still carry CORS headers for browser clients.
+    let router = router
+        .layer(RequestDecompressionLayer::new())
+        .layer(CompressionLayer::new());
 
     // Add CORS if enabled
     let router = if config.enable_cors {

--- a/crates/rest/tests/http_compression.rs
+++ b/crates/rest/tests/http_compression.rs
@@ -1,0 +1,262 @@
+//! HTTP compression conformance tests.
+//!
+//! Verifies the middleware stack assembled in `create_app_with_config`:
+//!
+//! - Request bodies sent with `Content-Encoding: gzip`/`deflate` are
+//!   decompressed before parsing.
+//! - Invalid compressed bodies produce a 4xx, unsupported encodings a 415.
+//! - `HFS_MAX_BODY_SIZE` applies to the *decompressed* body, so a small
+//!   highly-compressed payload cannot bypass the limit.
+//! - Responses are gzip-compressed when the client sends
+//!   `Accept-Encoding: gzip` (with `Content-Encoding` and
+//!   `Vary: Accept-Encoding` set) and left identity-encoded otherwise.
+//! - CORS preflight allows the `Content-Encoding` request header.
+
+use std::path::PathBuf;
+
+use axum::http::{Method, StatusCode};
+use axum_test::TestServer;
+use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+use helios_rest::ServerConfig;
+use serde_json::{Value, json};
+
+/// Creates a test server running the full middleware stack.
+fn create_test_server(config: ServerConfig) -> TestServer {
+    // Configure with data directory to load spec SearchParameters
+    // CARGO_MANIFEST_DIR for this test is crates/rest
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("data"))
+        .unwrap_or_else(|| PathBuf::from("data"));
+
+    let backend_config = SqliteBackendConfig {
+        data_dir: Some(data_dir),
+        ..Default::default()
+    };
+    let backend = SqliteBackend::with_config(":memory:", backend_config)
+        .expect("Failed to create SQLite backend");
+    backend.init_schema().expect("Failed to init schema");
+
+    let app = helios_rest::create_app_with_config(backend, config);
+    TestServer::new(app).expect("Failed to create test server")
+}
+
+fn test_config() -> ServerConfig {
+    ServerConfig {
+        default_tenant: "test-tenant".to_string(),
+        ..ServerConfig::for_testing()
+    }
+}
+
+fn patient_json() -> Value {
+    json!({
+        "resourceType": "Patient",
+        "name": [{"family": "Compressed"}],
+        "active": true
+    })
+}
+
+fn gzip_bytes(input: &[u8]) -> Vec<u8> {
+    use flate2::{Compression, write::GzEncoder};
+    use std::io::Write;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(input).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn gunzip_bytes(input: &[u8]) -> Vec<u8> {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+
+    let mut decoder = GzDecoder::new(input);
+    let mut output = Vec::new();
+    decoder.read_to_end(&mut output).unwrap();
+    output
+}
+
+// =============================================================================
+// Request decompression
+// =============================================================================
+
+#[tokio::test]
+async fn test_gzip_request_body_is_decompressed() {
+    let server = create_test_server(test_config());
+    let body = serde_json::to_vec(&patient_json()).unwrap();
+
+    let response = server
+        .post("/Patient")
+        .add_header("x-tenant-id", "test-tenant")
+        .add_header("content-encoding", "gzip")
+        .content_type("application/fhir+json")
+        .bytes(gzip_bytes(&body).into())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::CREATED);
+    let json: Value = response.json();
+    assert_eq!(json["resourceType"], "Patient");
+    assert_eq!(json["name"][0]["family"], "Compressed");
+}
+
+#[tokio::test]
+async fn test_uncompressed_request_still_works() {
+    let server = create_test_server(test_config());
+
+    let response = server
+        .post("/Patient")
+        .add_header("x-tenant-id", "test-tenant")
+        .content_type("application/fhir+json")
+        .json(&patient_json())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn test_invalid_gzip_request_body_is_client_error() {
+    let server = create_test_server(test_config());
+
+    let response = server
+        .post("/Patient")
+        .add_header("x-tenant-id", "test-tenant")
+        .add_header("content-encoding", "gzip")
+        .content_type("application/fhir+json")
+        .bytes(b"this is not gzip".to_vec().into())
+        .await;
+
+    assert!(
+        response.status_code().is_client_error(),
+        "invalid gzip body must produce a 4xx, got {}",
+        response.status_code()
+    );
+}
+
+#[tokio::test]
+async fn test_unsupported_content_encoding_is_rejected() {
+    let server = create_test_server(test_config());
+    let body = serde_json::to_vec(&patient_json()).unwrap();
+
+    let response = server
+        .post("/Patient")
+        .add_header("x-tenant-id", "test-tenant")
+        .add_header("content-encoding", "compress")
+        .content_type("application/fhir+json")
+        .bytes(body.into())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn test_body_limit_applies_to_decompressed_size() {
+    let config = ServerConfig {
+        max_body_size: 1024,
+        ..test_config()
+    };
+    let server = create_test_server(config);
+
+    // ~64 KiB of repeated text compresses to well under the 1 KiB limit,
+    // but the decompressed body must still be rejected with 413.
+    let mut patient = patient_json();
+    patient["name"][0]["family"] = json!("a".repeat(64 * 1024));
+    let raw = serde_json::to_vec(&patient).unwrap();
+    let compressed = gzip_bytes(&raw);
+    assert!(
+        compressed.len() < 1024,
+        "test payload must compress below the limit"
+    );
+
+    let response = server
+        .post("/Patient")
+        .add_header("x-tenant-id", "test-tenant")
+        .add_header("content-encoding", "gzip")
+        .content_type("application/fhir+json")
+        .bytes(compressed.into())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+// =============================================================================
+// Response compression
+// =============================================================================
+
+#[tokio::test]
+async fn test_response_is_gzip_compressed_on_accept_encoding() {
+    let server = create_test_server(test_config());
+
+    let response = server
+        .get("/metadata")
+        .add_header("x-tenant-id", "test-tenant")
+        .add_header("accept-encoding", "gzip")
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
+    let vary = response
+        .headers()
+        .get_all("vary")
+        .iter()
+        .map(|v| v.to_str().unwrap().to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join(",");
+    assert!(vary.contains("accept-encoding"), "Vary was: {vary}");
+
+    let decompressed = gunzip_bytes(response.as_bytes());
+    let json: Value = serde_json::from_slice(&decompressed).unwrap();
+    assert_eq!(json["resourceType"], "CapabilityStatement");
+}
+
+#[tokio::test]
+async fn test_response_is_not_compressed_without_accept_encoding() {
+    let server = create_test_server(test_config());
+
+    let response = server
+        .get("/metadata")
+        .add_header("x-tenant-id", "test-tenant")
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    assert!(response.headers().get("content-encoding").is_none());
+    let json: Value = response.json();
+    assert_eq!(json["resourceType"], "CapabilityStatement");
+}
+
+// =============================================================================
+// CORS
+// =============================================================================
+
+#[tokio::test]
+async fn test_cors_preflight_allows_content_encoding() {
+    // Default config: CORS enabled with the explicit default header list.
+    let config = ServerConfig {
+        default_tenant: "test-tenant".to_string(),
+        ..ServerConfig::default()
+    };
+    let server = create_test_server(config);
+
+    let response = server
+        .method(Method::OPTIONS, "/Patient")
+        .add_header("origin", "http://example.com")
+        .add_header("access-control-request-method", "POST")
+        .add_header("access-control-request-headers", "content-encoding")
+        .await;
+
+    assert!(
+        response.status_code().is_success(),
+        "preflight failed: {}",
+        response.status_code()
+    );
+    let allow_headers = response
+        .headers()
+        .get("access-control-allow-headers")
+        .expect("preflight response must list allowed headers")
+        .to_str()
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(
+        allow_headers.contains("content-encoding"),
+        "Access-Control-Allow-Headers was: {allow_headers}"
+    );
+}

--- a/crates/sof/Cargo.toml
+++ b/crates/sof/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = "1.0"
 anyhow = "1.0"
 axum = { version = "0.8", features = ["json", "query"] }
 tower = { version = "0.5", features = ["full"] }
-tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "timeout", "compression-full", "decompression-full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 http = "1.0"
@@ -60,6 +60,7 @@ bytes = "1.5"
 
 [dev-dependencies]
 axum-test = "18.0"
+flate2 = "1"
 tempfile = "3.8"
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/crates/sof/README.md
+++ b/crates/sof/README.md
@@ -357,6 +357,12 @@ curl http://localhost:8080/metadata
 
 The server can be configured using either command-line arguments or environment variables. Command-line arguments take precedence when both are provided.
 
+Request bodies sent with `Content-Encoding: gzip` (also `deflate`, `br`,
+`zstd`) are decompressed transparently; unsupported encodings are rejected
+with `415`. Responses are compressed when the client sends `Accept-Encoding`,
+except `application/parquet` and `application/zip` output, which is already
+compressed and returned as-is.
+
 ##### Environment Variables
 
 | Variable | Description | Default |
@@ -364,7 +370,7 @@ The server can be configured using either command-line arguments or environment 
 | `SOF_SERVER_PORT` | Server port | `8080` |
 | `SOF_SERVER_HOST` | Server host address | `127.0.0.1` |
 | `SOF_LOG_LEVEL` | Log level (error, warn, info, debug, trace) | `info` |
-| `SOF_MAX_BODY_SIZE` | Maximum request body size in bytes | `10485760` (10MB) |
+| `SOF_MAX_BODY_SIZE` | Maximum request body size in bytes (applies to the decompressed body for compressed requests) | `10485760` (10MB) |
 | `SOF_REQUEST_TIMEOUT` | Request timeout in seconds | `30` |
 | `SOF_ENABLE_CORS` | Enable CORS (true/false) | `true` |
 | `SOF_CORS_ORIGINS` | Allowed CORS origins (comma-separated, * for any) | `*` |

--- a/crates/sof/src/server.rs
+++ b/crates/sof/src/server.rs
@@ -64,13 +64,23 @@
 //! - `SOF_SERVER_PORT` / `--port`: Server port (default: 8080)
 //! - `SOF_SERVER_HOST` / `--host`: Server host (default: 127.0.0.1)
 //! - `SOF_LOG_LEVEL` / `--log-level`: Log level (default: info)
-//! - `SOF_MAX_BODY_SIZE` / `--max-body-size`: Max request size in bytes (default: 10MB)
+//! - `SOF_MAX_BODY_SIZE` / `--max-body-size`: Max request size in bytes (default: 10MB).
+//!   Applies to the decompressed body for compressed requests.
 //! - `SOF_REQUEST_TIMEOUT` / `--request-timeout`: Request timeout in seconds (default: 30)
 //! - `SOF_ENABLE_CORS` / `--enable-cors`: Enable CORS (default: true)
 //! - `SOF_CORS_ORIGINS` / `--cors-origins`: Allowed origins, comma-separated (default: *)
 //! - `SOF_CORS_METHODS` / `--cors-methods`: Allowed methods, comma-separated (default: *)
 //! - `SOF_CORS_HEADERS` / `--cors-headers`: Allowed headers, comma-separated (default: *)
 //! - `SOF_TERMINOLOGY_SERVER` / `--terminology-server`: Terminology server URL for FHIRPath functions
+//!
+//! ## HTTP Compression
+//!
+//! Request bodies sent with `Content-Encoding: gzip` (or `deflate`, `br`,
+//! `zstd`) are decompressed transparently before parsing; unsupported
+//! encodings are rejected with `415 Unsupported Media Type`. Responses are
+//! compressed when the client advertises support via `Accept-Encoding` —
+//! except `application/parquet` and `application/zip` outputs, which are
+//! already compressed and are returned as-is.
 //!
 //! ## CORS Configuration Examples
 //!
@@ -146,7 +156,7 @@ impl Default for ServerConfig {
             enable_cors: true,
             cors_origins: "*".to_string(),
             cors_methods: "GET,POST,PUT,DELETE,OPTIONS".to_string(),
-            cors_headers: "Accept,Accept-Language,Content-Type,Content-Language,Authorization,X-Requested-With".to_string(),
+            cors_headers: "Accept,Accept-Language,Content-Type,Content-Language,Authorization,X-Requested-With,Content-Encoding".to_string(),
             terminology_server: None,
         }
     }
@@ -269,7 +279,7 @@ fn parse_args() -> ServerConfig {
         #[arg(
             long,
             env = "SOF_CORS_HEADERS",
-            default_value = "Accept,Accept-Language,Content-Type,Content-Language,Authorization,X-Requested-With"
+            default_value = "Accept,Accept-Language,Content-Type,Content-Language,Authorization,X-Requested-With,Content-Encoding"
         )]
         cors_headers: String,
 
@@ -306,7 +316,17 @@ fn create_app_with_config(config: &ServerConfig) -> Router {
     use axum::extract::DefaultBodyLimit;
     use std::time::Duration;
     use tower::ServiceBuilder;
+    use tower_http::compression::CompressionLayer;
+    use tower_http::compression::predicate::{NotForContentType, Predicate, SizeAbove};
+    use tower_http::decompression::RequestDecompressionLayer;
     use tower_http::timeout::TimeoutLayer;
+
+    // Compress responses on `Accept-Encoding`, but never re-compress Parquet
+    // or ZIP output — both are already compressed, so HTTP-level compression
+    // would only burn CPU for no size win.
+    let compress_predicate = SizeAbove::new(32)
+        .and(NotForContentType::const_new("application/parquet"))
+        .and(NotForContentType::const_new("application/zip"));
 
     let mut app = Router::new()
         // FHIR endpoints
@@ -317,8 +337,15 @@ fn create_app_with_config(config: &ServerConfig) -> Router {
         )
         // Health check endpoint
         .route("/health", get(handlers::health_check))
-        // Add body size limit
+        // Add body size limit. The decompression layer below replaces the
+        // request body before extractors read it, so this limit applies to
+        // the *decompressed* bytes — a small highly-compressed payload
+        // cannot bypass SOF_MAX_BODY_SIZE.
         .layer(DefaultBodyLimit::max(config.max_body_size))
+        // Decompress request bodies sent with `Content-Encoding` (gzip,
+        // deflate, br, zstd); unsupported encodings get 415.
+        .layer(RequestDecompressionLayer::new())
+        .layer(CompressionLayer::new().compress_when(compress_predicate))
         // Add request timeout
         .layer(
             ServiceBuilder::new()
@@ -453,5 +480,235 @@ mod tests {
         let json: serde_json::Value = response.json();
         assert_eq!(json["status"], "ok");
         assert_eq!(json["service"], "sof-server");
+    }
+
+    // ── HTTP compression ──────────────────────────────────────────────────
+
+    /// A minimal valid `$viewdefinition-run` Parameters body.
+    fn run_request_body() -> serde_json::Value {
+        serde_json::json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {
+                    "name": "viewResource",
+                    "resource": {
+                        "resourceType": "ViewDefinition",
+                        "status": "active",
+                        "resource": "Patient",
+                        "select": [{
+                            "column": [
+                                {"name": "id", "path": "id"},
+                                {"name": "gender", "path": "gender"}
+                            ]
+                        }]
+                    }
+                },
+                {
+                    "name": "resource",
+                    "resource": {
+                        "resourceType": "Patient",
+                        "id": "example",
+                        "gender": "male"
+                    }
+                }
+            ]
+        })
+    }
+
+    fn gzip_bytes(input: &[u8]) -> Vec<u8> {
+        use flate2::{Compression, write::GzEncoder};
+        use std::io::Write;
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(input).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn gunzip_bytes(input: &[u8]) -> Vec<u8> {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        let mut decoder = GzDecoder::new(input);
+        let mut output = Vec::new();
+        decoder.read_to_end(&mut output).unwrap();
+        output
+    }
+
+    #[tokio::test]
+    async fn test_gzip_request_body_is_decompressed() {
+        let server = TestServer::new(create_app()).unwrap();
+        let body = serde_json::to_vec(&run_request_body()).unwrap();
+
+        let response = server
+            .post("/ViewDefinition/$viewdefinition-run")
+            .add_header("content-encoding", "gzip")
+            .add_header("accept", "application/json")
+            .content_type("application/json")
+            .bytes(gzip_bytes(&body).into())
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+        let json: serde_json::Value = response.json();
+        assert_eq!(json[0]["id"], "example");
+    }
+
+    #[tokio::test]
+    async fn test_deflate_request_body_is_decompressed() {
+        use flate2::{Compression, write::ZlibEncoder};
+        use std::io::Write;
+
+        let server = TestServer::new(create_app()).unwrap();
+        let body = serde_json::to_vec(&run_request_body()).unwrap();
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&body).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let response = server
+            .post("/ViewDefinition/$viewdefinition-run")
+            .add_header("content-encoding", "deflate")
+            .add_header("accept", "application/json")
+            .content_type("application/json")
+            .bytes(compressed.into())
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_uncompressed_request_still_works() {
+        let server = TestServer::new(create_app()).unwrap();
+
+        let response = server
+            .post("/ViewDefinition/$viewdefinition-run")
+            .add_header("accept", "application/json")
+            .json(&run_request_body())
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_gzip_request_body_is_client_error() {
+        let server = TestServer::new(create_app()).unwrap();
+
+        let response = server
+            .post("/ViewDefinition/$viewdefinition-run")
+            .add_header("content-encoding", "gzip")
+            .content_type("application/json")
+            .bytes(b"this is not gzip".to_vec().into())
+            .await;
+
+        assert!(
+            response.status_code().is_client_error(),
+            "invalid gzip body must produce a 4xx, got {}",
+            response.status_code()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_content_encoding_is_rejected() {
+        let server = TestServer::new(create_app()).unwrap();
+        let body = serde_json::to_vec(&run_request_body()).unwrap();
+
+        let response = server
+            .post("/ViewDefinition/$viewdefinition-run")
+            .add_header("content-encoding", "compress")
+            .content_type("application/json")
+            .bytes(body.into())
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_response_is_gzip_compressed_on_accept_encoding() {
+        let server = TestServer::new(create_app()).unwrap();
+
+        let response = server
+            .get("/metadata")
+            .add_header("accept-encoding", "gzip")
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+        assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
+        let vary = response
+            .headers()
+            .get_all("vary")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_ascii_lowercase())
+            .collect::<Vec<_>>()
+            .join(",");
+        assert!(vary.contains("accept-encoding"), "Vary was: {vary}");
+
+        let decompressed = gunzip_bytes(response.as_bytes());
+        let json: serde_json::Value = serde_json::from_slice(&decompressed).unwrap();
+        assert_eq!(json["resourceType"], "CapabilityStatement");
+    }
+
+    #[tokio::test]
+    async fn test_response_is_not_compressed_without_accept_encoding() {
+        let server = TestServer::new(create_app()).unwrap();
+
+        let response = server.get("/metadata").await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+        assert!(response.headers().get("content-encoding").is_none());
+        let json: serde_json::Value = response.json();
+        assert_eq!(json["resourceType"], "CapabilityStatement");
+    }
+
+    #[tokio::test]
+    async fn test_parquet_response_is_not_http_compressed() {
+        let server = TestServer::new(create_app()).unwrap();
+        let mut body = run_request_body();
+        body["parameter"].as_array_mut().unwrap().insert(
+            0,
+            serde_json::json!({"name": "_format", "valueCode": "application/parquet"}),
+        );
+
+        let response = server
+            .post("/ViewDefinition/$viewdefinition-run")
+            .add_header("accept-encoding", "gzip")
+            .json(&body)
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/parquet"
+        );
+        // Parquet is already compressed — the gzip layer must skip it.
+        assert!(response.headers().get("content-encoding").is_none());
+        assert!(response.as_bytes().starts_with(b"PAR1"));
+    }
+
+    #[tokio::test]
+    async fn test_body_limit_applies_to_decompressed_size() {
+        let config = ServerConfig {
+            max_body_size: 1024,
+            ..Default::default()
+        };
+        let server = TestServer::new(create_app_with_config(&config)).unwrap();
+
+        // ~64 KiB of repeated text compresses to well under the 1 KiB limit,
+        // but the decompressed body must still be rejected with 413.
+        let mut body = run_request_body();
+        body["parameter"][1]["resource"]["name"] =
+            serde_json::json!([{"family": "a".repeat(64 * 1024)}]);
+        let raw = serde_json::to_vec(&body).unwrap();
+        let compressed = gzip_bytes(&raw);
+        assert!(
+            compressed.len() < 1024,
+            "test payload must compress below the limit"
+        );
+
+        let response = server
+            .post("/ViewDefinition/$viewdefinition-run")
+            .add_header("content-encoding", "gzip")
+            .content_type("application/json")
+            .bytes(compressed.into())
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }


### PR DESCRIPTION
## Summary

Adds HTTP compression support to all three server binaries (`hfs` via `crates/rest`, `sof-server`, `hts`) and makes the request body-size limit uniform across them.

### Request decompression

- Request bodies sent with `Content-Encoding: gzip` / `deflate` / `br` / `zstd` are decompressed transparently before parsing (`tower_http::decompression::RequestDecompressionLayer`).
- Unsupported encodings are rejected with `415 Unsupported Media Type`; invalid compressed streams produce a 4xx instead of a parse failure deeper in the stack.
- Uncompressed requests are fully backward compatible.

### Response compression

- Responses are compressed when the client advertises support via `Accept-Encoding`, with `Content-Encoding` and `Vary: Accept-Encoding` set (`tower_http::compression::CompressionLayer`).
- SOF excludes `application/parquet` and `application/zip` output from compression — both are already compressed, so HTTP-level gzip would only burn CPU.

### Body-size limits

- The decompression layer runs before extractors, so `HFS_MAX_BODY_SIZE` / `SOF_MAX_BODY_SIZE` / `HTS_MAX_BODY_SIZE` are enforced on the **decompressed** body — a small highly-compressed payload cannot bypass the limit.
- New `HTS_MAX_BODY_SIZE` env var / `--max-body-size` flag (bytes, default `10485760`) gives HTS its first configurable limit, mirroring the existing HFS/SOF variables. HTS was previously stuck at axum's implicit 2 MiB default.

### Adjacent fixes

- **REST:** exceeding the body limit now returns `413` with a `too-long` OperationOutcome (new `RestError::PayloadTooLarge`). Previously the rejection collapsed into a generic `400 "Invalid JSON"`, for uncompressed requests too.
- **HTS CORS:** the explicit-origin path only set `allow-origin`, so every browser preflight failed. It now sets allow-methods and allow-headers (including `Content-Encoding`).
- `Content-Encoding` added to the default CORS allow-header lists of rest and sof so browser clients can send compressed bodies through preflight.

## Tests

25 new integration tests across the three crates (`crates/rest/tests/http_compression.rs`, `crates/hts/tests/http_compression.rs`, inline in `crates/sof/src/server.rs`) covering: gzip/deflate request bodies, invalid gzip → 4xx, unsupported encoding → 415, response compression + `Vary`, identity responses without `Accept-Encoding`, parquet exclusion, decompressed-size limit enforcement (413), and CORS preflight for `content-encoding`.

Validated with `cargo fmt --all`, clippy with the CI flag set (clean), and full `cargo test` runs for `helios-rest`, `helios-hts`, and `helios-sof`.

## Docs

Updated env-var tables and added compression notes in `CLAUDE.md`, the root `README.md`, the `hfs`/`rest`/`sof`/`hts` crate READMEs, and the mdBook pages (`configuration/environment-variables.md`, `ch06-sql-on-fhir.md`, `components/sql-on-fhir.md`, `appendix-a-cli.md`).