### PR TITLE
feat(fhirpath): HTTP compression and configurable body-size limit on fhirpath-server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,7 +374,10 @@ FHIRPATH_SERVER_PORT=8080 FHIRPATH_SERVER_HOST=0.0.0.0 cargo run --bin fhirpath-
 | `FHIRPATH_LOG_LEVEL` | info | Log level |
 | `FHIRPATH_ENABLE_CORS` | true | Enable CORS |
 | `FHIRPATH_CORS_ORIGINS` | * | Allowed origins |
+| `FHIRPATH_MAX_BODY_SIZE` | 10485760 | Max request body size (bytes; measured after decompression for compressed requests) |
 | `FHIRPATH_TERMINOLOGY_SERVER` | (none) | Terminology server URL |
+
+Request bodies sent with `Content-Encoding: gzip`/`deflate`/`br`/`zstd` are decompressed transparently before parsing (unsupported encodings → `415`); responses are compressed when the client sends `Accept-Encoding`. The body-size limit is enforced on the decompressed body.
 
 ## SOF Server Configuration
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,6 +3033,7 @@ dependencies = [
  "chumsky",
  "clap",
  "criterion",
+ "flate2",
  "futures",
  "helios-fhir",
  "helios-fhirpath-support",
@@ -3053,7 +3054,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower",
- "tower-http 0.5.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3122,7 +3123,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tower",
- "tower-http 0.6.8",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3171,7 +3172,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-test",
- "tower-http 0.6.8",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
@@ -3208,7 +3209,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tower",
- "tower-http 0.6.8",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3273,7 +3274,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower",
- "tower-http 0.6.8",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5722,7 +5723,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http 0.6.8",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6987,23 +6988,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.11.1",
- "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/crates/fhirpath/Cargo.toml
+++ b/crates/fhirpath/Cargo.toml
@@ -43,7 +43,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8" }
 tower = { version = "0.5" }
-tower-http = { version = "0.5", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "compression-full", "decompression-full"] }
 http = { version = "1.0" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -53,6 +53,7 @@ axum-test = "18.0"
 tempfile = "3.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 futures = "0.3"
+flate2 = "1" # gzip/deflate test payloads for HTTP compression tests
 
 [[bin]]
 name = "fhirpath-cli"

--- a/crates/fhirpath/README.md
+++ b/crates/fhirpath/README.md
@@ -761,7 +761,17 @@ The server can be configured via command-line arguments or environment variables
 | `FHIRPATH_CORS_ORIGINS` | `--cors-origins` | Allowed origins (comma-separated) | `*` |
 | `FHIRPATH_CORS_METHODS` | `--cors-methods` | Allowed methods | `GET,POST,OPTIONS` |
 | `FHIRPATH_CORS_HEADERS` | `--cors-headers` | Allowed headers | Common headers |
+| `FHIRPATH_MAX_BODY_SIZE` | `--max-body-size` | Max request body size in bytes, measured after decompression | `10485760` |
 | `FHIRPATH_DEBUG_TRACE` | — | Enable step-by-step debug trace output | `false` |
+
+#### HTTP Compression
+
+Request bodies sent with `Content-Encoding: gzip` (or `deflate`, `br`, `zstd`)
+are decompressed transparently before parsing; unsupported encodings are
+rejected with `415 Unsupported Media Type`. Responses are compressed when the
+client advertises support via `Accept-Encoding`, with `Content-Encoding` and
+`Vary: Accept-Encoding` set. Because `FHIRPATH_MAX_BODY_SIZE` is enforced on the
+decompressed body, a small highly-compressed payload cannot bypass the limit.
 
 #### Starting the Server
 

--- a/crates/fhirpath/src/server.rs
+++ b/crates/fhirpath/src/server.rs
@@ -12,6 +12,7 @@
 //! - **Variable Support**: Pass variables to expressions
 //! - **Context Expressions**: Evaluate expressions with context
 //! - **CORS Support**: Configurable cross-origin resource sharing
+//! - **HTTP Compression**: Transparent request decompression and response compression
 //! - **Health Check**: Basic health check endpoint
 //!
 //! ## API Endpoints
@@ -52,6 +53,18 @@
 //! - `FHIRPATH_LOG_LEVEL` / `--log-level`: Log level (default: info)
 //! - `FHIRPATH_ENABLE_CORS` / `--enable-cors`: Enable CORS (default: true)
 //! - `FHIRPATH_CORS_ORIGINS` / `--cors-origins`: Allowed origins (default: *)
+//! - `FHIRPATH_MAX_BODY_SIZE` / `--max-body-size`: Max request body size in
+//!   bytes, measured after decompression (default: 10485760)
+//!
+//! ## HTTP Compression
+//!
+//! Request bodies sent with `Content-Encoding: gzip` (or `deflate`, `br`,
+//! `zstd`) are decompressed transparently before parsing; unsupported
+//! encodings are rejected with `415 Unsupported Media Type`. Responses are
+//! compressed when the client advertises support via `Accept-Encoding`, with
+//! `Content-Encoding` and `Vary: Accept-Encoding` set accordingly. Because the
+//! body-size limit is enforced on the decompressed body, a small
+//! highly-compressed payload cannot bypass `FHIRPATH_MAX_BODY_SIZE`.
 //!
 //! ## Usage Example
 //!
@@ -70,14 +83,22 @@
 
 use axum::{
     Router,
+    extract::DefaultBodyLimit,
     routing::{get, post},
 };
 use clap::Parser;
 use http::{HeaderValue, Method};
 use std::net::SocketAddr;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
+use tower_http::decompression::RequestDecompressionLayer;
 use tower_http::trace::TraceLayer;
 use tracing::{info, warn};
+
+/// Default maximum request body size in bytes (10 MiB), measured after
+/// decompression. Mirrors `HFS_MAX_BODY_SIZE` / `SOF_MAX_BODY_SIZE` /
+/// `HTS_MAX_BODY_SIZE`.
+const DEFAULT_MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
 
 use crate::handlers::{evaluate_fhirpath, health_check};
 
@@ -98,6 +119,8 @@ pub struct ServerConfig {
     pub cors_methods: String,
     /// Allowed CORS headers (comma-separated list, "*" for any)
     pub cors_headers: String,
+    /// Maximum request body size in bytes, measured after decompression
+    pub max_body_size: usize,
     /// Terminology server URL (defaults based on FHIR version)
     pub terminology_server: Option<String>,
 }
@@ -111,8 +134,10 @@ impl Default for ServerConfig {
             enable_cors: true,
             cors_origins: "*".to_string(),
             cors_methods: "GET,POST,OPTIONS".to_string(),
-            cors_headers: "Accept,Accept-Language,Content-Type,Content-Language,Authorization"
-                .to_string(),
+            cors_headers:
+                "Accept,Accept-Language,Content-Type,Content-Language,Authorization,Content-Encoding"
+                    .to_string(),
+            max_body_size: DEFAULT_MAX_BODY_SIZE,
             terminology_server: None,
         }
     }
@@ -124,7 +149,7 @@ impl Default for ServerConfig {
     author,
     version,
     about = "FHIRPath HTTP server",
-    long_about = "HTTP server providing FHIRPath expression evaluation for fhirpath-lab integration\n\nEnvironment variables:\n  FHIRPATH_SERVER_PORT - Server port (default: 3000)\n  FHIRPATH_SERVER_HOST - Server host (default: 127.0.0.1)\n  FHIRPATH_LOG_LEVEL - Log level: error, warn, info, debug, trace (default: info)\n  FHIRPATH_ENABLE_CORS - Enable CORS: true/false (default: true)\n  FHIRPATH_CORS_ORIGINS - Allowed origins (comma-separated, * for any) (default: *)\n  FHIRPATH_CORS_METHODS - Allowed methods (comma-separated, * for any) (default: GET,POST,OPTIONS)\n  FHIRPATH_CORS_HEADERS - Allowed headers (comma-separated, * for any) (default: common headers)\n  FHIRPATH_TERMINOLOGY_SERVER - Terminology server URL (default: version-specific test servers)"
+    long_about = "HTTP server providing FHIRPath expression evaluation for fhirpath-lab integration\n\nEnvironment variables:\n  FHIRPATH_SERVER_PORT - Server port (default: 3000)\n  FHIRPATH_SERVER_HOST - Server host (default: 127.0.0.1)\n  FHIRPATH_LOG_LEVEL - Log level: error, warn, info, debug, trace (default: info)\n  FHIRPATH_ENABLE_CORS - Enable CORS: true/false (default: true)\n  FHIRPATH_CORS_ORIGINS - Allowed origins (comma-separated, * for any) (default: *)\n  FHIRPATH_CORS_METHODS - Allowed methods (comma-separated, * for any) (default: GET,POST,OPTIONS)\n  FHIRPATH_CORS_HEADERS - Allowed headers (comma-separated, * for any) (default: common headers)\n  FHIRPATH_MAX_BODY_SIZE - Max request body size in bytes, measured after decompression (default: 10485760)\n  FHIRPATH_TERMINOLOGY_SERVER - Terminology server URL (default: version-specific test servers)"
 )]
 pub struct ServerArgs {
     /// Port to bind the server to
@@ -169,9 +194,17 @@ pub struct ServerArgs {
     #[arg(
         long,
         env = "FHIRPATH_CORS_HEADERS",
-        default_value = "Accept,Accept-Language,Content-Type,Content-Language,Authorization"
+        default_value = "Accept,Accept-Language,Content-Type,Content-Language,Authorization,Content-Encoding"
     )]
     pub cors_headers: String,
+
+    /// Maximum request body size in bytes, measured after decompression
+    #[arg(
+        long,
+        env = "FHIRPATH_MAX_BODY_SIZE",
+        default_value_t = DEFAULT_MAX_BODY_SIZE
+    )]
+    pub max_body_size: usize,
 
     /// Terminology server URL (defaults based on FHIR version)
     #[arg(long, env = "FHIRPATH_TERMINOLOGY_SERVER")]
@@ -188,6 +221,7 @@ impl From<ServerArgs> for ServerConfig {
             cors_origins: args.cors_origins,
             cors_methods: args.cors_methods,
             cors_headers: args.cors_headers,
+            max_body_size: args.max_body_size,
             terminology_server: args.terminology_server,
         }
     }
@@ -260,10 +294,29 @@ pub fn create_app(config: &ServerConfig) -> Router {
         app = app.route("/r6", post(crate::handlers::evaluate_fhirpath_r6));
     }
 
+    // Transparently decompress request bodies sent with `Content-Encoding`
+    // (gzip, deflate, br, zstd) and compress responses when the client sends
+    // `Accept-Encoding`. Unsupported request encodings get 415. Because the
+    // decompression layer replaces the request body before any extractor or
+    // handler reads it, the body-size limit below applies to the
+    // *decompressed* bytes — a small highly-compressed payload cannot bypass
+    // `FHIRPATH_MAX_BODY_SIZE`. Kept inside the CORS layer so 415/413 error
+    // responses still carry CORS headers for browser clients.
+    app = app
+        .layer(RequestDecompressionLayer::new())
+        .layer(CompressionLayer::new());
+
     // Add CORS if enabled
     if config.enable_cors {
         app = app.layer(build_cors_layer(config));
     }
+
+    // Raise the body-size limit from axum's 2 MiB default to the configured
+    // ceiling so `FHIRPATH_MAX_BODY_SIZE` / `--max-body-size` actually takes
+    // effect. Without this, axum's `DefaultBodyLimit` extractor rejects any
+    // request > 2 MiB with 413 before the handler runs. Mirrors the pattern
+    // used in `crates/rest/src/lib.rs` and `crates/sof/src/server.rs`.
+    app = app.layer(DefaultBodyLimit::max(config.max_body_size));
 
     // Add tracing
     app = app.layer(TraceLayer::new_for_http());
@@ -405,8 +458,9 @@ mod tests {
         assert_eq!(config.cors_methods, "GET,POST,OPTIONS");
         assert_eq!(
             config.cors_headers,
-            "Accept,Accept-Language,Content-Type,Content-Language,Authorization"
+            "Accept,Accept-Language,Content-Type,Content-Language,Authorization,Content-Encoding"
         );
+        assert_eq!(config.max_body_size, 10 * 1024 * 1024);
     }
 
     #[test]
@@ -419,6 +473,7 @@ mod tests {
             cors_origins: "http://example.com".to_string(),
             cors_methods: "GET,POST".to_string(),
             cors_headers: "Content-Type".to_string(),
+            max_body_size: 2048,
             terminology_server: None,
         };
 
@@ -430,6 +485,7 @@ mod tests {
         assert_eq!(config.cors_origins, "http://example.com");
         assert_eq!(config.cors_methods, "GET,POST");
         assert_eq!(config.cors_headers, "Content-Type");
+        assert_eq!(config.max_body_size, 2048);
     }
 
     #[tokio::test]

--- a/crates/fhirpath/tests/http_compression.rs
+++ b/crates/fhirpath/tests/http_compression.rs
@@ -1,0 +1,261 @@
+//! HTTP compression conformance tests for the FHIRPath server.
+//!
+//! Verifies the middleware stack assembled in `create_app`:
+//!
+//! - Request bodies sent with `Content-Encoding: gzip`/`deflate` are
+//!   decompressed before parsing.
+//! - Invalid compressed bodies produce a 4xx, unsupported encodings a 415.
+//! - `FHIRPATH_MAX_BODY_SIZE` applies to the *decompressed* body, so a small
+//!   highly-compressed payload cannot bypass the limit.
+//! - Responses are gzip-compressed when the client sends
+//!   `Accept-Encoding: gzip` (with `Content-Encoding` and
+//!   `Vary: Accept-Encoding` set) and left identity-encoded otherwise.
+//! - CORS preflight allows the `Content-Encoding` request header.
+
+use axum::http::{Method, StatusCode};
+use axum_test::TestServer;
+use helios_fhirpath::server::{ServerConfig, create_app};
+use serde_json::{Value, json};
+
+fn create_test_server(config: ServerConfig) -> TestServer {
+    let app = create_app(&config);
+    TestServer::new(app).expect("Failed to create test server")
+}
+
+/// A valid fhirpath-lab evaluation request: `Patient.name.family` over a
+/// minimal Patient resource.
+fn evaluation_request() -> Value {
+    json!({
+        "resourceType": "Parameters",
+        "parameter": [
+            {
+                "name": "expression",
+                "valueString": "Patient.name.family"
+            },
+            {
+                "name": "resource",
+                "resource": {
+                    "resourceType": "Patient",
+                    "name": [{ "family": "Compressed" }]
+                }
+            }
+        ]
+    })
+}
+
+fn gzip_bytes(input: &[u8]) -> Vec<u8> {
+    use flate2::{Compression, write::GzEncoder};
+    use std::io::Write;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(input).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn deflate_bytes(input: &[u8]) -> Vec<u8> {
+    use flate2::{Compression, write::ZlibEncoder};
+    use std::io::Write;
+
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(input).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn gunzip_bytes(input: &[u8]) -> Vec<u8> {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+
+    let mut decoder = GzDecoder::new(input);
+    let mut output = Vec::new();
+    decoder.read_to_end(&mut output).unwrap();
+    output
+}
+
+// =============================================================================
+// Request decompression
+// =============================================================================
+
+#[tokio::test]
+async fn test_gzip_request_body_is_decompressed() {
+    let server = create_test_server(ServerConfig::default());
+    let body = serde_json::to_vec(&evaluation_request()).unwrap();
+
+    let response = server
+        .post("/")
+        .add_header("content-encoding", "gzip")
+        .content_type("application/json")
+        .bytes(gzip_bytes(&body).into())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let json: Value = response.json();
+    assert_eq!(json["resourceType"], "Parameters");
+}
+
+#[tokio::test]
+async fn test_deflate_request_body_is_decompressed() {
+    let server = create_test_server(ServerConfig::default());
+    let body = serde_json::to_vec(&evaluation_request()).unwrap();
+
+    let response = server
+        .post("/")
+        .add_header("content-encoding", "deflate")
+        .content_type("application/json")
+        .bytes(deflate_bytes(&body).into())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let json: Value = response.json();
+    assert_eq!(json["resourceType"], "Parameters");
+}
+
+#[tokio::test]
+async fn test_uncompressed_request_still_works() {
+    let server = create_test_server(ServerConfig::default());
+
+    let response = server
+        .post("/")
+        .content_type("application/json")
+        .json(&evaluation_request())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let json: Value = response.json();
+    assert_eq!(json["resourceType"], "Parameters");
+}
+
+#[tokio::test]
+async fn test_invalid_gzip_request_body_is_client_error() {
+    let server = create_test_server(ServerConfig::default());
+
+    let response = server
+        .post("/")
+        .add_header("content-encoding", "gzip")
+        .content_type("application/json")
+        .bytes(b"this is not gzip".to_vec().into())
+        .await;
+
+    assert!(
+        response.status_code().is_client_error(),
+        "invalid gzip body must produce a 4xx, got {}",
+        response.status_code()
+    );
+}
+
+#[tokio::test]
+async fn test_unsupported_content_encoding_is_rejected() {
+    let server = create_test_server(ServerConfig::default());
+    let body = serde_json::to_vec(&evaluation_request()).unwrap();
+
+    let response = server
+        .post("/")
+        .add_header("content-encoding", "compress")
+        .content_type("application/json")
+        .bytes(body.into())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn test_body_limit_applies_to_decompressed_size() {
+    let config = ServerConfig {
+        max_body_size: 1024,
+        ..ServerConfig::default()
+    };
+    let server = create_test_server(config);
+
+    // ~64 KiB of repeated text compresses to well under the 1 KiB limit,
+    // but the decompressed body must still be rejected with 413.
+    let mut request = evaluation_request();
+    request["parameter"][0]["valueString"] = json!(format!("'{}'", "a".repeat(64 * 1024)));
+    let raw = serde_json::to_vec(&request).unwrap();
+    let compressed = gzip_bytes(&raw);
+    assert!(
+        compressed.len() < 1024,
+        "test payload must compress below the limit"
+    );
+
+    let response = server
+        .post("/")
+        .add_header("content-encoding", "gzip")
+        .content_type("application/json")
+        .bytes(compressed.into())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+// =============================================================================
+// Response compression
+// =============================================================================
+
+#[tokio::test]
+async fn test_response_is_gzip_compressed_on_accept_encoding() {
+    let server = create_test_server(ServerConfig::default());
+
+    let response = server
+        .get("/health")
+        .add_header("accept-encoding", "gzip")
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
+    let vary = response
+        .headers()
+        .get_all("vary")
+        .iter()
+        .map(|v| v.to_str().unwrap().to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join(",");
+    assert!(vary.contains("accept-encoding"), "Vary was: {vary}");
+
+    let decompressed = gunzip_bytes(response.as_bytes());
+    let json: Value = serde_json::from_slice(&decompressed).unwrap();
+    assert_eq!(json["status"], "ok");
+}
+
+#[tokio::test]
+async fn test_response_is_not_compressed_without_accept_encoding() {
+    let server = create_test_server(ServerConfig::default());
+
+    let response = server.get("/health").await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    assert!(response.headers().get("content-encoding").is_none());
+    let json: Value = response.json();
+    assert_eq!(json["status"], "ok");
+}
+
+// =============================================================================
+// CORS
+// =============================================================================
+
+#[tokio::test]
+async fn test_cors_preflight_allows_content_encoding() {
+    let server = create_test_server(ServerConfig::default());
+
+    let response = server
+        .method(Method::OPTIONS, "/")
+        .add_header("origin", "http://example.com")
+        .add_header("access-control-request-method", "POST")
+        .add_header("access-control-request-headers", "content-encoding")
+        .await;
+
+    assert!(
+        response.status_code().is_success(),
+        "preflight failed: {}",
+        response.status_code()
+    );
+    let allow_headers = response
+        .headers()
+        .get("access-control-allow-headers")
+        .expect("preflight response must list allowed headers")
+        .to_str()
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(
+        allow_headers.contains("content-encoding"),
+        "Access-Control-Allow-Headers was: {allow_headers}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #142, which added HTTP compression and uniform body-size limits to the `hfs`, `sof-server`, and `hts` binaries. `fhirpath-server` was the one server binary left out — this brings it in line.

### Request decompression
- Request bodies sent with `Content-Encoding: gzip` / `deflate` / `br` / `zstd` are decompressed transparently before parsing (`tower_http::decompression::RequestDecompressionLayer`).
- Unsupported encodings are rejected with `415 Unsupported Media Type`; invalid compressed streams produce a 4xx.
- Uncompressed requests are fully backward compatible.

### Response compression
- Responses are compressed when the client advertises support via `Accept-Encoding`, with `Content-Encoding` and `Vary: Accept-Encoding` set (`tower_http::compression::CompressionLayer`).

### Body-size limit
- New `FHIRPATH_MAX_BODY_SIZE` env var / `--max-body-size` flag (bytes, default `10485760`). `fhirpath-server` previously had **no** configurable limit and was stuck at axum's implicit 2 MiB default — the same gap that #68 fixed for the REST router.
- The decompression layer runs before the `Json` extractor, so the limit is enforced on the **decompressed** body: a small highly-compressed payload cannot bypass it.

### CORS
- `Content-Encoding` added to the default CORS allow-header list so browser clients can send compressed bodies through preflight.

### Dependency
- Bumps `tower-http` `0.5 → 0.6` (with `compression-full` / `decompression-full`) to match the other server crates. This also drops the last `0.5` from the dependency tree — fhirpath was the only crate still on it.

## Tests

9 new integration tests in `crates/fhirpath/tests/http_compression.rs`: gzip/deflate request bodies, invalid gzip → 4xx, unsupported encoding → 415, response compression + `Vary`, identity responses without `Accept-Encoding`, decompressed-size limit enforcement (413), and CORS preflight for `content-encoding`.

Validated with `cargo fmt --all`, clippy with the CI flag set (clean), and `cargo test -p helios-fhirpath`.

## Docs

Updated the env-var tables / compression notes in `CLAUDE.md` and the `helios-fhirpath` crate README.