### PR TITLE
feat(fhirpath): implement resolve() and fix resource visibility in lambdas

### DIFF
--- a/crates/fhirpath/README.md
+++ b/crates/fhirpath/README.md
@@ -458,7 +458,7 @@ These functions extend the base FHIRPath specification with FHIR-specific capabi
     *   [extension()](https://build.fhir.org/fhirpath.html#functions): ✅ (Full support with variable URL resolution)
     *   [hasValue()](https://build.fhir.org/fhirpath.html#functions): ✅ (Tests if primitive has actual value beyond extensions)
     *   [getValue()](https://build.fhir.org/fhirpath.html#functions): ❌ Not Implemented
-    *   [resolve()](https://build.fhir.org/fhirpath.html#functions): ✅ (In-scope resolution: contained resources and resources in the evaluation context; returns a typed stub for unresolved `Type/id` references. No external/DB resolution.)
+    *   [resolve()](https://build.fhir.org/fhirpath.html#functions): ✅ (In-scope resolution: contained resources and resources in the evaluation context; returns a typed stub for unresolved `Type/id` references. No external/DB resolution — see [#167](https://github.com/HeliosSoftware/hfs/issues/167) for the storage-backed resolver follow-up.)
     *   [ofType()](https://build.fhir.org/fhirpath.html#functions): ✅ (Full FHIR type support)
     *   [elementDefinition()](https://build.fhir.org/fhirpath.html#functions): ❌ Not Implemented
     *   [slice()](https://build.fhir.org/fhirpath.html#functions): ❌ Not Implemented

--- a/crates/fhirpath/README.md
+++ b/crates/fhirpath/README.md
@@ -458,7 +458,7 @@ These functions extend the base FHIRPath specification with FHIR-specific capabi
     *   [extension()](https://build.fhir.org/fhirpath.html#functions): ✅ (Full support with variable URL resolution)
     *   [hasValue()](https://build.fhir.org/fhirpath.html#functions): ✅ (Tests if primitive has actual value beyond extensions)
     *   [getValue()](https://build.fhir.org/fhirpath.html#functions): ❌ Not Implemented
-    *   [resolve()](https://build.fhir.org/fhirpath.html#functions): ❌ Not Implemented (Requires resource resolver integration)
+    *   [resolve()](https://build.fhir.org/fhirpath.html#functions): ✅ (In-scope resolution: contained resources and resources in the evaluation context; returns a typed stub for unresolved `Type/id` references. No external/DB resolution.)
     *   [ofType()](https://build.fhir.org/fhirpath.html#functions): ✅ (Full FHIR type support)
     *   [elementDefinition()](https://build.fhir.org/fhirpath.html#functions): ❌ Not Implemented
     *   [slice()](https://build.fhir.org/fhirpath.html#functions): ❌ Not Implemented

--- a/crates/fhirpath/src/evaluator.rs
+++ b/crates/fhirpath/src/evaluator.rs
@@ -117,7 +117,11 @@ use std::sync::Arc;
 /// ```
 pub struct EvaluationContext {
     /// The FHIR resources being evaluated (available for context access)
-    pub resources: Vec<FhirResource>,
+    /// Shared via `Arc` so resources survive context cloning (`FhirResource` is
+    /// not `Clone`, but `Arc` clones cheaply by ref-count). This lets lambda
+    /// scopes (`where()`, `select()`, …), which run in child contexts, still see
+    /// the root resources for `%context`, `%resource`, and `resolve()`.
+    pub resources: Arc<Vec<FhirResource>>,
 
     /// The FHIR version being used for type checking and resource validation
     pub fhir_version: FhirVersion,
@@ -167,9 +171,9 @@ pub struct EvaluationContext {
 impl Clone for EvaluationContext {
     fn clone(&self) -> Self {
         EvaluationContext {
-            // Resources cannot be cloned, so child contexts start with empty resources
-            // This is a limitation but doesn't affect typical usage patterns
-            resources: Vec::new(),
+            // Resources are shared via Arc, so clones (and the child/parent chain)
+            // keep visibility of the root resources.
+            resources: self.resources.clone(),
             fhir_version: self.fhir_version,
             variables: self.variables.clone(),
             this: self.this.clone(),
@@ -233,7 +237,7 @@ impl EvaluationContext {
         let this = resources.first().map(convert_resource_to_result);
 
         Self {
-            resources,
+            resources: Arc::new(resources),
             fhir_version,
             variables: HashMap::new(),
             this,
@@ -266,7 +270,7 @@ impl EvaluationContext {
         let this = resources.first().map(convert_resource_to_result);
 
         Self {
-            resources,
+            resources: Arc::new(resources),
             fhir_version,
             variables: HashMap::new(),
             this,
@@ -296,7 +300,7 @@ impl EvaluationContext {
     /// A new empty `EvaluationContext` instance
     pub fn new_empty(fhir_version: FhirVersion) -> Self {
         Self {
-            resources: Vec::new(),
+            resources: Arc::new(Vec::new()),
             fhir_version,
             variables: HashMap::new(),
             this: None,
@@ -409,7 +413,12 @@ impl EvaluationContext {
     ///
     /// * `resource` - The FHIR resource to add to the context
     pub fn add_resource(&mut self, resource: FhirResource) {
-        self.resources.push(resource);
+        // Resources are shared via Arc and FhirResource is not Clone, so we can't
+        // copy-on-write. Require sole ownership — true for all call sites, which
+        // add resources at setup time before any context cloning occurs.
+        Arc::get_mut(&mut self.resources)
+            .expect("add_resource requires sole ownership of the resources Arc (call before cloning)")
+            .push(resource);
     }
 
     /// Sets a variable in the context to a string value
@@ -506,14 +515,12 @@ impl EvaluationContext {
     ///
     /// A new `EvaluationContext` with this context as its parent
     pub fn create_child_context(&self) -> EvaluationContext {
-        // Resources are not cloned in parent context to avoid Clone requirement
-        // Child context will maintain its own reference to resources
-        // This is a limitation of the current architecture but doesn't affect
-        // functionality since resources are typically only accessed from the
-        // active context, not parent contexts
+        // Resources are shared via Arc so the child (used for lambda bodies like
+        // where()/select()) still sees the root resources — needed for %context,
+        // %resource, and resolve() inside lambdas.
 
         EvaluationContext {
-            resources: Vec::new(), // Child starts with empty resources
+            resources: self.resources.clone(), // Cheap Arc clone — shares root resources
             fhir_version: self.fhir_version,
             variables: HashMap::new(), // Start with empty variables in child
             this: self.this.clone(),
@@ -1547,8 +1554,13 @@ fn evaluate_term(
             // Handle variables (%var, %context) next and return
             if let Invocation::Member(name) = invocation {
                 if let Some(var_name) = name.strip_prefix('%') {
-                    if var_name == "context" {
-                        // Return %context value
+                    if var_name == "context"
+                        || var_name == "resource"
+                        || var_name == "rootResource"
+                    {
+                        // Return %context / %resource / %rootResource value. In this
+                        // engine all three resolve to the resource(s) in scope: the
+                        // root resource being evaluated.
                         // Correctly wrap the entire conditional result in Ok()
                         return Ok(if context.resources.is_empty() {
                             EvaluationResult::Empty
@@ -1663,8 +1675,9 @@ fn evaluate_term(
         Term::Literal(literal) => Ok(evaluate_literal(literal)), // Wrap in Ok
         Term::ExternalConstant(name) => {
             // Look up external constant in the context
-            // Special handling for %context
-            if name == "context" {
+            // Special handling for %context / %resource / %rootResource — all
+            // resolve to the resource(s) currently in scope.
+            if name == "context" || name == "resource" || name == "rootResource" {
                 Ok(if context.resources.is_empty() {
                     EvaluationResult::Empty
                 } else if context.resources.len() == 1 {
@@ -1853,7 +1866,15 @@ fn evaluate_invocation_with_context(
                     };
 
                     // Check if trying to override system variables
-                    let system_vars = ["%context", "%ucum", "%sct", "%loinc", "%vs"];
+                    let system_vars = [
+                        "%context",
+                        "%resource",
+                        "%rootResource",
+                        "%ucum",
+                        "%sct",
+                        "%loinc",
+                        "%vs",
+                    ];
                     if system_vars.contains(&var_name.as_str()) {
                         return Err(EvaluationError::SemanticError(format!(
                             "Cannot override system variable '{}'",
@@ -2534,7 +2555,15 @@ fn evaluate_invocation(
                     };
 
                     // Check if trying to override system variables
-                    let system_vars = ["%context", "%ucum", "%sct", "%loinc", "%vs"];
+                    let system_vars = [
+                        "%context",
+                        "%resource",
+                        "%rootResource",
+                        "%ucum",
+                        "%sct",
+                        "%loinc",
+                        "%vs",
+                    ];
                     if system_vars.contains(&var_name.as_str()) {
                         return Err(EvaluationError::SemanticError(format!(
                             "Cannot override system variable '{}'",
@@ -6286,6 +6315,16 @@ fn call_function(
             // Delegate to the reference key functions module
             crate::reference_key_functions::get_reference_key_function(invocation_base, args)
         }
+        "resolve" => {
+            // Dereference a Reference (or reference string) to the resource it points
+            // to, searching resources in scope (context + contained).
+            if !args.is_empty() {
+                return Err(EvaluationError::InvalidArity(
+                    "Function 'resolve' expects 0 arguments".to_string(),
+                ));
+            }
+            crate::resolve_function::resolve_function(invocation_base, context)
+        }
         "hasValue" => {
             // hasValue() returns true if the element is a primitive with an actual value
             // Returns false if element is empty or is a primitive with extensions but no value
@@ -6529,6 +6568,7 @@ fn call_function(
                 "highBoundary",
                 "getResourceKey",
                 "getReferenceKey",
+                "resolve",
                 "sum",
                 "min",
                 "max",

--- a/crates/fhirpath/src/evaluator.rs
+++ b/crates/fhirpath/src/evaluator.rs
@@ -417,7 +417,9 @@ impl EvaluationContext {
         // copy-on-write. Require sole ownership — true for all call sites, which
         // add resources at setup time before any context cloning occurs.
         Arc::get_mut(&mut self.resources)
-            .expect("add_resource requires sole ownership of the resources Arc (call before cloning)")
+            .expect(
+                "add_resource requires sole ownership of the resources Arc (call before cloning)",
+            )
             .push(resource);
     }
 
@@ -1554,9 +1556,7 @@ fn evaluate_term(
             // Handle variables (%var, %context) next and return
             if let Invocation::Member(name) = invocation {
                 if let Some(var_name) = name.strip_prefix('%') {
-                    if var_name == "context"
-                        || var_name == "resource"
-                        || var_name == "rootResource"
+                    if var_name == "context" || var_name == "resource" || var_name == "rootResource"
                     {
                         // Return %context / %resource / %rootResource value. In this
                         // engine all three resolve to the resource(s) in scope: the

--- a/crates/fhirpath/src/lib.rs
+++ b/crates/fhirpath/src/lib.rs
@@ -287,6 +287,7 @@ mod polymorphic_access;
 mod reference_key_functions;
 mod repeat_all_function;
 mod repeat_function;
+mod resolve_function;
 mod resource_type;
 mod set_operations;
 mod subset_functions;

--- a/crates/fhirpath/src/resolve_function.rs
+++ b/crates/fhirpath/src/resolve_function.rs
@@ -321,7 +321,10 @@ mod tests {
         let resolved = resolve_one(&reference("1"), &candidates);
         match resolved {
             EvaluationResult::Object { map, .. } => {
-                assert_eq!(string_field(&map, "resourceType").as_deref(), Some("Organization"));
+                assert_eq!(
+                    string_field(&map, "resourceType").as_deref(),
+                    Some("Organization")
+                );
                 assert_eq!(string_field(&map, "id").as_deref(), Some("1"));
             }
             other => panic!("expected Organization object, got {other:?}"),
@@ -335,7 +338,10 @@ mod tests {
             ("id", string("p")),
             (
                 "contained",
-                obj(&[("resourceType", string("Practitioner")), ("id", string("pr1"))]),
+                obj(&[
+                    ("resourceType", string("Practitioner")),
+                    ("id", string("pr1")),
+                ]),
             ),
         ]);
         let candidates = pool(&[patient]);
@@ -379,8 +385,14 @@ mod tests {
         let resolved = resolve_one(&reference("Observation/missing"), &candidates);
         match &resolved {
             EvaluationResult::Object { map, type_info } => {
-                assert_eq!(string_field(map, "resourceType").as_deref(), Some("Observation"));
-                assert_eq!(type_info.as_ref().map(|t| t.name.as_str()), Some("Observation"));
+                assert_eq!(
+                    string_field(map, "resourceType").as_deref(),
+                    Some("Observation")
+                );
+                assert_eq!(
+                    type_info.as_ref().map(|t| t.name.as_str()),
+                    Some("Observation")
+                );
             }
             other => panic!("expected typed stub, got {other:?}"),
         }
@@ -405,8 +417,14 @@ mod tests {
                 "contained",
                 EvaluationResult::Collection {
                     items: vec![
-                        obj(&[("resourceType", string("Organization")), ("id", string("1"))]),
-                        obj(&[("resourceType", string("Organization")), ("id", string("2"))]),
+                        obj(&[
+                            ("resourceType", string("Organization")),
+                            ("id", string("1")),
+                        ]),
+                        obj(&[
+                            ("resourceType", string("Organization")),
+                            ("id", string("2")),
+                        ]),
                     ],
                     has_undefined_order: false,
                     type_info: None,
@@ -420,7 +438,10 @@ mod tests {
             .map(|r| resolve_one(r, &candidates))
             .collect();
         assert_eq!(out.len(), 2);
-        assert!(out.iter().all(|r| matches!(r, EvaluationResult::Object { .. })));
+        assert!(
+            out.iter()
+                .all(|r| matches!(r, EvaluationResult::Object { .. }))
+        );
         assert_eq!(
             out.iter()
                 .filter_map(|r| match r {

--- a/crates/fhirpath/src/resolve_function.rs
+++ b/crates/fhirpath/src/resolve_function.rs
@@ -1,0 +1,434 @@
+//! # FHIRPath `resolve()` Function
+//!
+//! Implements the FHIR-flavored FHIRPath `resolve()` function, which dereferences
+//! a `Reference` (or a reference/canonical string) to the resource it points to.
+//!
+//! Resolution is **in-scope only** — it searches resources already available to the
+//! evaluation context, with no external/database I/O:
+//!
+//! 1. `contained` resources of the resources in [`EvaluationContext::resources`]
+//!    (matched by fragment `#id` or bare `id`).
+//! 2. The context resources themselves and their contained resources, matched by
+//!    `ResourceType/id` (relative) or by the trailing `Type/id` of an absolute URL.
+//!
+//! When a `Type/id`-shaped (or absolute-URL-with-`Type/id`) reference cannot be
+//! resolved, a *typed stub* object `{ resourceType: Type }` is returned so that
+//! type filters such as `resolve() is Observation` still behave correctly. Bare or
+//! fragment references that cannot be resolved produce [`EvaluationResult::Empty`].
+
+use crate::evaluator::EvaluationContext;
+use helios_fhirpath_support::{
+    EvaluationError, EvaluationResult, IntoEvaluationResult, TypeInfoResult,
+};
+use std::collections::HashMap;
+
+/// Implementation of the FHIRPath `resolve()` function.
+///
+/// Operates on the invocation base, which may be a single `Reference`/string or a
+/// collection of them. Each item is resolved independently and the results are
+/// flattened, mirroring FHIRPath collection semantics.
+pub fn resolve_function(
+    invocation_base: &EvaluationResult,
+    context: &EvaluationContext,
+) -> Result<EvaluationResult, EvaluationError> {
+    // Build the candidate pool once and reuse it for every reference being resolved.
+    let candidates = build_candidate_pool(context);
+
+    match invocation_base {
+        EvaluationResult::Empty => Ok(EvaluationResult::Empty),
+        EvaluationResult::Collection { items, .. } => {
+            let mut resolved = Vec::new();
+            for item in items {
+                match resolve_one(item, &candidates) {
+                    EvaluationResult::Empty => {}
+                    other => resolved.push(other),
+                }
+            }
+            match resolved.len() {
+                0 => Ok(EvaluationResult::Empty),
+                1 => Ok(resolved.into_iter().next().unwrap()),
+                _ => Ok(EvaluationResult::Collection {
+                    items: resolved,
+                    has_undefined_order: false,
+                    type_info: None,
+                }),
+            }
+        }
+        single => Ok(resolve_one(single, &candidates)),
+    }
+}
+
+/// A single candidate resource available for resolution.
+struct Candidate {
+    resource_type: Option<String>,
+    id: Option<String>,
+    /// Whether this candidate came from a `contained` array (eligible for
+    /// fragment / bare-id matching).
+    is_contained: bool,
+    value: EvaluationResult,
+}
+
+/// Flattens the context resources and their `contained` children into a pool of
+/// candidates that can be matched against a reference.
+///
+/// `context.resources` is shared via `Arc` and survives cloning, so lambda bodies
+/// (`where()`, `select()`, …) — which run in child contexts — still see the root
+/// resources here. Without that sharing, `reference.where(resolve() is X)` would
+/// resolve to nothing.
+fn build_candidate_pool(context: &EvaluationContext) -> Vec<Candidate> {
+    let mut candidates = Vec::new();
+    for resource in context.resources.iter() {
+        let result = resource.to_evaluation_result();
+        collect_candidates(&result, false, &mut candidates);
+    }
+    candidates
+}
+
+/// Adds `value` (if it is a resource object) and its `contained` children to the pool.
+fn collect_candidates(value: &EvaluationResult, is_contained: bool, out: &mut Vec<Candidate>) {
+    if let EvaluationResult::Object { map, .. } = value {
+        let resource_type = string_field(map, "resourceType");
+        let id = string_field(map, "id");
+        // Only treat objects that look like resources (have a resourceType) as candidates.
+        if resource_type.is_some() {
+            out.push(Candidate {
+                resource_type: resource_type.clone(),
+                id: id.clone(),
+                is_contained,
+                value: value.clone(),
+            });
+        }
+
+        // Recurse into contained resources (one level is all FHIR allows, but
+        // iterating defensively is cheap).
+        if let Some(contained) = map.get("contained") {
+            match contained {
+                EvaluationResult::Collection { items, .. } => {
+                    for item in items {
+                        collect_candidates(item, true, out);
+                    }
+                }
+                obj @ EvaluationResult::Object { .. } => {
+                    collect_candidates(obj, true, out);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Resolves a single reference item against the candidate pool.
+fn resolve_one(item: &EvaluationResult, candidates: &[Candidate]) -> EvaluationResult {
+    let Some(reference) = extract_reference_string(item) else {
+        return EvaluationResult::Empty;
+    };
+
+    let parsed = ParsedReference::parse(&reference);
+
+    if let Some(found) = parsed.find(candidates) {
+        return found.clone();
+    }
+
+    // Unresolved fallback: a typed stub for Type/id-shaped references so that
+    // `resolve() is Type` continues to work.
+    if let Some(resource_type) = parsed.target_type() {
+        return typed_stub(resource_type);
+    }
+
+    EvaluationResult::Empty
+}
+
+/// Extracts the reference string from a `Reference` object (its `reference` field)
+/// or from a bare string (canonical / already-a-reference-string).
+fn extract_reference_string(item: &EvaluationResult) -> Option<String> {
+    match item {
+        EvaluationResult::String(s, _, _) => Some(s.clone()),
+        EvaluationResult::Object { map, .. } => match map.get("reference") {
+            Some(EvaluationResult::String(s, _, _)) => Some(s.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// A parsed FHIR reference, classified by form.
+enum ParsedReference {
+    /// `#id` fragment or bare `id` (no slash) — resolves only against contained resources.
+    Fragment(String),
+    /// `ResourceType/id` (relative) or an absolute URL whose tail is `Type/id`.
+    Typed { resource_type: String, id: String },
+    /// Anything else we can't classify (e.g. a `urn:uuid:` with no type) — best-effort
+    /// match by trailing id only.
+    Other(String),
+}
+
+impl ParsedReference {
+    fn parse(reference: &str) -> ParsedReference {
+        if let Some(fragment) = reference.strip_prefix('#') {
+            return ParsedReference::Fragment(fragment.to_string());
+        }
+
+        // Find the last `Type/id` pair. For absolute URLs this naturally takes the
+        // final two path segments (e.g. ".../Patient/123").
+        if let Some((resource_type, id)) = split_type_id(reference) {
+            return ParsedReference::Typed { resource_type, id };
+        }
+
+        // No slash at all → a bare local id (contained reference, as in the FHIR
+        // patient-container example where `reference` is just "1").
+        if !reference.contains('/') {
+            return ParsedReference::Fragment(reference.to_string());
+        }
+
+        ParsedReference::Other(reference.to_string())
+    }
+
+    /// The resource type implied by this reference, if any (used for the typed stub).
+    fn target_type(&self) -> Option<&str> {
+        match self {
+            ParsedReference::Typed { resource_type, .. } => Some(resource_type),
+            _ => None,
+        }
+    }
+
+    /// Finds the matching candidate, if any.
+    fn find<'a>(&self, candidates: &'a [Candidate]) -> Option<&'a EvaluationResult> {
+        match self {
+            ParsedReference::Fragment(id) => candidates
+                .iter()
+                .find(|c| c.is_contained && c.id.as_deref() == Some(id.as_str()))
+                .map(|c| &c.value),
+            ParsedReference::Typed { resource_type, id } => candidates
+                .iter()
+                .find(|c| {
+                    c.resource_type.as_deref() == Some(resource_type.as_str())
+                        && c.id.as_deref() == Some(id.as_str())
+                })
+                .map(|c| &c.value),
+            ParsedReference::Other(reference) => {
+                // Best-effort: match a candidate whose id is the trailing segment.
+                let tail = reference.rsplit('/').next().unwrap_or(reference);
+                candidates
+                    .iter()
+                    .find(|c| c.id.as_deref() == Some(tail))
+                    .map(|c| &c.value)
+            }
+        }
+    }
+}
+
+/// Splits a `ResourceType/id` reference (taking the final two segments of a path)
+/// into `(ResourceType, id)`. Returns `None` unless the type segment looks like a
+/// FHIR resource type (starts uppercase).
+fn split_type_id(reference: &str) -> Option<(String, String)> {
+    let mut segments = reference.rsplitn(3, '/');
+    let id = segments.next()?;
+    let resource_type = segments.next()?;
+    if id.is_empty() || resource_type.is_empty() {
+        return None;
+    }
+    // A FHIR resource type is a capitalized token without scheme separators.
+    if !resource_type
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_uppercase())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    Some((resource_type.to_string(), id.to_string()))
+}
+
+/// Builds a typed stub object `{ resourceType: Type }` carrying FHIR type info so
+/// that `resolve() is Type` matches.
+fn typed_stub(resource_type: &str) -> EvaluationResult {
+    let mut map = HashMap::new();
+    map.insert(
+        "resourceType".to_string(),
+        EvaluationResult::String(resource_type.to_string(), None, None),
+    );
+    EvaluationResult::Object {
+        map,
+        type_info: Some(TypeInfoResult::new("FHIR", resource_type)),
+    }
+}
+
+/// Reads a string field from an object map.
+fn string_field(map: &HashMap<String, EvaluationResult>, key: &str) -> Option<String> {
+    match map.get(key) {
+        Some(EvaluationResult::String(s, _, _)) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn string(s: &str) -> EvaluationResult {
+        EvaluationResult::String(s.to_string(), None, None)
+    }
+
+    fn reference(r: &str) -> EvaluationResult {
+        let mut map = HashMap::new();
+        map.insert("reference".to_string(), string(r));
+        EvaluationResult::Object {
+            map,
+            type_info: None,
+        }
+    }
+
+    fn obj(pairs: &[(&str, EvaluationResult)]) -> EvaluationResult {
+        let map = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect();
+        EvaluationResult::Object {
+            map,
+            type_info: None,
+        }
+    }
+
+    /// Builds a candidate pool directly from EvaluationResult objects (bypassing
+    /// FhirResource conversion) so the matching logic can be unit-tested in isolation.
+    fn pool(roots: &[EvaluationResult]) -> Vec<Candidate> {
+        let mut out = Vec::new();
+        for root in roots {
+            collect_candidates(root, false, &mut out);
+        }
+        out
+    }
+
+    #[test]
+    fn resolves_bare_id_against_contained() {
+        // Patient with a contained Organization/1, referenced by bare "1".
+        let patient = obj(&[
+            ("resourceType", string("Patient")),
+            ("id", string("example-container")),
+            (
+                "contained",
+                EvaluationResult::Collection {
+                    items: vec![obj(&[
+                        ("resourceType", string("Organization")),
+                        ("id", string("1")),
+                    ])],
+                    has_undefined_order: false,
+                    type_info: None,
+                },
+            ),
+        ]);
+        let candidates = pool(&[patient]);
+        let resolved = resolve_one(&reference("1"), &candidates);
+        match resolved {
+            EvaluationResult::Object { map, .. } => {
+                assert_eq!(string_field(&map, "resourceType").as_deref(), Some("Organization"));
+                assert_eq!(string_field(&map, "id").as_deref(), Some("1"));
+            }
+            other => panic!("expected Organization object, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_fragment_against_contained() {
+        let patient = obj(&[
+            ("resourceType", string("Patient")),
+            ("id", string("p")),
+            (
+                "contained",
+                obj(&[("resourceType", string("Practitioner")), ("id", string("pr1"))]),
+            ),
+        ]);
+        let candidates = pool(&[patient]);
+        let resolved = resolve_one(&reference("#pr1"), &candidates);
+        assert!(matches!(resolved, EvaluationResult::Object { .. }));
+    }
+
+    #[test]
+    fn resolves_relative_reference_in_context() {
+        let observation = obj(&[
+            ("resourceType", string("Observation")),
+            ("id", string("obs-1")),
+        ]);
+        let candidates = pool(&[observation]);
+        let resolved = resolve_one(&reference("Observation/obs-1"), &candidates);
+        match resolved {
+            EvaluationResult::Object { map, .. } => {
+                assert_eq!(string_field(&map, "id").as_deref(), Some("obs-1"));
+            }
+            other => panic!("expected Observation object, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_absolute_url_by_trailing_type_id() {
+        let observation = obj(&[
+            ("resourceType", string("Observation")),
+            ("id", string("obs-1")),
+        ]);
+        let candidates = pool(&[observation]);
+        let resolved = resolve_one(
+            &reference("http://example.org/fhir/Observation/obs-1"),
+            &candidates,
+        );
+        assert!(matches!(resolved, EvaluationResult::Object { .. }));
+    }
+
+    #[test]
+    fn typed_stub_when_unresolved() {
+        let candidates: Vec<Candidate> = Vec::new();
+        let resolved = resolve_one(&reference("Observation/missing"), &candidates);
+        match &resolved {
+            EvaluationResult::Object { map, type_info } => {
+                assert_eq!(string_field(map, "resourceType").as_deref(), Some("Observation"));
+                assert_eq!(type_info.as_ref().map(|t| t.name.as_str()), Some("Observation"));
+            }
+            other => panic!("expected typed stub, got {other:?}"),
+        }
+        // The stub carries FHIR/Observation type info and a resourceType field, both
+        // of which `is_of_type_with_context` consults — so `resolve() is Observation`
+        // is satisfied (verified end-to-end via the CLI integration check).
+    }
+
+    #[test]
+    fn unresolvable_bare_reference_is_empty() {
+        let candidates: Vec<Candidate> = Vec::new();
+        let resolved = resolve_one(&reference("nope"), &candidates);
+        assert!(matches!(resolved, EvaluationResult::Empty));
+    }
+
+    #[test]
+    fn resolves_collection_of_references() {
+        let patient = obj(&[
+            ("resourceType", string("Patient")),
+            ("id", string("p")),
+            (
+                "contained",
+                EvaluationResult::Collection {
+                    items: vec![
+                        obj(&[("resourceType", string("Organization")), ("id", string("1"))]),
+                        obj(&[("resourceType", string("Organization")), ("id", string("2"))]),
+                    ],
+                    has_undefined_order: false,
+                    type_info: None,
+                },
+            ),
+        ]);
+        let candidates = pool(&[patient]);
+        // Map resolve over each reference (the same flattening resolve_function performs).
+        let out: Vec<EvaluationResult> = [reference("1"), reference("2")]
+            .iter()
+            .map(|r| resolve_one(r, &candidates))
+            .collect();
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|r| matches!(r, EvaluationResult::Object { .. })));
+        assert_eq!(
+            out.iter()
+                .filter_map(|r| match r {
+                    EvaluationResult::Object { map, .. } => string_field(map, "id"),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            vec!["1".to_string(), "2".to_string()]
+        );
+    }
+}

--- a/crates/fhirpath/tests/data/r5/input/diagnosticreport-eric.json
+++ b/crates/fhirpath/tests/data/r5/input/diagnosticreport-eric.json
@@ -1,0 +1,153 @@
+{
+    "resourceType": "DiagnosticReport",
+    "id": "dgr-1.p2.pass",
+    "contained": [
+        {
+            "resourceType": "Composition",
+            "id": "comp",
+            "status": "final",
+            "type": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LP29684-5"
+                    }
+                ]
+            },
+            "subject": [{
+                "reference": "Patient/b248b1b2-1686-4b94-9936-37d7a5f94b51"
+            }],
+            "date": "2013-02-13T11:45:33+11:00",
+            "author": [
+                {
+                    "reference": "Practitioner/example"
+                }
+            ],
+            "title": "Diagnostic Report",
+            "section": [
+                {
+                    "entry": [
+                        {
+                            "reference": "#obs2"
+                        },
+                        {
+                            "reference": "#obs1"
+                        }
+                    ]
+                },
+                {
+                    "entry": [
+                        {
+                            "reference": "#foo"
+                        },
+                        {
+                            "reference": "#bar"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resourceType": "Basic",
+            "id": "foo",
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LP29684-5"
+                    }
+                ]
+            }
+        },
+        {
+            "resourceType": "Basic",
+            "id": "bar",
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "LP29684-5"
+                    }
+                ]
+            }
+        },
+        {
+            "resourceType": "Observation",
+            "id": "obs1",
+            "status": "final",
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "47527-7"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/b248b1b2-1686-4b94-9936-37d7a5f94b51"
+            },
+            "effectiveDateTime": "2013-02-11T10:33:33+11:00",
+            "issued": "2013-02-13T11:45:33+11:00",
+            "valueQuantity": {
+                "value": 1.0,
+                "unit": "mg/dL",
+                "system": "http://unitsofmeasure.org",
+                "code": "mg/dL"
+            },
+            "hasMember": [{
+                "reference": "#obs2"
+            }]
+        },
+        {
+            "resourceType": "Observation",
+            "id": "obs2",
+            "status": "final",
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "47527-7"
+                    }
+                ]
+            },
+            "subject": {
+                "reference": "Patient/b248b1b2-1686-4b94-9936-37d7a5f94b51"
+            },
+            "effectiveDateTime": "2013-02-11T10:33:33+11:00",
+            "issued": "2013-02-13T11:45:33+11:00",
+            "valueQuantity": {
+                "value": 1.0,
+                "unit": "mg/dL",
+                "system": "http://unitsofmeasure.org",
+                "code": "mg/dL"
+            }
+        }
+    ],
+    "status": "final",
+    "code": {
+        "coding": [
+            {
+                "system": "http://loinc.org",
+                "code": "47527-7"
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/b248b1b2-1686-4b94-9936-37d7a5f94b51"
+    },
+    "effectiveDateTime": "2013-02-11T10:33:33+11:00",
+    "issued": "2013-02-13T11:45:33+11:00",
+    "performer": [
+        {
+            "reference": "Practitioner/example"
+        }
+    ],
+    "result": [
+        {
+            "reference": "#obs1"
+        }
+    ],
+    "composition": {
+        "reference": "#comp"
+    }
+}

--- a/crates/fhirpath/tests/data/r5/known-test-failures.json
+++ b/crates/fhirpath/tests/data/r5/known-test-failures.json
@@ -18,16 +18,6 @@
       "reason": "conformsTo not yet implemented"
     },
     {
-      "groupName": "miscEngineTests",
-      "testName": "testContainedId",
-      "reason": "Multiple matches error - collection handling issue in resolve function"
-    },
-    {
-      "groupName": "miscEngineTests",
-      "testName": "testMultipleResolve",
-      "reason": "Multiple matches error - collection handling issue in resolve function"
-    },
-    {
       "groupName": "polymorphics",
       "testName": "testPolymorphicsB",
       "reason": "Test data issue?"

--- a/crates/fhirpath/tests/data/r5/known-test-failures.json
+++ b/crates/fhirpath/tests/data/r5/known-test-failures.json
@@ -14,8 +14,13 @@
     },
     {
       "groupName": "testConformsTo",
-      "testName": "*", 
+      "testName": "*",
       "reason": "conformsTo not yet implemented"
+    },
+    {
+      "groupName": "miscEngineTests",
+      "testName": "testContainedId",
+      "reason": "Output type fidelity: 'contained.id' returns FHIR type 'string' instead of 'id' (primitive id type not preserved through server evaluation). Unrelated to resolve()."
     },
     {
       "groupName": "polymorphics",


### PR DESCRIPTION
## Summary

Implements the FHIR-flavored FHIRPath `resolve()` function and fixes a
pre-existing limitation it surfaced (root resources were invisible inside
`where()`/`select()` lambda bodies).

### `resolve()`
Dereferences a `Reference` (or reference/canonical string) to the resource it
points to. **In-scope only** — no external/DB I/O:

- **contained** resources — matched by `#fragment` or bare `id`
- resources already in `EvaluationContext` — matched by `Type/id`, or the
  trailing `Type/id` of an absolute URL
- **unresolved** `Type/id` references return a typed stub `{resourceType: Type}`
  so `resolve() is Observation` type filters still work; bare/fragment misses
  return `{}`
- collections of references are mapped and flattened

New module `crates/fhirpath/src/resolve_function.rs`; dispatch arm + handled-functions
entry in `evaluator.rs`. README updated.

### `%resource` / `%rootResource`
Added both environment variables (both resolve to the root resource in scope,
mirroring `%context`).

### Fix: resources now survive context cloning
`EvaluationContext::clone()` set `resources: Vec::new()` because `FhirResource`
isn't `Clone`. Lambda bodies (`where`, `select`, …) run in **child** contexts, so
`%context`, `%resource`, and `resolve()` all returned empty inside them.

Fix: `resources: Arc<Vec<FhirResource>>`. `Arc` clones by ref-count without
requiring `T: Clone`, so the root resources stay visible through cloning and the
whole parent/child chain. Field reads are unchanged thanks to `Deref`.

### Test data
- Added `crates/fhirpath/tests/data/r5/input/diagnosticreport-eric.json` (from
  [FHIR/fhir-test-cases](https://github.com/FHIR/fhir-test-cases/blob/master/r5/diagnosticreport-eric.json)).
  The R5 harness resolves `inputfile=` only from `tests/data/r5/input/`, and this
  file (which lives at top-level `r5/` upstream, not `r5/examples/`) was never staged.
- `known-test-failures.json`: removed the stale `testMultipleResolve` entry (now
  **passes**) and the `testContainedId` entry (its stale reason wrongly blamed
  resolve; it remains auto-skipped by the harness for an unrelated "Unsupported
  output type: id" reason).

## Testing
- 7 new unit tests in `resolve_function.rs`
- Full `helios-fhirpath` suite (default/R4) and `helios-sof` suite pass
- R5 conformance suite green (0 failures); `testMultipleResolve` now passes
- Workspace builds clean

### Note
`resolve()` does **not** fetch from storage — references to server-stored
resources not present in the FHIRPath context resolve to a typed stub. A
storage-backed resolver is deliberately out of scope here and is tracked as a
follow-up in #167.