### PR TITLE
fix(docker): bump runtime base to trixie for glibc 2.38+ and rename container user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG BINARY_NAME
 ARG EXPOSE_PORT=8080
@@ -12,11 +12,11 @@ RUN test -n "$BINARY_NAME" || { echo "BINARY_NAME build arg is required"; exit 1
 
 # Install runtime dependencies
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libssl3 ca-certificates && \
+    apt-get install -y --no-install-recommends libssl3t64 ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
-RUN groupadd -g 1000 hfs && useradd -u 1000 -g hfs -m hfs
+RUN groupadd -g 1000 helios && useradd -u 1000 -g helios -m helios
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN chmod +x /app/${BINARY_NAME}
 ENV BINARY_NAME=${BINARY_NAME}
 
 # Create writable data directory for SQLite and other persistent data
-RUN mkdir -p /data && chown hfs:hfs /data
+RUN mkdir -p /data && chown helios:helios /data
 VOLUME /data
 
 # Default host binding for all servers (each binary reads only its own env var)
@@ -40,7 +40,7 @@ ENV FHIRPATH_SERVER_HOST=0.0.0.0
 ENV HTS_SERVER_HOST=0.0.0.0
 ENV HTS_BOOTSTRAP_DIR=${BOOTSTRAP_DIR}
 
-USER hfs
+USER helios
 
 EXPOSE ${EXPOSE_PORT}
 


### PR DESCRIPTION
## Problem

`docker run -p 8090:8090 ghcr.io/heliossoftware/hts:latest` crashes immediately:

```
/app/hts: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /app/hts)
```

Binaries are compiled on a self-hosted Linux CI runner with **glibc ≥ 2.38**, but the runtime image used `debian:bookworm-slim` (**glibc 2.36**). The dynamic linker fails before any application code runs. This affects **all four amd64 images** (hfs/hts/fhirpath-server/sof-server) — they share this single Dockerfile and the same build runner. (The systemd-deploy path is unaffected; those hosts have newer glibc.)

## Fix

- **Base image** `debian:bookworm-slim` → `debian:trixie-slim` (current Debian stable, glibc 2.41 ≥ 2.38).
- **OpenSSL package** `libssl3` → `libssl3t64`. Trixie renamed it in the 64-bit `time_t` transition and has no `libssl3` package, so a base bump alone would break `apt-get install`.
- **Container user** `hfs` → `helios`. This generic Dockerfile builds all server images, so the `hfs`-specific username was misleading. uid/gid stay **1000**, preserving `/data` volume permissions.

## Verification

| Base | glibc | `libssl3` apt pkg |
|------|-------|-------------------|
| `debian:bookworm-slim` (old) | 2.36 ❌ | `libssl3` |
| `debian:trixie-slim` (new) | 2.41 ✅ | `libssl3t64` |

Built the full Dockerfile locally with a stub binary (all layers succeed) and confirmed the runtime identity:

```
uid=1000(helios) gid=1000(helios) groups=1000(helios)
drwxr-xr-x 2 helios helios 4096 /data
```

The definitive end-to-end check is republishing the image from a `v*` tag and re-running the original `docker run`, since the real amd64 binary is produced only in CI.

## Follow-up (not in this PR)

The binary's glibc floor floats with whatever the self-hosted runner has installed — trixie clears today's 2.38, but a future runner upgrade could outrun it again. A durable fix would be a musl static build (`x86_64-unknown-linux-musl`) or building the binary inside a pinned container.