### PR TITLE
build: drop stale crates/hts workspace exclude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,6 +2071,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,6 +3161,47 @@ dependencies = [
  "sqlparser",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "helios-hts"
+version = "0.1.47"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "bytes",
+ "chrono",
+ "clap",
+ "csv",
+ "ctor",
+ "deadpool-postgres",
+ "flate2",
+ "form_urlencoded",
+ "futures",
+ "helios-fhir",
+ "helios-persistence",
+ "r2d2",
+ "r2d2_sqlite",
+ "regex",
+ "roxmltree",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tar",
+ "tempfile",
+ "testcontainers",
+ "testcontainers-modules",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-postgres",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -6737,6 +6788,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,6 @@
 members = [
 	"crates/*",
 ]
-exclude = [
-	# crates/hts contains planning docs but no Cargo.toml yet (HTS feature branch)
-	"crates/hts",
-]
 # Build all Rust crates by default, but skip pysof unless explicitly requested.
 # This keeps `cargo build` working on machines without Python while still
 # making `crates/pysof` an actual workspace member for maturin.


### PR DESCRIPTION
## Problem

The root workspace manifest excludes `crates/hts` with a comment claiming the crate has no `Cargo.toml`, while simultaneously listing `crates/hts` in `default-members`. The crate *does* have a manifest, so the `exclude` wins and `helios-hts` silently drops out of the workspace:

```
$ cargo build -p helios-hts
error: package ID specification `helios-hts` did not match any packages
help: a package with a similar name exists: `helios-hfs`
```

The same failure hits `cargo test -p helios-hts`, `cargo run --bin hts`, and any other root-level invocation that names the crate.

## Why it went unnoticed

`hts.yml` only triggers on `workflow_dispatch`, `schedule`, and `workflow_call` — never on `push`/`pull_request`. So the broken workspace resolution from a fresh `main` checkout is not exercised by normal PR CI.

## Fix

Remove the contradictory `exclude` block so `helios-hts` resolves as a workspace member again, and update `Cargo.lock` for the now-included crate (`helios-hts` plus its `tar`/`ctor` dependencies).

## Verification

- `cargo metadata --locked` resolves cleanly
- `cargo build -p helios-hts` ✓
- `cargo test -p helios-hts` ✓ (all tests pass)