### PR TITLE
style(pysof): fix rustfmt formatting in RemoteResolveConfig builder

### DIFF
--- a/crates/pysof/src/lib.rs
+++ b/crates/pysof/src/lib.rs
@@ -904,13 +904,17 @@ impl PyRemoteResolveConfig {
         let inner = RemoteResolveConfig {
             enabled,
             allowed_base_urls: parse_allowed_base_urls(&allowed_base_urls.join(",")),
-            timeout: timeout_ms.map(Duration::from_millis).unwrap_or(default.timeout),
+            timeout: timeout_ms
+                .map(Duration::from_millis)
+                .unwrap_or(default.timeout),
             max_fetches: max_fetches.unwrap_or(default.max_fetches),
             max_depth: max_depth.unwrap_or(default.max_depth),
             max_response_bytes: max_response_bytes.unwrap_or(default.max_response_bytes),
             concurrency: concurrency.map(|c| c.max(1)).unwrap_or(default.concurrency),
             allow_private_addresses,
-            cache_max_entries: cache_max_entries.map(|c| c.max(1)).unwrap_or(default.cache_max_entries),
+            cache_max_entries: cache_max_entries
+                .map(|c| c.max(1))
+                .unwrap_or(default.cache_max_entries),
             bearer_tokens: bearer_tokens
                 .map(|m| {
                     m.into_iter()

--- a/crates/sof/src/lib.rs
+++ b/crates/sof/src/lib.rs
@@ -2203,7 +2203,7 @@ pub async fn process_ndjson_chunked_remote<R: BufRead, W: Write>(
         output.write_all(b"[\n")?;
     }
 
-    while let Some(chunk) = reader.next() {
+    for chunk in reader.by_ref() {
         let chunk = chunk?;
 
         let external = if active {


### PR DESCRIPTION
Fixes the failing **Linting** job (`cargo fmt --all -- --check`) from CI run 27634127142.

`cargo fmt --all` flagged two over-long method chains in `crates/pysof/src/lib.rs`. Since `pysof` is excluded from the default workspace build, this only surfaces in the CI fmt step (`--all`), not in a plain `cargo build`/`cargo fmt` at the root.

## Notes
- The **Test FHIRPath** failure in that run is unrelated to this repo: the CI checks out `FHIR/fhir-test-cases` at `master` (unpinned) and downloads the latest `Hl7.Fhir.FhirPath.Validator` release. Upstream PR FHIR/fhir-test-cases#266 added `r5/parameters-example-html.xml` with an `xsi:schemaLocation` attribute the validator fatally rejected. Per discussion, we're not pinning `fhir-test-cases`; the validator was updated upstream instead — this will be picked up automatically once a new validator **release** is published (latest is still v0.1.14, 2026-02-11).