### PR TITLE
ci(inferno-us-core): add weekly scheduled tracking run

### DIFF
--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -1,7 +1,15 @@
 name: Inferno US Core Test Suite
 
 on:
-  workflow_dispatch: # Manual trigger only for initial implementation
+  workflow_dispatch: # Manual trigger
+  schedule:
+    # Weekly US Core conformance tracking run — Sunday 08:00 UTC (04:00 ET).
+    # Offset from the daily suites (hts-ig 03:00, hts 05:00) and clear of the
+    # weekday ci-extended 07:00 run, so this long (~2.5h) job has the
+    # self-hosted runners to itself. Runs as a status/early-warning signal —
+    # the suite is not yet consistently green, so treat a weekly red as a
+    # tracking indicator rather than a gate.
+    - cron: "0 8 * * 0"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Adds a weekly `schedule` trigger to `inferno-us-core.yml` — **Sunday 08:00 UTC** (04:00 ET).

## Why this slot
- Long job (~80–160 min) on shared self-hosted runners.
- Offset from the daily nightly suites (hts-ig 03:00 UTC, hts 05:00 UTC) and clear of the weekday-only ci-extended (07:00 UTC), so it has the runners to itself.
- Weekend small-hours US time → no contention with PR/push CI; results ready for Monday triage.

## Scope
- Runs as a **status / early-warning tracking signal**, not a gate — the suite is not yet consistently green (recent history is mostly red), so a weekly red is a tracking indicator.
- The existing manual `workflow_dispatch` trigger is retained.

Note: the schedule only takes effect once this is on `main` (GitHub reads `schedule` triggers from the default branch). First scheduled run will be the next Sunday after merge.