### PR TITLE
feat(rest): advertise real search modifiers and includes in CapabilityStatement

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/backend.rs
+++ b/crates/persistence/src/backends/elasticsearch/backend.rs
@@ -549,7 +549,7 @@ impl ElasticsearchBackend {
     /// Returns supported modifiers for a parameter type.
     ///
     /// ES supports more modifiers than SQLite, especially for full-text.
-    fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
+    pub(super) fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
             SearchParamType::String => vec!["exact", "contains", "text", "missing"],
             SearchParamType::Token => {

--- a/crates/persistence/src/backends/elasticsearch/search_impl.rs
+++ b/crates/persistence/src/backends/elasticsearch/search_impl.rs
@@ -340,6 +340,13 @@ impl SearchProvider for ElasticsearchBackend {
     fn supports_contained_search(&self) -> bool {
         true
     }
+
+    fn modifiers_for_param_type(
+        &self,
+        param_type: crate::types::SearchParamType,
+    ) -> Vec<&'static str> {
+        Self::modifiers_for_type(param_type)
+    }
 }
 
 impl ElasticsearchBackend {

--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -538,7 +538,7 @@ impl MongoBackend {
     /// does not implement `:missing`, token `:not`/`:of-type`, reference
     /// `:identifier`, or uri `:above`/`:below`; advertising only what
     /// `search_impl` accepts keeps the CapabilityStatement honest.
-    fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
+    pub(super) fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
             SearchParamType::String => vec!["exact", "contains", "text"],
             SearchParamType::Token => vec!["text", "code-text"],

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -331,6 +331,13 @@ impl SearchProvider for MongoBackend {
     fn supports_contained_search(&self) -> bool {
         true
     }
+
+    fn modifiers_for_param_type(
+        &self,
+        param_type: crate::types::SearchParamType,
+    ) -> Vec<&'static str> {
+        Self::modifiers_for_type(param_type)
+    }
 }
 
 #[async_trait]

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -752,7 +752,7 @@ impl SearchCapabilityProvider for PostgresBackend {
 
 impl PostgresBackend {
     /// Returns supported modifiers for a parameter type.
-    fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
+    pub(super) fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
             SearchParamType::String => vec!["exact", "contains", "text", "missing"],
             // `not-in` is intentionally omitted: it returns 501 (negated

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -354,6 +354,13 @@ impl SearchProvider for PostgresBackend {
     fn supports_contained_search(&self) -> bool {
         true
     }
+
+    fn modifiers_for_param_type(
+        &self,
+        param_type: crate::types::SearchParamType,
+    ) -> Vec<&'static str> {
+        Self::modifiers_for_type(param_type)
+    }
 }
 
 #[async_trait]

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -713,7 +713,7 @@ impl SearchCapabilityProvider for SqliteBackend {
 
 impl SqliteBackend {
     /// Returns supported modifiers for a parameter type.
-    fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
+    pub(super) fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
             SearchParamType::String => vec!["exact", "contains", "text", "missing"],
             // `not-in` is intentionally omitted: the SQLite backend returns 501

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -403,6 +403,13 @@ impl SearchProvider for SqliteBackend {
     fn supports_contained_search(&self) -> bool {
         true
     }
+
+    fn modifiers_for_param_type(
+        &self,
+        param_type: crate::types::SearchParamType,
+    ) -> Vec<&'static str> {
+        Self::modifiers_for_type(param_type)
+    }
 }
 
 #[async_trait]

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -997,6 +997,27 @@ impl SearchProvider for CompositeStorage {
             .map(|p| p.supports_contained_search())
             .unwrap_or(false)
     }
+
+    fn modifiers_for_param_type(
+        &self,
+        param_type: crate::types::SearchParamType,
+    ) -> Vec<&'static str> {
+        // Same routing as `search`: defer to the dedicated Search backend when
+        // configured, otherwise the primary provider.
+        if let Some(search_backend) = self
+            .config
+            .backends_with_role(super::config::BackendRole::Search)
+            .next()
+        {
+            if let Some(provider) = self.search_providers.get(&search_backend.id) {
+                return provider.modifiers_for_param_type(param_type);
+            }
+        }
+        self.search_providers
+            .get(self.config.primary_id().unwrap_or("primary"))
+            .map(|p| p.modifiers_for_param_type(param_type))
+            .unwrap_or_default()
+    }
 }
 
 #[async_trait]

--- a/crates/persistence/src/core/search.rs
+++ b/crates/persistence/src/core/search.rs
@@ -293,6 +293,19 @@ pub trait SearchProvider: ResourceStorage {
     fn supports_contained_search(&self) -> bool {
         false
     }
+
+    /// Returns the search modifiers this backend actually honors for a given
+    /// parameter type (e.g. `exact`, `contains` for strings; `not`, `in` for
+    /// tokens). Used by the REST layer to advertise supported modifiers in the
+    /// CapabilityStatement.
+    ///
+    /// Defaults to an empty list (advertise nothing); real search backends
+    /// override this to reflect what their search implementation accepts so the
+    /// CapabilityStatement stays honest.
+    fn modifiers_for_param_type(&self, param_type: SearchParamType) -> Vec<&'static str> {
+        let _ = param_type;
+        Vec::new()
+    }
 }
 
 /// Search provider that supports searching across multiple resource types.

--- a/crates/rest/src/handlers/capabilities.rs
+++ b/crates/rest/src/handlers/capabilities.rs
@@ -34,6 +34,14 @@ use crate::middleware::content_type::{FhirContentType, negotiate_format};
 use crate::responses::format_resource_response;
 use crate::state::AppState;
 
+/// Extension URL used to advertise the search modifiers a parameter supports.
+///
+/// FHIR R4/R5 `CapabilityStatement.rest.resource.searchParam` has no native
+/// `modifier` element, so the modifiers a backend actually honors are carried as
+/// repeating `valueCode` extensions on the `searchParam` entry.
+const SEARCH_MODIFIER_EXTENSION_URL: &str =
+    "http://heliossoftware.com/fhir/StructureDefinition/capabilitystatement-search-modifier";
+
 /// Handler for the capabilities interaction.
 ///
 /// Returns a CapabilityStatement describing the server's capabilities.
@@ -139,10 +147,41 @@ where
     // evaluate contained search (others reject them with 501).
     let supports_contained = state.storage().supports_contained_search();
 
+    // Per-parameter-type modifier sets the backend actually honors. Used to
+    // advertise supported modifiers (as `valueCode` extensions) on each
+    // resource-specific search param.
+    let modifier_map: std::collections::HashMap<SearchParamType, Vec<&'static str>> = [
+        SearchParamType::Number,
+        SearchParamType::Date,
+        SearchParamType::String,
+        SearchParamType::Token,
+        SearchParamType::Reference,
+        SearchParamType::Composite,
+        SearchParamType::Quantity,
+        SearchParamType::Uri,
+        SearchParamType::Special,
+    ]
+    .into_iter()
+    .map(|t| (t, state.storage().modifiers_for_param_type(t)))
+    .collect();
+
     let registry = state.storage().search_param_registry().read();
+
+    // Reverse-include index (target type -> "Source:code" tokens) for advertising
+    // each resource's real `searchRevInclude` targets.
+    let revinclude_by_target = build_revinclude_index(&registry);
+
     let resources: Vec<serde_json::Value> = resource_types
         .iter()
-        .map(|rt| build_resource_capability(rt, &registry, supports_contained))
+        .map(|rt| {
+            build_resource_capability(
+                rt,
+                &registry,
+                supports_contained,
+                &modifier_map,
+                &revinclude_by_target,
+            )
+        })
         .collect();
 
     #[allow(unused_mut)]
@@ -299,6 +338,8 @@ fn build_resource_capability(
     resource_type: &str,
     registry: &SearchParameterRegistry,
     supports_contained: bool,
+    modifier_map: &std::collections::HashMap<SearchParamType, Vec<&'static str>>,
+    revinclude_by_target: &std::collections::HashMap<String, std::collections::BTreeSet<String>>,
 ) -> serde_json::Value {
     let mut entry = serde_json::json!({
         "type": resource_type,
@@ -321,10 +362,25 @@ fn build_resource_capability(
         "conditionalRead": "full-support",
         "conditionalUpdate": true,
         "conditionalDelete": "single",
-        "searchInclude": ["*"],
-        "searchRevInclude": ["*"],
-        "searchParam": build_search_params(resource_type, registry, supports_contained)
+        "searchParam": build_search_params(resource_type, registry, supports_contained, modifier_map)
     });
+
+    // Advertise real `_include` targets: one "Type:code" per reference param on
+    // this type. Omitted entirely when the type has no reference params.
+    let search_include = build_search_includes(resource_type, registry);
+    if !search_include.is_empty() {
+        entry["searchInclude"] = serde_json::Value::Array(search_include);
+    }
+
+    // Advertise real `_revinclude` targets: "Source:code" tokens from other
+    // types' reference params that point at this type.
+    if let Some(rev) = revinclude_by_target.get(resource_type) {
+        if !rev.is_empty() {
+            entry["searchRevInclude"] = serde_json::Value::Array(
+                rev.iter().cloned().map(serde_json::Value::String).collect(),
+            );
+        }
+    }
     // Bulk Data Access IG: per-resource `$export` operation entries on Patient
     // and Group, in addition to the system-level `$export` advertised at
     // `rest[0].operation`.
@@ -354,6 +410,7 @@ fn build_search_params(
     resource_type: &str,
     registry: &SearchParameterRegistry,
     supports_contained: bool,
+    modifier_map: &std::collections::HashMap<SearchParamType, Vec<&'static str>>,
 ) -> Vec<serde_json::Value> {
     let mut params = build_common_search_params(supports_contained);
     let mut seen: std::collections::HashSet<String> = params
@@ -372,6 +429,24 @@ fn build_search_params(
         });
         if let Some(doc) = &def.description {
             param["documentation"] = serde_json::Value::String(doc.clone());
+        }
+        // Advertise the modifiers this backend honors for the param's type.
+        // R4/R5 `searchParam` has no `modifier` element, so they ride along as
+        // repeating `valueCode` extensions.
+        if let Some(modifiers) = modifier_map.get(&def.param_type) {
+            if !modifiers.is_empty() {
+                param["extension"] = serde_json::Value::Array(
+                    modifiers
+                        .iter()
+                        .map(|m| {
+                            serde_json::json!({
+                                "url": SEARCH_MODIFIER_EXTENSION_URL,
+                                "valueCode": m,
+                            })
+                        })
+                        .collect(),
+                );
+            }
         }
         params.push(param);
     }
@@ -392,6 +467,51 @@ fn fhir_search_param_type(t: SearchParamType) -> &'static str {
         SearchParamType::Uri => "uri",
         SearchParamType::Special => "special",
     }
+}
+
+/// Builds the reverse-include index used for `searchRevInclude`: maps each target
+/// resource type to the sorted set of "SourceType:code" tokens from every active
+/// reference search param that targets it.
+fn build_revinclude_index(
+    registry: &SearchParameterRegistry,
+) -> std::collections::HashMap<String, std::collections::BTreeSet<String>> {
+    let mut index: std::collections::HashMap<String, std::collections::BTreeSet<String>> =
+        std::collections::HashMap::new();
+    for source_type in registry.resource_types() {
+        for def in registry.get_active_params(&source_type) {
+            if def.param_type != SearchParamType::Reference || def.code.starts_with('_') {
+                continue;
+            }
+            if let Some(targets) = &def.target {
+                let token = format!("{}:{}", source_type, def.code);
+                for target in targets {
+                    index
+                        .entry(target.clone())
+                        .or_default()
+                        .insert(token.clone());
+                }
+            }
+        }
+    }
+    index
+}
+
+/// Returns the `searchInclude` tokens ("Type:code") for a resource type: one per
+/// active reference search param defined on it.
+fn build_search_includes(
+    resource_type: &str,
+    registry: &SearchParameterRegistry,
+) -> Vec<serde_json::Value> {
+    let mut includes: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for def in registry.get_active_params(resource_type) {
+        if def.param_type == SearchParamType::Reference && !def.code.starts_with('_') {
+            includes.insert(format!("{}:{}", resource_type, def.code));
+        }
+    }
+    includes
+        .into_iter()
+        .map(serde_json::Value::String)
+        .collect()
 }
 
 /// Builds common search parameters supported by all resources.
@@ -486,5 +606,101 @@ mod tests {
         let with = param_names(&build_common_search_params(true));
         assert!(with.contains(&"_contained".to_string()));
         assert!(with.contains(&"_containedType".to_string()));
+    }
+
+    fn ref_param(
+        url: &str,
+        code: &str,
+        base: &str,
+        targets: &[&str],
+    ) -> helios_persistence::search::SearchParameterDefinition {
+        helios_persistence::search::SearchParameterDefinition::new(
+            url,
+            code,
+            SearchParamType::Reference,
+            format!("{base}.{code}"),
+        )
+        .with_base([base])
+        .with_targets(targets.iter().copied())
+    }
+
+    #[test]
+    fn includes_and_revincludes_derived_from_reference_params() {
+        use helios_persistence::search::SearchParameterRegistry;
+
+        let mut reg = SearchParameterRegistry::new();
+        reg.register(ref_param(
+            "http://example.org/Patient-general-practitioner",
+            "general-practitioner",
+            "Patient",
+            &["Practitioner", "Organization"],
+        ))
+        .unwrap();
+        reg.register(ref_param(
+            "http://example.org/Observation-subject",
+            "subject",
+            "Observation",
+            &["Patient"],
+        ))
+        .unwrap();
+
+        // searchInclude for a type = its own reference params as "Type:code".
+        let includes: Vec<String> = build_search_includes("Patient", &reg)
+            .into_iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(includes, vec!["Patient:general-practitioner".to_string()]);
+
+        // searchRevInclude index: each target type maps to the "Source:code"
+        // tokens that point at it.
+        let rev = build_revinclude_index(&reg);
+        assert!(rev.get("Patient").unwrap().contains("Observation:subject"));
+        assert!(
+            rev.get("Practitioner")
+                .unwrap()
+                .contains("Patient:general-practitioner")
+        );
+        // Observation has no reference param pointing at it.
+        assert!(!rev.contains_key("Observation"));
+    }
+
+    #[test]
+    fn resource_specific_params_carry_modifier_extension() {
+        use helios_persistence::search::{SearchParameterDefinition, SearchParameterRegistry};
+        use std::collections::HashMap;
+
+        let mut reg = SearchParameterRegistry::new();
+        reg.register(
+            SearchParameterDefinition::new(
+                "http://example.org/Patient-name",
+                "name",
+                SearchParamType::String,
+                "Patient.name",
+            )
+            .with_base(["Patient"]),
+        )
+        .unwrap();
+
+        let mut modifier_map: HashMap<SearchParamType, Vec<&'static str>> = HashMap::new();
+        modifier_map.insert(SearchParamType::String, vec!["exact", "contains"]);
+
+        let params = build_search_params("Patient", &reg, false, &modifier_map);
+        let name = params
+            .iter()
+            .find(|p| p["name"] == "name")
+            .expect("name param advertised");
+        let ext = name["extension"]
+            .as_array()
+            .expect("modifier extension present");
+        let codes: Vec<&str> = ext
+            .iter()
+            .map(|e| e["valueCode"].as_str().unwrap())
+            .collect();
+        assert_eq!(codes, vec!["exact", "contains"]);
+        assert_eq!(ext[0]["url"], SEARCH_MODIFIER_EXTENSION_URL);
+
+        // Common control params (e.g. _id) do not carry the modifier extension.
+        let id = params.iter().find(|p| p["name"] == "_id").unwrap();
+        assert!(id.get("extension").is_none());
     }
 }

--- a/crates/rest/tests/capabilities_search_params.rs
+++ b/crates/rest/tests/capabilities_search_params.rs
@@ -1,0 +1,159 @@
+//! Integration tests for `GET /metadata` search-capability advertisement:
+//! real per-resource search parameters, `_include`/`_revinclude` targets, and
+//! per-parameter supported modifiers (carried as extensions).
+
+mod capabilities_search_param_tests {
+    use axum::http::{HeaderName, HeaderValue, StatusCode};
+    use axum_test::TestServer;
+    use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+    use helios_rest::ServerConfig;
+    use serde_json::Value;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    const X_TENANT_ID: HeaderName = HeaderName::from_static("x-tenant-id");
+    const SEARCH_MODIFIER_EXTENSION_URL: &str =
+        "http://heliossoftware.com/fhir/StructureDefinition/capabilitystatement-search-modifier";
+
+    /// Builds a server whose SQLite backend loads the full spec SearchParameter
+    /// registry from the repo `data/` directory (not just the minimal embedded set).
+    async fn create_test_server() -> TestServer {
+        let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.join("data"))
+            .unwrap_or_else(|| PathBuf::from("data"));
+
+        let backend_config = SqliteBackendConfig {
+            data_dir: Some(data_dir),
+            ..Default::default()
+        };
+        let backend =
+            SqliteBackend::with_config(":memory:", backend_config).expect("create SQLite backend");
+        backend.init_schema().expect("init schema");
+        let backend = Arc::new(backend);
+
+        let config = ServerConfig::for_testing();
+        let state = helios_rest::AppState::new(backend, config);
+        let app = helios_rest::routing::fhir_routes::create_routes(state);
+        TestServer::new(app).expect("create test server")
+    }
+
+    async fn fetch_metadata() -> Value {
+        let server = create_test_server().await;
+        let response = server
+            .get("/metadata")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status(StatusCode::OK);
+        serde_json::from_str(&response.text()).expect("metadata must be valid JSON")
+    }
+
+    /// Returns the `rest[0].resource` entry for a given resource type.
+    fn resource_entry<'a>(metadata: &'a Value, resource_type: &str) -> &'a Value {
+        metadata["rest"][0]["resource"]
+            .as_array()
+            .expect("rest[0].resource array")
+            .iter()
+            .find(|r| r["type"] == resource_type)
+            .unwrap_or_else(|| panic!("{resource_type} resource not advertised"))
+    }
+
+    fn search_param_names(resource: &Value) -> Vec<String> {
+        resource["searchParam"]
+            .as_array()
+            .expect("searchParam array")
+            .iter()
+            .filter_map(|p| p["name"].as_str().map(str::to_string))
+            .collect()
+    }
+
+    fn string_list(value: &Value, field: &str) -> Vec<String> {
+        value[field]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn advertises_real_per_resource_search_params() {
+        let metadata = fetch_metadata().await;
+
+        let patient = resource_entry(&metadata, "Patient");
+        let patient_params = search_param_names(patient);
+        assert!(
+            patient_params.contains(&"name".to_string()),
+            "Patient must advertise its real `name` param, got: {patient_params:?}"
+        );
+
+        let observation = resource_entry(&metadata, "Observation");
+        let observation_params = search_param_names(observation);
+        assert!(
+            observation_params.contains(&"code".to_string()),
+            "Observation must advertise its real `code` param, got: {observation_params:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn advertises_real_include_and_revinclude_targets() {
+        let metadata = fetch_metadata().await;
+        let patient = resource_entry(&metadata, "Patient");
+
+        // searchInclude is now derived from real reference params, not "*".
+        let includes = string_list(patient, "searchInclude");
+        assert!(
+            !includes.contains(&"*".to_string()),
+            "searchInclude must not be the wildcard, got: {includes:?}"
+        );
+        assert!(
+            includes.iter().all(|i| i.starts_with("Patient:")),
+            "every Patient searchInclude must be a `Patient:<code>` token, got: {includes:?}"
+        );
+
+        // Observation references Patient (e.g. Observation:subject / :patient), so
+        // Patient's searchRevInclude must surface an `Observation:*` token.
+        let revincludes = string_list(patient, "searchRevInclude");
+        assert!(
+            !revincludes.contains(&"*".to_string()),
+            "searchRevInclude must not be the wildcard, got: {revincludes:?}"
+        );
+        assert!(
+            revincludes.iter().any(|r| r.starts_with("Observation:")),
+            "Patient searchRevInclude must include an Observation reference, got: {revincludes:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reference_params_advertise_modifiers_via_extension() {
+        let metadata = fetch_metadata().await;
+        let patient = resource_entry(&metadata, "Patient");
+
+        // Find a reference-typed search param and confirm it carries the modifier
+        // extension with valid `valueCode` entries.
+        let reference_param = patient["searchParam"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["type"] == "reference")
+            .expect("Patient has at least one reference search param");
+
+        let ext = reference_param["extension"]
+            .as_array()
+            .expect("reference param carries a modifier extension");
+        assert!(
+            ext.iter()
+                .all(|e| e["url"] == SEARCH_MODIFIER_EXTENSION_URL),
+            "all modifier extensions use the modifier extension URL: {ext:?}"
+        );
+        let codes: Vec<&str> = ext.iter().filter_map(|e| e["valueCode"].as_str()).collect();
+        // SQLite advertises `below`/`above`/`identifier`/etc. for reference params.
+        assert!(
+            codes.contains(&"identifier"),
+            "reference modifier set should include `identifier`, got: {codes:?}"
+        );
+    }
+}


### PR DESCRIPTION
## What

`GET /metadata` now advertises the server's real search capabilities. The headline gap from the UI requirements doc (§7.9) — only seven static search params — was already fixed on `main`; this closes the two remaining gaps:

1. **`searchInclude` / `searchRevInclude`** were hardcoded `["*"]`. They are now derived from real reference search params:
   - `searchInclude` = `Type:code` for each reference param defined on the type.
   - `searchRevInclude` = `Source:code` for every reference param (on any type) that targets this type.
   - Omitted entirely when a type has none (no more unconditional `*`).
2. **Modifiers were never advertised.** Each resource-specific `searchParam` now carries the modifiers the backend actually honors (`:exact`, `:contains`, `:not`, `:identifier`, …) as repeating `valueCode` extensions under `http://heliossoftware.com/fhir/StructureDefinition/capabilitystatement-search-modifier`. R4/R5 `CapabilityStatement.rest.resource.searchParam` has no native `modifier` element, so an extension is the spec-compatible carrier.

## How

- New defaulted `SearchProvider::modifiers_for_param_type`; sqlite/postgres/elasticsearch/mongodb override it to surface their existing `modifiers_for_type` set, so the advertisement is per-backend honest. `CompositeStorage` (the storage the `hfs` binary runs) delegates with the same routing as `supports_contained_search`.
- Handler precomputes the modifier map and a reverse-include index once per request (under the existing registry read lock) and threads them into `build_resource_capability` / `build_search_params`.
- Modifiers are attached only to registry-driven params, not control params (`_id`, `_tag`, …), to avoid overclaiming.

## Scope notes

- No change to the already-correct real per-resource params or `_text`/`_content` typing.
- `comparator` is not advertised (no standard CapabilityStatement field).

## Tests

- Unit: include/revinclude derivation from a small registry; modifier extension presence + control-param exclusion.
- Integration (`crates/rest/tests/capabilities_search_params.rs`, SQLite + full spec registry): `GET /metadata` advertises `Patient.name` / `Observation.code`, non-wildcard `Patient` includes, an `Observation:*` revinclude, and the modifier extension on a reference param.

Verified: `cargo fmt --all`; CI-style `cargo clippy -p helios-persistence -p helios-rest --all-targets --features elasticsearch,postgres -- -D warnings ...` clean; `helios-rest` capabilities/sof_capabilities + new integration test, and `helios-persistence` lib (665) all green.