### PR TITLE
Align SoF async export to the simplified async interaction pattern

### DIFF
--- a/crates/rest/src/handlers/sof/export.rs
+++ b/crates/rest/src/handlers/sof/export.rs
@@ -29,12 +29,20 @@
 //!
 //! ## Poll response
 //!
+//! Per the FHIR Asynchronous Interaction Request Pattern, the status URL only
+//! reports polling machinery; the job's outcome is served from a separate
+//! result URL (`GET /export/{job-id}/result`):
+//!
 //! - `202 Accepted` + `X-Progress: running` while the job is running
-//! - `200 OK` with the completion manifest `Parameters` resource in the body
-//!   when complete (per the FHIR Asynchronous Bulk Data Request Pattern —
-//!   there is no `303 See Other` redirect and no separate result URL)
-//! - `500 Internal Server Error` + `OperationOutcome` if the job failed
+//! - `303 See Other` with a `Location` header carrying the result URL and an
+//!   empty body once the job has finished — whether it succeeded or failed
 //! - `404 Not Found` if the job ID is unknown or was cancelled
+//!
+//! ## Result response (`GET /export/{job-id}/result`)
+//!
+//! - `200 OK` with the completion manifest `Parameters` resource on success
+//! - `500 Internal Server Error` + `OperationOutcome` if the job failed
+//! - `404 Not Found` if the job is unknown, cancelled, or not yet finished
 
 use axum::{
     extract::{Path, State},
@@ -1028,9 +1036,10 @@ where
     S: ResourceStorage + Send + Sync + 'static,
 {
     // Spec Common Operation Behavior — Asynchronous Delivery: the `Accept`
-    // header on each poll governs that poll's response, including the
-    // completion manifest. The FHIR XML representation is not supported →
-    // 406, same as the run operations.
+    // header on each poll governs that poll's response (interim `202 Accepted`
+    // bodies and error responses). The FHIR XML representation is not supported
+    // → 406, same as the run operations. The completing poll itself is a
+    // `303 See Other` with an empty body, so its representation is unaffected.
     let accept = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok());
     if accept_requires_unsupported_fhir_xml(accept) {
         return Err(RestError::NotAcceptable {
@@ -1100,56 +1109,23 @@ where
                 .into_response())
         }
 
-        // Spec (Common Operation Behavior — Asynchronous Delivery): the
-        // status poll itself carries the terminal response. Failure returns
-        // the relevant error status code with an OperationOutcome body;
-        // polling-transport errors and operation failures are distinguished
-        // by the status code on the poll response itself.
-        Some(JobStatus::Failed { message, .. }) => Ok((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            axum::Json(json!({
-                "resourceType": "OperationOutcome",
-                "issue": [{
-                    "severity": "error",
-                    "code": "processing",
-                    "diagnostics": format!("Export job '{job_id}' failed: {message}")
-                }]
-            })),
-        )
-            .into_response()),
-
-        // Completion is `200 OK` with the manifest in the status-poll body —
-        // no `303 See Other` redirect and no separate result resource.
-        Some(JobStatus::Completed {
-            files,
-            submitted_at,
-            completed_at,
-            format,
-            client_tracking_id,
-        }) => {
-            // Spec: the completed status URL and download URLs SHALL be valid
-            // for at least 24 hours and MAY carry an `Expires` header. Format
-            // is IMF-fixdate per RFC 7231.
-            let expires_at = completed_at + chrono::Duration::hours(24);
-            let expires_str = expires_at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+        // Spec (Common Operation Behavior — Asynchronous Delivery, FHIR
+        // Asynchronous Interaction Request Pattern): once the job has finished
+        // — whether it succeeded or failed — the status poll returns
+        // `303 See Other` with a `Location` header carrying the result URL and
+        // an empty body. The status endpoint reflects polling machinery only;
+        // it never communicates the job's outcome. The outcome (manifest on
+        // success, OperationOutcome on failure) is served from the result URL.
+        Some(JobStatus::Failed { .. }) | Some(JobStatus::Completed { .. }) => {
+            let result_url = format!(
+                "{base}/export/{job_id}/result",
+                base = state.base_url().trim_end_matches('/'),
+            );
             let mut headers = HeaderMap::new();
-            if let Ok(v) = HeaderValue::from_str(&expires_str) {
-                headers.insert(header::EXPIRES, v);
+            if let Ok(v) = HeaderValue::from_str(&result_url) {
+                headers.insert(header::LOCATION, v);
             }
-            Ok((
-                StatusCode::OK,
-                headers,
-                axum::Json(build_completion_manifest(
-                    state.base_url(),
-                    &job_id,
-                    &files,
-                    submitted_at,
-                    completed_at,
-                    &format,
-                    client_tracking_id.as_deref(),
-                )),
-            )
-                .into_response())
+            Ok((StatusCode::SEE_OTHER, headers).into_response())
         }
     }
 }
@@ -1216,6 +1192,112 @@ fn build_completion_manifest(
         "resourceType": "Parameters",
         "parameter": params
     })
+}
+
+// ============================================================================
+// Result: GET /export/{job-id}/result
+// ============================================================================
+
+/// Serve the result of a finished export job.
+///
+/// Per the FHIR Asynchronous Interaction Request Pattern, the completing status
+/// poll redirects here with `303 See Other`. A successful export returns
+/// `200 OK` with the manifest `Parameters` resource; a failed export returns the
+/// relevant error status code (e.g. `500 Internal Server Error`) with an
+/// `OperationOutcome`. The result and its download URLs remain valid for at
+/// least 24 hours, so repeated fetches return the same outcome within that
+/// window. A job that is unknown, cancelled, or still in progress has no result
+/// to serve and returns `404 Not Found`.
+pub async fn get_export_result_handler<S>(
+    State(state): State<AppState<S>>,
+    tenant: TenantExtractor,
+    Path(job_id): Path<String>,
+    headers: HeaderMap,
+) -> Result<Response, RestError>
+where
+    S: ResourceStorage + Send + Sync + 'static,
+{
+    // The result `GET`'s `Accept` header governs the manifest representation.
+    // FHIR XML is not supported → 406, same as the run operations.
+    let accept = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok());
+    if accept_requires_unsupported_fhir_xml(accept) {
+        return Err(RestError::NotAcceptable {
+            message: "the application/fhir+xml representation is not supported; \
+                      use application/fhir+json"
+                .to_string(),
+        });
+    }
+
+    let controller = match state.export_controller() {
+        Some(c) => c,
+        None => {
+            return Ok((StatusCode::SERVICE_UNAVAILABLE, "export not configured").into_response());
+        }
+    };
+
+    match controller.get_status(tenant.tenant_id(), &job_id) {
+        // Unknown, cancelled, or still running → no result available. The
+        // result URL is only handed out (via the status poll's 303) once the
+        // job has finished, so reaching here otherwise means there is nothing
+        // to serve.
+        None | Some(JobStatus::Cancelled) | Some(JobStatus::Running { .. }) => Ok((
+            StatusCode::NOT_FOUND,
+            axum::Json(json!({
+                "resourceType": "OperationOutcome",
+                "issue": [{"severity": "error", "code": "not-found",
+                    "diagnostics": format!("No result available for export job '{job_id}'")}]
+            })),
+        )
+            .into_response()),
+
+        // Failed export → the relevant error status code with an
+        // OperationOutcome body explaining the failure.
+        Some(JobStatus::Failed { message, .. }) => Ok((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "error",
+                    "code": "processing",
+                    "diagnostics": format!("Export job '{job_id}' failed: {message}")
+                }]
+            })),
+        )
+            .into_response()),
+
+        // Successful export → `200 OK` with the manifest `Parameters` resource.
+        Some(JobStatus::Completed {
+            files,
+            submitted_at,
+            completed_at,
+            format,
+            client_tracking_id,
+        }) => {
+            // Spec: the result URL and download URLs SHALL be valid for at least
+            // 24 hours and MAY carry an `Expires` header. Format is IMF-fixdate
+            // per RFC 7231.
+            let expires_at = completed_at + chrono::Duration::hours(24);
+            let expires_str = expires_at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+            let mut headers = HeaderMap::new();
+            if let Ok(v) = HeaderValue::from_str(&expires_str) {
+                headers.insert(header::EXPIRES, v);
+            }
+            Ok((
+                StatusCode::OK,
+                headers,
+                axum::Json(build_completion_manifest(
+                    state.base_url(),
+                    &job_id,
+                    &files,
+                    submitted_at,
+                    completed_at,
+                    &format,
+                    client_tracking_id.as_deref(),
+                )),
+            )
+                .into_response())
+        }
+    }
 }
 
 // ============================================================================

--- a/crates/rest/src/handlers/sof/mod.rs
+++ b/crates/rest/src/handlers/sof/mod.rs
@@ -9,8 +9,8 @@ pub mod sqlquery;
 pub use capability::sof_capabilities_handler;
 pub use export::{
     cancel_export_handler, download_export_file_handler, export_stored_view_definition_handler,
-    export_view_definition_handler, get_export_status_handler, sqlquery_export_handler,
-    sqlquery_export_stored_handler,
+    export_view_definition_handler, get_export_result_handler, get_export_status_handler,
+    sqlquery_export_handler, sqlquery_export_stored_handler,
 };
 pub use run::{run_stored_view_definition_handler, run_view_definition_handler};
 pub use sqlquery::{sqlquery_run_handler, sqlquery_run_instance_handler};

--- a/crates/rest/src/routing/fhir_routes.rs
+++ b/crates/rest/src/routing/fhir_routes.rs
@@ -426,10 +426,18 @@ where
             get(handlers::sof::get_export_status_handler::<S>)
                 .delete(handlers::sof::cancel_export_handler::<S>),
         )
+        // Export result: GET /export/{job-id}/result
+        // Per the FHIR Asynchronous Interaction Request Pattern, the completing
+        // status poll returns `303 See Other` pointing here. This endpoint
+        // serves the manifest `Parameters` (200 OK) on success, or the relevant
+        // error status code with an `OperationOutcome` on failure. The static
+        // `result` segment takes priority over the `{filename}` download route
+        // below (matchit 0.8).
+        .route(
+            "/export/{job_id}/result",
+            get(handlers::sof::get_export_result_handler::<S>),
+        )
         // Export download: GET /export/{job-id}/{filename}
-        // (The completion manifest is served by the status endpoint with
-        // 200 OK per the spec's async pattern — there is no separate
-        // /result route.)
         .route(
             "/export/{job_id}/{filename}",
             get(handlers::sof::download_export_file_handler::<S>),

--- a/crates/rest/tests/sof_export.rs
+++ b/crates/rest/tests/sof_export.rs
@@ -84,14 +84,35 @@ mod sof_export_tests {
         })
     }
 
-    /// Polls the status URL until the job completes (200 OK with the
-    /// manifest in the poll body — no 303 redirect). Times out after ~2s.
+    /// Polls the status URL until the job finishes. Per the FHIR Asynchronous
+    /// Interaction Request Pattern, completion is signalled by a `303 See Other`
+    /// redirect to a separate result URL; this helper follows that redirect and
+    /// returns the manifest `Parameters` fetched (with `200 OK`) from the result
+    /// URL. Times out after ~2s.
     async fn poll_to_manifest(server: &TestServer, status_url: &str, tenant: &str) -> Value {
         for _ in 0..40 {
             tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
             let poll = server.get(status_url).add_header(X_TENANT_ID, tenant).await;
             match poll.status_code() {
-                StatusCode::OK => return poll.json::<Value>(),
+                StatusCode::SEE_OTHER => {
+                    let result_url = poll
+                        .headers()
+                        .get(axum::http::header::LOCATION)
+                        .and_then(|v| v.to_str().ok())
+                        .expect("303 completion response missing Location header")
+                        .to_string();
+                    let result = server
+                        .get(&result_url)
+                        .add_header(X_TENANT_ID, tenant)
+                        .await;
+                    assert_eq!(
+                        result.status_code(),
+                        StatusCode::OK,
+                        "result fetch failed: {}",
+                        result.text()
+                    );
+                    return result.json::<Value>();
+                }
                 StatusCode::ACCEPTED => continue,
                 other => panic!("unexpected poll status {other}: {}", poll.text()),
             }
@@ -136,7 +157,7 @@ mod sof_export_tests {
     }
 
     // =========================================================================
-    // 2. Poll → eventually 200 + manifest
+    // 2. Poll → eventually 303 See Other → result URL → 200 + manifest
     // =========================================================================
 
     #[tokio::test]
@@ -177,10 +198,112 @@ mod sof_export_tests {
         );
     }
 
+    /// The completing status poll signals completion with `303 See Other` and an
+    /// empty body, carrying the separate result URL in the `Location` header
+    /// (FHIR Asynchronous Interaction Request Pattern). The status URL itself
+    /// never returns the manifest with `200 OK`. Fetching the result URL returns
+    /// `200 OK` with the manifest `Parameters` resource.
+    #[tokio::test]
+    async fn test_export_completion_redirects_to_result() {
+        let (server, backend) = create_test_server_with_export().await;
+        seed_patients(&backend).await;
+
+        let submit_resp = server
+            .post("/ViewDefinition/$viewdefinition-export")
+            .add_header(PREFER, "respond-async")
+            .add_header(X_TENANT_ID, "test-tenant")
+            .json(&patient_view())
+            .await;
+        assert_eq!(submit_resp.status_code(), StatusCode::ACCEPTED);
+        let status_url = submit_resp
+            .headers()
+            .get("content-location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Poll until the job finishes; completion is a 303, never a 200.
+        let mut result_url = None;
+        for _ in 0..40 {
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            let poll = server
+                .get(&status_url)
+                .add_header(X_TENANT_ID, "test-tenant")
+                .await;
+            match poll.status_code() {
+                StatusCode::ACCEPTED => continue,
+                StatusCode::SEE_OTHER => {
+                    // Empty body, Location points to the result endpoint.
+                    assert!(
+                        poll.text().is_empty(),
+                        "completion poll must have an empty body, got: {}",
+                        poll.text()
+                    );
+                    let loc = poll
+                        .headers()
+                        .get(axum::http::header::LOCATION)
+                        .expect("303 missing Location header")
+                        .to_str()
+                        .unwrap()
+                        .to_string();
+                    assert!(
+                        loc.contains("/export/") && loc.ends_with("/result"),
+                        "unexpected result URL: {loc}"
+                    );
+                    result_url = Some(loc);
+                    break;
+                }
+                other => panic!("unexpected poll status {other}: {}", poll.text()),
+            }
+        }
+        let result_url = result_url.expect("export did not complete within 2s");
+
+        // The result URL serves the manifest with 200 OK.
+        let result = server
+            .get(&result_url)
+            .add_header(X_TENANT_ID, "test-tenant")
+            .await;
+        assert_eq!(result.status_code(), StatusCode::OK, "{}", result.text());
+        let manifest: Value = result.json();
+        assert_eq!(manifest["resourceType"].as_str(), Some("Parameters"));
+        // The result and download URLs are valid for ≥24h → Expires header.
+        assert!(
+            result.headers().contains_key(axum::http::header::EXPIRES),
+            "result response missing Expires header"
+        );
+
+        // The result is stable: a second fetch returns the same manifest.
+        let again = server
+            .get(&result_url)
+            .add_header(X_TENANT_ID, "test-tenant")
+            .await;
+        assert_eq!(again.status_code(), StatusCode::OK);
+        assert_eq!(again.json::<Value>(), manifest);
+    }
+
+    /// Fetching the result URL for a job that does not exist (or is not yet
+    /// finished) returns `404 Not Found` — the result is only available once the
+    /// status poll has redirected to it.
+    #[tokio::test]
+    async fn test_export_result_unknown_job_returns_404() {
+        let (server, _backend) = create_test_server_with_export().await;
+        let resp = server
+            .get("/export/00000000-0000-0000-0000-000000000000/result")
+            .add_header(X_TENANT_ID, "test-tenant")
+            .await;
+        assert_eq!(resp.status_code(), StatusCode::NOT_FOUND, "{}", resp.text());
+        assert_eq!(
+            resp.json::<Value>()["resourceType"].as_str(),
+            Some("OperationOutcome")
+        );
+    }
+
     /// `Accept: application/fhir+xml` (without fhir+json) on a status poll is
     /// not supported → `406 Not Acceptable` + OperationOutcome, same as the
-    /// run operations. The poll's `Accept` header governs the manifest
-    /// representation per Common Operation Behavior — Asynchronous Delivery.
+    /// run operations. The poll's `Accept` header governs that poll's
+    /// (interim/error) response per Common Operation Behavior — Asynchronous
+    /// Delivery.
     #[tokio::test]
     async fn test_export_status_poll_accept_fhir_xml_returns_406() {
         let (server, backend) = create_test_server_with_export().await;
@@ -937,8 +1060,8 @@ mod sof_export_tests {
             .unwrap()
             .to_string();
 
-        // Poll repeatedly; capture either the in-progress (202) or completed (200)
-        // shape and assert each body shape conforms to the spec.
+        // Poll repeatedly; capture either the in-progress (202) or completed
+        // (303 → result) shape and assert each body shape conforms to the spec.
         for _ in 0..40 {
             let poll = server
                 .get(&location)
@@ -980,9 +1103,22 @@ mod sof_export_tests {
                     });
                     assert!(n <= 99, "running percent must be <= 99, got {n}");
                 }
-                StatusCode::OK => {
-                    // Completed — the manifest rides in the poll body.
-                    let body: Value = poll.json();
+                StatusCode::SEE_OTHER => {
+                    // Completed — the poll redirects to the result URL, which
+                    // carries the manifest. The redirect body is empty.
+                    assert!(poll.text().is_empty(), "completion 303 must be empty");
+                    let result_url = poll
+                        .headers()
+                        .get(axum::http::header::LOCATION)
+                        .and_then(|v| v.to_str().ok())
+                        .expect("303 missing Location header")
+                        .to_string();
+                    let result = server
+                        .get(&result_url)
+                        .add_header(X_TENANT_ID, "test-tenant")
+                        .await;
+                    assert_eq!(result.status_code(), StatusCode::OK, "{}", result.text());
+                    let body: Value = result.json();
                     assert_eq!(body["resourceType"].as_str(), Some("Parameters"));
                     let params = body["parameter"].as_array().unwrap();
                     let status = params
@@ -1067,9 +1203,10 @@ mod sof_export_tests {
     }
 
     // =========================================================================
-    // 17. Failed jobs: the status poll itself returns 500 + OperationOutcome
-    //     (spec: no 303 redirect, no separate result URL).
-    //     Uses a test-only controller that always reports `Failed`.
+    // 17. Failed jobs: the status poll redirects with `303 See Other` to the
+    //     result URL, which returns 500 + OperationOutcome (FHIR Asynchronous
+    //     Interaction Request Pattern). Uses a test-only controller that always
+    //     reports `Failed`.
     // =========================================================================
 
     struct FailingController {
@@ -1105,7 +1242,7 @@ mod sof_export_tests {
     }
 
     #[tokio::test]
-    async fn test_export_failed_status_poll_returns_500_operation_outcome() {
+    async fn test_export_failed_status_poll_redirects_to_500_result() {
         let backend = SqliteBackend::with_config(":memory:", Default::default())
             .expect("failed to create SQLite backend");
         backend.init_schema().expect("failed to init schema");
@@ -1125,10 +1262,10 @@ mod sof_export_tests {
         let app = helios_rest::routing::fhir_routes::create_routes(state);
         let server = TestServer::new(app).expect("failed to create test server");
 
-        // Spec (Common Operation Behavior — Asynchronous Delivery): a failed
-        // job surfaces directly on the status poll as the relevant error
-        // status code with an OperationOutcome body. There is no 303 redirect.
-        // Poll twice to confirm the terminal failure response is stable.
+        // FHIR Asynchronous Interaction Request Pattern: a finished job — even a
+        // failed one — is signalled by `303 See Other` to the result URL with an
+        // empty body; the status endpoint never carries the outcome. Poll twice
+        // to confirm the terminal redirect is stable.
         for _ in 0..2 {
             let poll = server
                 .get("/export/fail-1/status")
@@ -1136,12 +1273,37 @@ mod sof_export_tests {
                 .await;
             assert_eq!(
                 poll.status_code(),
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed status poll should 500, got: {} {}",
+                StatusCode::SEE_OTHER,
+                "failed job should redirect to the result URL, got: {} {}",
                 poll.status_code(),
                 poll.text()
             );
-            let body: Value = poll.json();
+            assert!(poll.text().is_empty(), "303 body must be empty");
+            let result_url = poll
+                .headers()
+                .get(axum::http::header::LOCATION)
+                .expect("303 missing Location header")
+                .to_str()
+                .unwrap()
+                .to_string();
+            assert!(
+                result_url.ends_with("/result"),
+                "unexpected result URL: {result_url}"
+            );
+
+            // The result URL surfaces the failure as 500 + OperationOutcome.
+            let result = server
+                .get(&result_url)
+                .add_header(X_TENANT_ID, "test-tenant")
+                .await;
+            assert_eq!(
+                result.status_code(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed result should 500, got: {} {}",
+                result.status_code(),
+                result.text()
+            );
+            let body: Value = result.json();
             assert_eq!(body["resourceType"].as_str(), Some("OperationOutcome"));
             assert!(
                 body["issue"][0]["diagnostics"]
@@ -1190,7 +1352,7 @@ mod sof_export_tests {
     }
 
     // =========================================================================
-    // 19. Completion (200 OK) poll carries an `Expires` header (IMF-fixdate).
+    // 19. The result response (200 OK) carries an `Expires` header (IMF-fixdate).
     // =========================================================================
 
     #[tokio::test]
@@ -1213,18 +1375,32 @@ mod sof_export_tests {
             .unwrap()
             .to_string();
 
-        // Poll until the completing 200 OK so we can read its response
-        // headers — the manifest (and Expires) ride on the status poll.
-        let result = loop {
-            let poll = server
-                .get(&location)
-                .add_header(X_TENANT_ID, "test-tenant")
-                .await;
-            if poll.status_code() == StatusCode::OK {
-                break poll;
+        // Poll until the completing 303, then fetch the result URL — the
+        // manifest (and its Expires header) ride on the result response.
+        let result = {
+            let mut result_url = None;
+            for _ in 0..100 {
+                let poll = server
+                    .get(&location)
+                    .add_header(X_TENANT_ID, "test-tenant")
+                    .await;
+                if poll.status_code() == StatusCode::SEE_OTHER {
+                    result_url = poll
+                        .headers()
+                        .get(axum::http::header::LOCATION)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    break;
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
             }
-            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let result_url = result_url.expect("export did not complete");
+            server
+                .get(&result_url)
+                .add_header(X_TENANT_ID, "test-tenant")
+                .await
         };
+        assert_eq!(result.status_code(), StatusCode::OK, "{}", result.text());
         let expires = result
             .headers()
             .get("expires")
@@ -1737,7 +1913,7 @@ mod sof_export_tests {
     // =========================================================================
     // 30. Cancel after completion is a no-op: the cancel call returns 202
     //     (the job exists) but does not overwrite the `Completed` state, so
-    //     the status URL keeps serving the manifest.
+    //     the status URL keeps redirecting to the result manifest.
     // =========================================================================
 
     #[tokio::test]
@@ -1786,19 +1962,9 @@ mod sof_export_tests {
             cancel.text()
         );
 
-        // Status URL must still serve the Completed manifest with 200.
-        let result_after = server
-            .get(&status_url)
-            .add_header(X_TENANT_ID, "test-tenant")
-            .await;
-        assert_eq!(
-            result_after.status_code(),
-            StatusCode::OK,
-            "completed job should still 200 after spurious cancel: {} {}",
-            result_after.status_code(),
-            result_after.text()
-        );
-        let manifest_after: Value = result_after.json();
+        // The completed job must still redirect to its result, which serves the
+        // manifest — the spurious cancel must not have reset the state.
+        let manifest_after = poll_to_manifest(&server, &status_url, "test-tenant").await;
         let status_after = manifest_after["parameter"]
             .as_array()
             .unwrap()


### PR DESCRIPTION
## Summary

Updates the `$viewdefinition-export` and `$sqlquery-export` operations to follow the **FHIR Asynchronous Interaction Request Pattern** per [HL7/sql-on-fhir#369](https://github.com/HL7/sql-on-fhir/pull/369), replacing the prior Bulk Data completion behavior.

The core behavioral change: completion (and failure) is now signalled by a **`303 See Other`** redirect from the status poll to a **separate result URL** — instead of returning `200 OK` with the manifest directly on the status poll.

## Changes

**`crates/rest`**
- **`routing/fhir_routes.rs`** — Added `GET /export/{job_id}/result`. The static `result` segment takes priority over the existing `{filename}` download route (matchit 0.8 supports this overlap).
- **`handlers/sof/export.rs`**
  - `get_export_status_handler` — the `Completed`/`Failed` arms now return **`303 See Other`** with an empty body and a `Location` header carrying the absolute result URL. The status endpoint no longer communicates job outcome (still `202` while running, `404` for unknown/cancelled).
  - Added `get_export_result_handler` — serves the manifest `Parameters` with **`200 OK` + `Expires`** (24h) on success, the error status + `OperationOutcome` on failure, and `404` when the job is unknown/cancelled/still running.
  - Updated the module-level doc comment.
- **`handlers/sof/mod.rs`** — re-exported the new handler.

**Tests (`crates/rest/tests/sof_export.rs`)**
- Updated the `poll_to_manifest` helper to follow the `303 → result URL → 200` flow.
- Reworked the three tests that assumed the old direct-`200`-on-poll completion, and the failure test (now asserts `303 → 500` at the result URL).
- Added `test_export_completion_redirects_to_result` (empty-body 303, Location, stable repeat fetch, Expires) and `test_export_result_unknown_job_returns_404`.

## Not implemented (optional / client-side)
- `429 Too Many Requests` for excessive polling — spec says the server *MAY*; we don't rate-limit polls.
- Opaque-URL requirement — a client-side `MUST`; our URLs are already non-guessable (UUID job IDs).

## Caveat
HL7/sql-on-fhir#369 is still **open**, and the cited async-interaction pattern currently links an in-progress incubator branch — the exact `303`/result-URL contract could shift before it lands.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings ...` (clean)
- [x] `cargo test -p helios-rest --test sof_export` — 44 passed, 0 failed