### PR TITLE
feat(observability): uptime, Prometheus /metrics, and OTLP traces across all servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,14 @@ jobs:
         # helios-serde's own quick-xml (client FHIR XML) is already on 0.41 and
         # sits behind the non-default `xml` feature. Remove these once
         # object_store and octofhir-ucum ship builds on quick-xml >= 0.41.
+        #
+        # crossbeam-epoch 0.9.18 (transitive; present on main identically).
+        # RUSTSEC-2026-0204 is an invalid-pointer dereference in the
+        # `fmt::Pointer` impl for `Atomic`/`Shared`, reachable only when
+        # debug-formatting an already-invalid epoch pointer — we never format
+        # these types. 0.9.18 is the latest release; no fixed version exists yet.
+        # Ambient advisory (published 2026-07-06, after main's last green run).
+        # Remove once crossbeam-epoch ships a patched release.
         run: >-
           cargo audit
           --ignore RUSTSEC-2026-0118
@@ -312,6 +320,7 @@ jobs:
           --ignore RUSTSEC-2026-0185
           --ignore RUSTSEC-2026-0194
           --ignore RUSTSEC-2026-0195
+          --ignore RUSTSEC-2026-0204
  
   coverage:
     name: Code Coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,6 +3375,7 @@ dependencies = [
  "futures",
  "helios-fhir",
  "helios-fhirpath-support",
+ "helios-observability",
  "hex",
  "http 1.4.0",
  "lazy_static",
@@ -3417,6 +3418,7 @@ dependencies = [
  "helios-audit",
  "helios-auth",
  "helios-fhir",
+ "helios-observability",
  "helios-persistence",
  "helios-rest",
  "helios-sof",
@@ -3448,6 +3450,7 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "helios-fhir",
+ "helios-observability",
  "helios-persistence",
  "r2d2",
  "r2d2_sqlite",
@@ -3470,6 +3473,23 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "zip 0.6.6",
+]
+
+[[package]]
+name = "helios-observability"
+version = "0.1.47"
+dependencies = [
+ "axum",
+ "chrono",
+ "http 1.4.0",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3543,6 +3563,7 @@ dependencies = [
  "helios-audit",
  "helios-auth",
  "helios-fhir",
+ "helios-observability",
  "helios-persistence",
  "helios-serde",
  "helios-sof",
@@ -3617,6 +3638,7 @@ dependencies = [
  "helios-fhir",
  "helios-fhirpath",
  "helios-fhirpath-support",
+ "helios-observability",
  "http 1.4.0",
  "lru",
  "mime",
@@ -4739,6 +4761,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.14.0",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,6 +5287,68 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -5870,6 +6003,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6083,6 +6231,33 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "rayon"
@@ -6991,6 +7166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7641,6 +7822,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7744,6 +7936,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ default-members = [
 	"crates/auth",
 	"crates/audit",
 	"crates/subscriptions",
+	"crates/observability",
 ]
 resolver = "2"
 

--- a/crates/auth/src/scope/mod.rs
+++ b/crates/auth/src/scope/mod.rs
@@ -49,6 +49,26 @@ impl ScopeSet {
             .any(|scope| scope.permits(resource_type, permission))
     }
 
+    /// Check whether this set holds a **system-context, all-resource** scope
+    /// (`system/*.<perm>`) granting the given permission.
+    ///
+    /// Unlike [`is_permitted`](Self::is_permitted), this requires the scope's
+    /// context to be [`ScopeContext::System`] **and** its resource specifier to
+    /// be [`ResourceTypeSpec::Wildcard`] — a `user/*` or `patient/*` token, or a
+    /// system token scoped to a single resource type (`system/Patient.rs`), never
+    /// satisfies it.
+    ///
+    /// This is the gate for backend-service / administrative endpoints that span
+    /// every tenant (e.g. the cross-tenant console metrics), which no per-user or
+    /// per-patient app — however broad its wildcard — should be able to reach.
+    pub fn has_system_scope(&self, permission: SmartPermissions) -> bool {
+        self.scopes.iter().any(|scope| {
+            scope.context == ScopeContext::System
+                && matches!(scope.resource_type, ResourceTypeSpec::Wildcard)
+                && scope.permissions.contains(permission)
+        })
+    }
+
     /// Returns the parsed scopes.
     pub fn scopes(&self) -> &[SmartScope] {
         &self.scopes
@@ -167,5 +187,34 @@ mod tests {
     fn test_raw_retained() {
         let set = ScopeSet::parse("system/Patient.rs system/bulk-submit");
         assert_eq!(set.raw().len(), 2);
+    }
+
+    #[test]
+    fn test_has_system_scope_grants_for_system_wildcard() {
+        assert!(ScopeSet::parse("system/*.r").has_system_scope(SmartPermissions::READ));
+        assert!(ScopeSet::parse("system/*.rs").has_system_scope(SmartPermissions::READ));
+        assert!(ScopeSet::parse("system/*.cruds").has_system_scope(SmartPermissions::READ));
+        // The permission bit must actually be present.
+        assert!(!ScopeSet::parse("system/*.cud").has_system_scope(SmartPermissions::READ));
+    }
+
+    #[test]
+    fn test_has_system_scope_rejects_non_system_context() {
+        // This is the exact class of token that leaks today: a broad, wildcard,
+        // read-capable scope that is NOT system-context. It must be rejected.
+        assert!(!ScopeSet::parse("patient/*.rs").has_system_scope(SmartPermissions::READ));
+        assert!(!ScopeSet::parse("user/*.cruds").has_system_scope(SmartPermissions::READ));
+    }
+
+    #[test]
+    fn test_has_system_scope_rejects_non_wildcard_system() {
+        // System context but scoped to a single resource type is not system-wide.
+        assert!(!ScopeSet::parse("system/Patient.rs").has_system_scope(SmartPermissions::READ));
+    }
+
+    #[test]
+    fn test_has_system_scope_finds_grant_among_many() {
+        let set = ScopeSet::parse("patient/Patient.rs user/Observation.r system/*.r");
+        assert!(set.has_system_scope(SmartPermissions::READ));
     }
 }

--- a/crates/fhirpath/Cargo.toml
+++ b/crates/fhirpath/Cargo.toml
@@ -17,9 +17,13 @@ R4B = ["helios-fhir/R4B"]
 R5 = ["helios-fhir/R5"]
 R6 = ["helios-fhir/R6"]
 
+# OpenTelemetry OTLP trace export (heavy deps; opt-in for production images)
+otel = ["helios-observability/otel"]
+
 [dependencies]
 helios-fhir = { path = "../fhir", version = "0.2.1", default-features = false }
 helios-fhirpath-support = { path = "../fhirpath-support", version = "0.2.1" }
+helios-observability = { path = "../observability", version = "0.2.1" }
 chumsky = "0.10"
 roxmltree = "0.20"
 chrono = { workspace = true } # For date/time parsing and functions

--- a/crates/fhirpath/src/handlers.rs
+++ b/crates/fhirpath/src/handlers.rs
@@ -459,6 +459,8 @@ pub async fn health_check() -> impl IntoResponse {
         "status": "ok",
         "service": "fhirpath-server",
         "version": env!("CARGO_PKG_VERSION"),
+        "uptime_seconds": helios_observability::uptime::uptime_seconds(),
+        "started_at": helios_observability::uptime::started_at_rfc3339(),
         "timestamp": Utc::now().to_rfc3339()
     }))
 }

--- a/crates/fhirpath/src/server.rs
+++ b/crates/fhirpath/src/server.rs
@@ -229,16 +229,11 @@ impl From<ServerArgs> for ServerConfig {
 
 /// Run the FHIRPath server
 pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing
-    let filter = format!(
-        "fhirpath_server={},tower_http={}",
-        config.log_level, config.log_level
-    );
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| filter.into()),
-        )
-        .init();
+    // Initialize observability: logging/tracing (+ optional OTLP), uptime, and
+    // the Prometheus metrics recorder.
+    helios_observability::uptime::init();
+    helios_observability::telemetry::init("fhirpath-server", &config.log_level);
+    helios_observability::metrics::init("fhirpath-server");
 
     info!("Starting FHIRPath server...");
     info!("Configuration: {:?}", config);
@@ -320,6 +315,13 @@ pub fn create_app(config: &ServerConfig) -> Router {
 
     // Add tracing
     app = app.layer(TraceLayer::new_for_http());
+
+    // Observability: `/metrics` (state-free) + per-request metrics/trace span.
+    app = app
+        .merge(helios_observability::metrics::router())
+        .layer(axum::middleware::from_fn(
+            helios_observability::middleware::track,
+        ));
 
     app
 }

--- a/crates/hfs/Cargo.toml
+++ b/crates/hfs/Cargo.toml
@@ -47,6 +47,9 @@ bulk-submit-jwe = ["helios-rest/bulk-submit-jwe"]
 # Cloud audit backends
 cloudwatch = ["helios-audit/cloudwatch"]
 
+# OpenTelemetry OTLP trace export (heavy deps; opt-in for production images)
+otel = ["helios-observability/otel"]
+
 [build-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }
 
@@ -59,6 +62,7 @@ helios-auth = { path = "../auth", version = "0.2.1" }
 helios-audit = { path = "../audit", version = "0.2.1", default-features = false }
 helios-subscriptions = { path = "../subscriptions", version = "0.2.1", optional = true, default-features = false }
 helios-ui = { path = "../ui", version = "0.2.1", optional = true }
+helios-observability = { path = "../observability", version = "0.2.1" }
 
 # Export job controller
 dashmap = "6"

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -592,6 +592,7 @@ async fn serve(
 /// returns `(config, None)`.
 async fn init_auth_with_audit(
     audit_sink: Arc<dyn AuditSink>,
+    tenant_url_routing: bool,
 ) -> anyhow::Result<(AuthConfig, Option<Arc<AuthMiddlewareState>>)> {
     let auth_config = AuthConfig::from_env();
 
@@ -667,6 +668,7 @@ async fn init_auth_with_audit(
         audit_sink,
         audit_source_observer: audit_config.source_observer.clone(),
         audit_exclusion_filter: ExclusionFilter::new(audit_config.exclusions.clone()),
+        tenant_url_routing,
     });
 
     Ok((auth_config, Some(auth_state)))
@@ -786,7 +788,11 @@ async fn main() -> anyhow::Result<()> {
     let (audit_sink, audit_state) = init_audit(&config, backend_mode).await?;
 
     // Initialize authentication (with audit bridge if audit is enabled)
-    let (auth_config, auth_state) = init_auth_with_audit(audit_sink).await?;
+    let (auth_config, auth_state) = init_auth_with_audit(
+        audit_sink,
+        config.multitenancy.routing_mode.supports_url_path(),
+    )
+    .await?;
 
     let audit_config = AuditConfig::from_env();
 

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -25,9 +25,7 @@ use helios_audit::{
 };
 use helios_auth::{AuthConfig, InMemoryJtiCache, JtiCache, JwksBearerAuthProvider, JwksCache};
 use helios_persistence::{BackendKind, ResourceStorage, TenantContext};
-use helios_rest::{
-    AuthMiddlewareState, ServerConfig, StorageBackendMode, create_app_with_auth, init_logging,
-};
+use helios_rest::{AuthMiddlewareState, ServerConfig, StorageBackendMode, create_app_with_auth};
 use tracing::info;
 
 use helios_persistence::backends::local_fs::LocalFsOutputStore;
@@ -559,6 +557,15 @@ async fn serve(
 
     let addr = config.socket_addr();
     info!(address = %addr, "Server listening");
+
+    // Observability: expose `/metrics` (outside the auth layer, so scrapers
+    // need no token) and instrument every request with metrics + a trace span.
+    let app = app
+        .merge(helios_observability::metrics::router())
+        .layer(axum::middleware::from_fn(
+            helios_observability::middleware::track,
+        ));
+
     let listener = tokio::net::TcpListener::bind(&addr).await?;
 
     axum::serve(listener, app)
@@ -569,6 +576,8 @@ async fn serve(
                 lifecycle::record_shutdown(&*state.sink, &state.config.source_observer).await;
                 state.sink.flush().await;
             }
+            // Flush any buffered OTLP spans (no-op without the `otel` feature).
+            helios_observability::telemetry::shutdown();
         })
         .await?;
     Ok(())
@@ -743,7 +752,9 @@ async fn main() -> anyhow::Result<()> {
     // sub-structs — both `#[arg(skip)]` for clap — are populated from
     // their `HFS_*` environment variables.
     let config = ServerConfig::from_env();
-    init_logging(&config.log_level);
+    helios_observability::uptime::init();
+    helios_observability::telemetry::init("hfs", &config.log_level);
+    helios_observability::metrics::init("hfs");
 
     if let Err(errors) = config.validate() {
         for error in &errors {

--- a/crates/hts/Cargo.toml
+++ b/crates/hts/Cargo.toml
@@ -33,9 +33,13 @@ R4B = ["helios-fhir/R4B", "helios-persistence/R4B"]
 R5 = ["helios-fhir/R5", "helios-persistence/R5"]
 R6 = ["helios-fhir/R6", "helios-persistence/R6"]
 
+# OpenTelemetry OTLP trace export (heavy deps; opt-in for production images)
+otel = ["helios-observability/otel"]
+
 [dependencies]
 helios-fhir = { workspace = true }
 helios-persistence = { path = "../persistence", version = "0.2.1", default-features = false, features = ["sqlite"] }
+helios-observability = { path = "../observability", version = "0.2.1" }
 
 async-trait = "0.1"
 axum = { version = "0.8", features = ["json", "query"] }

--- a/crates/hts/src/main.rs
+++ b/crates/hts/src/main.rs
@@ -14,14 +14,6 @@ use helios_hts::state::AppState;
 #[cfg(feature = "postgres")]
 use helios_hts::backends::PostgresTerminologyBackend;
 
-fn init_logging(log_level: &str) {
-    use tracing_subscriber::{EnvFilter, fmt};
-
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level));
-
-    fmt().with_env_filter(filter).with_target(false).init();
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
@@ -30,7 +22,9 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| Command::Run(HtsConfig::parse_from(["hts"])))
     {
         Command::Run(config) => {
-            init_logging(&config.log_level);
+            helios_observability::uptime::init();
+            helios_observability::telemetry::init("hts", &config.log_level);
+            helios_observability::metrics::init("hts");
             info!(
                 port = config.port,
                 host = %config.host,
@@ -46,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
             } else {
                 &args.log_level
             };
-            init_logging(log_level);
+            helios_observability::telemetry::init("hts", log_level);
             let code = run_import(args).await?;
             std::process::exit(code);
         }

--- a/crates/hts/src/operations/health.rs
+++ b/crates/hts/src/operations/health.rs
@@ -33,6 +33,8 @@ where
             "service": "hts",
             "version": env!("CARGO_PKG_VERSION"),
             "backend": state.backend().backend_name(),
+            "uptime_seconds": helios_observability::uptime::uptime_seconds(),
+            "started_at": helios_observability::uptime::started_at_rfc3339(),
             "timestamp": chrono::Utc::now().to_rfc3339(),
         })),
     )

--- a/crates/hts/src/server.rs
+++ b/crates/hts/src/server.rs
@@ -188,6 +188,11 @@ where
         // responses when the client sends `Accept-Encoding`.
         .layer(RequestDecompressionLayer::new())
         .layer(CompressionLayer::new())
+        // Observability: `/metrics` (state-free) + per-request metrics/trace span.
+        .merge(helios_observability::metrics::router())
+        .layer(axum::middleware::from_fn(
+            helios_observability::middleware::track,
+        ))
         .layer(cors)
         .layer(TimeoutLayer::with_status_code(
             axum::http::StatusCode::REQUEST_TIMEOUT,

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "helios-observability"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage = "https://github.com/HeliosSoftware/hfs/tree/main/crates/observability"
+rust-version.workspace = true
+description = "Shared observability wiring (uptime, Prometheus /metrics, OTLP traces) for Helios servers"
+keywords = ["helios-software", "observability", "prometheus", "opentelemetry", "metrics"]
+categories = ["web-programming"]
+
+[features]
+default = []
+
+# Opt-in OpenTelemetry: OTLP trace export via tracing-opentelemetry. Kept out of
+# the default build because the OTel SDK + tonic stack noticeably increases build
+# time. The Prometheus `/metrics` endpoint and uptime tracking are always built.
+otel = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+]
+
+[dependencies]
+# Web framework (MatchedPath extractor needs the matched-path feature)
+axum = { version = "0.8", features = ["matched-path"] }
+http = "1.0"
+
+# Metrics facade + maintained Prometheus pull exporter
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.16", default-features = false }
+
+# Logging / tracing
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Date/time for started_at
+chrono.workspace = true
+
+# OpenTelemetry (feature-gated). Versions pinned to a mutually compatible set:
+# core 0.32 / tracing-opentelemetry 0.33 (runs one minor ahead of core).
+opentelemetry = { version = "0.32", optional = true }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace"], optional = true }
+tracing-opentelemetry = { version = "0.33", optional = true }

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -36,5 +36,6 @@
 
 pub mod metrics;
 pub mod middleware;
+pub mod reqlog;
 pub mod telemetry;
 pub mod uptime;

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -1,0 +1,40 @@
+//! Shared observability wiring for Helios servers.
+//!
+//! This crate centralizes the telemetry surface so the four Helios server
+//! binaries (`hfs`, `hts`, `sof-server`, `fhirpath-server`) expose a uniform
+//! set of endpoints and signals without duplicating wiring:
+//!
+//! - [`uptime`] — process start-time tracking, surfaced on `/health` and as the
+//!   `uptime_seconds` metric.
+//! - [`metrics`] — global Prometheus recorder + a `GET /metrics` router.
+//! - [`middleware`] — per-request count/latency metrics and a tracing span.
+//! - [`telemetry`] — `tracing-subscriber` init, optionally bridged to OTLP
+//!   (feature `otel`).
+//!
+//! ## Typical wiring
+//!
+//! ```rust,ignore
+//! // in main(), before serving:
+//! helios_observability::uptime::init();
+//! helios_observability::telemetry::init("hfs", &log_level);
+//! helios_observability::metrics::init("hfs");
+//!
+//! let app = my_router()
+//!     .merge(helios_observability::metrics::router())
+//!     .layer(axum::middleware::from_fn(helios_observability::middleware::track));
+//!
+//! // on graceful shutdown:
+//! helios_observability::telemetry::shutdown();
+//! ```
+//!
+//! ## Design notes
+//!
+//! - `/metrics` uses the maintained `metrics` + `metrics-exporter-prometheus`
+//!   stack, not `opentelemetry-prometheus` (unmaintained, RUSTSEC advisory).
+//! - OTLP *metrics* are expected to be produced by an OpenTelemetry Collector
+//!   scraping `/metrics`; the app itself only pushes OTLP *traces*.
+
+pub mod metrics;
+pub mod middleware;
+pub mod telemetry;
+pub mod uptime;

--- a/crates/observability/src/metrics.rs
+++ b/crates/observability/src/metrics.rs
@@ -42,6 +42,12 @@ pub fn router() -> Router {
     Router::new().route("/metrics", get(render))
 }
 
+// Note: per-tenant resource-count gauges are intentionally NOT exported here.
+// The `/metrics` endpoint is public (unauthenticated, for Prometheus scraping),
+// and tenant is never a metric label — exporting per-tenant counts would leak
+// cross-tenant data to any anonymous scraper. Per-tenant stored-resource counts
+// are served only via the authenticated console `resource-counts` JSON endpoint.
+
 /// Render the Prometheus exposition text. The `uptime_seconds` gauge is set
 /// immediately before rendering because the pull exporter has no scrape
 /// callback.

--- a/crates/observability/src/metrics.rs
+++ b/crates/observability/src/metrics.rs
@@ -9,11 +9,20 @@
 use std::sync::OnceLock;
 
 use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 
 use crate::uptime;
 
 static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
+/// Latency histogram buckets (seconds) for `http_request_duration_seconds`.
+/// Configuring explicit buckets makes `metrics-exporter-prometheus` emit a real
+/// Prometheus **histogram** (`_bucket` / `le` series) instead of a summary, so
+/// `histogram_quantile()` works and quantiles aggregate correctly across
+/// instances scraped into one backend. A standard HTTP-latency spread.
+const LATENCY_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
 
 /// Install the global Prometheus recorder. A global `service="<service_name>"`
 /// label is attached so the generic metric names (`http_requests_total`, …)
@@ -31,6 +40,11 @@ pub fn init(service_name: &str) {
     }
     let handle = PrometheusBuilder::new()
         .add_global_label("service", service_name)
+        .set_buckets_for_metric(
+            Matcher::Full("http_request_duration_seconds".to_string()),
+            LATENCY_BUCKETS,
+        )
+        .expect("failed to set latency histogram buckets")
         .install_recorder()
         .expect("failed to install Prometheus recorder");
     let _ = HANDLE.set(handle);

--- a/crates/observability/src/metrics.rs
+++ b/crates/observability/src/metrics.rs
@@ -1,0 +1,58 @@
+//! Prometheus metrics: global recorder installation and the `/metrics` endpoint.
+//!
+//! Uses the [`metrics`] facade with the maintained
+//! [`metrics_exporter_prometheus`] pull exporter. We deliberately avoid
+//! `opentelemetry-prometheus` (unmaintained, carries a RUSTSEC advisory via
+//! `protobuf`). OTLP *metrics* are produced out-of-process by an OpenTelemetry
+//! Collector scraping this `/metrics` endpoint.
+
+use std::sync::OnceLock;
+
+use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+use crate::uptime;
+
+static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
+/// Install the global Prometheus recorder. A global `service="<service_name>"`
+/// label is attached so the generic metric names (`http_requests_total`, …)
+/// stay distinct across the different Helios server processes when scraped into
+/// one backend. Idempotent across repeated calls within a process: the first
+/// call installs the recorder, later calls are no-ops (useful for tests).
+///
+/// # Panics
+///
+/// Panics only if a *different* global metrics recorder was already installed by
+/// something other than this function.
+pub fn init(service_name: &str) {
+    if HANDLE.get().is_some() {
+        return;
+    }
+    let handle = PrometheusBuilder::new()
+        .add_global_label("service", service_name)
+        .install_recorder()
+        .expect("failed to install Prometheus recorder");
+    let _ = HANDLE.set(handle);
+}
+
+/// A state-free [`Router`] exposing `GET /metrics`. Merge it into each server's
+/// router with `router.merge(helios_observability::metrics::router())`.
+pub fn router() -> Router {
+    Router::new().route("/metrics", get(render))
+}
+
+/// Render the Prometheus exposition text. The `uptime_seconds` gauge is set
+/// immediately before rendering because the pull exporter has no scrape
+/// callback.
+async fn render() -> impl IntoResponse {
+    metrics::gauge!("uptime_seconds").set(uptime::uptime_seconds());
+    match HANDLE.get() {
+        Some(handle) => handle.render().into_response(),
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "metrics recorder not initialized\n",
+        )
+            .into_response(),
+    }
+}

--- a/crates/observability/src/middleware.rs
+++ b/crates/observability/src/middleware.rs
@@ -46,6 +46,12 @@ pub async fn track(req: Request, next: Next) -> Response {
 
     span.record("http.status_code", status);
 
+    // Feed the in-process rolling log that backs the dashboard traffic widgets
+    // (windowed req/s, latency percentiles, per-tenant rollup). Cheap: a single
+    // bounded-buffer push. Tenant is recorded here for the per-tenant view but,
+    // as above, never becomes a Prometheus label.
+    crate::reqlog::record(status, elapsed, &tenant);
+
     let method = method.as_str().to_owned();
     let status = status.to_string();
     metrics::counter!(

--- a/crates/observability/src/middleware.rs
+++ b/crates/observability/src/middleware.rs
@@ -1,0 +1,67 @@
+//! Per-request instrumentation middleware.
+//!
+//! Records request count and latency as Prometheus metrics and opens a tracing
+//! span per request. Under the `otel` feature the span is exported as an OTLP
+//! trace span by the `tracing-opentelemetry` layer (see [`crate::telemetry`]).
+//!
+//! Cardinality discipline: the `route` label uses axum's templated
+//! [`MatchedPath`] (e.g. `/{resource_type}/{id}`), never the raw URI with
+//! concrete IDs. The tenant is recorded as a *span attribute* only (useful for
+//! per-tenant latency in traces) and is never a metric label, to avoid
+//! unbounded Prometheus series.
+
+use std::time::Instant;
+
+use axum::{extract::MatchedPath, extract::Request, middleware::Next, response::Response};
+use tracing::Instrument;
+
+/// Tower/axum middleware (`axum::middleware::from_fn`) that instruments every
+/// request. State-free, so it composes with any server's router.
+pub async fn track(req: Request, next: Next) -> Response {
+    let method = req.method().clone();
+    let route = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|m| m.as_str().to_owned())
+        .unwrap_or_else(|| "<unmatched>".to_owned());
+    let tenant = req
+        .headers()
+        .get("x-tenant-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+
+    let span = tracing::info_span!(
+        "http.request",
+        http.method = %method,
+        http.route = %route,
+        tenant = %tenant,
+        http.status_code = tracing::field::Empty,
+    );
+
+    let start = Instant::now();
+    let response = next.run(req).instrument(span.clone()).await;
+    let elapsed = start.elapsed().as_secs_f64();
+    let status = response.status().as_u16();
+
+    span.record("http.status_code", status);
+
+    let method = method.as_str().to_owned();
+    let status = status.to_string();
+    metrics::counter!(
+        "http_requests_total",
+        "method" => method.clone(),
+        "route" => route.clone(),
+        "status" => status.clone(),
+    )
+    .increment(1);
+    metrics::histogram!(
+        "http_request_duration_seconds",
+        "method" => method,
+        "route" => route,
+        "status" => status,
+    )
+    .record(elapsed);
+
+    response
+}

--- a/crates/observability/src/reqlog.rs
+++ b/crates/observability/src/reqlog.rs
@@ -1,0 +1,338 @@
+//! In-process rolling request log for dashboard traffic widgets.
+//!
+//! The Prometheus pull exporter ([`crate::metrics`]) holds *cumulative* counters
+//! and an all-time latency histogram — enough for Grafana to compute `rate()`
+//! and `histogram_quantile()` over a range, but not enough for a self-contained
+//! dashboard that wants "requests/sec, p95, and error rate over the last hour"
+//! without a Prometheus deployment.
+//!
+//! This module keeps a bounded ring buffer of recent request samples and derives
+//! windowed statistics from it on demand. It is intentionally lightweight:
+//!
+//! - Fixed capacity ([`CAPACITY`]); the oldest sample is evicted on overflow, so
+//!   memory is bounded regardless of traffic.
+//! - One `Mutex` guarding a `VecDeque`; the critical section is a push/pop, so
+//!   contention stays negligible at dashboard-relevant request rates.
+//! - No per-route retention — that would need windowed per-key aggregation;
+//!   route-level stats remain Prometheus's job.
+//!
+//! [`record`] is called once per request by [`crate::middleware::track`];
+//! [`snapshot`] and [`per_tenant`] back the console `traffic` and `tenants`
+//! endpoints.
+
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+
+/// Maximum number of request samples retained. At ~20 k samples the buffer
+/// covers a comfortably long window for any realistic dashboard refresh while
+/// staying well under a megabyte.
+pub const CAPACITY: usize = 20_000;
+
+/// Number of sub-buckets in a [`TrafficStats::series`] sparkline.
+const SERIES_BUCKETS: usize = 30;
+
+/// A single recorded request.
+#[derive(Clone)]
+struct Sample {
+    /// Epoch milliseconds when the request completed.
+    at_ms: i64,
+    /// End-to-end latency in milliseconds.
+    latency_ms: f32,
+    /// HTTP status code.
+    status: u16,
+    /// Resolved tenant id (`X-Tenant-ID`), or empty when not supplied.
+    tenant: Box<str>,
+}
+
+static LOG: OnceLock<Mutex<VecDeque<Sample>>> = OnceLock::new();
+
+fn log() -> &'static Mutex<VecDeque<Sample>> {
+    LOG.get_or_init(|| Mutex::new(VecDeque::with_capacity(1024)))
+}
+
+/// Record one completed request. Called from the request middleware.
+///
+/// `tenant` should be the raw `X-Tenant-ID` value (empty string if absent);
+/// [`per_tenant`] normalises the empty case to `"default"`.
+pub fn record(status: u16, latency_secs: f64, tenant: &str) {
+    let sample = Sample {
+        at_ms: chrono::Utc::now().timestamp_millis(),
+        latency_ms: (latency_secs * 1000.0) as f32,
+        status,
+        tenant: tenant.into(),
+    };
+    if let Ok(mut q) = log().lock() {
+        if q.len() >= CAPACITY {
+            q.pop_front();
+        }
+        q.push_back(sample);
+    }
+}
+
+/// Windowed traffic statistics, derived from the samples newer than
+/// `now - window_seconds`.
+#[derive(Debug, Clone)]
+pub struct TrafficStats {
+    /// The requested window length.
+    pub window_seconds: i64,
+    /// Span actually covered by the retained samples (≤ `window_seconds`; lower
+    /// when the buffer does not reach back the full window).
+    pub covered_seconds: f64,
+    /// Number of samples in the window.
+    pub sample_count: usize,
+    /// Mean requests per second across the window.
+    pub requests_per_second: f64,
+    /// Latency percentiles in milliseconds.
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub p99_ms: f64,
+    /// Fraction of requests with a 5xx status, in `0.0..=1.0`.
+    pub error_rate: f64,
+    /// Status-class counts.
+    pub status_2xx: u64,
+    pub status_3xx: u64,
+    pub status_4xx: u64,
+    pub status_5xx: u64,
+    /// Sparkline buckets, oldest first.
+    pub series: Vec<TrafficBucket>,
+}
+
+/// One sparkline bucket within a [`TrafficStats`] window.
+#[derive(Debug, Clone)]
+pub struct TrafficBucket {
+    /// Seconds before `now` at which this bucket starts (largest = oldest).
+    pub offset_seconds: i64,
+    /// Mean requests per second within the bucket.
+    pub requests_per_second: f64,
+    /// p95 latency (ms) within the bucket; `0.0` when the bucket is empty.
+    pub p95_ms: f64,
+}
+
+/// Compute traffic statistics over the last `window_seconds`.
+///
+/// Pass `tenant = Some(id)` to restrict to a single tenant, or `None` for all
+/// traffic. The lock is held only long enough to copy the in-window samples.
+pub fn snapshot(window_seconds: i64, tenant: Option<&str>) -> TrafficStats {
+    let window = window_seconds.max(1);
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let start_ms = now_ms - window * 1000;
+
+    let mut samples: Vec<(i64, f32, u16)> = Vec::new();
+    if let Ok(q) = log().lock() {
+        for s in q.iter() {
+            if s.at_ms >= start_ms && tenant.is_none_or(|t| &*s.tenant == t) {
+                samples.push((s.at_ms, s.latency_ms, s.status));
+            }
+        }
+    }
+
+    let sample_count = samples.len();
+    let covered_seconds = samples
+        .iter()
+        .map(|s| s.0)
+        .min()
+        .map(|oldest| (now_ms - oldest) as f64 / 1000.0)
+        .unwrap_or(0.0)
+        .min(window as f64);
+
+    let (mut s2, mut s3, mut s4, mut s5) = (0u64, 0u64, 0u64, 0u64);
+    let mut latencies: Vec<f32> = Vec::with_capacity(sample_count);
+    for &(_, latency, status) in &samples {
+        latencies.push(latency);
+        match status / 100 {
+            2 => s2 += 1,
+            3 => s3 += 1,
+            4 => s4 += 1,
+            5 => s5 += 1,
+            _ => {}
+        }
+    }
+
+    let requests_per_second = sample_count as f64 / window as f64;
+    let error_rate = if sample_count > 0 {
+        s5 as f64 / sample_count as f64
+    } else {
+        0.0
+    };
+
+    TrafficStats {
+        window_seconds: window,
+        covered_seconds,
+        sample_count,
+        requests_per_second,
+        p50_ms: percentile_ms(&mut latencies, 0.50),
+        p95_ms: percentile_ms(&mut latencies, 0.95),
+        p99_ms: percentile_ms(&mut latencies, 0.99),
+        error_rate,
+        status_2xx: s2,
+        status_3xx: s3,
+        status_4xx: s4,
+        status_5xx: s5,
+        series: build_series(&samples, start_ms, now_ms, window),
+    }
+}
+
+/// Per-tenant traffic rollup over the last `window_seconds`, busiest first.
+pub fn per_tenant(window_seconds: i64) -> Vec<TenantTraffic> {
+    let window = window_seconds.max(1);
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let start_ms = now_ms - window * 1000;
+
+    // Hold the lock only long enough to copy the in-window samples into a local
+    // Vec; build the per-tenant rollup (HashMap, key allocation, percentiles)
+    // after releasing the lock so `record()` is never stalled by this work.
+    let mut samples: Vec<(Box<str>, f32, u16)> = Vec::new();
+    if let Ok(q) = log().lock() {
+        for s in q.iter() {
+            if s.at_ms >= start_ms {
+                samples.push((s.tenant.clone(), s.latency_ms, s.status));
+            }
+        }
+    }
+
+    // tenant -> (latencies, 5xx count)
+    let mut by_tenant: std::collections::HashMap<String, (Vec<f32>, u64)> =
+        std::collections::HashMap::new();
+    for (tenant, latency, status) in samples {
+        let key = if tenant.is_empty() {
+            "default".to_string()
+        } else {
+            String::from(tenant)
+        };
+        let entry = by_tenant.entry(key).or_insert_with(|| (Vec::new(), 0));
+        entry.0.push(latency);
+        if status / 100 == 5 {
+            entry.1 += 1;
+        }
+    }
+
+    let mut out: Vec<TenantTraffic> = by_tenant
+        .into_iter()
+        .map(|(tenant, (mut latencies, errors))| {
+            let n = latencies.len();
+            TenantTraffic {
+                tenant,
+                sample_count: n,
+                requests_per_second: n as f64 / window as f64,
+                p95_ms: percentile_ms(&mut latencies, 0.95),
+                error_rate: if n > 0 { errors as f64 / n as f64 } else { 0.0 },
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| b.sample_count.cmp(&a.sample_count));
+    out
+}
+
+/// Per-tenant traffic figures returned by [`per_tenant`].
+#[derive(Debug, Clone)]
+pub struct TenantTraffic {
+    pub tenant: String,
+    pub sample_count: usize,
+    pub requests_per_second: f64,
+    pub p95_ms: f64,
+    pub error_rate: f64,
+}
+
+/// Nearest-rank percentile (in ms) over `latencies`, which is sorted in place.
+/// Returns `0.0` for an empty slice.
+fn percentile_ms(latencies: &mut [f32], q: f64) -> f64 {
+    if latencies.is_empty() {
+        return 0.0;
+    }
+    latencies.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let rank = (q * latencies.len() as f64).ceil() as usize;
+    let idx = rank.saturating_sub(1).min(latencies.len() - 1);
+    latencies[idx] as f64
+}
+
+/// Bucket the window into [`SERIES_BUCKETS`] equal slices and compute per-slice
+/// req/s and p95 for the sparkline.
+fn build_series(
+    samples: &[(i64, f32, u16)],
+    start_ms: i64,
+    now_ms: i64,
+    window: i64,
+) -> Vec<TrafficBucket> {
+    let span_ms = (now_ms - start_ms).max(1);
+    let bucket_ms = (span_ms as f64 / SERIES_BUCKETS as f64).max(1.0);
+    let bucket_secs = bucket_ms / 1000.0;
+
+    let mut latencies: Vec<Vec<f32>> = vec![Vec::new(); SERIES_BUCKETS];
+    for &(at_ms, latency, _) in samples {
+        let mut b = ((at_ms - start_ms) as f64 / bucket_ms) as usize;
+        if b >= SERIES_BUCKETS {
+            b = SERIES_BUCKETS - 1;
+        }
+        latencies[b].push(latency);
+    }
+
+    latencies
+        .into_iter()
+        .enumerate()
+        .map(|(i, mut lat)| {
+            let count = lat.len();
+            // Offset (seconds before now) at which this bucket *starts*.
+            let offset_seconds =
+                window - (i as f64 * bucket_secs).round() as i64;
+            TrafficBucket {
+                offset_seconds: offset_seconds.max(0),
+                requests_per_second: count as f64 / bucket_secs.max(1.0),
+                p95_ms: percentile_ms(&mut lat, 0.95),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_basic() {
+        let mut v: Vec<f32> = (1..=100).map(|n| n as f32).collect();
+        assert_eq!(percentile_ms(&mut v, 0.50), 50.0);
+        assert_eq!(percentile_ms(&mut v, 0.95), 95.0);
+        assert_eq!(percentile_ms(&mut v, 0.99), 99.0);
+        assert_eq!(percentile_ms(&mut [], 0.95), 0.0);
+    }
+
+    #[test]
+    fn snapshot_counts_recorded_requests() {
+        // Records land in the shared buffer; a wide window should see them and
+        // classify statuses. (Other tests share the process-global buffer, so we
+        // assert on monotonic presence rather than exact totals.)
+        record(200, 0.010, "tenant-a");
+        record(503, 0.050, "tenant-a");
+        let stats = snapshot(3600, Some("tenant-a"));
+        assert!(stats.sample_count >= 2);
+        assert!(stats.status_2xx >= 1);
+        assert!(stats.status_5xx >= 1);
+        assert!(stats.error_rate > 0.0);
+        assert_eq!(stats.series.len(), SERIES_BUCKETS);
+    }
+
+    #[test]
+    fn per_tenant_rolls_up_and_normalises_empty() {
+        // Unique tenant so we can assert on it despite the shared buffer.
+        record(200, 0.010, "tenant-pt");
+        record(503, 0.050, "tenant-pt");
+        // Empty tenant must normalise to "default".
+        record(200, 0.010, "");
+
+        let rows = per_tenant(3600);
+
+        let pt = rows
+            .iter()
+            .find(|r| r.tenant == "tenant-pt")
+            .expect("tenant-pt present");
+        assert!(pt.sample_count >= 2);
+        assert!(pt.error_rate > 0.0);
+
+        assert!(
+            rows.iter().any(|r| r.tenant == "default"),
+            "empty tenant should roll up under \"default\""
+        );
+        // Busiest-first ordering preserved.
+        assert!(rows.windows(2).all(|w| w[0].sample_count >= w[1].sample_count));
+    }
+}

--- a/crates/observability/src/reqlog.rs
+++ b/crates/observability/src/reqlog.rs
@@ -219,7 +219,7 @@ pub fn per_tenant(window_seconds: i64) -> Vec<TenantTraffic> {
             }
         })
         .collect();
-    out.sort_by(|a, b| b.sample_count.cmp(&a.sample_count));
+    out.sort_by_key(|b| std::cmp::Reverse(b.sample_count));
     out
 }
 

--- a/crates/observability/src/reqlog.rs
+++ b/crates/observability/src/reqlog.rs
@@ -272,8 +272,7 @@ fn build_series(
         .map(|(i, mut lat)| {
             let count = lat.len();
             // Offset (seconds before now) at which this bucket *starts*.
-            let offset_seconds =
-                window - (i as f64 * bucket_secs).round() as i64;
+            let offset_seconds = window - (i as f64 * bucket_secs).round() as i64;
             TrafficBucket {
                 offset_seconds: offset_seconds.max(0),
                 requests_per_second: count as f64 / bucket_secs.max(1.0),
@@ -333,6 +332,9 @@ mod tests {
             "empty tenant should roll up under \"default\""
         );
         // Busiest-first ordering preserved.
-        assert!(rows.windows(2).all(|w| w[0].sample_count >= w[1].sample_count));
+        assert!(
+            rows.windows(2)
+                .all(|w| w[0].sample_count >= w[1].sample_count)
+        );
     }
 }

--- a/crates/observability/src/telemetry.rs
+++ b/crates/observability/src/telemetry.rs
@@ -1,0 +1,90 @@
+//! Tracing-subscriber initialization, optionally bridged to OTLP.
+//!
+//! [`init`] replaces the ad-hoc `tracing_subscriber` setup each server used to
+//! do itself. It always installs an `fmt` + `EnvFilter` subscriber. When built
+//! with the `otel` feature **and** `OTEL_EXPORTER_OTLP_ENDPOINT` is set, it also
+//! exports spans over OTLP via `tracing-opentelemetry`. Call [`shutdown`] during
+//! graceful shutdown to flush buffered spans.
+
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+#[cfg(feature = "otel")]
+static PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
+    std::sync::OnceLock::new();
+
+/// Global default log directives when neither `RUST_LOG` nor the cli/env filter
+/// is set. Applies `level` globally; deps remain overridable via `RUST_LOG`.
+fn default_directives(level: &str) -> String {
+    level.to_string()
+}
+
+/// Initialize logging/tracing for a server process. `service_name` is used as
+/// the OTel resource service name (overridable by `OTEL_SERVICE_NAME`). Call
+/// once per process.
+pub fn init(service_name: &str, log_level: &str) {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(default_directives(log_level)));
+
+    #[cfg(feature = "otel")]
+    {
+        if let Some(provider) = build_otlp_tracer(service_name) {
+            use opentelemetry::trace::TracerProvider as _;
+            let tracer = provider.tracer("helios");
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(fmt::layer())
+                .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                .init();
+            let _ = PROVIDER.set(provider);
+            tracing::info!(service = service_name, "OTLP trace export enabled");
+            return;
+        }
+    }
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt::layer())
+        .init();
+    let _ = service_name;
+}
+
+/// Flush and shut down the OTLP exporter, if one was configured. A no-op when
+/// the `otel` feature is disabled or OTLP export was not configured.
+pub fn shutdown() {
+    #[cfg(feature = "otel")]
+    if let Some(provider) = PROVIDER.get() {
+        let _ = provider.shutdown();
+    }
+}
+
+/// Build an OTLP-exporting tracer provider, or `None` when
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` is not set (export disabled).
+#[cfg(feature = "otel")]
+fn build_otlp_tracer(service_name: &str) -> Option<opentelemetry_sdk::trace::SdkTracerProvider> {
+    use opentelemetry_otlp::SpanExporter;
+    use opentelemetry_sdk::{Resource, trace::SdkTracerProvider};
+
+    if std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_err() {
+        return None;
+    }
+
+    let exporter = match SpanExporter::builder().with_tonic().build() {
+        Ok(exporter) => exporter,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to build OTLP span exporter; tracing export disabled");
+            return None;
+        }
+    };
+
+    let service_name =
+        std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| service_name.to_string());
+    let resource = Resource::builder().with_service_name(service_name).build();
+
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(resource)
+        .build();
+
+    opentelemetry::global::set_tracer_provider(provider.clone());
+    Some(provider)
+}

--- a/crates/observability/src/uptime.rs
+++ b/crates/observability/src/uptime.rs
@@ -32,6 +32,17 @@ pub fn started_at_rfc3339() -> String {
     STARTED_AT.get().map(|t| t.to_rfc3339()).unwrap_or_default()
 }
 
+/// Identifier for this process instance, used to disambiguate per-instance
+/// figures (uptime, in-process traffic) in a clustered deployment behind a load
+/// balancer. Reads the `HOSTNAME` env var — set to the pod/container name by
+/// Kubernetes and Docker — and falls back to `"unknown"` when unset or empty.
+pub fn instance_id() -> String {
+    std::env::var("HOSTNAME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/observability/src/uptime.rs
+++ b/crates/observability/src/uptime.rs
@@ -1,0 +1,45 @@
+//! Process uptime tracking.
+//!
+//! [`init`] is called once at server startup to record the process start time.
+//! The accessors are cheap and lock-free, suitable for calling on every
+//! `/health` or `/metrics` request.
+
+use std::sync::OnceLock;
+use std::time::Instant;
+
+static START_INSTANT: OnceLock<Instant> = OnceLock::new();
+static STARTED_AT: OnceLock<chrono::DateTime<chrono::Utc>> = OnceLock::new();
+
+/// Record the process start time. Idempotent — the first call wins, so calling
+/// it more than once (e.g. from tests) is harmless.
+pub fn init() {
+    let _ = START_INSTANT.set(Instant::now());
+    let _ = STARTED_AT.set(chrono::Utc::now());
+}
+
+/// Seconds elapsed since [`init`] was called. Returns `0.0` if `init` was never
+/// called (e.g. in a unit test that exercises a handler directly).
+pub fn uptime_seconds() -> f64 {
+    START_INSTANT
+        .get()
+        .map(|start| start.elapsed().as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+/// RFC 3339 timestamp of when the process started, or an empty string if
+/// [`init`] was never called.
+pub fn started_at_rfc3339() -> String {
+    STARTED_AT.get().map(|t| t.to_rfc3339()).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uptime_is_non_negative_after_init() {
+        init();
+        assert!(uptime_seconds() >= 0.0);
+        assert!(!started_at_rfc3339().is_empty());
+    }
+}

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -517,6 +517,10 @@ impl ResourceStorage for MongoBackend {
         "mongodb"
     }
 
+    fn is_cluster_shared(&self) -> bool {
+        true
+    }
+
     fn sof_runner(&self) -> Option<std::sync::Arc<dyn crate::core::sof_runner::SofRunner>> {
         use crate::sof::mongodb::MongoInDbRunner;
         // Native in-DB runner: compiles the ViewDefinition to an aggregation

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -1252,10 +1252,9 @@ impl ResourceStorage for MongoBackend {
             }},
         ];
 
-        let mut cursor = history
-            .aggregate(pipeline)
-            .await
-            .map_err(|e| internal_error(format!("Failed to aggregate activity histogram: {}", e)))?;
+        let mut cursor = history.aggregate(pipeline).await.map_err(|e| {
+            internal_error(format!("Failed to aggregate activity histogram: {}", e))
+        })?;
 
         let mut out = Vec::new();
         while cursor
@@ -1286,10 +1285,7 @@ impl ResourceStorage for MongoBackend {
         Ok(out)
     }
 
-    async fn count_all_types(
-        &self,
-        tenant: &TenantContext,
-    ) -> StorageResult<Vec<(String, u64)>> {
+    async fn count_all_types(&self, tenant: &TenantContext) -> StorageResult<Vec<(String, u64)>> {
         let db = self.get_database().await?;
         let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
         let tenant_id = tenant.tenant_id().as_str();

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -1159,6 +1159,215 @@ impl ResourceStorage for MongoBackend {
             .await
             .map_err(|e| internal_error(format!("Failed to count resources: {}", e)))
     }
+
+    async fn count_by_day(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        since: DateTime<Utc>,
+    ) -> StorageResult<Vec<crate::core::DailyResourceCount>> {
+        let db = self.get_database().await?;
+        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+        let tenant_id = tenant.tenant_id().as_str();
+        let since_bson = BsonDateTime::from_millis(since.timestamp_millis());
+
+        // Bucket on the server: `$match` narrows to this tenant/type/window
+        // (covered by the `(tenant_id, last_updated)` index), then `$group`
+        // collapses to one document per UTC calendar day. `$dateToString` with an
+        // explicit UTC timezone keeps day boundaries consistent with the SQL
+        // backends.
+        let pipeline = vec![
+            doc! { "$match": {
+                "tenant_id": tenant_id,
+                "resource_type": resource_type,
+                "is_deleted": false,
+                "last_updated": { "$gte": since_bson },
+            }},
+            doc! { "$group": {
+                "_id": { "$dateToString": {
+                    "format": "%Y-%m-%d",
+                    "date": "$last_updated",
+                    "timezone": "UTC",
+                }},
+                "n": { "$sum": 1 },
+            }},
+            doc! { "$sort": { "_id": 1 } },
+        ];
+
+        let mut cursor = resources
+            .aggregate(pipeline)
+            .await
+            .map_err(|e| internal_error(format!("Failed to aggregate count_by_day: {}", e)))?;
+
+        let mut out = Vec::new();
+        while cursor
+            .advance()
+            .await
+            .map_err(|e| internal_error(format!("count_by_day cursor advance: {}", e)))?
+        {
+            let doc = cursor
+                .deserialize_current()
+                .map_err(|e| internal_error(format!("count_by_day cursor deserialize: {}", e)))?;
+            let day_str = doc.get_str("_id").unwrap_or_default();
+            // `$sum: 1` yields an int32 unless it overflows into int64.
+            let n = doc
+                .get_i32("n")
+                .map(i64::from)
+                .or_else(|_| doc.get_i64("n"))
+                .unwrap_or(0);
+            if let Ok(day) = chrono::NaiveDate::parse_from_str(day_str, "%Y-%m-%d") {
+                out.push(crate::core::DailyResourceCount {
+                    day,
+                    count: n.max(0) as u64,
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    async fn activity_histogram(
+        &self,
+        tenant: &TenantContext,
+        since: DateTime<Utc>,
+    ) -> StorageResult<Vec<crate::core::ActivityCell>> {
+        let db = self.get_database().await?;
+        let history = db.collection::<Document>(MongoBackend::RESOURCE_HISTORY_COLLECTION);
+        let tenant_id = tenant.tenant_id().as_str();
+        let since_bson = BsonDateTime::from_millis(since.timestamp_millis());
+
+        // `$dayOfWeek` returns 1=Sunday..7=Saturday and `$hour` 0..23, both in the
+        // requested timezone. We subtract 1 from the weekday below to land on the
+        // 0=Sunday..6=Saturday convention shared with the SQL backends.
+        let pipeline = vec![
+            doc! { "$match": {
+                "tenant_id": tenant_id,
+                "last_updated": { "$gte": since_bson },
+            }},
+            doc! { "$group": {
+                "_id": {
+                    "wd": { "$dayOfWeek": { "date": "$last_updated", "timezone": "UTC" } },
+                    "hr": { "$hour": { "date": "$last_updated", "timezone": "UTC" } },
+                },
+                "n": { "$sum": 1 },
+            }},
+        ];
+
+        let mut cursor = history
+            .aggregate(pipeline)
+            .await
+            .map_err(|e| internal_error(format!("Failed to aggregate activity histogram: {}", e)))?;
+
+        let mut out = Vec::new();
+        while cursor
+            .advance()
+            .await
+            .map_err(|e| internal_error(format!("activity cursor advance: {}", e)))?
+        {
+            let doc = cursor
+                .deserialize_current()
+                .map_err(|e| internal_error(format!("activity cursor deserialize: {}", e)))?;
+            let id = match doc.get_document("_id") {
+                Ok(id) => id,
+                Err(_) => continue,
+            };
+            let wd = id.get_i32("wd").unwrap_or(1); // 1=Sunday..7=Saturday
+            let hr = id.get_i32("hr").unwrap_or(0);
+            let n = doc
+                .get_i32("n")
+                .map(i64::from)
+                .or_else(|_| doc.get_i64("n"))
+                .unwrap_or(0);
+            out.push(crate::core::ActivityCell {
+                weekday: (wd - 1).clamp(0, 6) as u8,
+                hour: hr.clamp(0, 23) as u8,
+                count: n.max(0) as u64,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn count_all_types(
+        &self,
+        tenant: &TenantContext,
+    ) -> StorageResult<Vec<(String, u64)>> {
+        let db = self.get_database().await?;
+        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+        let tenant_id = tenant.tenant_id().as_str();
+        let pipeline = vec![
+            doc! { "$match": { "tenant_id": tenant_id, "is_deleted": false } },
+            doc! { "$group": { "_id": "$resource_type", "n": { "$sum": 1 } } },
+        ];
+        grouped_string_counts(resources, pipeline).await
+    }
+
+    async fn count_by_types(
+        &self,
+        tenant: &TenantContext,
+        resource_types: &[&str],
+    ) -> StorageResult<Vec<(String, u64)>> {
+        // Nothing to match; avoid an empty `$in` round-trip.
+        if resource_types.is_empty() {
+            return Ok(Vec::new());
+        }
+        let db = self.get_database().await?;
+        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+        let tenant_id = tenant.tenant_id().as_str();
+        // Same filters as `count_all_types` plus a `resource_type IN (...)` restriction.
+        let pipeline = vec![
+            doc! { "$match": {
+                "tenant_id": tenant_id,
+                "is_deleted": false,
+                "resource_type": { "$in": resource_types.to_vec() },
+            }},
+            doc! { "$group": { "_id": "$resource_type", "n": { "$sum": 1 } } },
+        ];
+        grouped_string_counts(resources, pipeline).await
+    }
+
+    async fn count_by_tenant(&self) -> StorageResult<Vec<(String, u64)>> {
+        // Cross-tenant admin aggregate (see trait docs): no tenant filter.
+        let db = self.get_database().await?;
+        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+        let pipeline = vec![
+            doc! { "$match": { "is_deleted": false } },
+            doc! { "$group": { "_id": "$tenant_id", "n": { "$sum": 1 } } },
+        ];
+        grouped_string_counts(resources, pipeline).await
+    }
+}
+
+/// Runs a `$group`-by-string aggregation and collects `(_id, n)` pairs, where
+/// `_id` is a string key and `n` a `$sum` count. Shared by `count_all_types`
+/// and `count_by_tenant`.
+async fn grouped_string_counts(
+    collection: mongodb::Collection<Document>,
+    pipeline: Vec<Document>,
+) -> StorageResult<Vec<(String, u64)>> {
+    let mut cursor = collection
+        .aggregate(pipeline)
+        .await
+        .map_err(|e| internal_error(format!("Failed to aggregate grouped counts: {}", e)))?;
+    let mut out = Vec::new();
+    while cursor
+        .advance()
+        .await
+        .map_err(|e| internal_error(format!("grouped counts cursor advance: {}", e)))?
+    {
+        let doc = cursor
+            .deserialize_current()
+            .map_err(|e| internal_error(format!("grouped counts cursor deserialize: {}", e)))?;
+        let key = doc.get_str("_id").unwrap_or_default().to_string();
+        if key.is_empty() {
+            continue;
+        }
+        let n = doc
+            .get_i32("n")
+            .map(i64::from)
+            .or_else(|_| doc.get_i64("n"))
+            .unwrap_or(0);
+        out.push((key, n.max(0) as u64));
+    }
+    Ok(out)
 }
 
 impl MongoBackend {

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -64,6 +64,10 @@ impl ResourceStorage for PostgresBackend {
         "postgres"
     }
 
+    fn is_cluster_shared(&self) -> bool {
+        true
+    }
+
     fn sof_runner(&self) -> Option<std::sync::Arc<dyn crate::core::sof_runner::SofRunner>> {
         use crate::sof::postgres::PgInDbRunner;
         Some(std::sync::Arc::new(PgInDbRunner::new(self.pool())))

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -466,6 +466,175 @@ impl ResourceStorage for PostgresBackend {
 
         Ok(count as u64)
     }
+
+    async fn count_by_day(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        since: DateTime<Utc>,
+    ) -> StorageResult<Vec<crate::core::DailyResourceCount>> {
+        let client = self.get_client().await?;
+        let tenant_id = tenant.tenant_id().as_str();
+
+        // `last_updated` is `TIMESTAMPTZ`; normalise to UTC before truncating to a
+        // calendar day so buckets are stable regardless of the session time zone.
+        // The `(tenant_id, last_updated)` index supports the `>= $3` range scan.
+        let rows = client
+            .query(
+                "SELECT (last_updated AT TIME ZONE 'UTC')::date AS day, COUNT(*)::bigint AS n \
+                 FROM resources \
+                 WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE \
+                   AND last_updated >= $3 \
+                 GROUP BY day ORDER BY day",
+                &[&tenant_id, &resource_type, &since],
+            )
+            .await
+            .map_err(|e| internal_error(format!("Failed to count resources by day: {}", e)))?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let day: chrono::NaiveDate = row.get(0);
+            let n: i64 = row.get(1);
+            out.push(crate::core::DailyResourceCount {
+                day,
+                count: n.max(0) as u64,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn activity_histogram(
+        &self,
+        tenant: &TenantContext,
+        since: DateTime<Utc>,
+    ) -> StorageResult<Vec<crate::core::ActivityCell>> {
+        let client = self.get_client().await?;
+        let tenant_id = tenant.tenant_id().as_str();
+
+        // Normalise to UTC, then EXTRACT weekday (DOW: 0=Sunday..6=Saturday) and
+        // hour (0..23) so the grid matches the SQL/Mongo backends and JS's
+        // `Date.getDay()`. The `(tenant_id, last_updated)` history index backs
+        // the `>= $2` range scan.
+        let rows = client
+            .query(
+                "SELECT EXTRACT(DOW FROM (last_updated AT TIME ZONE 'UTC'))::int AS wd, \
+                        EXTRACT(HOUR FROM (last_updated AT TIME ZONE 'UTC'))::int AS hr, \
+                        COUNT(*)::bigint AS n \
+                 FROM resource_history \
+                 WHERE tenant_id = $1 AND last_updated >= $2 \
+                 GROUP BY wd, hr",
+                &[&tenant_id, &since],
+            )
+            .await
+            .map_err(|e| internal_error(format!("Failed to compute activity histogram: {}", e)))?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let wd: i32 = row.get(0);
+            let hr: i32 = row.get(1);
+            let n: i64 = row.get(2);
+            out.push(crate::core::ActivityCell {
+                weekday: wd.clamp(0, 6) as u8,
+                hour: hr.clamp(0, 23) as u8,
+                count: n.max(0) as u64,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn count_all_types(
+        &self,
+        tenant: &TenantContext,
+    ) -> StorageResult<Vec<(String, u64)>> {
+        let client = self.get_client().await?;
+        let tenant_id = tenant.tenant_id().as_str();
+        let rows = client
+            .query(
+                "SELECT resource_type, COUNT(*)::bigint FROM resources \
+                 WHERE tenant_id = $1 AND is_deleted = FALSE \
+                 GROUP BY resource_type",
+                &[&tenant_id],
+            )
+            .await
+            .map_err(|e| internal_error(format!("Failed to count all types: {}", e)))?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let rt: String = row.get(0);
+            let n: i64 = row.get(1);
+            out.push((rt, n.max(0) as u64));
+        }
+        Ok(out)
+    }
+
+    async fn count_by_types(
+        &self,
+        tenant: &TenantContext,
+        resource_types: &[&str],
+    ) -> StorageResult<Vec<(String, u64)>> {
+        // An empty `IN ()` is invalid SQL; nothing to count.
+        if resource_types.is_empty() {
+            return Ok(Vec::new());
+        }
+        let client = self.get_client().await?;
+        let tenant_id = tenant.tenant_id().as_str();
+
+        // Bind tenant_id as $1 and each requested type as $2, $3, ...; the type
+        // names are bound as parameters, never interpolated into the SQL text.
+        let placeholders = (0..resource_types.len())
+            .map(|i| format!("${}", i + 2))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT resource_type, COUNT(*)::bigint FROM resources \
+             WHERE tenant_id = $1 AND is_deleted = FALSE AND resource_type IN ({}) \
+             GROUP BY resource_type",
+            placeholders
+        );
+
+        // Owned bind values in $1..$n order: tenant first, then the requested types.
+        let mut query_params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> =
+            Vec::with_capacity(resource_types.len() + 1);
+        query_params.push(Box::new(tenant_id.to_string()));
+        for rt in resource_types {
+            query_params.push(Box::new(rt.to_string()));
+        }
+        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = query_params
+            .iter()
+            .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
+
+        let rows = client
+            .query(&sql, &param_refs)
+            .await
+            .map_err(|e| internal_error(format!("Failed to count by types: {}", e)))?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let rt: String = row.get(0);
+            let n: i64 = row.get(1);
+            out.push((rt, n.max(0) as u64));
+        }
+        Ok(out)
+    }
+
+    async fn count_by_tenant(&self) -> StorageResult<Vec<(String, u64)>> {
+        // Cross-tenant admin aggregate (see trait docs): no tenant filter.
+        let client = self.get_client().await?;
+        let rows = client
+            .query(
+                "SELECT tenant_id, COUNT(*)::bigint FROM resources \
+                 WHERE is_deleted = FALSE GROUP BY tenant_id",
+                &[],
+            )
+            .await
+            .map_err(|e| internal_error(format!("Failed to count by tenant: {}", e)))?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let tid: String = row.get(0);
+            let n: i64 = row.get(1);
+            out.push((tid, n.max(0) as u64));
+        }
+        Ok(out)
+    }
 }
 
 // ============================================================================

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -542,10 +542,7 @@ impl ResourceStorage for PostgresBackend {
         Ok(out)
     }
 
-    async fn count_all_types(
-        &self,
-        tenant: &TenantContext,
-    ) -> StorageResult<Vec<(String, u64)>> {
+    async fn count_all_types(&self, tenant: &TenantContext) -> StorageResult<Vec<(String, u64)>> {
         let client = self.get_client().await?;
         let tenant_id = tenant.tenant_id().as_str();
         let rows = client

--- a/crates/persistence/src/backends/s3/storage.rs
+++ b/crates/persistence/src/backends/s3/storage.rs
@@ -466,6 +466,13 @@ impl ResourceStorage for S3Backend {
         "s3"
     }
 
+    fn is_cluster_shared(&self) -> bool {
+        // S3 is a networked object store shared by every instance; `count` (and
+        // thus the console `count_by_types` totals) reads the shared bucket, so
+        // the counts this backend produces are cluster-consistent.
+        true
+    }
+
     fn sof_runner(&self) -> Option<std::sync::Arc<dyn crate::core::sof_runner::SofRunner>> {
         use crate::sof::in_process::{InProcessSofRunner, ResourceScan};
         use crate::sof::reference_resolver::StorageBackedResolver;

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -65,6 +65,10 @@ impl ResourceStorage for SqliteBackend {
         "sqlite"
     }
 
+    fn is_cluster_shared(&self) -> bool {
+        false
+    }
+
     fn sof_runner(&self) -> Option<std::sync::Arc<dyn crate::core::sof_runner::SofRunner>> {
         use crate::sof::sqlite::SqliteInDbRunner;
         Some(std::sync::Arc::new(SqliteInDbRunner::new(self.pool())))

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -476,6 +476,214 @@ impl ResourceStorage for SqliteBackend {
 
         Ok(count as u64)
     }
+
+    async fn count_by_day(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        since: chrono::DateTime<chrono::Utc>,
+    ) -> StorageResult<Vec<crate::core::DailyResourceCount>> {
+        let conn = self.get_connection()?;
+        let tenant_id = tenant.tenant_id().as_str();
+        // `last_updated` is stored as an RFC3339 UTC string (Utc::now().to_rfc3339()),
+        // e.g. `2026-06-01T14:30:00.123+00:00` — always `+00:00`, with a fixed-width
+        // `YYYY-MM-DDTHH:MM:SS` prefix. Its first 10 characters are the UTC calendar
+        // day, so we bucket on that prefix in SELECT/GROUP BY. The WHERE filter, by
+        // contrast, ranges over the *raw* column so the `(tenant_id, last_updated)`
+        // index can prune by date (wrapping the column in `substr(...)` would force a
+        // full scan). `since_bound` is the start-of-day timestamp for `since` in the
+        // stored format; since every stored value shares that fixed prefix and any
+        // sub-day suffix (`.` = 0x2E or `+` = 0x2B) sorts at/after `...T00:00:00+00:00`,
+        // the lexicographic `>=` selects exactly the rows the day-prefix filter did.
+        let since_bound = since
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .expect("00:00:00 is always a valid time")
+            .and_utc()
+            .to_rfc3339();
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT substr(last_updated, 1, 10) AS day, COUNT(*) AS n \
+                 FROM resources \
+                 WHERE tenant_id = ?1 AND resource_type = ?2 AND is_deleted = 0 \
+                   AND last_updated >= ?3 \
+                 GROUP BY day ORDER BY day",
+            )
+            .map_err(|e| internal_error(format!("Failed to prepare count_by_day: {}", e)))?;
+
+        let rows = stmt
+            .query_map(params![tenant_id, resource_type, since_bound], |row| {
+                let day: String = row.get(0)?;
+                let n: i64 = row.get(1)?;
+                Ok((day, n))
+            })
+            .map_err(|e| internal_error(format!("Failed to query count_by_day: {}", e)))?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            let (day_str, n) = row
+                .map_err(|e| internal_error(format!("Failed to read count_by_day row: {}", e)))?;
+            if let Ok(day) = chrono::NaiveDate::parse_from_str(&day_str, "%Y-%m-%d") {
+                out.push(crate::core::DailyResourceCount {
+                    day,
+                    count: n.max(0) as u64,
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    async fn activity_histogram(
+        &self,
+        tenant: &TenantContext,
+        since: chrono::DateTime<chrono::Utc>,
+    ) -> StorageResult<Vec<crate::core::ActivityCell>> {
+        let conn = self.get_connection()?;
+        let tenant_id = tenant.tenant_id().as_str();
+        // Start-of-day bound for `since` in the stored RFC3339 UTC format; see
+        // `count_by_day` for why a raw-column `last_updated >= ?` range is both
+        // sargable (uses the `(tenant_id, last_updated)` history index) and selects
+        // exactly the same rows the old `substr(last_updated, 1, 10) >= day` filter did.
+        let since_bound = since
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .expect("00:00:00 is always a valid time")
+            .and_utc()
+            .to_rfc3339();
+
+        // `strftime` parses the stored RFC3339 UTC string and yields UTC weekday
+        // (`%w`: 0=Sunday..6=Saturday) and hour (`%H`: 00..23).
+        let mut stmt = conn
+            .prepare(
+                "SELECT CAST(strftime('%w', last_updated) AS INTEGER) AS wd, \
+                        CAST(strftime('%H', last_updated) AS INTEGER) AS hr, \
+                        COUNT(*) AS n \
+                 FROM resource_history \
+                 WHERE tenant_id = ?1 AND last_updated >= ?2 \
+                 GROUP BY wd, hr",
+            )
+            .map_err(|e| internal_error(format!("Failed to prepare activity_histogram: {}", e)))?;
+
+        let rows = stmt
+            .query_map(params![tenant_id, since_bound], |row| {
+                let wd: i64 = row.get(0)?;
+                let hr: i64 = row.get(1)?;
+                let n: i64 = row.get(2)?;
+                Ok((wd, hr, n))
+            })
+            .map_err(|e| internal_error(format!("Failed to query activity_histogram: {}", e)))?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            let (wd, hr, n) = row
+                .map_err(|e| internal_error(format!("Failed to read activity row: {}", e)))?;
+            out.push(crate::core::ActivityCell {
+                weekday: wd.clamp(0, 6) as u8,
+                hour: hr.clamp(0, 23) as u8,
+                count: n.max(0) as u64,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn count_all_types(
+        &self,
+        tenant: &TenantContext,
+    ) -> StorageResult<Vec<(String, u64)>> {
+        let conn = self.get_connection()?;
+        let tenant_id = tenant.tenant_id().as_str();
+        let mut stmt = conn
+            .prepare(
+                "SELECT resource_type, COUNT(*) FROM resources \
+                 WHERE tenant_id = ?1 AND is_deleted = 0 \
+                 GROUP BY resource_type",
+            )
+            .map_err(|e| internal_error(format!("Failed to prepare count_all_types: {}", e)))?;
+        let rows = stmt
+            .query_map(params![tenant_id], |row| {
+                let rt: String = row.get(0)?;
+                let n: i64 = row.get(1)?;
+                Ok((rt, n.max(0) as u64))
+            })
+            .map_err(|e| internal_error(format!("Failed to query count_all_types: {}", e)))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| internal_error(format!("count_all_types row: {}", e)))?);
+        }
+        Ok(out)
+    }
+
+    async fn count_by_types(
+        &self,
+        tenant: &TenantContext,
+        resource_types: &[&str],
+    ) -> StorageResult<Vec<(String, u64)>> {
+        // An empty `IN ()` is invalid SQL; nothing to count.
+        if resource_types.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.get_connection()?;
+        let tenant_id = tenant.tenant_id().as_str();
+
+        // Bind tenant_id as ?1 and each requested type as ?2, ?3, ...; the type
+        // names are bound as parameters, never interpolated into the SQL text.
+        let placeholders = (0..resource_types.len())
+            .map(|i| format!("?{}", i + 2))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT resource_type, COUNT(*) FROM resources \
+             WHERE tenant_id = ?1 AND is_deleted = 0 AND resource_type IN ({}) \
+             GROUP BY resource_type",
+            placeholders
+        );
+
+        // Positional bind values matching the `?1..?n` order above: tenant first,
+        // then the requested types.
+        let mut binds: Vec<&str> = Vec::with_capacity(resource_types.len() + 1);
+        binds.push(tenant_id);
+        binds.extend_from_slice(resource_types);
+
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| internal_error(format!("Failed to prepare count_by_types: {}", e)))?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(binds), |row| {
+                let rt: String = row.get(0)?;
+                let n: i64 = row.get(1)?;
+                Ok((rt, n.max(0) as u64))
+            })
+            .map_err(|e| internal_error(format!("Failed to query count_by_types: {}", e)))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| internal_error(format!("count_by_types row: {}", e)))?);
+        }
+        Ok(out)
+    }
+
+    async fn count_by_tenant(&self) -> StorageResult<Vec<(String, u64)>> {
+        // Cross-tenant admin aggregate (see trait docs): no tenant filter.
+        let conn = self.get_connection()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT tenant_id, COUNT(*) FROM resources \
+                 WHERE is_deleted = 0 GROUP BY tenant_id",
+            )
+            .map_err(|e| internal_error(format!("Failed to prepare count_by_tenant: {}", e)))?;
+        let rows = stmt
+            .query_map([], |row| {
+                let tid: String = row.get(0)?;
+                let n: i64 = row.get(1)?;
+                Ok((tid, n.max(0) as u64))
+            })
+            .map_err(|e| internal_error(format!("Failed to query count_by_tenant: {}", e)))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| internal_error(format!("count_by_tenant row: {}", e)))?);
+        }
+        Ok(out)
+    }
 }
 
 // Search Index Helpers

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -3658,6 +3658,173 @@ mod tests {
         assert_eq!(backend.count(&tenant, None).await.unwrap(), 3);
     }
 
+    // ========================================================================
+    // Console dashboard count_* tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_count_by_types() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        // Seed a small deterministic dataset: 2 Patients, 1 Observation.
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        let counts = backend
+            .count_by_types(&tenant, &["Patient", "Observation", "Encounter"])
+            .await
+            .unwrap();
+        let map: std::collections::HashMap<String, u64> = counts.into_iter().collect();
+        assert_eq!(map.get("Patient"), Some(&2));
+        assert_eq!(map.get("Observation"), Some(&1));
+        // A type with zero rows is ABSENT from the result, not a 0 row.
+        assert!(!map.contains_key("Encounter"));
+    }
+
+    #[tokio::test]
+    async fn test_count_all_types() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        let counts = backend.count_all_types(&tenant).await.unwrap();
+        let map: std::collections::HashMap<String, u64> = counts.into_iter().collect();
+        assert_eq!(map.get("Patient"), Some(&2));
+        assert_eq!(map.get("Observation"), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn test_count_by_day() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        // `since` = start of today (UTC midnight), built the same way the handler
+        // does; `today` is derived from the same clock so this stays date-robust.
+        let since = Utc::now()
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc();
+        let today = Utc::now().date_naive();
+
+        let rows = backend
+            .count_by_day(&tenant, "Patient", since)
+            .await
+            .unwrap();
+        let today_row = rows
+            .iter()
+            .find(|r| r.day == today)
+            .expect("today bucket should be present");
+        assert_eq!(today_row.count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_activity_histogram() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        // 3 writes for this tenant -> 3 resource_history rows.
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        let since = Utc::now()
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc();
+
+        let cells = backend.activity_histogram(&tenant, since).await.unwrap();
+        assert!(!cells.is_empty());
+        // Total across returned cells equals the number of writes seeded.
+        let total: u64 = cells.iter().map(|c| c.count).sum();
+        assert_eq!(total, 3);
+    }
+
+    #[tokio::test]
+    async fn test_count_by_tenant() {
+        let backend = create_test_backend();
+        let tenant_a =
+            TenantContext::new(TenantId::new("tenant-a"), TenantPermissions::full_access());
+        let tenant_b =
+            TenantContext::new(TenantId::new("tenant-b"), TenantPermissions::full_access());
+
+        // tenant-a: 3 resources, tenant-b: 2 resources.
+        backend
+            .create(&tenant_a, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant_a, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant_a, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant_b, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant_b, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        // Cross-tenant admin aggregate: takes NO TenantContext.
+        let counts = backend.count_by_tenant().await.unwrap();
+        let map: std::collections::HashMap<String, u64> = counts.into_iter().collect();
+        assert_eq!(map.get("tenant-a"), Some(&3));
+        assert_eq!(map.get("tenant-b"), Some(&2));
+    }
+
+    #[test]
+    fn test_is_cluster_shared() {
+        let backend = create_test_backend();
+        assert!(!backend.is_cluster_shared());
+    }
+
     #[tokio::test]
     async fn test_tenant_isolation() {
         let backend = create_test_backend();

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -522,8 +522,8 @@ impl ResourceStorage for SqliteBackend {
 
         let mut out = Vec::new();
         for row in rows {
-            let (day_str, n) = row
-                .map_err(|e| internal_error(format!("Failed to read count_by_day row: {}", e)))?;
+            let (day_str, n) =
+                row.map_err(|e| internal_error(format!("Failed to read count_by_day row: {}", e)))?;
             if let Ok(day) = chrono::NaiveDate::parse_from_str(&day_str, "%Y-%m-%d") {
                 out.push(crate::core::DailyResourceCount {
                     day,
@@ -576,8 +576,8 @@ impl ResourceStorage for SqliteBackend {
 
         let mut out = Vec::new();
         for row in rows {
-            let (wd, hr, n) = row
-                .map_err(|e| internal_error(format!("Failed to read activity row: {}", e)))?;
+            let (wd, hr, n) =
+                row.map_err(|e| internal_error(format!("Failed to read activity row: {}", e)))?;
             out.push(crate::core::ActivityCell {
                 weekday: wd.clamp(0, 6) as u8,
                 hour: hr.clamp(0, 23) as u8,
@@ -587,10 +587,7 @@ impl ResourceStorage for SqliteBackend {
         Ok(out)
     }
 
-    async fn count_all_types(
-        &self,
-        tenant: &TenantContext,
-    ) -> StorageResult<Vec<(String, u64)>> {
+    async fn count_all_types(&self, tenant: &TenantContext) -> StorageResult<Vec<(String, u64)>> {
         let conn = self.get_connection()?;
         let tenant_id = tenant.tenant_id().as_str();
         let mut stmt = conn

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -715,6 +715,10 @@ impl ResourceStorage for CompositeStorage {
         "composite"
     }
 
+    fn is_cluster_shared(&self) -> bool {
+        self.primary.is_cluster_shared()
+    }
+
     fn sof_runner(&self) -> Option<Arc<dyn SofRunner>> {
         // SQL-on-FHIR runs as in-DB SQL against the primary store (where all
         // writes land), so delegate to the primary backend. Composites whose

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -910,6 +910,41 @@ impl ResourceStorage for CompositeStorage {
     ) -> StorageResult<u64> {
         self.primary.count(tenant, resource_type).await
     }
+
+    async fn count_by_day(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        since: chrono::DateTime<chrono::Utc>,
+    ) -> StorageResult<Vec<crate::core::DailyResourceCount>> {
+        // Counts are an authoritative-store concern; the search secondary may
+        // lag or omit soft-deletes. Delegate to the primary backend, which owns
+        // the canonical `resources` table. (`count_by_types` uses the default
+        // impl, which routes through `count` — also primary-backed above.)
+        self.primary
+            .count_by_day(tenant, resource_type, since)
+            .await
+    }
+
+    async fn activity_histogram(
+        &self,
+        tenant: &TenantContext,
+        since: chrono::DateTime<chrono::Utc>,
+    ) -> StorageResult<Vec<crate::core::ActivityCell>> {
+        // History/activity is owned by the authoritative primary store.
+        self.primary.activity_histogram(tenant, since).await
+    }
+
+    async fn count_all_types(
+        &self,
+        tenant: &TenantContext,
+    ) -> StorageResult<Vec<(String, u64)>> {
+        self.primary.count_all_types(tenant).await
+    }
+
+    async fn count_by_tenant(&self) -> StorageResult<Vec<(String, u64)>> {
+        self.primary.count_by_tenant().await
+    }
 }
 
 #[async_trait]

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -935,10 +935,7 @@ impl ResourceStorage for CompositeStorage {
         self.primary.activity_histogram(tenant, since).await
     }
 
-    async fn count_all_types(
-        &self,
-        tenant: &TenantContext,
-    ) -> StorageResult<Vec<(String, u64)>> {
+    async fn count_all_types(&self, tenant: &TenantContext) -> StorageResult<Vec<(String, u64)>> {
         self.primary.count_all_types(tenant).await
     }
 

--- a/crates/persistence/src/core/mod.rs
+++ b/crates/persistence/src/core/mod.rs
@@ -148,8 +148,8 @@ pub use search::{
 };
 pub use sof_runner::{RowStream, SofError, SofRunner, ViewFilters, ViewRow};
 pub use storage::{
-    ConditionalCreateResult, ConditionalDeleteResult, ConditionalPatchResult, ConditionalStorage,
-    ActivityCell, ConditionalUpdateResult, DailyResourceCount, PatchFormat, PurgableStorage,
+    ActivityCell, ConditionalCreateResult, ConditionalDeleteResult, ConditionalPatchResult,
+    ConditionalStorage, ConditionalUpdateResult, DailyResourceCount, PatchFormat, PurgableStorage,
     ResourceStorage,
 };
 pub use transaction::{

--- a/crates/persistence/src/core/mod.rs
+++ b/crates/persistence/src/core/mod.rs
@@ -149,7 +149,8 @@ pub use search::{
 pub use sof_runner::{RowStream, SofError, SofRunner, ViewFilters, ViewRow};
 pub use storage::{
     ConditionalCreateResult, ConditionalDeleteResult, ConditionalPatchResult, ConditionalStorage,
-    ConditionalUpdateResult, PatchFormat, PurgableStorage, ResourceStorage,
+    ActivityCell, ConditionalUpdateResult, DailyResourceCount, PatchFormat, PurgableStorage,
+    ResourceStorage,
 };
 pub use transaction::{
     BundleEntry, BundleEntryResult, BundleMethod, BundleProvider, BundleResult, BundleType,

--- a/crates/persistence/src/core/storage.rs
+++ b/crates/persistence/src/core/storage.rs
@@ -211,6 +211,15 @@ pub trait ResourceStorage: Send + Sync {
     /// Returns a human-readable name for this storage backend.
     fn backend_name(&self) -> &'static str;
 
+    /// Whether this backend's stored data is shared across all HFS instances in a
+    /// cluster (a networked database) vs. local to one instance (e.g. an on-disk
+    /// SQLite file). Used to label console metrics honestly in multi-instance
+    /// deployments. Conservative default: `false` (never over-claims cluster
+    /// consistency).
+    fn is_cluster_shared(&self) -> bool {
+        false
+    }
+
     /// Creates a new resource.
     ///
     /// # Arguments

--- a/crates/persistence/src/core/storage.rs
+++ b/crates/persistence/src/core/storage.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use chrono::{DateTime, NaiveDate, Utc};
 use helios_fhir::FhirVersion;
 use serde_json::Value;
 
@@ -14,6 +15,33 @@ use crate::core::sof_runner::SofRunner;
 use crate::error::{StorageError, StorageResult};
 use crate::tenant::TenantContext;
 use crate::types::StoredResource;
+
+/// One UTC-day bucket of stored-resource counts.
+///
+/// Returned by [`ResourceStorage::count_by_day`] to back "FHIR resources over
+/// time" dashboards. See that method for the precise counting semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DailyResourceCount {
+    /// The UTC calendar day this bucket covers.
+    pub day: NaiveDate,
+    /// Number of non-deleted, current-version resources whose `last_updated`
+    /// falls on `day`.
+    pub count: u64,
+}
+
+/// One `(weekday, hour)` cell of write-activity, used by
+/// [`ResourceStorage::activity_histogram`] to back the dashboard's "Activity"
+/// heatmap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActivityCell {
+    /// UTC day of week, `0` = Sunday … `6` = Saturday (matching JavaScript's
+    /// `Date.getDay()`, so the frontend can index directly).
+    pub weekday: u8,
+    /// UTC hour of day, `0` … `23`.
+    pub hour: u8,
+    /// Number of write operations (resource versions) in this cell.
+    pub count: u64,
+}
 
 /// Audit event helpers for purge operations.
 #[cfg(feature = "audit")]
@@ -380,6 +408,120 @@ pub trait ResourceStorage: Send + Sync {
     /// The default implementation returns `None`.
     fn sof_runner(&self) -> Option<Arc<dyn SofRunner>> {
         None
+    }
+
+    /// Counts non-deleted resources for several types in one call.
+    ///
+    /// Returns `(resource_type, count)` pairs in the same order as
+    /// `resource_types`. The default implementation issues one
+    /// [`count`](Self::count) query per type; backends may override with a
+    /// single grouped query.
+    ///
+    /// # Arguments
+    ///
+    /// * `tenant` - The tenant context for this operation
+    /// * `resource_types` - The FHIR resource types to count
+    async fn count_by_types(
+        &self,
+        tenant: &TenantContext,
+        resource_types: &[&str],
+    ) -> StorageResult<Vec<(String, u64)>> {
+        let mut counts = Vec::with_capacity(resource_types.len());
+        for &rt in resource_types {
+            counts.push((rt.to_string(), self.count(tenant, Some(rt)).await?));
+        }
+        Ok(counts)
+    }
+
+    /// Counts non-deleted, current-version resources of `resource_type`,
+    /// grouped by the UTC calendar day of their `last_updated`, restricted to
+    /// days on or after `since`.
+    ///
+    /// Only non-empty days are returned, in ascending day order. This powers
+    /// "FHIR resources over time" dashboards.
+    ///
+    /// # Semantics
+    ///
+    /// A resource contributes to the day of its **most recent** version, so a
+    /// running cumulative sum of these buckets converges to the current total
+    /// reported by [`count`](Self::count); it does not reconstruct historical
+    /// creation dates. A creation-time-accurate series would require
+    /// aggregating `resource_history` and is intentionally out of scope here.
+    ///
+    /// The default implementation returns an empty series for backends that
+    /// cannot bucket by time; callers should treat that as "no time resolution
+    /// available" and fall back to the current total.
+    ///
+    /// # Arguments
+    ///
+    /// * `tenant` - The tenant context for this operation
+    /// * `resource_type` - The FHIR resource type to bucket
+    /// * `since` - Inclusive lower bound; only days on or after this instant
+    async fn count_by_day(
+        &self,
+        _tenant: &TenantContext,
+        _resource_type: &str,
+        _since: DateTime<Utc>,
+    ) -> StorageResult<Vec<DailyResourceCount>> {
+        Ok(Vec::new())
+    }
+
+    /// Buckets write activity into a weekly-rhythm grid by UTC weekday and hour.
+    ///
+    /// Every resource version (create, update, or delete) recorded in
+    /// `resource_history` on or after `since` counts as one write operation; the
+    /// result is the per-`(weekday, hour)` operation count aggregated across the
+    /// whole window. Only non-empty cells are returned, so callers densify into
+    /// the full 7×24 grid themselves.
+    ///
+    /// This powers the dashboard "Activity" heatmap. It reflects **writes only**
+    /// — reads and searches are not in `resource_history`; an
+    /// all-operations variant would draw from `AuditEvent` instead.
+    ///
+    /// The default implementation returns an empty grid for backends that cannot
+    /// bucket by time.
+    ///
+    /// # Arguments
+    ///
+    /// * `tenant` - The tenant context for this operation
+    /// * `since` - Inclusive lower bound; only versions on or after this instant
+    async fn activity_histogram(
+        &self,
+        _tenant: &TenantContext,
+        _since: DateTime<Utc>,
+    ) -> StorageResult<Vec<ActivityCell>> {
+        Ok(Vec::new())
+    }
+
+    /// Counts non-deleted resources grouped by resource type for `tenant`,
+    /// returning one `(resource_type, count)` pair per type present. Order is
+    /// unspecified; callers sort as needed.
+    ///
+    /// Powers the dashboard "resource composition" treemap. Unlike
+    /// [`count_by_types`](Self::count_by_types), the caller does not supply the
+    /// type list — every stored type is discovered via a single `GROUP BY`. The
+    /// default implementation returns an empty list (it cannot enumerate types
+    /// without such a query); the SQL and document backends override it.
+    ///
+    /// # Arguments
+    ///
+    /// * `tenant` - The tenant context for this operation
+    async fn count_all_types(
+        &self,
+        _tenant: &TenantContext,
+    ) -> StorageResult<Vec<(String, u64)>> {
+        Ok(Vec::new())
+    }
+
+    /// Counts non-deleted resources grouped by tenant across the entire backend.
+    ///
+    /// **This intentionally spans tenants** and exists for operator/admin
+    /// dashboards (the per-tenant comparison widget), not for tenant-scoped
+    /// request handling — hence it takes no [`TenantContext`]. The default
+    /// implementation returns an empty list; the SQL and document backends
+    /// override it with a single `GROUP BY tenant_id`.
+    async fn count_by_tenant(&self) -> StorageResult<Vec<(String, u64)>> {
+        Ok(Vec::new())
     }
 }
 

--- a/crates/persistence/src/core/storage.rs
+++ b/crates/persistence/src/core/storage.rs
@@ -506,10 +506,7 @@ pub trait ResourceStorage: Send + Sync {
     /// # Arguments
     ///
     /// * `tenant` - The tenant context for this operation
-    async fn count_all_types(
-        &self,
-        _tenant: &TenantContext,
-    ) -> StorageResult<Vec<(String, u64)>> {
+    async fn count_all_types(&self, _tenant: &TenantContext) -> StorageResult<Vec<(String, u64)>> {
         Ok(Vec::new())
     }
 

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -927,6 +927,188 @@ async fn mongodb_integration_count_and_batch() {
     assert_eq!(batch.len(), 3);
 }
 
+// ============================================================================
+// Console Dashboard count_* tests
+// ============================================================================
+
+#[tokio::test]
+async fn mongodb_integration_count_by_types() {
+    let Some(backend) = create_backend("console_count_by_types").await else {
+        eprintln!("Skipping mongodb_integration_count_by_types (set HFS_TEST_MONGODB_URL)");
+        return;
+    };
+    let tenant = create_tenant("tenant-console-count-by-types");
+
+    // Seed a small deterministic dataset: 2 Patients, 1 Observation.
+    backend
+        .create(&tenant, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant, "Observation", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+
+    let counts = backend
+        .count_by_types(&tenant, &["Patient", "Observation", "Encounter"])
+        .await
+        .unwrap();
+    let map: std::collections::HashMap<String, u64> = counts.into_iter().collect();
+    assert_eq!(map.get("Patient"), Some(&2));
+    assert_eq!(map.get("Observation"), Some(&1));
+    // A type with zero rows is ABSENT from the result, not a 0 row.
+    assert!(!map.contains_key("Encounter"));
+}
+
+#[tokio::test]
+async fn mongodb_integration_count_all_types() {
+    let Some(backend) = create_backend("console_count_all_types").await else {
+        eprintln!("Skipping mongodb_integration_count_all_types (set HFS_TEST_MONGODB_URL)");
+        return;
+    };
+    let tenant = create_tenant("tenant-console-count-all-types");
+
+    backend
+        .create(&tenant, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant, "Observation", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+
+    let counts = backend.count_all_types(&tenant).await.unwrap();
+    let map: std::collections::HashMap<String, u64> = counts.into_iter().collect();
+    assert_eq!(map.get("Patient"), Some(&2));
+    assert_eq!(map.get("Observation"), Some(&1));
+}
+
+#[tokio::test]
+async fn mongodb_integration_count_by_day() {
+    let Some(backend) = create_backend("console_count_by_day").await else {
+        eprintln!("Skipping mongodb_integration_count_by_day (set HFS_TEST_MONGODB_URL)");
+        return;
+    };
+    let tenant = create_tenant("tenant-console-count-by-day");
+
+    backend
+        .create(&tenant, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+
+    // `since` = start of today (UTC midnight), built the same way the handler
+    // does; `today` is derived from the same clock so this stays date-robust.
+    let since = chrono::Utc::now()
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc();
+    let today = chrono::Utc::now().date_naive();
+
+    let rows = backend
+        .count_by_day(&tenant, "Patient", since)
+        .await
+        .unwrap();
+    let today_row = rows
+        .iter()
+        .find(|r| r.day == today)
+        .expect("today bucket should be present");
+    assert_eq!(today_row.count, 2);
+}
+
+#[tokio::test]
+async fn mongodb_integration_activity_histogram() {
+    let Some(backend) = create_backend("console_activity_histogram").await else {
+        eprintln!("Skipping mongodb_integration_activity_histogram (set HFS_TEST_MONGODB_URL)");
+        return;
+    };
+    let tenant = create_tenant("tenant-console-activity-histogram");
+
+    // 3 writes for this tenant -> 3 resource_history rows.
+    backend
+        .create(&tenant, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant, "Observation", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+
+    let since = chrono::Utc::now()
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc();
+
+    let cells = backend.activity_histogram(&tenant, since).await.unwrap();
+    assert!(!cells.is_empty());
+    // Total across returned cells equals the number of writes seeded.
+    let total: u64 = cells.iter().map(|c| c.count).sum();
+    assert_eq!(total, 3);
+}
+
+#[tokio::test]
+async fn mongodb_integration_count_by_tenant() {
+    let Some(backend) = create_backend("console_count_by_tenant").await else {
+        eprintln!("Skipping mongodb_integration_count_by_tenant (set HFS_TEST_MONGODB_URL)");
+        return;
+    };
+    // Each test runs against a freshly-named database, so fixed tenant IDs are
+    // isolated to this test's cross-tenant aggregate.
+    let tenant_a = create_tenant("tenant-a");
+    let tenant_b = create_tenant("tenant-b");
+
+    // tenant-a: 3 resources, tenant-b: 2 resources.
+    backend
+        .create(&tenant_a, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant_a, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant_a, "Observation", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant_b, "Patient", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant_b, "Observation", json!({}), FhirVersion::default())
+        .await
+        .unwrap();
+
+    // Cross-tenant admin aggregate: takes NO TenantContext.
+    let counts = backend.count_by_tenant().await.unwrap();
+    let map: std::collections::HashMap<String, u64> = counts.into_iter().collect();
+    assert_eq!(map.get("tenant-a"), Some(&3));
+    assert_eq!(map.get("tenant-b"), Some(&2));
+}
+
+#[tokio::test]
+async fn mongodb_integration_is_cluster_shared() {
+    let backend = MongoBackend::new(MongoBackendConfig::default()).unwrap();
+    assert!(backend.is_cluster_shared());
+}
+
 #[tokio::test]
 async fn mongodb_integration_create_or_update() {
     let Some(backend) = create_backend("create_or_update").await else {

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -1186,6 +1186,174 @@ mod postgres_integration {
     }
 
     // ========================================================================
+    // Console Dashboard count_* Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn postgres_integration_count_by_types() {
+        let backend = create_backend().await;
+        let tenant = create_tenant("console-count-by-types");
+
+        // Seed a small deterministic dataset: 2 Patients, 1 Observation.
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        let counts = backend
+            .count_by_types(&tenant, &["Patient", "Observation", "Encounter"])
+            .await
+            .unwrap();
+        let map: std::collections::HashMap<String, u64> = counts.into_iter().collect();
+        assert_eq!(map.get("Patient"), Some(&2));
+        assert_eq!(map.get("Observation"), Some(&1));
+        // A type with zero rows is ABSENT from the result, not a 0 row.
+        assert!(!map.contains_key("Encounter"));
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_count_all_types() {
+        let backend = create_backend().await;
+        let tenant = create_tenant("console-count-all-types");
+
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        let counts = backend.count_all_types(&tenant).await.unwrap();
+        let map: std::collections::HashMap<String, u64> = counts.into_iter().collect();
+        assert_eq!(map.get("Patient"), Some(&2));
+        assert_eq!(map.get("Observation"), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_count_by_day() {
+        let backend = create_backend().await;
+        let tenant = create_tenant("console-count-by-day");
+
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        // `since` = start of today (UTC midnight), built the same way the handler
+        // does; `today` is derived from the same clock so this stays date-robust.
+        let since = chrono::Utc::now()
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc();
+        let today = chrono::Utc::now().date_naive();
+
+        let rows = backend
+            .count_by_day(&tenant, "Patient", since)
+            .await
+            .unwrap();
+        let today_row = rows
+            .iter()
+            .find(|r| r.day == today)
+            .expect("today bucket should be present");
+        assert_eq!(today_row.count, 2);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_activity_histogram() {
+        let backend = create_backend().await;
+        let tenant = create_tenant("console-activity-histogram");
+
+        // 3 writes for this tenant -> 3 resource_history rows.
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        let since = chrono::Utc::now()
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc();
+
+        let cells = backend.activity_histogram(&tenant, since).await.unwrap();
+        assert!(!cells.is_empty());
+        // Total across returned cells equals the number of writes seeded.
+        let total: u64 = cells.iter().map(|c| c.count).sum();
+        assert_eq!(total, 3);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_console_count_by_tenant() {
+        let backend = create_backend().await;
+        // Unique tenant IDs isolate this cross-tenant aggregate from every other
+        // test sharing the same PostgreSQL container.
+        let tenant_a = create_tenant("console-count-by-tenant-a");
+        let tenant_b = create_tenant("console-count-by-tenant-b");
+
+        // tenant-a: 3 resources, tenant-b: 2 resources.
+        backend
+            .create(&tenant_a, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant_a, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant_a, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant_b, "Patient", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+        backend
+            .create(&tenant_b, "Observation", json!({}), FhirVersion::default())
+            .await
+            .unwrap();
+
+        // Cross-tenant admin aggregate: takes NO TenantContext. Look up by the
+        // actual (uuid-suffixed) tenant IDs so other tests' rows never interfere.
+        let counts = backend.count_by_tenant().await.unwrap();
+        let map: std::collections::HashMap<String, u64> = counts.into_iter().collect();
+        assert_eq!(map.get(tenant_a.tenant_id().as_str()), Some(&3));
+        assert_eq!(map.get(tenant_b.tenant_id().as_str()), Some(&2));
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_is_cluster_shared() {
+        let backend = create_backend().await;
+        assert!(backend.is_cluster_shared());
+    }
+
+    // ========================================================================
     // Batch Read Tests
     // ========================================================================
 

--- a/crates/rest/Cargo.toml
+++ b/crates/rest/Cargo.toml
@@ -41,6 +41,9 @@ subscriptions = ["dep:helios-subscriptions"]
 # record a `not-supported` manifest-level error (documented non-conformance).
 bulk-submit-jwe = ["dep:aes-gcm"]
 
+# OpenTelemetry OTLP trace export (forwards to helios-observability)
+otel = ["helios-observability/otel"]
+
 [dependencies]
 # Core dependencies
 helios-fhir = { path = "../fhir", version = "0.2.1", default-features = false }
@@ -50,6 +53,7 @@ helios-sof = { path = "../sof", version = "0.2.1", default-features = false }
 helios-auth = { path = "../auth", version = "0.2.1" }
 helios-audit = { path = "../audit", version = "0.2.1", default-features = false }
 helios-subscriptions = { path = "../subscriptions", version = "0.2.1", optional = true, default-features = false }
+helios-observability = { path = "../observability", version = "0.2.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/rest/docs/console-metrics.md
+++ b/crates/rest/docs/console-metrics.md
@@ -1,0 +1,371 @@
+# Console Metrics Endpoints
+
+JSON endpoints that back the **Helios FHIR Server Console** dashboard
+(uptime stat + "FHIR Resources over time" chart). They are served by the `hfs`
+binary and are intended to be consumed directly by the management-console web
+app.
+
+Endpoints fall into three trust tiers:
+
+| Tier | Endpoints | Requirement |
+|---|---|---|
+| **Public** | `uptime` | none — mounted outside auth (like `/health`) |
+| **Tenant-scoped** | `resource-counts`, `activity`, `resource-distribution` | a valid `Authorization: Bearer <token>` (else `401`); returns only the caller's own tenant |
+| **Admin (cross-tenant)** | `tenants`, `traffic` | a valid token **and** a system-context scope `system/*.r` (else `403`) |
+
+All endpoints are covered by the server's CORS, timeout, body-limit, and tracing
+middleware.
+
+Behind auth, the tenant is taken **authoritatively from the JWT claim** (see
+`TenantExtractor`); with `strict_validation` enabled a request whose `X-Tenant-ID`
+disagrees with the token is rejected (`400`). So a spoofed `X-Tenant-ID` cannot
+widen access beyond the caller's token.
+
+The **admin** endpoints span every tenant — `tenants` returns the full tenant
+roster and per-tenant sizes, `traffic` returns server-wide throughput/latency.
+They are therefore gated by `admin_authz_middleware`, which requires a
+system-context, all-resource scope (`system/*.r`, `system/*.rs`, `system/*.cruds`,
+…). An ordinary `user/*` or `patient/*` token — **even a wildcard one** — is
+rejected `403`.
+
+> When auth is **disabled** server-wide, all endpoints (including the admin tier)
+> are unprotected like every other route — matching existing server behaviour.
+
+The same counts are also exported as Prometheus gauges on `/metrics` (see
+[Prometheus](#prometheus) below).
+
+> **Tenant** — like every HFS request, the active tenant is resolved from the
+> `X-Tenant-ID` header (or the configured default tenant). Pass `X-Tenant-ID` to
+> scope the counts to a specific tenant.
+
+---
+
+## `GET /console/metrics/uptime`
+
+Process uptime and server identity.
+
+### Response `200 OK`
+
+```json
+{
+  "service": "hfs",
+  "version": "0.1.47",
+  "started_at": "2026-06-30T08:00:00.123456+00:00",
+  "now": "2026-06-30T12:04:51.654321+00:00",
+  "uptime_seconds": 14691.53,
+  "uptime_human": "4h 4m 51s",
+  "availability": {
+    "tracked": false,
+    "note": "availability tracking is not enabled; uptime_seconds reflects time since the current process started"
+  }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `uptime_seconds` | Seconds since the current process started (float). |
+| `uptime_human` | Compact human form, e.g. `"4d 2h 13m 5s"`. |
+| `started_at` / `now` | RFC 3339 timestamps. |
+| `availability` | Honest placeholder. A real "99.98% over 30d" figure needs health-probe history that HFS does not yet record; this is surfaced as `tracked: false` rather than a fabricated number. |
+
+---
+
+## `GET /console/metrics/resource-counts`
+
+Per-type stored-resource totals plus a dense daily series for the
+"resources over time" chart.
+
+### Query parameters (all optional)
+
+| Param | Default | Notes |
+|-------|---------|-------|
+| `types` | The eight dashboard types¹ | Comma-separated FHIR resource types, e.g. `types=Patient,Observation`. |
+| `days` | `30` | Daily window size, clamped to `1..=365`. |
+
+¹ `Patient, Observation, Encounter, Condition, MedicationRequest,
+DiagnosticReport, Procedure, AllergyIntolerance`.
+
+### Example
+
+```
+GET /console/metrics/resource-counts?types=Patient,Observation&days=30
+X-Tenant-ID: acme-health
+```
+
+### Response `200 OK`
+
+```json
+{
+  "tenant": "acme-health",
+  "generated_at": "2026-06-30T12:04:51.654321+00:00",
+  "window": {
+    "interval": "day",
+    "days": 30,
+    "since": "2026-06-01",
+    "until": "2026-06-30"
+  },
+  "total_resources": 61423,
+  "series": [
+    {
+      "resource_type": "Patient",
+      "total": 1204,
+      "points": [
+        { "date": "2026-06-01", "count": 2,  "cumulative": 1180 },
+        { "date": "2026-06-02", "count": 0,  "cumulative": 1180 },
+        { "date": "2026-06-30", "count": 5,  "cumulative": 1204 }
+      ]
+    },
+    {
+      "resource_type": "Observation",
+      "total": 38910,
+      "points": [ "… one entry per day …" ]
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `total_resources` | Count of all non-deleted resources for the tenant (matches the dashboard's "Stored resources" stat). |
+| `series[].total` | Current count for that resource type. |
+| `series[].points[]` | Exactly `days` entries, one per UTC day in `[since, until]`. |
+| `points[].count` | Resources whose `meta.lastUpdated` falls on that day. |
+| `points[].cumulative` | Running total; ends at `series[].total` on the final day. |
+
+### Counting semantics (read this)
+
+The series buckets resources by the day of their **most recent** version
+(`meta.lastUpdated`), then presents a running cumulative total seeded with the
+count of resources last updated *before* the window. Consequences:
+
+- The cumulative curve **ends exactly at the current total** — good for a
+  growth-style chart whose endpoint matches the "Stored resources" stat.
+- It is **not** a true historical creation-date curve. A resource updated today
+  contributes to today's bucket, not its original creation day. A
+  creation-time-accurate series would require aggregating `resource_history` and
+  is intentionally out of scope for v1.
+
+Backends that cannot bucket by time (e.g. S3) return a flat series at the
+current total (no time resolution available). SQLite, PostgreSQL, and MongoDB —
+and composite configurations layered on them — return real daily buckets.
+
+---
+
+## `GET /console/metrics/activity`
+
+Weekly-rhythm **activity heatmap** — write operations (resource versions:
+creates, updates, deletes) bucketed by UTC weekday and hour, for the dashboard's
+"Activity" card.
+
+### Query parameters (all optional)
+
+| Param | Default | Notes |
+|-------|---------|-------|
+| `days` | `30` | Rolling window, clamped to `1..=365`. Buckets aggregate across the window (e.g. all Mondays-at-09:00 in the last 30 days). |
+
+### Response `200 OK`
+
+```json
+{
+  "tenant": "acme-health",
+  "generated_at": "2026-06-30T12:04:51.654321+00:00",
+  "source": "writes",
+  "window": { "days": 30, "since": "2026-06-01", "until": "2026-06-30" },
+  "total": 14302,
+  "max_cell": 412,
+  "cells": [
+    { "weekday": 0, "hour": 0, "count": 3 },
+    { "weekday": 0, "hour": 1, "count": 0 },
+    "… 168 entries total, dense and zero-filled …",
+    { "weekday": 6, "hour": 23, "count": 11 }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `cells` | **Dense** 7×24 = 168 entries, ascending by `weekday` then `hour` — no gap-filling needed client-side. |
+| `weekday` | `0` = Sunday … `6` = Saturday (matches JS `Date.getDay()`). |
+| `hour` | `0` … `23`, UTC. |
+| `count` | Write operations in that weekday/hour bucket, summed across the window. |
+| `max_cell` | Largest single-cell count, for colour scaling. |
+| `source` | Where the data came from. Currently always `"writes"` (from `resource_history`). |
+
+### Source semantics
+
+This version reflects **writes only** — every row in `resource_history` is one
+create/update/delete. Reads and searches are not recorded there. The `source`
+field is part of the contract so an `AuditEvent`-backed `"all-operations"` source
+(including reads, when the audit DB sink is enabled) can be added later without
+changing the response shape. Backends that cannot bucket by time (e.g. S3) return
+an all-zero grid.
+
+---
+
+## `GET /console/metrics/traffic`
+
+Windowed request throughput, latency percentiles, error rate, and a sparkline —
+the "Traffic & Latency" panel. Derived from an **in-process rolling request log**
+fed by the request middleware, so it needs no Prometheus deployment.
+
+> **🔒 Admin endpoint** — server-wide traffic across all tenants. Requires a valid
+> token **and** a `system/*.r` scope; other tokens get `403`.
+
+### Query parameters (all optional)
+
+| Param | Default | Notes |
+|-------|---------|-------|
+| `window` | `3600` | Look-back in seconds, clamped to `60..=86_400`. |
+| `tenant` | (all) | Restrict to a single tenant id. |
+
+### Response `200 OK`
+
+```json
+{
+  "generated_at": "2026-06-30T12:04:51+00:00",
+  "window_seconds": 3600,
+  "covered_seconds": 3600,
+  "sample_count": 12483,
+  "requests_per_second": 3.47,
+  "latency_ms": { "p50": 5.2, "p95": 18.0, "p99": 42.1 },
+  "error_rate": 0.0041,
+  "status_classes": { "2xx": 12000, "3xx": 40, "4xx": 438, "5xx": 5 },
+  "series": [ { "offset_seconds": 3600, "requests_per_second": 3.1, "p95_ms": 17.0 }, "… 30 buckets, oldest first …" ]
+}
+```
+
+> **Caveat:** the window is in-process — it **resets on restart** and retains at
+> most the most recent ~20 k requests (`covered_seconds` reports the true span).
+> For long-horizon/durable history, scrape the Prometheus `/metrics` histogram
+> instead. `error_rate` counts 5xx responses.
+
+---
+
+## `GET /console/metrics/resource-distribution`
+
+Every stored resource type with its count, busiest first — the "resource
+composition" treemap.
+
+### Query parameters (all optional)
+
+| Param | Default | Notes |
+|-------|---------|-------|
+| `top` | `20` | Keep the N largest types; the remainder collapses into a single `other` bucket (with a `types` count). Clamped to `1..=100`. |
+
+### Response `200 OK`
+
+```json
+{
+  "tenant": "acme-health",
+  "generated_at": "2026-06-30T12:04:51+00:00",
+  "total_resources": 61423,
+  "distinct_types": 47,
+  "types": [
+    { "resource_type": "Observation", "count": 38910 },
+    { "resource_type": "Claim",       "count": 8430 },
+    { "resource_type": "other",       "count": 1240, "types": 27 }
+  ]
+}
+```
+
+---
+
+## `GET /console/metrics/tenants`
+
+Per-tenant comparison — authoritative stored-resource counts joined with windowed
+traffic. Sorted by resource count, busiest first.
+
+> **🔒 Admin endpoint** — this **enumerates every tenant** and its data volume, so
+> it is the most sensitive console endpoint. Requires a valid token **and** a
+> system-context scope `system/*.r`; ordinary `user/*` / `patient/*` tokens (even
+> wildcard ones) get `403`.
+
+### Query parameters (all optional)
+
+| Param | Default | Notes |
+|-------|---------|-------|
+| `window` | `3600` | Traffic look-back in seconds, clamped to `60..=86_400`. |
+
+### Response `200 OK`
+
+```json
+{
+  "generated_at": "2026-06-30T12:04:51+00:00",
+  "window_seconds": 3600,
+  "tenant_count": 3,
+  "tenants": [
+    { "tenant": "acme-health", "resources": 48210, "requests_per_second": 2.9, "p95_ms": 19.0, "error_rate": 0.003 },
+    { "tenant": "northwind",   "resources": 11013, "requests_per_second": 0.4, "p95_ms": 12.0, "error_rate": 0.0 },
+    { "tenant": "sandbox",     "resources": 2200,  "requests_per_second": 0.0, "p95_ms": 0.0,  "error_rate": 0.0 }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `resources` | Authoritative count from the backend (this aggregate **spans tenants** by design — an operator view). |
+| `requests_per_second` / `p95_ms` / `error_rate` | Best-effort, from the in-process request log, keyed by `X-Tenant-ID` (empty → `default`). A tenant with stored data but no recent traffic reports zeroes; a tenant seen only in traffic appears with `resources: 0`. |
+
+---
+
+## Prometheus
+
+The `/metrics` endpoint is public (unauthenticated, for Prometheus scraping) and
+exposes only tenant-agnostic series:
+
+```
+http_requests_total{service="hfs",method="GET",route="/{resource_type}/{id}",status="200"}  4213
+http_request_duration_seconds{service="hfs",...}                                            ...
+uptime_seconds{service="hfs"}                                                                14691.53
+```
+
+Per-tenant stored-resource counts are **deliberately NOT exported to
+`/metrics`**. Tenant is never a metric label (see the rule in
+`crates/observability/src/middleware.rs` and `CLAUDE.md`): because `/metrics` is
+unauthenticated, a tenant-labelled gauge would leak the identity and
+resource counts of every tenant to any anonymous scraper — the same cross-tenant
+data the `tenants` endpoint gates behind a `system/*.r` admin scope. Per-tenant
+counts are available only via the authenticated `resource-counts` /
+`resource-distribution` JSON endpoints above.
+
+---
+
+## Manual verification
+
+> With auth enabled (`HFS_AUTH_*`), every call below except `uptime` needs an
+> `Authorization: Bearer <token>` header, and the admin endpoints (`tenants`,
+> `traffic`) additionally need that token to carry a `system/*.r` scope. The
+> default dev server runs with auth disabled, so these work as-is.
+
+```bash
+# Start the server (default: R4, SQLite, port 8080)
+cargo run --bin hfs
+
+# Seed a couple of resources
+curl -s -X POST localhost:8080/Patient -H 'Content-Type: application/fhir+json' \
+  -d '{"resourceType":"Patient","name":[{"family":"Smith"}]}'
+
+# Uptime
+curl -s localhost:8080/console/metrics/uptime | jq
+
+# Resource counts (default 8 types, 30 days)
+curl -s 'localhost:8080/console/metrics/resource-counts?types=Patient&days=7' \
+  -H 'X-Tenant-ID: default' | jq
+
+# Activity heatmap (write ops by weekday/hour, last 30 days)
+curl -s 'localhost:8080/console/metrics/activity?days=30' \
+  -H 'X-Tenant-ID: default' | jq '{source, total, max_cell, cells: (.cells | length)}'
+
+# Traffic & latency (last hour) — issue a few requests first so the log fills
+curl -s 'localhost:8080/console/metrics/traffic?window=3600' | jq 'del(.series)'
+
+# Resource composition treemap (top 15 + "other")
+curl -s 'localhost:8080/console/metrics/resource-distribution?top=15' \
+  -H 'X-Tenant-ID: default' | jq
+
+# Per-tenant comparison
+curl -s 'localhost:8080/console/metrics/tenants' | jq
+
+# Prometheus (public, tenant-agnostic: request counters, latency, uptime)
+curl -s localhost:8080/metrics | grep -E 'http_requests_total|uptime_seconds'
+```

--- a/crates/rest/docs/console-metrics.md
+++ b/crates/rest/docs/console-metrics.md
@@ -31,12 +31,131 @@ rejected `403`.
 > When auth is **disabled** server-wide, all endpoints (including the admin tier)
 > are unprotected like every other route — matching existing server behaviour.
 
-The same counts are also exported as Prometheus gauges on `/metrics` (see
-[Prometheus](#prometheus) below).
-
 > **Tenant** — like every HFS request, the active tenant is resolved from the
 > `X-Tenant-ID` header (or the configured default tenant). Pass `X-Tenant-ID` to
 > scope the counts to a specific tenant.
+
+---
+
+## Clustering / multi-instance
+
+When HFS runs as **multiple instances behind a load balancer** (all sharing one
+database), these endpoints split into two categories: values read from the
+shared persistence backend are **cluster-consistent**, while values derived from
+in-process state are **single-instance**. Each response now carries explicit
+scope fields so the console can label them honestly.
+
+| Signal | Scope | Source |
+|---|---|---|
+| `resource-counts`, `activity`, `resource-distribution`, and the per-tenant **`resources`** column of `tenants` | **Cluster** | Shared persistence backend |
+| `traffic` (all fields), the **traffic columns** of `tenants` (`requests_per_second` / `p95_ms` / `error_rate`), and `uptime` | **Single-instance** | In-process request-log ring buffer + process start time |
+
+### Operator guidance — what to trust for fleet-wide views
+
+- **Cluster-wide resource numbers** (how many resources exist across the fleet):
+  trust the DB-backed endpoints — `resource-counts`, `activity`,
+  `resource-distribution`, and the `resources` column of `tenants`. On a shared
+  database every instance returns the same numbers.
+- **`/traffic` and `/uptime` are instance-local diagnostics.** Treat them as a
+  quick look at whichever single instance answered — never as a fleet total.
+- **Fleet-wide request rate, latency percentiles, error rate, and any
+  alerting/SLOs** must come from **Prometheus (scraped `/metrics`) + Grafana**,
+  not from these JSON endpoints.
+- **The management-console web app reaches instances only through the load
+  balancer**, so it **cannot itself** produce fleet-wide traffic or uptime: each
+  poll lands on a random instance and sees only that one. Any fleet-wide traffic
+  or uptime view must be built in Prometheus/Grafana, not by the console
+  aggregating these endpoints.
+
+### Cluster-consistent (shared database)
+
+`resource-counts`, `activity`, `resource-distribution`, and the per-tenant
+`resources` counts in `tenants` all query the shared persistence backend, so
+**every instance returns the same fleet-wide numbers** regardless of which one
+the load balancer routes to.
+
+> **Caveat:** this only holds for a genuinely shared backend (PostgreSQL,
+> Postgres + Elasticsearch, MongoDB). A pure-**SQLite** deployment is not really
+> "clustered" — each instance has its own local file — so these counts would
+> diverge across instances there.
+
+This caveat is now **reflected in the JSON, not just prose.** The three DB-backed
+endpoints (`resource-counts`, `activity`, `resource-distribution`) each carry a
+top-level `scope` field, and `tenants` carries `resources_scope`. Both are
+**backend-derived** from the primary CRUD store via
+`ResourceStorage::is_cluster_shared()`: `"cluster"` on networked stores
+(PostgreSQL, MongoDB, S3), `"single-instance"` on SQLite. So a SQLite deployment
+self-labels its counts `"single-instance"` and the console can render the caveat
+automatically rather than hard-coding it. Composite backends delegate to their
+primary store, so the label is accurate for them too — a Postgres-primary
+composite such as `postgres-elasticsearch` is labelled `"cluster"` (its counts
+come from the Postgres primary), while a SQLite-primary composite such as
+`sqlite-elasticsearch` is `"single-instance"`. The default for any unrecognised
+backend is `"single-instance"`, erring toward *not* over-claiming cluster
+consistency.
+
+### Single-instance (in-process state)
+
+`traffic`, the traffic columns of `tenants`, and `uptime` are derived from an
+**in-process rolling request log** (`helios_observability::reqlog`) and the
+process start time. They are **not** shared across the cluster:
+
+- Behind a load balancer they reflect **only the one instance that answered the
+  request** (the LB picks it); a follow-up call may land on a different instance
+  and report different numbers.
+- They **reset on restart / redeploy** — there is no durable history.
+
+To make this explicit, the responses expose the answering instance and the scope
+of each figure:
+
+| Field | Endpoint(s) | Meaning |
+|---|---|---|
+| `instance` | `traffic`, `tenants` | Hostname (pod/container) of the answering instance. Deliberately **omitted** from the public `uptime` endpoint — it is unauthenticated, and a pod/container hostname is infrastructure-identifying (same reason the storage backend name is not exposed there). |
+| `scope: "single-instance"` | `uptime`, `traffic` | Always instance-local — the whole response is process-local. |
+| `scope` (backend-derived) | `resource-counts`, `activity`, `resource-distribution` | `"cluster"` on PostgreSQL/MongoDB/S3, `"single-instance"` on SQLite — follows the primary CRUD store (composites delegate to their primary). |
+| `resources_scope` (backend-derived) | `tenants` | `"cluster"` on PostgreSQL/MongoDB/S3, `"single-instance"` on SQLite — the `resources` column follows the backend (composites delegate to their primary). |
+| `traffic_scope: "single-instance"` | `tenants` | The traffic columns are always instance-local. |
+
+> **Note:** the `tenants` response is mixed-scope, so it deliberately **omits a
+> single top-level `scope`** — its `resources_scope` and `traffic_scope` fields
+> label the resource and traffic columns separately instead.
+
+### Cluster-wide traffic / latency → Prometheus
+
+For **fleet-wide** request rate, latency percentiles, and error rate, do not use
+these JSON endpoints — scrape each instance's `/metrics` endpoint and aggregate
+in Prometheus / Grafana (HFS configures explicit latency buckets on
+`http_request_duration_seconds`, so it is emitted as a real Prometheus histogram
+and the `_bucket` / `le` series that `histogram_quantile()` needs exist):
+
+```promql
+# Fleet-wide request rate (sums across all instances)
+sum(rate(http_requests_total{service="hfs"}[5m]))
+
+# Fleet-wide p95 latency — histogram buckets add up correctly across instances
+histogram_quantile(0.95,
+  sum by (le) (rate(http_request_duration_seconds_bucket{service="hfs"}[5m])))
+
+# Fleet-wide error rate
+sum(rate(http_requests_total{service="hfs",status=~"5.."}[5m]))
+  / sum(rate(http_requests_total{service="hfs"}[5m]))
+```
+
+Per-tenant traffic is intentionally **not** a Prometheus label — both to bound
+cardinality and because `/metrics` is unauthenticated (see [Prometheus](#prometheus)
+below). Tenant is instead recorded as a trace / OTLP **span attribute**, so
+per-tenant breakdowns come from the tracing backend, not from `/metrics`.
+
+### Auth / tenancy are stateless
+
+Authentication and tenancy hold **no shared session state**: the tenant is taken
+from the JWT claim and the admin scope is checked in middleware on each request.
+Any instance can serve any request, so the auth/tenancy behaviour is identical
+and cluster-safe regardless of which instance the load balancer selects.
+
+This matches HFS's existing multi-instance patterns — `/metrics` is per-instance
+and aggregated externally, and bulk export coordinates across instances by
+sharing job state in the database rather than in process memory.
 
 ---
 
@@ -49,6 +168,7 @@ Process uptime and server identity.
 ```json
 {
   "service": "hfs",
+  "scope": "single-instance",
   "version": "0.1.47",
   "started_at": "2026-06-30T08:00:00.123456+00:00",
   "now": "2026-06-30T12:04:51.654321+00:00",
@@ -66,6 +186,7 @@ Process uptime and server identity.
 | `uptime_seconds` | Seconds since the current process started (float). |
 | `uptime_human` | Compact human form, e.g. `"4d 2h 13m 5s"`. |
 | `started_at` / `now` | RFC 3339 timestamps. |
+| `scope` | `"single-instance"` — uptime is process-local (per-instance). See [Clustering / multi-instance](#clustering--multi-instance). |
 | `availability` | Honest placeholder. A real "99.98% over 30d" figure needs health-probe history that HFS does not yet record; this is surfaced as `tracked: false` rather than a fabricated number. |
 
 ---
@@ -97,6 +218,7 @@ X-Tenant-ID: acme-health
 ```json
 {
   "tenant": "acme-health",
+  "scope": "cluster",
   "generated_at": "2026-06-30T12:04:51.654321+00:00",
   "window": {
     "interval": "day",
@@ -126,6 +248,7 @@ X-Tenant-ID: acme-health
 
 | Field | Meaning |
 |-------|---------|
+| `scope` | Backend-derived: `"cluster"` on PostgreSQL/MongoDB/S3, `"single-instance"` on SQLite. See [Clustering / multi-instance](#clustering--multi-instance). |
 | `total_resources` | Count of all non-deleted resources for the tenant (matches the dashboard's "Stored resources" stat). |
 | `series[].total` | Current count for that resource type. |
 | `series[].points[]` | Exactly `days` entries, one per UTC day in `[since, until]`. |
@@ -168,6 +291,7 @@ creates, updates, deletes) bucketed by UTC weekday and hour, for the dashboard's
 ```json
 {
   "tenant": "acme-health",
+  "scope": "cluster",
   "generated_at": "2026-06-30T12:04:51.654321+00:00",
   "source": "writes",
   "window": { "days": 30, "since": "2026-06-01", "until": "2026-06-30" },
@@ -184,6 +308,7 @@ creates, updates, deletes) bucketed by UTC weekday and hour, for the dashboard's
 
 | Field | Meaning |
 |-------|---------|
+| `scope` | Backend-derived: `"cluster"` on PostgreSQL/MongoDB/S3, `"single-instance"` on SQLite. See [Clustering / multi-instance](#clustering--multi-instance). |
 | `cells` | **Dense** 7×24 = 168 entries, ascending by `weekday` then `hour` — no gap-filling needed client-side. |
 | `weekday` | `0` = Sunday … `6` = Saturday (matches JS `Date.getDay()`). |
 | `hour` | `0` … `23`, UTC. |
@@ -222,6 +347,8 @@ fed by the request middleware, so it needs no Prometheus deployment.
 
 ```json
 {
+  "instance": "hfs-6d4f9c8b7-2xkql",
+  "scope": "single-instance",
   "generated_at": "2026-06-30T12:04:51+00:00",
   "window_seconds": 3600,
   "covered_seconds": 3600,
@@ -236,8 +363,10 @@ fed by the request middleware, so it needs no Prometheus deployment.
 
 > **Caveat:** the window is in-process — it **resets on restart** and retains at
 > most the most recent ~20 k requests (`covered_seconds` reports the true span).
-> For long-horizon/durable history, scrape the Prometheus `/metrics` histogram
-> instead. `error_rate` counts 5xx responses.
+> Behind a load balancer it reflects **only the instance that answered** (see the
+> `instance` / `scope` fields and [Clustering / multi-instance](#clustering--multi-instance)).
+> For long-horizon/durable or fleet-wide history, scrape the Prometheus `/metrics`
+> histogram instead. `error_rate` counts 5xx responses.
 
 ---
 
@@ -257,6 +386,7 @@ composition" treemap.
 ```json
 {
   "tenant": "acme-health",
+  "scope": "cluster",
   "generated_at": "2026-06-30T12:04:51+00:00",
   "total_resources": 61423,
   "distinct_types": 47,
@@ -267,6 +397,10 @@ composition" treemap.
   ]
 }
 ```
+
+The top-level `scope` is backend-derived (`"cluster"` on PostgreSQL/MongoDB/S3,
+`"single-instance"` on SQLite); see
+[Clustering / multi-instance](#clustering--multi-instance).
 
 ---
 
@@ -290,6 +424,9 @@ traffic. Sorted by resource count, busiest first.
 
 ```json
 {
+  "instance": "hfs-6d4f9c8b7-2xkql",
+  "resources_scope": "cluster",
+  "traffic_scope": "single-instance",
   "generated_at": "2026-06-30T12:04:51+00:00",
   "window_seconds": 3600,
   "tenant_count": 3,
@@ -303,8 +440,9 @@ traffic. Sorted by resource count, busiest first.
 
 | Field | Meaning |
 |-------|---------|
-| `resources` | Authoritative count from the backend (this aggregate **spans tenants** by design — an operator view). |
-| `requests_per_second` / `p95_ms` / `error_rate` | Best-effort, from the in-process request log, keyed by `X-Tenant-ID` (empty → `default`). A tenant with stored data but no recent traffic reports zeroes; a tenant seen only in traffic appears with `resources: 0`. |
+| `resources` | Authoritative count from the backend (this aggregate **spans tenants** by design — an operator view). `resources_scope` is backend-derived — `"cluster"` on a shared DB (PostgreSQL/MongoDB/S3), `"single-instance"` on SQLite. |
+| `requests_per_second` / `p95_ms` / `error_rate` | Best-effort, from the in-process request log, keyed by `X-Tenant-ID` (empty → `default`). A tenant with stored data but no recent traffic reports zeroes; a tenant seen only in traffic appears with `resources: 0`. **Single-instance** (`traffic_scope: "single-instance"`) — behind a load balancer these reflect only the answering `instance`; see [Clustering / multi-instance](#clustering--multi-instance). |
+| `instance` / `resources_scope` / `traffic_scope` | The answering instance's hostname, and the scope of the resource vs. traffic columns (`"cluster"` / `"single-instance"`). |
 
 ---
 

--- a/crates/rest/src/error.rs
+++ b/crates/rest/src/error.rs
@@ -270,9 +270,19 @@ impl fmt::Display for RestError {
 
 impl std::error::Error for RestError {}
 
-impl IntoResponse for RestError {
-    fn into_response(self) -> Response {
-        let (status, code, details) = match &self {
+impl RestError {
+    /// Computes the client-facing `(status, issue code, message)` triple for
+    /// this error.
+    ///
+    /// This is the single source of truth for how a [`RestError`] is surfaced
+    /// to callers, shared by [`IntoResponse`] and the batch/transaction handler
+    /// so both sanitize identically. Internal/backend errors are collapsed to a
+    /// generic message here (and their raw detail is logged server-side) so
+    /// backend/driver/SQL detail — table and column names, connection strings,
+    /// query fragments — never leaks; safe classes (not-found, conflict,
+    /// validation, gone, …) keep their specific, actionable message.
+    pub(crate) fn client_response(&self) -> (StatusCode, &'static str, String) {
+        match self {
             RestError::NotFound { resource_type, id } => (
                 StatusCode::NOT_FOUND,
                 "not-found",
@@ -326,16 +336,7 @@ impl IntoResponse for RestError {
                 message.clone(),
             ),
             RestError::Unauthorized { message } => {
-                let operation_outcome = create_operation_outcome("error", "login", message);
-                return (
-                    StatusCode::UNAUTHORIZED,
-                    [(
-                        axum::http::header::WWW_AUTHENTICATE,
-                        axum::http::HeaderValue::from_static("Bearer"),
-                    )],
-                    Json(operation_outcome),
-                )
-                    .into_response();
+                (StatusCode::UNAUTHORIZED, "login", message.clone())
             }
             RestError::Forbidden { message } => {
                 (StatusCode::FORBIDDEN, "forbidden", message.clone())
@@ -360,11 +361,17 @@ impl IntoResponse for RestError {
             RestError::NotSupported { feature } => {
                 (StatusCode::BAD_REQUEST, "not-supported", feature.clone())
             }
-            RestError::InternalError { message } => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "exception",
-                message.clone(),
-            ),
+            RestError::InternalError { message } => {
+                // Log the full underlying detail server-side so operators keep it,
+                // but never leak backend/driver/SQL detail (table and column names,
+                // connection strings, query fragments) to the HTTP client.
+                tracing::error!(error.detail = %message, "internal error while processing request");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "exception",
+                    "An internal error occurred while processing the request.".to_string(),
+                )
+            }
             RestError::NotAcceptable { message } => {
                 (StatusCode::NOT_ACCEPTABLE, "not-supported", message.clone())
             }
@@ -373,9 +380,29 @@ impl IntoResponse for RestError {
                 "invalid",
                 format!("Invalid parameter '{}': {}", param, message),
             ),
-        };
+        }
+    }
+}
 
+impl IntoResponse for RestError {
+    fn into_response(self) -> Response {
+        let (status, code, details) = self.client_response();
         let operation_outcome = create_operation_outcome("error", code, &details);
+
+        // Unauthorized additionally carries a Bearer challenge in the
+        // WWW-Authenticate header.
+        if matches!(self, RestError::Unauthorized { .. }) {
+            return (
+                status,
+                [(
+                    axum::http::header::WWW_AUTHENTICATE,
+                    axum::http::HeaderValue::from_static("Bearer"),
+                )],
+                Json(operation_outcome),
+            )
+                .into_response();
+        }
+
         (status, Json(operation_outcome)).into_response()
     }
 }
@@ -718,6 +745,92 @@ mod tests {
         assert_eq!(outcome["resourceType"], "OperationOutcome");
         assert_eq!(outcome["issue"][0]["severity"], "error");
         assert_eq!(outcome["issue"][0]["code"], "not-found");
+    }
+
+    #[tokio::test]
+    async fn test_internal_error_does_not_leak_backend_detail() {
+        // A backend/internal error whose message embeds sensitive DB detail
+        // (table/column names, SQL fragments) must NOT reach the client body.
+        let raw_detail = "query execution failed: table \"resources\" column x does not exist";
+        let err = RestError::InternalError {
+            message: raw_detail.to_string(),
+        };
+
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+
+        // The raw backend detail must be absent from the client-facing body.
+        assert!(
+            !body.contains("resources"),
+            "response leaked raw backend detail: {body}"
+        );
+        assert!(
+            !body.contains("column x"),
+            "response leaked raw backend detail: {body}"
+        );
+        // The generic, non-revealing message must be present, and the shape
+        // must remain a valid OperationOutcome with the exception issue code.
+        assert!(body.contains("An internal error occurred while processing the request."));
+        let outcome: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(outcome["resourceType"], "OperationOutcome");
+        assert_eq!(outcome["issue"][0]["severity"], "error");
+        assert_eq!(outcome["issue"][0]["code"], "exception");
+    }
+
+    #[tokio::test]
+    async fn test_bad_request_preserves_specific_message() {
+        // Safe error classes (400/404/etc.) must keep their actionable detail.
+        let err = RestError::BadRequest {
+            message: "missing required field: name".to_string(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(body.contains("missing required field: name"));
+    }
+
+    #[test]
+    fn test_client_response_sanitizes_internal() {
+        // The shared helper (also used by the batch/transaction handler) must
+        // collapse internal errors to the generic message with a 5xx status.
+        let err = RestError::InternalError {
+            message: "table \"resources\" column x does not exist".to_string(),
+        };
+        let (status, code, message) = err.client_response();
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(code, "exception");
+        assert!(!message.contains("resources"), "leaked detail: {message}");
+        assert_eq!(
+            message,
+            "An internal error occurred while processing the request."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unauthorized_still_sets_www_authenticate() {
+        // Routing IntoResponse through client_response must not drop the
+        // Bearer challenge header for Unauthorized.
+        let err = RestError::Unauthorized {
+            message: "missing token".to_string(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::WWW_AUTHENTICATE)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer")
+        );
     }
 
     #[test]

--- a/crates/rest/src/extractors/tenant.rs
+++ b/crates/rest/src/extractors/tenant.rs
@@ -180,7 +180,15 @@ where
             // configured default so single-tenant-with-auth deployments keep working.
             let resolver = TenantResolver::new(&config.multitenancy);
             let resolved = resolver.resolve(parts, &config.multitenancy, &config.default_tenant);
-            if resolved.tenant_id_str() != config.default_tenant {
+            // An empty resolved tenant means nothing real was requested — e.g. an
+            // empty JWT tenant claim re-surfaced by the resolver's JwtTenantExtractor
+            // (which runs even in HeaderOnly mode), with no header/URL tenant
+            // supplied. Treat that as "no request" and fall back to the configured
+            // default. Only a genuine, non-empty, non-default header/URL tenant
+            // yields 403, preserving tenant isolation.
+            if !resolved.tenant_id_str().is_empty()
+                && resolved.tenant_id_str() != config.default_tenant
+            {
                 return Err((
                     StatusCode::FORBIDDEN,
                     "Authenticated token is missing the required tenant claim".to_string(),

--- a/crates/rest/src/extractors/tenant.rs
+++ b/crates/rest/src/extractors/tenant.rs
@@ -252,4 +252,223 @@ mod tests {
         let extractor = TenantExtractor::new("my-tenant", TenantSource::Header);
         assert_eq!(format!("{}", extractor), "my-tenant");
     }
+
+    // ── `FromRequestParts` resolution branches ──────────────────────────────
+    //
+    // These exercise the Principal-aware tenant resolution in
+    // `TenantExtractor::from_request_parts`, which cannot be reached through the
+    // header/URL integration tests (they run with auth disabled, so no
+    // `Principal` is ever present in request extensions).
+
+    mod from_request_parts {
+        use std::sync::Arc;
+
+        use axum::http::{HeaderValue, Request, StatusCode};
+        use helios_auth::{Principal, ScopeSet};
+        use helios_persistence::backends::sqlite::SqliteBackend;
+
+        use super::super::*;
+        use crate::config::{MultitenancyConfig, ServerConfig, TenantRoutingMode};
+
+        /// Builds an in-memory-backed `AppState` with the given strict-validation
+        /// flag and default tenant. Routing is `HeaderOnly` so the X-Tenant-ID
+        /// header is honoured by the resolver.
+        fn make_state(strict: bool, default_tenant: &str) -> AppState<SqliteBackend> {
+            let backend = Arc::new(SqliteBackend::in_memory().expect("in-memory sqlite backend"));
+            let config = ServerConfig {
+                multitenancy: MultitenancyConfig {
+                    routing_mode: TenantRoutingMode::HeaderOnly,
+                    strict_validation: strict,
+                    ..Default::default()
+                },
+                default_tenant: default_tenant.to_string(),
+                ..ServerConfig::for_testing()
+            };
+            AppState::new(backend, config)
+        }
+
+        /// Builds request `Parts` for `/Patient/123`, optionally carrying an
+        /// `X-Tenant-ID` header and/or a `Principal` extension.
+        fn make_parts(tenant_header: Option<&str>, principal: Option<Principal>) -> Parts {
+            let mut builder = Request::builder().uri("/Patient/123");
+            if let Some(t) = tenant_header {
+                builder = builder.header("x-tenant-id", HeaderValue::from_str(t).unwrap());
+            }
+            let mut parts = builder.body(()).unwrap().into_parts().0;
+            if let Some(p) = principal {
+                parts.extensions.insert(p);
+            }
+            parts
+        }
+
+        /// Builds a `Principal` with the given tenant claim and no scopes.
+        fn make_principal(tenant_id: Option<&str>) -> Principal {
+            Principal {
+                subject: "test-subject".to_string(),
+                issuer: "https://issuer.example".to_string(),
+                tenant_id: tenant_id.map(|t| t.to_string()),
+                scopes: ScopeSet::empty(),
+                jti: None,
+                expires_at: chrono::Utc::now(),
+                custom_claims: serde_json::Map::new(),
+            }
+        }
+
+        #[tokio::test]
+        async fn test_jwt_tenant_claim_is_authoritative() {
+            // Principal with a tenant claim → JwtClaim source, tenant from token.
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(None, Some(make_principal(Some("acme"))));
+
+            let extractor = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect("should resolve to JWT tenant");
+            assert_eq!(extractor.tenant_id(), "acme");
+            assert_eq!(extractor.source(), TenantSource::JwtClaim);
+        }
+
+        #[tokio::test]
+        async fn test_jwt_claim_strict_matching_header_succeeds() {
+            // strict_validation + matching header tenant → still JwtClaim.
+            let state = make_state(true, "test-tenant");
+            let mut parts = make_parts(Some("acme"), Some(make_principal(Some("acme"))));
+
+            let extractor = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect("matching JWT/header should succeed");
+            assert_eq!(extractor.tenant_id(), "acme");
+            assert_eq!(extractor.source(), TenantSource::JwtClaim);
+        }
+
+        #[tokio::test]
+        async fn test_jwt_claim_strict_mismatching_header_is_bad_request() {
+            // strict_validation + a non-default header tenant that disagrees with
+            // the JWT tenant → 400.
+            let state = make_state(true, "test-tenant");
+            let mut parts = make_parts(Some("other"), Some(make_principal(Some("acme"))));
+
+            let err = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect_err("mismatch should be rejected");
+            assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn test_empty_claim_no_request_falls_back_to_default() {
+            // An empty tenant claim is treated as "no claim"; with nothing else
+            // requested, fall back to the configured default.
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(None, Some(make_principal(Some(""))));
+
+            let extractor = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect("empty claim should fall back to default");
+            assert_eq!(extractor.tenant_id(), "test-tenant");
+            assert_eq!(extractor.source(), TenantSource::Default);
+        }
+
+        #[tokio::test]
+        async fn test_no_claim_no_request_falls_back_to_default() {
+            // No tenant claim, no header → configured default tenant.
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(None, Some(make_principal(None)));
+
+            let extractor = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect("no claim + no request should use default");
+            assert_eq!(extractor.tenant_id(), "test-tenant");
+            assert_eq!(extractor.source(), TenantSource::Default);
+        }
+
+        #[tokio::test]
+        async fn test_no_claim_nondefault_header_is_forbidden() {
+            // Claimless token + client-selected non-default tenant via header → 403
+            // (must not silently widen access to a spoofed tenant).
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(Some("other-tenant"), Some(make_principal(None)));
+
+            let err = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect_err("non-default requested tenant without claim should be forbidden");
+            assert_eq!(err.0, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn test_no_claim_empty_default_is_bad_request() {
+            // Claimless token, nothing requested, but the configured default tenant
+            // is empty (misconfiguration) → fail closed with 400.
+            let state = make_state(false, "");
+            let mut parts = make_parts(None, Some(make_principal(None)));
+
+            let err = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect_err("empty default tenant should fail closed");
+            assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn test_no_principal_resolves_header() {
+            // No Principal at all → resolver path; header tenant is used.
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(Some("acme"), None);
+
+            let extractor = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect("resolver should use header tenant");
+            assert_eq!(extractor.tenant_id(), "acme");
+            assert_eq!(extractor.source(), TenantSource::Header);
+        }
+
+        #[tokio::test]
+        async fn test_no_principal_no_header_uses_default() {
+            // No Principal, no header → resolver falls back to the default tenant.
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(None, None);
+
+            let extractor = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect("resolver should fall back to default");
+            assert_eq!(extractor.tenant_id(), "test-tenant");
+            assert_eq!(extractor.source(), TenantSource::Default);
+        }
+
+        #[tokio::test]
+        async fn test_no_principal_empty_default_is_bad_request() {
+            // Resolver path with an empty resolved tenant (empty default) → 400.
+            let state = make_state(false, "");
+            let mut parts = make_parts(None, None);
+
+            let err = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect_err("empty resolved tenant should be rejected");
+            assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn test_jwt_claim_ignores_conflicting_header_non_strict() {
+            // Non-strict mode: a valid JWT tenant claim is authoritative and a
+            // conflicting X-Tenant-ID header is ignored (not honoured, not an error).
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(Some("other-tenant"), Some(make_principal(Some("acme"))));
+
+            let extractor = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect("JWT claim should win over a conflicting header in non-strict mode");
+            assert_eq!(extractor.tenant_id(), "acme");
+            assert_eq!(extractor.source(), TenantSource::JwtClaim);
+        }
+
+        #[tokio::test]
+        async fn test_empty_claim_nondefault_header_is_forbidden() {
+            // An empty claim is treated as "no claim": a non-default requested
+            // tenant still yields 403 (same fail-loud path as a missing claim).
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(Some("other-tenant"), Some(make_principal(Some(""))));
+
+            let err = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect_err("empty claim + non-default header should be forbidden");
+            assert_eq!(err.0, StatusCode::FORBIDDEN);
+        }
+    }
 }

--- a/crates/rest/src/extractors/tenant.rs
+++ b/crates/rest/src/extractors/tenant.rs
@@ -143,7 +143,7 @@ where
         // verify that the JWT tenant matches any header/URL tenant to prevent
         // confusion between URL context and actual data access.
         if let Some(principal) = parts.extensions.get::<helios_auth::Principal>() {
-            if let Some(jwt_tenant) = principal.tenant_id() {
+            if let Some(jwt_tenant) = principal.tenant_id().filter(|t| !t.is_empty()) {
                 if config.multitenancy.strict_validation {
                     let resolver = TenantResolver::new(&config.multitenancy);
                     let resolved =
@@ -165,6 +165,36 @@ where
                     crate::tenant::TenantSource::JwtClaim,
                 ));
             }
+
+            // A Principal is present (auth enabled + token validated) but the token
+            // carries no (usable) tenant claim. We must NOT trust the client-supplied
+            // X-Tenant-ID header or URL-path tenant here — doing so would let an
+            // authenticated caller widen access to an arbitrary tenant by spoofing
+            // the header.
+            //
+            // Determine what tenant the REQUEST asked for. If the client explicitly
+            // selected a specific, non-default tenant via header/URL, fail loud: a
+            // claimless token silently collapsing to the default would commingle
+            // distinct tenants into one bucket in a multitenant-with-auth deployment.
+            // If nothing (or only the default) was requested, fall back to the
+            // configured default so single-tenant-with-auth deployments keep working.
+            let resolver = TenantResolver::new(&config.multitenancy);
+            let resolved = resolver.resolve(parts, &config.multitenancy, &config.default_tenant);
+            if resolved.tenant_id_str() != config.default_tenant {
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    "Authenticated token is missing the required tenant claim".to_string(),
+                ));
+            }
+            // Fail closed on a misconfigured empty default tenant rather than
+            // building an empty-tenant context (mirrors the resolver path below).
+            if config.default_tenant.is_empty() {
+                return Err((StatusCode::BAD_REQUEST, "Invalid tenant ID".to_string()));
+            }
+            return Ok(TenantExtractor::new(
+                &config.default_tenant,
+                TenantSource::Default,
+            ));
         }
 
         // Create resolver based on configuration

--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -17,7 +17,7 @@ use helios_fhir::FhirVersion;
 use helios_persistence::core::{
     BundleEntry, BundleEntryResult, BundleMethod, BundleProvider, ResourceStorage,
 };
-use helios_persistence::error::TransactionError;
+use helios_persistence::error::{StorageError, TransactionError};
 use serde_json::Value;
 use tracing::{debug, error, warn};
 
@@ -290,7 +290,11 @@ where
             Ok((StatusCode::OK, Json(response_bundle)).into_response())
         }
         Err(e) => {
-            let rollback_reason = e.to_string();
+            // Derive a sanitized reason so backend detail carried by a
+            // rolled-back/internal transaction error never reaches the client
+            // response, the audit trail, or the entry outcome. The raw detail is
+            // preserved server-side by the `error!` log below.
+            let (_, _, rollback_reason) = transaction_error_response_parts(&e);
             let rollback_result =
                 create_error_result(500, &format!("Transaction rolled back: {rollback_reason}"));
             for (orig_idx, entry, _) in &indexed_entries {
@@ -370,7 +374,10 @@ where
             {
                 Ok(Some(stored)) => BundleEntryResult::ok(stored),
                 Ok(None) => create_error_result(404, "Resource not found"),
-                Err(e) => create_error_result(500, &e.to_string()),
+                Err(e) => {
+                    let (status, message) = entry_error(e);
+                    create_error_result(status, &message)
+                }
             }
         }
         "POST" => {
@@ -394,7 +401,10 @@ where
                 .await
             {
                 Ok(stored) => BundleEntryResult::created(stored),
-                Err(e) => create_error_result(400, &e.to_string()),
+                Err(e) => {
+                    let (status, message) = entry_error(e);
+                    create_error_result(status, &message)
+                }
             }
         }
         "PUT" => {
@@ -428,7 +438,10 @@ where
                         result
                     }
                 }
-                Err(e) => create_error_result(400, &e.to_string()),
+                Err(e) => {
+                    let (status, message) = entry_error(e);
+                    create_error_result(status, &message)
+                }
             }
         }
         "DELETE" => {
@@ -439,7 +452,10 @@ where
                 .await
             {
                 Ok(()) => BundleEntryResult::deleted(),
-                Err(e) => create_error_result(404, &e.to_string()),
+                Err(e) => {
+                    let (status, message) = entry_error(e);
+                    create_error_result(status, &message)
+                }
             }
         }
         _ => {
@@ -686,10 +702,16 @@ fn status_text(code: &str) -> &'static str {
         "201" => "Created",
         "204" => "No Content",
         "400" => "Bad Request",
+        "401" => "Unauthorized",
+        "403" => "Forbidden",
         "404" => "Not Found",
         "405" => "Method Not Allowed",
+        "406" => "Not Acceptable",
         "409" => "Conflict",
+        "410" => "Gone",
         "412" => "Precondition Failed",
+        "415" => "Unsupported Media Type",
+        "422" => "Unprocessable Entity",
         "500" => "Internal Server Error",
         "501" => "Not Implemented",
         _ => "Unknown",
@@ -881,18 +903,37 @@ fn build_full_url(result: &BundleEntryResult, base_url: &str) -> Option<String> 
     None
 }
 
-/// Converts a TransactionError to an HTTP response with OperationOutcome.
-fn transaction_error_to_response(err: TransactionError) -> RestResult<Response> {
-    let (status_code, issue_code, message) = match &err {
+/// Derives a sanitized `(status, message)` for a batch/transaction entry
+/// OperationOutcome from a storage error.
+///
+/// Reuses [`RestError`]'s client-facing mapping so backend/internal detail is
+/// never leaked to callers (and is logged server-side) while safe classes keep
+/// their specific, actionable message and correct HTTP status.
+fn entry_error(err: StorageError) -> (u16, String) {
+    let (status, _code, message) = RestError::from(err).client_response();
+    (status.as_u16(), message)
+}
+
+/// Computes the sanitized `(status, issue code, message)` for a failed
+/// transaction.
+///
+/// Status codes and issue codes preserve the FHIR mapping used for the overall
+/// transaction response. Only the rolled-back case is sanitized: its `reason`
+/// can embed raw backend/driver/SQL detail, so it is collapsed to a generic
+/// message (the raw detail is logged separately by the caller). Validation,
+/// conditional-match, timeout, and not-supported errors keep their specific,
+/// non-sensitive message.
+fn transaction_error_response_parts(err: &TransactionError) -> (StatusCode, &'static str, String) {
+    match err {
         TransactionError::BundleError { index, message } => (
             StatusCode::BAD_REQUEST,
             "processing",
             format!("Transaction failed at entry {}: {}", index, message),
         ),
-        TransactionError::RolledBack { reason } => (
+        TransactionError::RolledBack { .. } => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "transient",
-            format!("Transaction rolled back: {}", reason),
+            "The transaction could not be completed and was rolled back.".to_string(),
         ),
         TransactionError::Timeout { timeout_ms } => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -919,7 +960,12 @@ fn transaction_error_to_response(err: TransactionError) -> RestResult<Response> 
             "not-supported",
             format!("Isolation level '{}' is not supported", level),
         ),
-    };
+    }
+}
+
+/// Converts a TransactionError to an HTTP response with OperationOutcome.
+fn transaction_error_to_response(err: TransactionError) -> RestResult<Response> {
+    let (status_code, issue_code, message) = transaction_error_response_parts(&err);
 
     let outcome = serde_json::json!({
         "resourceType": "OperationOutcome",
@@ -1048,6 +1094,66 @@ mod tests {
             }
         }
         details
+    }
+
+    #[test]
+    fn test_entry_error_sanitizes_backend_detail() {
+        // A backend/internal storage error whose Display embeds sensitive DB
+        // detail (table/column names, SQL fragments) must be collapsed to the
+        // generic client message with a 5xx status.
+        use helios_persistence::error::BackendError;
+
+        let raw_detail = "query execution failed: table \"resources\" column x does not exist";
+        let err = StorageError::Backend(BackendError::QueryError {
+            message: raw_detail.to_string(),
+        });
+
+        let (status, message) = entry_error(err);
+        assert_eq!(status, 500);
+        assert!(
+            !message.contains("resources"),
+            "entry outcome leaked raw backend detail: {message}"
+        );
+        assert!(
+            !message.contains("column x"),
+            "entry outcome leaked raw backend detail: {message}"
+        );
+        assert_eq!(
+            message,
+            "An internal error occurred while processing the request."
+        );
+    }
+
+    #[test]
+    fn test_entry_error_preserves_not_found() {
+        // Safe error classes keep their specific message and correct status.
+        use helios_persistence::error::ResourceError;
+
+        let err = StorageError::Resource(ResourceError::NotFound {
+            resource_type: "Patient".to_string(),
+            id: "123".to_string(),
+        });
+
+        let (status, message) = entry_error(err);
+        assert_eq!(status, 404);
+        assert!(message.contains("Patient/123"), "message was: {message}");
+    }
+
+    #[test]
+    fn test_transaction_rollback_reason_is_sanitized() {
+        // The rolled-back reason from the persistence layer can carry backend
+        // detail; it must not appear in the transaction response/audit text.
+        let raw_detail = "connection failed to postgres: password authentication failed";
+        let err = TransactionError::RolledBack {
+            reason: raw_detail.to_string(),
+        };
+        let (status, _code, message) = transaction_error_response_parts(&err);
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(
+            !message.contains("password"),
+            "rollback text leaked raw backend detail: {message}"
+        );
+        assert!(!message.contains("postgres"), "leaked backend name: {message}");
     }
 
     #[tokio::test]

--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -1153,7 +1153,10 @@ mod tests {
             !message.contains("password"),
             "rollback text leaked raw backend detail: {message}"
         );
-        assert!(!message.contains("postgres"), "leaked backend name: {message}");
+        assert!(
+            !message.contains("postgres"),
+            "leaked backend name: {message}"
+        );
     }
 
     #[tokio::test]

--- a/crates/rest/src/handlers/capabilities.rs
+++ b/crates/rest/src/handlers/capabilities.rs
@@ -135,8 +135,6 @@ fn build_capability_statement<S>(
 where
     S: ResourceStorage + SearchProvider + Send + Sync + 'static,
 {
-    let backend_name = state.storage().backend_name();
-
     // Get resource types for the requested FHIR version
     let resource_types = get_resource_type_names_for_version(version);
 
@@ -227,7 +225,7 @@ where
         "fhirVersion": version.full_version(),
         "format": formats,
         "implementation": {
-            "description": format!("Helios FHIR Server ({})", backend_name),
+            "description": "Helios FHIR Server",
             "url": base_url
         },
         "rest": [rest_entry]

--- a/crates/rest/src/handlers/console_metrics.rs
+++ b/crates/rest/src/handlers/console_metrics.rs
@@ -157,7 +157,10 @@ where
     for rt in &types {
         let total = totals_by_type.get(rt.as_str()).copied().unwrap_or(0);
 
-        let buckets = state.storage().count_by_day(ctx, rt.as_str(), since).await?;
+        let buckets = state
+            .storage()
+            .count_by_day(ctx, rt.as_str(), since)
+            .await?;
 
         // Collapse buckets into a day -> count map, summing only days inside the
         // window (defensive against any future-dated `last_updated`).

--- a/crates/rest/src/handlers/console_metrics.rs
+++ b/crates/rest/src/handlers/console_metrics.rs
@@ -1,0 +1,530 @@
+//! Management-console metrics endpoints.
+//!
+//! These return plain JSON (not FHIR resources) for the admin console
+//! dashboard:
+//!
+//! - `GET /console/metrics/uptime` — process uptime + server identity.
+//! - `GET /console/metrics/resource-counts` — per-type stored-resource counts
+//!   and a daily "resources over time" series for charting.
+//!
+//! Trust tiers are assigned in [`crate::routing::console_metrics`]: `uptime` is
+//! public (mounted outside auth, like `/metrics`); `resource-counts`, `activity`,
+//! and `resource-distribution` require authentication and are tenant-scoped; and
+//! the cross-tenant `tenants` / `traffic` endpoints additionally require a
+//! system-context scope (`system/*.r`). Per-tenant resource counts are served
+//! only in these authenticated JSON responses — they are deliberately NOT
+//! exported to the public `/metrics` endpoint, because tenant is never a metric
+//! label and `/metrics` is unauthenticated.
+
+use std::collections::HashMap;
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use helios_persistence::core::ResourceStorage;
+use serde_json::json;
+use tracing::debug;
+
+use crate::error::RestResult;
+use crate::extractors::TenantExtractor;
+use crate::state::AppState;
+
+/// Resource types charted by the console dashboard's "FHIR Resources over time"
+/// card when the caller does not specify an explicit `types` filter.
+const DEFAULT_TYPES: &[&str] = &[
+    "Patient",
+    "Observation",
+    "Encounter",
+    "Condition",
+    "MedicationRequest",
+    "DiagnosticReport",
+    "Procedure",
+    "AllergyIntolerance",
+];
+
+/// Default number of daily buckets in the over-time series.
+const DEFAULT_WINDOW_DAYS: i64 = 30;
+/// Upper bound on the requested window, to keep the response and query bounded.
+const MAX_WINDOW_DAYS: i64 = 365;
+/// Cap on how many resource types a single `resource-counts` request may chart.
+/// The list drives one batched `count_by_types` query plus one `count_by_day`
+/// per type, so this bounds the work an authenticated caller can amplify via the
+/// `types` parameter.
+const MAX_REQUESTED_TYPES: usize = 50;
+
+/// `GET /console/metrics/uptime`
+///
+/// Reports process uptime (seconds since start, plus a human-readable form),
+/// the start timestamp, and basic server identity. `availability` is surfaced
+/// as explicitly untracked rather than fabricated — a real availability
+/// percentage (e.g. "99.98% over 30d") would require health-probe history that
+/// HFS does not yet record.
+pub async fn uptime_handler<S>(State(_state): State<AppState<S>>) -> RestResult<Response>
+where
+    S: ResourceStorage + Send + Sync,
+{
+    debug!("Processing console uptime request");
+
+    let seconds = helios_observability::uptime::uptime_seconds();
+
+    let body = json!({
+        "service": "hfs",
+        "version": env!("CARGO_PKG_VERSION"),
+        "started_at": helios_observability::uptime::started_at_rfc3339(),
+        "now": chrono::Utc::now().to_rfc3339(),
+        "uptime_seconds": seconds,
+        "uptime_human": humanize_uptime(seconds),
+        "availability": {
+            "tracked": false,
+            "note": "availability tracking is not enabled; uptime_seconds reflects \
+                     time since the current process started"
+        }
+    });
+
+    Ok((StatusCode::OK, Json(body)).into_response())
+}
+
+/// `GET /console/metrics/resource-counts`
+///
+/// Query parameters (all optional):
+/// - `types` — comma-separated FHIR resource types (defaults to the eight
+///   dashboard types in [`DEFAULT_TYPES`]).
+/// - `days` — size of the daily window, clamped to `1..=365` (default 30).
+///
+/// For each requested type it returns the current `total` and a dense daily
+/// `points` array (`date`, `count`, `cumulative`). The cumulative series starts
+/// from the count of resources last updated *before* the window and converges
+/// to `total` at the final day, giving a growth-style curve whose endpoint
+/// matches the dashboard's "Stored resources" stat. See
+/// [`ResourceStorage::count_by_day`] for the exact bucketing semantics.
+pub async fn resource_counts_handler<S>(
+    State(state): State<AppState<S>>,
+    tenant: TenantExtractor,
+    Query(params): Query<HashMap<String, String>>,
+) -> RestResult<Response>
+where
+    S: ResourceStorage + Send + Sync,
+{
+    let ctx = tenant.context();
+    let tenant_id = tenant.tenant_id();
+    debug!(tenant = %tenant_id, "Processing console resource-counts request");
+
+    // Window size; clamp to a sane range so a stray `?days=100000` can't force an
+    // unbounded scan or response. Unparseable values fall back to the default.
+    let days = params
+        .get("days")
+        .and_then(|d| d.parse::<i64>().ok())
+        .unwrap_or(DEFAULT_WINDOW_DAYS)
+        .clamp(1, MAX_WINDOW_DAYS);
+
+    // Resource types to chart: an explicit comma-separated `types` filter
+    // (whitespace-trimmed, empty entries dropped), otherwise the dashboard set.
+    // Capped at MAX_REQUESTED_TYPES so the per-type query fan-out stays bounded.
+    let mut types: Vec<String> = match params.get("types") {
+        Some(s) if !s.trim().is_empty() => s
+            .split(',')
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect(),
+        _ => DEFAULT_TYPES.iter().map(|t| t.to_string()).collect(),
+    };
+    types.truncate(MAX_REQUESTED_TYPES);
+
+    // Window: `days` daily buckets ending today (all UTC, midnight-aligned).
+    let now = chrono::Utc::now();
+    let today = now.date_naive();
+    let start_date = today - chrono::Duration::days(days - 1);
+    let since = start_date
+        .and_hms_opt(0, 0, 0)
+        .unwrap_or_default()
+        .and_utc();
+
+    // Fetch all per-type totals in one batched call (backends may serve this
+    // with a single grouped query), instead of one `count()` round-trip per
+    // type. Build a type -> total lookup; a type with no row counts as 0.
+    let type_refs: Vec<&str> = types.iter().map(|t| t.as_str()).collect();
+    let totals_by_type: HashMap<String, u64> = state
+        .storage()
+        .count_by_types(ctx, &type_refs)
+        .await?
+        .into_iter()
+        .collect();
+
+    let mut series = Vec::with_capacity(types.len());
+    for rt in &types {
+        let total = totals_by_type.get(rt.as_str()).copied().unwrap_or(0);
+
+        let buckets = state.storage().count_by_day(ctx, rt.as_str(), since).await?;
+
+        // Collapse buckets into a day -> count map, summing only days inside the
+        // window (defensive against any future-dated `last_updated`).
+        let mut by_day: HashMap<chrono::NaiveDate, u64> = HashMap::new();
+        let mut in_window: u64 = 0;
+        for b in &buckets {
+            if b.day >= start_date && b.day <= today {
+                *by_day.entry(b.day).or_insert(0) += b.count;
+                in_window += b.count;
+            }
+        }
+
+        // Resources last updated before the window form the cumulative baseline.
+        let baseline = total.saturating_sub(in_window);
+
+        let mut points = Vec::with_capacity(days as usize);
+        let mut cumulative = baseline;
+        for i in 0..days {
+            let d = start_date + chrono::Duration::days(i);
+            let count = by_day.get(&d).copied().unwrap_or(0);
+            cumulative += count;
+            points.push(json!({
+                "date": d.format("%Y-%m-%d").to_string(),
+                "count": count,
+                "cumulative": cumulative,
+            }));
+        }
+
+        series.push(json!({
+            "resource_type": rt,
+            "total": total,
+            "points": points,
+        }));
+    }
+
+    let total_resources = state.storage().count(ctx, None).await?;
+
+    let body = json!({
+        "tenant": tenant_id,
+        "generated_at": now.to_rfc3339(),
+        "window": {
+            "interval": "day",
+            "days": days,
+            "since": start_date.format("%Y-%m-%d").to_string(),
+            "until": today.format("%Y-%m-%d").to_string(),
+        },
+        "total_resources": total_resources,
+        "series": series,
+    });
+
+    Ok((StatusCode::OK, Json(body)).into_response())
+}
+
+/// `GET /console/metrics/activity`
+///
+/// Weekly-rhythm activity heatmap: write operations (resource versions) bucketed
+/// by UTC weekday (`0` = Sunday … `6` = Saturday) and hour (`0` … `23`) over a
+/// rolling window.
+///
+/// Query parameters (all optional):
+/// - `days` — window size, clamped to `1..=365` (default 30).
+///
+/// The `cells` array is **dense** — all 168 `weekday × hour` cells, zero-filled,
+/// ascending by `weekday` then `hour` — so the frontend renders the grid without
+/// gap-filling. `max_cell` is provided for colour scaling. `source` reports where
+/// the data came from; this version always reports `"writes"` (from
+/// `resource_history`), leaving room to add an `AuditEvent`-backed
+/// `"all-operations"` source without changing the response shape.
+pub async fn activity_handler<S>(
+    State(state): State<AppState<S>>,
+    tenant: TenantExtractor,
+    Query(params): Query<HashMap<String, String>>,
+) -> RestResult<Response>
+where
+    S: ResourceStorage + Send + Sync,
+{
+    let ctx = tenant.context();
+    let tenant_id = tenant.tenant_id();
+    debug!(tenant = %tenant_id, "Processing console activity request");
+
+    let days = params
+        .get("days")
+        .and_then(|d| d.parse::<i64>().ok())
+        .unwrap_or(DEFAULT_WINDOW_DAYS)
+        .clamp(1, MAX_WINDOW_DAYS);
+
+    let now = chrono::Utc::now();
+    let today = now.date_naive();
+    let start_date = today - chrono::Duration::days(days - 1);
+    let since = start_date
+        .and_hms_opt(0, 0, 0)
+        .unwrap_or_default()
+        .and_utc();
+
+    let histogram = state.storage().activity_histogram(ctx, since).await?;
+
+    // Densify into a 7×24 grid, summing any duplicate cells defensively.
+    let mut grid = [[0u64; 24]; 7];
+    for cell in &histogram {
+        let wd = cell.weekday.min(6) as usize;
+        let hr = cell.hour.min(23) as usize;
+        grid[wd][hr] = grid[wd][hr].saturating_add(cell.count);
+    }
+
+    let mut cells = Vec::with_capacity(7 * 24);
+    let mut total: u64 = 0;
+    let mut max_cell: u64 = 0;
+    for (wd, hours) in grid.iter().enumerate() {
+        for (hr, &count) in hours.iter().enumerate() {
+            total += count;
+            max_cell = max_cell.max(count);
+            cells.push(json!({ "weekday": wd, "hour": hr, "count": count }));
+        }
+    }
+
+    let body = json!({
+        "tenant": tenant_id,
+        "generated_at": now.to_rfc3339(),
+        "source": "writes",
+        "window": {
+            "days": days,
+            "since": start_date.format("%Y-%m-%d").to_string(),
+            "until": today.format("%Y-%m-%d").to_string(),
+        },
+        "total": total,
+        "max_cell": max_cell,
+        "cells": cells,
+    });
+
+    Ok((StatusCode::OK, Json(body)).into_response())
+}
+
+/// `GET /console/metrics/traffic`
+///
+/// Windowed request throughput, latency percentiles, error rate, and a sparkline
+/// — derived from the in-process rolling request log
+/// ([`helios_observability::reqlog`]). Unlike the Prometheus `/metrics` counters,
+/// these arrive already windowed and ready to chart, with no PromQL.
+///
+/// Query parameters (all optional):
+/// - `window` — look-back in seconds, clamped to `60..=86_400` (default 3600).
+/// - `tenant` — restrict to a single tenant id (default: all traffic).
+///
+/// The window is in-process and resets on restart; it covers at most the most
+/// recent [`helios_observability::reqlog::CAPACITY`] requests.
+pub async fn traffic_handler<S>(
+    State(_state): State<AppState<S>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> RestResult<Response>
+where
+    S: ResourceStorage + Send + Sync,
+{
+    debug!("Processing console traffic request");
+
+    let window = params
+        .get("window")
+        .and_then(|w| w.parse::<i64>().ok())
+        .unwrap_or(3600)
+        .clamp(60, 86_400);
+    let tenant_filter = params.get("tenant").map(|s| s.as_str());
+
+    let stats = helios_observability::reqlog::snapshot(window, tenant_filter);
+
+    let series: Vec<_> = stats
+        .series
+        .iter()
+        .map(|b| {
+            json!({
+                "offset_seconds": b.offset_seconds,
+                "requests_per_second": b.requests_per_second,
+                "p95_ms": b.p95_ms,
+            })
+        })
+        .collect();
+
+    let body = json!({
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "window_seconds": stats.window_seconds,
+        "covered_seconds": stats.covered_seconds,
+        "sample_count": stats.sample_count,
+        "requests_per_second": stats.requests_per_second,
+        "latency_ms": { "p50": stats.p50_ms, "p95": stats.p95_ms, "p99": stats.p99_ms },
+        "error_rate": stats.error_rate,
+        "status_classes": {
+            "2xx": stats.status_2xx,
+            "3xx": stats.status_3xx,
+            "4xx": stats.status_4xx,
+            "5xx": stats.status_5xx,
+        },
+        "series": series,
+    });
+
+    Ok((StatusCode::OK, Json(body)).into_response())
+}
+
+/// `GET /console/metrics/resource-distribution`
+///
+/// Every stored resource type for the tenant with its count, busiest first — the
+/// data behind the "resource composition" treemap.
+///
+/// Query parameters (all optional):
+/// - `top` — keep the N largest types and roll the remainder into a single
+///   `other` bucket, clamped to `1..=100` (default 20).
+pub async fn resource_distribution_handler<S>(
+    State(state): State<AppState<S>>,
+    tenant: TenantExtractor,
+    Query(params): Query<HashMap<String, String>>,
+) -> RestResult<Response>
+where
+    S: ResourceStorage + Send + Sync,
+{
+    let ctx = tenant.context();
+    let tenant_id = tenant.tenant_id();
+    debug!(tenant = %tenant_id, "Processing console resource-distribution request");
+
+    let top = params
+        .get("top")
+        .and_then(|t| t.parse::<usize>().ok())
+        .unwrap_or(20)
+        .clamp(1, 100);
+
+    let mut counts = state.storage().count_all_types(ctx).await?;
+    // Busiest first; tie-break alphabetically for stable output.
+    counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let total: u64 = counts.iter().map(|(_, n)| *n).sum();
+    let distinct_types = counts.len();
+
+    let mut types = Vec::new();
+    if counts.len() > top {
+        for (rt, n) in &counts[..top] {
+            types.push(json!({ "resource_type": rt, "count": n }));
+        }
+        let tail = &counts[top..];
+        let other_count: u64 = tail.iter().map(|(_, n)| *n).sum();
+        types.push(json!({
+            "resource_type": "other",
+            "count": other_count,
+            "types": tail.len(),
+        }));
+    } else {
+        for (rt, n) in &counts {
+            types.push(json!({ "resource_type": rt, "count": n }));
+        }
+    }
+
+    let body = json!({
+        "tenant": tenant_id,
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "total_resources": total,
+        "distinct_types": distinct_types,
+        "types": types,
+    });
+
+    Ok((StatusCode::OK, Json(body)).into_response())
+}
+
+/// `GET /console/metrics/tenants`
+///
+/// Per-tenant comparison: authoritative stored-resource counts (cross-tenant
+/// backend aggregate) joined with windowed traffic (best-effort, from the
+/// in-process request log). Sorted by resource count, busiest first.
+///
+/// Query parameters (all optional):
+/// - `window` — traffic look-back in seconds, clamped to `60..=86_400`
+///   (default 3600).
+///
+/// Traffic is keyed by the `X-Tenant-ID` seen on requests (empty → `"default"`),
+/// so a tenant with stored data but no recent traffic reports zero rates, and a
+/// tenant with traffic but no stored resources still appears (with `resources:
+/// 0`).
+pub async fn tenants_handler<S>(
+    State(state): State<AppState<S>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> RestResult<Response>
+where
+    S: ResourceStorage + Send + Sync,
+{
+    debug!("Processing console tenants request");
+
+    let window = params
+        .get("window")
+        .and_then(|w| w.parse::<i64>().ok())
+        .unwrap_or(3600)
+        .clamp(60, 86_400);
+
+    let mut resource_counts = state.storage().count_by_tenant().await?;
+    resource_counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let traffic = helios_observability::reqlog::per_tenant(window);
+    let traffic_by_tenant: HashMap<&str, &helios_observability::reqlog::TenantTraffic> =
+        traffic.iter().map(|t| (t.tenant.as_str(), t)).collect();
+
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut tenants = Vec::new();
+    for (tenant, resources) in &resource_counts {
+        seen.insert(tenant.as_str());
+        let tr = traffic_by_tenant.get(tenant.as_str());
+        tenants.push(json!({
+            "tenant": tenant,
+            "resources": resources,
+            "requests_per_second": tr.map(|t| t.requests_per_second).unwrap_or(0.0),
+            "p95_ms": tr.map(|t| t.p95_ms).unwrap_or(0.0),
+            "error_rate": tr.map(|t| t.error_rate).unwrap_or(0.0),
+        }));
+    }
+    // Tenants seen only in traffic (no stored resources yet).
+    for t in &traffic {
+        if !seen.contains(t.tenant.as_str()) {
+            tenants.push(json!({
+                "tenant": t.tenant,
+                "resources": 0,
+                "requests_per_second": t.requests_per_second,
+                "p95_ms": t.p95_ms,
+                "error_rate": t.error_rate,
+            }));
+        }
+    }
+
+    let body = json!({
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "window_seconds": window,
+        "tenant_count": tenants.len(),
+        "tenants": tenants,
+    });
+
+    Ok((StatusCode::OK, Json(body)).into_response())
+}
+
+/// Formats a duration in seconds as a compact `"4d 2h 13m 5s"` string, omitting
+/// leading zero units. Always shows at least seconds (`"0s"`).
+fn humanize_uptime(seconds: f64) -> String {
+    let total = seconds.max(0.0) as u64;
+    let days = total / 86_400;
+    let hours = (total % 86_400) / 3_600;
+    let mins = (total % 3_600) / 60;
+    let secs = total % 60;
+
+    let mut parts = Vec::new();
+    if days > 0 {
+        parts.push(format!("{days}d"));
+    }
+    if hours > 0 || !parts.is_empty() {
+        parts.push(format!("{hours}h"));
+    }
+    if mins > 0 || !parts.is_empty() {
+        parts.push(format!("{mins}m"));
+    }
+    parts.push(format!("{secs}s"));
+    parts.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn humanize_uptime_formats_units() {
+        assert_eq!(humanize_uptime(0.0), "0s");
+        assert_eq!(humanize_uptime(45.0), "45s");
+        assert_eq!(humanize_uptime(90.0), "1m 30s");
+        assert_eq!(humanize_uptime(3_661.0), "1h 1m 1s");
+        assert_eq!(humanize_uptime(90_061.0), "1d 1h 1m 1s");
+    }
+
+    #[test]
+    fn humanize_uptime_clamps_negative() {
+        assert_eq!(humanize_uptime(-5.0), "0s");
+    }
+}

--- a/crates/rest/src/handlers/console_metrics.rs
+++ b/crates/rest/src/handlers/console_metrics.rs
@@ -55,6 +55,26 @@ const MAX_WINDOW_DAYS: i64 = 365;
 /// `types` parameter.
 const MAX_REQUESTED_TYPES: usize = 50;
 
+/// Classifies the storage backend as cluster-shared vs. instance-local for the
+/// `scope` / `resources_scope` fields. The console `count_*` calls delegate to
+/// the primary CRUD store, so shared-ness tracks that primary: networked stores
+/// (PostgreSQL, MongoDB, S3) are shared across a fleet (`"cluster"`), while
+/// SQLite (a per-instance file) is instance-local (`"single-instance"`).
+///
+/// This is derived from [`ResourceStorage::is_cluster_shared`], whose
+/// conservative default is `"single-instance"` so an unknown backend never
+/// over-claims cluster-consistency. Composite backends delegate to their primary
+/// store, so a Postgres-primary composite (e.g. `postgres-elasticsearch`) is
+/// correctly labelled `"cluster"` and a SQLite-primary composite (e.g.
+/// `sqlite-elasticsearch`) `"single-instance"`.
+fn resources_scope<S: ResourceStorage>(storage: &S) -> &'static str {
+    if storage.is_cluster_shared() {
+        "cluster"
+    } else {
+        "single-instance"
+    }
+}
+
 /// `GET /console/metrics/uptime`
 ///
 /// Reports process uptime (seconds since start, plus a human-readable form),
@@ -62,6 +82,14 @@ const MAX_REQUESTED_TYPES: usize = 50;
 /// as explicitly untracked rather than fabricated — a real availability
 /// percentage (e.g. "99.98% over 30d") would require health-probe history that
 /// HFS does not yet record.
+///
+/// **Scope: single-instance.** `uptime_seconds` is the age of *this* process
+/// only, and `scope` is `"single-instance"`. Behind a load balancer this reflects
+/// just the instance that served the request. The answering instance's hostname
+/// is deliberately NOT returned here — this endpoint is unauthenticated, and a
+/// hostname is infrastructure-identifying; instance attribution lives on the
+/// authenticated `traffic`/`tenants` endpoints. Aggregate Prometheus `/metrics`
+/// for fleet-wide figures.
 pub async fn uptime_handler<S>(State(_state): State<AppState<S>>) -> RestResult<Response>
 where
     S: ResourceStorage + Send + Sync,
@@ -72,6 +100,7 @@ where
 
     let body = json!({
         "service": "hfs",
+        "scope": "single-instance",
         "version": env!("CARGO_PKG_VERSION"),
         "started_at": helios_observability::uptime::started_at_rfc3339(),
         "now": chrono::Utc::now().to_rfc3339(),
@@ -200,6 +229,7 @@ where
 
     let body = json!({
         "tenant": tenant_id,
+        "scope": resources_scope(state.storage()),
         "generated_at": now.to_rfc3339(),
         "window": {
             "interval": "day",
@@ -278,6 +308,7 @@ where
 
     let body = json!({
         "tenant": tenant_id,
+        "scope": resources_scope(state.storage()),
         "generated_at": now.to_rfc3339(),
         "source": "writes",
         "window": {
@@ -299,6 +330,12 @@ where
 /// — derived from the in-process rolling request log
 /// ([`helios_observability::reqlog`]). Unlike the Prometheus `/metrics` counters,
 /// these arrive already windowed and ready to chart, with no PromQL.
+///
+/// **Scope: single-instance.** The request log is per-process, so every figure
+/// here reflects only the instance that answered (identified by the top-level
+/// `instance` field; `scope` is `"single-instance"`). In a clustered deployment
+/// behind a load balancer, fleet-wide throughput and latency must be aggregated
+/// from Prometheus `/metrics`, not from this endpoint.
 ///
 /// Query parameters (all optional):
 /// - `window` — look-back in seconds, clamped to `60..=86_400` (default 3600).
@@ -337,6 +374,8 @@ where
         .collect();
 
     let body = json!({
+        "instance": helios_observability::uptime::instance_id(),
+        "scope": "single-instance",
         "generated_at": chrono::Utc::now().to_rfc3339(),
         "window_seconds": stats.window_seconds,
         "covered_seconds": stats.covered_seconds,
@@ -409,6 +448,7 @@ where
 
     let body = json!({
         "tenant": tenant_id,
+        "scope": resources_scope(state.storage()),
         "generated_at": chrono::Utc::now().to_rfc3339(),
         "total_resources": total,
         "distinct_types": distinct_types,
@@ -423,6 +463,17 @@ where
 /// Per-tenant comparison: authoritative stored-resource counts (cross-tenant
 /// backend aggregate) joined with windowed traffic (best-effort, from the
 /// in-process request log). Sorted by resource count, busiest first.
+///
+/// **Mixed scope.** The per-row `resources` column is a shared-DB cross-tenant
+/// aggregate whose `resources_scope` is backend-derived (`"cluster"` on
+/// PostgreSQL/MongoDB, `"single-instance"` on SQLite), but the per-row traffic
+/// columns (`requests_per_second` / `p95_ms` / `error_rate`) come from this
+/// process's request log and reflect only the instance that answered
+/// (`traffic_scope: "single-instance"`, identified by the top-level `instance`
+/// field). Fleet-wide *per-tenant* traffic cannot come from Prometheus
+/// `/metrics` — tenant is deliberately not a metric label (it is recorded as a
+/// trace/OTLP span attribute instead), so per-tenant fleet aggregation must come
+/// from the tracing/OTLP backend, not from `/metrics`.
 ///
 /// Query parameters (all optional):
 /// - `window` — traffic look-back in seconds, clamped to `60..=86_400`
@@ -481,6 +532,9 @@ where
     }
 
     let body = json!({
+        "instance": helios_observability::uptime::instance_id(),
+        "resources_scope": resources_scope(state.storage()),
+        "traffic_scope": "single-instance",
         "generated_at": chrono::Utc::now().to_rfc3339(),
         "window_seconds": window,
         "tenant_count": tenants.len(),

--- a/crates/rest/src/handlers/health.rs
+++ b/crates/rest/src/handlers/health.rs
@@ -27,20 +27,16 @@ use crate::state::AppState;
 ///
 /// - `200 OK` - Server is healthy
 /// - `503 Service Unavailable` - Server is unhealthy
-pub async fn health_handler<S>(State(state): State<AppState<S>>) -> RestResult<Response>
+pub async fn health_handler<S>(State(_state): State<AppState<S>>) -> RestResult<Response>
 where
     S: ResourceStorage + Send + Sync,
 {
     debug!("Processing health check request");
 
-    // Perform a simple check - we could add more sophisticated checks here
-    let backend_name = state.storage().backend_name();
-
     let health_response = serde_json::json!({
         "status": "ok",
         "service": "hfs",
         "version": env!("CARGO_PKG_VERSION"),
-        "backend": backend_name,
         "uptime_seconds": helios_observability::uptime::uptime_seconds(),
         "started_at": helios_observability::uptime::started_at_rfc3339(),
         "timestamp": chrono::Utc::now().to_rfc3339()
@@ -67,7 +63,7 @@ pub async fn liveness_handler() -> impl IntoResponse {
 /// # HTTP Request
 ///
 /// `GET [base]/_readiness`
-pub async fn readiness_handler<S>(State(state): State<AppState<S>>) -> RestResult<Response>
+pub async fn readiness_handler<S>(State(_state): State<AppState<S>>) -> RestResult<Response>
 where
     S: ResourceStorage + Send + Sync,
 {
@@ -75,11 +71,8 @@ where
 
     // Try a simple operation to verify storage is working
     // In a real implementation, we might try a count or read operation
-    let backend_name = state.storage().backend_name();
-
     let response = serde_json::json!({
         "status": "ready",
-        "backend": backend_name,
         "checks": {
             "storage": "ok"
         }

--- a/crates/rest/src/handlers/health.rs
+++ b/crates/rest/src/handlers/health.rs
@@ -41,6 +41,8 @@ where
         "service": "hfs",
         "version": env!("CARGO_PKG_VERSION"),
         "backend": backend_name,
+        "uptime_seconds": helios_observability::uptime::uptime_seconds(),
+        "started_at": helios_observability::uptime::started_at_rfc3339(),
         "timestamp": chrono::Utc::now().to_rfc3339()
     });
 

--- a/crates/rest/src/handlers/mod.rs
+++ b/crates/rest/src/handlers/mod.rs
@@ -21,6 +21,7 @@ pub mod bulk_export;
 pub mod bulk_submit;
 pub mod capabilities;
 pub mod compartment;
+pub mod console_metrics;
 pub mod create;
 pub mod delete;
 pub mod health;

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -651,6 +651,13 @@ where
         }
     };
 
+    // Handles to the state for the console-metrics routers (public + protected),
+    // merged below — the public tier outside the auth layer, the protected tier
+    // behind it (see further down).
+    let console_public_state = state.clone();
+    let console_protected_state = state.clone();
+    let console_admin_state = state.clone();
+
     // Build the router with all FHIR routes
     let router = routing::fhir_routes::create_routes(state);
 
@@ -678,6 +685,58 @@ where
     } else {
         router
     };
+
+    // Public console metrics — only the server-global `uptime` endpoint — are
+    // mounted OUTSIDE the auth/audit layers above (mirroring `/metrics`/`/health`)
+    // so the console can show liveness without a bearer token. Still covered by
+    // the shared CORS / timeout / body-limit / tracing stack applied below.
+    let router = router.merge(routing::console_metrics::public_routes(console_public_state));
+
+    // Tenant-scoped console metrics sit behind the same bearer-token auth as the
+    // FHIR routes. The tenant is taken authoritatively from the JWT claim (see
+    // TenantExtractor), so a spoofed `X-Tenant-ID` cannot widen access, and each
+    // handler only ever reads the caller's own tenant. `authz_middleware` no
+    // longer mis-classifies these `/console/*` paths as FHIR operations (see
+    // `extract_operation`), so it is a no-op here — authentication alone is the
+    // control. When auth is disabled server-wide, this tier is unprotected like
+    // every other route, matching existing behaviour.
+    let protected_console = routing::console_metrics::protected_routes(console_protected_state);
+    let protected_console = if let Some(ref auth) = auth_state {
+        protected_console
+            .layer(axum::middleware::from_fn_with_state(
+                auth.clone(),
+                middleware::auth::authz_middleware,
+            ))
+            .layer(axum::middleware::from_fn_with_state(
+                auth.clone(),
+                middleware::auth::auth_middleware,
+            ))
+    } else {
+        protected_console
+    };
+    let router = router.merge(protected_console);
+
+    // Cross-tenant console metrics (`tenants`, `traffic`) expose data spanning
+    // every tenant, so they require an administrative, system-context scope on top
+    // of authentication. `admin_authz_middleware` requires `system/*.r`, rejecting
+    // ordinary user-/patient-context tokens (even wildcard ones) with `403`. As
+    // with the other tiers, when auth is disabled server-wide there is no
+    // Principal and the middleware passes through, keeping dev-mode behaviour.
+    let admin_console = routing::console_metrics::admin_routes(console_admin_state);
+    let admin_console = if let Some(ref auth) = auth_state {
+        admin_console
+            .layer(axum::middleware::from_fn_with_state(
+                auth.clone(),
+                middleware::auth::admin_authz_middleware,
+            ))
+            .layer(axum::middleware::from_fn_with_state(
+                auth.clone(),
+                middleware::auth::auth_middleware,
+            ))
+    } else {
+        admin_console
+    };
+    let router = router.merge(admin_console);
 
     // Build middleware stack
     let service_builder = ServiceBuilder::new()

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -690,7 +690,9 @@ where
     // mounted OUTSIDE the auth/audit layers above (mirroring `/metrics`/`/health`)
     // so the console can show liveness without a bearer token. Still covered by
     // the shared CORS / timeout / body-limit / tracing stack applied below.
-    let router = router.merge(routing::console_metrics::public_routes(console_public_state));
+    let router = router.merge(routing::console_metrics::public_routes(
+        console_public_state,
+    ));
 
     // Tenant-scoped console metrics sit behind the same bearer-token auth as the
     // FHIR routes. The tenant is taken authoritatively from the JWT claim (see

--- a/crates/rest/src/middleware/auth.rs
+++ b/crates/rest/src/middleware/auth.rs
@@ -19,9 +19,13 @@ use axum::{
 };
 use helios_audit::{AuditAction, AuditAgent, AuditEventBuilder, AuditSink, ExclusionFilter};
 use helios_auth::{
-    AuthConfig, AuthError, AuthProvider, FhirOperation, Principal, SmartScopePolicy,
+    AuthConfig, AuthError, AuthProvider, FhirOperation, Principal, SmartPermissions,
+    SmartScopePolicy,
 };
+use helios_fhir::FhirVersion;
 use tracing::{debug, warn};
+
+use crate::middleware::tenant_prefix::extract_tenant_from_path;
 
 /// Shared state for the auth middleware layers.
 pub struct AuthMiddlewareState {
@@ -35,6 +39,15 @@ pub struct AuthMiddlewareState {
     pub audit_source_observer: String,
     /// Exclusion filter for audit events.
     pub audit_exclusion_filter: ExclusionFilter,
+    /// Whether URL-path tenant routing (`url_path`/`both`) is enabled.
+    ///
+    /// When set, the tenant prefix is stripped from the request path *inside*
+    /// the FHIR router, which runs downstream of the authorization layer — so
+    /// `authz_middleware` sees the un-stripped `/{tenant}/{type}/{id}` path and
+    /// must strip the leading tenant segment itself before classifying the
+    /// operation. In `header_only` mode this is `false` and the path is used
+    /// verbatim.
+    pub tenant_url_routing: bool,
 }
 
 /// Paths that are exempt from authentication.
@@ -165,8 +178,12 @@ pub async fn authz_middleware(
     let path = request.uri().path().to_string();
     let method = request.method().clone();
 
-    // Determine the FHIR operation and resource type from the path
-    if let Some((resource_type, operation)) = extract_operation(&path, method.as_str()) {
+    // Determine the FHIR operation and resource type from the path. Under
+    // URL-path tenant routing the tenant prefix has not been stripped yet (that
+    // happens downstream, inside the FHIR router), so strip it here first.
+    if let Some((resource_type, operation)) =
+        extract_operation_for_routing(&path, method.as_str(), auth_state.tenant_url_routing)
+    {
         match SmartScopePolicy::check(&principal, &resource_type, operation) {
             Ok(()) => {
                 debug!(
@@ -207,6 +224,110 @@ pub async fn authz_middleware(
     next.run(request).await
 }
 
+/// Authorization middleware for the console's **cross-tenant** admin endpoints
+/// (`/console/metrics/tenants`, `/console/metrics/traffic`).
+///
+/// These surface data spanning every tenant — the full tenant roster and sizes,
+/// server-wide traffic — so, unlike the per-tenant console endpoints, they must
+/// not be reachable by ordinary user- or patient-context tokens. This layer
+/// requires a **system-context, all-resource** scope (`system/*.r`); anything
+/// less is rejected `403`.
+///
+/// Consistent with [`authz_middleware`], if no [`Principal`] is present (auth
+/// disabled server-wide, or an exempt path) the request passes through, so this
+/// tier stays open in the same dev-mode configurations as every other route.
+pub async fn admin_authz_middleware(
+    State(auth_state): State<Arc<AuthMiddlewareState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    // If no principal, pass through (auth disabled). Matches authz_middleware.
+    let principal = match request.extensions().get::<Principal>() {
+        Some(p) => p.clone(),
+        None => return next.run(request).await,
+    };
+
+    let path = request.uri().path().to_string();
+
+    if principal.scopes.has_system_scope(SmartPermissions::READ) {
+        debug!(
+            sub = %principal.subject(),
+            path = %path,
+            "Console admin authorization granted"
+        );
+        let event = AuditEventBuilder::new(&auth_state.audit_source_observer)
+            .action(AuditAction::Execute)
+            .outcome("0")
+            .outcome_desc(format!("Granted: console admin access to {path}"))
+            .agent(principal.subject(), None, true)
+            .build();
+        auth_state.audit_sink.record(event).await;
+        next.run(request).await
+    } else {
+        warn!(
+            sub = %principal.subject(),
+            path = %path,
+            "Console admin authorization denied: system-level scope required"
+        );
+        let event = AuditEventBuilder::new(&auth_state.audit_source_observer)
+            .action(AuditAction::Execute)
+            .outcome("8")
+            .outcome_desc(format!(
+                "Forbidden: console admin access to {path} requires a system-level scope"
+            ))
+            .agent(principal.subject(), None, true)
+            .build();
+        auth_state.audit_sink.record(event).await;
+        forbidden_response("This endpoint requires a system-level scope (system/*.read)")
+    }
+}
+
+/// Classify the FHIR operation for authorization, accounting for URL-path
+/// tenant routing.
+///
+/// When `tenant_url_routing` is set (routing mode `url_path`/`both`), the
+/// request path still carries its `/{tenant}` prefix at this layer — the router
+/// strips it further downstream. Left in place, that leading segment shifts
+/// every other segment right, so `extract_operation` would authorize
+/// `/{tenant}/Patient/123` as `Search` on type `123` and `/{tenant}/Patient` as
+/// `Read`/`Create` on type `{tenant}` — the wrong resource type entirely.
+///
+/// We therefore re-classify against the tenant-stripped path, reusing the exact
+/// same [`extract_tenant_from_path`] logic the router uses (so reserved paths
+/// and real FHIR resource types are never mistaken for tenants). System/console
+/// paths that [`extract_operation`] already declines on the raw path (returning
+/// `None`) are honoured as-is and never stripped — notably `/console/metrics/*`,
+/// which the router serves verbatim rather than as a tenant-prefixed route.
+///
+/// In `header_only` mode `tenant_url_routing` is `false` and the raw path is
+/// used verbatim, leaving behaviour byte-for-byte unchanged.
+fn extract_operation_for_routing(
+    path: &str,
+    method: &str,
+    tenant_url_routing: bool,
+) -> Option<(String, FhirOperation)> {
+    // Strip a URL-path tenant prefix BEFORE classifying, mirroring the router.
+    // Classifying the raw path first would wrongly `None`-out (and thus skip the
+    // scope check for) a path whose tenant segment happens to look system-like to
+    // `extract_operation` — e.g. `/_x/Patient/123`, where `_x` is a valid,
+    // non-reserved tenant the router strips, yet `extract_operation` sees the
+    // leading `_` and returns `None`. `extract_tenant_from_path` returns `None`
+    // for reserved first segments (real FHIR resource types, `metadata`,
+    // `_history`, `console`, …), so those fall through to the raw classification
+    // and behave exactly as before.
+    if tenant_url_routing {
+        if let Some((_tenant, remaining)) =
+            extract_tenant_from_path(path, &FhirVersion::default_enabled())
+        {
+            // Classify against the tenant-stripped path the router will actually
+            // dispatch to.
+            return extract_operation(&remaining, method);
+        }
+    }
+
+    extract_operation(path, method)
+}
+
 /// Extract the FHIR resource type and operation from a request path and method.
 ///
 /// Returns `None` for system-level operations (batch, history) where
@@ -220,8 +341,20 @@ fn extract_operation(path: &str, method: &str) -> Option<(String, FhirOperation)
         return None;
     }
 
-    // System-level paths
     let first = segments[0];
+
+    // The management console (`/console/metrics/*`) is not a FHIR resource
+    // operation — mapping it onto a FHIR resource type here would authorize it
+    // against a bogus type (e.g. Search on "tenants"), which is meaningless and,
+    // worse, admits any wildcard-search token. Its cross-tenant admin routes are
+    // gated separately by `admin_authz_middleware`. Scoped narrowly to the
+    // `console/metrics` namespace so it cannot shadow a tenant named "console"
+    // under URL-path tenant routing (where authz sees the un-stripped path).
+    if first == "console" && segments.get(1) == Some(&"metrics") {
+        return None;
+    }
+
+    // System-level paths
     if first.starts_with('_') || first.starts_with('$') || first == "metadata" || first == "health"
     {
         return None;
@@ -387,6 +520,18 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_operation_console_is_not_a_fhir_op() {
+        // Console endpoints must not be mapped onto FHIR resource operations —
+        // otherwise `/console/metrics/tenants` would be authorized as a Search on
+        // resource type "tenants", admitting any wildcard-search token. They are
+        // gated separately by `admin_authz_middleware`.
+        assert!(extract_operation("/console/metrics/tenants", "GET").is_none());
+        assert!(extract_operation("/console/metrics/traffic", "GET").is_none());
+        assert!(extract_operation("/console/metrics/resource-counts", "GET").is_none());
+        assert!(extract_operation("/console/metrics/uptime", "GET").is_none());
+    }
+
+    #[test]
     fn test_extract_operation_metadata() {
         assert!(extract_operation("/metadata", "GET").is_none());
     }
@@ -413,5 +558,115 @@ mod tests {
         let (rt, op) = extract_operation("/Patient/123/_history", "GET").unwrap();
         assert_eq!(rt, "Patient");
         assert_eq!(op, FhirOperation::Read);
+    }
+
+    // ── URL-path tenant routing: authz must classify the TENANT-STRIPPED path ──
+
+    #[test]
+    fn test_url_routing_read_strips_tenant() {
+        // GET /{tenant}/Patient/123 must authorize Read on Patient, NOT the id.
+        let (rt, op) = extract_operation_for_routing("/acme/Patient/123", "GET", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Read);
+    }
+
+    #[test]
+    fn test_url_routing_underscore_tenant_strips_and_classifies() {
+        // Regression: an authenticated caller sends GET /_x/Patient/123 under
+        // URL-path routing. `_x` is a valid, non-reserved tenant that the router
+        // strips, but the leading `_` makes `extract_operation` decline the raw
+        // path (`None`). Classifying the raw path first would skip the scope
+        // check entirely — a full SMART scope-enforcement bypass. Stripping first
+        // must yield Read Patient so the scope check runs.
+        let (rt, op) = extract_operation_for_routing("/_x/Patient/123", "GET", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Read);
+    }
+
+    #[test]
+    fn test_url_routing_search_strips_tenant() {
+        // GET /{tenant}/Patient must authorize Search on Patient, NOT the tenant.
+        let (rt, op) = extract_operation_for_routing("/acme/Patient", "GET", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Search);
+    }
+
+    #[test]
+    fn test_url_routing_create_strips_tenant() {
+        let (rt, op) = extract_operation_for_routing("/acme/Patient", "POST", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Create);
+    }
+
+    #[test]
+    fn test_url_routing_update_strips_tenant() {
+        let (rt, op) = extract_operation_for_routing("/acme/Patient/123", "PUT", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Update);
+    }
+
+    #[test]
+    fn test_url_routing_compartment_search_strips_tenant() {
+        // GET /{tenant}/Patient/123/Observation → Search on the target type.
+        let (rt, op) =
+            extract_operation_for_routing("/acme/Patient/123/Observation", "GET", true).unwrap();
+        assert_eq!(rt, "Observation");
+        assert_eq!(op, FhirOperation::Search);
+    }
+
+    #[test]
+    fn test_url_routing_untenanted_path_unchanged() {
+        // A resource-type first segment is not a tenant, so nothing is stripped.
+        let (rt, op) = extract_operation_for_routing("/Patient/123", "GET", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Read);
+    }
+
+    #[test]
+    fn test_url_routing_console_not_stripped() {
+        // /console/metrics/* is served verbatim by the router (never as a tenant
+        // prefix) and must stay unauthorized-as-FHIR even with URL routing on.
+        assert!(extract_operation_for_routing("/console/metrics/uptime", "GET", true).is_none());
+        assert!(extract_operation_for_routing("/console/metrics/tenants", "GET", true).is_none());
+        assert!(
+            extract_operation_for_routing("/console/metrics/resource-counts", "GET", true)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_url_routing_system_paths_none() {
+        // `metadata` and `_history` are reserved first segments (never stripped as
+        // tenants), so they fall through to raw classification → system-level None.
+        assert!(extract_operation_for_routing("/metadata", "GET", true).is_none());
+        assert!(extract_operation_for_routing("/_history", "GET", true).is_none());
+    }
+
+    #[test]
+    fn test_url_routing_tenant_system_history_none() {
+        // GET /{tenant}/_history strips to /_history → system-level, no per-type authz.
+        assert!(extract_operation_for_routing("/acme/_history", "GET", true).is_none());
+    }
+
+    #[test]
+    fn test_header_only_mode_does_not_strip() {
+        // With tenant_url_routing=false, the path is used verbatim: this must be
+        // identical to calling extract_operation directly (header_only unchanged).
+        let (rt, op) = extract_operation_for_routing("/Patient/123", "GET", false).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Read);
+
+        // A path that *looks* tenant-prefixed is NOT stripped in header_only mode,
+        // matching the raw extract_operation compartment classification.
+        let (rt, op) = extract_operation_for_routing("/acme/Patient/123", "GET", false).unwrap();
+        assert_eq!(rt, extract_operation("/acme/Patient/123", "GET").unwrap().0);
+        assert_eq!(op, extract_operation("/acme/Patient/123", "GET").unwrap().1);
+
+        // A leading `_`-tenant path must NOT be stripped in header_only mode: it
+        // matches raw extract_operation, which declines the `_`-prefixed first
+        // segment as a system path (`None`). (In url_path mode it strips — see
+        // `test_url_routing_underscore_tenant_strips_and_classifies`.)
+        assert!(extract_operation_for_routing("/_x/Patient/123", "GET", false).is_none());
+        assert_eq!(extract_operation("/_x/Patient/123", "GET"), None);
     }
 }

--- a/crates/rest/src/middleware/auth.rs
+++ b/crates/rest/src/middleware/auth.rs
@@ -669,4 +669,95 @@ mod tests {
         assert!(extract_operation_for_routing("/_x/Patient/123", "GET", false).is_none());
         assert_eq!(extract_operation("/_x/Patient/123", "GET"), None);
     }
+
+    // ── Additional branch coverage for `extract_operation` ──
+
+    #[test]
+    fn test_extract_operation_patch() {
+        // PATCH /Patient/123 → Update (same variant as PUT).
+        let (rt, op) = extract_operation("/Patient/123", "PATCH").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Update);
+    }
+
+    #[test]
+    fn test_extract_operation_type_history_is_read() {
+        // GET /Patient/_history — 2 segments, second starts with '_' → Read (history).
+        let (rt, op) = extract_operation("/Patient/_history", "GET").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Read);
+    }
+
+    #[test]
+    fn test_extract_operation_head_search() {
+        // HEAD is classified like GET: HEAD /Patient → Search.
+        let (rt, op) = extract_operation("/Patient", "HEAD").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Search);
+    }
+
+    #[test]
+    fn test_extract_operation_head_read() {
+        // HEAD /Patient/123 → Read.
+        let (rt, op) = extract_operation("/Patient/123", "HEAD").unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Read);
+    }
+
+    #[test]
+    fn test_extract_operation_head_compartment_search() {
+        // HEAD is in the compartment-search branch too: target type, Search.
+        let (rt, op) = extract_operation("/Patient/123/Observation", "HEAD").unwrap();
+        assert_eq!(rt, "Observation");
+        assert_eq!(op, FhirOperation::Search);
+    }
+
+    #[test]
+    fn test_extract_operation_dollar_system_op_none() {
+        // A first segment starting with '$' is a system-level operation → None.
+        assert!(extract_operation("/$export", "GET").is_none());
+        assert!(extract_operation("/$export", "POST").is_none());
+    }
+
+    #[test]
+    fn test_extract_operation_unknown_method_none() {
+        // Methods other than GET/HEAD/POST/PUT/PATCH/DELETE fall through to None.
+        assert!(extract_operation("/Patient", "OPTIONS").is_none());
+        assert!(extract_operation("/Patient/123", "OPTIONS").is_none());
+    }
+
+    // ── Additional branch coverage for `extract_operation_for_routing` ──
+
+    #[test]
+    fn test_url_routing_delete_strips_tenant() {
+        // DELETE /{tenant}/Patient/123 → Delete on Patient (tenant stripped).
+        let (rt, op) = extract_operation_for_routing("/acme/Patient/123", "DELETE", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Delete);
+    }
+
+    #[test]
+    fn test_url_routing_patch_strips_tenant() {
+        let (rt, op) = extract_operation_for_routing("/acme/Patient/123", "PATCH", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Update);
+    }
+
+    #[test]
+    fn test_url_routing_reserved_first_segment_not_stripped() {
+        // A reserved first segment (a real FHIR resource type) is never treated as
+        // a tenant, so with routing on it classifies exactly like the raw path.
+        let (rt, op) = extract_operation_for_routing("/Observation", "POST", true).unwrap();
+        assert_eq!(rt, "Observation");
+        assert_eq!(op, FhirOperation::Create);
+    }
+
+    #[test]
+    fn test_url_routing_search_post_strips_tenant() {
+        // POST /{tenant}/Patient/_search → Search on Patient (tenant stripped).
+        let (rt, op) =
+            extract_operation_for_routing("/acme/Patient/_search", "POST", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Search);
+    }
 }

--- a/crates/rest/src/middleware/tenant_prefix.rs
+++ b/crates/rest/src/middleware/tenant_prefix.rs
@@ -19,6 +19,10 @@ const RESERVED_SYSTEM_PATHS: &[&str] = &[
     "v1",
     "v2",
     "fhir",
+    // Management-console namespace (`/console/metrics/*`). Reserved so a tenant
+    // can never be named `console` under URL-path routing, keeping the console
+    // paths unambiguous with the authz console guard (see `middleware::auth`).
+    "console",
 ];
 
 /// Checks if a path segment is a reserved path (not a tenant identifier).
@@ -207,6 +211,11 @@ mod tests {
         assert!(extract_tenant_from_path("/Provenance/123", &version).is_none());
         assert!(extract_tenant_from_path("/AuditEvent/456", &version).is_none());
         assert!(extract_tenant_from_path("/Binary/789", &version).is_none());
+
+        // The management-console namespace must never be parsed as a tenant, so
+        // `console` cannot shadow / be confused with a tenant literally named
+        // "console" under URL-path routing.
+        assert!(extract_tenant_from_path("/console/metrics/uptime", &version).is_none());
     }
 
     #[test]
@@ -216,6 +225,11 @@ mod tests {
         // System paths
         assert!(is_reserved_path("metadata", &version));
         assert!(is_reserved_path("health", &version));
+
+        // Management-console namespace is reserved (case-insensitive), so a
+        // tenant named "console" cannot exist under URL-path routing.
+        assert!(is_reserved_path("console", &version));
+        assert!(is_reserved_path("Console", &version));
 
         // FHIR resource types (case insensitive)
         assert!(is_reserved_path("Patient", &version));

--- a/crates/rest/src/routing/console_metrics.rs
+++ b/crates/rest/src/routing/console_metrics.rs
@@ -1,0 +1,97 @@
+//! Routers for the management-console metrics endpoints.
+//!
+//! Console routes split into three trust tiers:
+//!
+//! - [`public_routes`] — only the server-global, non-sensitive `uptime` endpoint
+//!   (like `/health`). Merged **outside** the auth layer so the console's login
+//!   screen can show liveness without a token. Still covered by the shared CORS /
+//!   timeout / body-limit / tracing stack.
+//! - [`protected_routes`] — **tenant-scoped** endpoints (`resource-counts`,
+//!   `activity`, `resource-distribution`). These require authentication;
+//!   `build_app` layers the same bearer-token auth used by the FHIR routes around
+//!   this router. Behind auth, the tenant is taken from the JWT claim (see
+//!   [`crate::extractors::TenantExtractor`]), so a spoofed `X-Tenant-ID` cannot
+//!   widen access beyond the caller's own tenant.
+//! - [`admin_routes`] — **cross-tenant** endpoints (`tenants`, `traffic`) that
+//!   surface data spanning every tenant. `build_app` additionally requires a
+//!   system-context scope (`system/*.r`) via
+//!   [`crate::middleware::auth::admin_authz_middleware`], so an ordinary
+//!   user-/patient-context token — even one with a broad wildcard — cannot read
+//!   the tenant roster or server-wide traffic.
+//!
+//! All three are merged into the application by `build_app` in `crate::lib`.
+
+use axum::{Router, routing::get};
+use helios_persistence::core::ResourceStorage;
+
+use crate::handlers::console_metrics;
+use crate::state::AppState;
+
+/// Console routes that may be served without authentication.
+///
+/// Only `uptime` — server-global and non-sensitive, like `/health`. Everything
+/// that touches tenant data lives in [`protected_routes`].
+pub fn public_routes<S>(state: AppState<S>) -> Router
+where
+    S: ResourceStorage + Send + Sync + 'static,
+{
+    Router::new()
+        .route(
+            "/console/metrics/uptime",
+            get(console_metrics::uptime_handler::<S>),
+        )
+        .with_state(state)
+}
+
+/// Tenant-scoped console routes: they require authentication but return only the
+/// caller's own tenant data.
+///
+/// `build_app` wraps this router in the FHIR routes' bearer-token authentication.
+/// `resource-counts`, `activity`, and `resource-distribution` are tenant-scoped —
+/// the tenant is taken from the JWT claim behind auth (see
+/// [`crate::extractors::TenantExtractor`]), so any authenticated principal sees
+/// only its own tenant. Cross-tenant endpoints live in [`admin_routes`].
+pub fn protected_routes<S>(state: AppState<S>) -> Router
+where
+    S: ResourceStorage + Send + Sync + 'static,
+{
+    Router::new()
+        .route(
+            "/console/metrics/resource-counts",
+            get(console_metrics::resource_counts_handler::<S>),
+        )
+        .route(
+            "/console/metrics/activity",
+            get(console_metrics::activity_handler::<S>),
+        )
+        .route(
+            "/console/metrics/resource-distribution",
+            get(console_metrics::resource_distribution_handler::<S>),
+        )
+        .with_state(state)
+}
+
+/// Cross-tenant console routes: they expose data spanning **every** tenant and so
+/// require an administrative, system-context scope on top of authentication.
+///
+/// `build_app` wraps this router in bearer-token auth **and**
+/// [`crate::middleware::auth::admin_authz_middleware`], which requires a
+/// `system/*.r` scope. `tenants` returns the full tenant roster and per-tenant
+/// sizes; `traffic` returns server-wide throughput and latency — neither is
+/// scoped to a single tenant, so an ordinary `user/*` or `patient/*` token (even
+/// a wildcard one) is rejected `403`.
+pub fn admin_routes<S>(state: AppState<S>) -> Router
+where
+    S: ResourceStorage + Send + Sync + 'static,
+{
+    Router::new()
+        .route(
+            "/console/metrics/traffic",
+            get(console_metrics::traffic_handler::<S>),
+        )
+        .route(
+            "/console/metrics/tenants",
+            get(console_metrics::tenants_handler::<S>),
+        )
+        .with_state(state)
+}

--- a/crates/rest/src/routing/mod.rs
+++ b/crates/rest/src/routing/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains the routing configuration that maps HTTP paths
 //! to handlers.
 
+pub mod console_metrics;
 pub mod fhir_routes;
 
 pub use fhir_routes::create_routes;

--- a/crates/rest/src/tenant/resolver.rs
+++ b/crates/rest/src/tenant/resolver.rs
@@ -26,6 +26,11 @@ const RESERVED_SYSTEM_PATHS: &[&str] = &[
     "v1",
     "v2",
     "fhir",
+    // Management-console namespace (`/console/metrics/*`). Kept in sync with
+    // `middleware::tenant_prefix::RESERVED_SYSTEM_PATHS` so a tenant can never be
+    // named `console` and strict-validation never mis-resolves the console path
+    // to a `console` tenant under URL-path routing.
+    "console",
 ];
 
 /// Result of resolving a tenant from a request.

--- a/crates/rest/tests/console_metrics.rs
+++ b/crates/rest/tests/console_metrics.rs
@@ -1,0 +1,346 @@
+//! Integration tests for the management-console metrics HTTP handlers.
+//!
+//! Exercises every `/console/metrics/*` endpoint against an in-memory
+//! SQLite-backed test server (auth disabled — the default — so all console
+//! tiers, including the cross-tenant `tenants`/`traffic` endpoints, are
+//! reachable). Assertions check response shape and the stable enum-string
+//! fields (e.g. `scope`, `service`, `source`), not values that vary between
+//! runs (uptime numbers, timestamps).
+//!
+//! The harness mirrors `tenant_resolution.rs::create_test_server`: same
+//! `SqliteBackend::with_config(":memory:", ...)` + `init_schema()` +
+//! `ServerConfig` construction and `AppState`. Because the console routers are
+//! merged in `build_app` (not in `fhir_routes::create_routes`), this harness
+//! reproduces the auth-disabled merge from `helios_rest::lib` by merging the
+//! three console routers onto the FHIR routes with no auth layer.
+
+mod common;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::http::{HeaderName, HeaderValue};
+use axum_test::TestServer;
+use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+use helios_persistence::core::ResourceStorage;
+use helios_rest::ServerConfig;
+use helios_rest::config::{MultitenancyConfig, TenantRoutingMode};
+
+const CONTENT_TYPE: HeaderName = HeaderName::from_static("content-type");
+
+/// Creates an in-memory SQLite-backed console test server with auth disabled.
+///
+/// Mirrors `tenant_resolution.rs::create_test_server`, then additionally merges
+/// the console-metrics routers (public + protected + admin) exactly as
+/// `helios_rest::build_app` does when auth is disabled — a plain `merge` with no
+/// auth layer — so all `/console/metrics/*` endpoints are reachable.
+async fn create_test_server() -> (TestServer, Arc<SqliteBackend>) {
+    // Configure with data directory to load spec SearchParameters.
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("data"))
+        .unwrap_or_else(|| PathBuf::from("data"));
+
+    let backend_config = SqliteBackendConfig {
+        data_dir: Some(data_dir),
+        ..Default::default()
+    };
+    let backend = SqliteBackend::with_config(":memory:", backend_config)
+        .expect("Failed to create SQLite backend");
+    backend.init_schema().expect("Failed to init schema");
+    let backend = Arc::new(backend);
+
+    let config = ServerConfig {
+        multitenancy: MultitenancyConfig {
+            routing_mode: TenantRoutingMode::HeaderOnly,
+            ..Default::default()
+        },
+        base_url: "http://localhost:8080".to_string(),
+        default_tenant: "default-tenant".to_string(),
+        ..ServerConfig::for_testing()
+    };
+
+    let state = helios_rest::AppState::new(Arc::clone(&backend), config);
+
+    // FHIR routes plus the three console tiers, merged as in `build_app`'s
+    // auth-disabled path (no auth/admin middleware layered on).
+    let router = helios_rest::routing::fhir_routes::create_routes(state.clone());
+    let router = router.merge(helios_rest::routing::console_metrics::public_routes(
+        state.clone(),
+    ));
+    let router = router.merge(helios_rest::routing::console_metrics::protected_routes(
+        state.clone(),
+    ));
+    let router = router.merge(helios_rest::routing::console_metrics::admin_routes(state));
+
+    let server = TestServer::new(router).expect("Failed to create test server");
+
+    (server, backend)
+}
+
+/// Seeds a resource through the normal REST create path (POST /[type]) so the
+/// DB-backed console endpoints have non-trivial data (rows + write history).
+async fn seed(server: &TestServer, resource_type: &str, resource: serde_json::Value) {
+    let response = server
+        .post(&format!("/{resource_type}"))
+        .add_header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/fhir+json"),
+        )
+        .json(&resource)
+        .await;
+
+    response.assert_status(axum::http::StatusCode::CREATED);
+}
+
+/// Seeds a couple of Patients and an Observation for the default tenant.
+async fn seed_default_tenant(server: &TestServer) {
+    seed(
+        server,
+        "Patient",
+        serde_json::json!({
+            "resourceType": "Patient",
+            "name": [{ "family": "Smith" }]
+        }),
+    )
+    .await;
+    seed(
+        server,
+        "Patient",
+        serde_json::json!({
+            "resourceType": "Patient",
+            "name": [{ "family": "Jones" }]
+        }),
+    )
+    .await;
+    seed(
+        server,
+        "Observation",
+        serde_json::json!({
+            "resourceType": "Observation",
+            "status": "final",
+            "code": { "text": "test observation" }
+        }),
+    )
+    .await;
+}
+
+// =============================================================================
+// uptime (public)
+// =============================================================================
+
+#[tokio::test]
+async fn test_uptime_shape_and_no_infra_leak() {
+    let (server, _backend) = create_test_server().await;
+
+    let response = server.get("/console/metrics/uptime").await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["service"], "hfs");
+    assert_eq!(body["scope"], "single-instance");
+    assert!(body["version"].is_string(), "version should be present");
+    assert!(
+        body["uptime_seconds"].is_number(),
+        "uptime_seconds should be a number"
+    );
+    assert!(
+        body["started_at"].is_string(),
+        "started_at should be present"
+    );
+
+    // Public, unauthenticated endpoint must not leak infrastructure identity.
+    // Check the whole key set against an allowlist so a regression that adds a
+    // hostname under ANY key (instance / backend / host / hostname / node / …)
+    // fails, not just the two documented names.
+    let allowed = [
+        "service",
+        "scope",
+        "version",
+        "started_at",
+        "now",
+        "uptime_seconds",
+        "uptime_human",
+        "availability",
+    ];
+    for key in body.as_object().expect("uptime body is an object").keys() {
+        assert!(
+            allowed.contains(&key.as_str()),
+            "uptime exposed an unexpected field `{key}` (possible infra leak)"
+        );
+    }
+}
+
+// =============================================================================
+// resource-counts (tenant-scoped)
+// =============================================================================
+
+#[tokio::test]
+async fn test_resource_counts_shape() {
+    let (server, _backend) = create_test_server().await;
+    seed_default_tenant(&server).await;
+
+    let response = server.get("/console/metrics/resource-counts").await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert!(body["tenant"].is_string(), "tenant should be present");
+    assert_eq!(body["scope"], "single-instance");
+    assert!(
+        body["total_resources"].is_number(),
+        "total_resources should be a number"
+    );
+    assert!(body["series"].is_array(), "series should be an array");
+    // At least the three seeded resources (2 Patient + 1 Observation).
+    assert!(body["total_resources"].as_u64().unwrap() >= 3);
+}
+
+#[tokio::test]
+async fn test_resource_counts_with_days_and_types_filter() {
+    let (server, _backend) = create_test_server().await;
+    seed_default_tenant(&server).await;
+
+    let response = server
+        .get("/console/metrics/resource-counts?days=7&types=Patient")
+        .await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    let series = body["series"].as_array().expect("series is an array");
+    // Only the requested type is charted.
+    assert_eq!(series.len(), 1);
+    assert_eq!(series[0]["resource_type"], "Patient");
+    assert_eq!(body["window"]["days"].as_i64().unwrap(), 7);
+}
+
+#[tokio::test]
+async fn test_resource_counts_days_clamped() {
+    let (server, _backend) = create_test_server().await;
+
+    // A stray oversized window must not force an unbounded scan; it is clamped.
+    let response = server
+        .get("/console/metrics/resource-counts?days=100000")
+        .await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["window"]["days"].as_i64().unwrap(), 365);
+}
+
+// =============================================================================
+// activity (tenant-scoped)
+// =============================================================================
+
+#[tokio::test]
+async fn test_activity_shape() {
+    let (server, _backend) = create_test_server().await;
+    seed_default_tenant(&server).await;
+
+    let response = server.get("/console/metrics/activity").await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["source"], "writes");
+    assert_eq!(body["scope"], "single-instance");
+    let cells = body["cells"].as_array().expect("cells is an array");
+    // Dense 7 weekdays x 24 hours grid.
+    assert_eq!(cells.len(), 168);
+}
+
+// =============================================================================
+// resource-distribution (tenant-scoped)
+// =============================================================================
+
+#[tokio::test]
+async fn test_resource_distribution_shape() {
+    let (server, _backend) = create_test_server().await;
+    seed_default_tenant(&server).await;
+
+    let response = server.get("/console/metrics/resource-distribution").await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert!(body["types"].is_array(), "types should be an array");
+    assert_eq!(body["scope"], "single-instance");
+    assert!(body["total_resources"].as_u64().unwrap() >= 3);
+}
+
+#[tokio::test]
+async fn test_resource_distribution_top_param() {
+    let (server, _backend) = create_test_server().await;
+    seed_default_tenant(&server).await;
+
+    let response = server
+        .get("/console/metrics/resource-distribution?top=3")
+        .await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert!(body["types"].is_array());
+}
+
+// =============================================================================
+// tenants (cross-tenant / admin; reachable with auth disabled)
+// =============================================================================
+
+#[tokio::test]
+async fn test_tenants_shape() {
+    let (server, _backend) = create_test_server().await;
+    seed_default_tenant(&server).await;
+
+    let response = server.get("/console/metrics/tenants").await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert!(body["tenants"].is_array(), "tenants should be an array");
+    assert_eq!(body["resources_scope"], "single-instance");
+    assert_eq!(body["traffic_scope"], "single-instance");
+    assert!(body["instance"].is_string(), "instance should be present");
+}
+
+// =============================================================================
+// traffic (cross-tenant / admin; reachable with auth disabled)
+// =============================================================================
+
+#[tokio::test]
+async fn test_traffic_shape() {
+    let (server, _backend) = create_test_server().await;
+
+    // This test router has no request-tracking middleware, so the in-process
+    // request log stays empty and the traffic fields default to 0 — assert shape,
+    // not values.
+    let response = server.get("/console/metrics/traffic").await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert!(
+        body["requests_per_second"].is_number(),
+        "requests_per_second should be a number"
+    );
+    assert!(
+        body["latency_ms"].is_object(),
+        "latency_ms should be an object"
+    );
+    assert!(
+        body["latency_ms"]["p50"].is_number(),
+        "latency_ms.p50 should be present"
+    );
+    assert!(
+        body["status_classes"].is_object(),
+        "status_classes should be an object"
+    );
+    assert_eq!(body["scope"], "single-instance");
+    assert!(body["instance"].is_string(), "instance should be present");
+}
+
+#[tokio::test]
+async fn test_traffic_window_param() {
+    let (server, _backend) = create_test_server().await;
+
+    let response = server.get("/console/metrics/traffic?window=120").await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["window_seconds"].as_i64().unwrap(), 120);
+}

--- a/crates/rest/tests/console_metrics.rs
+++ b/crates/rest/tests/console_metrics.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 use axum::http::{HeaderName, HeaderValue};
 use axum_test::TestServer;
 use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
-use helios_persistence::core::ResourceStorage;
 use helios_rest::ServerConfig;
 use helios_rest::config::{MultitenancyConfig, TenantRoutingMode};
 

--- a/crates/sof/Cargo.toml
+++ b/crates/sof/Cargo.toml
@@ -25,10 +25,14 @@ R4B = ["helios-fhir/R4B", "helios-fhirpath/R4B"]
 R5 = ["helios-fhir/R5", "helios-fhirpath/R5"]
 R6 = ["helios-fhir/R6", "helios-fhirpath/R6"]
 
+# OpenTelemetry OTLP trace export (heavy deps; opt-in for production images)
+otel = ["helios-observability/otel"]
+
 [dependencies]
 clap = { version = "4.0", features = ["derive", "env"] }
 tokio = { version = "1.0", features = ["full"] }
 helios-fhir = { path = "../fhir", version = "0.2.1", default-features = false }
+helios-observability = { path = "../observability", version = "0.2.1" }
 helios-fhirpath = { path = "../fhirpath", version = "0.2.1", default-features = false }
 helios-fhirpath-support = { path = "../fhirpath-support", version = "0.2.1" }
 serde = { workspace = true }

--- a/crates/sof/src/handlers.rs
+++ b/crates/sof/src/handlers.rs
@@ -1027,6 +1027,8 @@ pub async fn health_check() -> impl IntoResponse {
         "status": "ok",
         "service": "sof-server",
         "version": env!("CARGO_PKG_VERSION"),
+        "uptime_seconds": helios_observability::uptime::uptime_seconds(),
+        "started_at": helios_observability::uptime::started_at_rfc3339(),
         "timestamp": chrono::Utc::now().to_rfc3339()
     }))
 }

--- a/crates/sof/src/server.rs
+++ b/crates/sof/src/server.rs
@@ -168,16 +168,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse command line arguments first to get log level
     let config = parse_args();
 
-    // Initialize tracing subscriber for logging with configured level
-    let filter = format!(
-        "sof_server={},tower_http={}",
-        config.log_level, config.log_level
-    );
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| filter.into()),
-        )
-        .init();
+    // Initialize observability: logging/tracing (+ optional OTLP), uptime, and
+    // the Prometheus metrics recorder.
+    helios_observability::uptime::init();
+    helios_observability::telemetry::init("sof-server", &config.log_level);
+    helios_observability::metrics::init("sof-server");
 
     // Propagate SOF_TERMINOLOGY_SERVER to FHIRPATH_TERMINOLOGY_SERVER so that any
     // FHIRPath evaluation (memberOf, subsumes, etc.) delegates terminology
@@ -401,6 +396,13 @@ fn create_app_with_config(config: &ServerConfig) -> Router {
 
     // Add tracing
     app = app.layer(TraceLayer::new_for_http());
+
+    // Observability: `/metrics` (state-free) + per-request metrics/trace span.
+    app = app
+        .merge(helios_observability::metrics::router())
+        .layer(axum::middleware::from_fn(
+            helios_observability::middleware::track,
+        ));
 
     app
 }


### PR DESCRIPTION
## Summary

Adds a shared `helios-observability` crate and wires it into all four server
binaries (`hfs`, `hts`, `sof-server`, `fhirpath-server`):

- `GET /metrics` Prometheus endpoint — `http_requests_total`,
  `http_request_duration_seconds`, `uptime_seconds`, with a `service` global
  label and a templated `route` label.
- `/health` enriched with `uptime_seconds` + `started_at`.
- Per-request metrics + a tracing span. Tenant is a span attribute only, never a
  metric label (cardinality).
- Feature-gated (`otel`) OTLP trace export via `tracing-opentelemetry`
  (opentelemetry 0.32). OTLP metrics are produced out-of-process by a Collector
  scraping `/metrics` — we avoid the unmaintained `opentelemetry-prometheus`
  (protobuf RUSTSEC advisory).

## Verification
- Workspace `cargo check` (default) compiles; observability also compiles with
  `--features otel`. Clippy clean (CI flags) for touched crates. Unit tests pass.
- End-to-end smoke test against `fhirpath-server`: `/health` uptime + `/metrics`
  counter/gauge/histogram confirmed.

## Notes / known gaps in local verification
1. Full HFS server not run locally — SQLite WAL fails over the WSL filesystem
   under the Windows toolchain (environment limitation, not a code issue). The
   stateless `fhirpath-server` exercised the same wiring successfully.
2. Clippy not run with `--all-features` locally (build window). A pre-existing
   `dead_code` warning on `build_embedded_job_store` appears only under default
   features; CI's `--all-features` run won't hit it. CI is the authoritative gate.
