### PR TITLE
feat(hts): multilingual SNOMED CT support (#148) + all-language generalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -608,6 +608,12 @@ Load terminology packages directly from the filesystem without going through the
 cargo run --bin hts -- import ./hl7.terminology.r4-6.0.0.tgz
 
 # SNOMED CT RF2 ZIP  ⚠️  requires NRC license
+# Descriptions in all languages (incl. per-language Description files from
+# national extensions) are imported as FHIR concept.designation entries
+# tagged with the RF2 language code; language refsets pick the preferred
+# synonym for display (en-US, then en-GB) and add dialect-tagged
+# preferredForLanguage designations. Query via displayLanguage or the
+# Accept-Language header on $lookup / $expand / $validate-code.
 cargo run --bin hts -- import ./SnomedCT_InternationalRF2_*.zip --format snomed-rf2
 
 # LOINC CSV ZIP  ⚠️  requires free Regenstrief registration at loinc.org

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -610,10 +610,12 @@ cargo run --bin hts -- import ./hl7.terminology.r4-6.0.0.tgz
 # SNOMED CT RF2 ZIP  ⚠️  requires NRC license
 # Descriptions in all languages (incl. per-language Description files from
 # national extensions) are imported as FHIR concept.designation entries
-# tagged with the RF2 language code; language refsets pick the preferred
-# synonym for display (en-US, then en-GB) and add dialect-tagged
-# preferredForLanguage designations. Query via displayLanguage or the
-# Accept-Language header on $lookup / $expand / $validate-code.
+# tagged with the RF2 language code; every language refset marks its
+# preferred synonyms with preferredForLanguage designations (bare language
+# tag, plus a dialect tag like en-US/da-DK/fr-CA for the published national
+# refsets) and en-US→en-GB preference picks the display. Query via
+# displayLanguage or the Accept-Language header on $lookup / $expand /
+# $validate-code; matching is BCP-47-aware (de-DE finds de, fr accepts fr-CA).
 cargo run --bin hts -- import ./SnomedCT_InternationalRF2_*.zip --format snomed-rf2
 
 # LOINC CSV ZIP  ⚠️  requires free Regenstrief registration at loinc.org

--- a/crates/hts/README.md
+++ b/crates/hts/README.md
@@ -755,11 +755,17 @@ per-language Description files shipped by national extensions, e.g.
 `sct2_Description_Snapshot-de_*.txt`) are imported as FHIR
 `concept.designation` entries tagged with the RF2 language code and a `use`
 Coding carrying the SNOMED description type (FSN / synonym). Language
-reference sets are used to pick the preferred synonym for the concept
-`display` (US English first, then GB English) and to add dialect-tagged
-`en-US` / `en-GB` `preferredForLanguage` designations. `$lookup`, `$expand`,
-and `$validate-code` resolve these via the `displayLanguage` parameter or the
-`Accept-Language` HTTP header:
+reference sets — every one in the archive, not just the English ones — are
+used to pick the preferred synonym for the concept `display` (US English
+first, then GB English) and to add `preferredForLanguage` designations for
+each refset-preferred synonym: one tagged with its bare RF2 language code,
+plus a BCP-47 dialect-tagged copy (`en-US`, `en-GB`, `da-DK`, `fr-CA`,
+`nl-BE`, `sv-SE`, …) when the refset is one of the published
+national-edition language refsets. `$lookup`, `$expand`, and
+`$validate-code` resolve these via the `displayLanguage` parameter or the
+`Accept-Language` HTTP header. Language matching is BCP-47-aware (RFC 4647):
+a request for `de-DE` (what a browser typically sends) finds designations
+tagged `de`, and a request for `fr` accepts `fr-CA`:
 
 ```bash
 curl -X POST http://localhost:8090/CodeSystem/\$lookup \

--- a/crates/hts/README.md
+++ b/crates/hts/README.md
@@ -768,6 +768,16 @@ curl -X POST http://localhost:8090/CodeSystem/\$lookup \
   -d '{"resourceType":"Parameters","parameter":[{"name":"system","valueUri":"http://snomed.info/sct"},{"name":"code","valueCode":"22298006"}]}'
 ```
 
+Multiple editions of the same code system (e.g. the SNOMED International
+release plus a national edition) coexist as separate versions keyed on
+`(url, version)`; unversioned requests resolve to the highest version.
+When the requested `displayLanguage` has no designation in that version,
+`$lookup` falls back to the newest *other* stored version that carries the
+language (`$expand` and `$validate-code` match designations across versions
+of the canonical URL by design) — so a German term from a national edition
+is still found when a newer international release is the default. Pinning
+`version` disables the fallback.
+
 ---
 
 ### LOINC

--- a/crates/hts/README.md
+++ b/crates/hts/README.md
@@ -750,6 +750,24 @@ hts import ./SnomedCT_InternationalRF2_PRODUCTION_20250901T120000Z.zip --format 
 
 For large imports, add `--batch-size 200 --verbose` to monitor progress.
 
+Descriptions in **all languages** present in the archive (including the
+per-language Description files shipped by national extensions, e.g.
+`sct2_Description_Snapshot-de_*.txt`) are imported as FHIR
+`concept.designation` entries tagged with the RF2 language code and a `use`
+Coding carrying the SNOMED description type (FSN / synonym). Language
+reference sets are used to pick the preferred synonym for the concept
+`display` (US English first, then GB English) and to add dialect-tagged
+`en-US` / `en-GB` `preferredForLanguage` designations. `$lookup`, `$expand`,
+and `$validate-code` resolve these via the `displayLanguage` parameter or the
+`Accept-Language` HTTP header:
+
+```bash
+curl -X POST http://localhost:8090/CodeSystem/\$lookup \
+  -H "Content-Type: application/fhir+json" \
+  -H "Accept-Language: de" \
+  -d '{"resourceType":"Parameters","parameter":[{"name":"system","valueUri":"http://snomed.info/sct"},{"name":"code","valueCode":"22298006"}]}'
+```
+
 ---
 
 ### LOINC

--- a/crates/hts/src/backends/postgres/code_system.rs
+++ b/crates/hts/src/backends/postgres/code_system.rs
@@ -156,9 +156,11 @@ impl CodeSystemOperations for PostgresTerminologyBackend {
         // `concept_designations`).
         if let Some(lang) = req.display_language.as_deref() {
             if req.version.is_none()
-                && !all_designations
-                    .iter()
-                    .any(|d| d.language.as_deref() == Some(lang))
+                && !all_designations.iter().any(|d| {
+                    d.language
+                        .as_deref()
+                        .is_some_and(|l| crate::language::lang_matches(lang, l))
+                })
             {
                 all_designations.extend(
                     fetch_designations_cross_version(
@@ -174,12 +176,16 @@ impl CodeSystemOperations for PostgresTerminologyBackend {
         }
         let all_designations = all_designations;
 
+        // Matching is BCP-47-aware (RFC 4647 Lookup): an exact tag wins,
+        // then a stored dialect of the requested tag (`de` → `de-CH`), then
+        // truncations of the requested tag (`de-DE` → `de`).
         let display = if let Some(lang) = req.display_language.as_deref() {
-            all_designations
-                .iter()
-                .find(|d| d.language.as_deref() == Some(lang))
-                .map(|d| d.value.clone())
-                .or(display)
+            crate::language::best_lang_match_index(
+                lang,
+                all_designations.iter().map(|d| d.language.as_deref()),
+            )
+            .map(|idx| all_designations[idx].value.clone())
+            .or(display)
         } else {
             display
         };
@@ -187,7 +193,11 @@ impl CodeSystemOperations for PostgresTerminologyBackend {
         let designations = if let Some(lang) = req.display_language.as_deref() {
             all_designations
                 .into_iter()
-                .filter(|d| d.language.as_deref() == Some(lang))
+                .filter(|d| {
+                    d.language
+                        .as_deref()
+                        .is_some_and(|l| crate::language::lang_matches(lang, l))
+                })
                 .collect()
         } else {
             all_designations
@@ -1626,7 +1636,8 @@ async fn fetch_designations(
         .collect())
 }
 
-/// Designations for `code` in `lang` from stored versions of the canonical
+/// Designations for `code` matching `lang` (BCP-47-aware, see
+/// [`crate::language::lang_matches`]) from stored versions of the canonical
 /// `url` *other than* `exclude_system_id`, taken from the newest such version
 /// that has any (insertion order within that version is preserved so
 /// preferred terms stay first).
@@ -1643,20 +1654,26 @@ async fn fetch_designations_cross_version(
              FROM concept_designations cd
              JOIN concepts c ON c.id = cd.concept_id
              JOIN code_systems s ON s.id = c.system_id
-             WHERE s.url = $1 AND c.code = $2 AND s.id <> $3 AND cd.language = $4
+             WHERE s.url = $1 AND c.code = $2 AND s.id <> $3
              ORDER BY COALESCE(s.version, '') DESC, cd.id",
-            &[&url, &code, &exclude_system_id, &lang],
+            &[&url, &code, &exclude_system_id],
         )
         .await
         .map_err(|e| HtsError::StorageError(e.to_string()))?;
 
-    let newest: String = match rows.first() {
+    // Language matching happens here rather than in SQL so the RFC 4647
+    // fallback rules (`de-DE` → `de`, `de` → `de-CH`) apply.
+    let lang_ok = |row: &tokio_postgres::Row| {
+        row.get::<_, Option<String>>(0)
+            .is_some_and(|l| crate::language::lang_matches(lang, &l))
+    };
+    let newest: String = match rows.iter().find(|r| lang_ok(r)) {
         Some(row) => row.get(4),
         None => return Ok(Vec::new()),
     };
     Ok(rows
         .into_iter()
-        .take_while(|row| row.get::<_, String>(4) == newest)
+        .filter(|row| row.get::<_, String>(4) == newest && lang_ok(row))
         .map(|row| DesignationValue {
             language: row.get(0),
             use_system: row.get(1),

--- a/crates/hts/src/backends/postgres/code_system.rs
+++ b/crates/hts/src/backends/postgres/code_system.rs
@@ -144,7 +144,35 @@ impl CodeSystemOperations for PostgresTerminologyBackend {
             out
         };
 
-        let all_designations = fetch_designations(&client, concept_id).await?;
+        let mut all_designations = fetch_designations(&client, concept_id).await?;
+
+        // Cross-version designation fallback: when the caller pinned no
+        // version and the resolved (newest) version has no designation in the
+        // requested language, pull matching designations from the newest
+        // *other* stored version of the same canonical URL. This covers e.g.
+        // a national SNOMED edition whose translations would otherwise be
+        // shadowed by a newer international release ($expand and
+        // $validate-code already match designations URL-wide via
+        // `concept_designations`).
+        if let Some(lang) = req.display_language.as_deref() {
+            if req.version.is_none()
+                && !all_designations
+                    .iter()
+                    .any(|d| d.language.as_deref() == Some(lang))
+            {
+                all_designations.extend(
+                    fetch_designations_cross_version(
+                        &client,
+                        &req.system,
+                        &req.code,
+                        &system_id,
+                        lang,
+                    )
+                    .await?,
+                );
+            }
+        }
+        let all_designations = all_designations;
 
         let display = if let Some(lang) = req.display_language.as_deref() {
             all_designations
@@ -1588,6 +1616,47 @@ async fn fetch_designations(
 
     Ok(rows
         .into_iter()
+        .map(|row| DesignationValue {
+            language: row.get(0),
+            use_system: row.get(1),
+            use_code: row.get(2),
+            value: row.get(3),
+            source: None,
+        })
+        .collect())
+}
+
+/// Designations for `code` in `lang` from stored versions of the canonical
+/// `url` *other than* `exclude_system_id`, taken from the newest such version
+/// that has any (insertion order within that version is preserved so
+/// preferred terms stay first).
+async fn fetch_designations_cross_version(
+    client: &tokio_postgres::Client,
+    url: &str,
+    code: &str,
+    exclude_system_id: &str,
+    lang: &str,
+) -> Result<Vec<DesignationValue>, HtsError> {
+    let rows = client
+        .query(
+            "SELECT cd.language, cd.use_system, cd.use_code, cd.value, COALESCE(s.version, '')
+             FROM concept_designations cd
+             JOIN concepts c ON c.id = cd.concept_id
+             JOIN code_systems s ON s.id = c.system_id
+             WHERE s.url = $1 AND c.code = $2 AND s.id <> $3 AND cd.language = $4
+             ORDER BY COALESCE(s.version, '') DESC, cd.id",
+            &[&url, &code, &exclude_system_id, &lang],
+        )
+        .await
+        .map_err(|e| HtsError::StorageError(e.to_string()))?;
+
+    let newest: String = match rows.first() {
+        Some(row) => row.get(4),
+        None => return Ok(Vec::new()),
+    };
+    Ok(rows
+        .into_iter()
+        .take_while(|row| row.get::<_, String>(4) == newest)
         .map(|row| DesignationValue {
             language: row.get(0),
             use_system: row.get(1),

--- a/crates/hts/src/backends/sqlite/code_system.rs
+++ b/crates/hts/src/backends/sqlite/code_system.rs
@@ -320,9 +320,11 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
             // URL-wide via `concept_designations`).
             if let Some(lang) = req.display_language.as_deref() {
                 if req.version.is_none()
-                    && !all_designations
-                        .iter()
-                        .any(|d| d.language.as_deref() == Some(lang))
+                    && !all_designations.iter().any(|d| {
+                        d.language
+                            .as_deref()
+                            .is_some_and(|l| crate::language::lang_matches(lang, l))
+                    })
                 {
                     all_designations.extend(fetch_designations_cross_version(
                         &conn,
@@ -336,13 +338,17 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
             let all_designations = all_designations;
 
             // 10.2: When displayLanguage is set and a matching designation
-            // exists, prefer its value as the concept display.
+            // exists, prefer its value as the concept display. Matching is
+            // BCP-47-aware (RFC 4647 Lookup): an exact tag wins, then a
+            // stored dialect of the requested tag (`de` → `de-CH`), then
+            // truncations of the requested tag (`de-DE` → `de`).
             let display = if let Some(lang) = req.display_language.as_deref() {
-                all_designations
-                    .iter()
-                    .find(|d| d.language.as_deref() == Some(lang))
-                    .map(|d| d.value.clone())
-                    .or(display)
+                crate::language::best_lang_match_index(
+                    lang,
+                    all_designations.iter().map(|d| d.language.as_deref()),
+                )
+                .map(|idx| all_designations[idx].value.clone())
+                .or(display)
             } else {
                 display
             };
@@ -351,7 +357,11 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
             let designations = if let Some(lang) = req.display_language.as_deref() {
                 all_designations
                     .into_iter()
-                    .filter(|d| d.language.as_deref() == Some(lang))
+                    .filter(|d| {
+                        d.language
+                            .as_deref()
+                            .is_some_and(|l| crate::language::lang_matches(lang, l))
+                    })
                     .collect()
             } else {
                 all_designations
@@ -2007,7 +2017,8 @@ fn fetch_designations(
     .collect()
 }
 
-/// Designations for `code` in `lang` from stored versions of the canonical
+/// Designations for `code` matching `lang` (BCP-47-aware, see
+/// [`crate::language::lang_matches`]) from stored versions of the canonical
 /// `url` *other than* `exclude_system_id`, taken from the newest such version
 /// that has any (insertion order within that version is preserved so
 /// preferred terms stay first).
@@ -2024,38 +2035,42 @@ fn fetch_designations_cross_version(
              FROM concept_designations cd \
              JOIN concepts c ON c.id = cd.concept_id \
              JOIN code_systems s ON s.id = c.system_id \
-             WHERE s.url = ?1 AND c.code = ?2 AND s.id <> ?3 AND cd.language = ?4 \
+             WHERE s.url = ?1 AND c.code = ?2 AND s.id <> ?3 \
              ORDER BY COALESCE(s.version, '') DESC, cd.id",
         )
         .map_err(|e| HtsError::StorageError(e.to_string()))?;
 
     let rows: Vec<(DesignationValue, String)> = stmt
-        .query_map(
-            rusqlite::params![url, code, exclude_system_id, lang],
-            |row| {
-                Ok((
-                    DesignationValue {
-                        language: row.get(0)?,
-                        use_system: row.get(1)?,
-                        use_code: row.get(2)?,
-                        value: row.get(3)?,
-                        source: None,
-                    },
-                    row.get::<_, String>(4)?,
-                ))
-            },
-        )
+        .query_map(rusqlite::params![url, code, exclude_system_id], |row| {
+            Ok((
+                DesignationValue {
+                    language: row.get(0)?,
+                    use_system: row.get(1)?,
+                    use_code: row.get(2)?,
+                    value: row.get(3)?,
+                    source: None,
+                },
+                row.get::<_, String>(4)?,
+            ))
+        })
         .map_err(|e| HtsError::StorageError(e.to_string()))?
         .collect::<Result<_, _>>()
         .map_err(|e| HtsError::StorageError(e.to_string()))?;
 
-    let newest = match rows.first() {
+    // Language matching happens here rather than in SQL so the RFC 4647
+    // fallback rules (`de-DE` → `de`, `de` → `de-CH`) apply.
+    let lang_ok = |d: &DesignationValue| {
+        d.language
+            .as_deref()
+            .is_some_and(|l| crate::language::lang_matches(lang, l))
+    };
+    let newest = match rows.iter().find(|(d, _)| lang_ok(d)) {
         Some((_, v)) => v.clone(),
         None => return Ok(Vec::new()),
     };
     Ok(rows
         .into_iter()
-        .take_while(|(_, v)| *v == newest)
+        .filter(|(d, v)| *v == newest && lang_ok(d))
         .map(|(d, _)| d)
         .collect())
 }

--- a/crates/hts/src/backends/sqlite/code_system.rs
+++ b/crates/hts/src/backends/sqlite/code_system.rs
@@ -308,7 +308,32 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
                 out
             };
 
-            let all_designations = fetch_designations(&conn, concept_id)?;
+            let mut all_designations = fetch_designations(&conn, concept_id)?;
+
+            // Cross-version designation fallback: when the caller pinned no
+            // version and the resolved (newest) version has no designation in
+            // the requested language, pull matching designations from the
+            // newest *other* stored version of the same canonical URL. This
+            // covers e.g. a national SNOMED edition whose translations would
+            // otherwise be shadowed by a newer international release
+            // ($expand and $validate-code already match designations
+            // URL-wide via `concept_designations`).
+            if let Some(lang) = req.display_language.as_deref() {
+                if req.version.is_none()
+                    && !all_designations
+                        .iter()
+                        .any(|d| d.language.as_deref() == Some(lang))
+                {
+                    all_designations.extend(fetch_designations_cross_version(
+                        &conn,
+                        &req.system,
+                        &req.code,
+                        &system_id,
+                        lang,
+                    )?);
+                }
+            }
+            let all_designations = all_designations;
 
             // 10.2: When displayLanguage is set and a matching designation
             // exists, prefer its value as the concept display.
@@ -1982,6 +2007,59 @@ fn fetch_designations(
     .collect()
 }
 
+/// Designations for `code` in `lang` from stored versions of the canonical
+/// `url` *other than* `exclude_system_id`, taken from the newest such version
+/// that has any (insertion order within that version is preserved so
+/// preferred terms stay first).
+fn fetch_designations_cross_version(
+    conn: &rusqlite::Connection,
+    url: &str,
+    code: &str,
+    exclude_system_id: &str,
+    lang: &str,
+) -> Result<Vec<DesignationValue>, HtsError> {
+    let mut stmt = conn
+        .prepare_cached(
+            "SELECT cd.language, cd.use_system, cd.use_code, cd.value, COALESCE(s.version, '') \
+             FROM concept_designations cd \
+             JOIN concepts c ON c.id = cd.concept_id \
+             JOIN code_systems s ON s.id = c.system_id \
+             WHERE s.url = ?1 AND c.code = ?2 AND s.id <> ?3 AND cd.language = ?4 \
+             ORDER BY COALESCE(s.version, '') DESC, cd.id",
+        )
+        .map_err(|e| HtsError::StorageError(e.to_string()))?;
+
+    let rows: Vec<(DesignationValue, String)> = stmt
+        .query_map(
+            rusqlite::params![url, code, exclude_system_id, lang],
+            |row| {
+                Ok((
+                    DesignationValue {
+                        language: row.get(0)?,
+                        use_system: row.get(1)?,
+                        use_code: row.get(2)?,
+                        value: row.get(3)?,
+                        source: None,
+                    },
+                    row.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .map_err(|e| HtsError::StorageError(e.to_string()))?
+        .collect::<Result<_, _>>()
+        .map_err(|e| HtsError::StorageError(e.to_string()))?;
+
+    let newest = match rows.first() {
+        Some((_, v)) => v.clone(),
+        None => return Ok(Vec::new()),
+    };
+    Ok(rows
+        .into_iter()
+        .take_while(|(_, v)| *v == newest)
+        .map(|(d, _)| d)
+        .collect())
+}
+
 /// Build a minimal synthetic FHIR resource JSON when `resource_json` is absent.
 ///
 /// Used as a fallback for resources that pre-date the `resource_json` column.
@@ -2571,6 +2649,108 @@ mod tests {
                     (100, 'de', NULL, NULL, 'Begriff auf Deutsch');",
         )
         .unwrap();
+    }
+
+    /// Three coexisting versions of one canonical URL: the newest (20260601)
+    /// has only English content; the two older ones carry German designations.
+    fn seed_multiversion(b: &SqliteTerminologyBackend) {
+        let conn = b.pool().get().unwrap();
+        conn.execute_batch(
+            "INSERT INTO code_systems
+                 (id, url, version, name, status, content, created_at, updated_at)
+             VALUES ('cs-v2', 'http://example.org/cs-mv', '20260601', 'MV CS',
+                     'active', 'complete', '2024-01-01', '2024-01-01'),
+                    ('cs-v1', 'http://example.org/cs-mv', '20260515', 'MV CS',
+                     'active', 'complete', '2024-01-01', '2024-01-01'),
+                    ('cs-v0', 'http://example.org/cs-mv', '20240101', 'MV CS',
+                     'active', 'complete', '2024-01-01', '2024-01-01');
+
+             INSERT INTO concepts (id, system_id, code, display)
+             VALUES (200, 'cs-v2', 'C1', 'Color (newest)'),
+                    (201, 'cs-v1', 'C1', 'Color (edition)'),
+                    (202, 'cs-v0', 'C1', 'Color (oldest)');
+
+             INSERT INTO concept_designations (concept_id, language, use_system, use_code, value)
+             VALUES (200, 'en', NULL, NULL, 'Hue'),
+                    (201, 'de', NULL, NULL, 'Farbe'),
+                    (201, 'de', NULL, NULL, 'Färbung'),
+                    (202, 'de', NULL, NULL, 'Alte Farbe');",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn lookup_display_language_falls_back_to_newest_other_version() {
+        let b = backend();
+        seed_multiversion(&b);
+
+        let resp = b
+            .lookup(
+                &ctx(),
+                LookupRequest {
+                    system: "http://example.org/cs-mv".into(),
+                    code: "C1".into(),
+                    display_language: Some("de".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // German comes from 20260515 (the newest version that has it) —
+        // both its designations in insertion order, nothing from 20240101.
+        assert_eq!(resp.display.as_deref(), Some("Farbe"));
+        assert_eq!(resp.version.as_deref(), Some("20260601"));
+        assert_eq!(resp.designations.len(), 2);
+        assert_eq!(resp.designations[0].value, "Farbe");
+        assert_eq!(resp.designations[1].value, "Färbung");
+    }
+
+    #[tokio::test]
+    async fn lookup_pinned_version_does_not_fall_back() {
+        let b = backend();
+        seed_multiversion(&b);
+
+        let resp = b
+            .lookup(
+                &ctx(),
+                LookupRequest {
+                    system: "http://example.org/cs-mv".into(),
+                    code: "C1".into(),
+                    version: Some("20260601".into()),
+                    display_language: Some("de".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // Explicit version pin is respected strictly: no German available.
+        assert_eq!(resp.display.as_deref(), Some("Color (newest)"));
+        assert!(resp.designations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn lookup_no_fallback_when_resolved_version_has_language() {
+        let b = backend();
+        seed_multiversion(&b);
+
+        let resp = b
+            .lookup(
+                &ctx(),
+                LookupRequest {
+                    system: "http://example.org/cs-mv".into(),
+                    code: "C1".into(),
+                    display_language: Some("en".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // English exists in the resolved newest version — served from there.
+        assert_eq!(resp.display.as_deref(), Some("Hue"));
+        assert_eq!(resp.designations.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/hts/src/import/snomed_rf2.rs
+++ b/crates/hts/src/import/snomed_rf2.rs
@@ -9,9 +9,11 @@
 //! `languageCode` and a `use` Coding carrying the SNOMED description type
 //! (FSN / synonym). Language reference sets are consulted to pick the
 //! preferred synonym for the concept `display` (US English, then GB English)
-//! and to emit additional dialect-tagged (`en-US` / `en-GB`)
-//! `preferredForLanguage` designations, so `displayLanguage` /
-//! `Accept-Language` requests resolve to the right term.
+//! and to emit `preferredForLanguage` designations for every
+//! refset-preferred synonym — tagged with the synonym's bare RF2 language
+//! and, for the known national-edition refsets, a BCP-47 dialect tag
+//! (`en-US`, `da-DK`, `fr-CA`, …) — so `displayLanguage` /
+//! `Accept-Language` requests resolve to the right term in any language.
 //!
 //! # ⚠️  LICENSE REQUIRED
 //!
@@ -48,8 +50,32 @@ const ACCEPTABILITY_PREFERRED: &str = "900000000000548007";
 const REFSET_EN_US: &str = "900000000000509007";
 /// GB English language refset.
 const REFSET_EN_GB: &str = "900000000000508004";
-/// Known language refsets with their BCP-47 dialect tags.
-const LANG_REFSET_DIALECTS: &[(&str, &str)] = &[(REFSET_EN_US, "en-US"), (REFSET_EN_GB, "en-GB")];
+/// Known language refsets with their BCP-47 dialect tags, covering the
+/// published national-edition refsets. SCTIDs follow the dialect map shipped
+/// by SNOMED International's Snowstorm server (`search.dialect.config.*`).
+/// Refsets whose tag would add nothing over the description's own RF2
+/// `languageCode` (e.g. the bare-`de` German refset) are intentionally
+/// absent — every refset-preferred synonym already receives a
+/// `preferredForLanguage` designation in its bare language.
+const LANG_REFSET_DIALECTS: &[(&str, &str)] = &[
+    (REFSET_EN_US, "en-US"),
+    (REFSET_EN_GB, "en-GB"),
+    ("554461000005103", "da-DK"),
+    ("32570271000036106", "en-AU"),
+    ("19491000087109", "en-CA"),
+    ("21000220103", "en-IE"),
+    ("271000210107", "en-NZ"),
+    ("5641000179103", "es-UY"),
+    ("71000181105", "et-EE"),
+    ("21000172104", "fr-BE"),
+    ("20581000087109", "fr-CA"),
+    ("10031000315102", "fr-FR"),
+    ("61000202103", "nb-NO"),
+    ("91000202106", "nn-NO"),
+    ("31000172101", "nl-BE"),
+    ("31000146106", "nl-NL"),
+    ("46011000052107", "sv-SE"),
+];
 
 /// FHIR designation-use system for `preferredForLanguage` (matches the
 /// coding the `$expand` displayLanguage swap emits).
@@ -654,8 +680,9 @@ fn parse_language_refsets(
 /// Designations carry every active description (all languages), synonyms
 /// before FSNs and refset-preferred terms first within each group, so
 /// language-keyed first-match lookups resolve to the preferred term.
-/// Synonyms preferred in a known dialect refset additionally get a
-/// dialect-tagged (`en-US` / `en-GB`) `preferredForLanguage` designation.
+/// Every refset-preferred synonym additionally gets a `preferredForLanguage`
+/// designation in its bare RF2 language, plus dialect-tagged copies
+/// (`en-US`, `da-DK`, `fr-CA`, …) for refsets in [`LANG_REFSET_DIALECTS`].
 fn build_concept_terms(
     by_desc_id: HashMap<String, (usize, ParsedDescription)>,
     preferred_in: &HashMap<String, HashSet<String>>,
@@ -724,16 +751,28 @@ fn build_concept_terms(
                 use_code: d.type_id.clone(),
                 value: d.term.clone(),
             });
-            if d.type_id == TYPE_SYNONYM {
-                for (refset_id, dialect) in LANG_REFSET_DIALECTS {
-                    if is_preferred_in(d, refset_id) {
-                        designations.push(OwnedDesignation {
-                            language: (*dialect).to_string(),
-                            use_system: HL7_TERM_MAINT_INFRA,
-                            use_code: "preferredForLanguage".to_string(),
-                            value: d.term.clone(),
-                        });
-                    }
+            if d.type_id == TYPE_SYNONYM && is_preferred_any(d) {
+                // One `preferredForLanguage` per distinct BCP-47 tag: the
+                // known-dialect tags of the refsets this synonym is preferred
+                // in (sorted for determinism), plus the bare RF2
+                // `languageCode` so preference stays queryable for editions
+                // whose refset is not in the dialect table (German, Spanish,
+                // Swiss, …).
+                let mut tags: Vec<&str> = LANG_REFSET_DIALECTS
+                    .iter()
+                    .filter(|(refset_id, _)| is_preferred_in(d, refset_id))
+                    .map(|(_, dialect)| *dialect)
+                    .collect();
+                tags.push(d.language.as_str());
+                tags.sort_unstable();
+                tags.dedup();
+                for tag in tags {
+                    designations.push(OwnedDesignation {
+                        language: tag.to_string(),
+                        use_system: HL7_TERM_MAINT_INFRA,
+                        use_code: "preferredForLanguage".to_string(),
+                        value: d.term.clone(),
+                    });
                 }
             }
         }
@@ -1313,7 +1352,7 @@ BADLINE\r\n";
         assert_eq!(stats.concepts, 2);
         assert_eq!(count_rows(&backend, "concepts"), 2);
         assert_eq!(count_rows(&backend, "concept_hierarchy"), 1);
-        assert_eq!(count_rows(&backend, "concept_designations"), 8);
+        assert_eq!(count_rows(&backend, "concept_designations"), 10);
     }
 
     #[tokio::test]
@@ -1329,8 +1368,11 @@ BADLINE\r\n";
             .await
             .unwrap();
 
-        // 123456001: en×2 + FSN + de + en-US + en-GB = 6; 789012001: en FSN + de FSN = 2.
-        assert_eq!(count_rows(&backend, "concept_designations"), 8);
+        // 123456001: en×2 + FSN + de = 4 descriptions, plus per preferred
+        // synonym a bare-`en` and a dialect preferredForLanguage row
+        // (111005 → en + en-US, 111001 → en + en-GB) = 8;
+        // 789012001: en FSN + de FSN = 2.
+        assert_eq!(count_rows(&backend, "concept_designations"), 10);
 
         // displayLanguage=de resolves the German synonym as the display.
         let resp = backend
@@ -1375,6 +1417,150 @@ BADLINE\r\n";
             .await
             .unwrap();
         assert_eq!(resp.display.as_deref(), Some("Foo disorder"));
+
+        // A region-qualified request falls back to the bare RF2 language
+        // tag (RFC 4647 truncation: de-DE → de) — what a browser's
+        // Accept-Language header typically produces.
+        let resp = backend
+            .lookup(
+                &ctx,
+                LookupRequest {
+                    system: SNOMED_URL.into(),
+                    code: "123456001".into(),
+                    display_language: Some("de-DE".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.display.as_deref(), Some("Foo Erkrankung"));
+    }
+
+    /// A national-edition style archive with no English content at all:
+    /// Danish synonyms preferred via the Danish language refset (which is in
+    /// the dialect table → tagged `da-DK` + `da`) and German synonyms
+    /// preferred via the German refset (not in the table → bare `de` only).
+    #[tokio::test]
+    async fn import_snomed_rf2_national_edition_languages() {
+        use crate::traits::CodeSystemOperations;
+        use crate::types::LookupRequest;
+
+        const NE_CONCEPT_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\tdefinitionStatusId\r\n\
+123456001\t20240101\t1\t900000000000207008\t900000000000074008\r\n";
+        const NE_DESCRIPTION_DA_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\tconceptId\tlanguageCode\ttypeId\tterm\tcaseSignificanceId\r\n\
+411001\t20240101\t1\t900000000000207008\t123456001\tda\t900000000000013009\tFoo sygdom\t900000000000448009\r\n";
+        const NE_DESCRIPTION_DE_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\tconceptId\tlanguageCode\ttypeId\tterm\tcaseSignificanceId\r\n\
+411002\t20240101\t1\t900000000000207008\t123456001\tde\t900000000000013009\tFoo Erkrankung\t900000000000448009\r\n";
+        // 554461000005103 = Danish language refset (in LANG_REFSET_DIALECTS),
+        // 722130004 = German language refset (deliberately not in the table).
+        const NE_LANGUAGE_REFSET_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\trefsetId\treferencedComponentId\tacceptabilityId\r\n\
+N1\t20240101\t1\t900000000000207008\t554461000005103\t411001\t900000000000548007\r\n\
+N2\t20240101\t1\t900000000000207008\t722130004\t411002\t900000000000548007\r\n";
+        const NE_RELATIONSHIP_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\tsourceId\tdestinationId\trelationshipGroup\ttypeId\tcharacteristicTypeId\tmodifierId\r\n";
+
+        let tmp = NamedTempFile::new().unwrap();
+        {
+            let mut zip = zip::ZipWriter::new(tmp.reopen().unwrap());
+            let opts = zip::write::FileOptions::default();
+            for (name, content) in [
+                (
+                    "Snapshot/Terminology/sct2_Concept_Snapshot_NE_20240101.txt",
+                    NE_CONCEPT_TSV,
+                ),
+                (
+                    "Snapshot/Terminology/sct2_Description_Snapshot-da_NE_20240101.txt",
+                    NE_DESCRIPTION_DA_TSV,
+                ),
+                (
+                    "Snapshot/Terminology/sct2_Description_Snapshot-de_NE_20240101.txt",
+                    NE_DESCRIPTION_DE_TSV,
+                ),
+                (
+                    "Snapshot/Refset/Language/der2_cRefset_LanguageSnapshot-da_NE_20240101.txt",
+                    NE_LANGUAGE_REFSET_TSV,
+                ),
+                (
+                    "Snapshot/Terminology/sct2_Relationship_Snapshot_NE_20240101.txt",
+                    NE_RELATIONSHIP_TSV,
+                ),
+            ] {
+                zip.start_file(name, opts).unwrap();
+                zip.write_all(content.as_bytes()).unwrap();
+            }
+            zip.finish().unwrap();
+        }
+
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        let ctx = TenantContext::system();
+        import_snomed_rf2(&backend, &ctx, tmp.path(), 500, false)
+            .await
+            .unwrap();
+
+        // Danish refset is in the dialect table: a region-qualified request
+        // resolves via the da-DK preferredForLanguage designation.
+        let resp = backend
+            .lookup(
+                &ctx,
+                LookupRequest {
+                    system: SNOMED_URL.into(),
+                    code: "123456001".into(),
+                    display_language: Some("da-DK".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.display.as_deref(), Some("Foo sygdom"));
+        assert!(resp.designations.iter().any(|d| {
+            d.language.as_deref() == Some("da-DK")
+                && d.use_code.as_deref() == Some("preferredForLanguage")
+        }));
+        assert!(
+            resp.designations
+                .iter()
+                .any(|d| d.language.as_deref() == Some("da"))
+        );
+
+        // German refset is not in the dialect table: preference is still
+        // recorded under the bare RF2 language, and a region-qualified
+        // request reaches it via RFC 4647 truncation (de-DE → de).
+        let resp = backend
+            .lookup(
+                &ctx,
+                LookupRequest {
+                    system: SNOMED_URL.into(),
+                    code: "123456001".into(),
+                    display_language: Some("de-DE".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.display.as_deref(), Some("Foo Erkrankung"));
+        assert!(resp.designations.iter().any(|d| {
+            d.language.as_deref() == Some("de")
+                && d.use_code.as_deref() == Some("preferredForLanguage")
+        }));
+
+        // No English anywhere: the display falls back to a preferred
+        // synonym in a non-English language instead of coming up empty.
+        let resp = backend
+            .lookup(
+                &ctx,
+                LookupRequest {
+                    system: SNOMED_URL.into(),
+                    code: "123456001".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert!(resp.display.is_some());
     }
 
     #[tokio::test]

--- a/crates/hts/src/import/snomed_rf2.rs
+++ b/crates/hts/src/import/snomed_rf2.rs
@@ -3,6 +3,16 @@
 //! Reads a SNOMED CT RF2 distribution ZIP and imports active concepts,
 //! preferred terms, and `Is-a` hierarchy edges into the HTS normalized schema.
 //!
+//! All active descriptions — in every language present in the archive,
+//! including per-language description files shipped by national editions —
+//! are imported as FHIR `concept.designation` entries tagged with the RF2
+//! `languageCode` and a `use` Coding carrying the SNOMED description type
+//! (FSN / synonym). Language reference sets are consulted to pick the
+//! preferred synonym for the concept `display` (US English, then GB English)
+//! and to emit additional dialect-tagged (`en-US` / `en-GB`)
+//! `preferredForLanguage` designations, so `displayLanguage` /
+//! `Accept-Language` requests resolve to the right term.
+//!
 //! # ⚠️  LICENSE REQUIRED
 //!
 //! Real SNOMED CT data requires a license from SNOMED International.
@@ -18,7 +28,7 @@ use crate::error::HtsError;
 use crate::import::BundleImportBackend;
 use crate::import::ImportStats;
 use crate::import::bundle_builder::{
-    BuilderConcept, BuilderProperty, CodeSystemMeta, build_code_system_bundle,
+    BuilderConcept, BuilderDesignation, BuilderProperty, CodeSystemMeta, build_code_system_bundle,
 };
 
 // ── SNOMED CT constants ───────────────────────────────────────────────────────
@@ -31,6 +41,19 @@ const SNOMED_TITLE: &str = "SNOMED CT";
 const TYPE_FSN: &str = "900000000000003001";
 const TYPE_SYNONYM: &str = "900000000000013009";
 const IS_A_TYPE: &str = "116680003";
+
+/// Language refset acceptability: preferred.
+const ACCEPTABILITY_PREFERRED: &str = "900000000000548007";
+/// US English language refset.
+const REFSET_EN_US: &str = "900000000000509007";
+/// GB English language refset.
+const REFSET_EN_GB: &str = "900000000000508004";
+/// Known language refsets with their BCP-47 dialect tags.
+const LANG_REFSET_DIALECTS: &[(&str, &str)] = &[(REFSET_EN_US, "en-US"), (REFSET_EN_GB, "en-GB")];
+
+/// FHIR designation-use system for `preferredForLanguage` (matches the
+/// coding the `$expand` displayLanguage swap emits).
+const HL7_TERM_MAINT_INFRA: &str = "http://terminology.hl7.org/CodeSystem/hl7TermMaintInfra";
 
 /// Map from concept code to a list of `(type_id, destination_code)` pairs.
 type RoleProps = HashMap<String, Vec<(String, String)>>;
@@ -46,10 +69,39 @@ const ASSOC_REFSET_EQUIVALENCES: &[(&str, &str, &str)] = &[
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
+/// One active RF2 description row.
+#[derive(Debug, Clone)]
+struct ParsedDescription {
+    desc_id: String,
+    concept_id: String,
+    language: String,
+    type_id: String,
+    term: String,
+}
+
+/// Owned designation, converted to a borrowed [`BuilderDesignation`] per batch.
+#[derive(Debug, Clone)]
+struct OwnedDesignation {
+    /// BCP-47 tag — RF2 `languageCode` (`en`, `de`, …) or a dialect tag
+    /// (`en-US`) for language-refset-preferred synonyms.
+    language: String,
+    use_system: &'static str,
+    /// SNOMED description type id, or `preferredForLanguage`.
+    use_code: String,
+    value: String,
+}
+
+/// Display term plus designations for one concept.
+#[derive(Debug, Clone, Default)]
+struct ConceptTerms {
+    display: String,
+    designations: Vec<OwnedDesignation>,
+}
+
 #[derive(Debug)]
 struct SnomedParseResult {
-    /// concept id → display term.
-    preferred_terms: HashMap<String, String>,
+    /// concept id → display term + designations.
+    concept_terms: HashMap<String, ConceptTerms>,
     /// (child, parent) is-a edges.
     is_a_edges: Vec<(String, String)>,
     /// source_concept_id → Vec<(type_id, destination_concept_id)> for non-IS_A relationships.
@@ -73,13 +125,15 @@ pub async fn import_snomed_rf2(
 
     let path_owned = path.to_path_buf();
     let parsed = tokio::task::spawn_blocking(move || -> Result<SnomedParseResult, HtsError> {
-        let (concept_path, desc_path, rel_path, assoc_refset_paths) = find_rf2_paths(&path_owned)?;
+        let (concept_path, desc_paths, rel_path, assoc_refset_paths, lang_refset_paths) =
+            find_rf2_paths(&path_owned)?;
 
         tracing::info!(
             concept_file = %concept_path,
-            description_file = %desc_path,
+            description_files = desc_paths.len(),
             relationship_file = %rel_path,
             assoc_refset_files = assoc_refset_paths.len(),
+            lang_refset_files = lang_refset_paths.len(),
             "Located RF2 files in archive"
         );
 
@@ -93,12 +147,33 @@ pub async fn import_snomed_rf2(
             parse_active_concepts(BufReader::new(entry), &mut parse_errors)
         };
 
-        let preferred_terms = {
-            let mut zip = open_zip(&path_owned)?;
-            let entry = zip.by_name(&desc_path).map_err(|e| {
-                HtsError::InvalidRequest(format!("Cannot open description file: {e}"))
-            })?;
-            parse_preferred_terms(BufReader::new(entry), &active_concepts, &mut parse_errors)
+        let concept_terms = {
+            let mut by_desc_id: HashMap<String, (usize, ParsedDescription)> = HashMap::new();
+            let mut next_order = 0usize;
+            for desc_path in &desc_paths {
+                let mut zip = open_zip(&path_owned)?;
+                let entry = zip.by_name(desc_path).map_err(|e| {
+                    HtsError::InvalidRequest(format!("Cannot open description file: {e}"))
+                })?;
+                parse_descriptions(
+                    BufReader::new(entry),
+                    &active_concepts,
+                    &mut next_order,
+                    &mut by_desc_id,
+                    &mut parse_errors,
+                );
+            }
+
+            let mut preferred_in: HashMap<String, HashSet<String>> = HashMap::new();
+            for refset_path in &lang_refset_paths {
+                let mut zip = open_zip(&path_owned)?;
+                let entry = zip.by_name(refset_path).map_err(|e| {
+                    HtsError::InvalidRequest(format!("Cannot open language refset file: {e}"))
+                })?;
+                parse_language_refsets(BufReader::new(entry), &mut preferred_in, &mut parse_errors);
+            }
+
+            build_concept_terms(by_desc_id, &preferred_in, &active_concepts)
         };
 
         let (is_a_edges, role_relationships) = {
@@ -127,7 +202,7 @@ pub async fn import_snomed_rf2(
         let release_version = extract_release_date(&concept_path);
 
         Ok(SnomedParseResult {
-            preferred_terms,
+            concept_terms,
             is_a_edges,
             role_relationships,
             association_refsets,
@@ -139,7 +214,7 @@ pub async fn import_snomed_rf2(
     .map_err(|e| HtsError::Internal(format!("SNOMED parser panicked: {e}")))??;
 
     let SnomedParseResult {
-        preferred_terms,
+        concept_terms,
         is_a_edges,
         role_relationships,
         association_refsets,
@@ -147,7 +222,7 @@ pub async fn import_snomed_rf2(
         parse_errors,
     } = parsed;
 
-    let concept_count = preferred_terms.len() as u32;
+    let concept_count = concept_terms.len() as u32;
     let edge_count = is_a_edges.len();
     let role_count: usize = role_relationships.values().map(|v| v.len()).sum();
     let assoc_count: usize = association_refsets.values().map(|v| v.len()).sum();
@@ -193,7 +268,7 @@ pub async fn import_snomed_rf2(
     stats.code_systems = seed_stats.code_systems;
     stats.errors.extend(seed_stats.errors);
 
-    let concept_list: Vec<(String, String)> = preferred_terms.into_iter().collect();
+    let concept_list: Vec<(String, ConceptTerms)> = concept_terms.into_iter().collect();
     let total = concept_list.len();
     let total_batches = total.div_ceil(batch_size).max(1);
 
@@ -236,16 +311,33 @@ pub async fn import_snomed_rf2(
             })
             .collect();
 
+        let desig_sets: Vec<Vec<BuilderDesignation<'_>>> = chunk
+            .iter()
+            .map(|(_, terms)| {
+                terms
+                    .designations
+                    .iter()
+                    .map(|d| BuilderDesignation {
+                        language: Some(d.language.as_str()),
+                        use_system: Some(d.use_system),
+                        use_code: Some(d.use_code.as_str()),
+                        value: d.value.as_str(),
+                    })
+                    .collect()
+            })
+            .collect();
+
         let builder: Vec<BuilderConcept<'_>> = chunk
             .iter()
             .enumerate()
-            .map(|(idx, (code, display))| BuilderConcept {
+            .map(|(idx, (code, terms))| BuilderConcept {
                 code: code.as_str(),
-                display: Some(display.as_str()).filter(|s| !s.is_empty()),
+                display: Some(terms.display.as_str()).filter(|s| !s.is_empty()),
                 parent_code: parents_of
                     .get(code)
                     .and_then(|p| p.first().map(|s| s.as_str())),
                 extra_properties: extras_per[idx].as_slice(),
+                designations: desig_sets[idx].as_slice(),
                 ..Default::default()
             })
             .collect();
@@ -304,13 +396,33 @@ fn open_zip(path: &Path) -> Result<ZipArchive<std::fs::File>, HtsError> {
         .map_err(|e| HtsError::InvalidRequest(format!("Not a valid ZIP archive: {e}")))
 }
 
-fn find_rf2_paths(path: &Path) -> Result<(String, String, String, Vec<String>), HtsError> {
+/// When an archive carries Full/Snapshot/Delta variants of the same content
+/// (the standard RF2 distribution layout), keep only the Snapshot files so a
+/// component's state is read exactly once.
+fn prefer_snapshot(paths: Vec<String>) -> Vec<String> {
+    let snapshots: Vec<String> = paths
+        .iter()
+        .filter(|p| p.to_lowercase().contains("snapshot"))
+        .cloned()
+        .collect();
+    if snapshots.is_empty() {
+        paths
+    } else {
+        snapshots
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn find_rf2_paths(
+    path: &Path,
+) -> Result<(String, Vec<String>, String, Vec<String>, Vec<String>), HtsError> {
     let mut zip = open_zip(path)?;
 
     let mut concept_path: Option<String> = None;
-    let mut desc_path: Option<String> = None;
+    let mut desc_paths: Vec<String> = Vec::new();
     let mut rel_path: Option<String> = None;
     let mut assoc_refset_paths: Vec<String> = Vec::new();
+    let mut lang_refset_paths: Vec<String> = Vec::new();
 
     for i in 0..zip.len() {
         let entry = zip
@@ -325,6 +437,8 @@ fn find_rf2_paths(path: &Path) -> Result<(String, String, String, Vec<String>), 
         if lower.contains("refset") {
             if lower.contains("association") {
                 assoc_refset_paths.push(name);
+            } else if lower.contains("language") {
+                lang_refset_paths.push(name);
             }
             continue;
         }
@@ -332,10 +446,24 @@ fn find_rf2_paths(path: &Path) -> Result<(String, String, String, Vec<String>), 
         if lower.contains("concept_") {
             concept_path = Some(name);
         } else if lower.contains("description_") {
-            desc_path = Some(name);
+            desc_paths.push(name);
         } else if lower.contains("relationship_") && !lower.contains("statedrelationship") {
             rel_path = Some(name);
         }
+    }
+
+    // National editions ship one Description file per language; sort for a
+    // deterministic read order across platforms.
+    let mut desc_paths = prefer_snapshot(desc_paths);
+    desc_paths.sort();
+    let mut lang_refset_paths = prefer_snapshot(lang_refset_paths);
+    lang_refset_paths.sort();
+
+    if desc_paths.is_empty() {
+        return Err(HtsError::InvalidRequest(
+            "No Description RF2 file found. Expected a file containing 'Description_' in its path."
+                .into(),
+        ));
     }
 
     Ok((
@@ -345,12 +473,7 @@ fn find_rf2_paths(path: &Path) -> Result<(String, String, String, Vec<String>), 
                     .into(),
             )
         })?,
-        desc_path.ok_or_else(|| {
-            HtsError::InvalidRequest(
-                "No Description RF2 file found. Expected a file containing 'Description_' in its path."
-                    .into(),
-            )
-        })?,
+        desc_paths,
         rel_path.ok_or_else(|| {
             HtsError::InvalidRequest(
                 "No Relationship RF2 file found. Expected a file containing 'Relationship_' in its path."
@@ -358,6 +481,7 @@ fn find_rf2_paths(path: &Path) -> Result<(String, String, String, Vec<String>), 
             )
         })?,
         assoc_refset_paths,
+        lang_refset_paths,
     ))
 }
 
@@ -397,14 +521,17 @@ fn parse_active_concepts(reader: impl BufRead, errors: &mut Vec<String>) -> Hash
     active
 }
 
-fn parse_preferred_terms(
+/// Parse one RF2 Description file into `by_desc_id`, keyed on description id
+/// so re-stated rows (Full files, overlapping releases) keep last-state-wins
+/// semantics. Inactive rows remove any earlier state. `next_order` preserves
+/// first-seen file order for stable designation ordering.
+fn parse_descriptions(
     reader: impl BufRead,
     active_concepts: &HashSet<String>,
+    next_order: &mut usize,
+    by_desc_id: &mut HashMap<String, (usize, ParsedDescription)>,
     errors: &mut Vec<String>,
-) -> HashMap<String, String> {
-    let mut synonyms: HashMap<String, String> = HashMap::new();
-    let mut fsns: HashMap<String, String> = HashMap::new();
-
+) {
     for (line_num, line_result) in reader.lines().enumerate() {
         let line = match line_result {
             Ok(l) => l,
@@ -424,39 +551,193 @@ fn parse_preferred_terms(
             continue;
         }
 
+        let desc_id = parts[0].trim();
         let active = parts[2].trim() == "1";
         let concept_id = parts[4].trim();
         let language = parts[5].trim();
         let type_id = parts[6].trim();
         let term = parts[7].trim();
 
-        if !active || language != "en" || !active_concepts.contains(concept_id) {
+        if !active {
+            by_desc_id.remove(desc_id);
+            continue;
+        }
+        if !active_concepts.contains(concept_id) || term.is_empty() {
             continue;
         }
 
-        match type_id {
-            TYPE_SYNONYM => {
-                synonyms
-                    .entry(concept_id.to_string())
-                    .or_insert_with(|| term.to_string());
+        let desc = ParsedDescription {
+            desc_id: desc_id.to_string(),
+            concept_id: concept_id.to_string(),
+            language: language.to_string(),
+            type_id: type_id.to_string(),
+            term: term.to_string(),
+        };
+        match by_desc_id.entry(desc_id.to_string()) {
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                e.get_mut().1 = desc;
             }
-            TYPE_FSN => {
-                fsns.entry(concept_id.to_string())
-                    .or_insert_with(|| term.to_string());
+            std::collections::hash_map::Entry::Vacant(e) => {
+                e.insert((*next_order, desc));
+                *next_order += 1;
             }
-            _ => {}
         }
     }
+}
 
-    let mut terms: HashMap<String, String> = synonyms;
-    for concept_id in active_concepts {
-        if !terms.contains_key(concept_id) {
-            if let Some(fsn) = fsns.get(concept_id) {
-                terms.insert(concept_id.clone(), fsn.clone());
-            } else {
-                terms.entry(concept_id.clone()).or_default();
+/// Parse an RF2 Language refset file, recording which descriptions are
+/// *preferred* in which language refset.
+///
+/// Columns: `id effectiveTime active moduleId refsetId referencedComponentId
+/// acceptabilityId`.
+fn parse_language_refsets(
+    reader: impl BufRead,
+    preferred_in: &mut HashMap<String, HashSet<String>>,
+    errors: &mut Vec<String>,
+) {
+    for (line_num, line_result) in reader.lines().enumerate() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if line_num == 0 || line.is_empty() {
+            continue;
+        }
+
+        let parts: Vec<&str> = line.splitn(8, '\t').collect();
+        if parts.len() < 7 {
+            errors.push(format!(
+                "Language refset line {}: expected ≥7 fields, got {} — skipped",
+                line_num + 1,
+                parts.len()
+            ));
+            continue;
+        }
+
+        let active = parts[2].trim() == "1";
+        let refset_id = parts[4].trim();
+        let desc_id = parts[5].trim();
+        let acceptability = parts[6].trim();
+
+        if desc_id.is_empty() || refset_id.is_empty() {
+            continue;
+        }
+        let entry = preferred_in.entry(desc_id.to_string()).or_default();
+        if active && acceptability == ACCEPTABILITY_PREFERRED {
+            entry.insert(refset_id.to_string());
+        } else {
+            // Inactive or demoted-to-acceptable rows revoke a previously
+            // recorded preference (last-state-wins across Full files).
+            entry.remove(refset_id);
+        }
+    }
+}
+
+/// Assemble per-concept display + designations from parsed descriptions.
+///
+/// Display selection: US-preferred English synonym → GB-preferred → any
+/// refset-preferred English synonym → first English synonym → English FSN →
+/// first synonym in any language → first FSN in any language.
+///
+/// Designations carry every active description (all languages), synonyms
+/// before FSNs and refset-preferred terms first within each group, so
+/// language-keyed first-match lookups resolve to the preferred term.
+/// Synonyms preferred in a known dialect refset additionally get a
+/// dialect-tagged (`en-US` / `en-GB`) `preferredForLanguage` designation.
+fn build_concept_terms(
+    by_desc_id: HashMap<String, (usize, ParsedDescription)>,
+    preferred_in: &HashMap<String, HashSet<String>>,
+    active_concepts: &HashSet<String>,
+) -> HashMap<String, ConceptTerms> {
+    let is_preferred_in = |desc: &ParsedDescription, refset: &str| {
+        preferred_in
+            .get(&desc.desc_id)
+            .is_some_and(|s| s.contains(refset))
+    };
+    let is_preferred_any = |desc: &ParsedDescription| {
+        preferred_in
+            .get(&desc.desc_id)
+            .is_some_and(|s| !s.is_empty())
+    };
+
+    // Group by concept, preserving file order.
+    let mut by_concept: HashMap<String, Vec<(usize, ParsedDescription)>> = HashMap::new();
+    for (_, (order, desc)) in by_desc_id {
+        by_concept
+            .entry(desc.concept_id.clone())
+            .or_default()
+            .push((order, desc));
+    }
+
+    let mut terms: HashMap<String, ConceptTerms> = HashMap::with_capacity(active_concepts.len());
+    for (concept_id, mut descs) in by_concept {
+        // Synonyms before FSNs before anything else; refset-preferred first
+        // within each group; original file order as the tie-breaker.
+        descs.sort_by_key(|(order, d)| {
+            let type_rank = match d.type_id.as_str() {
+                TYPE_SYNONYM => 0u8,
+                TYPE_FSN => 1,
+                _ => 2,
+            };
+            (type_rank, u8::from(!is_preferred_any(d)), *order)
+        });
+
+        let en_synonym = |pred: &dyn Fn(&ParsedDescription) -> bool| {
+            descs
+                .iter()
+                .find(|(_, d)| d.language == "en" && d.type_id == TYPE_SYNONYM && pred(d))
+                .map(|(_, d)| d.term.clone())
+        };
+        let first_term = |pred: &dyn Fn(&ParsedDescription) -> bool| {
+            descs
+                .iter()
+                .find(|(_, d)| pred(d))
+                .map(|(_, d)| d.term.clone())
+        };
+
+        let display = en_synonym(&|d| is_preferred_in(d, REFSET_EN_US))
+            .or_else(|| en_synonym(&|d| is_preferred_in(d, REFSET_EN_GB)))
+            .or_else(|| en_synonym(&|d| is_preferred_any(d)))
+            .or_else(|| en_synonym(&|_| true))
+            .or_else(|| first_term(&|d| d.language == "en" && d.type_id == TYPE_FSN))
+            .or_else(|| first_term(&|d| d.type_id == TYPE_SYNONYM))
+            .or_else(|| first_term(&|d| d.type_id == TYPE_FSN))
+            .unwrap_or_default();
+
+        let mut designations: Vec<OwnedDesignation> = Vec::with_capacity(descs.len());
+        for (_, d) in &descs {
+            designations.push(OwnedDesignation {
+                language: d.language.clone(),
+                use_system: SNOMED_URL,
+                use_code: d.type_id.clone(),
+                value: d.term.clone(),
+            });
+            if d.type_id == TYPE_SYNONYM {
+                for (refset_id, dialect) in LANG_REFSET_DIALECTS {
+                    if is_preferred_in(d, refset_id) {
+                        designations.push(OwnedDesignation {
+                            language: (*dialect).to_string(),
+                            use_system: HL7_TERM_MAINT_INFRA,
+                            use_code: "preferredForLanguage".to_string(),
+                            value: d.term.clone(),
+                        });
+                    }
+                }
             }
         }
+
+        terms.insert(
+            concept_id,
+            ConceptTerms {
+                display,
+                designations,
+            },
+        );
+    }
+
+    // Active concepts without any description keep an (empty-display) entry.
+    for concept_id in active_concepts {
+        terms.entry(concept_id.clone()).or_default();
     }
     terms
 }
@@ -643,7 +924,21 @@ id\teffectiveTime\tactive\tmoduleId\tconceptId\tlanguageCode\ttypeId\tterm\tcase
 111001\t20240101\t1\t900000000000207008\t123456001\ten\t900000000000013009\tFoo disorder\t900000000000448009\r\n\
 111002\t20240101\t1\t900000000000207008\t123456001\ten\t900000000000003001\tFoo disorder (disorder)\t900000000000448009\r\n\
 111003\t20240101\t1\t900000000000207008\t789012001\ten\t900000000000003001\tBar finding (finding)\t900000000000448009\r\n\
-111004\t20240101\t1\t900000000000207008\t999999001\ten\t900000000000013009\tInactive concept\t900000000000448009\r\n";
+111004\t20240101\t1\t900000000000207008\t999999001\ten\t900000000000013009\tInactive concept\t900000000000448009\r\n\
+111005\t20240101\t1\t900000000000207008\t123456001\ten\t900000000000013009\tFoo malady\t900000000000448009\r\n";
+
+    /// Per-language Description file as shipped by national editions.
+    const DESCRIPTION_DE_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\tconceptId\tlanguageCode\ttypeId\tterm\tcaseSignificanceId\r\n\
+211001\t20240101\t1\t900000000000207008\t123456001\tde\t900000000000013009\tFoo Erkrankung\t900000000000448009\r\n\
+211002\t20240101\t1\t900000000000207008\t789012001\tde\t900000000000003001\tBar Befund (Befund)\t900000000000448009\r\n";
+
+    /// `Foo malady` (111005) is US-preferred; `Foo disorder` (111001) is
+    /// GB-preferred — display selection must pick the US term despite file order.
+    const LANGUAGE_REFSET_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\trefsetId\treferencedComponentId\tacceptabilityId\r\n\
+L1\t20240101\t1\t900000000000207008\t900000000000509007\t111005\t900000000000548007\r\n\
+L2\t20240101\t1\t900000000000207008\t900000000000508004\t111001\t900000000000548007\r\n";
 
     const RELATIONSHIP_TSV: &str = "\
 id\teffectiveTime\tactive\tmoduleId\tsourceId\tdestinationId\trelationshipGroup\ttypeId\tcharacteristicTypeId\tmodifierId\r\n\
@@ -663,11 +958,25 @@ id\teffectiveTime\tactive\tmoduleId\tsourceId\tdestinationId\trelationshipGroup\
             zip.write_all(CONCEPT_TSV.as_bytes()).unwrap();
 
             zip.start_file(
-                "Snapshot/Terminology/sct2_Description_Snapshot_INT_20240101.txt",
+                "Snapshot/Terminology/sct2_Description_Snapshot-en_INT_20240101.txt",
                 opts,
             )
             .unwrap();
             zip.write_all(DESCRIPTION_TSV.as_bytes()).unwrap();
+
+            zip.start_file(
+                "Snapshot/Terminology/sct2_Description_Snapshot-de_INT_20240101.txt",
+                opts,
+            )
+            .unwrap();
+            zip.write_all(DESCRIPTION_DE_TSV.as_bytes()).unwrap();
+
+            zip.start_file(
+                "Snapshot/Refset/Language/der2_cRefset_LanguageSnapshot-en_INT_20240101.txt",
+                opts,
+            )
+            .unwrap();
+            zip.write_all(LANGUAGE_REFSET_TSV.as_bytes()).unwrap();
 
             zip.start_file(
                 "Snapshot/Terminology/sct2_Relationship_Snapshot_INT_20240101.txt",
@@ -679,6 +988,39 @@ id\teffectiveTime\tactive\tmoduleId\tsourceId\tdestinationId\trelationshipGroup\
             zip.finish().unwrap();
         }
         tmp
+    }
+
+    /// Run the description/refset parsing pipeline over the test fixtures.
+    fn parse_fixture_terms() -> HashMap<String, ConceptTerms> {
+        let mut errors = Vec::new();
+        let active = parse_active_concepts(CONCEPT_TSV.as_bytes(), &mut errors);
+
+        let mut by_desc_id = HashMap::new();
+        let mut next_order = 0;
+        parse_descriptions(
+            DESCRIPTION_TSV.as_bytes(),
+            &active,
+            &mut next_order,
+            &mut by_desc_id,
+            &mut errors,
+        );
+        parse_descriptions(
+            DESCRIPTION_DE_TSV.as_bytes(),
+            &active,
+            &mut next_order,
+            &mut by_desc_id,
+            &mut errors,
+        );
+
+        let mut preferred_in = HashMap::new();
+        parse_language_refsets(
+            LANGUAGE_REFSET_TSV.as_bytes(),
+            &mut preferred_in,
+            &mut errors,
+        );
+
+        assert!(errors.is_empty(), "unexpected parse errors: {errors:?}");
+        build_concept_terms(by_desc_id, &preferred_in, &active)
     }
 
     fn count_rows(backend: &SqliteTerminologyBackend, table: &str) -> i64 {
@@ -702,20 +1044,121 @@ id\teffectiveTime\tactive\tmoduleId\tsourceId\tdestinationId\trelationshipGroup\
     }
 
     #[test]
-    fn parse_preferred_terms_synonym_takes_priority_over_fsn() {
-        let mut errors = Vec::new();
-        let active = parse_active_concepts(CONCEPT_TSV.as_bytes(), &mut errors);
-        let terms = parse_preferred_terms(DESCRIPTION_TSV.as_bytes(), &active, &mut errors);
+    fn display_prefers_us_preferred_synonym_then_gb_then_fsn() {
+        let terms = parse_fixture_terms();
 
+        // 111005 "Foo malady" is US-preferred and must win over the
+        // GB-preferred "Foo disorder" that appears earlier in the file.
+        assert_eq!(terms.get("123456001").unwrap().display, "Foo malady");
+        // No synonym at all → FSN fallback.
         assert_eq!(
-            terms.get("123456001").map(String::as_str),
-            Some("Foo disorder")
-        );
-        assert_eq!(
-            terms.get("789012001").map(String::as_str),
-            Some("Bar finding (finding)")
+            terms.get("789012001").unwrap().display,
+            "Bar finding (finding)"
         );
         assert!(!terms.contains_key("999999001"));
+    }
+
+    #[test]
+    fn display_without_language_refsets_keeps_first_synonym() {
+        let mut errors = Vec::new();
+        let active = parse_active_concepts(CONCEPT_TSV.as_bytes(), &mut errors);
+        let mut by_desc_id = HashMap::new();
+        let mut next_order = 0;
+        parse_descriptions(
+            DESCRIPTION_TSV.as_bytes(),
+            &active,
+            &mut next_order,
+            &mut by_desc_id,
+            &mut errors,
+        );
+        let terms = build_concept_terms(by_desc_id, &HashMap::new(), &active);
+
+        assert_eq!(terms.get("123456001").unwrap().display, "Foo disorder");
+    }
+
+    #[test]
+    fn descriptions_in_all_languages_become_designations() {
+        let terms = parse_fixture_terms();
+        let foo = terms.get("123456001").unwrap();
+
+        // German synonym from the per-language description file.
+        let de: Vec<_> = foo
+            .designations
+            .iter()
+            .filter(|d| d.language == "de")
+            .collect();
+        assert_eq!(de.len(), 1);
+        assert_eq!(de[0].value, "Foo Erkrankung");
+        assert_eq!(de[0].use_system, SNOMED_URL);
+        assert_eq!(de[0].use_code, TYPE_SYNONYM);
+
+        // English FSN retained as a designation with the FSN type code.
+        assert!(foo.designations.iter().any(|d| d.language == "en"
+            && d.use_code == TYPE_FSN
+            && d.value == "Foo disorder (disorder)"));
+
+        // Dialect-preferred synonyms get en-US / en-GB preferredForLanguage rows.
+        assert!(foo.designations.iter().any(|d| d.language == "en-US"
+            && d.use_code == "preferredForLanguage"
+            && d.use_system == HL7_TERM_MAINT_INFRA
+            && d.value == "Foo malady"));
+        assert!(
+            foo.designations
+                .iter()
+                .any(|d| d.language == "en-GB" && d.value == "Foo disorder")
+        );
+    }
+
+    #[test]
+    fn refset_preferred_synonym_ordered_before_other_designations_per_language() {
+        let terms = parse_fixture_terms();
+        let foo = terms.get("123456001").unwrap();
+
+        // First "en" designation must be a refset-preferred synonym, and all
+        // synonyms must precede the FSN (language-keyed lookups take the
+        // first match in stored order).
+        let first_en = foo
+            .designations
+            .iter()
+            .find(|d| d.language == "en")
+            .unwrap();
+        assert_eq!(first_en.use_code, TYPE_SYNONYM);
+        assert!(["Foo malady", "Foo disorder"].contains(&first_en.value.as_str()));
+
+        let fsn_pos = foo
+            .designations
+            .iter()
+            .position(|d| d.use_code == TYPE_FSN)
+            .unwrap();
+        let last_syn_pos = foo
+            .designations
+            .iter()
+            .rposition(|d| d.use_code == TYPE_SYNONYM)
+            .unwrap();
+        assert!(last_syn_pos < fsn_pos, "synonyms must precede the FSN");
+    }
+
+    #[test]
+    fn inactive_description_row_revokes_earlier_state() {
+        let mut errors = Vec::new();
+        let active = parse_active_concepts(CONCEPT_TSV.as_bytes(), &mut errors);
+
+        // Full-file style: the synonym is later inactivated.
+        let full_tsv = "\
+id\teffectiveTime\tactive\tmoduleId\tconceptId\tlanguageCode\ttypeId\tterm\tcaseSignificanceId\r\n\
+111001\t20240101\t1\t900000000000207008\t123456001\ten\t900000000000013009\tFoo disorder\t900000000000448009\r\n\
+111001\t20250101\t0\t900000000000207008\t123456001\ten\t900000000000013009\tFoo disorder\t900000000000448009\r\n";
+        let mut by_desc_id = HashMap::new();
+        let mut next_order = 0;
+        parse_descriptions(
+            full_tsv.as_bytes(),
+            &active,
+            &mut next_order,
+            &mut by_desc_id,
+            &mut errors,
+        );
+
+        assert!(by_desc_id.is_empty());
     }
 
     #[test]
@@ -794,6 +1237,67 @@ BADLINE\r\n";
         assert_eq!(count_rows(&backend, "code_systems"), 1);
         assert_eq!(count_rows(&backend, "concepts"), 2);
         assert_eq!(count_rows(&backend, "concept_hierarchy"), 1);
+    }
+
+    #[tokio::test]
+    async fn import_snomed_rf2_writes_multilingual_designations() {
+        use crate::traits::CodeSystemOperations;
+        use crate::types::LookupRequest;
+
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        let ctx = TenantContext::system();
+        let zip_file = make_test_rf2_zip();
+
+        import_snomed_rf2(&backend, &ctx, zip_file.path(), 500, false)
+            .await
+            .unwrap();
+
+        // 123456001: en×2 + FSN + de + en-US + en-GB = 6; 789012001: en FSN + de FSN = 2.
+        assert_eq!(count_rows(&backend, "concept_designations"), 8);
+
+        // displayLanguage=de resolves the German synonym as the display.
+        let resp = backend
+            .lookup(
+                &ctx,
+                LookupRequest {
+                    system: SNOMED_URL.into(),
+                    code: "123456001".into(),
+                    display_language: Some("de".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.display.as_deref(), Some("Foo Erkrankung"));
+
+        // Without displayLanguage the US-preferred English synonym wins.
+        let resp = backend
+            .lookup(
+                &ctx,
+                LookupRequest {
+                    system: SNOMED_URL.into(),
+                    code: "123456001".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.display.as_deref(), Some("Foo malady"));
+
+        // Dialect-tagged lookup resolves the en-GB preferred term.
+        let resp = backend
+            .lookup(
+                &ctx,
+                LookupRequest {
+                    system: SNOMED_URL.into(),
+                    code: "123456001".into(),
+                    display_language: Some("en-GB".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.display.as_deref(), Some("Foo disorder"));
     }
 
     #[tokio::test]

--- a/crates/hts/src/import/snomed_rf2.rs
+++ b/crates/hts/src/import/snomed_rf2.rs
@@ -412,15 +412,25 @@ fn prefer_snapshot(paths: Vec<String>) -> Vec<String> {
     }
 }
 
+/// Pick a single file from candidate paths, preferring Snapshot variants and
+/// sorting for determinism. Production RF2 ZIPs ship `Full/` and `Snapshot/`
+/// side by side; the Full variant must not be parsed by the snapshot-oriented
+/// single-pass parsers.
+fn pick_single(paths: Vec<String>) -> Option<String> {
+    let mut paths = prefer_snapshot(paths);
+    paths.sort();
+    paths.into_iter().next()
+}
+
 #[allow(clippy::type_complexity)]
 fn find_rf2_paths(
     path: &Path,
 ) -> Result<(String, Vec<String>, String, Vec<String>, Vec<String>), HtsError> {
     let mut zip = open_zip(path)?;
 
-    let mut concept_path: Option<String> = None;
+    let mut concept_paths: Vec<String> = Vec::new();
     let mut desc_paths: Vec<String> = Vec::new();
-    let mut rel_path: Option<String> = None;
+    let mut rel_paths: Vec<String> = Vec::new();
     let mut assoc_refset_paths: Vec<String> = Vec::new();
     let mut lang_refset_paths: Vec<String> = Vec::new();
 
@@ -444,11 +454,11 @@ fn find_rf2_paths(
         }
 
         if lower.contains("concept_") {
-            concept_path = Some(name);
+            concept_paths.push(name);
         } else if lower.contains("description_") {
             desc_paths.push(name);
         } else if lower.contains("relationship_") && !lower.contains("statedrelationship") {
-            rel_path = Some(name);
+            rel_paths.push(name);
         }
     }
 
@@ -458,6 +468,8 @@ fn find_rf2_paths(
     desc_paths.sort();
     let mut lang_refset_paths = prefer_snapshot(lang_refset_paths);
     lang_refset_paths.sort();
+    let mut assoc_refset_paths = prefer_snapshot(assoc_refset_paths);
+    assoc_refset_paths.sort();
 
     if desc_paths.is_empty() {
         return Err(HtsError::InvalidRequest(
@@ -467,14 +479,14 @@ fn find_rf2_paths(
     }
 
     Ok((
-        concept_path.ok_or_else(|| {
+        pick_single(concept_paths).ok_or_else(|| {
             HtsError::InvalidRequest(
                 "No Concept RF2 file found. Expected a file containing 'Concept_' in its path."
                     .into(),
             )
         })?,
         desc_paths,
-        rel_path.ok_or_else(|| {
+        pick_single(rel_paths).ok_or_else(|| {
             HtsError::InvalidRequest(
                 "No Relationship RF2 file found. Expected a file containing 'Relationship_' in its path."
                     .into(),
@@ -990,6 +1002,52 @@ id\teffectiveTime\tactive\tmoduleId\tsourceId\tdestinationId\trelationshipGroup\
         tmp
     }
 
+    /// Like [`make_test_rf2_zip`], but the archive also carries `Full/`
+    /// variants (as production RF2 distributions do) whose extra rows would
+    /// corrupt the import if they were parsed alongside the Snapshot files.
+    fn make_full_and_snapshot_rf2_zip() -> NamedTempFile {
+        // Poison rows: an extra concept, description, and relationship that
+        // exist only in the Full files.
+        const FULL_CONCEPT_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\tdefinitionStatusId\r\n\
+123456001\t20240101\t1\t900000000000207008\t900000000000074008\r\n\
+789012001\t20240101\t1\t900000000000207008\t900000000000074008\r\n\
+555555001\t20230101\t1\t900000000000207008\t900000000000074008\r\n";
+        const FULL_DESCRIPTION_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\tconceptId\tlanguageCode\ttypeId\tterm\tcaseSignificanceId\r\n\
+311001\t20230101\t1\t900000000000207008\t123456001\ten\t900000000000013009\tStale full-file term\t900000000000448009\r\n";
+        const FULL_RELATIONSHIP_TSV: &str = "\
+id\teffectiveTime\tactive\tmoduleId\tsourceId\tdestinationId\trelationshipGroup\ttypeId\tcharacteristicTypeId\tmodifierId\r\n\
+444001\t20230101\t1\t900000000000207008\t123456001\t789012001\t0\t116680003\t900000000000011006\t900000000000451002\r\n";
+
+        let tmp = make_test_rf2_zip();
+        {
+            let mut zip = zip::ZipWriter::new_append(tmp.reopen().unwrap()).unwrap();
+            let opts = zip::write::FileOptions::default();
+
+            zip.start_file("Full/Terminology/sct2_Concept_Full_INT_20240101.txt", opts)
+                .unwrap();
+            zip.write_all(FULL_CONCEPT_TSV.as_bytes()).unwrap();
+
+            zip.start_file(
+                "Full/Terminology/sct2_Description_Full-en_INT_20240101.txt",
+                opts,
+            )
+            .unwrap();
+            zip.write_all(FULL_DESCRIPTION_TSV.as_bytes()).unwrap();
+
+            zip.start_file(
+                "Full/Terminology/sct2_Relationship_Full_INT_20240101.txt",
+                opts,
+            )
+            .unwrap();
+            zip.write_all(FULL_RELATIONSHIP_TSV.as_bytes()).unwrap();
+
+            zip.finish().unwrap();
+        }
+        tmp
+    }
+
     /// Run the description/refset parsing pipeline over the test fixtures.
     fn parse_fixture_terms() -> HashMap<String, ConceptTerms> {
         let mut errors = Vec::new();
@@ -1237,6 +1295,25 @@ BADLINE\r\n";
         assert_eq!(count_rows(&backend, "code_systems"), 1);
         assert_eq!(count_rows(&backend, "concepts"), 2);
         assert_eq!(count_rows(&backend, "concept_hierarchy"), 1);
+    }
+
+    #[tokio::test]
+    async fn import_snomed_rf2_ignores_full_files_when_snapshot_present() {
+        let backend = SqliteTerminologyBackend::in_memory().unwrap();
+        let ctx = TenantContext::system();
+        let zip_file = make_full_and_snapshot_rf2_zip();
+
+        let stats = import_snomed_rf2(&backend, &ctx, zip_file.path(), 500, false)
+            .await
+            .expect("import should succeed");
+
+        // Identical to the snapshot-only archive: the Full files' poison rows
+        // (extra concept 555555001, stale description, duplicate edge) must
+        // not be parsed.
+        assert_eq!(stats.concepts, 2);
+        assert_eq!(count_rows(&backend, "concepts"), 2);
+        assert_eq!(count_rows(&backend, "concept_hierarchy"), 1);
+        assert_eq!(count_rows(&backend, "concept_designations"), 8);
     }
 
     #[tokio::test]

--- a/crates/hts/src/language.rs
+++ b/crates/hts/src/language.rs
@@ -1,0 +1,116 @@
+//! BCP-47 / RFC 4647 language-tag matching for designation selection.
+//!
+//! Designation languages come from heterogeneous sources — SNOMED RF2 ships
+//! bare primary tags (`de`, `da`), LOINC linguistic variants ship
+//! region-qualified tags (`de-DE`, `fr-FR`) — while clients send whatever
+//! their locale produces (browsers typically `de-DE` via `Accept-Language`).
+//! Exact string equality therefore fails in both directions. The helpers
+//! here implement RFC 4647 §3.4 *Lookup* with progressive truncation of the
+//! requested tag, plus the extends-with-a-subtag rule already used by
+//! `$expand` (requested `de` accepts stored `de-CH`).
+
+/// Rank a stored designation language tag against a requested tag.
+///
+/// Lower rank is a better match; `None` means no match. For each truncation
+/// of the requested tag (`de-DE-1996` → `de-DE` → `de`), in order:
+///
+/// * the stored tag equals the candidate (case-insensitive) — rank `2*i`;
+/// * the stored tag extends the candidate with a `-` subtag (so `de`
+///   accepts `de-CH` but not `den`) — rank `2*i + 1`.
+///
+/// Examples (requested → stored): `de`→`de` is 0, `de`→`de-CH` is 1,
+/// `de-DE`→`de` is 2, `de-DE`→`de-CH` is 3, `de`→`den` is `None`.
+pub(crate) fn lang_match_rank(requested: &str, stored: &str) -> Option<u32> {
+    let stored = stored.to_ascii_lowercase();
+    let mut candidate = requested.trim().to_ascii_lowercase();
+    let mut i = 0u32;
+    loop {
+        if stored == candidate {
+            return Some(2 * i);
+        }
+        if stored.len() > candidate.len()
+            && stored.starts_with(candidate.as_str())
+            && stored.as_bytes()[candidate.len()] == b'-'
+        {
+            return Some(2 * i + 1);
+        }
+        match candidate.rfind('-') {
+            Some(pos) => {
+                candidate.truncate(pos);
+                i += 1;
+            }
+            None => return None,
+        }
+    }
+}
+
+/// `true` when the stored tag satisfies the requested tag under
+/// [`lang_match_rank`].
+pub(crate) fn lang_matches(requested: &str, stored: &str) -> bool {
+    lang_match_rank(requested, stored).is_some()
+}
+
+/// Index of the best-matching language among `langs` for `requested`, or
+/// `None` when nothing matches. Ties keep the earliest item, so callers that
+/// order designations preferred-first retain that preference.
+pub(crate) fn best_lang_match_index<'a>(
+    requested: &str,
+    langs: impl IntoIterator<Item = Option<&'a str>>,
+) -> Option<usize> {
+    let mut best: Option<(u32, usize)> = None;
+    for (idx, lang) in langs.into_iter().enumerate() {
+        if let Some(rank) = lang.and_then(|l| lang_match_rank(requested, l)) {
+            if best.is_none_or(|(r, _)| rank < r) {
+                best = Some((rank, idx));
+            }
+        }
+    }
+    best.map(|(_, idx)| idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_match_is_best() {
+        assert_eq!(lang_match_rank("de", "de"), Some(0));
+        assert_eq!(lang_match_rank("de-DE", "de-DE"), Some(0));
+        assert_eq!(lang_match_rank("en-US", "en-us"), Some(0));
+    }
+
+    #[test]
+    fn stored_dialect_satisfies_bare_request() {
+        assert_eq!(lang_match_rank("de", "de-CH"), Some(1));
+        assert_eq!(lang_match_rank("fr", "fr-FR"), Some(1));
+        // No subtag boundary — must not match.
+        assert_eq!(lang_match_rank("de", "den"), None);
+    }
+
+    #[test]
+    fn requested_dialect_truncates_to_bare_stored() {
+        assert_eq!(lang_match_rank("de-DE", "de"), Some(2));
+        assert_eq!(lang_match_rank("de-DE", "de-CH"), Some(3));
+        assert_eq!(lang_match_rank("zh-Hans-CN", "zh"), Some(4));
+    }
+
+    #[test]
+    fn unrelated_languages_do_not_match() {
+        assert_eq!(lang_match_rank("de", "en"), None);
+        assert_eq!(lang_match_rank("de-DE", "en-US"), None);
+        assert!(!lang_matches("sv-SE", "da"));
+    }
+
+    #[test]
+    fn best_index_prefers_rank_then_order() {
+        // Exact beats dialect-extension regardless of order.
+        let langs = [Some("de-CH"), Some("de")];
+        assert_eq!(best_lang_match_index("de", langs), Some(1));
+        // Equal ranks keep the earliest (preferred-first ordering).
+        let langs = [Some("de"), Some("de")];
+        assert_eq!(best_lang_match_index("de", langs), Some(0));
+        let langs = [Some("en"), None, Some("fr")];
+        assert_eq!(best_lang_match_index("fr-FR", langs), Some(2));
+        assert_eq!(best_lang_match_index("ja", langs), None);
+    }
+}

--- a/crates/hts/src/lib.rs
+++ b/crates/hts/src/lib.rs
@@ -41,6 +41,7 @@ pub mod config;
 pub mod ecl;
 pub mod error;
 pub mod import;
+pub(crate) mod language;
 pub mod operations;
 pub mod server;
 pub mod state;

--- a/crates/hts/src/operations/expand.rs
+++ b/crates/hts/src/operations/expand.rs
@@ -1062,26 +1062,18 @@ fn apply_display_language<'a, B: TerminologyBackend>(
         }
         // (system, code) → (designation language tag, designation value).
         // Match using BCP 47 / RFC 4647 Lookup: prefer an exact match, then
-        // accept any designation whose tag starts with the requested tag plus
-        // a `-` subtag separator (so `de` matches `de-CH` but not `den`).
+        // a designation whose tag extends the requested tag with a `-`
+        // subtag (so `de` matches `de-CH` but not `den`), then the same two
+        // rules against truncations of the requested tag (`de-DE` → `de`).
         let mut match_map: HashMap<(String, String), (Option<String>, String)> = HashMap::new();
         for (system, codes) in &by_system {
             if let Ok(ds) = backend.concept_designations(ctx, system, codes).await {
                 for (code, list) in ds {
-                    let exact = list
-                        .iter()
-                        .find(|d| d.language.as_deref() == Some(language));
-                    let chosen = exact.cloned().or_else(|| {
-                        list.into_iter().find(|d| {
-                            d.language.as_deref().is_some_and(|lang| {
-                                let prefix = format!("{language}-");
-                                lang.eq_ignore_ascii_case(language)
-                                    || lang
-                                        .to_ascii_lowercase()
-                                        .starts_with(&prefix.to_ascii_lowercase())
-                            })
-                        })
-                    });
+                    let chosen = crate::language::best_lang_match_index(
+                        language,
+                        list.iter().map(|d| d.language.as_deref()),
+                    )
+                    .and_then(|idx| list.into_iter().nth(idx));
                     if let Some(d) = chosen {
                         match_map.insert(((*system).to_string(), code), (d.language, d.value));
                     }

--- a/crates/hts/src/operations/lookup.rs
+++ b/crates/hts/src/operations/lookup.rs
@@ -647,6 +647,40 @@ mod tests {
         assert_eq!(display_param["valueString"], "Alpha Bêta Charlie");
     }
 
+    /// A realistic browser header carries a region-qualified primary tag
+    /// (`fr-FR`); the stored designation is tagged bare `fr`. RFC 4647
+    /// truncation must bridge the two.
+    #[tokio::test]
+    async fn lookup_accept_language_regional_tag_falls_back_to_base_language() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "system", "valueUri": "http://example.org/cs"},
+                {"name": "code", "valueCode": "ABC"}
+            ]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/CodeSystem/$lookup")
+                    .header("content-type", "application/json")
+                    .header("accept-language", "fr-FR,fr;q=0.9,en;q=0.8")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+        let display_param = params.iter().find(|p| p["name"] == "display").unwrap();
+        assert_eq!(display_param["valueString"], "Alpha Bêta Charlie");
+    }
+
     #[tokio::test]
     async fn lookup_explicit_display_language_wins_over_accept_language_header() {
         let app = make_app();

--- a/crates/hts/src/operations/lookup.rs
+++ b/crates/hts/src/operations/lookup.rs
@@ -416,7 +416,8 @@ pub async fn lookup_handler<B: TerminologyBackend>(
 ) -> Result<Response, HtsError> {
     let accept = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok());
     let format = negotiate_format(raw.as_deref(), accept);
-    let params = extract_parameter_array(&body)?;
+    let mut params = extract_parameter_array(&body)?;
+    crate::operations::expand::inject_accept_language(&headers, &mut params);
     Ok(fhir_respond(process_lookup(&state, params).await?, format))
 }
 
@@ -433,7 +434,8 @@ pub async fn get_lookup_handler<B: TerminologyBackend>(
     let accept = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok());
     let format = negotiate_format(raw.as_deref(), accept);
     let pairs = parse_query_string(raw.as_deref().unwrap_or(""));
-    let params = query_params_to_fhir_params(pairs);
+    let mut params = query_params_to_fhir_params(pairs);
+    crate::operations::expand::inject_accept_language(&headers, &mut params);
     Ok(fhir_respond(process_lookup(&state, params).await?, format))
 }
 
@@ -498,10 +500,9 @@ pub async fn lookup_by_id_post<B: TerminologyBackend>(
     let raw_params = body
         .and_then(|Json(v)| extract_parameter_array(&v).ok())
         .unwrap_or_default();
-    Ok(fhir_respond(
-        process_lookup(&state, inject_system(raw_params, system)).await?,
-        format,
-    ))
+    let mut params = inject_system(raw_params, system);
+    crate::operations::expand::inject_accept_language(&headers, &mut params);
+    Ok(fhir_respond(process_lookup(&state, params).await?, format))
 }
 
 /// `GET /CodeSystem/{id}/$lookup?code=<code>`
@@ -526,10 +527,9 @@ pub async fn get_lookup_by_id<B: TerminologyBackend>(
 
     let pairs = parse_query_string(raw.as_deref().unwrap_or(""));
     let params = query_params_to_fhir_params(pairs);
-    Ok(fhir_respond(
-        process_lookup(&state, inject_system(params, system)).await?,
-        format,
-    ))
+    let mut params = inject_system(params, system);
+    crate::operations::expand::inject_accept_language(&headers, &mut params);
+    Ok(fhir_respond(process_lookup(&state, params).await?, format))
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -568,7 +568,8 @@ mod tests {
         Router::new()
             .route(
                 "/CodeSystem/$lookup",
-                post(lookup_handler::<SqliteTerminologyBackend>),
+                post(lookup_handler::<SqliteTerminologyBackend>)
+                    .get(get_lookup_handler::<SqliteTerminologyBackend>),
             )
             .with_state(state)
     }
@@ -613,6 +614,92 @@ mod tests {
         let params = json["parameter"].as_array().unwrap();
         let display_param = params.iter().find(|p| p["name"] == "display").unwrap();
         assert_eq!(display_param["valueString"], "Alpha Beta Charlie");
+    }
+
+    #[tokio::test]
+    async fn lookup_accept_language_header_selects_designation_display() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "system", "valueUri": "http://example.org/cs"},
+                {"name": "code", "valueCode": "ABC"}
+            ]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/CodeSystem/$lookup")
+                    .header("content-type", "application/json")
+                    .header("accept-language", "fr, en;q=0.8")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+        let display_param = params.iter().find(|p| p["name"] == "display").unwrap();
+        assert_eq!(display_param["valueString"], "Alpha Bêta Charlie");
+    }
+
+    #[tokio::test]
+    async fn lookup_explicit_display_language_wins_over_accept_language_header() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "system", "valueUri": "http://example.org/cs"},
+                {"name": "code", "valueCode": "ABC"},
+                {"name": "displayLanguage", "valueCode": "en"}
+            ]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/CodeSystem/$lookup")
+                    .header("content-type", "application/json")
+                    .header("accept-language", "fr")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+        let display_param = params.iter().find(|p| p["name"] == "display").unwrap();
+        // No `en` designation exists, so the default display is kept — the
+        // injected header must NOT have overridden the explicit parameter.
+        assert_eq!(display_param["valueString"], "Alpha Beta Charlie");
+    }
+
+    #[tokio::test]
+    async fn get_lookup_accept_language_header_selects_designation_display() {
+        let app = make_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/CodeSystem/$lookup?system=http%3A%2F%2Fexample.org%2Fcs&code=ABC")
+                    .header("accept-language", "fr")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let json = body_json(resp).await;
+        let params = json["parameter"].as_array().unwrap();
+        let display_param = params.iter().find(|p| p["name"] == "display").unwrap();
+        assert_eq!(display_param["valueString"], "Alpha Bêta Charlie");
     }
 
     #[tokio::test]

--- a/crates/hts/src/operations/validate_code.rs
+++ b/crates/hts/src/operations/validate_code.rs
@@ -2465,7 +2465,8 @@ pub async fn get_validate_code_handler<B: TerminologyBackend>(
     let accept = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok());
     let format = negotiate_format(raw.as_deref(), accept);
     let pairs = parse_query_string(raw.as_deref().unwrap_or(""));
-    let params = query_params_to_fhir_params(pairs);
+    let mut params = query_params_to_fhir_params(pairs);
+    crate::operations::expand::inject_accept_language(&headers, &mut params);
     match process_validate_code(&state, params).await {
         Ok(v) => Ok(fhir_respond(v, format)),
         Err(e) => match invalid_display_language_response(&e) {
@@ -5822,7 +5823,8 @@ pub async fn get_vs_validate_code_handler<B: TerminologyBackend>(
     let accept = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok());
     let format = negotiate_format(raw.as_deref(), accept);
     let pairs = parse_query_string(raw.as_deref().unwrap_or(""));
-    let params = query_params_to_fhir_params(pairs);
+    let mut params = query_params_to_fhir_params(pairs);
+    crate::operations::expand::inject_accept_language(&headers, &mut params);
     match process_vs_validate_code(&state, params).await {
         Ok(v) => Ok(fhir_respond(v, format)),
         Err(e) => {
@@ -5868,8 +5870,10 @@ pub async fn vs_validate_by_id_post<B: TerminologyBackend>(
     let raw_params = body
         .and_then(|Json(v)| extract_parameter_array(&v).ok())
         .unwrap_or_default();
+    let mut params = inject_url(raw_params, url);
+    crate::operations::expand::inject_accept_language(&headers, &mut params);
     Ok(fhir_respond(
-        process_vs_validate_code(&state, inject_url(raw_params, url)).await?,
+        process_vs_validate_code(&state, params).await?,
         format,
     ))
 }
@@ -5890,8 +5894,10 @@ pub async fn get_vs_validate_by_id<B: TerminologyBackend>(
 
     let pairs = parse_query_string(raw.as_deref().unwrap_or(""));
     let params = query_params_to_fhir_params(pairs);
+    let mut params = inject_url(params, url);
+    crate::operations::expand::inject_accept_language(&headers, &mut params);
     Ok(fhir_respond(
-        process_vs_validate_code(&state, inject_url(params, url)).await?,
+        process_vs_validate_code(&state, params).await?,
         format,
     ))
 }

--- a/crates/hts/src/operations/validate_code.rs
+++ b/crates/hts/src/operations/validate_code.rs
@@ -660,19 +660,25 @@ async fn apply_language_display_validation<B: TerminologyBackend>(
         .unwrap_or_default();
 
     // Find the "preferred" display in any of the requested languages, if any.
-    // Returns the first designation whose language equals one of the requested
-    // languages (case-insensitive, exact match — IG fixtures don't exercise
-    // language-tag fallback like `de-CH` → `de`).
+    // Matching is BCP-47-aware (RFC 4647 Lookup, see [`crate::language`]):
+    // an exact tag wins, then a stored dialect of a requested tag
+    // (`de` → `de-CH`), then truncations of a requested tag (`de-DE` → `de`);
+    // ties keep the earliest designation.
     let preferred_for_lang: Option<&(String, Option<String>)> = if requested_langs.is_empty() {
         None
     } else {
-        displays_for_lang.iter().find(|(_, lang_opt)| {
-            lang_opt.as_deref().is_some_and(|l| {
+        displays_for_lang
+            .iter()
+            .filter_map(|entry| {
+                let stored = entry.1.as_deref()?;
                 requested_langs
                     .iter()
-                    .any(|req| l.eq_ignore_ascii_case(req))
+                    .filter_map(|req| crate::language::lang_match_rank(req, stored))
+                    .min()
+                    .map(|rank| (rank, entry))
             })
-        })
+            .min_by_key(|(rank, _)| *rank)
+            .map(|(_, entry)| entry)
     };
 
     // Surface the language-preferred display on the response (overriding the

--- a/crates/hts/src/server.rs
+++ b/crates/hts/src/server.rs
@@ -213,7 +213,8 @@ fn build_cors(config: &HtsConfig) -> CorsLayer {
             .collect();
 
         // With explicit origins the browser enforces the allow-lists below;
-        // include `Content-Encoding` so clients can send compressed bodies.
+        // include `Content-Encoding` so clients can send compressed bodies
+        // and `Accept-Language` so they can request designation languages.
         CorsLayer::new()
             .allow_origin(origins)
             .allow_methods([
@@ -226,6 +227,7 @@ fn build_cors(config: &HtsConfig) -> CorsLayer {
             .allow_headers([
                 header::CONTENT_TYPE,
                 header::ACCEPT,
+                header::ACCEPT_LANGUAGE,
                 header::AUTHORIZATION,
                 header::CONTENT_ENCODING,
             ])

--- a/crates/hts/tests/postgres_integration_tests.rs
+++ b/crates/hts/tests/postgres_integration_tests.rs
@@ -325,6 +325,85 @@ async fn lookup_filters_properties() {
 }
 
 #[tokio::test]
+async fn lookup_display_language_falls_back_to_newest_other_version() {
+    let backend = fresh_backend().await;
+    let base = base_url!("lkp-mv");
+    let cs_url = format!("{base}cs");
+
+    // Two coexisting versions of one canonical URL: the newest (20260601)
+    // has only English content; the older edition carries the German term.
+    for (version, designations) in [
+        ("20260601", serde_json::json!([])),
+        (
+            "20260515",
+            serde_json::json!([{"language": "de", "value": "Farbe"}]),
+        ),
+    ] {
+        let uid = uuid::Uuid::new_v4().simple().to_string();
+        let bundle = serde_json::json!({
+            "resourceType": "Bundle",
+            "type": "collection",
+            "entry": [{
+                "resource": {
+                    "resourceType": "CodeSystem",
+                    "id": format!("cs-{uid}"),
+                    "url": cs_url,
+                    "name": "TestCS",
+                    "version": version,
+                    "status": "active",
+                    "content": "complete",
+                    "concept": [{
+                        "code": "C1",
+                        "display": format!("Color ({version})"),
+                        "designation": designations
+                    }]
+                }
+            }]
+        });
+        backend
+            .import_bundle(&ctx(), &serde_json::to_vec(&bundle).unwrap())
+            .await
+            .expect("Seed import should succeed");
+    }
+
+    // Unversioned lookup resolves 20260601 (no German) — the German
+    // designation must be served from the older 20260515 edition.
+    let resp = CodeSystemOperations::lookup(
+        &backend,
+        &ctx(),
+        LookupRequest {
+            system: cs_url.clone(),
+            code: "C1".into(),
+            display_language: Some("de".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(resp.display.as_deref(), Some("Farbe"));
+    assert_eq!(resp.version.as_deref(), Some("20260601"));
+    assert_eq!(resp.designations.len(), 1);
+    assert_eq!(resp.designations[0].language.as_deref(), Some("de"));
+
+    // An explicit version pin is respected strictly: no fallback.
+    let resp = CodeSystemOperations::lookup(
+        &backend,
+        &ctx(),
+        LookupRequest {
+            system: cs_url,
+            code: "C1".into(),
+            version: Some("20260601".into()),
+            display_language: Some("de".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(resp.display.as_deref(), Some("Color (20260601)"));
+    assert!(resp.designations.is_empty());
+}
+
+#[tokio::test]
 async fn lookup_display_language_preferred() {
     let backend = fresh_backend().await;
     let base = base_url!("lkp-lang");


### PR DESCRIPTION
## Summary

Lands @darthcav's multilingual SNOMED CT work from #148 (his three commits are included as-authored, re-signed for our signing policy), plus one follow-up commit that generalizes the language handling beyond English and German to every language SNOMED supports.

## From #148 (authored by @darthcav)

- All RF2 Description files are imported (every language), with each active description becoming a `concept.designation` tagged with the RF2 language code and SNOMED description type.
- Language refsets drive display selection (en-US → en-GB → any preferred) and designation ordering; en-US/en-GB dialect-tagged `preferredForLanguage` designations.
- Full/Snapshot separation fix; Accept-Language injection on `$lookup`/`$validate-code`; CORS allow-header; cross-version designation fallback in `$lookup`.

See #148 for the full write-up.

## Generalization (new commit)

1. **BCP-47 / RFC 4647 Lookup matching** wherever a requested `displayLanguage` is compared to a stored designation tag — `$lookup` (display swap, designation filter, cross-version fallback; SQLite + PostgreSQL), `$expand`, and `$validate-code`. A browser sending `Accept-Language: de-DE,de;q=0.9` now resolves designations stored as `de` (SNOMED tags bare RF2 codes), and a request for `fr` accepts `fr-CA`/`fr-FR` (as LOINC linguistic variants are stored). Previously only `en-US`/`en-GB` region-qualified requests worked, because only those dialect designations existed.
2. **`LANG_REFSET_DIALECTS` extended** from en-US/en-GB to the published national-edition language refsets — da-DK, en-AU, en-CA, en-IE, en-NZ, es-UY, et-EE, fr-BE, fr-CA, fr-FR, nb-NO, nn-NO, nl-BE, nl-NL, sv-SE — SCTIDs per SNOMED International's Snowstorm dialect configuration (`search.dialect.config.*`).
3. **`preferredForLanguage` for every refset-preferred synonym**, tagged with its bare RF2 language (plus the dialect tag when the refset is in the table). Editions whose refset is not in the table (German, Spanish, Swiss, …) get explicit preference metadata instead of relying on designation ordering alone.

New shared `crate::language` module implements the rank-based matcher (exact > stored-dialect-of-requested > truncated-requested), with unit tests.

## Testing

- 607 `helios-hts` lib tests pass, including new coverage: matcher unit tests, a national-edition import test (Danish + German, no English content — exercises both the known-dialect and unknown-refset paths plus the non-English display fallback), `de-DE` → `de` lookup fallback, and a realistic `Accept-Language: fr-FR,fr;q=0.9,en;q=0.8` handler test.
- All hts integration suites green, including 83 PostgreSQL tests against testcontainers.
- `cargo fmt` and `cargo clippy` (CI flags) clean.

Closes #148.