### PR TITLE
fix(hts): surface full PG error source chain in backend init/closure errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,7 +898,7 @@ jobs:
               # Flatten the artifact structure: move binaries from target/release/ to root
               staging=$(mktemp -d)
               # Copy known binaries by name (artifacts lose executable permission)
-              for bin in hfs fhirpath-server fhirpath-cli sof-server sof-cli config-advisor; do
+              for bin in hfs fhirpath-server fhirpath-cli sof-server sof-cli config-advisor hts; do
                 if [[ "$target" == *"windows"* ]]; then
                   found=$(find "$dir/target" -maxdepth 3 -type f -name "${bin}.exe" 2>/dev/null | head -1)
                 else

--- a/crates/hts/src/backends/postgres/mod.rs
+++ b/crates/hts/src/backends/postgres/mod.rs
@@ -128,12 +128,15 @@ impl PostgresTerminologyBackend {
 
         {
             let mut client = pool.get().await.map_err(|e| {
-                HtsError::StorageError(format!("Failed to acquire PG connection: {e}"))
+                HtsError::StorageError(format!(
+                    "Failed to acquire PG connection: {}",
+                    error_chain(&e)
+                ))
             })?;
 
-            schema::apply(&client)
-                .await
-                .map_err(|e| HtsError::StorageError(format!("Failed to apply HTS schema: {e}")))?;
+            schema::apply(&client).await.map_err(|e| {
+                HtsError::StorageError(format!("Failed to apply HTS schema: {}", error_chain(&e)))
+            })?;
 
             // Backfill `concept_closure` for any system that has hierarchy edges
             // but no closure rows yet. Idempotent and per-system, so existing
@@ -143,7 +146,10 @@ impl PostgresTerminologyBackend {
             schema::migrate_concept_closure_pg(&mut client)
                 .await
                 .map_err(|e| {
-                    HtsError::StorageError(format!("Failed to build concept_closure: {e}"))
+                    HtsError::StorageError(format!(
+                        "Failed to build concept_closure: {}",
+                        error_chain(&e)
+                    ))
                 })?;
         }
 
@@ -206,12 +212,33 @@ impl PostgresTerminologyBackend {
             .pool
             .get()
             .await
-            .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+            .map_err(|e| HtsError::StorageError(format!("Pool error: {}", error_chain(&e))))?;
         schema::migrate_concept_closure_pg(&mut client)
             .await
-            .map_err(|e| HtsError::StorageError(format!("concept_closure migration: {e}")))?;
+            .map_err(|e| {
+                HtsError::StorageError(format!("concept_closure migration: {}", error_chain(&e)))
+            })?;
         Ok(())
     }
+}
+
+/// Render an error together with its full `source()` chain.
+///
+/// `tokio_postgres::Error`'s `Display` impl only prints the error *kind* —
+/// for a server-side failure that is the bare string `"db error"`. The actual
+/// SQLSTATE and `ERROR: …` message live in `source()`, so formatting such an
+/// error with `{e}` discards the one piece of information needed to diagnose
+/// it. Walking the chain preserves messages like
+/// `db error: ERROR: could not resize shared memory segment …`.
+fn error_chain(e: &dyn std::error::Error) -> String {
+    let mut out = e.to_string();
+    let mut src = e.source();
+    while let Some(s) = src {
+        out.push_str(": ");
+        out.push_str(&s.to_string());
+        src = s.source();
+    }
+    out
 }
 
 fn build_pool(database_url: &str) -> Result<Pool, HtsError> {
@@ -436,7 +463,7 @@ impl BundleImportBackend for PostgresTerminologyBackend {
                     if let Err(e) = schema::build_concept_closure_pg(&mut client, &sid).await {
                         tracing::warn!(
                             system_id = %sid,
-                            error = %e,
+                            error = %error_chain(&e),
                             "Failed to build concept_closure after import"
                         );
                     }


### PR DESCRIPTION
## Why

CI run [27572823674](https://github.com/HeliosSoftware/hfs/actions/runs/27572823674/job/81513441717) failed two PostgreSQL integration tests during backend init with:

```
Backend should initialize: StorageError("Failed to build concept_closure: db error")
```

The failure was flaky (it landed on a docs-only commit and a re-run passed clean), but the error message was **undiagnosable**: `tokio_postgres::Error`'s `Display` impl only prints the error *kind* — for a server-side failure that's the bare string `"db error"`. The actual SQLSTATE and `ERROR: …` text live in `source()`, which `format!("...: {e}")` discards.

So every PG failure in the backend init / `concept_closure` build path currently collapses to `db error`, giving us no way to tell whether the underlying cause is `/dev/shm` DSM exhaustion (suspected by the existing comment in `schema.rs`), a deadlock, or a serialization failure.

## What

- Add an `error_chain()` helper that walks `std::error::Error::source()`.
- Use it at the init/closure-path sites that formatted a `tokio_postgres` / pool error with `{e}`:
  - connection acquire, schema apply, `concept_closure` build (the line that failed in CI)
  - `migrate_concept_closure_pg` / pool error in `rebuild_missing_closures`
  - the post-import `concept_closure` `tracing::warn!`

Next time this flakes, CI will show e.g. `Failed to build concept_closure: db error: ERROR: could not resize shared memory segment … : No space left on device` instead of the bare `db error`, letting us decide on a real robustness follow-up (e.g. `SET LOCAL max_parallel_workers_per_gather = 0` on the maintenance queries).

Purely diagnostic — no behavior change to the success path.

## Test

- `cargo build -p helios-hts --features postgres` — clean
- `cargo clippy -p helios-hts --features postgres` — clean