### PR TITLE
ci: reap leaked testcontainers by label + age

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,32 @@ jobs:
     runs-on: [self-hosted, Linux]
     needs: [test-rust]
     if: always()
+    env:
+      # Reap any testcontainer older than this many minutes. Must comfortably
+      # exceed the longest CI job runtime so a *concurrent* run's live
+      # containers on the shared docker host are never killed mid-test.
+      MAX_CONTAINER_AGE_MIN: 90
     steps:
-      - name: Remove testcontainers from this run
+      - name: Reap leaked testcontainers
         run: |
-          docker ps -aq --filter "label=github.run_id=${{ github.run_id }}" | xargs -r docker rm -f || true
+          # testcontainers-rs cleans up on clean process exit, but a cancelled,
+          # timed-out, or OOM-killed test run leaks its containers. It stamps
+          # every container with `org.testcontainers.managed-by=testcontainers`
+          # (never github.run_id), so we reap by that label + age: anything
+          # older than MAX_CONTAINER_AGE_MIN is a leak from a dead run and is
+          # safe to remove without affecting a live concurrent job.
+          now=$(date +%s)
+          reaped=0
+          for id in $(docker ps -q --filter "label=org.testcontainers.managed-by=testcontainers"); do
+            started=$(docker inspect -f '{{.State.StartedAt}}' "$id" 2>/dev/null) || continue
+            age_min=$(( (now - $(date -d "$started" +%s)) / 60 ))
+            if [ "$age_min" -ge "$MAX_CONTAINER_AGE_MIN" ]; then
+              echo "Reaping $id (age ${age_min}m)"
+              docker rm -f "$id" || true
+              reaped=$((reaped + 1))
+            fi
+          done
+          echo "Reaped ${reaped} leaked testcontainer(s)."
 
   test-python:
     name: Test Python


### PR DESCRIPTION
## Problem

The `cleanup-test-containers` job in `ci.yml` was meant to remove testcontainers after each run, but it filtered on `label=github.run_id=<id>` — a label **testcontainers-rs never sets**. testcontainers-rs 0.27 unconditionally stamps every container with `org.testcontainers.managed-by=testcontainers` (see `async_runner.rs`, "always unconditionally applied"). The filter therefore matched nothing and the job silently no-op'd.

Result: containers from cancelled / timed-out / OOM-killed test runs (where the Rust `Drop` cleanup never fires) piled up on the shared CI docker host. Observed dozens of `postgres:11-alpine`, `mongo:5.0.6`, and `elasticsearch:7.16.1` containers still `Up` going back two weeks.

## Fix

Reap by the **real** testcontainers label plus an **age guard**:

- `label=org.testcontainers.managed-by=testcontainers` — matches every testcontainers-managed container (all backends: PG, Mongo, ES, MinIO, Mailpit), not a label we hoped was set.
- Only remove containers older than `MAX_CONTAINER_AGE_MIN` (90m). This must exceed the longest CI job runtime so that a **concurrent** run's fresh containers on the same shared docker host are never killed mid-test. Anything older than that is necessarily a leak from a dead run.

Because it reaps by label+age regardless of origin, this also sweeps leaks from the other testcontainer-using workflows (hts, inferno, subscriptions, benchmarks) whenever CI runs.

## Notes / follow-ups

- The 90m guard means a run that leaks its own containers won't have them removed until a later CI run ages them past the threshold — acceptable lag, and the safe tradeoff on a shared daemon.
- Root cause of the leaks is force-killed runs (recent WiredTiger OOM tuning is the same failure mode). A standalone scheduled sweep on the docker host would make cleanup independent of CI running at all — happy to open that separately if wanted.
- Validated: YAML parses, `bash -n` clean, and the age arithmetic correctly parses Docker's RFC3339-nano `StartedAt` format.