### PR TITLE
test(user-settings): cover Mongo unparseable-timestamp read path

### DIFF
--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -2659,3 +2659,38 @@ async fn mongodb_integration_settings_get_surfaces_decode_error() {
     let err = backend.get_settings(&user).await.unwrap_err();
     assert!(matches!(err, StorageError::Backend(_)));
 }
+
+/// A row with a valid JSON document but a non-datetime `updated_at` must still
+/// read back successfully — the malformed timestamp falls back to "now" rather
+/// than failing the read. Mirrors the SQLite `user_settings`
+/// `get_settings_tolerates_unparseable_timestamp` coverage.
+#[tokio::test]
+async fn mongodb_integration_settings_get_tolerates_unparseable_timestamp() {
+    let Some(backend) = settings_mongo::backend("settings_odd_ts").await else {
+        eprintln!(
+            "Skipping mongodb_integration_settings_get_tolerates_unparseable_timestamp (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let user = unique_user_key("odd-ts");
+
+    // Valid JSON document but a malformed `updated_at` (a string, not a BSON
+    // datetime): the read must not fail, bypassing the store to plant the row.
+    let client = Client::with_uri_str(&backend.config().connection_string)
+        .await
+        .expect("connect raw mongo client");
+    let db = client.database(&backend.config().database_name);
+    db.collection::<Document>("user_settings")
+        .insert_one(doc! {
+            "user_key": &user,
+            "data": "{}",
+            "version": 3_i64,
+            "updated_at": "not-a-timestamp",
+        })
+        .await
+        .expect("insert user_settings row with odd timestamp");
+
+    let stored = backend.get_settings(&user).await.unwrap().unwrap();
+    assert_eq!(stored.version, 3);
+    assert_eq!(stored.document, json!({}));
+}


### PR DESCRIPTION
## Summary

Adds one MongoDB `SettingsStore` test that mirrors SQLite's existing `get_settings_tolerates_unparseable_timestamp` coverage: it plants a row with a valid JSON document but a **non-datetime `updated_at`**, then asserts `get_settings` still returns the document and version — exercising the timestamp-fallback branch (`get_datetime(...).map(...).unwrap_or_else(|_| Utc::now())`) instead of failing the read.

This closes the last cleanly, deterministically testable gap in `mongodb/user_settings.rs`, bringing its error-path suite to parity with the SQLite backend. The remaining uncovered lines there are DB-error-injection `.map_err` arms and concurrency-race branches — the same class the PostgreSQL backend also leaves uncovered — which aren't worth fault-injection or flaky timing tests.

## Stacking

> **Base branch is `feat/user-ui-settings` (PR #151), not `main`**, because the MongoDB `SettingsStore` this test targets is introduced by #151 and does not exist on `main`. 

Once #151 merges, this PR will be **retargeted to `main`** (and rebased), at which point it picks up full CI. Until then, as a stacked PR (base ≠ main) it does not trigger the HFS CI workflow.

## Test plan

- `cargo test -p helios-persistence --features mongodb --test mongodb_tests mongodb_integration_settings_get_tolerates_unparseable_timestamp` (runs against a Mongo testcontainer, or `HFS_TEST_MONGODB_URL` if set; skips gracefully when neither is available).
