### PR TITLE
docs(i18n): mark multi-language approach as ratified

### DIFF
--- a/docs/multi-language.md
+++ b/docs/multi-language.md
@@ -1,7 +1,7 @@
 # Multi-language support — approach, guidelines, and rules of the road
 
-**Status:** Foundation / discussion (living document)
-**Branch:** `feat/i18n-foundation` (off `main`)
+**Status:** Ratified — 2026-07-06 (living document; changes via PR)
+**Delivered:** merged to `main` (#187 catalogs/doc, #191/#195 runtime wiring in `crates/ui`)
 **Owner:** Angela
 **Relates to:** #186 (HTMX-first web UI foundation), `feat/user-ui-settings`,
 `feat/smart-ui-auth`


### PR DESCRIPTION
Flips the header of `docs/multi-language.md` to **Ratified — 2026-07-06** and replaces the stale branch pointer with where the deliverables actually live on `main` (#187 catalogs/doc via 850b1f0c, runtime wiring via #192/#191/#195).

Ratification per #187 acceptance criteria — see the closing comment there.