### PR TITLE
test(observability): cover console-metrics, batch, reqlog & readiness branches

### DIFF
--- a/crates/observability/src/reqlog.rs
+++ b/crates/observability/src/reqlog.rs
@@ -337,4 +337,31 @@ mod tests {
                 .all(|w| w[0].sample_count >= w[1].sample_count)
         );
     }
+
+    #[test]
+    fn snapshot_classifies_all_status_classes() {
+        // The status-class match arms for 3xx/4xx (and the non-standard `_`
+        // fallthrough) are only reached by non-2xx/5xx codes; the other tests
+        // exercise 2xx/5xx exclusively. Record one of each for a unique tenant so
+        // the shared process-global buffer can't hide the assertions.
+        record(301, 0.010, "tenant-status");
+        record(404, 0.020, "tenant-status");
+        // A sub-200 status (`status / 100 == 1`) hits the `_ => {}` arm: counted
+        // toward the sample total but into none of the status-class buckets.
+        record(199, 0.005, "tenant-status");
+
+        let stats = snapshot(3600, Some("tenant-status"));
+        assert!(stats.status_3xx >= 1, "3xx must be classified");
+        assert!(stats.status_4xx >= 1, "4xx must be classified");
+        // No 5xx recorded for this tenant, so the error rate stays zero even
+        // though 4xx/other responses are present.
+        assert_eq!(stats.status_5xx, 0);
+        assert_eq!(stats.error_rate, 0.0);
+        // The sub-200 sample is counted but classified into no 2xx/3xx/4xx/5xx bucket.
+        assert!(stats.sample_count >= 3);
+        assert!(
+            stats.status_2xx + stats.status_3xx + stats.status_4xx + stats.status_5xx
+                < stats.sample_count as u64
+        );
+    }
 }

--- a/crates/rest/Cargo.toml
+++ b/crates/rest/Cargo.toml
@@ -116,6 +116,10 @@ aes-gcm = { version = "0.10", optional = true }
 # HTTP testing
 axum-test = "18.0"
 
+# Inject synthetic request-log traffic in console-metrics tests (the same
+# in-process request log the handlers read for per-tenant traffic).
+helios-observability = { path = "../observability" }
+
 # gzip test payloads for HTTP compression tests
 flate2 = "1"
 

--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -1159,6 +1159,101 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_transaction_error_response_parts_maps_every_variant() {
+        // Exhaustively map each variant to its (status, code) so a future variant
+        // or a re-mapped status is caught. Complements
+        // `test_transaction_rollback_reason_is_sanitized`, which covers RolledBack.
+        let cases: Vec<(TransactionError, StatusCode, &str)> = vec![
+            (
+                TransactionError::BundleError {
+                    index: 2,
+                    message: "boom".to_string(),
+                },
+                StatusCode::BAD_REQUEST,
+                "processing",
+            ),
+            (
+                TransactionError::Timeout { timeout_ms: 1500 },
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "timeout",
+            ),
+            (
+                TransactionError::MultipleMatches {
+                    operation: "update".to_string(),
+                    count: 3,
+                },
+                StatusCode::PRECONDITION_FAILED,
+                "multiple-matches",
+            ),
+            (
+                TransactionError::InvalidTransaction,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "exception",
+            ),
+            (
+                TransactionError::NestedNotSupported,
+                StatusCode::NOT_IMPLEMENTED,
+                "not-supported",
+            ),
+            (
+                TransactionError::UnsupportedIsolationLevel {
+                    level: "serializable".to_string(),
+                },
+                StatusCode::NOT_IMPLEMENTED,
+                "not-supported",
+            ),
+        ];
+
+        for (err, want_status, want_code) in cases {
+            let (status, code, message) = transaction_error_response_parts(&err);
+            assert_eq!(status, want_status, "status for {err:?}");
+            assert_eq!(code, want_code, "code for {err:?}");
+            assert!(!message.is_empty(), "message for {err:?} must be non-empty");
+        }
+
+        // Detail-bearing variants surface their specifics in the message text.
+        let (_, _, msg) = transaction_error_response_parts(&TransactionError::Timeout {
+            timeout_ms: 1500,
+        });
+        assert!(msg.contains("1500"), "timeout message: {msg}");
+        let (_, _, msg) =
+            transaction_error_response_parts(&TransactionError::UnsupportedIsolationLevel {
+                level: "serializable".to_string(),
+            });
+        assert!(msg.contains("serializable"), "isolation message: {msg}");
+    }
+
+    #[test]
+    fn test_status_text_covers_known_and_unknown_codes() {
+        // The batch response builder renders a reason phrase per entry status; the
+        // full table is only exercised when entries produce these codes.
+        let known = [
+            ("200", "OK"),
+            ("201", "Created"),
+            ("204", "No Content"),
+            ("400", "Bad Request"),
+            ("401", "Unauthorized"),
+            ("403", "Forbidden"),
+            ("404", "Not Found"),
+            ("405", "Method Not Allowed"),
+            ("406", "Not Acceptable"),
+            ("409", "Conflict"),
+            ("410", "Gone"),
+            ("412", "Precondition Failed"),
+            ("415", "Unsupported Media Type"),
+            ("422", "Unprocessable Entity"),
+            ("500", "Internal Server Error"),
+            ("501", "Not Implemented"),
+        ];
+        for (code, phrase) in known {
+            assert_eq!(status_text(code), phrase, "reason phrase for {code}");
+        }
+        // Any unmapped code falls through to the catch-all.
+        assert_eq!(status_text("418"), "Unknown");
+        assert_eq!(status_text(""), "Unknown");
+    }
+
     #[tokio::test]
     async fn test_emit_batch_entry_audit_records_per_entry() {
         let sink = Arc::new(CollectorSink {

--- a/crates/rest/tests/console_metrics.rs
+++ b/crates/rest/tests/console_metrics.rs
@@ -279,6 +279,40 @@ async fn test_resource_distribution_top_param() {
     assert!(body["types"].is_array());
 }
 
+#[tokio::test]
+async fn test_resource_distribution_rolls_up_tail_into_other() {
+    let (server, _backend) = create_test_server().await;
+    // Seed more distinct types than `top` so the handler must truncate the tail
+    // into a synthetic `other` bucket (the `counts.len() > top` branch).
+    seed_default_tenant(&server).await; // Patient (x2) + Observation
+    seed(
+        &server,
+        "Encounter",
+        serde_json::json!({ "resourceType": "Encounter", "status": "finished" }),
+    )
+    .await;
+
+    // top=1 keeps only the busiest type; the other two collapse into `other`.
+    let response = server
+        .get("/console/metrics/resource-distribution?top=1")
+        .await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    let types = body["types"].as_array().expect("types is an array");
+    // One charted type plus the rolled-up `other` row.
+    assert_eq!(types.len(), 2);
+    let other = types
+        .iter()
+        .find(|t| t["resource_type"] == "other")
+        .expect("an `other` roll-up row must be present");
+    // Two distinct types were folded into the tail.
+    assert_eq!(other["types"].as_u64().unwrap(), 2);
+    assert!(other["count"].as_u64().unwrap() >= 2);
+    // distinct_types still reflects the true count, not the truncated view.
+    assert_eq!(body["distinct_types"].as_u64().unwrap(), 3);
+}
+
 // =============================================================================
 // tenants (cross-tenant / admin; reachable with auth disabled)
 // =============================================================================
@@ -331,6 +365,35 @@ async fn test_traffic_shape() {
     );
     assert_eq!(body["scope"], "single-instance");
     assert!(body["instance"].is_string(), "instance should be present");
+}
+
+#[tokio::test]
+async fn test_tenants_includes_traffic_only_tenant() {
+    let (server, _backend) = create_test_server().await;
+    seed_default_tenant(&server).await;
+
+    // A tenant that has recent traffic but no stored resources must still appear
+    // in the roster (the "seen only in traffic" branch), reporting `resources: 0`
+    // alongside its live rates. Inject the traffic directly into the in-process
+    // request log the handler reads — the test router has no request-tracking
+    // middleware, so HTTP calls alone would leave the log empty.
+    let ghost = "ghost-traffic-tenant";
+    for _ in 0..3 {
+        helios_observability::reqlog::record(200, 0.010, ghost);
+    }
+
+    let response = server.get("/console/metrics/tenants").await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    let tenants = body["tenants"].as_array().expect("tenants is an array");
+    let row = tenants
+        .iter()
+        .find(|t| t["tenant"] == ghost)
+        .expect("a traffic-only tenant must still be listed");
+    // No resources stored for this tenant, but traffic was observed.
+    assert_eq!(row["resources"].as_u64().unwrap(), 0);
+    assert!(row["requests_per_second"].as_f64().unwrap() > 0.0);
 }
 
 #[tokio::test]

--- a/crates/rest/tests/tenant_resolution.rs
+++ b/crates/rest/tests/tenant_resolution.rs
@@ -258,6 +258,24 @@ mod url_path_mode {
     }
 
     #[tokio::test]
+    async fn test_readiness_endpoint_reports_storage_ok() {
+        let config = MultitenancyConfig {
+            routing_mode: TenantRoutingMode::UrlPath,
+            ..Default::default()
+        };
+        let (server, _backend) = create_test_server(config).await;
+
+        // Readiness should work at root level (not tenant-scoped) and report the
+        // storage check as healthy.
+        let response = server.get("/_readiness").await;
+        response.assert_status_ok();
+
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["status"], "ready");
+        assert_eq!(body["checks"]["storage"], "ok");
+    }
+
+    #[tokio::test]
     async fn test_tenant_search() {
         let config = MultitenancyConfig {
             routing_mode: TenantRoutingMode::UrlPath,


### PR DESCRIPTION
Stacked on top of #150 (`feat/observability-uptime`). Adds tests for the genuinely-uncovered behavioral branches that PR #150's Codecov report flagged.

## Context

Most of PR #150's reported patch-coverage gap is **not** new-test-addressable:
- **error-handling closures** (`.map_err(|e| internal_error(...))` on SQL failures) — unreachable without fault injection;
- **stale carryforward** — code that already has in-tree tests but shows uncovered because Codecov's snapshot predates this branch's own test commits (a fresh coverage run clears these);
- **Docker/OTLP-bound** — mongodb/postgres/composite/telemetry.

This PR covers the branches that were *actually* uncovered and cheaply testable.

## Tests added

- **reqlog** — 3xx / 4xx / sub-200 status-class classification arms (existing tests only exercised 2xx/5xx).
- **console resource-distribution** — the `other` roll-up bucket taken when distinct types exceed `top`.
- **console tenants** — a tenant present only in request-log traffic (reported with `resources: 0`).
- **batch** — exhaustive `TransactionError -> (status, code)` mapping and the `status_text` reason-phrase table.
- **health** — the `/_readiness` handler response shape.

Adds `helios-observability` as a **dev-dependency** of `helios-rest` so the console integration test can seed the in-process request log directly (the test router has no request-tracking middleware).

## CI note

Because the repo gates `pull_request` CI to `base: main`, this stacked PR (base `feat/observability-uptime`) will not run CI/Codecov until #150 merges and GitHub auto-retargets it to `main`.
