### PR TITLE
feat(sof): SQL-on-FHIR runners for MongoDB (native) and S3 (in-process)

### DIFF
--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -149,7 +149,13 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      max-parallel: 2
+      # Serialized: all matrix jobs share one Inferno instance, which runs a
+      # single test run at a time. Running two jobs in parallel made the second
+      # collide with the first's in-progress run ("Cannot run new test while
+      # another test run is in progress" / SQLite "database is locked"), and the
+      # per-job retry window (~30s) is far shorter than a run (~30min), so the
+      # loser always failed. One at a time avoids the contention entirely.
+      max-parallel: 1
       matrix:
         suite_id:
           [

--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -19,6 +19,41 @@ use crate::search::{SearchParameterExtractor, SearchParameterLoader, SearchParam
 
 use super::schema;
 
+/// Builds a MongoDB client from a backend configuration.
+///
+/// Standalone (rather than a `&self` method) so both [`MongoBackend`] and the
+/// in-DB SOF runner can initialise the shared client cell from a cloned config.
+pub(crate) async fn connect_client(config: &MongoBackendConfig) -> StorageResult<Client> {
+    let mut client_options = ClientOptions::parse(&config.connection_string)
+        .await
+        .map_err(|e| {
+            StorageError::Backend(BackendError::ConnectionFailed {
+                backend_name: "mongodb".to_string(),
+                message: e.to_string(),
+            })
+        })?;
+
+    client_options.max_pool_size = Some(config.max_connections);
+    client_options.connect_timeout = Some(Duration::from_millis(config.connect_timeout_ms));
+    client_options.app_name = Some("helios-persistence".to_string());
+
+    // Fail fast when no healthy server can be selected. `connect_timeout`
+    // only covers new TCP handshakes; this caps requests once server
+    // monitoring has marked the server unavailable.
+    client_options.server_selection_timeout = Some(SERVER_SELECTION_TIMEOUT);
+    // Recycle idle connections so stale ones (e.g. silently dropped by a
+    // NAT/firewall on a long-lived network path) are not handed out.
+    client_options.max_idle_time = Some(MAX_CONNECTION_IDLE_TIME);
+
+    Client::with_options(client_options).map_err(|e| {
+        StorageError::Backend(BackendError::Internal {
+            backend_name: "mongodb".to_string(),
+            message: format!("Failed to create MongoDB client: {}", e),
+            source: None,
+        })
+    })
+}
+
 /// Upper bound for selecting a usable server before an operation gives up.
 const SERVER_SELECTION_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -37,8 +72,10 @@ const MAX_CONNECTION_IDLE_TIME: Duration = Duration::from_secs(60);
 pub struct MongoBackend {
     config: MongoBackendConfig,
     /// Lazily initialized MongoDB client. MongoDB clients own their connection
-    /// pools, so each backend instance must reuse one client.
-    client: OnceCell<Client>,
+    /// pools, so each backend instance must reuse one client. Wrapped in an
+    /// `Arc` so the in-DB SOF runner can share the same pooled client (it is
+    /// constructed from `&self` but outlives the borrow).
+    client: Arc<OnceCell<Client>>,
     /// Search parameter registry (in-memory cache of active parameters).
     search_registry: Arc<RwLock<SearchParameterRegistry>>,
     /// Extractor for deriving searchable values from resources.
@@ -131,7 +168,7 @@ impl MongoBackend {
 
         Ok(Self {
             config,
-            client: OnceCell::new(),
+            client: Arc::new(OnceCell::new()),
             search_registry,
             search_extractor,
         })
@@ -311,44 +348,19 @@ impl MongoBackend {
     }
 
     /// Creates a MongoDB client from backend configuration.
-    async fn create_client(&self) -> StorageResult<Client> {
-        let mut client_options = ClientOptions::parse(&self.config.connection_string)
-            .await
-            .map_err(|e| {
-                StorageError::Backend(BackendError::ConnectionFailed {
-                    backend_name: "mongodb".to_string(),
-                    message: e.to_string(),
-                })
-            })?;
-
-        client_options.max_pool_size = Some(self.config.max_connections);
-        client_options.connect_timeout =
-            Some(Duration::from_millis(self.config.connect_timeout_ms));
-        client_options.app_name = Some("helios-persistence".to_string());
-
-        // Fail fast when no healthy server can be selected. `connect_timeout`
-        // only covers new TCP handshakes; this caps requests once server
-        // monitoring has marked the server unavailable.
-        client_options.server_selection_timeout = Some(SERVER_SELECTION_TIMEOUT);
-        // Recycle idle connections so stale ones (e.g. silently dropped by a
-        // NAT/firewall on a long-lived network path) are not handed out.
-        client_options.max_idle_time = Some(MAX_CONNECTION_IDLE_TIME);
-
-        Client::with_options(client_options).map_err(|e| {
-            StorageError::Backend(BackendError::Internal {
-                backend_name: "mongodb".to_string(),
-                message: format!("Failed to create MongoDB client: {}", e),
-                source: None,
-            })
-        })
-    }
-
     /// Returns the shared MongoDB client for this backend.
     pub(crate) async fn get_client(&self) -> StorageResult<Client> {
         self.client
-            .get_or_try_init(|| self.create_client())
+            .get_or_try_init(|| connect_client(&self.config))
             .await
             .cloned()
+    }
+
+    /// Returns a handle to the shared client cell, so collaborators constructed
+    /// from `&self` (e.g. the in-DB SOF runner) can lazily initialise and reuse
+    /// the same pooled client.
+    pub(crate) fn client_cell(&self) -> Arc<OnceCell<Client>> {
+        Arc::clone(&self.client)
     }
 
     /// Returns the configured MongoDB database handle.

--- a/crates/persistence/src/backends/mongodb/mod.rs
+++ b/crates/persistence/src/backends/mongodb/mod.rs
@@ -15,7 +15,7 @@
 //!
 //! Advanced search/composite behavior remains part of later phases.
 
-mod backend;
+pub(crate) mod backend;
 mod bulk_export;
 pub(crate) mod schema;
 mod search_impl;

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -517,6 +517,16 @@ impl ResourceStorage for MongoBackend {
         "mongodb"
     }
 
+    fn sof_runner(&self) -> Option<std::sync::Arc<dyn crate::core::sof_runner::SofRunner>> {
+        use crate::sof::mongodb::MongoInDbRunner;
+        // Native in-DB runner: compiles the ViewDefinition to an aggregation
+        // pipeline executed against the `resources` collection.
+        Some(std::sync::Arc::new(MongoInDbRunner::new(
+            self.client_cell(),
+            self.config().clone(),
+        )))
+    }
+
     async fn create(
         &self,
         tenant: &TenantContext,

--- a/crates/persistence/src/backends/s3/storage.rs
+++ b/crates/persistence/src/backends/s3/storage.rs
@@ -316,6 +316,38 @@ impl S3Backend {
         Ok(keys)
     }
 
+    /// Scans every live (non-deleted) resource of `resource_type` for `tenant`
+    /// and returns their raw FHIR JSON content.
+    ///
+    /// Shares the `list_current_keys` + `get_json_object` walk used by bulk
+    /// export ([`super::bulk_export`]); used by the in-process SQL-on-FHIR
+    /// runner to feed the `helios-sof` engine.
+    pub(crate) async fn scan_live_resources(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+    ) -> StorageResult<Vec<Value>> {
+        let location = self.tenant_location(tenant)?;
+        let keys = self
+            .list_current_keys(&location, Some(resource_type))
+            .await?;
+
+        let mut resources = Vec::new();
+        for key in keys {
+            let Some((resource, _)) = self
+                .get_json_object::<StoredResource>(&location.bucket, &key)
+                .await?
+            else {
+                continue;
+            };
+            if resource.is_deleted() {
+                continue;
+            }
+            resources.push(resource.content().clone());
+        }
+        Ok(resources)
+    }
+
     /// Loads history entries by scanning all index event objects under `prefix`.
     ///
     /// For each event key found, the corresponding versioned history snapshot is
@@ -432,6 +464,18 @@ impl S3Backend {
 impl ResourceStorage for S3Backend {
     fn backend_name(&self) -> &'static str {
         "s3"
+    }
+
+    fn sof_runner(&self) -> Option<std::sync::Arc<dyn crate::core::sof_runner::SofRunner>> {
+        use crate::sof::in_process::{InProcessSofRunner, ResourceScan};
+        // S3 is object storage with no query engine, so SQL-on-FHIR runs
+        // in-process over the scanned resources via the `helios-sof` engine.
+        let scan: std::sync::Arc<dyn ResourceScan> = std::sync::Arc::new(self.clone());
+        Some(std::sync::Arc::new(InProcessSofRunner::new(
+            scan,
+            FhirVersion::default_enabled(),
+            "s3-in-process",
+        )))
     }
 
     async fn create(
@@ -1119,6 +1163,19 @@ impl ConditionalStorage for S3Backend {
             backend_name: "S3".to_string(),
             capability: "conditional_delete".to_string(),
         }))
+    }
+}
+
+#[async_trait]
+impl crate::sof::in_process::ResourceScan for S3Backend {
+    async fn scan_resources(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+    ) -> Result<Vec<Value>, crate::core::sof_runner::SofError> {
+        self.scan_live_resources(tenant, resource_type)
+            .await
+            .map_err(|e| crate::core::sof_runner::SofError::Storage(e.to_string()))
     }
 }
 

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -48,9 +48,9 @@ use crate::core::{
     ConditionalCreateResult, ConditionalDeleteResult, ConditionalPatchResult, ConditionalStorage,
     ConditionalUpdateResult, ExportDataProvider, ExportRequest, GroupExportProvider,
     IncludeProvider, InstanceHistoryProvider, NdjsonBatch, PatchFormat, PatientExportProvider,
-    ResourceStorage, RevincludeProvider, SearchProvider, SearchResult, StorageCapabilities,
-    SystemHistoryProvider, TerminologySearchProvider, TextSearchProvider, TypeHistoryProvider,
-    VersionedStorage,
+    ResourceStorage, RevincludeProvider, SearchProvider, SearchResult, SofRunner,
+    StorageCapabilities, SystemHistoryProvider, TerminologySearchProvider, TextSearchProvider,
+    TypeHistoryProvider, VersionedStorage,
 };
 use crate::error::{BackendError, StorageError, StorageResult, TransactionError};
 use crate::tenant::TenantContext;
@@ -713,6 +713,14 @@ impl CompositeStorage {
 impl ResourceStorage for CompositeStorage {
     fn backend_name(&self) -> &'static str {
         "composite"
+    }
+
+    fn sof_runner(&self) -> Option<Arc<dyn SofRunner>> {
+        // SQL-on-FHIR runs as in-DB SQL against the primary store (where all
+        // writes land), so delegate to the primary backend. Composites whose
+        // primary is SOF-capable (e.g. sqlite-elasticsearch) thus expose a
+        // runner; others inherit `None`.
+        self.primary.sof_runner()
     }
 
     #[instrument(skip(self, tenant, resource), fields(resource_type = %resource_type))]

--- a/crates/persistence/src/core/sof_runner.rs
+++ b/crates/persistence/src/core/sof_runner.rs
@@ -1,15 +1,20 @@
 //! SQL-on-FHIR runner abstraction.
 //!
-//! This module defines the [`SofRunner`] trait, implemented by per-backend
-//! **in-DB runners** that compile a [`ViewDefinition`] to SQL and execute it
-//! directly inside the storage backend, skipping FHIRPath evaluation entirely.
-//! Two implementations exist today: one for SQLite and one for PostgreSQL.
-//! Backends advertise the capability via [`BackendCapability::InDbSofRunner`].
+//! This module defines the [`SofRunner`] trait, implemented per-backend. Two
+//! strategies exist:
 //!
-//! There is no in-process FHIRPath fallback — if the configured backend does
-//! not provide a runner, the `$viewdefinition-run` handler returns
-//! `501 Not Implemented`. Inline `resource:` parameters are materialised into
-//! a transient in-memory SQLite backend so they reuse the same in-DB pipeline.
+//! - **In-DB runners** compile a [`ViewDefinition`] to a native query executed
+//!   inside the storage backend, skipping FHIRPath evaluation entirely: SQLite
+//!   and PostgreSQL compile to SQL, MongoDB compiles to an aggregation pipeline.
+//! - **In-process runners** stream the resources out of a backend that has no
+//!   query engine (S3 object storage, and S3-primary composites) and evaluate
+//!   the view with the `helios-sof` FHIRPath engine
+//!   ([`InProcessSofRunner`](crate::sof::in_process::InProcessSofRunner)).
+//!
+//! If the configured backend provides no runner at all, the
+//! `$viewdefinition-run` handler returns `501 Not Implemented`. Inline
+//! `resource:` parameters are materialised into a transient in-memory SQLite
+//! backend so they reuse the same in-DB pipeline.
 //!
 //! The handler layer streams the result rows directly into the HTTP response.
 

--- a/crates/persistence/src/sof/compile_view.rs
+++ b/crates/persistence/src/sof/compile_view.rs
@@ -39,6 +39,7 @@ const FOREACH_ALIAS_PREFIX: &str = "fe";
 pub fn build_plan(
     view_json: &Value,
     dialect: &dyn super::dialect::Dialect,
+    target: super::compiler::CompileTarget,
     fhir_version: FhirVersion,
 ) -> Result<(PlanNode, Vec<LitValue>), SofError> {
     let resource_type = view_json
@@ -113,6 +114,7 @@ pub fn build_plan(
         &mut env,
         &mut alias_seq,
         dialect,
+        target,
     )
     .and_then(ensure_project)?;
     Ok((plan, env.param_bindings))
@@ -187,6 +189,7 @@ fn plan_clause_list(
     env: &mut CompileEnv,
     alias_seq: &mut AliasSeq,
     dialect: &dyn super::dialect::Dialect,
+    target: super::compiler::CompileTarget,
 ) -> Result<PlanNode, SofError> {
     // Single-pass: collect sibling root columns + at most one `forEach` per
     // level + handle a single `unionAll` clause. Multiple unionAll clauses at
@@ -212,14 +215,21 @@ fn plan_clause_list(
             union_branches = Some(branches);
             // Sibling columns/forEach in this same clause are merged into
             // every branch (handled below).
-            let parts =
-                read_clause_columns_and_iter(clause, parent_focus, env, alias_seq, dialect)?;
+            let parts = read_clause_columns_and_iter(
+                clause,
+                parent_focus,
+                env,
+                alias_seq,
+                dialect,
+                target,
+            )?;
             shared_columns.extend(parts.columns);
             shared_unnests.extend(parts.unnests);
             continue;
         }
 
-        let parts = read_clause_columns_and_iter(clause, parent_focus, env, alias_seq, dialect)?;
+        let parts =
+            read_clause_columns_and_iter(clause, parent_focus, env, alias_seq, dialect, target)?;
         if let Some(rec) = parts.recurse {
             if shared_recurse.is_some() {
                 return Err(SofError::Uncompilable {
@@ -285,7 +295,8 @@ fn plan_clause_list(
     // wrapped in a Union.
     let mut branch_plans: Vec<PlanNode> = Vec::with_capacity(flat_branches.len());
     for branch in &flat_branches {
-        let parts = read_clause_columns_and_iter(branch, &branch_focus, env, alias_seq, dialect)?;
+        let parts =
+            read_clause_columns_and_iter(branch, &branch_focus, env, alias_seq, dialect, target)?;
         // A unionAll branch may itself carry a `repeat:` clause — wrap that
         // branch's plan in a Recurse and let the per-branch Project read off
         // the recursive CTE alias.
@@ -404,6 +415,7 @@ fn read_clause_columns_and_iter(
     env: &mut CompileEnv,
     alias_seq: &mut AliasSeq,
     dialect: &dyn super::dialect::Dialect,
+    target: super::compiler::CompileTarget,
 ) -> Result<ClauseParts, SofError> {
     // `repeat:` is mutually exclusive with `forEach`/`forEachOrNull`.
     if let Some(repeat) = clause.get("repeat").and_then(|v| v.as_array()) {
@@ -446,7 +458,8 @@ fn read_clause_columns_and_iter(
         let mut nested_unnests: Vec<UnnestStep> = Vec::new();
         if let Some(nested) = clause.get("select").and_then(|v| v.as_array()) {
             for sub in nested {
-                let sub_parts = read_clause_columns_and_iter(sub, &focus, env, alias_seq, dialect)?;
+                let sub_parts =
+                    read_clause_columns_and_iter(sub, &focus, env, alias_seq, dialect, target)?;
                 if sub_parts.recurse.is_some() {
                     return Err(SofError::Uncompilable {
                         reason: "select.repeat with nested repeat is not yet supported".to_string(),
@@ -509,7 +522,14 @@ fn read_clause_columns_and_iter(
             Some(super::ir::PathStep::Index(n)) if path.0.len() > 1 => Some(*n),
             _ => None,
         };
-        if let Some(idx) = trailing_index {
+        // SQL targets lower trailing-`[N]` forEach into a correlated
+        // `ScalarFromChain` subquery (SQLite forbids correlated FROM
+        // subqueries). Targets without that constraint — MongoDB — instead
+        // fall through to the normal unnest path below, which tags the last
+        // unnest with `flat_index` for the emitter to lower to `$arrayElemAt`.
+        if let Some(idx) = trailing_index
+            && target.supports_correlated_from_subqueries()
+        {
             let trimmed_path = super::ir::JsonPath(path.0[..path.0.len() - 1].to_vec());
             let segments = split_path_into_segments(&trimmed_path);
             let (chain_sql, deepest_alias) =
@@ -561,7 +581,16 @@ fn read_clause_columns_and_iter(
         // semantics).
         let mut unnests: Vec<UnnestStep> = Vec::new();
         let mut focus = parent_focus.to_string();
-        let segments = split_path_into_segments(&path);
+        // When a trailing `[N]` is present (the non-SQL fall-through, e.g.
+        // MongoDB), drop it from the unnest segments and apply it as
+        // `flat_index` below — otherwise the segment navigation would index
+        // `[N]` and `flat_index` would index it a second time.
+        let unnest_path = if trailing_index.is_some() {
+            super::ir::JsonPath(path.0[..path.0.len() - 1].to_vec())
+        } else {
+            path.clone()
+        };
+        let segments = split_path_into_segments(&unnest_path);
         let last_idx = segments.len().saturating_sub(1);
         for (i, seg_path) in segments.into_iter().enumerate() {
             let alias = alias_seq.next();
@@ -621,7 +650,8 @@ fn read_clause_columns_and_iter(
                     reason: "unionAll nested inside another select is not supported".to_string(),
                 });
             }
-            let sub_parts = read_clause_columns_and_iter(sub, &focus, env, alias_seq, dialect)?;
+            let sub_parts =
+                read_clause_columns_and_iter(sub, &focus, env, alias_seq, dialect, target)?;
             if sub_parts.recurse.is_some() {
                 return Err(SofError::Uncompilable {
                     reason: "select.repeat nested inside another select is not yet supported"

--- a/crates/persistence/src/sof/compiler.rs
+++ b/crates/persistence/src/sof/compiler.rs
@@ -1,12 +1,14 @@
-//! ViewDefinition → SQL compiler (SQLite and PostgreSQL dialects).
+//! ViewDefinition compiler (SQLite/PostgreSQL SQL and MongoDB pipelines).
 //!
 //! Thin façade over the IR-based pipeline:
 //!
 //! 1. [`build_plan`] walks the ViewDefinition JSON and produces a
 //!    [`PlanNode`](super::ir::PlanNode) tree plus the resolved
-//!    `ViewDefinition.constant[]` values.
-//! 2. [`emit_plan`] lowers the plan to dialect-appropriate SQL via the
-//!    [`Dialect`] trait.
+//!    `ViewDefinition.constant[]` values. The [`CompileTarget`] tunes
+//!    target-specific lowering (e.g. trailing-`[N]` forEach).
+//! 2. The emitter lowers the plan to the target form: [`emit_plan`] for SQL via
+//!    the [`Dialect`] trait, or [`emit_mongo`](super::emit_mongo::emit_mongo)
+//!    for a MongoDB aggregation pipeline.
 //!
 //! Returns [`SofError::Uncompilable`] for FHIRPath constructs the in-DB
 //! pipeline doesn't yet handle (e.g. `where(crit)` chains, the boundary
@@ -32,6 +34,35 @@ pub enum SqlDialect {
     Postgres,
 }
 
+/// Backend a ViewDefinition is being compiled for. Drives target-specific
+/// lowering decisions in [`build_plan`] (e.g. whether trailing-`[N]` forEach
+/// paths may use a correlated subquery) and selects the emitter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompileTarget {
+    /// SQLite SQL emitter.
+    Sqlite,
+    /// PostgreSQL SQL emitter.
+    Postgres,
+    /// MongoDB aggregation-pipeline emitter.
+    #[cfg(feature = "mongodb")]
+    Mongo,
+}
+
+impl CompileTarget {
+    /// Whether the target can index a flattened collection via a correlated
+    /// subquery in `FROM`. SQL backends can (`ScalarFromChain`); the MongoDB
+    /// emitter instead carries `flat_index` on the unnest and lowers it to
+    /// `$arrayElemAt`, so `build_plan` must NOT produce `ScalarFromChain` nodes
+    /// for it.
+    pub(super) fn supports_correlated_from_subqueries(self) -> bool {
+        match self {
+            CompileTarget::Sqlite | CompileTarget::Postgres => true,
+            #[cfg(feature = "mongodb")]
+            CompileTarget::Mongo => false,
+        }
+    }
+}
+
 /// Output of a successful ViewDefinition compilation.
 #[derive(Debug, Clone)]
 pub struct CompiledQuery {
@@ -45,6 +76,33 @@ pub struct CompiledQuery {
     /// Resolved `ViewDefinition.constant[]` values, in allocation order.
     /// Bound by the runners as `$3..` / `?3..` after `tenant_id` and
     /// `resource_type`.
+    pub constants: Vec<super::ir::LitValue>,
+}
+
+/// Compiled SQL-on-FHIR view, in the form the target backend executes:
+/// parameterised SQL, or a MongoDB aggregation pipeline.
+#[derive(Debug, Clone)]
+pub enum CompiledView {
+    /// SQL text + bind constants for the SQLite / PostgreSQL runners.
+    Sql(CompiledQuery),
+    /// Aggregation pipeline for the MongoDB runner.
+    #[cfg(feature = "mongodb")]
+    Mongo(CompiledPipeline),
+}
+
+/// Output of compiling a ViewDefinition to a MongoDB aggregation pipeline.
+#[cfg(feature = "mongodb")]
+#[derive(Debug, Clone)]
+pub struct CompiledPipeline {
+    /// Aggregation stages, ready to pass to `Collection::aggregate`. The leading
+    /// `$match` already constrains `tenant_id`/`resource_type`/`is_deleted`.
+    pub pipeline: Vec<mongodb::bson::Document>,
+    /// Column names in `select` order (the keys of the final `$project`).
+    pub columns: Vec<String>,
+    /// Resolved `ViewDefinition.constant[]` values, in allocation order.
+    ///
+    /// MongoDB has no out-of-band bind parameters, so the emitter inlines these
+    /// as BSON literals; they are surfaced here for parity/diagnostics only.
     pub constants: Vec<super::ir::LitValue>,
 }
 
@@ -83,14 +141,73 @@ pub fn compile_view_definition_dialect(
     dialect: SqlDialect,
     fhir_version: FhirVersion,
 ) -> Result<CompiledQuery, SofError> {
-    let dial = dialect_for(dialect);
-    let (plan, constants) = build_plan(view_json, dial.as_ref(), fhir_version)?;
-    let emitted = emit_plan(&plan, dial.as_ref())?;
-    Ok(CompiledQuery {
-        sql: emitted.sql,
-        columns: emitted.columns,
-        constants,
-    })
+    let target = match dialect {
+        SqlDialect::Sqlite => CompileTarget::Sqlite,
+        SqlDialect::Postgres => CompileTarget::Postgres,
+    };
+    match compile_view_target(view_json, target, fhir_version)? {
+        CompiledView::Sql(q) => Ok(q),
+        #[cfg(feature = "mongodb")]
+        CompiledView::Mongo(_) => unreachable!("SQL dialect never compiles to a Mongo pipeline"),
+    }
+}
+
+/// Compiles a ViewDefinition for an arbitrary [`CompileTarget`], returning the
+/// target-appropriate [`CompiledView`]. Single funnel through [`build_plan`]
+/// so every target shares the JSON→IR lowering.
+fn compile_view_target(
+    view_json: &Value,
+    target: CompileTarget,
+    fhir_version: FhirVersion,
+) -> Result<CompiledView, SofError> {
+    match target {
+        CompileTarget::Sqlite | CompileTarget::Postgres => {
+            let dialect = if target == CompileTarget::Postgres {
+                SqlDialect::Postgres
+            } else {
+                SqlDialect::Sqlite
+            };
+            let dial = dialect_for(dialect);
+            let (plan, constants) = build_plan(view_json, dial.as_ref(), target, fhir_version)?;
+            let emitted = emit_plan(&plan, dial.as_ref())?;
+            Ok(CompiledView::Sql(CompiledQuery {
+                sql: emitted.sql,
+                columns: emitted.columns,
+                constants,
+            }))
+        }
+        #[cfg(feature = "mongodb")]
+        CompileTarget::Mongo => {
+            // The dialect is unused on the Mongo path (build_plan only consults
+            // it inside the correlated-subquery lowering, which Mongo skips), so
+            // a SQLite dialect serves purely as a never-called placeholder.
+            let dial = dialect_for(SqlDialect::Sqlite);
+            let (plan, constants) = build_plan(view_json, dial.as_ref(), target, fhir_version)?;
+            let emitted = super::emit_mongo::emit_mongo(&plan, &constants)?;
+            Ok(CompiledView::Mongo(CompiledPipeline {
+                pipeline: emitted.pipeline,
+                columns: emitted.columns,
+                constants,
+            }))
+        }
+    }
+}
+
+/// Compiles a raw ViewDefinition JSON value into a MongoDB aggregation pipeline.
+///
+/// # Errors
+///
+/// Returns [`SofError::Uncompilable`] for constructs the Mongo emitter does not
+/// yet support (e.g. `lowBoundary`/`highBoundary`, `repeat:`, collections).
+#[cfg(feature = "mongodb")]
+pub fn compile_view_definition_mongo(
+    view_json: &Value,
+    fhir_version: FhirVersion,
+) -> Result<CompiledPipeline, SofError> {
+    match compile_view_target(view_json, CompileTarget::Mongo, fhir_version)? {
+        CompiledView::Mongo(p) => Ok(p),
+        CompiledView::Sql(_) => unreachable!("Mongo target never compiles to SQL"),
+    }
 }
 
 // ============================================================================

--- a/crates/persistence/src/sof/emit_mongo.rs
+++ b/crates/persistence/src/sof/emit_mongo.rs
@@ -1,0 +1,566 @@
+//! MongoDB aggregation-pipeline emitter for the SQL-on-FHIR compiler.
+//!
+//! Lowers the dialect-agnostic [`PlanNode`] IR (produced by
+//! [`build_plan`](super::compile_view::build_plan)) into a MongoDB aggregation
+//! pipeline (`Vec<bson::Document>`), the analogue of the SQL emitter in
+//! [`emit`](super::emit). Resources are stored as native BSON sub-documents
+//! under the `data` field, so a FHIR path `name.family` becomes navigation under
+//! `$data`.
+//!
+//! This is the **Stage 1** emitter: it covers the common path (scans, `forEach`
+//! unnests, projections, top-level `where`, and scalar expressions) and returns
+//! [`SofError::Uncompilable`] — surfaced by the handler as `422` — for
+//! constructs that need later stages (collections, `where()` chains, unions,
+//! `repeat:`, and the boundary functions).
+//!
+//! ## Root-alias mapping
+//!
+//! The IR addresses values through SQL-style roots: `r.data` (the scanned
+//! resource), `fe.value` / `fe2.value` (lateral-unnest iteration rows). Each
+//! maps to a MongoDB field: `r.data` → `data`; `feN.value` → a synthetic
+//! top-level field `__feN` that the emitter `$set`s to the unnest source and
+//! then `$unwind`s.
+
+use mongodb::bson::{Bson, Document, doc};
+
+use crate::core::sof_runner::SofError;
+
+use super::ir::{BinOp, JsonPath, LitValue, PathStep, PlanNode, SqlExpr, UnaryOp};
+
+/// Output of [`emit_mongo`]: a ready-to-run pipeline plus its output columns.
+pub struct EmittedMongo {
+    /// Aggregation stages. The leading `$match` constrains `resource_type` and
+    /// `is_deleted`; the runner prepends the tenant/`since` predicates.
+    pub pipeline: Vec<Document>,
+    /// Output column names, in `select` order.
+    pub columns: Vec<String>,
+}
+
+fn uncompilable(reason: impl Into<String>) -> SofError {
+    SofError::Uncompilable {
+        reason: reason.into(),
+    }
+}
+
+/// Lowers a plan tree into a MongoDB aggregation pipeline.
+///
+/// `constants` holds the resolved `ViewDefinition.constant[]` values; the
+/// emitter inlines them where the IR references `Param(n)` (n ≥ 3).
+pub fn emit_mongo(plan: &PlanNode, constants: &[LitValue]) -> Result<EmittedMongo, SofError> {
+    let PlanNode::Project { parent, columns } = plan else {
+        return Err(uncompilable(
+            "Mongo emitter expects a Project at the plan root (unions/recursion unsupported)",
+        ));
+    };
+
+    let mut pipeline = Vec::new();
+    lower_source(parent, &mut pipeline, constants)?;
+
+    // Final projection. Column names come verbatim from `column[].name`.
+    let mut project = doc! { "_id": 0i32 };
+    let mut names = Vec::with_capacity(columns.len());
+    for column in columns {
+        validate_column_name(&column.name)?;
+        if column.collection {
+            return Err(uncompilable(
+                "collection columns are not supported by the Mongo emitter (stage 1)",
+            ));
+        }
+        let expr = lower_expr(&column.expr, constants)?;
+        project.insert(column.name.clone(), expr);
+        names.push(column.name.clone());
+    }
+    pipeline.push(doc! { "$project": project });
+
+    Ok(EmittedMongo {
+        pipeline,
+        columns: names,
+    })
+}
+
+/// Walks the row-source chain (Scan → unnests/filters), appending pipeline
+/// stages parent-first so the scan `$match` lands first.
+fn lower_source(
+    plan: &PlanNode,
+    pipeline: &mut Vec<Document>,
+    constants: &[LitValue],
+) -> Result<(), SofError> {
+    match plan {
+        PlanNode::Scan { resource_type, .. } => {
+            pipeline.push(doc! {
+                "$match": { "resource_type": resource_type.clone(), "is_deleted": false }
+            });
+            Ok(())
+        }
+        PlanNode::LateralUnnest {
+            parent,
+            source,
+            out_alias,
+            left_join,
+            on_filter,
+            flat_index,
+        } => {
+            lower_source(parent, pipeline, constants)?;
+            if flat_index.is_some() {
+                return Err(uncompilable(
+                    "trailing-[N] forEach indexing is not supported by the Mongo emitter (stage 1)",
+                ));
+            }
+            if on_filter.is_some() {
+                return Err(uncompilable(
+                    "forEach with a trailing where() filter is not supported by the Mongo emitter (stage 1)",
+                ));
+            }
+            let base = unnest_base(out_alias);
+            let source_expr = lower_unnest_source(source)?;
+            pipeline.push(doc! { "$set": { &base: source_expr } });
+            pipeline.push(doc! {
+                "$unwind": { "path": format!("${base}"), "preserveNullAndEmptyArrays": *left_join }
+            });
+            Ok(())
+        }
+        PlanNode::Filter { parent, predicate } => {
+            lower_source(parent, pipeline, constants)?;
+            let pred = truthy(lower_expr(predicate, constants)?);
+            pipeline.push(doc! { "$match": { "$expr": pred } });
+            Ok(())
+        }
+        PlanNode::Project { .. } => Err(uncompilable(
+            "nested Project is not supported by the Mongo emitter",
+        )),
+        PlanNode::Union(_) => Err(uncompilable(
+            "unionAll is not supported by the Mongo emitter (stage 1)",
+        )),
+        PlanNode::Recurse { .. } => Err(uncompilable(
+            "repeat: is not supported by the Mongo emitter",
+        )),
+    }
+}
+
+/// Synthetic top-level field a `feN.value` iteration row is bound to.
+fn unnest_base(out_alias: &str) -> String {
+    format!("__{out_alias}")
+}
+
+/// Resolves an IR root alias to the MongoDB field it lives under.
+///
+/// `r.data` → `data`; `feN.value` → `__feN`. Anything else (e.g. a recursion
+/// node) is unsupported.
+fn root_base(root: &str) -> Result<String, SofError> {
+    if root == "r.data" {
+        return Ok("data".to_string());
+    }
+    if let Some(alias) = root.strip_suffix(".value")
+        && alias.starts_with("fe")
+    {
+        return Ok(unnest_base(alias));
+    }
+    Err(uncompilable(format!("unsupported value root '{root}'")))
+}
+
+/// `$<field>` reference for an IR root alias.
+fn root_ref(root: &str) -> Result<Bson, SofError> {
+    Ok(Bson::String(format!("${}", root_base(root)?)))
+}
+
+/// Lowers a `forEach` source path to the array expression to unwind.
+///
+/// Unlike column navigation this does NOT first-element-flatten: `forEach`
+/// iterates the whole collection. `build_plan` splits multi-segment paths into
+/// one unnest per field, so each source carries a single `Field`.
+fn lower_unnest_source(source: &SqlExpr) -> Result<Bson, SofError> {
+    let SqlExpr::JsonPath { root, path } = source else {
+        return Err(uncompilable("forEach source must be a JSON path"));
+    };
+    let mut acc = root_ref(root)?;
+    for step in &path.0 {
+        match step {
+            PathStep::Field(name) => {
+                acc = doc! { "$getField": { "field": name.clone(), "input": acc } }.into();
+            }
+            PathStep::Index(n) => {
+                acc = doc! { "$arrayElemAt": [acc, *n] }.into();
+            }
+            // Polymorphic type guards are collapsed during AST lowering; treat
+            // any residual as no-op navigation (matching the SQL emitter).
+            PathStep::OfType(_) | PathStep::TypeFilter(_) => {}
+        }
+    }
+    Ok(acc)
+}
+
+/// Lowers a JSON navigation used as a scalar column value, replicating the SQL
+/// emitter's first-element flattening: at each `Field` step, if the current
+/// focus is an array, descend into its first element before reading the field.
+fn lower_json_path(root: &str, path: &JsonPath, _constants: &[LitValue]) -> Result<Bson, SofError> {
+    let mut acc = root_ref(root)?;
+    for step in &path.0 {
+        match step {
+            PathStep::Field(name) => {
+                let flattened = doc! {
+                    "$cond": [
+                        doc! { "$isArray": acc.clone() },
+                        doc! { "$first": acc.clone() },
+                        acc,
+                    ]
+                };
+                acc = doc! { "$getField": { "field": name.clone(), "input": flattened } }.into();
+            }
+            PathStep::Index(n) => {
+                acc = doc! { "$arrayElemAt": [acc, *n] }.into();
+            }
+            PathStep::OfType(_) | PathStep::TypeFilter(_) => {}
+        }
+    }
+    Ok(acc)
+}
+
+/// Lowers a `LitValue` to a BSON literal value.
+fn lit_to_bson(v: &LitValue) -> Bson {
+    match v {
+        LitValue::Null => Bson::Null,
+        LitValue::Bool(b) => Bson::Boolean(*b),
+        LitValue::Int(i) => Bson::Int64(*i),
+        LitValue::Decimal(s) => s
+            .parse::<f64>()
+            .map(Bson::Double)
+            .unwrap_or_else(|_| Bson::String(s.clone())),
+        LitValue::Str(s) => Bson::String(s.clone()),
+    }
+}
+
+/// Wraps a value as a `$literal` so leading-`$` strings aren't read as field
+/// references.
+fn literal_expr(v: &LitValue) -> Bson {
+    doc! { "$literal": lit_to_bson(v) }.into()
+}
+
+/// Lowers an IR value expression to a MongoDB aggregation expression.
+fn lower_expr(expr: &SqlExpr, constants: &[LitValue]) -> Result<Bson, SofError> {
+    match expr {
+        SqlExpr::Lit(v) => Ok(literal_expr(v)),
+        SqlExpr::JsonPath { root, path } => lower_json_path(root, path, constants),
+        SqlExpr::Param(n) => {
+            // 1 = tenant_id, 2 = resource_type are scan predicates and never
+            // appear in value position. 3.. index the inlined constants.
+            if *n >= 3 {
+                constants
+                    .get(*n - 3)
+                    .map(literal_expr)
+                    .ok_or_else(|| uncompilable(format!("constant param ${n} out of range")))
+            } else {
+                Err(uncompilable(format!(
+                    "parameter ${n} is not valid in value position"
+                )))
+            }
+        }
+        SqlExpr::Alias { inner, .. } => lower_expr(inner, constants),
+        SqlExpr::AsJson(inner) => lower_expr(inner, constants),
+        SqlExpr::Cast { inner, .. } => {
+            // MongoDB is dynamically typed; stage 1 passes the value through.
+            lower_expr(inner, constants)
+        }
+        SqlExpr::BinOp { op, lhs, rhs } => lower_binop(*op, lhs, rhs, constants),
+        SqlExpr::UnaryOp { op, inner } => lower_unaryop(*op, inner, constants),
+        SqlExpr::Case { arms, else_ } => {
+            let mut branches = Vec::with_capacity(arms.len());
+            for (cond, val) in arms {
+                let case = truthy(lower_expr(cond, constants)?);
+                let then = lower_expr(val, constants)?;
+                branches.push(Bson::from(doc! { "case": case, "then": then }));
+            }
+            let default = match else_ {
+                Some(e) => lower_expr(e, constants)?,
+                None => Bson::Null,
+            };
+            Ok(doc! { "$switch": { "branches": branches, "default": default } }.into())
+        }
+        SqlExpr::Coalesce(parts) => {
+            let mut args = Vec::with_capacity(parts.len() + 1);
+            for p in parts {
+                args.push(lower_expr(p, constants)?);
+            }
+            args.push(Bson::Null);
+            Ok(doc! { "$ifNull": args }.into())
+        }
+        SqlExpr::NullIf(a, b) => {
+            let a = lower_expr(a, constants)?;
+            let b = lower_expr(b, constants)?;
+            Ok(doc! {
+                "$cond": [ doc! { "$eq": [a.clone(), b] }, Bson::Null, a ]
+            }
+            .into())
+        }
+        SqlExpr::ReferenceKey {
+            reference,
+            expected_type,
+        } => lower_reference_key(reference, expected_type.as_deref(), constants),
+        // Constructs reserved for later stages.
+        SqlExpr::ColRef(_)
+        | SqlExpr::JsonAgg(_)
+        | SqlExpr::Scalar(_)
+        | SqlExpr::Exists(_)
+        | SqlExpr::CountSub(_)
+        | SqlExpr::Boundary { .. }
+        | SqlExpr::WhereExists { .. }
+        | SqlExpr::WhereScalar { .. }
+        | SqlExpr::JoinAggregate { .. }
+        | SqlExpr::CollectionAgg { .. }
+        | SqlExpr::ScalarFromChain { .. } => Err(uncompilable(
+            "expression construct is not supported by the Mongo emitter (stage 1)",
+        )),
+    }
+}
+
+fn lower_binop(
+    op: BinOp,
+    lhs: &SqlExpr,
+    rhs: &SqlExpr,
+    constants: &[LitValue],
+) -> Result<Bson, SofError> {
+    // AND/OR coerce their operands to booleans; the rest operate on values.
+    if matches!(op, BinOp::And | BinOp::Or) {
+        let l = truthy(lower_expr(lhs, constants)?);
+        let r = truthy(lower_expr(rhs, constants)?);
+        let key = if op == BinOp::And { "$and" } else { "$or" };
+        return Ok(doc! { key: [l, r] }.into());
+    }
+
+    let l = lower_expr(lhs, constants)?;
+    let r = lower_expr(rhs, constants)?;
+    let key = match op {
+        BinOp::Eq => "$eq",
+        BinOp::Neq => "$ne",
+        BinOp::Lt => "$lt",
+        BinOp::Lte => "$lte",
+        BinOp::Gt => "$gt",
+        BinOp::Gte => "$gte",
+        BinOp::Add => "$add",
+        BinOp::Sub => "$subtract",
+        BinOp::Mul => "$multiply",
+        BinOp::Div => "$divide",
+        BinOp::Concat => "$concat",
+        BinOp::Like | BinOp::RegexMatch => {
+            return Err(uncompilable(
+                "LIKE/regex matching is not supported by the Mongo emitter (stage 1)",
+            ));
+        }
+        BinOp::And | BinOp::Or => unreachable!("handled above"),
+    };
+    Ok(doc! { key: [l, r] }.into())
+}
+
+fn lower_unaryop(op: UnaryOp, inner: &SqlExpr, constants: &[LitValue]) -> Result<Bson, SofError> {
+    let v = lower_expr(inner, constants)?;
+    let out = match op {
+        UnaryOp::Not => doc! { "$not": [ truthy(v) ] },
+        UnaryOp::IsNull => doc! { "$eq": [ doc! { "$ifNull": [v, Bson::Null] }, Bson::Null ] },
+        UnaryOp::IsNotNull => doc! { "$ne": [ doc! { "$ifNull": [v, Bson::Null] }, Bson::Null ] },
+        UnaryOp::Neg => doc! { "$multiply": [v, -1i64] },
+    };
+    Ok(out.into())
+}
+
+/// `getReferenceKey()` — the trailing id segment of `Reference.reference`, with
+/// an optional resource-type guard.
+fn lower_reference_key(
+    reference: &SqlExpr,
+    expected_type: Option<&str>,
+    constants: &[LitValue],
+) -> Result<Bson, SofError> {
+    let reference = lower_expr(reference, constants)?;
+    // Guard against null references (`$split` of null errors).
+    let last_segment = doc! {
+        "$cond": [
+            doc! { "$eq": [ doc! { "$ifNull": [reference.clone(), Bson::Null] }, Bson::Null ] },
+            Bson::Null,
+            doc! { "$arrayElemAt": [ doc! { "$split": [reference.clone(), "/"] }, -1i64 ] },
+        ]
+    };
+
+    match expected_type {
+        None => Ok(last_segment.into()),
+        Some(ty) => {
+            // Keep the key only when the reference points at `<ty>/...`.
+            let regex = format!("(^|/){ty}/");
+            Ok(doc! {
+                "$cond": [
+                    doc! { "$regexMatch": { "input": reference, "regex": regex } },
+                    last_segment,
+                    Bson::Null,
+                ]
+            }
+            .into())
+        }
+    }
+}
+
+/// FHIRPath/SoF truthiness for `$match`/`$expr` and boolean operands: a value
+/// is truthy iff it is non-null, non-`false`, non-zero, and non-empty-string.
+/// Mirrors the SQL `truthy_predicate` dialect helper.
+fn truthy(expr: Bson) -> Bson {
+    doc! {
+        "$and": [
+            doc! { "$ne": [ doc! { "$ifNull": [expr.clone(), Bson::Null] }, Bson::Null ] },
+            doc! { "$ne": [expr.clone(), false] },
+            doc! { "$ne": [expr.clone(), 0i64] },
+            doc! { "$ne": [expr, ""] },
+        ]
+    }
+    .into()
+}
+
+/// MongoDB forbids field names that are empty, start with `$`, or contain `.`.
+fn validate_column_name(name: &str) -> Result<(), SofError> {
+    if name.is_empty() || name.starts_with('$') || name.contains('.') {
+        return Err(uncompilable(format!(
+            "column name '{name}' is not a valid MongoDB projection key"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use helios_fhir::FhirVersion;
+    use serde_json::json;
+
+    use crate::core::sof_runner::SofError;
+    use crate::sof::compiler::compile_view_definition_mongo;
+
+    fn compile(view: serde_json::Value) -> Vec<mongodb::bson::Document> {
+        compile_view_definition_mongo(&view, FhirVersion::R4)
+            .expect("view should compile")
+            .pipeline
+    }
+
+    fn stage_op(stage: &mongodb::bson::Document) -> &str {
+        stage.keys().next().map(String::as_str).unwrap_or("")
+    }
+
+    #[test]
+    fn flat_column_scans_and_projects() {
+        let pipeline = compile(json!({
+            "resourceType": "ViewDefinition",
+            "resource": "Patient",
+            "select": [{ "column": [{ "name": "id", "path": "id" }] }],
+        }));
+
+        assert_eq!(pipeline.len(), 2, "expected [$match, $project]");
+
+        let match_doc = pipeline[0].get_document("$match").unwrap();
+        assert_eq!(match_doc.get_str("resource_type").unwrap(), "Patient");
+        assert!(!match_doc.get_bool("is_deleted").unwrap());
+
+        let project = pipeline[1].get_document("$project").unwrap();
+        assert_eq!(project.get_i32("_id").unwrap(), 0);
+        assert!(project.contains_key("id"), "id column must be projected");
+    }
+
+    #[test]
+    fn dotted_path_uses_first_element_flattening() {
+        let pipeline = compile(json!({
+            "resourceType": "ViewDefinition",
+            "resource": "Patient",
+            "select": [{ "column": [{ "name": "family", "path": "name.family" }] }],
+        }));
+        // The projected expression must navigate `family` off the FIRST element
+        // of the `name` array — i.e. contain a `$first`/`$isArray` guard.
+        let rendered = format!("{:?}", pipeline.last().unwrap());
+        assert!(
+            rendered.contains("$getField"),
+            "expected $getField navigation"
+        );
+        assert!(
+            rendered.contains("$first"),
+            "expected first-element flattening"
+        );
+        assert!(rendered.contains("$isArray"), "expected array guard");
+    }
+
+    #[test]
+    fn foreach_emits_set_and_unwind() {
+        let pipeline = compile(json!({
+            "resourceType": "ViewDefinition",
+            "resource": "Patient",
+            "select": [{ "forEach": "name", "column": [{ "name": "family", "path": "family" }] }],
+        }));
+        // [$match, $set(__fe), $unwind(__fe), $project]
+        assert_eq!(pipeline.len(), 4);
+        assert_eq!(stage_op(&pipeline[1]), "$set");
+        assert!(
+            pipeline[1]
+                .get_document("$set")
+                .unwrap()
+                .contains_key("__fe")
+        );
+
+        let unwind = pipeline[2].get_document("$unwind").unwrap();
+        assert_eq!(unwind.get_str("path").unwrap(), "$__fe");
+        assert!(!unwind.get_bool("preserveNullAndEmptyArrays").unwrap());
+    }
+
+    #[test]
+    fn foreach_or_null_preserves_empties() {
+        let pipeline = compile(json!({
+            "resourceType": "ViewDefinition",
+            "resource": "Patient",
+            "select": [{ "forEachOrNull": "name", "column": [{ "name": "family", "path": "family" }] }],
+        }));
+        let unwind = pipeline[2].get_document("$unwind").unwrap();
+        assert!(unwind.get_bool("preserveNullAndEmptyArrays").unwrap());
+    }
+
+    #[test]
+    fn low_boundary_is_uncompilable() {
+        let err = compile_view_definition_mongo(
+            &json!({
+                "resourceType": "ViewDefinition",
+                "resource": "Observation",
+                "select": [{ "column": [{
+                    "name": "low", "path": "value.ofType(Quantity).value.lowBoundary()"
+                }] }],
+            }),
+            FhirVersion::R4,
+        );
+        assert!(matches!(err, Err(SofError::Uncompilable { .. })));
+    }
+
+    #[test]
+    fn columns_match_sqlite_compilation() {
+        use crate::sof::compiler::{SqlDialect, compile_view_definition_dialect};
+
+        let view = json!({
+            "resourceType": "ViewDefinition",
+            "resource": "Patient",
+            "select": [{
+                "column": [
+                    { "name": "id", "path": "id" },
+                    { "name": "family", "path": "name.family" },
+                ]
+            }],
+        });
+
+        let mongo = compile_view_definition_mongo(&view, FhirVersion::R4).unwrap();
+        let sql =
+            compile_view_definition_dialect(&view, SqlDialect::Sqlite, FhirVersion::R4).unwrap();
+        // The output schema must not depend on the target backend.
+        assert_eq!(mongo.columns, sql.columns);
+        assert_eq!(mongo.columns, vec!["id".to_string(), "family".to_string()]);
+    }
+
+    #[test]
+    fn collection_column_is_uncompilable() {
+        let err = compile_view_definition_mongo(
+            &json!({
+                "resourceType": "ViewDefinition",
+                "resource": "Patient",
+                "select": [{ "column": [{
+                    "name": "given", "path": "name.given", "collection": true
+                }] }],
+            }),
+            FhirVersion::R4,
+        );
+        assert!(matches!(err, Err(SofError::Uncompilable { .. })));
+    }
+}

--- a/crates/persistence/src/sof/in_process.rs
+++ b/crates/persistence/src/sof/in_process.rs
@@ -1,0 +1,191 @@
+//! Generic in-process SQL-on-FHIR runner.
+//!
+//! Unlike the SQLite and PostgreSQL runners — which compile a ViewDefinition to
+//! native SQL and execute it inside the database — this runner streams the
+//! resources of the view's target type out of a backend and evaluates the
+//! ViewDefinition with the in-process `helios-sof` FHIRPath engine. It exists
+//! for backends that have no query engine to push the computation into (S3
+//! object storage, and S3-primary composites such as `s3-elasticsearch`).
+//!
+//! The heavy lifting is delegated to [`helios_sof::PreparedViewDefinition`],
+//! the same engine that serves inline `resource:` runs and the `sof-cli`/`sof-server`
+//! tools, so this runner introduces no new SQL-on-FHIR semantics. Resource
+//! access is abstracted behind [`ResourceScan`] so the runner is
+//! backend-agnostic.
+
+use async_trait::async_trait;
+use helios_fhir::FhirVersion;
+use helios_sof::{
+    PreparedViewDefinition, ResourceChunk, filter_resources_by_patient_and_group,
+    filter_resources_by_since, parse_view_definition_for_version,
+};
+use serde_json::{Map, Value};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::debug;
+
+use crate::core::sof_runner::{RowStream, SofError, SofRunner, ViewFilters, ViewRow};
+use crate::tenant::TenantContext;
+
+/// Channel buffer depth (rows that can be queued ahead of the consumer).
+const CHANNEL_BUFFER: usize = 256;
+
+/// Number of resources handed to the engine per [`PreparedViewDefinition::process_chunk`]
+/// call. Bounds peak memory when scanning large resource types.
+const CHUNK_SIZE: usize = 1024;
+
+/// Streams the live resources of a single resource type for a tenant.
+///
+/// Implemented by backends that lack an in-DB SOF runner so they can reuse
+/// [`InProcessSofRunner`]. Implementations must return the raw FHIR resource
+/// JSON (the `content()` of each stored resource), excluding soft-deleted ones.
+#[async_trait]
+pub trait ResourceScan: Send + Sync {
+    /// Returns every live resource of `resource_type` visible to `tenant` as
+    /// raw FHIR JSON.
+    async fn scan_resources(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+    ) -> Result<Vec<Value>, SofError>;
+}
+
+/// In-process SQL-on-FHIR runner backed by an arbitrary [`ResourceScan`].
+pub struct InProcessSofRunner {
+    scan: std::sync::Arc<dyn ResourceScan>,
+    fhir_version: FhirVersion,
+    runner_name: &'static str,
+}
+
+impl InProcessSofRunner {
+    /// Creates a runner that scans resources via `scan` and evaluates views
+    /// against `fhir_version`. `runner_name` is surfaced in logs/diagnostics
+    /// (e.g. `"s3-in-process"`).
+    pub fn new(
+        scan: std::sync::Arc<dyn ResourceScan>,
+        fhir_version: FhirVersion,
+        runner_name: &'static str,
+    ) -> Self {
+        Self {
+            scan,
+            fhir_version,
+            runner_name,
+        }
+    }
+}
+
+/// Maps a `helios_sof` engine error onto the persistence-layer [`SofError`].
+///
+/// Structural/validation problems and the spec's absent-target case become
+/// `InvalidViewDefinition` (surfaced as a 4xx); everything else is a runtime
+/// backend error.
+fn map_engine_error(e: helios_sof::SofError) -> SofError {
+    use helios_sof::SofError as E;
+    match e {
+        E::InvalidViewDefinition(m) => SofError::InvalidViewDefinition(m),
+        E::ReferencedResourceNotFound(m) => SofError::InvalidViewDefinition(m),
+        other => SofError::Backend(other.to_string()),
+    }
+}
+
+/// Zips one engine row (`columns` × `values`) into a flat JSON object, the
+/// same shape the SQL runners emit. Missing/`None` values become JSON `null`.
+fn row_to_view_row(columns: &[String], values: &[Option<Value>]) -> ViewRow {
+    let mut obj = Map::with_capacity(columns.len());
+    for (i, column) in columns.iter().enumerate() {
+        let value = values.get(i).and_then(|v| v.as_ref()).cloned();
+        obj.insert(column.clone(), value.unwrap_or(Value::Null));
+    }
+    Value::Object(obj)
+}
+
+#[async_trait]
+impl SofRunner for InProcessSofRunner {
+    fn runner_name(&self) -> &'static str {
+        self.runner_name
+    }
+
+    async fn run_view(
+        &self,
+        tenant: &TenantContext,
+        view_definition: Value,
+        filters: ViewFilters,
+    ) -> Result<RowStream, SofError> {
+        let view = parse_view_definition_for_version(view_definition, self.fhir_version)
+            .map_err(map_engine_error)?;
+        let prepared = PreparedViewDefinition::new(view).map_err(map_engine_error)?;
+        let resource_type = prepared.target_resource_type().to_string();
+
+        debug!(
+            runner = self.runner_name,
+            tenant = %tenant.tenant_id(),
+            resource_type = %resource_type,
+            "executing in-process ViewDefinition"
+        );
+
+        // Scan the view's target type, then apply the SoF run filters that the
+        // engine itself does not handle (patient/group compartment and `since`).
+        let mut resources = self.scan.scan_resources(tenant, &resource_type).await?;
+        if let Some(since) = filters.since {
+            resources = filter_resources_by_since(resources, since).map_err(map_engine_error)?;
+        }
+        if !filters.patient.is_empty() || !filters.group.is_empty() {
+            resources = filter_resources_by_patient_and_group(
+                resources,
+                &filters.patient,
+                &filters.group,
+                self.fhir_version,
+            )
+            .map_err(map_engine_error)?;
+        }
+
+        let limit = filters.limit;
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<ViewRow, SofError>>(CHANNEL_BUFFER);
+
+        // FHIRPath evaluation is CPU-bound (and `process_chunk` parallelises via
+        // rayon), so run it off the async runtime.
+        tokio::task::spawn_blocking(move || {
+            let columns = prepared.columns().to_vec();
+            let total = resources.len();
+            let mut emitted = 0usize;
+            let mut offset = 0usize;
+            let mut chunk_index = 0usize;
+
+            while offset < total {
+                let end = (offset + CHUNK_SIZE).min(total);
+                let chunk = ResourceChunk {
+                    resources: resources[offset..end].to_vec(),
+                    chunk_index,
+                    is_last: end >= total,
+                };
+                offset = end;
+                chunk_index += 1;
+
+                let result = match prepared.process_chunk(chunk) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = tx.blocking_send(Err(map_engine_error(e)));
+                        return;
+                    }
+                };
+
+                for row in &result.rows {
+                    if let Some(cap) = limit
+                        && emitted >= cap
+                    {
+                        return;
+                    }
+                    emitted += 1;
+                    let view_row = row_to_view_row(&columns, &row.values);
+                    if tx.blocking_send(Ok(view_row)).is_err() {
+                        // Receiver dropped (client disconnected) — stop.
+                        return;
+                    }
+                }
+            }
+
+            debug!(rows = emitted, "in-process view run complete");
+        });
+
+        Ok(Box::pin(ReceiverStream::new(rx)))
+    }
+}

--- a/crates/persistence/src/sof/mod.rs
+++ b/crates/persistence/src/sof/mod.rs
@@ -12,8 +12,12 @@
 //!    `compile_view_definition_dialect`, the entry point used by the runners.
 //!
 //! Backend runners:
-//! - [`sqlite`] — [`SqliteInDbRunner`] implementing [`SofRunner`] for SQLite.
-//! - [`postgres`] — [`PgInDbRunner`] implementing [`SofRunner`] for PostgreSQL.
+//! - [`sqlite`] — `SqliteInDbRunner` (SQL) for SQLite.
+//! - [`postgres`] — `PgInDbRunner` (SQL) for PostgreSQL.
+//! - [`mongodb`] — `MongoInDbRunner` (aggregation pipeline) for MongoDB.
+//! - [`in_process`] — `InProcessSofRunner`, a backend-agnostic runner that
+//!   evaluates the view with the `helios-sof` engine over scanned resources
+//!   (used by S3 / S3-primary composites, which have no query engine).
 //!
 //! Inline `resource:` parameters on `$viewdefinition-run` are handled by the
 //! REST layer via the in-process `helios-sof` FHIRPath evaluator, so this
@@ -24,6 +28,7 @@ pub mod compile_view;
 pub mod compiler;
 pub mod dialect;
 pub mod emit;
+pub mod in_process;
 pub mod ir;
 
 #[cfg(feature = "sqlite")]
@@ -34,6 +39,12 @@ pub mod sqlite_udfs;
 
 #[cfg(feature = "postgres")]
 pub mod postgres;
+
+#[cfg(feature = "mongodb")]
+pub mod emit_mongo;
+
+#[cfg(feature = "mongodb")]
+pub mod mongodb;
 
 use helios_fhir::FhirVersion;
 

--- a/crates/persistence/src/sof/mongodb.rs
+++ b/crates/persistence/src/sof/mongodb.rs
@@ -1,0 +1,169 @@
+//! MongoDB in-DB SQL-on-FHIR runner.
+//!
+//! [`MongoInDbRunner`] compiles a ViewDefinition to a MongoDB aggregation
+//! pipeline (via [`compile_view_definition_mongo`](super::compiler::compile_view_definition_mongo))
+//! and executes it directly against the `resources` collection, bypassing
+//! in-process FHIRPath evaluation. Resources are stored as native BSON
+//! sub-documents under `data`, so the emitted pipeline navigates them with
+//! `$getField`/dotted paths.
+//!
+//! The runtime filters that depend on the request (tenant, `_since`, row limit)
+//! are layered onto the compiled pipeline here: a leading `$match` constrains
+//! the tenant (and `last_updated` for `since`), and a trailing `$limit` caps the
+//! output.
+
+use std::sync::Arc;
+
+use mongodb::bson::{Bson, DateTime as BsonDateTime, Document, doc};
+use mongodb::{Client, Collection};
+use tokio::sync::OnceCell;
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::debug;
+
+use crate::backends::mongodb::backend::{MongoBackend, MongoBackendConfig, connect_client};
+use crate::core::sof_runner::{RowStream, SofError, SofRunner, ViewFilters, ViewRow};
+use crate::tenant::TenantContext;
+
+use super::compiler::compile_view_definition_mongo;
+
+/// Channel buffer depth (rows that can be queued ahead of the consumer).
+const CHANNEL_BUFFER: usize = 256;
+
+/// SQL-on-FHIR runner that compiles ViewDefinitions to MongoDB aggregation
+/// pipelines.
+pub struct MongoInDbRunner {
+    /// Shared (lazily initialised) client cell — the same pool the backend uses.
+    client: Arc<OnceCell<Client>>,
+    config: MongoBackendConfig,
+}
+
+impl MongoInDbRunner {
+    /// Creates a runner sharing the backend's client cell and configuration.
+    pub fn new(client: Arc<OnceCell<Client>>, config: MongoBackendConfig) -> Self {
+        Self { client, config }
+    }
+
+    /// Resolves the `resources` collection, initialising the shared client on
+    /// first use.
+    async fn resources(&self) -> Result<Collection<Document>, SofError> {
+        let client = self
+            .client
+            .get_or_try_init(|| connect_client(&self.config))
+            .await
+            .map_err(|e| SofError::Storage(e.to_string()))?;
+        Ok(client
+            .database(&self.config.database_name)
+            .collection(MongoBackend::RESOURCES_COLLECTION))
+    }
+}
+
+#[async_trait::async_trait]
+impl SofRunner for MongoInDbRunner {
+    fn runner_name(&self) -> &'static str {
+        "mongo-indb"
+    }
+
+    async fn run_view(
+        &self,
+        tenant: &TenantContext,
+        view_definition: serde_json::Value,
+        filters: ViewFilters,
+    ) -> Result<RowStream, SofError> {
+        if !filters.patient.is_empty() || !filters.group.is_empty() {
+            // Compartment filtering for the Mongo runner lands in a later stage.
+            return Err(SofError::Uncompilable {
+                reason: "patient/group filters are not yet supported by the MongoDB runner"
+                    .to_string(),
+            });
+        }
+
+        let compiled = compile_view_definition_mongo(&view_definition, self.config.fhir_version)?;
+
+        debug!(
+            runner = "mongo-indb",
+            tenant = %tenant.tenant_id(),
+            "executing compiled ViewDefinition"
+        );
+
+        // Leading tenant (and optional `since`) predicate, prepended to the
+        // compiled pipeline. Kept first so the `tenant_id + resource_type +
+        // is_deleted` index can serve the scan.
+        let mut tenant_match = doc! { "tenant_id": tenant.tenant_id().to_string() };
+        if let Some(since) = filters.since {
+            tenant_match.insert(
+                "last_updated",
+                doc! { "$gte": BsonDateTime::from_millis(since.timestamp_millis()) },
+            );
+        }
+
+        let mut pipeline: Vec<Document> = Vec::with_capacity(compiled.pipeline.len() + 2);
+        pipeline.push(doc! { "$match": tenant_match });
+        pipeline.extend(compiled.pipeline);
+        if let Some(limit) = filters.limit {
+            pipeline.push(doc! { "$limit": limit as i64 });
+        }
+
+        let collection = self.resources().await?;
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<ViewRow, SofError>>(CHANNEL_BUFFER);
+
+        tokio::spawn(async move {
+            let mut cursor = match collection.aggregate(pipeline).await {
+                Ok(c) => c,
+                Err(e) => {
+                    let _ = tx
+                        .send(Err(SofError::Backend(format!("aggregate failed: {e}"))))
+                        .await;
+                    return;
+                }
+            };
+
+            let mut count = 0usize;
+            loop {
+                match cursor.advance().await {
+                    Ok(true) => {}
+                    Ok(false) => break,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(SofError::Backend(format!("cursor advance: {e}"))))
+                            .await;
+                        return;
+                    }
+                }
+
+                let doc = match cursor.deserialize_current() {
+                    Ok(d) => d,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(SofError::Backend(format!("cursor deserialize: {e}"))))
+                            .await;
+                        return;
+                    }
+                };
+
+                let row = match mongodb::bson::from_bson::<ViewRow>(Bson::Document(doc)) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(SofError::Backend(format!("row decode: {e}"))))
+                            .await;
+                        return;
+                    }
+                };
+
+                count += 1;
+                if tx.send(Ok(row)).await.is_err() {
+                    // Receiver dropped (client disconnected) — stop iterating.
+                    return;
+                }
+            }
+
+            debug!(
+                runner = "mongo-indb",
+                rows = count,
+                "in-DB view run complete"
+            );
+        });
+
+        Ok(Box::pin(ReceiverStream::new(rx)))
+    }
+}


### PR DESCRIPTION
## Problem

`HFS_SOF_ENABLED` defaults to `true`, so the server **panics at startup** (`crates/rest/src/lib.rs:497`) for any storage backend whose `sof_runner()` returns `None`. This broke the `mongodb`, `sqlite-elasticsearch`, and `s3-elasticsearch` Inferno US Core CI jobs (only SQLite and PostgreSQL had runners). Originally surfaced via [run 27504246077](https://github.com/HeliosSoftware/hfs/actions/runs/27504246077/job/81294159041).

## Approach

Give every backend a SOF runner.

- **Composite** (`composite/storage.rs`): `sof_runner()` delegates to the primary backend, so `sqlite-elasticsearch` (SQLite primary) and `s3-elasticsearch` (S3 primary) expose their primary's runner automatically.
- **S3 / in-process** (`sof/in_process.rs`): new `InProcessSofRunner` + backend-agnostic `ResourceScan` trait that reuse the 125/125-conformant `helios-sof` `PreparedViewDefinition` engine over scanned resources. `S3Backend::scan_live_resources` feeds it. For backends with no query engine to push computation into.
- **MongoDB / native** (`sof/emit_mongo.rs`, `sof/mongodb.rs`, compiler seam): compile the ViewDefinition to a MongoDB **aggregation pipeline** executed in-DB. Resources are stored as native BSON under `data`, so `name.family` → `$data.name.family`. New `CompileTarget` seam (`CompiledView`/`CompiledPipeline` + `compile_view_definition_mongo`); `build_plan` threads `CompileTarget` so trailing-`[N]` forEach uses `flat_index` instead of the SQLite-only `ScalarFromChain` — **SQL output is byte-for-byte unchanged**. `MongoInDbRunner` shares the backend's pooled client via a shared `Arc<OnceCell<Client>>` + standalone `connect_client`.

## Emitter staging

**Stage 1 (this PR)** covers scans (`$match`), `forEach`/`forEachOrNull` (`$unwind`), projections (`$project`), top-level `where`, and common scalar expressions (with JSON first-element flattening via `$cond[$isArray→$first]`, inlined constants, `getReferenceKey`). Collections, `where()`-chains, unions, `repeat:`, regex, and the boundary functions return `Uncompilable` (→ HTTP 422) for later stages. US Core CI never calls `$viewdefinition-run`, so the runners only need to exist at startup to clear the panic.

## Verification

- Builds: default, `s3`, `mongodb`, all-backends, `--no-default-features --features sqlite,R4` (cfg-leak guard), and the `hfs` binary with all backends.
- Tests: **37 sof lib** (incl. unchanged SQL golden tests + 7 new Mongo emitter/parity tests) and **23 s3 lib** — all green.
- Clippy clean on all new/changed files.

## Follow-ups (not in this PR)

- Emitter Stages 2–4 (regex → collections/unions/where-chains/compartment `$match` → `repeat:`); boundary functions stay `Uncompilable` on Mongo by design.
- Testcontainer integration test comparing Mongo pipeline rows against the SQLite runner.