### PR TITLE
fix(hts): don't default to hierarchical expansion for paged is-a filters (#227)

### DIFF
--- a/crates/hts/src/operations/expand.rs
+++ b/crates/hts/src/operations/expand.rs
@@ -1620,7 +1620,18 @@ async fn process_expand_inner<B: TerminologyBackend>(
         // pure-full-system case this applies to URL-resolved ValueSets too
         // (the IG `search/search-filter-yes` fixture is URL-resolved). Inspect
         // the inline compose when present, else fetch the referenced VS.
-        if hierarchical.is_none() {
+        //
+        // Paging suppresses this default. Tree mode returns the whole subtree —
+        // the backends drop `count`/`offset` and report no `offset` — so nesting a
+        // paged request would silently ignore what the caller asked for, and
+        // answering `count=10` over a SNOMED is-a root would first read that
+        // root's ~10^5 descendants. The IG agrees: every fixture pairing a
+        // subsumption filter with count/offset (`simple-cases/simple-expand-isa-
+        // {c2,o2,o2c2}`, `snomed/expand-pc-none`) expects a flat list, and no
+        // fixture expecting nesting pages. A text `filter` does NOT suppress it —
+        // `search/search-filter-yes` filters and still expects a tree. An explicit
+        // `hierarchical=true` / `excludeNested=false` nests regardless.
+        if hierarchical.is_none() && count.is_none() && offset.is_none() {
             let ctx = TenantContext::system();
             let resolved_vs: Option<Value> = if value_set.is_some() {
                 value_set.clone()

--- a/crates/hts/tests/value_set_ops.rs
+++ b/crates/hts/tests/value_set_ops.rs
@@ -168,6 +168,140 @@ async fn expand_is_a_codesystem_flat_with_exclude_nested() {
     );
 }
 
+/// An include carrying an `is-a` filter designates a hierarchy subtree, so an
+/// unpaged expansion of it nests by default (IG `search/search-filter-yes`).
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn expand_is_a_filter_nests_by_default() {
+    let app = TestApp::new();
+    app.import_bundle_ok(ISA_HIERARCHY_BUNDLE).await;
+
+    let (status, body) = app
+        .post_fhir("/ValueSet/$expand", isa_filter_expand(&[]))
+        .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let top = body["expansion"]["contains"].as_array().unwrap();
+    let top_codes: Vec<&str> = top.iter().filter_map(|c| c["code"].as_str()).collect();
+    assert_eq!(
+        top_codes,
+        vec!["parent"],
+        "an is-a filter should nest its matches under the filter root, got {body}"
+    );
+
+    let children: Vec<&str> = top[0]["contains"]
+        .as_array()
+        .expect("parent should nest its children")
+        .iter()
+        .filter_map(|c| c["code"].as_str())
+        .collect();
+    assert_eq!(children, vec!["child1", "child2"]);
+}
+
+/// Paging suppresses the is-a-filter default nesting. Tree mode returns the whole
+/// subtree and ignores `count`/`offset`, so a paged request must stay flat and
+/// honour `count` — otherwise `count=10` over a SNOMED root reads ~10^5 concepts
+/// and returns all of them (regression guard for issue #227).
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn expand_is_a_filter_stays_flat_when_paged() {
+    let app = TestApp::new();
+    app.import_bundle_ok(ISA_HIERARCHY_BUNDLE).await;
+
+    let req = isa_filter_expand(&[r#"{"name":"count","valueInteger":2}"#]);
+    let (status, body) = app.post_fhir("/ValueSet/$expand", req).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let top = body["expansion"]["contains"].as_array().unwrap();
+    assert_eq!(top.len(), 2, "count=2 must cap the expansion, got {body}");
+    assert!(
+        top.iter().all(|c| c.get("contains").is_none()),
+        "a paged expansion must stay flat: {body}"
+    );
+}
+
+/// Unlike paging, a text `filter` does NOT suppress the default nesting: the IG
+/// `search/search-filter-yes` fixture filters on `"data"` and still expects the
+/// matches nested under `data-exchange`. Mirrors that fixture locally.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn expand_is_a_filter_with_text_filter_still_nests() {
+    let app = TestApp::new();
+    app.import_bundle_ok(DATA_EXCHANGE_BUNDLE).await;
+
+    let req = r#"{"resourceType":"Parameters","parameter":[
+      {"name":"filter","valueString":"data"},
+      {"name":"valueSet","resource":{"resourceType":"ValueSet","url":"http://hts.test/vs/de-filter","status":"active",
+        "compose":{"include":[{"system":"http://hts.test/search",
+          "filter":[{"property":"code","op":"is-a","value":"data-exchange"}]}]}}}
+    ]}"#;
+    let (status, body) = app.post_fhir("/ValueSet/$expand", req).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let top = body["expansion"]["contains"].as_array().unwrap();
+    let top_codes: Vec<&str> = top.iter().filter_map(|c| c["code"].as_str()).collect();
+    assert_eq!(
+        top_codes,
+        vec!["data-exchange"],
+        "a text-filtered subsumption expansion should still nest, got {body}"
+    );
+
+    let children: Vec<&str> = top[0]["contains"]
+        .as_array()
+        .expect("data-exchange should nest its children")
+        .iter()
+        .filter_map(|c| c["code"].as_str())
+        .collect();
+    assert_eq!(
+        children,
+        vec!["data-exchange1", "data-exchange2", "data-exchange3"]
+    );
+}
+
+/// Mirrors the IG `search` CodeSystem: a `data-exchange` root whose three
+/// children all match the text filter `"data"`.
+#[cfg(feature = "sqlite")]
+const DATA_EXCHANGE_BUNDLE: &str = r#"{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    { "resource": {
+        "resourceType": "CodeSystem",
+        "id": "search-cs",
+        "url": "http://hts.test/search",
+        "version": "1.0",
+        "status": "active",
+        "content": "complete",
+        "hierarchyMeaning": "is-a",
+        "concept": [
+          { "code": "data-exchange", "display": "Data Exchange",
+            "concept": [
+              { "code": "data-exchange1", "display": "Data Exchange1" },
+              { "code": "data-exchange2", "display": "Data Exchange2" },
+              { "code": "data-exchange3", "display": "Data Exchange3" }
+            ]
+          }
+        ]
+    }}
+  ]
+}"#;
+
+/// `$expand` of an inline compose whose only include carries `is-a parent` over
+/// [`ISA_HIERARCHY_BUNDLE`], plus any `extra` Parameters entries.
+#[cfg(feature = "sqlite")]
+fn isa_filter_expand(extra: &[&str]) -> String {
+    let mut parameter = extra.to_vec();
+    parameter.push(
+        r#"{"name":"valueSet","resource":{"resourceType":"ValueSet","url":"http://hts.test/vs/isa-filter","status":"active",
+             "compose":{"include":[{"system":"http://hts.test/isa",
+               "filter":[{"property":"concept","op":"is-a","value":"parent"}]}]}}}"#,
+    );
+    format!(
+        r#"{{"resourceType":"Parameters","parameter":[{}]}}"#,
+        parameter.join(",")
+    )
+}
+
 // ── $validate-code (ValueSet) ─────────────────────────────────────────────────
 
 #[cfg(feature = "sqlite")]


### PR DESCRIPTION
Fixes the ValueSet-`$expand` half of #227 — the EX02/EX08 collapse.

## Root cause

`6c1876c01` ("nest is-a/descendent-of filter expansions by default") made any compose whose include carries an `is-a` / `descendent-of` filter default to tree mode, so the IG `search/search-filter-yes` fixture would nest. The default also fired for **paged** expansions, and tree mode is not a shape a paged caller can use:

- every closure-backed `LIMIT`/`OFFSET` fast path is gated on `req.hierarchical != Some(true)` (`postgres/value_set.rs:357,783`, `sqlite/value_set.rs:591`), so nesting skips all of them;
- `pg_filter_is_a` then fetches the **full** descendant set — the code comment already says "~140k rows for a SNOMED root" (`postgres/value_set.rs:3088-3097`);
- `build_hierarchical_expansion` loads the **entire** `concept_hierarchy` edge table for the system (`SELECT parent_code, child_code FROM concept_hierarchy WHERE system_id = $1`, `postgres/value_set.rs:3370`, `sqlite/value_set.rs:5923`);
- the tree branch returns with `offset: None` and no truncation — `count`/`offset` are dropped (`postgres/value_set.rs:1004-1013`, `sqlite/value_set.rs:1144-1154`).

So `count=10` over a SNOMED is-a root read ~10^5 concepts plus ~10^6 edges **per request** and answered with the whole subtree. The benchmark's EX02 (`descendent-of 64572001`, count=10) and EX08 (`is-a 404684003` + property + text filter, count=10) are exactly that shape:

| Test | v0.2.0 | main | cause |
|---|---|---|---|
| SQLite EX08 | 24,493 rps | 68 rps | full subtree materialized per request |
| PG EX02 | 21,840 rps | 6 rps, p95 = 30s | same, hits `statement_timeout` |

The same block also put an **extra `ValueSet` lookup on every URL-resolved `$expand`** that omitted `hierarchical`/`excludeNested`, which is EX01/EX03/EX04's hot path.

## Fix

Suppress the *default* when the request pages (`count`/`offset`). Explicit `hierarchical=true` / `excludeNested=false` is untouched.

This is what the IG requires, not just what's fast. Scanning `HL7/fhir-tx-ecosystem-ig`'s `test-cases.json`:

- **Every** expand fixture pairing a subsumption filter with `count`/`offset` expects a **flat** list: `simple-cases/simple-expand-isa-c2`, `-o2`, `-o2c2`, and `snomed/expand-pc-none`.
- **No** fixture that expects nesting passes `count`/`offset` — they all pass `excludeNested`, or nothing.
- A text `filter` must **keep** nesting: `search/search-filter-yes` sends `filter=data` and expects `data-exchange1/2/3` nested under `data-exchange`. So `filter` is deliberately *not* part of the guard.

## Tests

This path had no Rust coverage at all — `search-filter-yes` was only exercised by the external IG conformance workflow. Adds three cases to `crates/hts/tests/value_set_ops.rs`:

- `expand_is_a_filter_nests_by_default` — unpaged is-a filter nests.
- `expand_is_a_filter_stays_flat_when_paged` — `count=2` stays flat and honours `count` (the #227 guard; also pins `simple-expand-isa-c2`).
- `expand_is_a_filter_with_text_filter_still_nests` — mirrors `search-filter-yes` locally.

## Validation

- HTS IG conformance + HTS benchmark dispatched on this branch; results posted below.
- Does **not** address the other half of #227 (the uniform ~65–80% throughput drop on both backends, suspected per-request observability middleware). That stays open on the issue.