### PR TITLE
feat(sof): cross-resource and remote resolve() for SQL-on-FHIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,6 +3350,7 @@ dependencies = [
  "helios-fhirpath",
  "helios-fhirpath-support",
  "http 1.4.0",
+ "lru",
  "mime",
  "object_store",
  "parking_lot",
@@ -3369,6 +3370,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wiremock",
  "zip 2.4.2",
 ]
 
@@ -5474,6 +5476,7 @@ dependencies = [
  "pythonize",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,6 +104,15 @@ Longer-term ideas we are exploring. These are not yet committed and may evolve s
 - **SMART on FHIR** — Full launch framework (standalone launch, EHR launch) and fine-grained scoped access
 - **GraphQL API** — [FHIR GraphQL](https://hl7.org/fhir/graphql.html) support for resource retrieval, search, and graph traversal as an alternative to the REST API
 
+### SQL-on-FHIR & FHIRPath
+
+Follow-ups to `resolve()` in SQL-on-FHIR, which today dereferences references against the input bundle (and their `contained` resources) and can optionally fetch from explicitly allowlisted, trusted remote servers:
+
+- **Logical (identifier-based) reference resolution** — `resolve()` handles literal `Reference.reference` strings (relative `Type/id`, absolute URLs, and `#contained` fragments). References that identify their target only by a business `identifier` (no `reference` string) are not yet resolved.
+- **Storage-backed and cross-run resolution cache for `resolve()`** ([#167](https://github.com/HeliosSoftware/hfs/issues/167)) — Resolve against server-stored resources, and persist fetched resources across runs, as a layer over the current in-bundle pool and per-run in-memory prefetch cache.
+- **Async FHIRPath evaluator** — The FHIRPath engine is synchronous (executed under Rayon by the SQL-on-FHIR core), so remote `resolve()` is handled by an up-front prefetch pass rather than inline I/O. A general async evaluator would let effectful functions (inline remote resolution, terminology lookups) run during evaluation.
+- **OAuth client-credentials for remote `resolve()`** — Trusted-server authentication is per-host bearer tokens today; a client-credentials grant flow would better suit servers fronted by OAuth.
+
 ### Advanced Persistence
 
 - Cassandra as a primary store
@@ -119,6 +128,20 @@ An intelligent recommendation engine for storage configuration:
 - Analyze a FHIR query and recommend an optimal persistence configuration
 - Leverage historical benchmark data to inform recommendations
 - Web UI for interactive configuration guidance
+
+### Build & Dependencies
+
+- **Upgrade `lru` to the latest version** — `helios-sof` uses `lru` for the
+  streaming remote-`resolve()` cross-chunk cache. It is currently pinned to `0.12`
+  to match `aws-sdk-s3`, which pins `lru = "^0.12"` as a non-optional dependency
+  (pulled by the optional `s3` feature in `helios-persistence` / `helios-rest`).
+  Matching the SDK keeps a single `lru` version compiled across all feature
+  combinations. The latest `lru` is 0.18; raising `helios-sof`'s pin would compile
+  two `lru` versions whenever `s3` is enabled, because the AWS SDK's `^0.12` pin (a
+  third-party crate we don't control) is semver-incompatible with 0.18. Bump
+  `helios-sof` to the latest `lru` once the AWS SDK updates its own pin, collapsing
+  back to a single version. Tracked so the pin is re-evaluated on the next AWS SDK
+  upgrade.
 
 ---
 

--- a/book/src/appendix-b-fhirpath-functions.md
+++ b/book/src/appendix-b-fhirpath-functions.md
@@ -296,7 +296,7 @@ Object creation syntax (`typename { element: value, ... }`): ✅
 | `extension(url)` | ✅ | Full support with variable URL resolution |
 | `hasValue()` | ✅ | Tests if primitive has a value beyond extensions |
 | `getValue()` | ❌ | Not implemented |
-| `resolve()` | ❌ | Requires resource resolver integration |
+| `resolve()` | ✅ | In-scope resolution: `contained` resources and resources available to the evaluation context (matched by `Type/id`, including the trailing `Type/id` of an absolute URL); unresolved `Type/id` references return a typed stub so `resolve() is X` works. In SQL-on-FHIR the resolution scope is the **whole input bundle**, so a ViewDefinition can follow a `Reference` to a sibling resource (e.g. `Encounter.subject.resolve()` → `Patient`). Remote resolution against **explicitly allowlisted** servers is available opt-in (`SOF_RESOLVE_*`); see [SQL-on-FHIR → Resolving References](ch06-sql-on-fhir.md). Storage-backed resolution remains tracked in [#167](https://github.com/HeliosSoftware/hfs/issues/167). |
 | `ofType()` (FHIR form) | ✅ | Full FHIR type support |
 | `elementDefinition()` | ❌ | Not implemented |
 | `slice()` | ❌ | Not implemented |

--- a/book/src/ch06-sql-on-fhir.md
+++ b/book/src/ch06-sql-on-fhir.md
@@ -64,6 +64,124 @@ p1,1980-04-14,male,John,Smith,,john@example.com,555-1234,...
 
 ---
 
+## Resolving References Across Resources
+
+ViewDefinitions can follow a FHIR `Reference` to the resource it points at with
+the FHIRPath `resolve()` function. The resolution scope is the **entire input
+bundle**, so a view over one resource type can pull columns from a *different*
+resource elsewhere in the bundle. For example, flattening `Encounter`s together
+with their subject `Patient`:
+
+```json
+{
+  "resourceType": "ViewDefinition",
+  "resource": "Encounter",
+  "select": [
+    { "column": [{ "name": "encounter_id", "path": "id" }] },
+    {
+      "forEach": "subject.resolve()",
+      "column": [
+        { "name": "patient_id",     "path": "id" },
+        { "name": "patient_family", "path": "name.family" }
+      ]
+    }
+  ]
+}
+```
+
+Given a bundle that contains both the `Encounter` (`subject.reference =
+"Patient/pat-1"`) and the sibling `Patient/pat-1`, this produces one row joining
+the two resources. `resolve()` also works inside `where` clauses, e.g.
+`"path": "subject.resolve().gender = 'female'"`.
+
+What `resolve()` can dereference:
+
+- **Bundle-level references** — `Type/id` (e.g. `Patient/pat-1`) matched against
+  any resource in the input bundle, regardless of its type.
+- **Absolute URLs** — the trailing `Type/id` of a URL such as
+  `http://example.org/fhir/Patient/pat-1`.
+- **Contained resources** — `#fragment` (and bare-id) references resolved against
+  the `contained` array of the resource being processed.
+
+Behavior and limits:
+
+- A `Type/id` reference that matches no resource yields a typed stub, so
+  `resolve() is Patient` still evaluates correctly while data columns are null
+  (the reference simply produces null values rather than an error).
+- In **streaming NDJSON mode** (`sof-cli` on large `.ndjson` inputs), the scope
+  is limited to the current chunk; a reference that points at a resource in a
+  different chunk will not resolve. Use a single Bundle for full cross-resource
+  resolution.
+
+### Remote resolution against trusted servers
+
+By default `resolve()` only searches resources present in the input. You can
+optionally let it fetch references that point at **explicitly trusted** FHIR
+servers, so a reference like `https://fhir.example.org/r4/Patient/pat-1` is
+retrieved over the network and folded into the resolution pool before rows are
+generated.
+
+This is **off by default** and gated by a strict allowlist. Enable it with the
+`SOF_RESOLVE_*` environment variables (or the `sof-cli` flags):
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `SOF_RESOLVE_REMOTE` | `false` | Master switch. |
+| `SOF_RESOLVE_ALLOWED_BASE_URLS` | *(empty)* | Comma-separated trusted bases, e.g. `https://fhir.example.org/r4,https://hapi.example.com/baseR4`. Empty ⇒ nothing is fetched. |
+| `SOF_RESOLVE_TIMEOUT_MS` | `5000` | Per-request timeout. |
+| `SOF_RESOLVE_MAX_FETCHES` | `256` | Hard cap on fetches per run. |
+| `SOF_RESOLVE_MAX_DEPTH` | `1` | Rounds of chained-reference following. |
+| `SOF_RESOLVE_MAX_RESPONSE_BYTES` | `5000000` | Response size cap. |
+| `SOF_RESOLVE_CONCURRENCY` | `8` | Max concurrent fetches. |
+| `SOF_RESOLVE_AUTH` | *(none)* | Optional per-host bearer tokens, `host=token,host2=token2`. |
+| `SOF_RESOLVE_ALLOW_PRIVATE_ADDRESSES` | `false` | Permit allowlisted hostnames to resolve to private/internal addresses (RFC1918 / IPv6-ULA), e.g. an internal load balancer. Loopback and link-local stay blocked. |
+| `SOF_RESOLVE_CACHE_MAX_ENTRIES` | `10000` | Max entries in the streaming cross-chunk fetched-resource cache (LRU, with negative caching). Bounds memory; evicted-then-reused references re-fetch. Ignored by the single-Bundle path. |
+
+```bash
+sof-cli --view v.json --bundle b.json \
+  --resolve-remote \
+  --resolve-allowed-base-urls "https://fhir.example.org/r4"
+
+# Internal deployment behind a load balancer (e.g. Traefik) addressed by hostname:
+sof-cli --view v.json --bundle b.json \
+  --resolve-remote \
+  --resolve-allowed-base-urls "https://fhir.internal.corp/r4" \
+  --resolve-allow-private-addresses
+```
+
+Security model (default-deny):
+
+- A reference is fetched only if it is an absolute `http`/`https` URL that matches
+  an allowlist entry on **scheme + host + port + path-prefix** (parsed-URL
+  comparison, never substring).
+- Hostnames are resolved and validated before connecting, and the HTTP client is
+  pinned to the validated addresses (this defeats DNS rebinding). By default a name
+  that resolves to a private, loopback, link-local, or otherwise non-public address
+  is **blocked**.
+- **Internal servers and load balancers** (e.g. Traefik) addressed by hostname are
+  supported via `SOF_RESOLVE_ALLOW_PRIVATE_ADDRESSES=true` /
+  `--resolve-allow-private-addresses`, which permits allowlisted hosts to resolve
+  to RFC1918 / IPv6-ULA addresses. Even then, **loopback and link-local (including
+  the `169.254.169.254` cloud-metadata endpoint) remain blocked**. Allowlisting a
+  literal IP (e.g. `https://10.0.0.5/r4`) is also accepted as an explicit operator
+  decision.
+- `http://` is permitted only where an `http://` base is explicitly allowlisted;
+  redirects are disabled; per-request timeout, response-size, and total-fetch
+  caps are enforced.
+- Any failure (disallowed host, timeout, non-2xx, oversize, unparseable) is
+  non-fatal — the reference falls back to the typed-stub/null behavior above.
+
+Notes:
+
+- Enabling remote resolution makes a run's output depend on remote server state
+  at query time, trading reproducibility for cross-server joins.
+- Remote resolution works in **streaming / NDJSON** mode too: each chunk's external references are prefetched and folded into that chunk's pool, with one cache shared across the whole stream (a reference recurring across chunks is fetched once, bounded by `SOF_RESOLVE_CACHE_MAX_ENTRIES`) and `SOF_RESOLVE_MAX_FETCHES` applied as a per-stream cap. Note this resolves *remote* references only — a reference to a resource in a **different chunk of the same input** is still not resolved locally (in-bundle resolution is per-chunk).
+- Resolution against arbitrary (non-allowlisted) servers and logical
+  (identifier-based) references remain out of scope; see issue
+  [#167](https://github.com/HeliosSoftware/hfs/issues/167).
+
+---
+
 ## Using sof-cli for Batch Transforms
 
 ```

--- a/crates/fhirpath/src/evaluator.rs
+++ b/crates/fhirpath/src/evaluator.rs
@@ -423,6 +423,25 @@ impl EvaluationContext {
             .push(resource);
     }
 
+    /// Replaces the pool of resources available for resolution.
+    ///
+    /// This swaps the (`Arc`-shared) set of resources that `resolve()` searches —
+    /// see [`crate::resolve_function`] — **without** changing `this`, the FHIR
+    /// version, or `%context` / `%resource` / `%rootResource` semantics. Those all
+    /// derive from `this` (with `resources[0]` used only as a fallback when `this`
+    /// is `None`), so callers that have already set `this` to the resource under
+    /// evaluation can widen the resolution pool freely.
+    ///
+    /// SQL-on-FHIR uses this to expose the *entire input bundle* so that
+    /// `Reference.resolve()` can reach sibling resources elsewhere in the bundle,
+    /// not just the resource currently being processed and its `contained`
+    /// children. Sharing via `Arc` keeps this cheap across the many per-resource
+    /// (and per-iteration) contexts SOF creates, and it survives `Clone` into
+    /// lambda/child contexts.
+    pub fn set_resolution_scope(&mut self, resources: Arc<Vec<FhirResource>>) {
+        self.resources = resources;
+    }
+
     /// Sets a variable in the context to a string value
     ///
     /// This method is provided for backward compatibility with code that expects

--- a/crates/pysof/Cargo.toml
+++ b/crates/pysof/Cargo.toml
@@ -24,6 +24,9 @@ serde_json = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 pythonize = "0.29"
 csv = "1.3"
+# Drives helios-sof's async remote-resolve functions from the synchronous
+# PyO3 entry points via a current-thread runtime.
+tokio = { version = "1", default-features = false, features = ["rt", "net", "time"] }
 
 [features]
 default = ["R4"]

--- a/crates/pysof/README.md
+++ b/crates/pysof/README.md
@@ -147,6 +147,44 @@ result = pysof.run_view_definition_with_options(
 )
 ```
 
+### Remote `resolve()` (Trusted Servers)
+
+`resolve()` dereferences references against the input bundle by default. You can
+optionally let it fetch references that point at **explicitly trusted** FHIR
+servers and fold them into the resolution pool before rows are generated. This is
+**off by default** and gated by a strict allowlist (matching scheme + host + port
++ path-prefix; private/loopback addresses are blocked unless opted in).
+
+```python
+import pysof
+
+config = pysof.RemoteResolveConfig(
+    ["https://fhir.example.org/r4"],   # trusted base URLs (allowlist)
+    max_fetches=256,                    # per-run/-stream fetch cap
+    max_depth=1,                        # chained-reference rounds
+    allow_private_addresses=False,      # allow internal LBs (e.g. Traefik) by hostname
+    bearer_tokens={"fhir.example.org": "TOKEN"},  # optional per-host auth
+)
+
+# Or build it from SOF_RESOLVE_* environment variables:
+# config = pysof.RemoteResolveConfig.from_env()
+
+result = pysof.run_view_definition_remote(
+    view_definition, bundle, "json", config, fhir_version="R4"
+)
+
+# Streaming NDJSON with remote resolve() (one shared cache across chunks):
+stats = pysof.process_ndjson_to_file_remote(
+    view_definition, "input.ndjson", "output.json", "ndjson", config, chunk_size=1000
+)
+```
+
+When `config.is_active()` is `False` (disabled or empty allowlist) these behave
+exactly like their non-remote counterparts. Enabling remote resolution makes
+output depend on remote server state at run time. See the
+[SQL-on-FHIR guide](../../book/src/ch06-sql-on-fhir.md) for the full security
+model and configuration reference.
+
 ### Utility Functions
 
 ```python

--- a/crates/pysof/python-tests/test_remote_resolve.py
+++ b/crates/pysof/python-tests/test_remote_resolve.py
@@ -1,0 +1,141 @@
+"""Tests for the remote resolve() Python bindings.
+
+These exercise the RemoteResolveConfig class and the *_remote entry points
+without requiring network access: an *inactive* config (no allowlist) drives the
+same async pipeline as the active one but performs no fetches, so it still does
+bundle-level (in-scope) resolution. End-to-end remote fetching against a server is
+covered by the Rust integration tests (crates/sof/tests/resolve_remote_tests.rs).
+"""
+
+import json
+from typing import Any, Dict
+
+import pysof
+
+
+def encounter_with_subject_view() -> Dict[str, Any]:
+    return {
+        "resourceType": "ViewDefinition",
+        "status": "active",
+        "resource": "Encounter",
+        "select": [
+            {"column": [{"name": "encounter_id", "path": "id"}]},
+            {
+                "forEach": "subject.resolve()",
+                "column": [
+                    {"name": "patient_id", "path": "id"},
+                    {"name": "patient_family", "path": "name.family"},
+                ],
+            },
+        ],
+    }
+
+
+def bundle_with_sibling_patient() -> Dict[str, Any]:
+    return {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [
+            {
+                "resource": {
+                    "resourceType": "Patient",
+                    "id": "pat-1",
+                    "name": [{"family": "Sibling"}],
+                }
+            },
+            {
+                "resource": {
+                    "resourceType": "Encounter",
+                    "id": "enc-1",
+                    "status": "finished",
+                    "subject": {"reference": "Patient/pat-1"},
+                }
+            },
+        ],
+    }
+
+
+def test_remote_symbols_exported() -> None:
+    for name in [
+        "RemoteResolveConfig",
+        "run_view_definition_remote",
+        "process_ndjson_to_file_remote",
+    ]:
+        assert name in pysof.__all__
+        assert hasattr(pysof, name)
+
+
+def test_remote_resolve_config_construction() -> None:
+    cfg = pysof.RemoteResolveConfig(
+        ["https://fhir.example.org/r4"],
+        max_fetches=10,
+        max_depth=2,
+        allow_private_addresses=True,
+        bearer_tokens={"fhir.example.org": "tok"},
+    )
+    assert cfg.is_active() is True  # enabled (default) + non-empty allowlist
+
+    # Disabled or empty allowlist => inactive.
+    assert pysof.RemoteResolveConfig([]).is_active() is False
+    assert (
+        pysof.RemoteResolveConfig(
+            ["https://fhir.example.org/r4"], enabled=False
+        ).is_active()
+        is False
+    )
+
+    # from_env() is constructible and inactive by default (no env set).
+    assert isinstance(pysof.RemoteResolveConfig.from_env(), pysof.RemoteResolveConfig)
+
+
+def test_run_view_definition_remote_inactive_does_in_bundle_resolution() -> None:
+    # With an inactive remote config (no allowlist), no fetch happens, but the
+    # bundle-level resolution pool still resolves Encounter.subject to the sibling
+    # Patient in the same bundle.
+    cfg = pysof.RemoteResolveConfig([])  # inactive
+    result = pysof.run_view_definition_remote(
+        encounter_with_subject_view(),
+        bundle_with_sibling_patient(),
+        "json",
+        cfg,
+    )
+    rows = json.loads(result)
+    assert len(rows) == 1
+    assert rows[0]["encounter_id"] == "enc-1"
+    assert rows[0]["patient_id"] == "pat-1"
+    assert rows[0]["patient_family"] == "Sibling"
+
+
+def test_process_ndjson_to_file_remote_inactive(tmp_path: Any) -> None:
+    # Two Encounters referencing patients that are not in the stream; with an
+    # inactive config nothing is fetched, so the resolved columns are null, but
+    # the call succeeds and returns stats.
+    input_path = tmp_path / "in.ndjson"
+    output_path = tmp_path / "out.json"
+    lines = [
+        json.dumps(
+            {
+                "resourceType": "Encounter",
+                "id": f"enc-{i}",
+                "status": "finished",
+                "subject": {"reference": f"Patient/p{i}"},
+            }
+        )
+        for i in range(2)
+    ]
+    input_path.write_text("\n".join(lines))
+
+    cfg = pysof.RemoteResolveConfig([])  # inactive
+    stats = pysof.process_ndjson_to_file_remote(
+        encounter_with_subject_view(),
+        str(input_path),
+        str(output_path),
+        "json",
+        cfg,
+        chunk_size=1,
+    )
+    assert stats["resources_processed"] == 2
+    rows = json.loads(output_path.read_text())
+    assert len(rows) == 2
+    for row in rows:
+        assert row["patient_family"] is None

--- a/crates/pysof/src/lib.rs
+++ b/crates/pysof/src/lib.rs
@@ -6,14 +6,18 @@
 use chrono::{DateTime, Utc};
 use helios_sof::{
     ChunkConfig, ChunkedResult, ContentType, NdjsonChunkReader, PreparedViewDefinition,
-    ProcessingStats, RunOptions, SofBundle, SofError as RustSofError, SofViewDefinition,
-    process_ndjson_chunked, run_view_definition, run_view_definition_with_options,
+    ProcessingStats, RemoteResolveConfig, RunOptions, SofBundle, SofError as RustSofError,
+    SofViewDefinition, parse_allowed_base_urls, process_ndjson_chunked,
+    process_ndjson_chunked_remote, run_view_definition, run_view_definition_with_options,
+    run_view_definition_with_options_remote,
 };
 use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
+use std::time::Duration;
 
 // Custom Python exception types - using different names to avoid conflicts
 pyo3::create_exception!(
@@ -757,6 +761,323 @@ fn py_process_ndjson_to_file(
     stats_to_pydict(py, &stats)
 }
 
+// --- Remote resolve() support -------------------------------------------------
+
+/// Parses a Python ViewDefinition + Bundle into version-specific SOF types.
+fn parse_sof_view_and_bundle(
+    view_def_json: serde_json::Value,
+    bundle_json: serde_json::Value,
+    fhir_version: &str,
+) -> PyResult<(SofViewDefinition, SofBundle)> {
+    match fhir_version {
+        #[cfg(feature = "R4")]
+        "R4" => {
+            let v: helios_fhir::r4::ViewDefinition =
+                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
+            let b: helios_fhir::r4::Bundle =
+                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
+            Ok((SofViewDefinition::R4(v), SofBundle::R4(b)))
+        }
+        #[cfg(feature = "R4B")]
+        "R4B" => {
+            let v: helios_fhir::r4b::ViewDefinition =
+                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
+            let b: helios_fhir::r4b::Bundle =
+                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
+            Ok((SofViewDefinition::R4B(v), SofBundle::R4B(b)))
+        }
+        #[cfg(feature = "R5")]
+        "R5" => {
+            let v: helios_fhir::r5::ViewDefinition =
+                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
+            let b: helios_fhir::r5::Bundle =
+                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
+            Ok((SofViewDefinition::R5(v), SofBundle::R5(b)))
+        }
+        #[cfg(feature = "R6")]
+        "R6" => {
+            let v: helios_fhir::r6::ViewDefinition =
+                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
+            let b: helios_fhir::r6::Bundle =
+                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
+            Ok((SofViewDefinition::R6(v), SofBundle::R6(b)))
+        }
+        _ => Err(PyUnsupportedContentTypeError::new_err(format!(
+            "Unsupported FHIR version: {}",
+            fhir_version
+        ))),
+    }
+}
+
+/// Parses a Python ViewDefinition into a version-specific SOF type.
+fn parse_sof_view(
+    view_def_json: serde_json::Value,
+    fhir_version: &str,
+) -> PyResult<SofViewDefinition> {
+    match fhir_version {
+        #[cfg(feature = "R4")]
+        "R4" => Ok(SofViewDefinition::R4(
+            serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?,
+        )),
+        #[cfg(feature = "R4B")]
+        "R4B" => Ok(SofViewDefinition::R4B(
+            serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?,
+        )),
+        #[cfg(feature = "R5")]
+        "R5" => Ok(SofViewDefinition::R5(
+            serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?,
+        )),
+        #[cfg(feature = "R6")]
+        "R6" => Ok(SofViewDefinition::R6(
+            serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?,
+        )),
+        _ => Err(PyUnsupportedContentTypeError::new_err(format!(
+            "Unsupported FHIR version: {}",
+            fhir_version
+        ))),
+    }
+}
+
+/// Builds a current-thread Tokio runtime to drive the async remote-resolve work.
+fn build_remote_runtime() -> PyResult<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| PyIoError::new_err(format!("failed to create async runtime: {}", e)))
+}
+
+/// Configuration for remote `resolve()` (fetching references from trusted servers).
+///
+/// Remote resolution is **off by default** and gated by a strict allowlist. Pass an
+/// instance to `run_view_definition_remote` / `process_ndjson_to_file_remote`.
+///
+/// Args:
+///     allowed_base_urls (list[str]): Trusted base URLs that references must match
+///         (scheme + host + port + path-prefix), e.g. ["https://fhir.example.org/r4"].
+///     enabled (bool): Master switch. Defaults to True (set False to disable).
+///     timeout_ms (int, optional): Per-request timeout in milliseconds.
+///     max_fetches (int, optional): Hard cap on fetches per run/stream.
+///     max_depth (int, optional): Rounds of chained-reference following.
+///     max_response_bytes (int, optional): Response size cap.
+///     concurrency (int, optional): Max concurrent fetches.
+///     allow_private_addresses (bool): Permit allowlisted hostnames to resolve to
+///         private/internal addresses (RFC1918 / IPv6-ULA), e.g. an internal load
+///         balancer. Loopback and link-local stay blocked. Defaults to False.
+///     cache_max_entries (int, optional): Max entries in the streaming cross-chunk cache.
+///     bearer_tokens (dict[str, str], optional): Per-host bearer tokens (host -> token).
+#[pyclass(name = "RemoteResolveConfig", module = "pysof", from_py_object)]
+#[derive(Clone)]
+struct PyRemoteResolveConfig {
+    inner: RemoteResolveConfig,
+}
+
+#[pymethods]
+impl PyRemoteResolveConfig {
+    #[new]
+    #[pyo3(signature = (
+        allowed_base_urls,
+        *,
+        enabled = true,
+        timeout_ms = None,
+        max_fetches = None,
+        max_depth = None,
+        max_response_bytes = None,
+        concurrency = None,
+        allow_private_addresses = false,
+        cache_max_entries = None,
+        bearer_tokens = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        allowed_base_urls: Vec<String>,
+        enabled: bool,
+        timeout_ms: Option<u64>,
+        max_fetches: Option<usize>,
+        max_depth: Option<usize>,
+        max_response_bytes: Option<usize>,
+        concurrency: Option<usize>,
+        allow_private_addresses: bool,
+        cache_max_entries: Option<usize>,
+        bearer_tokens: Option<HashMap<String, String>>,
+    ) -> Self {
+        let default = RemoteResolveConfig::default();
+        let inner = RemoteResolveConfig {
+            enabled,
+            allowed_base_urls: parse_allowed_base_urls(&allowed_base_urls.join(",")),
+            timeout: timeout_ms.map(Duration::from_millis).unwrap_or(default.timeout),
+            max_fetches: max_fetches.unwrap_or(default.max_fetches),
+            max_depth: max_depth.unwrap_or(default.max_depth),
+            max_response_bytes: max_response_bytes.unwrap_or(default.max_response_bytes),
+            concurrency: concurrency.map(|c| c.max(1)).unwrap_or(default.concurrency),
+            allow_private_addresses,
+            cache_max_entries: cache_max_entries.map(|c| c.max(1)).unwrap_or(default.cache_max_entries),
+            bearer_tokens: bearer_tokens
+                .map(|m| {
+                    m.into_iter()
+                        .map(|(k, v)| (k.to_ascii_lowercase(), v))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        };
+        Self { inner }
+    }
+
+    /// Build configuration from the `SOF_RESOLVE_*` environment variables.
+    #[staticmethod]
+    fn from_env() -> Self {
+        Self {
+            inner: RemoteResolveConfig::from_env(),
+        }
+    }
+
+    /// Whether remote resolution will fetch anything (enabled and allowlist non-empty).
+    fn is_active(&self) -> bool {
+        self.inner.is_active()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "RemoteResolveConfig(enabled={}, allowed_base_urls={}, allow_private_addresses={}, max_fetches={}, max_depth={})",
+            self.inner.enabled,
+            self.inner.allowed_base_urls.len(),
+            self.inner.allow_private_addresses,
+            self.inner.max_fetches,
+            self.inner.max_depth
+        )
+    }
+}
+
+/// Transform a FHIR Bundle using a ViewDefinition with remote `resolve()` enabled.
+///
+/// Like `run_view_definition_with_options`, but references pointing at trusted
+/// (allowlisted) servers are fetched and folded into the resolution pool before
+/// rows are generated.
+///
+/// Args:
+///     view_definition (dict): ViewDefinition resource.
+///     bundle (dict): FHIR Bundle resource.
+///     format (str): Output format ("csv", "csv_with_header", "json", "ndjson", "parquet").
+///     remote_config (RemoteResolveConfig): Remote resolution configuration.
+///     since (str, optional): Filter resources modified after this ISO8601 datetime.
+///     limit (int, optional): Limit the number of results.
+///     page (int, optional): Page number (1-based).
+///     fhir_version (str, optional): "R4" (default), "R4B", "R5", "R6".
+///
+/// Returns:
+///     bytes: Transformed data in the requested format.
+#[pyfunction]
+#[pyo3(signature = (view_definition, bundle, format, remote_config, *, since = None, limit = None, page = None, fhir_version = "R4"))]
+#[allow(clippy::too_many_arguments)]
+fn py_run_view_definition_with_options_remote(
+    py: Python<'_>,
+    view_definition: &Bound<'_, PyAny>,
+    bundle: &Bound<'_, PyAny>,
+    format: &str,
+    remote_config: PyRemoteResolveConfig,
+    since: Option<&str>,
+    limit: Option<usize>,
+    page: Option<usize>,
+    fhir_version: &str,
+) -> PyResult<Py<PyBytes>> {
+    let content_type = ContentType::from_string(format).map_err(rust_sof_error_to_py_err)?;
+    let view_def_json: serde_json::Value = pythonize::depythonize(view_definition)?;
+    let bundle_json: serde_json::Value = pythonize::depythonize(bundle)?;
+    let (sof_view_def, sof_bundle) =
+        parse_sof_view_and_bundle(view_def_json, bundle_json, fhir_version)?;
+
+    let mut options = RunOptions::default();
+    if let Some(since_str) = since {
+        options.since = Some(
+            since_str
+                .parse::<DateTime<Utc>>()
+                .map_err(|e| PyValueError::new_err(format!("Invalid 'since' datetime: {}", e)))?,
+        );
+    }
+    options.limit = limit;
+    options.page = page;
+
+    let config = remote_config.inner;
+    let runtime = build_remote_runtime()?;
+    // Release the GIL while performing network I/O and parallel row generation.
+    let result = py
+        .detach(|| {
+            runtime.block_on(run_view_definition_with_options_remote(
+                sof_view_def,
+                sof_bundle,
+                content_type,
+                options,
+                &config,
+            ))
+        })
+        .map_err(rust_sof_error_to_py_err)?;
+
+    Ok(PyBytes::new(py, &result).into())
+}
+
+/// Stream an NDJSON file through a ViewDefinition with remote `resolve()` enabled.
+///
+/// Like `process_ndjson_to_file` (streaming, bounded memory), but each chunk's
+/// references to trusted (allowlisted) servers are prefetched and folded into that
+/// chunk's resolution pool. A single shared cache spans the stream, so a reference
+/// recurring across chunks is fetched once and `max_fetches` is a per-stream cap.
+///
+/// Args:
+///     view_definition (dict): ViewDefinition resource.
+///     input_path (str): Path to the input NDJSON file.
+///     output_path (str): Path to write the output file.
+///     format (str): Output format ("csv", "csv_with_header", "ndjson", "json").
+///     remote_config (RemoteResolveConfig): Remote resolution configuration.
+///     chunk_size (int, optional): Resources per chunk. Defaults to 1000.
+///     skip_invalid (bool, optional): Skip invalid JSON lines. Defaults to False.
+///     fhir_version (str, optional): "R4" (default), "R4B", "R5", "R6".
+///
+/// Returns:
+///     dict: Processing statistics.
+#[pyfunction]
+#[pyo3(signature = (view_definition, input_path, output_path, format, remote_config, *, chunk_size = 1000, skip_invalid = false, fhir_version = "R4"))]
+#[allow(clippy::too_many_arguments)]
+fn py_process_ndjson_to_file_remote(
+    py: Python<'_>,
+    view_definition: &Bound<'_, PyAny>,
+    input_path: &str,
+    output_path: &str,
+    format: &str,
+    remote_config: PyRemoteResolveConfig,
+    chunk_size: usize,
+    skip_invalid: bool,
+    fhir_version: &str,
+) -> PyResult<Py<PyAny>> {
+    let content_type = ContentType::from_string(format).map_err(rust_sof_error_to_py_err)?;
+    let view_def_json: serde_json::Value = pythonize::depythonize(view_definition)?;
+    let sof_view_def = parse_sof_view(view_def_json, fhir_version)?;
+
+    let input_file = File::open(input_path).map_err(|e| PyIoError::new_err(e.to_string()))?;
+    let input_reader = BufReader::new(input_file);
+    let output_file = File::create(output_path).map_err(|e| PyIoError::new_err(e.to_string()))?;
+    let output_writer = std::io::BufWriter::new(output_file);
+
+    let config = ChunkConfig {
+        chunk_size,
+        skip_invalid_lines: skip_invalid,
+    };
+    let remote = remote_config.inner;
+    let runtime = build_remote_runtime()?;
+    let stats = py
+        .detach(|| {
+            runtime.block_on(process_ndjson_chunked_remote(
+                sof_view_def,
+                input_reader,
+                output_writer,
+                content_type,
+                config,
+                &remote,
+            ))
+        })
+        .map_err(rust_sof_error_to_py_err)?;
+
+    stats_to_pydict(py, &stats)
+}
+
 /// Python module definition
 #[pymodule]
 fn _pysof(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -771,9 +1092,15 @@ fn _pysof(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_parse_content_type, m)?)?;
     m.add_function(wrap_pyfunction!(py_get_supported_fhir_versions, m)?)?;
     m.add_function(wrap_pyfunction!(py_process_ndjson_to_file, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        py_run_view_definition_with_options_remote,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(py_process_ndjson_to_file_remote, m)?)?;
 
     // Add classes
     m.add_class::<ChunkedProcessor>()?;
+    m.add_class::<PyRemoteResolveConfig>()?;
 
     // Add exception classes with the Python names (not Py prefixed)
     m.add("SofError", m.py().get_type::<PySofError>())?;

--- a/crates/pysof/src/pysof/__init__.py
+++ b/crates/pysof/src/pysof/__init__.py
@@ -6,6 +6,9 @@ transformation of FHIR resources into tabular data using ViewDefinitions.
 Public API:
     run_view_definition: Transform FHIR data using ViewDefinition
     run_view_definition_with_options: Transform with filtering/pagination
+    run_view_definition_remote: Transform with remote resolve() (trusted servers)
+    process_ndjson_to_file_remote: Stream NDJSON with remote resolve()
+    RemoteResolveConfig: Configuration for remote resolve()
     validate_view_definition: Pre-validate ViewDefinition structure
     validate_bundle: Pre-validate Bundle structure
     get_supported_fhir_versions: List available FHIR versions
@@ -38,6 +41,8 @@ try:
         InvalidSourceError,
         InvalidViewDefinitionError,
         IoError,
+        # Remote resolve() configuration class
+        RemoteResolveConfig,
         SerializationError,
         # Exception classes
         SofError,
@@ -49,8 +54,10 @@ try:
         __version__,
         py_get_supported_fhir_versions,
         py_parse_content_type,
+        py_process_ndjson_to_file_remote,
         py_run_view_definition,
         py_run_view_definition_with_options,
+        py_run_view_definition_with_options_remote,
         py_validate_bundle,
         py_validate_view_definition,
     )
@@ -181,6 +188,91 @@ try:
         """
         return py_get_supported_fhir_versions()
 
+    def run_view_definition_remote(
+        view: dict[str, Any],
+        bundle: dict[str, Any],
+        format: str,
+        remote_config: Any,
+        *,
+        since: str | None = None,
+        limit: int | None = None,
+        page: int | None = None,
+        fhir_version: str = "R4",
+    ) -> bytes:
+        """Transform FHIR Bundle data with remote ``resolve()`` enabled.
+
+        Like :func:`run_view_definition_with_options`, but references pointing at
+        trusted (allowlisted) servers are fetched and folded into the resolution
+        pool before rows are generated. Remote resolution is off unless
+        ``remote_config`` is active (enabled with a non-empty allowlist).
+
+        Args:
+            view: ViewDefinition resource as a Python dictionary
+            bundle: FHIR Bundle resource as a Python dictionary
+            format: Output format ("csv", "csv_with_header", "json", "ndjson", "parquet")
+            remote_config: A :class:`RemoteResolveConfig` instance
+            since: Filter resources modified after this ISO8601 datetime
+            limit: Limit the number of results returned
+            page: Page number for pagination (1-based)
+            fhir_version: FHIR version to use ("R4", "R4B", "R5", "R6"). Defaults to "R4"
+
+        Returns:
+            Transformed data in the requested format as bytes
+        """
+        return py_run_view_definition_with_options_remote(
+            view,
+            bundle,
+            format,
+            remote_config,
+            since=since,
+            limit=limit,
+            page=page,
+            fhir_version=fhir_version,
+        )
+
+    def process_ndjson_to_file_remote(
+        view: dict[str, Any],
+        input_path: str,
+        output_path: str,
+        format: str,
+        remote_config: Any,
+        *,
+        chunk_size: int = 1000,
+        skip_invalid: bool = False,
+        fhir_version: str = "R4",
+    ) -> dict[str, Any]:
+        """Stream an NDJSON file through a ViewDefinition with remote ``resolve()``.
+
+        Like the streaming file processor, but each chunk's references to trusted
+        (allowlisted) servers are prefetched and folded into that chunk's
+        resolution pool. A single cache spans the whole stream, so a reference
+        recurring across chunks is fetched once and ``max_fetches`` is a per-stream
+        cap.
+
+        Args:
+            view: ViewDefinition resource as a Python dictionary
+            input_path: Path to the input NDJSON file
+            output_path: Path to write the output file
+            format: Output format ("csv", "csv_with_header", "ndjson", "json")
+            remote_config: A :class:`RemoteResolveConfig` instance
+            chunk_size: Number of resources per chunk. Defaults to 1000.
+            skip_invalid: Skip invalid JSON lines. Defaults to False.
+            fhir_version: FHIR version to use ("R4", "R4B", "R5", "R6"). Defaults to "R4"
+
+        Returns:
+            Processing statistics as a dictionary
+        """
+        return py_process_ndjson_to_file_remote(
+            view,
+            input_path,
+            output_path,
+            format,
+            remote_config,
+            chunk_size=chunk_size,
+            skip_invalid=skip_invalid,
+            fhir_version=fhir_version,
+        )
+
 except ImportError as e:
     # Fallback for when the Rust extension is not available
     import warnings
@@ -293,6 +385,42 @@ except ImportError as e:
     def get_supported_fhir_versions() -> list[str]:
         raise NotImplementedError("Rust extension module not available")
 
+    class RemoteResolveConfig:  # type: ignore[no-redef]
+        """Configuration for remote resolve() (placeholder)."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError("Rust extension module not available")
+
+        @staticmethod
+        def from_env() -> "RemoteResolveConfig":
+            raise NotImplementedError("Rust extension module not available")
+
+    def run_view_definition_remote(
+        view: dict[str, Any],
+        bundle: dict[str, Any],
+        format: str,
+        remote_config: Any,
+        *,
+        since: str | None = None,
+        limit: int | None = None,
+        page: int | None = None,
+        fhir_version: str = "R4",
+    ) -> bytes:
+        raise NotImplementedError("Rust extension module not available")
+
+    def process_ndjson_to_file_remote(
+        view: dict[str, Any],
+        input_path: str,
+        output_path: str,
+        format: str,
+        remote_config: Any,
+        *,
+        chunk_size: int = 1000,
+        skip_invalid: bool = False,
+        fhir_version: str = "R4",
+    ) -> dict[str, Any]:
+        raise NotImplementedError("Rust extension module not available")
+
     # Set fallback version when Rust extension is not available
     __version__ = "0.0.0-dev"
 
@@ -301,6 +429,9 @@ __all__: list[str] = [
     # Core functions
     "run_view_definition",
     "run_view_definition_with_options",
+    "run_view_definition_remote",
+    "process_ndjson_to_file_remote",
+    "RemoteResolveConfig",
     "validate_view_definition",
     "validate_bundle",
     "get_supported_fhir_versions",

--- a/crates/pysof/src/pysof/_pysof.pyi
+++ b/crates/pysof/src/pysof/_pysof.pyi
@@ -20,6 +20,26 @@ class SourceReadError(SofError): ...
 class InvalidSourceContentError(SofError): ...
 class UnsupportedSourceProtocolError(SofError): ...
 
+# Remote resolve() configuration
+class RemoteResolveConfig:
+    def __init__(
+        self,
+        allowed_base_urls: list[str],
+        *,
+        enabled: bool = True,
+        timeout_ms: int | None = None,
+        max_fetches: int | None = None,
+        max_depth: int | None = None,
+        max_response_bytes: int | None = None,
+        concurrency: int | None = None,
+        allow_private_addresses: bool = False,
+        cache_max_entries: int | None = None,
+        bearer_tokens: dict[str, str] | None = None,
+    ) -> None: ...
+    @staticmethod
+    def from_env() -> RemoteResolveConfig: ...
+    def is_active(self) -> bool: ...
+
 # Core functions
 def py_run_view_definition(
     view: dict[str, Any],
@@ -47,3 +67,25 @@ def py_validate_bundle(
 ) -> bool: ...
 def py_parse_content_type(mime_type: str) -> str: ...
 def py_get_supported_fhir_versions() -> list[str]: ...
+def py_run_view_definition_with_options_remote(
+    view: dict[str, Any],
+    bundle: dict[str, Any],
+    format: str,
+    remote_config: RemoteResolveConfig,
+    *,
+    since: str | None = None,
+    limit: int | None = None,
+    page: int | None = None,
+    fhir_version: str = "R4",
+) -> bytes: ...
+def py_process_ndjson_to_file_remote(
+    view: dict[str, Any],
+    input_path: str,
+    output_path: str,
+    format: str,
+    remote_config: RemoteResolveConfig,
+    *,
+    chunk_size: int = 1000,
+    skip_invalid: bool = False,
+    fhir_version: str = "R4",
+) -> dict[str, Any]: ...

--- a/crates/sof/Cargo.toml
+++ b/crates/sof/Cargo.toml
@@ -46,6 +46,15 @@ mime = "0.3"
 chrono = { workspace = true, features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 url = "2.5"
+# Cross-chunk cache for streaming remote resolve().
+# Pinned to 0.12 to MATCH aws-sdk-s3, which pins `lru = "^0.12"` as a non-optional
+# dependency (pulled by the optional `s3` feature in helios-persistence/-rest).
+# This keeps a single lru version compiled across all feature combinations,
+# including `s3` builds. The latest lru is 0.18, but raising this would compile two
+# lru versions whenever `s3` is enabled, since the AWS SDK's `^0.12` pin (a
+# third-party crate we don't control) is semver-incompatible with 0.18. Bump to the
+# latest once the AWS SDK updates its lru pin — see ROADMAP.md ("Build & Dependencies").
+lru = "0.12"
 async-trait = "0.1"
 object_store = { version = "0.11", features = ["aws", "gcp", "azure"] }
 rayon = "1.8"
@@ -66,6 +75,7 @@ axum-test = "18.0"
 flate2 = "1"
 tempfile = "3.8"
 criterion = { version = "0.5", features = ["html_reports"] }
+wiremock = "0.6"
 
 [[bench]]
 name = "parallel_processing_bench"

--- a/crates/sof/src/cli.rs
+++ b/crates/sof/src/cli.rs
@@ -134,7 +134,8 @@ use helios_sof::{
     ChunkConfig, ContentType, ParquetOptions, ProcessingStats, RunOptions, SofBundle,
     SofViewDefinition,
     data_source::{DataSource, UniversalDataSource, parse_fhir_content},
-    process_ndjson_chunked, run_view_definition_with_options,
+    process_ndjson_chunked, process_ndjson_chunked_remote, run_view_definition_with_options,
+    run_view_definition_with_options_remote,
 };
 use std::fs::{self, File};
 use std::io::{self, BufReader, BufWriter, Read};
@@ -250,6 +251,40 @@ struct Args {
     /// Terminology server URL for FHIRPath terminology functions (memberOf, subsumes, etc.)
     #[arg(long, env = "SOF_TERMINOLOGY_SERVER")]
     terminology_server: Option<String>,
+
+    /// Enable remote resolution of `Reference.resolve()` against trusted servers.
+    /// Off by default; requires --resolve-allowed-base-urls (or SOF_RESOLVE_ALLOWED_BASE_URLS).
+    #[arg(long)]
+    resolve_remote: bool,
+
+    /// Comma-separated trusted base URLs that remote `resolve()` may fetch from,
+    /// e.g. `https://fhir.example.org/r4,https://hapi.example.com/baseR4`.
+    /// Overrides SOF_RESOLVE_ALLOWED_BASE_URLS. Other limits use SOF_RESOLVE_* env vars.
+    #[arg(long)]
+    resolve_allowed_base_urls: Option<String>,
+
+    /// Allow allowlisted hostnames to resolve to private/internal addresses
+    /// (RFC1918 / IPv6-ULA), e.g. for an internal load balancer such as Traefik.
+    /// Loopback and link-local (cloud-metadata) addresses remain blocked.
+    /// Overrides SOF_RESOLVE_ALLOW_PRIVATE_ADDRESSES.
+    #[arg(long)]
+    resolve_allow_private_addresses: bool,
+}
+
+/// Builds the remote-resolution config from env vars, with CLI flags taking
+/// precedence (CLI > env > default).
+fn build_remote_resolve_config(args: &Args) -> helios_sof::RemoteResolveConfig {
+    let mut config = helios_sof::RemoteResolveConfig::from_env();
+    if args.resolve_remote {
+        config.enabled = true;
+    }
+    if let Some(csv) = &args.resolve_allowed_base_urls {
+        config.allowed_base_urls = helios_sof::parse_allowed_base_urls(csv);
+    }
+    if args.resolve_allow_private_addresses {
+        config.allow_private_addresses = true;
+    }
+    config
 }
 
 /// Normalize a source path to a URL.
@@ -422,29 +457,57 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             skip_invalid_lines: args.skip_invalid,
         };
 
+        // Remote `resolve()` (trusted-server prefetch) for the streaming path uses
+        // a per-stream shared cache; inactive config takes the plain sync path.
+        let remote_config = build_remote_resolve_config(&args);
+
         // Create output writer
         let stats: ProcessingStats = match &args.output {
             Some(path) => {
                 let file = File::create(path)?;
                 let mut writer = BufWriter::new(file);
-                process_ndjson_chunked(
-                    view_definition,
-                    reader,
-                    &mut writer,
-                    content_type,
-                    chunk_config,
-                )?
+                if remote_config.is_active() {
+                    process_ndjson_chunked_remote(
+                        view_definition,
+                        reader,
+                        &mut writer,
+                        content_type,
+                        chunk_config,
+                        &remote_config,
+                    )
+                    .await?
+                } else {
+                    process_ndjson_chunked(
+                        view_definition,
+                        reader,
+                        &mut writer,
+                        content_type,
+                        chunk_config,
+                    )?
+                }
             }
             None => {
                 let stdout = io::stdout();
                 let mut handle = stdout.lock();
-                process_ndjson_chunked(
-                    view_definition,
-                    reader,
-                    &mut handle,
-                    content_type,
-                    chunk_config,
-                )?
+                if remote_config.is_active() {
+                    process_ndjson_chunked_remote(
+                        view_definition,
+                        reader,
+                        &mut handle,
+                        content_type,
+                        chunk_config,
+                        &remote_config,
+                    )
+                    .await?
+                } else {
+                    process_ndjson_chunked(
+                        view_definition,
+                        reader,
+                        &mut handle,
+                        content_type,
+                        chunk_config,
+                    )?
+                }
             }
         };
 
@@ -551,8 +614,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         write_parquet_with_splitting(view_definition, bundle, output, options)?;
     } else {
         // Standard processing for all other cases
-        let result =
-            run_view_definition_with_options(view_definition, bundle, content_type, options)?;
+        let remote_config = build_remote_resolve_config(&args);
+        let result = if remote_config.is_active() {
+            run_view_definition_with_options_remote(
+                view_definition,
+                bundle,
+                content_type,
+                options,
+                &remote_config,
+            )
+            .await?
+        } else {
+            run_view_definition_with_options(view_definition, bundle, content_type, options)?
+        };
 
         // Output result
         match args.output {

--- a/crates/sof/src/handlers.rs
+++ b/crates/sof/src/handlers.rs
@@ -20,6 +20,7 @@ use helios_sof::{
     get_fhir_version_string, get_newest_enabled_fhir_version,
     parse_view_definition_for_version as sof_parse_view_definition_for_version,
     process_view_definition, run_view_definition_with_options,
+    run_view_definition_with_options_remote,
 };
 use tracing::{debug, info};
 
@@ -536,12 +537,26 @@ pub async fn run_view_definition_handler(
         // duplicate `apply_result_filtering` pass that used to re-parse
         // and re-serialize the output — it was inefficient and
         // CSV-fragile (line-splits assumed no embedded newlines).
-        let filtered_output = run_view_definition_with_options(
-            view_definition,
-            bundle,
-            validated_params.format,
-            run_options,
-        )?;
+        // Remote `resolve()` (trusted-server prefetch) is configured via
+        // SOF_RESOLVE_* env vars; when inactive this is a no-op fast path.
+        let remote_config = helios_sof::RemoteResolveConfig::from_env();
+        let filtered_output = if remote_config.is_active() {
+            run_view_definition_with_options_remote(
+                view_definition,
+                bundle,
+                validated_params.format,
+                run_options,
+                &remote_config,
+            )
+            .await?
+        } else {
+            run_view_definition_with_options(
+                view_definition,
+                bundle,
+                validated_params.format,
+                run_options,
+            )?
+        };
 
         // Determine the MIME type for the response: each format's native
         // media type per the SoF v2 Common Operation Behavior table

--- a/crates/sof/src/lib.rs
+++ b/crates/sof/src/lib.rs
@@ -186,6 +186,9 @@ pub mod data_source;
 pub mod fhir_format;
 pub mod params;
 pub mod parquet_schema;
+pub mod reference_collector;
+pub mod remote_fetch;
+pub mod remote_resolver;
 pub mod sqlquery;
 pub mod traits;
 
@@ -193,6 +196,11 @@ pub use compartment::{resolve_group_members_to_patient_refs, resource_in_patient
 pub use constants::{ConstantValue, parse_constant_from_json};
 pub use params::{
     ExtractedRunParams, body_has_view_definition, extract_run_params_from_json, split_csv_refs,
+};
+pub use remote_fetch::{RemoteResolver, prefetch_external_resources};
+pub use remote_resolver::{
+    AllowedBaseUrl, DenyReason, FetchDecision, RemoteResolveConfig, is_blocked_address,
+    is_disallowed_ip, parse_allowed_base_urls,
 };
 pub use sqlquery::{
     BoundParam, ColumnFhirType, DependsOnView, InMemorySqlEngine, LibraryParameter, QueryResult,
@@ -1679,6 +1687,37 @@ impl PreparedViewDefinition {
     /// Returns a `ChunkedResult` containing the rows generated from the chunk.
     /// Uses parallel processing via rayon for improved throughput.
     pub fn process_chunk(&self, chunk: ResourceChunk) -> Result<ChunkedResult, SofError> {
+        self.process_chunk_with_external(chunk, Vec::new())
+    }
+
+    /// Like [`Self::process_chunk`], but folds `external` resources into this
+    /// chunk's resolution pool. Used by the streaming remote-`resolve()` driver
+    /// ([`process_ndjson_chunked_remote`]) to inject resources prefetched from
+    /// trusted servers for references found in the chunk.
+    pub fn process_chunk_with_external(
+        &self,
+        chunk: ResourceChunk,
+        external: Vec<helios_fhir::FhirResource>,
+    ) -> Result<ChunkedResult, SofError> {
+        // Build the resolution pool for `resolve()` from the resources in this chunk
+        // plus any remotely-prefetched `external` resources.
+        //
+        // NOTE: in-bundle resolution in the streaming path is limited to the
+        // *current chunk* — a reference to a resource in another chunk of the same
+        // input cannot be resolved locally (it falls back to a typed stub / empty).
+        // Remote references (to allowlisted trusted servers) are resolved via the
+        // `external` resources prefetched per chunk with a cross-chunk cache. The
+        // non-streaming Bundle path resolves across the entire bundle.
+        let version = self.view_definition.version();
+        let mut pool: Vec<helios_fhir::FhirResource> = chunk
+            .resources
+            .iter()
+            .filter_map(|json| parse_json_to_fhir_resource(json.clone(), version).ok())
+            .collect();
+        pool.extend(external);
+        let resolution_scope: std::sync::Arc<Vec<helios_fhir::FhirResource>> =
+            std::sync::Arc::new(pool);
+
         // Process resources in parallel using rayon
         let results: Result<Vec<Vec<ProcessedRow>>, SofError> = chunk
             .resources
@@ -1694,7 +1733,7 @@ impl PreparedViewDefinition {
                     None
                 } else {
                     // Process single resource based on version
-                    Some(self.process_single_resource(resource_json))
+                    Some(self.process_single_resource(resource_json, &resolution_scope))
                 }
             })
             .collect();
@@ -1715,16 +1754,25 @@ impl PreparedViewDefinition {
     fn process_single_resource(
         &self,
         resource_json: &serde_json::Value,
+        resolution_scope: &std::sync::Arc<Vec<helios_fhir::FhirResource>>,
     ) -> Result<Vec<ProcessedRow>, SofError> {
         match &self.view_definition {
             #[cfg(feature = "R4")]
-            SofViewDefinition::R4(vd) => self.process_single_resource_generic(vd, resource_json),
+            SofViewDefinition::R4(vd) => {
+                self.process_single_resource_generic(vd, resource_json, resolution_scope)
+            }
             #[cfg(feature = "R4B")]
-            SofViewDefinition::R4B(vd) => self.process_single_resource_generic(vd, resource_json),
+            SofViewDefinition::R4B(vd) => {
+                self.process_single_resource_generic(vd, resource_json, resolution_scope)
+            }
             #[cfg(feature = "R5")]
-            SofViewDefinition::R5(vd) => self.process_single_resource_generic(vd, resource_json),
+            SofViewDefinition::R5(vd) => {
+                self.process_single_resource_generic(vd, resource_json, resolution_scope)
+            }
             #[cfg(feature = "R6")]
-            SofViewDefinition::R6(vd) => self.process_single_resource_generic(vd, resource_json),
+            SofViewDefinition::R6(vd) => {
+                self.process_single_resource_generic(vd, resource_json, resolution_scope)
+            }
         }
     }
 
@@ -1732,6 +1780,7 @@ impl PreparedViewDefinition {
         &self,
         view_definition: &VD,
         resource_json: &serde_json::Value,
+        resolution_scope: &std::sync::Arc<Vec<helios_fhir::FhirResource>>,
     ) -> Result<Vec<ProcessedRow>, SofError>
     where
         VD: ViewDefinitionTrait,
@@ -1741,6 +1790,8 @@ impl PreparedViewDefinition {
         let fhir_resource =
             parse_json_to_fhir_resource(resource_json.clone(), self.view_definition.version())?;
         let mut context = EvaluationContext::new(vec![fhir_resource]);
+        // Expose the chunk-wide pool so `resolve()` can reach sibling resources.
+        context.set_resolution_scope(std::sync::Arc::clone(resolution_scope));
 
         // Add variables to the context
         for (name, value) in &self.variables {
@@ -2037,40 +2088,13 @@ pub fn process_ndjson_chunked<R: BufRead, W: Write>(
         stats.output_rows += chunk_result.rows.len();
         stats.chunks_processed += 1;
 
-        // Write chunk output
-        match content_type {
-            ContentType::Csv | ContentType::CsvWithHeader => {
-                write_csv_chunk(&chunk_result, &mut output)?;
-            }
-            ContentType::NdJson => {
-                write_ndjson_chunk(&chunk_result, &mut output)?;
-            }
-            ContentType::Json => {
-                // Write JSON rows with proper comma handling
-                for (i, row) in chunk_result.rows.iter().enumerate() {
-                    if !is_first_chunk || i > 0 {
-                        output.write_all(b",\n")?;
-                    }
-
-                    let mut row_obj = serde_json::Map::new();
-                    for (j, column) in chunk_result.columns.iter().enumerate() {
-                        let value = row
-                            .values
-                            .get(j)
-                            .and_then(|v| v.as_ref())
-                            .cloned()
-                            .unwrap_or(serde_json::Value::Null);
-                        row_obj.insert(column.clone(), value);
-                    }
-                    let json = serde_json::to_string_pretty(&serde_json::Value::Object(row_obj))?;
-                    output.write_all(json.as_bytes())?;
-                }
-            }
-            ContentType::Parquet => unreachable!(), // Already checked above
-        }
-
+        write_chunk_output(
+            &chunk_result,
+            content_type,
+            &mut output,
+            &mut is_first_chunk,
+        )?;
         output.flush()?;
-        is_first_chunk = false;
     }
 
     // Close JSON array if needed
@@ -2083,6 +2107,136 @@ pub fn process_ndjson_chunked<R: BufRead, W: Write>(
     // Update stats with line/skip counts from the iterator
     stats.total_lines_read = iterator.lines_read();
     stats.skipped_lines = iterator.skipped_lines();
+
+    Ok(stats)
+}
+
+/// Writes one chunk's rows in the requested streaming format. Shared by the sync
+/// ([`process_ndjson_chunked`]) and remote ([`process_ndjson_chunked_remote`])
+/// drivers. `is_first_chunk` is consulted (and cleared) only for JSON, to manage
+/// inter-row commas across chunks.
+fn write_chunk_output<W: Write>(
+    chunk_result: &ChunkedResult,
+    content_type: ContentType,
+    output: &mut W,
+    is_first_chunk: &mut bool,
+) -> Result<(), SofError> {
+    match content_type {
+        ContentType::Csv | ContentType::CsvWithHeader => {
+            write_csv_chunk(chunk_result, output)?;
+        }
+        ContentType::NdJson => {
+            write_ndjson_chunk(chunk_result, output)?;
+        }
+        ContentType::Json => {
+            // Write JSON rows with proper comma handling
+            for (i, row) in chunk_result.rows.iter().enumerate() {
+                if !*is_first_chunk || i > 0 {
+                    output.write_all(b",\n")?;
+                }
+
+                let mut row_obj = serde_json::Map::new();
+                for (j, column) in chunk_result.columns.iter().enumerate() {
+                    let value = row
+                        .values
+                        .get(j)
+                        .and_then(|v| v.as_ref())
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null);
+                    row_obj.insert(column.clone(), value);
+                }
+                let json = serde_json::to_string_pretty(&serde_json::Value::Object(row_obj))?;
+                output.write_all(json.as_bytes())?;
+            }
+        }
+        ContentType::Parquet => unreachable!(), // Caller rejects Parquet for streaming
+    }
+
+    *is_first_chunk = false;
+    Ok(())
+}
+
+/// Streaming NDJSON processing with remote `resolve()` enabled.
+///
+/// Like [`process_ndjson_chunked`], but for each chunk it prefetches references
+/// pointing at trusted (allowlisted) servers and folds them into that chunk's
+/// resolution pool before row generation. A single [`RemoteResolver`] is shared
+/// across all chunks, so a reference recurring across chunks is fetched once
+/// (bounded LRU cache) and `SOF_RESOLVE_MAX_FETCHES` is a **per-stream** cap.
+///
+/// In-bundle resolution remains per-chunk (a reference to a resource in another
+/// chunk of the same input is not resolved locally). When `remote_config` is
+/// inactive this is equivalent to [`process_ndjson_chunked`].
+pub async fn process_ndjson_chunked_remote<R: BufRead, W: Write>(
+    view_definition: SofViewDefinition,
+    input: R,
+    mut output: W,
+    content_type: ContentType,
+    config: ChunkConfig,
+    remote_config: &RemoteResolveConfig,
+) -> Result<ProcessingStats, SofError> {
+    if content_type == ContentType::Parquet {
+        return Err(SofError::UnsupportedContentType(
+            "Parquet output is not supported for streaming. Use batch processing instead."
+                .to_string(),
+        ));
+    }
+
+    let version = view_definition.version();
+    let prepared = PreparedViewDefinition::new(view_definition)?;
+    let resource_type = prepared.target_resource_type().to_string();
+    let columns = prepared.columns().to_vec();
+    let mut reader =
+        NdjsonChunkReader::new(input, config).with_resource_type_filter(Some(resource_type));
+
+    // One resolver for the whole stream: cross-chunk cache + per-stream fetch cap.
+    let resolver = remote_fetch::RemoteResolver::new(remote_config.clone());
+    let active = remote_config.is_active();
+
+    let mut stats = ProcessingStats::default();
+    let mut is_first_chunk = true;
+
+    if content_type == ContentType::CsvWithHeader {
+        write_csv_header(&columns, &mut output)?;
+    }
+    if content_type == ContentType::Json {
+        output.write_all(b"[\n")?;
+    }
+
+    while let Some(chunk) = reader.next() {
+        let chunk = chunk?;
+
+        let external = if active {
+            let refs =
+                reference_collector::collect_reference_strings_from_resources(&chunk.resources);
+            let keys = reference_collector::collect_resource_keys_from_resources(&chunk.resources);
+            resolver.resolve(refs, &keys, version).await
+        } else {
+            Vec::new()
+        };
+
+        let chunk_result = prepared.process_chunk_with_external(chunk, external)?;
+
+        stats.resources_processed += chunk_result.resources_in_chunk;
+        stats.output_rows += chunk_result.rows.len();
+        stats.chunks_processed += 1;
+
+        write_chunk_output(
+            &chunk_result,
+            content_type,
+            &mut output,
+            &mut is_first_chunk,
+        )?;
+        output.flush()?;
+    }
+
+    if content_type == ContentType::Json {
+        output.write_all(b"\n]")?;
+    }
+    output.flush()?;
+
+    stats.total_lines_read = reader.lines_read();
+    stats.skipped_lines = reader.skipped_lines();
 
     Ok(stats)
 }
@@ -2198,8 +2352,62 @@ pub fn run_view_definition_with_options(
         bundle
     };
 
+    run_view_definition_inner(
+        view_definition,
+        filtered_bundle,
+        content_type,
+        options,
+        Vec::new(),
+    )
+}
+
+/// Runs a ViewDefinition with remote `resolve()` enabled.
+///
+/// When `config` is active, references pointing at trusted (allowlisted) servers
+/// are fetched up-front and folded into the resolution pool before the
+/// (synchronous) row generation runs. When inactive, this behaves exactly like
+/// [`run_view_definition_with_options`]. Remote resolution applies to the
+/// (non-streaming) Bundle path only.
+pub async fn run_view_definition_with_options_remote(
+    view_definition: SofViewDefinition,
+    bundle: SofBundle,
+    content_type: ContentType,
+    options: RunOptions,
+    config: &RemoteResolveConfig,
+) -> Result<Vec<u8>, SofError> {
+    let filtered_bundle = if let Some(since) = options.since {
+        filter_bundle_by_since(bundle, since)?
+    } else {
+        bundle
+    };
+
+    let external = if config.is_active() {
+        remote_fetch::prefetch_external_resources(&filtered_bundle, config).await
+    } else {
+        Vec::new()
+    };
+
+    run_view_definition_inner(
+        view_definition,
+        filtered_bundle,
+        content_type,
+        options,
+        external,
+    )
+}
+
+/// Shared tail of the run pipeline: process (with any external resources) →
+/// paginate → format. The `bundle` must already be `since`-filtered.
+fn run_view_definition_inner(
+    view_definition: SofViewDefinition,
+    bundle: SofBundle,
+    content_type: ContentType,
+    options: RunOptions,
+    external: Vec<helios_fhir::FhirResource>,
+) -> Result<Vec<u8>, SofError> {
     // Process the ViewDefinition to generate tabular data
-    let processed_result = process_view_definition(view_definition, filtered_bundle)?;
+    let processed_result =
+        process_view_definition_with_external(view_definition, bundle, external)?;
 
     // Apply pagination if needed
     let processed_result = if options.limit.is_some() || options.page.is_some() {
@@ -2220,6 +2428,17 @@ pub fn process_view_definition(
     view_definition: SofViewDefinition,
     bundle: SofBundle,
 ) -> Result<ProcessedResult, SofError> {
+    process_view_definition_with_external(view_definition, bundle, Vec::new())
+}
+
+/// Like [`process_view_definition`], but folds `external` resources (fetched by the
+/// remote `resolve()` prefetch) into the resolution pool. `external` must already
+/// be parsed in the bundle's FHIR version.
+pub fn process_view_definition_with_external(
+    view_definition: SofViewDefinition,
+    bundle: SofBundle,
+    external: Vec<helios_fhir::FhirResource>,
+) -> Result<ProcessedResult, SofError> {
     // Ensure both resources use the same FHIR version
     if view_definition.version() != bundle.version() {
         return Err(SofError::InvalidViewDefinition(
@@ -2230,19 +2449,19 @@ pub fn process_view_definition(
     match (view_definition, bundle) {
         #[cfg(feature = "R4")]
         (SofViewDefinition::R4(vd), SofBundle::R4(bundle)) => {
-            process_view_definition_generic(vd, bundle)
+            process_view_definition_generic(vd, bundle, external)
         }
         #[cfg(feature = "R4B")]
         (SofViewDefinition::R4B(vd), SofBundle::R4B(bundle)) => {
-            process_view_definition_generic(vd, bundle)
+            process_view_definition_generic(vd, bundle, external)
         }
         #[cfg(feature = "R5")]
         (SofViewDefinition::R5(vd), SofBundle::R5(bundle)) => {
-            process_view_definition_generic(vd, bundle)
+            process_view_definition_generic(vd, bundle, external)
         }
         #[cfg(feature = "R6")]
         (SofViewDefinition::R6(vd), SofBundle::R6(bundle)) => {
-            process_view_definition_generic(vd, bundle)
+            process_view_definition_generic(vd, bundle, external)
         }
         // This case should never happen due to the version check above,
         // but is needed for exhaustive pattern matching when multiple features are enabled
@@ -2285,6 +2504,7 @@ fn extract_view_definition_constants<VD: ViewDefinitionTrait>(
 pub(crate) fn process_view_definition_generic<VD, B>(
     view_definition: VD,
     bundle: B,
+    external: Vec<helios_fhir::FhirResource>,
 ) -> Result<ProcessedResult, SofError>
 where
     VD: ViewDefinitionTrait,
@@ -2302,6 +2522,14 @@ where
         .resource()
         .ok_or_else(|| SofError::InvalidViewDefinition("Resource type is required".to_string()))?;
 
+    // Build the bundle-wide resolution scope *before* filtering by resource type.
+    // `resolve()` must be able to reach any resource in the input bundle (e.g.
+    // `Encounter.subject.resolve()` -> a sibling `Patient`), not just resources of
+    // the ViewDefinition's target type. This is parsed once and shared (via `Arc`)
+    // across every per-resource and per-iteration evaluation context below.
+    // `external` contributes remotely-prefetched resources to the same pool.
+    let resolution_scope = build_resolution_scope(&bundle, external);
+
     let filtered_resources = filter_resources(&bundle, target_resource_type)?;
 
     // Step 3: Apply where clauses to filter resources
@@ -2309,6 +2537,7 @@ where
         filtered_resources,
         view_definition.where_clauses(),
         &variables,
+        &resolution_scope,
     )?;
 
     // Step 4: Process all select clauses to generate rows with forEach support
@@ -2317,8 +2546,12 @@ where
     })?;
 
     // Generate rows for each resource using the forEach-aware approach
-    let (all_columns, rows) =
-        generate_rows_from_selects(&filtered_resources, select_clauses, &variables)?;
+    let (all_columns, rows) = generate_rows_from_selects(
+        &filtered_resources,
+        select_clauses,
+        &variables,
+        &resolution_scope,
+    )?;
 
     Ok(ProcessedResult {
         columns: all_columns,
@@ -2505,6 +2738,34 @@ fn get_column_names<S: ViewDefinitionSelectTrait>(select: &S) -> Result<Vec<Stri
     Ok(column_names)
 }
 
+/// Builds the bundle-wide resolution pool that `resolve()` searches.
+///
+/// Every resource in the input bundle — regardless of type — is parsed into a
+/// version-agnostic [`helios_fhir::FhirResource`] once and shared via `Arc`, so
+/// that `Reference.resolve()` can dereference to any sibling resource in the
+/// bundle (not only resources of the ViewDefinition's target type, and not only
+/// `contained` children of the resource under evaluation).
+///
+/// The returned pool is installed on each evaluation context via
+/// [`EvaluationContext::set_resolution_scope`].
+///
+/// `external` holds resources fetched from trusted remote servers (the remote
+/// `resolve()` prefetch, [`remote_fetch::prefetch_external_resources`]); they are
+/// appended *after* the bundle's own resources so that an in-bundle resource always
+/// wins over a remotely-fetched copy of the same `Type/id`.
+fn build_resolution_scope<B: BundleTrait>(
+    bundle: &B,
+    external: Vec<helios_fhir::FhirResource>,
+) -> std::sync::Arc<Vec<helios_fhir::FhirResource>> {
+    let mut resources: Vec<helios_fhir::FhirResource> = bundle
+        .entries()
+        .into_iter()
+        .map(|resource| resource.to_fhir_resource())
+        .collect();
+    resources.extend(external);
+    std::sync::Arc::new(resources)
+}
+
 // Generic resource filtering
 fn filter_resources<'a, B: BundleTrait>(
     bundle: &'a B,
@@ -2522,6 +2783,7 @@ fn apply_where_clauses<'a, R, W>(
     resources: Vec<&'a R>,
     where_clauses: Option<&[W]>,
     variables: &HashMap<String, EvaluationResult>,
+    resolution_scope: &std::sync::Arc<Vec<helios_fhir::FhirResource>>,
 ) -> Result<Vec<&'a R>, SofError>
 where
     R: ResourceTrait,
@@ -2537,6 +2799,8 @@ where
             for where_clause in wheres {
                 let fhir_resource = resource.to_fhir_resource();
                 let mut context = EvaluationContext::new(vec![fhir_resource]);
+                // Expose the whole bundle so `where` clauses can use `resolve()`.
+                context.set_resolution_scope(std::sync::Arc::clone(resolution_scope));
 
                 // Add variables to the context
                 for (name, value) in variables {
@@ -2706,6 +2970,7 @@ fn generate_rows_from_selects<R, S>(
     resources: &[&R],
     selects: &[S],
     variables: &HashMap<String, EvaluationResult>,
+    resolution_scope: &std::sync::Arc<Vec<helios_fhir::FhirResource>>,
 ) -> Result<(Vec<String>, Vec<ProcessedRow>), SofError>
 where
     R: ResourceTrait + Sync,
@@ -2718,8 +2983,13 @@ where
         .map(|resource| {
             // Each thread gets its own local column vector
             let mut local_columns = Vec::new();
-            let resource_rows =
-                generate_rows_for_resource(*resource, selects, &mut local_columns, variables)?;
+            let resource_rows = generate_rows_for_resource(
+                *resource,
+                selects,
+                &mut local_columns,
+                variables,
+                resolution_scope,
+            )?;
             Ok::<(Vec<String>, Vec<ProcessedRow>), SofError>((local_columns, resource_rows))
         })
         .collect();
@@ -2749,6 +3019,7 @@ fn generate_rows_for_resource<R, S>(
     selects: &[S],
     all_columns: &mut Vec<String>,
     variables: &HashMap<String, EvaluationResult>,
+    resolution_scope: &std::sync::Arc<Vec<helios_fhir::FhirResource>>,
 ) -> Result<Vec<ProcessedRow>, SofError>
 where
     R: ResourceTrait,
@@ -2757,6 +3028,9 @@ where
 {
     let fhir_resource = resource.to_fhir_resource();
     let mut context = EvaluationContext::new(vec![fhir_resource]);
+    // Expose the whole bundle so column/forEach paths can use `resolve()`. `this`
+    // stays the current resource, so `%resource`/root semantics are unchanged.
+    context.set_resolution_scope(std::sync::Arc::clone(resolution_scope));
 
     // Add variables to the context
     for (name, value) in variables {
@@ -3019,7 +3293,7 @@ where
     // For each iteration item, create new combinations
     for item in &iteration_items {
         // Create a new context with the iteration item
-        let _item_context = create_iteration_context(item, variables);
+        let _item_context = create_iteration_context(item, variables, &context.resources);
 
         for existing_combo in existing_combinations {
             let mut new_combo = existing_combo.clone();
@@ -3043,7 +3317,7 @@ where
                                 item.clone()
                             } else {
                                 // Evaluate the path on the iteration item
-                                evaluate_path_on_item(path, item, variables)?
+                                evaluate_path_on_item(path, item, variables, &context.resources)?
                             };
 
                             // Check if this column is marked as a collection
@@ -3068,7 +3342,7 @@ where
         let mut final_combinations = Vec::new();
 
         for item in &iteration_items {
-            let item_context = create_iteration_context(item, variables);
+            let item_context = create_iteration_context(item, variables, &context.resources);
 
             // For each iteration item, we need to start with the combinations that have
             // the correct column values for this forEach scope
@@ -3093,7 +3367,12 @@ where
                                 let result = if path == "$this" {
                                     item.clone()
                                 } else {
-                                    evaluate_path_on_item(path, item, variables)?
+                                    evaluate_path_on_item(
+                                        path,
+                                        item,
+                                        variables,
+                                        &context.resources,
+                                    )?
                                 };
 
                                 // Check if this column is marked as a collection
@@ -3135,7 +3414,7 @@ where
         let mut union_combinations = Vec::new();
 
         for item in &iteration_items {
-            let item_context = create_iteration_context(item, variables);
+            let item_context = create_iteration_context(item, variables, &context.resources);
 
             // For each iteration item, process all unionAll selects
             for existing_combo in existing_combinations {
@@ -3157,7 +3436,12 @@ where
                                 let result = if path == "$this" {
                                     item.clone()
                                 } else {
-                                    evaluate_path_on_item(path, item, variables)?
+                                    evaluate_path_on_item(
+                                        path,
+                                        item,
+                                        variables,
+                                        &context.resources,
+                                    )?
                                 };
 
                                 // Check if this column is marked as a collection
@@ -3191,7 +3475,12 @@ where
                                         let result = if path == "$this" {
                                             item.clone()
                                         } else {
-                                            evaluate_path_on_item(path, item, variables)?
+                                            evaluate_path_on_item(
+                                                path,
+                                                item,
+                                                variables,
+                                                &context.resources,
+                                            )?
                                         };
 
                                         // Check if this column is marked as a collection
@@ -3292,7 +3581,12 @@ where
                                 let result = if path == "$this" {
                                     child_item.clone()
                                 } else {
-                                    evaluate_path_on_item(path, child_item, variables)?
+                                    evaluate_path_on_item(
+                                        path,
+                                        child_item,
+                                        variables,
+                                        &context.resources,
+                                    )?
                                 };
 
                                 let is_collection = col.collection().unwrap_or(false);
@@ -3307,7 +3601,8 @@ where
                 }
 
                 // Create context for this child item
-                let child_context = create_iteration_context(child_item, variables);
+                let child_context =
+                    create_iteration_context(child_item, variables, &context.resources);
 
                 // Start with the child combination we just created
                 let mut child_combinations = vec![child_combo.clone()];
@@ -3371,6 +3666,7 @@ fn evaluate_path_on_item(
     path: &str,
     item: &EvaluationResult,
     variables: &HashMap<String, EvaluationResult>,
+    resolution_scope: &std::sync::Arc<Vec<helios_fhir::FhirResource>>,
 ) -> Result<EvaluationResult, SofError> {
     // Create a temporary context with the iteration item as the root resource
     let mut temp_context = match item {
@@ -3383,6 +3679,10 @@ fn evaluate_path_on_item(
         }
         _ => EvaluationContext::new(vec![]),
     };
+    // Carry the bundle-wide resolution pool so chained `resolve()` calls (e.g.
+    // `forEach: list.resolve()` then a column that resolves a nested reference)
+    // can still reach sibling resources from this fresh, item-rooted context.
+    temp_context.set_resolution_scope(std::sync::Arc::clone(resolution_scope));
 
     // Add variables to the temporary context
     for (name, value) in variables {
@@ -3411,10 +3711,14 @@ fn evaluate_path_on_item(
 fn create_iteration_context(
     item: &EvaluationResult,
     variables: &HashMap<String, EvaluationResult>,
+    resolution_scope: &std::sync::Arc<Vec<helios_fhir::FhirResource>>,
 ) -> EvaluationContext {
     // Create a new context with the iteration item as the root
     let mut context = EvaluationContext::new(vec![]);
     context.this = Some(item.clone());
+    // Keep the bundle-wide resolution pool available to nested selects/columns
+    // evaluated against this iteration item, so `resolve()` still works here.
+    context.set_resolution_scope(std::sync::Arc::clone(resolution_scope));
 
     // Preserve variables from the parent context
     for (name, value) in variables {

--- a/crates/sof/src/reference_collector.rs
+++ b/crates/sof/src/reference_collector.rs
@@ -1,0 +1,185 @@
+//! Reference collection for remote `resolve()` prefetch (Phase 3).
+//!
+//! Gathers the FHIR `Reference.reference` strings present in an input bundle (and,
+//! during chained prefetch, in fetched resources) so the prefetch stage can decide
+//! which ones are eligible for remote fetching. This module is pure (no I/O).
+//!
+//! References are found by structurally walking the JSON for `"reference"` string
+//! fields, which captures every `Reference` element regardless of the path it
+//! appears at. Candidates are later filtered against the allowlist
+//! ([`crate::remote_resolver::RemoteResolveConfig::fetch_decision`]), so occasional
+//! non-`Reference` `"reference"` keys are harmless — they simply won't match.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use crate::SofBundle;
+
+/// Collects all unique `reference` strings found anywhere in the bundle.
+pub fn collect_reference_strings(bundle: &SofBundle) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    if let Some(json) = bundle_to_json(bundle) {
+        collect_into(&json, &mut out);
+    }
+    out.into_iter().collect()
+}
+
+/// Collects all unique `reference` strings from an arbitrary resource JSON value
+/// (used to discover chained references inside fetched resources).
+pub fn collect_references_from_json(value: &Value) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    collect_into(value, &mut out);
+    out.into_iter().collect()
+}
+
+/// Collects all unique `reference` strings across a slice of raw resource JSON
+/// values (the streaming/NDJSON chunk shape).
+pub fn collect_reference_strings_from_resources(resources: &[Value]) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    for resource in resources {
+        collect_into(resource, &mut out);
+    }
+    out.into_iter().collect()
+}
+
+/// Collects the `"ResourceType/id"` keys of a slice of raw resource JSON values.
+pub fn collect_resource_keys_from_resources(resources: &[Value]) -> BTreeSet<String> {
+    let mut keys = BTreeSet::new();
+    for resource in resources {
+        if let (Some(rt), Some(id)) = (
+            resource.get("resourceType").and_then(Value::as_str),
+            resource.get("id").and_then(Value::as_str),
+        ) {
+            keys.insert(format!("{rt}/{id}"));
+        }
+    }
+    keys
+}
+
+/// Collects the `"ResourceType/id"` keys of every resource already in the bundle,
+/// so the prefetch can skip references that resolve locally.
+pub fn collect_resource_keys(bundle: &SofBundle) -> BTreeSet<String> {
+    let mut keys = BTreeSet::new();
+    let Some(json) = bundle_to_json(bundle) else {
+        return keys;
+    };
+    let Some(entries) = json.get("entry").and_then(Value::as_array) else {
+        return keys;
+    };
+    for entry in entries {
+        let resource = entry.get("resource").unwrap_or(entry);
+        if let (Some(rt), Some(id)) = (
+            resource.get("resourceType").and_then(Value::as_str),
+            resource.get("id").and_then(Value::as_str),
+        ) {
+            keys.insert(format!("{rt}/{id}"));
+        }
+    }
+    keys
+}
+
+/// Returns the `"Type/id"` key implied by a reference string (relative or the
+/// trailing `Type/id` of an absolute URL), used to test local resolvability.
+///
+/// Mirrors the (capitalised-type) heuristic of the in-scope resolver. Returns
+/// `None` for fragment/bare references and anything without a `Type/id` tail.
+pub fn reference_type_id(reference: &str) -> Option<String> {
+    // Drop query/fragment before inspecting path segments.
+    let without_query = reference.split(['?', '#']).next().unwrap_or(reference);
+    let trimmed = without_query.trim_end_matches('/');
+    let mut segments = trimmed.rsplitn(3, '/');
+    let id = segments.next()?;
+    let resource_type = segments.next()?;
+    if id.is_empty() || resource_type.is_empty() {
+        return None;
+    }
+    // A FHIR resource type is a capitalised token.
+    if !resource_type
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_uppercase())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    Some(format!("{resource_type}/{id}"))
+}
+
+/// Whether `reference` already resolves against a resource present in the bundle.
+pub fn resolves_in_bundle(reference: &str, bundle_keys: &BTreeSet<String>) -> bool {
+    match reference_type_id(reference) {
+        Some(key) => bundle_keys.contains(&key),
+        None => false,
+    }
+}
+
+fn collect_into(value: &Value, out: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::String(reference)) = map.get("reference") {
+                out.insert(reference.clone());
+            }
+            for child in map.values() {
+                collect_into(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_into(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn bundle_to_json(bundle: &SofBundle) -> Option<Value> {
+    match bundle {
+        #[cfg(feature = "R4")]
+        SofBundle::R4(b) => serde_json::to_value(b).ok(),
+        #[cfg(feature = "R4B")]
+        SofBundle::R4B(b) => serde_json::to_value(b).ok(),
+        #[cfg(feature = "R5")]
+        SofBundle::R5(b) => serde_json::to_value(b).ok(),
+        #[cfg(feature = "R6")]
+        SofBundle::R6(b) => serde_json::to_value(b).ok(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_type_id_from_relative_and_absolute() {
+        assert_eq!(
+            reference_type_id("Patient/123").as_deref(),
+            Some("Patient/123")
+        );
+        assert_eq!(
+            reference_type_id("https://example.org/fhir/Patient/123").as_deref(),
+            Some("Patient/123")
+        );
+        assert_eq!(
+            reference_type_id("https://example.org/fhir/Patient/123?_format=json").as_deref(),
+            Some("Patient/123")
+        );
+        assert_eq!(reference_type_id("#contained"), None);
+        assert_eq!(reference_type_id("urn:uuid:abc"), None);
+    }
+
+    #[test]
+    fn collects_nested_references() {
+        let resource = serde_json::json!({
+            "resourceType": "Encounter",
+            "subject": { "reference": "Patient/1" },
+            "participant": [
+                { "individual": { "reference": "Practitioner/2" } },
+                { "individual": { "reference": "Practitioner/3" } }
+            ]
+        });
+        let mut refs = collect_references_from_json(&resource);
+        refs.sort();
+        assert_eq!(refs, vec!["Patient/1", "Practitioner/2", "Practitioner/3"]);
+    }
+}

--- a/crates/sof/src/remote_fetch.rs
+++ b/crates/sof/src/remote_fetch.rs
@@ -1,0 +1,369 @@
+//! Remote reference prefetch (Phases 4–5, plus streaming support).
+//!
+//! This is the only part of remote `resolve()` that performs I/O. It runs at the
+//! async edge (CLI / server), *before* the synchronous, rayon-parallel row
+//! generation, and returns the fetched resources so they can be folded into the
+//! in-memory resolution pool (see `build_resolution_scope` in `lib.rs`). The
+//! evaluation core therefore stays pure and the run remains reproducible from
+//! `(bundle + fetched snapshot)`.
+//!
+//! [`RemoteResolver`] holds the config plus a bounded, cross-call cache and a
+//! fetch counter, so it serves a whole *run*:
+//! - **single Bundle** — one [`RemoteResolver::resolve`] call over all bundle
+//!   references ([`prefetch_external_resources`]);
+//! - **streaming / NDJSON** — one resolver shared across every chunk, so a
+//!   reference recurring across chunks is fetched once and `max_fetches` is a
+//!   per-stream cap. The cache is a bounded LRU (with negative caching) so
+//!   streaming memory stays bounded.
+//!
+//! Per resolve call:
+//! 1. Keep only references the allowlist permits and that do not already resolve
+//!    locally — [`RemoteResolveConfig::fetch_decision`] / `resolves_in_bundle`.
+//! 2. Serve cache hits; for misses, validate each host (literal IPs were
+//!    explicitly allowlisted; hostnames are resolved via DNS and **pinned** to
+//!    addresses that pass [`is_blocked_address`] — enforcing the SSRF guard and
+//!    defeating DNS rebinding), then fetch concurrently under the per-run cap,
+//!    timeout, size cap, and optional per-host bearer auth.
+//! 3. Cache results (success and miss), follow chained references up to
+//!    `max_depth`, and parse the collected JSON into [`FhirResource`]s of the
+//!    bundle's version (skipping anything that fails to parse — non-fatal).
+
+use std::collections::{BTreeSet, HashSet};
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use futures::stream::{self, StreamExt};
+use lru::LruCache;
+use serde_json::Value;
+use tokio::net::lookup_host;
+use url::{Host, Url};
+
+use helios_fhir::{FhirResource, FhirVersion};
+
+use crate::reference_collector::{
+    collect_reference_strings, collect_references_from_json, collect_resource_keys,
+    resolves_in_bundle,
+};
+use crate::remote_resolver::{RemoteResolveConfig, is_blocked_address};
+use crate::{SofBundle, parse_json_to_fhir_resource_pub};
+
+/// A reusable remote-resolution engine for one run (a Bundle or an NDJSON stream).
+///
+/// Holds the [`RemoteResolveConfig`], a bounded LRU cache of fetched resource JSON
+/// (with negative caching of misses), and a fetch counter. Sharing one instance
+/// across a stream's chunks means a reference seen in many chunks is fetched once,
+/// and `max_fetches` is enforced across the whole run.
+pub struct RemoteResolver {
+    config: RemoteResolveConfig,
+    /// Reference string → fetched resource JSON, or `None` for a known miss.
+    cache: Mutex<LruCache<String, Option<Value>>>,
+    /// Total fetches performed this run (capped at `config.max_fetches`).
+    fetched: AtomicUsize,
+}
+
+impl RemoteResolver {
+    /// Creates a resolver with an empty cache sized to `config.cache_max_entries`.
+    pub fn new(config: RemoteResolveConfig) -> Self {
+        let cap = NonZeroUsize::new(config.cache_max_entries.max(1)).expect("cap >= 1");
+        Self {
+            config,
+            cache: Mutex::new(LruCache::new(cap)),
+            fetched: AtomicUsize::new(0),
+        }
+    }
+
+    /// Resolves `seed_refs` — and, within `max_depth`, references discovered inside
+    /// fetched resources — returning the parsed external resources to fold into a
+    /// resolution pool. References already resolvable in `local_keys` are skipped.
+    pub async fn resolve(
+        &self,
+        seed_refs: Vec<String>,
+        local_keys: &BTreeSet<String>,
+        version: FhirVersion,
+    ) -> Vec<FhirResource> {
+        if !self.config.is_active() {
+            return Vec::new();
+        }
+
+        let mut resolved_json: Vec<Value> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut frontier: Vec<String> = seed_refs
+            .into_iter()
+            .filter(|r| self.config.fetch_decision(r).is_allowed())
+            .filter(|r| !resolves_in_bundle(r, local_keys))
+            .filter(|r| seen.insert(r.clone()))
+            .collect();
+
+        let mut depth = 0;
+        while depth < self.config.max_depth && !frontier.is_empty() {
+            depth += 1;
+
+            // Partition this round into cache hits and misses.
+            let mut round_json: Vec<Value> = Vec::new();
+            let mut misses: Vec<String> = Vec::new();
+            {
+                let mut cache = self.cache.lock().unwrap();
+                for reference in frontier.drain(..) {
+                    match cache.get(&reference) {
+                        Some(Some(json)) => round_json.push(json.clone()),
+                        Some(None) => {} // known miss — skip
+                        None => misses.push(reference),
+                    }
+                }
+            }
+
+            // Fetch the misses, then record results (success or miss) in the cache.
+            if !misses.is_empty() {
+                let fetched = self.fetch_batch(misses).await;
+                let mut cache = self.cache.lock().unwrap();
+                for (reference, result) in fetched {
+                    if let Some(json) = &result {
+                        round_json.push(json.clone());
+                    }
+                    cache.put(reference, result);
+                }
+            }
+
+            // Queue chained references discovered in fetched resources.
+            if depth < self.config.max_depth {
+                for json in &round_json {
+                    for reference in collect_references_from_json(json) {
+                        if self.config.fetch_decision(&reference).is_allowed()
+                            && !resolves_in_bundle(&reference, local_keys)
+                            && seen.insert(reference.clone())
+                        {
+                            frontier.push(reference);
+                        }
+                    }
+                }
+            }
+
+            resolved_json.extend(round_json);
+        }
+
+        resolved_json
+            .into_iter()
+            .filter_map(
+                |json| match parse_json_to_fhir_resource_pub(json, version) {
+                    Ok(resource) => Some(resource),
+                    Err(err) => {
+                        tracing::warn!(error = %err, "remote resolve: skipping unparseable resource");
+                        None
+                    }
+                },
+            )
+            .collect()
+    }
+
+    /// Fetches a batch of (uncached) references concurrently, honouring the per-run
+    /// fetch cap, host validation, timeout and size limits. Returns
+    /// `(reference, Some(json))` on success and `(reference, None)` on any failure
+    /// or cap exhaustion, so the caller can (negative-)cache every outcome.
+    async fn fetch_batch(&self, references: Vec<String>) -> Vec<(String, Option<Value>)> {
+        let already = self.fetched.load(Ordering::Relaxed);
+        let remaining = self.config.max_fetches.saturating_sub(already);
+        if remaining == 0 {
+            tracing::warn!(
+                max_fetches = self.config.max_fetches,
+                "remote resolve: fetch cap reached; skipping further fetches"
+            );
+            return references.into_iter().map(|r| (r, None)).collect();
+        }
+
+        let (to_fetch, skipped): (Vec<String>, Vec<String>) = if references.len() > remaining {
+            tracing::warn!(
+                skipped = references.len() - remaining,
+                max_fetches = self.config.max_fetches,
+                "remote resolve: fetch cap reached; some references not fetched"
+            );
+            let mut iter = references.into_iter();
+            let take: Vec<String> = iter.by_ref().take(remaining).collect();
+            (take, iter.collect())
+        } else {
+            (references, Vec::new())
+        };
+        self.fetched.fetch_add(to_fetch.len(), Ordering::Relaxed);
+
+        let (client, allowed_hosts) = build_validated_client(&to_fetch, &self.config).await;
+        let config = &self.config;
+        let allowed = &allowed_hosts;
+
+        let mut results: Vec<(String, Option<Value>)> = stream::iter(to_fetch)
+            .map(|reference| {
+                let client = client.clone();
+                async move {
+                    let json = if host_is_allowed(&reference, allowed) {
+                        fetch_one(&client, &reference, config).await
+                    } else {
+                        None
+                    };
+                    (reference, json)
+                }
+            })
+            .buffer_unordered(config.concurrency)
+            .collect()
+            .await;
+
+        // Negative-cache the cap-skipped references too (not retried this run).
+        results.extend(skipped.into_iter().map(|r| (r, None)));
+        results
+    }
+}
+
+/// Fetches the allowlisted external references reachable from `bundle` and returns
+/// them as parsed resources to merge into the resolution pool (single-Bundle path).
+///
+/// Returns an empty vector when remote resolution is inactive. Never errors: every
+/// failure mode (disallowed host, timeout, non-2xx, oversize, unparseable) is
+/// logged and skipped, leaving the reference to fall back to the in-scope
+/// typed-stub/empty behaviour.
+pub async fn prefetch_external_resources(
+    bundle: &SofBundle,
+    config: &RemoteResolveConfig,
+) -> Vec<FhirResource> {
+    if !config.is_active() {
+        return Vec::new();
+    }
+    let resolver = RemoteResolver::new(config.clone());
+    let refs = collect_reference_strings(bundle);
+    let keys = collect_resource_keys(bundle);
+    let fetched = resolver.resolve(refs, &keys, bundle.version()).await;
+    if !fetched.is_empty() {
+        tracing::info!(
+            count = fetched.len(),
+            "remote resolve: prefetched resources"
+        );
+    }
+    fetched
+}
+
+/// Builds an HTTP client whose DNS is pinned to SSRF-validated addresses, and
+/// returns the set of (lowercased) hosts that are cleared to fetch.
+///
+/// Literal-IP hosts are cleared as-is (they could only reach here by being
+/// explicitly allowlisted). Hostnames are resolved once; if every resolved
+/// address passes [`is_blocked_address`] the host is pinned to those addresses,
+/// otherwise it is dropped.
+async fn build_validated_client(
+    batch: &[String],
+    config: &RemoteResolveConfig,
+) -> (reqwest::Client, HashSet<String>) {
+    let mut builder = reqwest::Client::builder()
+        .timeout(config.timeout)
+        .redirect(reqwest::redirect::Policy::none())
+        .user_agent(concat!("helios-sof/", env!("CARGO_PKG_VERSION")));
+
+    let mut allowed_hosts: HashSet<String> = HashSet::new();
+    let mut processed: HashSet<String> = HashSet::new();
+
+    for reference in batch {
+        let Ok(url) = Url::parse(reference) else {
+            continue;
+        };
+        let (Some(host), Some(host_str)) = (url.host(), url.host_str()) else {
+            continue;
+        };
+        let host_key = host_str.to_ascii_lowercase();
+        if !processed.insert(host_key.clone()) {
+            continue;
+        }
+        let port = url.port_or_known_default().unwrap_or(443);
+
+        match host {
+            // Explicitly-allowlisted literal IPs are the operator's own decision.
+            Host::Ipv4(_) | Host::Ipv6(_) => {
+                allowed_hosts.insert(host_key);
+            }
+            Host::Domain(name) => match lookup_host((name, port)).await {
+                Ok(addrs) => {
+                    let addrs: Vec<std::net::SocketAddr> = addrs.collect();
+                    if addrs.is_empty() {
+                        tracing::warn!(host = name, "remote resolve: host did not resolve");
+                    } else if addrs
+                        .iter()
+                        .any(|addr| is_blocked_address(addr.ip(), config.allow_private_addresses))
+                    {
+                        tracing::warn!(
+                            host = name,
+                            "remote resolve: host resolves to a disallowed address; blocked"
+                        );
+                    } else {
+                        builder = builder.resolve_to_addrs(name, &addrs);
+                        allowed_hosts.insert(host_key);
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(host = name, error = %err, "remote resolve: DNS lookup failed")
+                }
+            },
+        }
+    }
+
+    let client = builder.build().unwrap_or_else(|err| {
+        tracing::warn!(error = %err, "remote resolve: client build failed; using default client");
+        reqwest::Client::new()
+    });
+    (client, allowed_hosts)
+}
+
+fn host_is_allowed(reference: &str, allowed_hosts: &HashSet<String>) -> bool {
+    Url::parse(reference)
+        .ok()
+        .and_then(|url| url.host_str().map(|h| h.to_ascii_lowercase()))
+        .map(|host| allowed_hosts.contains(&host))
+        .unwrap_or(false)
+}
+
+/// Fetches a single reference, enforcing auth, status, and size limits.
+async fn fetch_one(
+    client: &reqwest::Client,
+    reference: &str,
+    config: &RemoteResolveConfig,
+) -> Option<Value> {
+    let url = Url::parse(reference).ok()?;
+    let host = url.host_str()?.to_ascii_lowercase();
+
+    let mut request = client
+        .get(url.clone())
+        .header(reqwest::header::ACCEPT, "application/fhir+json");
+    if let Some(token) = config.bearer_for_host(&host) {
+        request = request.bearer_auth(token);
+    }
+
+    let response = match request.send().await {
+        Ok(resp) => resp,
+        Err(err) => {
+            tracing::debug!(reference, error = %err, "remote resolve: request failed");
+            return None;
+        }
+    };
+
+    if !response.status().is_success() {
+        tracing::debug!(reference, status = %response.status(), "remote resolve: non-success");
+        return None;
+    }
+
+    if response
+        .content_length()
+        .is_some_and(|len| len as usize > config.max_response_bytes)
+    {
+        tracing::warn!(
+            reference,
+            "remote resolve: response exceeds size cap (Content-Length)"
+        );
+        return None;
+    }
+
+    let bytes = response.bytes().await.ok()?;
+    if bytes.len() > config.max_response_bytes {
+        tracing::warn!(
+            reference,
+            len = bytes.len(),
+            "remote resolve: response exceeds size cap"
+        );
+        return None;
+    }
+
+    serde_json::from_slice(&bytes).ok()
+}

--- a/crates/sof/src/remote_resolver.rs
+++ b/crates/sof/src/remote_resolver.rs
@@ -1,0 +1,856 @@
+//! Remote reference resolution — configuration and the trusted-server gate.
+//!
+//! This module holds the configuration and the allowlist + SSRF guard for remote
+//! `resolve()`. See the user-facing docs in `book/src/ch06-sql-on-fhir.md`
+//! ("Remote resolution against trusted servers") and the storage-backed follow-up
+//! tracked in issue [#167](https://github.com/HeliosSoftware/hfs/issues/167).
+//!
+//! It contains **no networking**. It only decides *whether* a given reference URL
+//! is eligible to be fetched from a trusted server, under a default-deny policy.
+//! The actual prefetch/fetch stage (Phase 4) consumes [`RemoteResolveConfig`] and
+//! reuses [`is_disallowed_ip`] for the post-DNS rebinding re-check.
+//!
+//! ## Security posture (default-deny, strict allowlist)
+//!
+//! A reference is fetchable only if **all** of the following hold:
+//! 1. Remote resolution is enabled and the allowlist is non-empty.
+//! 2. The reference is an absolute `http`/`https` URL.
+//! 3. It matches an allowlist entry on **scheme + host + port + path-prefix**
+//!    (parsed-URL comparison, never substring — so
+//!    `https://evil/?u=https://trusted.org` does not match `https://trusted.org`).
+//!
+//! Because matching requires *scheme equality*, an `http://` reference can only
+//! match an `http://` allowlist entry — i.e. plaintext is allowed only where an
+//! operator has explicitly opted in (typically a trusted internal/test server).
+//! Likewise, a reference to a private/loopback IP literal can only be fetched if
+//! that exact IP host was explicitly allowlisted; otherwise it fails to match.
+//!
+//! The [`is_blocked_address`] guard runs at the fetch stage on DNS-resolved
+//! addresses (DNS-rebinding defense). By default an allowlisted *hostname* that
+//! resolves to a private/internal address is refused; setting
+//! `SOF_RESOLVE_ALLOW_PRIVATE_ADDRESSES=true`
+//! ([`RemoteResolveConfig::allow_private_addresses`]) permits RFC1918 / IPv6-ULA
+//! targets so references can point at an internal load balancer or reverse proxy
+//! (e.g. Traefik) by hostname. The most dangerous ranges — loopback and
+//! link-local (incl. the cloud-metadata endpoint) — stay blocked either way.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::time::Duration;
+
+use url::Url;
+
+/// Environment variable names (documented in `book/src/ch06-sql-on-fhir.md`).
+pub mod env_keys {
+    pub const ENABLED: &str = "SOF_RESOLVE_REMOTE";
+    pub const ALLOWED_BASE_URLS: &str = "SOF_RESOLVE_ALLOWED_BASE_URLS";
+    pub const TIMEOUT_MS: &str = "SOF_RESOLVE_TIMEOUT_MS";
+    pub const MAX_FETCHES: &str = "SOF_RESOLVE_MAX_FETCHES";
+    pub const MAX_DEPTH: &str = "SOF_RESOLVE_MAX_DEPTH";
+    pub const MAX_RESPONSE_BYTES: &str = "SOF_RESOLVE_MAX_RESPONSE_BYTES";
+    pub const CONCURRENCY: &str = "SOF_RESOLVE_CONCURRENCY";
+    /// Per-host bearer tokens, formatted `host=token,host2=token2`.
+    pub const AUTH: &str = "SOF_RESOLVE_AUTH";
+    /// Allow allowlisted hosts to resolve to private/internal addresses.
+    pub const ALLOW_PRIVATE_ADDRESSES: &str = "SOF_RESOLVE_ALLOW_PRIVATE_ADDRESSES";
+    /// Max entries in the cross-chunk fetched-resource cache (streaming path).
+    pub const CACHE_MAX_ENTRIES: &str = "SOF_RESOLVE_CACHE_MAX_ENTRIES";
+}
+
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_MAX_FETCHES: usize = 256;
+const DEFAULT_MAX_DEPTH: usize = 1;
+const DEFAULT_MAX_RESPONSE_BYTES: usize = 5_000_000;
+const DEFAULT_CONCURRENCY: usize = 8;
+const DEFAULT_CACHE_MAX_ENTRIES: usize = 10_000;
+
+/// Configuration for remote (trusted-server) `resolve()`.
+///
+/// Defaults are **off**: an empty/default config never permits a fetch. Build one
+/// from the process environment with [`RemoteResolveConfig::from_env`].
+#[derive(Debug, Clone)]
+pub struct RemoteResolveConfig {
+    /// Master switch (`SOF_RESOLVE_REMOTE`). When `false`, nothing is ever fetched.
+    pub enabled: bool,
+    /// Trusted base URLs that references must match to be fetchable.
+    pub allowed_base_urls: Vec<AllowedBaseUrl>,
+    /// Per-request timeout (`SOF_RESOLVE_TIMEOUT_MS`).
+    pub timeout: Duration,
+    /// Hard cap on total fetches per run (`SOF_RESOLVE_MAX_FETCHES`).
+    pub max_fetches: usize,
+    /// Bounded prefetch rounds for chained references (`SOF_RESOLVE_MAX_DEPTH`).
+    pub max_depth: usize,
+    /// Maximum accepted response size in bytes (`SOF_RESOLVE_MAX_RESPONSE_BYTES`).
+    pub max_response_bytes: usize,
+    /// Maximum concurrent fetches (`SOF_RESOLVE_CONCURRENCY`).
+    pub concurrency: usize,
+    /// Optional per-host bearer tokens (`SOF_RESOLVE_AUTH`), keyed by lowercased
+    /// host. Sent only on requests to that exact (already-allowlisted) host.
+    pub bearer_tokens: std::collections::HashMap<String, String>,
+    /// Allow allowlisted *hostnames* to resolve to private/internal addresses —
+    /// RFC1918 (`10/8`, `172.16/12`, `192.168/16`) and IPv6 ULA (`fc00::/7`)
+    /// (`SOF_RESOLVE_ALLOW_PRIVATE_ADDRESSES`, default `false`).
+    ///
+    /// Needed for internal deployments where references point at an internal
+    /// load balancer / reverse proxy (e.g. Traefik) by hostname. Even when `true`,
+    /// the always-blocked ranges (loopback, link-local incl. cloud metadata,
+    /// multicast, broadcast, unspecified, CGNAT, reserved) remain refused — see
+    /// [`is_blocked_address`].
+    pub allow_private_addresses: bool,
+    /// Maximum entries in the cross-chunk fetched-resource cache used by the
+    /// streaming path (`SOF_RESOLVE_CACHE_MAX_ENTRIES`). The cache (LRU, with
+    /// negative caching of misses) lets a reference recurring across chunks be
+    /// fetched once; bounding it keeps streaming memory bounded — evicted-then-
+    /// reused references are re-fetched. Ignored by the single-Bundle path, which
+    /// holds all references in one pass.
+    pub cache_max_entries: usize,
+}
+
+impl Default for RemoteResolveConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            allowed_base_urls: Vec::new(),
+            timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+            max_fetches: DEFAULT_MAX_FETCHES,
+            max_depth: DEFAULT_MAX_DEPTH,
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+            concurrency: DEFAULT_CONCURRENCY,
+            bearer_tokens: std::collections::HashMap::new(),
+            allow_private_addresses: false,
+            cache_max_entries: DEFAULT_CACHE_MAX_ENTRIES,
+        }
+    }
+}
+
+impl RemoteResolveConfig {
+    /// Builds the configuration from the process environment.
+    ///
+    /// Malformed numeric values fall back to their defaults (with a `tracing`
+    /// warning); malformed allowlist entries are skipped individually.
+    pub fn from_env() -> Self {
+        Self::from_env_with(|key| std::env::var(key).ok())
+    }
+
+    /// Builds the configuration from an arbitrary environment lookup.
+    ///
+    /// Exposed so the parsing logic can be unit-tested without touching the
+    /// process-global environment.
+    pub fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Self {
+        let enabled = get(env_keys::ENABLED)
+            .map(|v| parse_bool(&v))
+            .unwrap_or(false);
+
+        let allowed_base_urls = get(env_keys::ALLOWED_BASE_URLS)
+            .map(|v| parse_allowlist(&v))
+            .unwrap_or_default();
+
+        let timeout = Duration::from_millis(parse_or_default(
+            get(env_keys::TIMEOUT_MS).as_deref(),
+            env_keys::TIMEOUT_MS,
+            DEFAULT_TIMEOUT_MS,
+        ));
+        let max_fetches = parse_or_default(
+            get(env_keys::MAX_FETCHES).as_deref(),
+            env_keys::MAX_FETCHES,
+            DEFAULT_MAX_FETCHES,
+        );
+        let max_depth = parse_or_default(
+            get(env_keys::MAX_DEPTH).as_deref(),
+            env_keys::MAX_DEPTH,
+            DEFAULT_MAX_DEPTH,
+        );
+        let max_response_bytes = parse_or_default(
+            get(env_keys::MAX_RESPONSE_BYTES).as_deref(),
+            env_keys::MAX_RESPONSE_BYTES,
+            DEFAULT_MAX_RESPONSE_BYTES,
+        );
+        let concurrency = parse_or_default(
+            get(env_keys::CONCURRENCY).as_deref(),
+            env_keys::CONCURRENCY,
+            DEFAULT_CONCURRENCY,
+        )
+        .max(1);
+
+        let bearer_tokens = get(env_keys::AUTH)
+            .map(|v| parse_bearer_tokens(&v))
+            .unwrap_or_default();
+
+        let allow_private_addresses = get(env_keys::ALLOW_PRIVATE_ADDRESSES)
+            .map(|v| parse_bool(&v))
+            .unwrap_or(false);
+
+        let cache_max_entries = parse_or_default(
+            get(env_keys::CACHE_MAX_ENTRIES).as_deref(),
+            env_keys::CACHE_MAX_ENTRIES,
+            DEFAULT_CACHE_MAX_ENTRIES,
+        )
+        .max(1);
+
+        Self {
+            enabled,
+            allowed_base_urls,
+            timeout,
+            max_fetches,
+            max_depth,
+            max_response_bytes,
+            concurrency,
+            bearer_tokens,
+            allow_private_addresses,
+            cache_max_entries,
+        }
+    }
+
+    /// Returns the bearer token configured for `host`, if any (case-insensitive).
+    pub fn bearer_for_host(&self, host: &str) -> Option<&str> {
+        self.bearer_tokens
+            .get(&host.to_ascii_lowercase())
+            .map(String::as_str)
+    }
+
+    /// Whether remote resolution can fetch anything at all (enabled *and* the
+    /// allowlist is non-empty). When `false`, [`Self::fetch_decision`] always denies.
+    pub fn is_active(&self) -> bool {
+        self.enabled && !self.allowed_base_urls.is_empty()
+    }
+
+    /// Decides whether `reference` may be fetched from a trusted server.
+    ///
+    /// This is the single gate enforcing the default-deny policy. It performs no
+    /// I/O and no DNS resolution.
+    pub fn fetch_decision(&self, reference: &str) -> FetchDecision {
+        if !self.enabled {
+            return FetchDecision::Deny(DenyReason::Disabled);
+        }
+
+        let url = match Url::parse(reference) {
+            Ok(u) => u,
+            Err(_) => return FetchDecision::Deny(DenyReason::NotAbsoluteUrl),
+        };
+
+        // `Url::parse` accepts relative-looking inputs as some schemes; require a
+        // real network scheme with a host.
+        match url.scheme() {
+            "http" | "https" => {}
+            _ => return FetchDecision::Deny(DenyReason::UnsupportedScheme),
+        }
+        if url.host_str().is_none() {
+            return FetchDecision::Deny(DenyReason::NotAbsoluteUrl);
+        }
+
+        if self.allowed_base_urls.iter().any(|base| base.matches(&url)) {
+            FetchDecision::Allow
+        } else {
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        }
+    }
+}
+
+/// A parsed, normalised trusted base URL.
+///
+/// Matching compares scheme, lowercased host, effective port (scheme default when
+/// absent), and a path prefix anchored on segment boundaries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllowedBaseUrl {
+    scheme: String,
+    host: String,
+    port: u16,
+    /// Path prefix without a trailing slash; empty means "any path on this host".
+    path_prefix: String,
+}
+
+impl AllowedBaseUrl {
+    /// Parses a single allowlist entry such as `https://fhir.example.org/r4`.
+    pub fn parse(raw: &str) -> Result<Self, AllowlistParseError> {
+        let url = Url::parse(raw.trim()).map_err(|_| AllowlistParseError::InvalidUrl)?;
+
+        let scheme = url.scheme().to_string();
+        if scheme != "http" && scheme != "https" {
+            return Err(AllowlistParseError::UnsupportedScheme);
+        }
+
+        let host = url
+            .host_str()
+            .ok_or(AllowlistParseError::MissingHost)?
+            .to_ascii_lowercase();
+
+        let port = url
+            .port_or_known_default()
+            .ok_or(AllowlistParseError::MissingPort)?;
+
+        let path_prefix = url.path().trim_end_matches('/').to_string();
+
+        Ok(Self {
+            scheme,
+            host,
+            port,
+            path_prefix,
+        })
+    }
+
+    /// Returns `true` if `url` falls within this trusted base.
+    fn matches(&self, url: &Url) -> bool {
+        url.scheme() == self.scheme
+            && url
+                .host_str()
+                .map(|h| h.eq_ignore_ascii_case(&self.host))
+                .unwrap_or(false)
+            && url.port_or_known_default() == Some(self.port)
+            && path_prefix_matches(&self.path_prefix, url.path())
+    }
+}
+
+/// Errors from parsing a single allowlist entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AllowlistParseError {
+    #[error("not a valid absolute URL")]
+    InvalidUrl,
+    #[error("unsupported scheme (only http/https are allowed)")]
+    UnsupportedScheme,
+    #[error("URL has no host")]
+    MissingHost,
+    #[error("URL has no resolvable port")]
+    MissingPort,
+}
+
+/// Outcome of [`RemoteResolveConfig::fetch_decision`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchDecision {
+    /// The reference matches a trusted base and may be fetched.
+    Allow,
+    /// The reference must not be fetched, with the reason.
+    Deny(DenyReason),
+}
+
+impl FetchDecision {
+    /// Convenience: whether the decision is [`FetchDecision::Allow`].
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, FetchDecision::Allow)
+    }
+}
+
+/// Why a reference was denied remote resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DenyReason {
+    /// Remote resolution is disabled (`SOF_RESOLVE_REMOTE` is not set/true).
+    Disabled,
+    /// The reference is not an absolute URL (e.g. `Patient/1`, `#frag`).
+    NotAbsoluteUrl,
+    /// The URL scheme is not `http`/`https`.
+    UnsupportedScheme,
+    /// The URL did not match any trusted base in the allowlist.
+    NotAllowlisted,
+}
+
+/// Strict SSRF guard: `true` if `ip` must never be the target of a fetch under
+/// the default (most restrictive) policy.
+///
+/// Equivalent to [`is_blocked_address(ip, false)`](is_blocked_address): the union
+/// of the always-blocked ranges and the private/internal ranges. Retained as the
+/// canonical predicate used where private addresses are never acceptable.
+pub fn is_disallowed_ip(ip: IpAddr) -> bool {
+    is_blocked_address(ip, false)
+}
+
+/// SSRF guard parameterised by whether private/internal addresses are permitted.
+///
+/// Applied by the fetch stage to addresses obtained from DNS resolution (to defeat
+/// DNS rebinding): an allowlisted *hostname* that resolves to a blocked address is
+/// refused.
+///
+/// - The **always-blocked** ranges are refused regardless of `allow_private`:
+///   loopback, link-local (incl. the `169.254.169.254` cloud-metadata endpoint),
+///   unspecified, broadcast, multicast, carrier-grade NAT, documentation/test, and
+///   reserved (`0.0.0.0/8`, `240.0.0.0/4`).
+/// - The **private/internal** ranges — RFC1918 (`10/8`, `172.16/12`, `192.168/16`)
+///   and IPv6 ULA (`fc00::/7`) — are refused only when `allow_private` is `false`.
+///   Setting it `true` (via `SOF_RESOLVE_ALLOW_PRIVATE_ADDRESSES`) lets an
+///   allowlisted hostname point at an internal load balancer / reverse proxy.
+pub fn is_blocked_address(ip: IpAddr, allow_private: bool) -> bool {
+    let (always_blocked, private) = match ip {
+        IpAddr::V4(v4) => (is_always_blocked_ipv4(v4), v4.is_private()),
+        IpAddr::V6(v6) => {
+            // IPv4-mapped (`::ffff:a.b.c.d`) addresses are reachable as IPv4.
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                (is_always_blocked_ipv4(mapped), mapped.is_private())
+            } else {
+                (is_always_blocked_ipv6(v6), is_unique_local_ipv6(v6))
+            }
+        }
+    };
+    always_blocked || (!allow_private && private)
+}
+
+fn is_always_blocked_ipv4(ip: Ipv4Addr) -> bool {
+    let [a, b, _, _] = ip.octets();
+    ip.is_unspecified()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        || ip.is_multicast()
+        // "this network" 0.0.0.0/8
+        || a == 0
+        // carrier-grade NAT 100.64.0.0/10
+        || (a == 100 && (64..=127).contains(&b))
+        // reserved for future use 240.0.0.0/4 (and 255.* broadcast)
+        || a >= 240
+}
+
+fn is_always_blocked_ipv6(ip: Ipv6Addr) -> bool {
+    let first = ip.segments()[0];
+    ip.is_unspecified()
+        || ip.is_loopback()
+        || ip.is_multicast()
+        // link-local unicast fe80::/10
+        || (first & 0xffc0) == 0xfe80
+}
+
+/// IPv6 unique-local addresses `fc00::/7` (the ULA "private" range).
+fn is_unique_local_ipv6(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xfe00) == 0xfc00
+}
+
+/// Anchored path-prefix match: `path` must equal `prefix` or continue past it at
+/// a `/` boundary. An empty `prefix` matches any path.
+fn path_prefix_matches(prefix: &str, path: &str) -> bool {
+    if prefix.is_empty() {
+        return true;
+    }
+    let path = path.trim_end_matches('/');
+    path == prefix || path.starts_with(&format!("{prefix}/"))
+}
+
+/// Parses a comma-separated allowlist into trusted base URLs, skipping (and
+/// warning about) malformed entries. Exposed for CLI/server wiring that builds a
+/// [`RemoteResolveConfig`] from flags rather than the environment.
+pub fn parse_allowed_base_urls(csv: &str) -> Vec<AllowedBaseUrl> {
+    parse_allowlist(csv)
+}
+
+/// Parses `host=token,host2=token2` into a per-host bearer map (hosts lowercased).
+fn parse_bearer_tokens(csv: &str) -> std::collections::HashMap<String, String> {
+    csv.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|pair| {
+            let (host, token) = pair.split_once('=')?;
+            let host = host.trim();
+            let token = token.trim();
+            if host.is_empty() || token.is_empty() {
+                tracing::warn!(pair, "ignoring malformed {} entry", env_keys::AUTH);
+                return None;
+            }
+            Some((host.to_ascii_lowercase(), token.to_string()))
+        })
+        .collect()
+}
+
+/// Parses a comma-separated allowlist, skipping (and warning about) bad entries.
+fn parse_allowlist(csv: &str) -> Vec<AllowedBaseUrl> {
+    csv.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|entry| match AllowedBaseUrl::parse(entry) {
+            Ok(base) => Some(base),
+            Err(err) => {
+                tracing::warn!(
+                    entry,
+                    error = %err,
+                    "ignoring invalid {} entry",
+                    env_keys::ALLOWED_BASE_URLS
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+fn parse_bool(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn parse_or_default<T: std::str::FromStr>(value: Option<&str>, key: &str, default: T) -> T {
+    match value {
+        None => default,
+        Some(raw) => match raw.trim().parse() {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                tracing::warn!(key, value = raw, "invalid value; using default");
+                default
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn cfg(enabled: bool, allow: &[&str]) -> RemoteResolveConfig {
+        RemoteResolveConfig {
+            enabled,
+            allowed_base_urls: allow
+                .iter()
+                .map(|s| AllowedBaseUrl::parse(s).expect("valid test base"))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    // ---- Phase 1: configuration parsing -------------------------------------
+
+    #[test]
+    fn default_config_is_off() {
+        let c = RemoteResolveConfig::default();
+        assert!(!c.enabled);
+        assert!(c.allowed_base_urls.is_empty());
+        assert!(!c.is_active());
+        assert_eq!(c.timeout, Duration::from_millis(DEFAULT_TIMEOUT_MS));
+        assert_eq!(c.max_depth, DEFAULT_MAX_DEPTH);
+    }
+
+    #[test]
+    fn from_env_parses_values() {
+        let env: HashMap<&str, &str> = HashMap::from([
+            (env_keys::ENABLED, "true"),
+            (
+                env_keys::ALLOWED_BASE_URLS,
+                "https://fhir.example.org/r4, https://hapi.example.com/baseR4",
+            ),
+            (env_keys::TIMEOUT_MS, "1500"),
+            (env_keys::MAX_FETCHES, "10"),
+            (env_keys::MAX_DEPTH, "3"),
+            (env_keys::CONCURRENCY, "4"),
+        ]);
+        let c = RemoteResolveConfig::from_env_with(|k| env.get(k).map(|s| s.to_string()));
+
+        assert!(c.enabled);
+        assert!(c.is_active());
+        assert_eq!(c.allowed_base_urls.len(), 2);
+        assert_eq!(c.timeout, Duration::from_millis(1500));
+        assert_eq!(c.max_fetches, 10);
+        assert_eq!(c.max_depth, 3);
+        assert_eq!(c.concurrency, 4);
+    }
+
+    #[test]
+    fn from_env_defaults_off_when_unset() {
+        let c = RemoteResolveConfig::from_env_with(|_| None);
+        assert!(!c.enabled);
+        assert!(c.allowed_base_urls.is_empty());
+    }
+
+    #[test]
+    fn from_env_skips_invalid_allowlist_entries() {
+        let env: HashMap<&str, &str> = HashMap::from([
+            (env_keys::ENABLED, "1"),
+            (
+                env_keys::ALLOWED_BASE_URLS,
+                "https://ok.example.org/fhir, not-a-url, ftp://nope.example.org, ",
+            ),
+        ]);
+        let c = RemoteResolveConfig::from_env_with(|k| env.get(k).map(|s| s.to_string()));
+        assert_eq!(c.allowed_base_urls.len(), 1);
+    }
+
+    #[test]
+    fn from_env_bad_numbers_fall_back_to_default() {
+        let env: HashMap<&str, &str> =
+            HashMap::from([(env_keys::TIMEOUT_MS, "abc"), (env_keys::MAX_FETCHES, "")]);
+        let c = RemoteResolveConfig::from_env_with(|k| env.get(k).map(|s| s.to_string()));
+        assert_eq!(c.timeout, Duration::from_millis(DEFAULT_TIMEOUT_MS));
+        assert_eq!(c.max_fetches, DEFAULT_MAX_FETCHES);
+    }
+
+    #[test]
+    fn bool_parsing_is_lenient() {
+        for v in ["1", "true", "TRUE", "Yes", "on"] {
+            assert!(parse_bool(v), "{v} should be true");
+        }
+        for v in ["0", "false", "no", "", "off", "maybe"] {
+            assert!(!parse_bool(v), "{v} should be false");
+        }
+    }
+
+    // ---- Phase 2: allowlist matching ----------------------------------------
+
+    #[test]
+    fn allows_reference_under_trusted_base() {
+        let c = cfg(true, &["https://fhir.example.org/r4"]);
+        assert!(
+            c.fetch_decision("https://fhir.example.org/r4/Patient/123")
+                .is_allowed()
+        );
+        // The base path itself matches.
+        assert!(c.fetch_decision("https://fhir.example.org/r4").is_allowed());
+        // Query strings are irrelevant to the host/path decision.
+        assert!(
+            c.fetch_decision("https://fhir.example.org/r4/Patient/1?_format=json")
+                .is_allowed()
+        );
+    }
+
+    #[test]
+    fn path_prefix_is_anchored_on_segment_boundary() {
+        let c = cfg(true, &["https://fhir.example.org/r4"]);
+        // `/r4extra` must NOT be treated as under `/r4`.
+        assert_eq!(
+            c.fetch_decision("https://fhir.example.org/r4extra/Patient/1"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+        assert_eq!(
+            c.fetch_decision("https://fhir.example.org/other"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+    }
+
+    #[test]
+    fn host_scheme_and_port_must_match() {
+        let c = cfg(true, &["https://fhir.example.org/r4"]);
+        // Wrong host.
+        assert_eq!(
+            c.fetch_decision("https://evil.example.org/r4/Patient/1"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+        // Wrong scheme (only the https base is trusted).
+        assert_eq!(
+            c.fetch_decision("http://fhir.example.org/r4/Patient/1"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+        // Wrong (explicit) port.
+        assert_eq!(
+            c.fetch_decision("https://fhir.example.org:8443/r4/Patient/1"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+    }
+
+    #[test]
+    fn substring_smuggling_does_not_match() {
+        let c = cfg(true, &["https://fhir.example.org/r4"]);
+        // Host is evil.com; the trusted URL only appears in the query.
+        assert_eq!(
+            c.fetch_decision("https://evil.com/?u=https://fhir.example.org/r4/Patient/1"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+        // Userinfo trick: real host is still evil.com.
+        assert_eq!(
+            c.fetch_decision("https://fhir.example.org@evil.com/r4/Patient/1"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+    }
+
+    #[test]
+    fn explicit_http_base_allows_plaintext() {
+        // Operators may opt into a trusted internal/test http server.
+        let c = cfg(true, &["http://localhost:8080/baseR4"]);
+        assert!(
+            c.fetch_decision("http://localhost:8080/baseR4/Patient/1")
+                .is_allowed()
+        );
+        // https to the same host/port is a different base and is not trusted.
+        assert_eq!(
+            c.fetch_decision("https://localhost:8080/baseR4/Patient/1"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+    }
+
+    #[test]
+    fn literal_private_ip_requires_explicit_allowlisting() {
+        // Not allowlisted -> denied (this is the SSRF-by-literal-IP case).
+        let c = cfg(true, &["https://fhir.example.org/r4"]);
+        assert_eq!(
+            c.fetch_decision("https://10.0.0.5/r4/Patient/1"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+        // Explicitly allowlisted private host -> the operator owns that decision.
+        let c2 = cfg(true, &["https://10.0.0.5/r4"]);
+        assert!(
+            c2.fetch_decision("https://10.0.0.5/r4/Patient/1")
+                .is_allowed()
+        );
+    }
+
+    #[test]
+    fn non_absolute_and_unsupported_schemes_are_denied() {
+        let c = cfg(true, &["https://fhir.example.org/r4"]);
+        assert_eq!(
+            c.fetch_decision("Patient/123"),
+            FetchDecision::Deny(DenyReason::NotAbsoluteUrl)
+        );
+        assert_eq!(
+            c.fetch_decision("#contained-1"),
+            FetchDecision::Deny(DenyReason::NotAbsoluteUrl)
+        );
+        assert_eq!(
+            c.fetch_decision("ftp://fhir.example.org/r4/Patient/1"),
+            FetchDecision::Deny(DenyReason::UnsupportedScheme)
+        );
+        assert_eq!(
+            c.fetch_decision("file:///etc/passwd"),
+            FetchDecision::Deny(DenyReason::UnsupportedScheme)
+        );
+    }
+
+    #[test]
+    fn disabled_or_empty_allowlist_denies_everything() {
+        let disabled = cfg(false, &["https://fhir.example.org/r4"]);
+        assert_eq!(
+            disabled.fetch_decision("https://fhir.example.org/r4/Patient/1"),
+            FetchDecision::Deny(DenyReason::Disabled)
+        );
+
+        let empty = cfg(true, &[]);
+        assert!(!empty.is_active());
+        assert_eq!(
+            empty.fetch_decision("https://fhir.example.org/r4/Patient/1"),
+            FetchDecision::Deny(DenyReason::NotAllowlisted)
+        );
+    }
+
+    #[test]
+    fn root_base_matches_any_path_on_host() {
+        let c = cfg(true, &["https://fhir.example.org"]);
+        assert!(
+            c.fetch_decision("https://fhir.example.org/anything/here")
+                .is_allowed()
+        );
+        assert!(c.fetch_decision("https://fhir.example.org/").is_allowed());
+    }
+
+    // ---- Phase 2: SSRF IP guard ---------------------------------------------
+
+    #[test]
+    fn disallowed_ipv4_ranges() {
+        for ip in [
+            "0.0.0.0",
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "172.31.255.255",
+            "192.168.1.1",
+            "169.254.169.254", // cloud metadata
+            "100.64.0.1",      // CGNAT
+            "192.0.2.1",       // documentation
+            "255.255.255.255",
+            "224.0.0.1", // multicast
+            "240.0.0.1", // reserved
+        ] {
+            assert!(
+                is_disallowed_ip(ip.parse().unwrap()),
+                "{ip} should be disallowed"
+            );
+        }
+    }
+
+    #[test]
+    fn allowed_public_ipv4() {
+        for ip in ["8.8.8.8", "1.1.1.1", "93.184.216.34"] {
+            assert!(
+                !is_disallowed_ip(ip.parse().unwrap()),
+                "{ip} should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn disallowed_ipv6_ranges() {
+        for ip in [
+            "::1",                    // loopback
+            "fe80::1",                // link-local
+            "fc00::1",                // unique local
+            "fd12:3456::1",           // unique local
+            "ff02::1",                // multicast
+            "::",                     // unspecified
+            "::ffff:127.0.0.1",       // v4-mapped loopback
+            "::ffff:169.254.169.254", // v4-mapped metadata
+        ] {
+            assert!(
+                is_disallowed_ip(ip.parse().unwrap()),
+                "{ip} should be disallowed"
+            );
+        }
+    }
+
+    #[test]
+    fn allowed_public_ipv6() {
+        for ip in [
+            "2606:4700:4700::1111",
+            "2001:4860:4860::8888",
+            "::ffff:8.8.8.8",
+        ] {
+            assert!(
+                !is_disallowed_ip(ip.parse().unwrap()),
+                "{ip} should be allowed"
+            );
+        }
+    }
+
+    // ---- Phase 5: private-address opt-in (internal load balancers) ----------
+
+    #[test]
+    fn allow_private_permits_rfc1918_and_ula() {
+        // With opt-in, internal LB ranges (RFC1918 + IPv6 ULA) are reachable...
+        for ip in [
+            "10.0.0.5",
+            "172.16.4.4",
+            "192.168.1.10",
+            "fc00::1",
+            "fd12:3456::1",
+        ] {
+            let addr: IpAddr = ip.parse().unwrap();
+            assert!(
+                is_blocked_address(addr, false),
+                "{ip} must be blocked by default"
+            );
+            assert!(
+                !is_blocked_address(addr, true),
+                "{ip} must be permitted when allow_private is set"
+            );
+        }
+    }
+
+    #[test]
+    fn always_blocked_ranges_ignore_allow_private() {
+        // ...but loopback, link-local/metadata, and friends stay blocked even then.
+        for ip in [
+            "127.0.0.1",
+            "169.254.169.254", // cloud metadata
+            "0.0.0.0",
+            "100.64.0.1", // CGNAT
+            "224.0.0.1",  // multicast
+            "240.0.0.1",  // reserved
+            "::1",
+            "fe80::1",          // link-local
+            "::ffff:127.0.0.1", // v4-mapped loopback
+        ] {
+            let addr: IpAddr = ip.parse().unwrap();
+            assert!(
+                is_blocked_address(addr, true),
+                "{ip} must stay blocked even with allow_private"
+            );
+        }
+    }
+
+    #[test]
+    fn public_addresses_allowed_regardless_of_flag() {
+        for ip in ["8.8.8.8", "2606:4700:4700::1111"] {
+            let addr: IpAddr = ip.parse().unwrap();
+            assert!(!is_blocked_address(addr, false));
+            assert!(!is_blocked_address(addr, true));
+        }
+    }
+
+    #[test]
+    fn from_env_parses_allow_private() {
+        let env: HashMap<&str, &str> = HashMap::from([(env_keys::ALLOW_PRIVATE_ADDRESSES, "true")]);
+        let c = RemoteResolveConfig::from_env_with(|k| env.get(k).map(|s| s.to_string()));
+        assert!(c.allow_private_addresses);
+        // Default (unset) stays false.
+        let d = RemoteResolveConfig::from_env_with(|_| None);
+        assert!(!d.allow_private_addresses);
+    }
+}

--- a/crates/sof/tests/resolve_remote_tests.rs
+++ b/crates/sof/tests/resolve_remote_tests.rs
@@ -1,0 +1,417 @@
+//! Integration tests for remote `Reference.resolve()` (trusted-server prefetch).
+//!
+//! These exercise the end-to-end remote path against a `wiremock` server:
+//! references to an allowlisted server are fetched and folded into the resolution
+//! pool before row generation. The mock listens on `127.0.0.1`; the SSRF guard
+//! blocks loopback for *hostnames*, but a literal IP that is **explicitly
+//! allowlisted** is permitted — which is the documented escape hatch and what we
+//! configure here (the allowlist base is the mock's own `http://127.0.0.1:PORT`).
+
+use std::io::Cursor;
+
+use helios_sof::{
+    ChunkConfig, ContentType, RemoteResolveConfig, RunOptions, SofBundle, SofViewDefinition,
+    process_ndjson_chunked_remote, run_view_definition_with_options_remote,
+};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn bundle(resources: &[serde_json::Value]) -> SofBundle {
+    let mut bundle_json = serde_json::json!({
+        "resourceType": "Bundle",
+        "id": "test-bundle",
+        "type": "collection",
+        "entry": []
+    });
+    let entries = bundle_json["entry"].as_array_mut().unwrap();
+    for resource in resources {
+        entries.push(serde_json::json!({ "resource": resource }));
+    }
+    SofBundle::R4(serde_json::from_value(bundle_json).expect("valid R4 bundle"))
+}
+
+fn view(view_json: serde_json::Value) -> SofViewDefinition {
+    let mut v = view_json;
+    let obj = v.as_object_mut().unwrap();
+    obj.insert("resourceType".into(), "ViewDefinition".into());
+    obj.insert("status".into(), "active".into());
+    SofViewDefinition::R4(serde_json::from_value(v).expect("valid R4 ViewDefinition"))
+}
+
+fn config(base: &str, max_depth: usize, max_fetches: usize) -> RemoteResolveConfig {
+    RemoteResolveConfig {
+        enabled: true,
+        allowed_base_urls: helios_sof::parse_allowed_base_urls(base),
+        max_depth,
+        max_fetches,
+        ..Default::default()
+    }
+}
+
+fn opts() -> RunOptions {
+    RunOptions {
+        since: None,
+        limit: None,
+        page: None,
+        parquet_options: None,
+    }
+}
+
+async fn run(
+    v: SofViewDefinition,
+    b: SofBundle,
+    cfg: &RemoteResolveConfig,
+) -> Vec<serde_json::Value> {
+    let bytes = run_view_definition_with_options_remote(v, b, ContentType::Json, opts(), cfg)
+        .await
+        .expect("run remote");
+    serde_json::from_slice(&bytes).expect("json rows")
+}
+
+fn encounter_referencing(id: &str, subject_ref: &str) -> serde_json::Value {
+    serde_json::json!({
+        "resourceType": "Encounter",
+        "id": id,
+        "status": "finished",
+        "subject": { "reference": subject_ref }
+    })
+}
+
+fn subject_resolve_view() -> serde_json::Value {
+    serde_json::json!({
+        "resource": "Encounter",
+        "select": [
+            { "column": [{ "name": "encounter_id", "path": "id" }] },
+            {
+                "forEach": "subject.resolve()",
+                "column": [
+                    { "name": "patient_id", "path": "id" },
+                    { "name": "patient_family", "path": "name.family" }
+                ]
+            }
+        ]
+    })
+}
+
+/// A reference to an allowlisted server is fetched and resolved end-to-end.
+#[tokio::test]
+async fn remote_resolve_fetches_from_trusted_server() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/Patient/pat-remote"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resourceType": "Patient",
+            "id": "pat-remote",
+            "name": [{ "family": "Remote" }]
+        })))
+        .mount(&server)
+        .await;
+
+    let base = server.uri();
+    let reference = format!("{base}/Patient/pat-remote");
+    let b = bundle(&[encounter_referencing("enc-1", &reference)]);
+    let cfg = config(&base, 1, 256);
+
+    let rows = run(view(subject_resolve_view()), b, &cfg).await;
+    assert_eq!(rows.len(), 1, "rows: {rows:#?}");
+    assert_eq!(rows[0]["patient_id"], serde_json::json!("pat-remote"));
+    assert_eq!(rows[0]["patient_family"], serde_json::json!("Remote"));
+}
+
+/// A reference whose host is NOT allowlisted is never fetched; the column is null.
+#[tokio::test]
+async fn remote_resolve_skips_non_allowlisted_host() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/Patient/pat-remote"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resourceType": "Patient", "id": "pat-remote", "name": [{ "family": "Remote" }]
+        })))
+        .mount(&server)
+        .await;
+
+    let reference = format!("{}/Patient/pat-remote", server.uri());
+    // Allowlist a *different* server, so the mock reference must not be fetched.
+    let cfg = config("https://trusted.example.org/fhir", 1, 256);
+    let b = bundle(&[encounter_referencing("enc-1", &reference)]);
+
+    let rows = run(view(subject_resolve_view()), b, &cfg).await;
+    assert_eq!(rows.len(), 1, "rows: {rows:#?}");
+    assert!(
+        rows[0]["patient_family"].is_null(),
+        "non-allowlisted reference must not resolve: {:#?}",
+        rows[0]
+    );
+    assert!(
+        server.received_requests().await.unwrap().is_empty(),
+        "mock server must receive no requests for a non-allowlisted host"
+    );
+}
+
+/// A non-success response (404) is non-fatal: the column is null, no error.
+#[tokio::test]
+async fn remote_resolve_404_is_non_fatal() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/Patient/missing"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let base = server.uri();
+    let reference = format!("{base}/Patient/missing");
+    let cfg = config(&base, 1, 256);
+    let b = bundle(&[encounter_referencing("enc-1", &reference)]);
+
+    let rows = run(view(subject_resolve_view()), b, &cfg).await;
+    assert_eq!(rows.len(), 1, "rows: {rows:#?}");
+    assert!(rows[0]["patient_family"].is_null());
+}
+
+/// The fetch cap bounds the number of remote requests in a run.
+#[tokio::test]
+async fn remote_resolve_respects_fetch_cap() {
+    let server = MockServer::start().await;
+    for (id, family) in [("p1", "One"), ("p2", "Two")] {
+        Mock::given(method("GET"))
+            .and(path(format!("/Patient/{id}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "resourceType": "Patient", "id": id, "name": [{ "family": family }]
+            })))
+            .mount(&server)
+            .await;
+    }
+
+    let base = server.uri();
+    let b = bundle(&[
+        encounter_referencing("enc-1", &format!("{base}/Patient/p1")),
+        encounter_referencing("enc-2", &format!("{base}/Patient/p2")),
+    ]);
+    let cfg = config(&base, 1, 1); // cap = 1
+
+    let _ = run(view(subject_resolve_view()), b, &cfg).await;
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        1,
+        "fetch cap of 1 must allow exactly one remote request"
+    );
+}
+
+fn chained_view() -> serde_json::Value {
+    serde_json::json!({
+        "resource": "Encounter",
+        "select": [{
+            "forEach": "subject.resolve()",
+            "column": [
+                { "name": "patient_family", "path": "name.family" },
+                { "name": "gp_family", "path": "generalPractitioner.resolve().name.family" }
+            ]
+        }]
+    })
+}
+
+async fn mount_chained(server: &MockServer, base: &str) {
+    Mock::given(method("GET"))
+        .and(path("/Patient/p1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resourceType": "Patient",
+            "id": "p1",
+            "name": [{ "family": "Root" }],
+            "generalPractitioner": [{ "reference": format!("{base}/Practitioner/pr1") }]
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Practitioner/pr1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resourceType": "Practitioner", "id": "pr1", "name": [{ "family": "Doc" }]
+        })))
+        .mount(server)
+        .await;
+}
+
+/// With `max_depth = 1`, only the first-level reference is fetched; a chained
+/// reference discovered inside the fetched resource is not.
+#[tokio::test]
+async fn remote_resolve_depth_one_does_not_follow_chains() {
+    let server = MockServer::start().await;
+    let base = server.uri();
+    mount_chained(&server, &base).await;
+
+    let b = bundle(&[encounter_referencing(
+        "enc-1",
+        &format!("{base}/Patient/p1"),
+    )]);
+    let cfg = config(&base, 1, 256);
+
+    let rows = run(view(chained_view()), b, &cfg).await;
+    assert_eq!(rows[0]["patient_family"], serde_json::json!("Root"));
+    assert!(
+        rows[0]["gp_family"].is_null(),
+        "depth=1 must not fetch the second-level Practitioner: {:#?}",
+        rows[0]
+    );
+}
+
+/// With `max_depth = 2`, the chained reference is fetched in the second round.
+#[tokio::test]
+async fn remote_resolve_depth_two_follows_one_chain() {
+    let server = MockServer::start().await;
+    let base = server.uri();
+    mount_chained(&server, &base).await;
+
+    let b = bundle(&[encounter_referencing(
+        "enc-1",
+        &format!("{base}/Patient/p1"),
+    )]);
+    let cfg = config(&base, 2, 256);
+
+    let rows = run(view(chained_view()), b, &cfg).await;
+    assert_eq!(rows[0]["patient_family"], serde_json::json!("Root"));
+    assert_eq!(rows[0]["gp_family"], serde_json::json!("Doc"));
+}
+
+/// An allowlisted *hostname* that resolves to a loopback address is blocked even
+/// when `allow_private_addresses` is enabled — the always-blocked tier (loopback,
+/// link-local/metadata) is never bypassed by the private-address opt-in. (We use
+/// `localhost`, which resolves to loopback; a real internal LB would resolve to an
+/// RFC1918 address, which the opt-in *does* permit — covered by the unit tests.)
+#[tokio::test]
+async fn remote_resolve_allow_private_still_blocks_loopback_hostname() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/Patient/pat-remote"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resourceType": "Patient", "id": "pat-remote", "name": [{ "family": "Remote" }]
+        })))
+        .mount(&server)
+        .await;
+
+    let port = server.address().port();
+    let base = format!("http://localhost:{port}");
+    let reference = format!("{base}/Patient/pat-remote");
+    let cfg = RemoteResolveConfig {
+        enabled: true,
+        allowed_base_urls: helios_sof::parse_allowed_base_urls(&base),
+        allow_private_addresses: true, // even so, loopback stays blocked
+        ..Default::default()
+    };
+    let b = bundle(&[encounter_referencing("enc-1", &reference)]);
+
+    let rows = run(view(subject_resolve_view()), b, &cfg).await;
+    assert!(
+        rows[0]["patient_family"].is_null(),
+        "loopback hostname must be blocked even with allow_private: {:#?}",
+        rows[0]
+    );
+    assert!(
+        server.received_requests().await.unwrap().is_empty(),
+        "no request must reach a loopback host"
+    );
+}
+
+// ---- Streaming / NDJSON remote resolution -------------------------------------
+
+fn ndjson(resources: &[serde_json::Value]) -> String {
+    resources
+        .iter()
+        .map(|r| serde_json::to_string(r).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+async fn run_stream(
+    v: SofViewDefinition,
+    input: String,
+    cfg: &RemoteResolveConfig,
+    chunk_size: usize,
+) -> Vec<serde_json::Value> {
+    let mut out: Vec<u8> = Vec::new();
+    let chunk_config = ChunkConfig {
+        chunk_size,
+        skip_invalid_lines: false,
+    };
+    process_ndjson_chunked_remote(
+        v,
+        Cursor::new(input.into_bytes()),
+        &mut out,
+        ContentType::Json,
+        chunk_config,
+        cfg,
+    )
+    .await
+    .expect("stream remote");
+    serde_json::from_slice(&out).expect("json rows")
+}
+
+/// A reference shared by Encounters in different chunks is fetched once (the
+/// cross-chunk LRU cache), and resolves in every chunk. `chunk_size = 1` forces
+/// one resource per chunk, so the two Encounters land in separate chunks.
+#[tokio::test]
+async fn remote_resolve_streaming_caches_shared_reference_across_chunks() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/Patient/shared"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resourceType": "Patient", "id": "shared", "name": [{ "family": "Shared" }]
+        })))
+        .mount(&server)
+        .await;
+
+    let base = server.uri();
+    let reference = format!("{base}/Patient/shared");
+    let input = ndjson(&[
+        encounter_referencing("e1", &reference),
+        encounter_referencing("e2", &reference),
+    ]);
+    let cfg = config(&base, 1, 256);
+
+    let rows = run_stream(view(subject_resolve_view()), input, &cfg, 1).await;
+    assert_eq!(rows.len(), 2, "expected one row per Encounter: {rows:#?}");
+    for row in &rows {
+        assert_eq!(row["patient_family"], serde_json::json!("Shared"));
+    }
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        1,
+        "a reference shared across chunks must be fetched only once"
+    );
+}
+
+/// `SOF_RESOLVE_MAX_FETCHES` is a per-stream cap: across chunks, only the first
+/// distinct reference is fetched when the cap is 1.
+#[tokio::test]
+async fn remote_resolve_streaming_fetch_cap_is_per_stream() {
+    let server = MockServer::start().await;
+    for (id, family) in [("p1", "One"), ("p2", "Two")] {
+        Mock::given(method("GET"))
+            .and(path(format!("/Patient/{id}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "resourceType": "Patient", "id": id, "name": [{ "family": family }]
+            })))
+            .mount(&server)
+            .await;
+    }
+
+    let base = server.uri();
+    let input = ndjson(&[
+        encounter_referencing("e1", &format!("{base}/Patient/p1")),
+        encounter_referencing("e2", &format!("{base}/Patient/p2")),
+    ]);
+    let cfg = config(&base, 1, 1); // per-stream cap of 1
+
+    let rows = run_stream(view(subject_resolve_view()), input, &cfg, 1).await;
+    assert_eq!(rows.len(), 2, "{rows:#?}");
+    // Chunks are processed in input order: e1's reference is fetched, e2's is capped.
+    assert_eq!(rows[0]["patient_family"], serde_json::json!("One"));
+    assert!(
+        rows[1]["patient_family"].is_null(),
+        "second distinct reference must be skipped by the per-stream cap: {:#?}",
+        rows[1]
+    );
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        1,
+        "per-stream cap of 1 must allow exactly one fetch across all chunks"
+    );
+}

--- a/crates/sof/tests/resolve_tests.rs
+++ b/crates/sof/tests/resolve_tests.rs
@@ -1,0 +1,304 @@
+//! Integration tests for `Reference.resolve()` in SQL-on-FHIR ViewDefinitions.
+//!
+//! These tests pin the behaviour of bundle-level reference resolution: a
+//! `ViewDefinition` processing one resource type (e.g. `Encounter`) can follow a
+//! `Reference` (`subject.resolve()`) to a *different* resource that lives
+//! elsewhere in the same input bundle (e.g. a `Patient`).
+//!
+//! Background: previously `resolve()` only saw the single resource being
+//! processed plus its `contained` children, so `Encounter.subject.resolve()`
+//! against a sibling `Patient` returned a typed stub with no fields (null
+//! columns). SOF now exposes the whole bundle as the resolution scope, so
+//! cross-resource resolution works. See `build_resolution_scope` in
+//! `crates/sof/src/lib.rs` and `EvaluationContext::set_resolution_scope`.
+
+use helios_sof::{ContentType, SofBundle, SofViewDefinition, run_view_definition};
+
+fn create_test_bundle(
+    resources: &[serde_json::Value],
+) -> Result<SofBundle, Box<dyn std::error::Error>> {
+    let mut bundle_json = serde_json::json!({
+        "resourceType": "Bundle",
+        "id": "test-bundle",
+        "type": "collection",
+        "entry": []
+    });
+
+    if let Some(entry_array) = bundle_json["entry"].as_array_mut() {
+        for resource in resources {
+            entry_array.push(serde_json::json!({ "resource": resource }));
+        }
+    }
+
+    let bundle: helios_fhir::r4::Bundle = serde_json::from_value(bundle_json)?;
+    Ok(SofBundle::R4(bundle))
+}
+
+fn parse_view_definition(
+    view_json: &serde_json::Value,
+) -> Result<SofViewDefinition, Box<dyn std::error::Error>> {
+    let mut view_def = view_json.clone();
+    if let Some(obj) = view_def.as_object_mut() {
+        obj.insert(
+            "resourceType".to_string(),
+            serde_json::Value::String("ViewDefinition".to_string()),
+        );
+        obj.insert(
+            "status".to_string(),
+            serde_json::Value::String("active".to_string()),
+        );
+    }
+
+    let view_definition: helios_fhir::r4::ViewDefinition = serde_json::from_value(view_def)?;
+    Ok(SofViewDefinition::R4(view_definition))
+}
+
+fn run(view: &serde_json::Value, bundle: SofBundle) -> Vec<serde_json::Value> {
+    let view_definition = parse_view_definition(view).expect("Failed to parse ViewDefinition");
+    let result = run_view_definition(view_definition, bundle, ContentType::Json)
+        .expect("Failed to run ViewDefinition");
+    serde_json::from_slice(&result).expect("Failed to parse result as JSON")
+}
+
+/// `Encounter.subject.resolve()` should reach a `Patient` that is a *separate*
+/// resource elsewhere in the bundle. This is the core gap the fix addresses.
+#[test]
+fn resolve_basic_cross_resource() {
+    let bundle = create_test_bundle(&[
+        serde_json::json!({
+            "resourceType": "Patient",
+            "id": "pat-1",
+            "name": [{ "family": "Sibling", "given": ["Bundle"] }]
+        }),
+        serde_json::json!({
+            "resourceType": "Encounter",
+            "id": "enc-1",
+            "status": "finished",
+            "subject": { "reference": "Patient/pat-1" }
+        }),
+    ])
+    .expect("bundle");
+
+    let view = serde_json::json!({
+        "resource": "Encounter",
+        "select": [
+            { "column": [{ "name": "encounter_id", "path": "id" }] },
+            {
+                "forEach": "subject.resolve()",
+                "column": [
+                    { "name": "patient_id", "path": "id" },
+                    { "name": "patient_family", "path": "name.family" }
+                ]
+            }
+        ]
+    });
+
+    let rows = run(&view, bundle);
+    assert_eq!(rows.len(), 1, "expected one row, got {rows:#?}");
+    assert_eq!(rows[0]["encounter_id"], serde_json::json!("enc-1"));
+    assert_eq!(
+        rows[0]["patient_id"],
+        serde_json::json!("pat-1"),
+        "subject.resolve() must dereference the sibling Patient, not a stub"
+    );
+    assert_eq!(rows[0]["patient_family"], serde_json::json!("Sibling"));
+}
+
+/// A reference that points at a resource not present in the bundle must not
+/// error or hang; the resolved-resource columns are simply null.
+#[test]
+fn resolve_missing_ref_yields_nulls() {
+    let bundle = create_test_bundle(&[serde_json::json!({
+        "resourceType": "Encounter",
+        "id": "enc-1",
+        "status": "finished",
+        "subject": { "reference": "Patient/does-not-exist" }
+    })])
+    .expect("bundle");
+
+    let view = serde_json::json!({
+        "resource": "Encounter",
+        "select": [
+            { "column": [{ "name": "encounter_id", "path": "id" }] },
+            {
+                "forEach": "subject.resolve()",
+                "column": [{ "name": "patient_family", "path": "name.family" }]
+            }
+        ]
+    });
+
+    let rows = run(&view, bundle);
+    // A typed stub is produced for the unresolved Type/id reference, so the
+    // forEach still yields one row, but the target field is null.
+    assert_eq!(rows.len(), 1, "expected one row, got {rows:#?}");
+    assert_eq!(rows[0]["encounter_id"], serde_json::json!("enc-1"));
+    assert!(
+        rows[0]["patient_family"].is_null(),
+        "missing reference must produce a null column, got {:#?}",
+        rows[0]["patient_family"]
+    );
+}
+
+/// `contained` resolution (the previously-supported case) must keep working
+/// alongside the new bundle-level resolution.
+#[test]
+fn resolve_contained_still_works() {
+    let bundle = create_test_bundle(&[serde_json::json!({
+        "resourceType": "Encounter",
+        "id": "enc-1",
+        "status": "finished",
+        "contained": [{
+            "resourceType": "Patient",
+            "id": "pat-1",
+            "name": [{ "family": "Contained" }]
+        }],
+        "subject": { "reference": "#pat-1" }
+    })])
+    .expect("bundle");
+
+    let view = serde_json::json!({
+        "resource": "Encounter",
+        "select": [
+            { "column": [{ "name": "encounter_id", "path": "id" }] },
+            {
+                "forEach": "subject.resolve()",
+                "column": [
+                    { "name": "patient_id", "path": "id" },
+                    { "name": "patient_family", "path": "name.family" }
+                ]
+            }
+        ]
+    });
+
+    let rows = run(&view, bundle);
+    assert_eq!(rows.len(), 1, "expected one row, got {rows:#?}");
+    assert_eq!(rows[0]["patient_id"], serde_json::json!("pat-1"));
+    assert_eq!(rows[0]["patient_family"], serde_json::json!("Contained"));
+}
+
+/// Resolution must work across the *full* bundle: resources are filtered to the
+/// ViewDefinition's target type for row generation, but references still resolve
+/// to resources of other types. Multiple Encounters resolve to distinct Patients.
+#[test]
+fn resolve_full_bundle_scope() {
+    let bundle = create_test_bundle(&[
+        serde_json::json!({
+            "resourceType": "Patient",
+            "id": "pat-1",
+            "name": [{ "family": "Alpha" }]
+        }),
+        serde_json::json!({
+            "resourceType": "Patient",
+            "id": "pat-2",
+            "name": [{ "family": "Beta" }]
+        }),
+        serde_json::json!({
+            "resourceType": "Encounter",
+            "id": "enc-1",
+            "status": "finished",
+            "subject": { "reference": "Patient/pat-1" }
+        }),
+        serde_json::json!({
+            "resourceType": "Encounter",
+            "id": "enc-2",
+            "status": "finished",
+            "subject": { "reference": "Patient/pat-2" }
+        }),
+    ])
+    .expect("bundle");
+
+    let view = serde_json::json!({
+        "resource": "Encounter",
+        "select": [
+            { "column": [{ "name": "encounter_id", "path": "id" }] },
+            {
+                "forEach": "subject.resolve()",
+                "column": [{ "name": "patient_family", "path": "name.family" }]
+            }
+        ]
+    });
+
+    let mut rows = run(&view, bundle);
+    assert_eq!(rows.len(), 2, "expected two rows, got {rows:#?}");
+    rows.sort_by(|a, b| a["encounter_id"].as_str().cmp(&b["encounter_id"].as_str()));
+    assert_eq!(rows[0]["encounter_id"], serde_json::json!("enc-1"));
+    assert_eq!(rows[0]["patient_family"], serde_json::json!("Alpha"));
+    assert_eq!(rows[1]["encounter_id"], serde_json::json!("enc-2"));
+    assert_eq!(rows[1]["patient_family"], serde_json::json!("Beta"));
+}
+
+/// An absolute-URL reference whose trailing `Type/id` matches a bundle resource
+/// must resolve.
+#[test]
+fn resolve_absolute_url() {
+    let bundle = create_test_bundle(&[
+        serde_json::json!({
+            "resourceType": "Patient",
+            "id": "pat-1",
+            "name": [{ "family": "Absolute" }]
+        }),
+        serde_json::json!({
+            "resourceType": "Encounter",
+            "id": "enc-1",
+            "status": "finished",
+            "subject": { "reference": "http://example.org/fhir/Patient/pat-1" }
+        }),
+    ])
+    .expect("bundle");
+
+    let view = serde_json::json!({
+        "resource": "Encounter",
+        "select": [{
+            "forEach": "subject.resolve()",
+            "column": [{ "name": "patient_family", "path": "name.family" }]
+        }]
+    });
+
+    let rows = run(&view, bundle);
+    assert_eq!(rows.len(), 1, "expected one row, got {rows:#?}");
+    assert_eq!(rows[0]["patient_family"], serde_json::json!("Absolute"));
+}
+
+/// `resolve()` used inside a `where` clause must see the whole bundle too.
+#[test]
+fn resolve_in_where_clause() {
+    let bundle = create_test_bundle(&[
+        serde_json::json!({
+            "resourceType": "Patient",
+            "id": "pat-1",
+            "gender": "female"
+        }),
+        serde_json::json!({
+            "resourceType": "Encounter",
+            "id": "enc-1",
+            "status": "finished",
+            "subject": { "reference": "Patient/pat-1" }
+        }),
+        serde_json::json!({
+            "resourceType": "Patient",
+            "id": "pat-2",
+            "gender": "male"
+        }),
+        serde_json::json!({
+            "resourceType": "Encounter",
+            "id": "enc-2",
+            "status": "finished",
+            "subject": { "reference": "Patient/pat-2" }
+        }),
+    ])
+    .expect("bundle");
+
+    let view = serde_json::json!({
+        "resource": "Encounter",
+        "where": [{ "path": "subject.resolve().gender = 'female'" }],
+        "select": [{ "column": [{ "name": "encounter_id", "path": "id" }] }]
+    });
+
+    let rows = run(&view, bundle);
+    assert_eq!(
+        rows.len(),
+        1,
+        "only the Encounter whose Patient is female should match, got {rows:#?}"
+    );
+    assert_eq!(rows[0]["encounter_id"], serde_json::json!("enc-1"));
+}


### PR DESCRIPTION
## Summary

Implements the SQL-on-FHIR `resolve()` function for **cross-resource** reference resolution and adds **opt-in remote resolution** against trusted FHIR servers, then exposes both through the CLI, HTTP server, and Python bindings.

Before this change, `resolve()` in SQL-on-FHIR only saw the single resource being processed plus its `contained` children. A reference such as `Encounter.subject.resolve()` pointing at a **separate** `Patient` in the same bundle did not resolve — it fell back to a typed stub and produced null columns. This was confirmed empirically with `sof-cli` (sibling Patient → null; contained Patient → resolves) before the fix.

---

## 1. Bundle-level resolution

A `ViewDefinition` can now follow a `Reference` to **any** resource in the input bundle, regardless of type, not just the resource under evaluation and its `contained` children.

- **`EvaluationContext::set_resolution_scope`** (helios-fhirpath) swaps the resource pool that `resolve()` searches, while leaving `this` — and therefore `%context` / `%resource` / `%rootResource` and the evaluation root — unchanged. Those consult `this` first and only fall back to `resources[0]`, so widening the pool is safe.
- **`build_resolution_scope`** (helios-sof) parses the whole input bundle once (all resource types, before type filtering) into a shared `Arc<Vec<FhirResource>>` and installs it on every evaluation context created during execution: per-resource row generation, `where` clauses, and the per-iteration `forEach` / `repeat` contexts.
- Streaming/NDJSON keeps in-bundle resolution scoped to the current chunk.

**Why:** the SQL-on-FHIR v2 `resolve()` semantics require resolving references across the resources being processed; the prior per-resource scope made the common Encounter→Patient style of view impossible.

## 2. Remote resolution against trusted servers (opt-in, default-off)

References whose absolute URL points at an **explicitly allowlisted** FHIR server can be fetched over the network and folded into the resolution pool.

- **Prefetch architecture.** The FHIRPath evaluator is synchronous and runs under Rayon; rather than make `resolve()` itself perform I/O, external references are collected and fetched **at the async edge before** row generation, then injected into the pool. The parallel evaluation core stays pure and a run remains reproducible from `(bundle + fetched snapshot)`.
- **Default-deny allowlist.** A reference is fetched only if it is an absolute `http`/`https` URL matching an allowlist entry on **scheme + host + port + path-prefix** (parsed-URL comparison, never substring — so `https://evil/?u=https://trusted.org` does not match).
- **SSRF / DNS-rebinding guard.** Hostnames are resolved once and the HTTP client is pinned to the validated addresses. Loopback, link-local (including the `169.254.169.254` cloud-metadata endpoint), multicast, broadcast, CGNAT and reserved ranges are always blocked. Private RFC1918 / IPv6-ULA targets are blocked **unless** `SOF_RESOLVE_ALLOW_PRIVATE_ADDRESSES` is set, which lets an allowlisted hostname resolve to an internal load balancer / reverse proxy (e.g. Traefik) — loopback and link-local stay blocked even then.
- **Other hardening:** redirects disabled; optional per-host bearer auth; per-request timeout, response-size and total-fetch caps; bounded-depth chained resolution. Any failure (disallowed host, timeout, non-2xx, oversize, unparseable) is non-fatal and falls back to the typed-stub/empty behaviour.
- **Streaming/NDJSON:** a single resolver spans the whole stream with a bounded **LRU cross-chunk cache** (a reference recurring across chunks is fetched once) and `SOF_RESOLVE_MAX_FETCHES` applied as a **per-stream** cap.

### Configuration

`SOF_RESOLVE_*` environment variables and `sof-cli` flags; the HTTP server reads the same env config.

| Variable | Default | Meaning |
|----------|---------|---------|
| `SOF_RESOLVE_REMOTE` | `false` | Master switch. |
| `SOF_RESOLVE_ALLOWED_BASE_URLS` | *(empty)* | Comma-separated trusted base URLs. |
| `SOF_RESOLVE_ALLOW_PRIVATE_ADDRESSES` | `false` | Permit allowlisted hostnames to resolve to private/internal addresses. |
| `SOF_RESOLVE_TIMEOUT_MS` | `5000` | Per-request timeout. |
| `SOF_RESOLVE_MAX_FETCHES` | `256` | Fetch cap (per-stream when streaming). |
| `SOF_RESOLVE_MAX_DEPTH` | `1` | Chained-reference rounds. |
| `SOF_RESOLVE_MAX_RESPONSE_BYTES` | `5000000` | Response size cap. |
| `SOF_RESOLVE_CONCURRENCY` | `8` | Max concurrent fetches. |
| `SOF_RESOLVE_CACHE_MAX_ENTRIES` | `10000` | Streaming cross-chunk cache size. |
| `SOF_RESOLVE_AUTH` | *(none)* | Per-host bearer tokens (`host=token,...`). |

CLI: `--resolve-remote`, `--resolve-allowed-base-urls`, `--resolve-allow-private-addresses`.

**Why:** enables cross-server joins for deployments that explicitly trust specific FHIR endpoints, without compromising the safe default (it is entirely off unless configured) and without turning the evaluator into a network client.

## 3. Python bindings (pysof)

Adds `RemoteResolveConfig`, `run_view_definition_remote`, and `process_ndjson_to_file_remote`. The async remote functions are driven from the synchronous PyO3 entry points via a current-thread Tokio runtime with the GIL released. All additions are additive; existing entry points are unchanged. The wrapper package, type stub, and README are updated.

## 4. Dependencies — `lru`

Adds `lru` for the streaming cross-chunk cache, **pinned to `0.12`**. `aws-sdk-s3` (pulled by the optional `s3` feature in `helios-persistence` / `helios-rest`) declares `lru = "^0.12"` as a non-optional dependency; matching it keeps a **single** `lru` version compiled across all feature combinations, including `s3` builds. The latest `lru` is `0.18`, but raising the pin would compile two `lru` versions whenever `s3` is enabled, because the AWS SDK's `^0.12` (a third-party crate we don't control) is semver-incompatible with `0.18`. The upgrade to the latest `lru` is tracked in `ROADMAP.md` (Build & Dependencies) for re-evaluation once the AWS SDK bumps its own pin.

## Tests

- `crates/sof/tests/resolve_tests.rs` — in-bundle cross-resource resolution, missing refs, contained refs, full-bundle scope, absolute URLs, and `where` clauses.
- `crates/sof/tests/resolve_remote_tests.rs` — wiremock-backed: allowlist pass/deny, 404 non-fatal, fetch cap, chained depth, the private-address hostname rule, and streaming cross-chunk cache / per-stream cap.
- `remote_resolver` unit tests — allowlist matching (including substring/userinfo smuggling), the tiered SSRF IP guard for IPv4/IPv6, and config parsing.
- `crates/pysof/python-tests/test_remote_resolve.py` — symbol export, config construction, and an inactive-config end-to-end run (verified at runtime against a built extension).

All `helios-sof`, `helios-fhirpath`, `helios-rest`, and `helios-hfs` test suites pass; `cargo clippy` is clean for the changed crates.

## Documentation

- `book/src/ch06-sql-on-fhir.md` — a "Resolving References Across Resources" section and a "Remote resolution against trusted servers" subsection with the full config reference and security model.
- `book/src/appendix-b-fhirpath-functions.md` — corrected `resolve()` status.
- `crates/pysof/README.md` — remote-resolve usage.
- `ROADMAP.md` — follow-ups (logical/identifier-based references, storage-backed / cross-run cache, async FHIRPath evaluator, OAuth client-credentials, and the `lru` upgrade).

## Compatibility

All library API changes are additive. `resolve()` behaviour with remote resolution disabled (the default) is unchanged apart from the new bundle-level in-scope resolution. Streaming output for the non-remote path is unchanged.