### PR TITLE
fix(hts): make single-version (R5-only) builds compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,5 @@ rust-version = "1.90"
 [workspace.dependencies]
 serde = { version = "=1.0.224", features = ["derive"] }
 serde_json = "=1.0.144"
-helios-fhir = { path = "crates/fhir" }
+helios-fhir = { path = "crates/fhir", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/fhirpath/src/polymorphic_access.rs
+++ b/crates/fhirpath/src/polymorphic_access.rs
@@ -172,7 +172,7 @@ fn get_polymorphic_fields(
     // match unrelated fields whose names happen to start with `base_name`.
     let mut consulted_field_types = false;
     if let Some(EvaluationResult::String(resource_type, _, _)) = obj.get("resourceType")
-        && let Some(table) = helios_fhir::field_types(helios_fhir::FhirVersion::default())
+        && let Some(table) = helios_fhir::field_types(helios_fhir::FhirVersion::default_enabled())
     {
         consulted_field_types = true;
         for (parent, field, _ty, _is_collection) in table {
@@ -410,7 +410,7 @@ pub fn is_choice_element(field_name: &str) -> bool {
 /// `effective`, `onset`, …) instead of the always-false fallback that
 /// preceded this.
 fn is_polymorphic_base_in_default_version(name: &str) -> bool {
-    let table: &[(&str, &str, &str, bool)] = match helios_fhir::FhirVersion::default() {
+    let table: &[(&str, &str, &str, bool)] = match helios_fhir::FhirVersion::default_enabled() {
         #[cfg(feature = "R4")]
         helios_fhir::FhirVersion::R4 => helios_fhir::r4::FIELD_TYPES,
         #[cfg(feature = "R4B")]

--- a/crates/hts/src/operations/crud.rs
+++ b/crates/hts/src/operations/crud.rs
@@ -118,7 +118,7 @@ mod inner {
 
         // 1. Persist raw FHIR JSON (version_id = "1", ETag = W/"1").
         let stored = store
-            .create(&ctx, resource_type, body, FhirVersion::default())
+            .create(&ctx, resource_type, body, FhirVersion::default_enabled())
             .await
             .map_err(|e| HtsError::StorageError(e.to_string()))?;
 

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -51,7 +51,7 @@ fn fhir_version_from_output_format(output_format: Option<&str>) -> FhirVersion {
                     .and_then(FhirVersion::from_mime_param)
             })
         })
-        .unwrap_or_default()
+        .unwrap_or_else(FhirVersion::default_enabled)
 }
 
 #[async_trait]

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -50,7 +50,7 @@ fn fhir_version_from_output_format(output_format: Option<&str>) -> FhirVersion {
                     .and_then(FhirVersion::from_mime_param)
             })
         })
-        .unwrap_or_default()
+        .unwrap_or_else(FhirVersion::default_enabled)
 }
 
 fn internal_error(message: String) -> StorageError {

--- a/crates/persistence/src/sof/compile_path.rs
+++ b/crates/persistence/src/sof/compile_path.rs
@@ -92,7 +92,7 @@ impl CompileEnv {
             column_type_hint: None,
             next_where_alias: 0,
             resource_type: String::new(),
-            fhir_version: FhirVersion::default(),
+            fhir_version: FhirVersion::default_enabled(),
         }
     }
 

--- a/crates/persistence/src/sof/compiler.rs
+++ b/crates/persistence/src/sof/compiler.rs
@@ -59,9 +59,13 @@ fn dialect_for(d: SqlDialect) -> Box<dyn Dialect> {
 /// Compiles a raw ViewDefinition JSON value into a [`CompiledQuery`] for SQLite.
 ///
 /// Shorthand for `compile_view_definition_dialect(view_json, SqlDialect::Sqlite,
-/// FhirVersion::default())`.
+/// FhirVersion::default_enabled())`.
 pub fn compile_view_definition(view_json: &Value) -> Result<CompiledQuery, SofError> {
-    compile_view_definition_dialect(view_json, SqlDialect::Sqlite, FhirVersion::default())
+    compile_view_definition_dialect(
+        view_json,
+        SqlDialect::Sqlite,
+        FhirVersion::default_enabled(),
+    )
 }
 
 /// Compiles a raw ViewDefinition JSON value into a [`CompiledQuery`] for the given dialect.

--- a/crates/persistence/src/sof/postgres.rs
+++ b/crates/persistence/src/sof/postgres.rs
@@ -40,7 +40,7 @@ impl PgInDbRunner {
     pub fn new(pool: Pool) -> Self {
         Self {
             pool,
-            fhir_version: FhirVersion::default(),
+            fhir_version: FhirVersion::default_enabled(),
         }
     }
 

--- a/crates/persistence/src/sof/sqlite.rs
+++ b/crates/persistence/src/sof/sqlite.rs
@@ -40,7 +40,7 @@ impl SqliteInDbRunner {
     pub fn new(pool: Pool<SqliteConnectionManager>) -> Self {
         Self {
             pool,
-            fhir_version: FhirVersion::default(),
+            fhir_version: FhirVersion::default_enabled(),
         }
     }
 


### PR DESCRIPTION
## Problem

The `HTS Terminology IG Conformance` workflow's **Build HTS binary (\<backend\> / R5)** step builds a genuine single-version binary:

```
cargo build -p helios-hts --no-default-features --features "<sqlite|postgres>,R5"
```

and was failing to compile ([failing run](https://github.com/HeliosSoftware/hfs/actions/runs/27501214595)) with `error[E0004]: non-exhaustive patterns: FhirVersion::R4 not covered` in `helios-sof`.

This is a **real compile break**, not the known upstream-HEAD conformance flakiness — note a prior scheduled run passed on the *same* headSha purely due to a cargo-cache fluke.

## Root cause

Two latent issues, both masked by the default-feature build:

1. **R4 feature leak.** `crates/hts/Cargo.toml` inherits `helios-fhir` via `{ workspace = true }`, but the root `[workspace.dependencies]` entry had no `default-features = false`. So every hts build pulled in `helios-fhir`'s default `R4` feature, keeping the `FhirVersion::R4` enum variant present while `helios-sof`/`helios-fhirpath` were R5-only — making their cfg-gated `match` arms non-exhaustive. Every other crate already disables defaults on its own `helios-fhir` dep; hts was the lone holdout via workspace inheritance.

2. **`FhirVersion::default()` is `#[cfg(feature = "R4")]`-gated** and doesn't exist in non-R4 single-version builds. Real (non-test) call sites are switched to `FhirVersion::default_enabled()`, which returns the newest *enabled* version — also semantically more correct (an R5 server should default to R5, not R4).

## Changes (9 files)

- `Cargo.toml` — add `default-features = false` to the `helios-fhir` workspace dep (only `hts` is affected).
- `helios-fhirpath`, `helios-persistence` (sof + sqlite/postgres `bulk_submit`), `helios-hts` — `FhirVersion::default()` → `default_enabled()`.

## Verification

All four CI matrix cells build clean locally (`Finished`, exit 0): **sqlite/R5, sqlite/R4, postgres/R5, postgres/R4**.

## Out of scope

The ES/Mongo backends have the same `FhirVersion::default()` pattern but aren't in this CI matrix (es/mongo features off), so they're left untouched here; they'd break an ES/Mongo single-version non-R4 build.