### PR TITLE
fix(ci): make Claude code review post to PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,13 @@
 name: Claude Code Review
 
 on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review (for manual runs)"
+        required: true
 
 jobs:
   claude-review:
@@ -31,7 +37,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.inputs.pr_number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
The code-review workflow ran but never produced visible output: the /code-review prompt writes findings to the agent's own stdout, not to the PR, so reviews evaporated into the job log. Add --comment so findings are posted as inline PR comments.

Also restore the pull_request trigger (it had been switched to workflow_dispatch-only, which has no PR context, leaving an empty .../pull/ target). Keep a manual workflow_dispatch path with an explicit pr_number input for on-demand runs.