### PR TITLE
style: rustfmt batch.rs (unbreak main's fmt check)

### DIFF
--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -1213,9 +1213,8 @@ mod tests {
         }
 
         // Detail-bearing variants surface their specifics in the message text.
-        let (_, _, msg) = transaction_error_response_parts(&TransactionError::Timeout {
-            timeout_ms: 1500,
-        });
+        let (_, _, msg) =
+            transaction_error_response_parts(&TransactionError::Timeout { timeout_ms: 1500 });
         assert!(msg.contains("1500"), "timeout message: {msg}");
         let (_, _, msg) =
             transaction_error_response_parts(&TransactionError::UnsupportedIsolationLevel {


### PR DESCRIPTION
`main` (0b87bc164) currently fails `cargo fmt --all -- --check` at `crates/rest/src/handlers/batch.rs:1213` — a `TransactionError::Timeout { timeout_ms: 1500 }` constructor that rustfmt collapses onto one line. It slipped in via 3f1203fad (observability test coverage).

Because PR CI lints *branch-merged-with-main*, this ambient violation currently fails the **Linting** job on every open PR (surfaced while working on #219). This is a **formatting-only** change — one hunk, no behavior change — to unblock main and all open PRs.

```diff
-        let (_, _, msg) = transaction_error_response_parts(&TransactionError::Timeout {
-            timeout_ms: 1500,
-        });
+        let (_, _, msg) =
+            transaction_error_response_parts(&TransactionError::Timeout { timeout_ms: 1500 });
```