### PR TITLE
test(mongo): raise container nofile limit; tolerate neighbor noise in pool test

### DIFF
--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -267,6 +267,13 @@ mod shared_mongo {
                     // image default and keeps the mapped port reachable once we
                     // supply our own command.
                     .with_cmd(["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "0.25"])
+                    // Every test creates its own uniquely-named database, and
+                    // WiredTiger holds file handles open per collection/index
+                    // across all of them. With 50+ test databases the stock
+                    // container nofile limit is exhausted and index builds die
+                    // with TooManyFilesOpen (error 264) late in the run. 64000
+                    // is mongod's own recommended minimum.
+                    .with_ulimit("nofile", 64000, Some(64000))
                     .with_startup_timeout(std::time::Duration::from_secs(120))
                     .start()
                     .await
@@ -574,8 +581,14 @@ async fn mongodb_integration_reuses_client_pool_under_concurrent_read_search() {
     };
 
     let created_during_test = after - before;
+    // `totalCreated` is a server-global counter on the SHARED mongo, so
+    // concurrently running neighbor tests (each with its own client pool)
+    // inflate it — observed spilling past 50 on wide runners. The regression
+    // this guards against (a fresh client per operation) creates at least one
+    // connection per iteration: 8 tasks × 20 ops ≥ 160. A 120 ceiling keeps
+    // that detectable while tolerating neighbor noise.
     assert!(
-        created_during_test <= 50,
+        created_during_test <= 120,
         "MongoDB backend should reuse one client pool; created {} connections during concurrent read/search",
         created_during_test
     );


### PR DESCRIPTION
Two stability fixes for the shared-container MongoDB integration suite, each observed as a real one-off failure:

1. **`TooManyFilesOpen` (error 264) in the coverage job** ([seen on #230's run](https://github.com/HeliosSoftware/hfs/actions) — `mongodb_integration_settings_optimistic_lock` died during an index build). Every test creates its own uniquely-named database, and WiredTiger keeps file handles open per collection/index across all of them — 50+ test databases exhaust the stock container `nofile` limit late in the run. The shared testcontainer now starts with `--ulimit nofile=64000` (mongod's own recommended minimum). Same tuning spot as the earlier WiredTiger cache cap.

2. **`mongodb_integration_reuses_client_pool_under_concurrent_read_search` flaking on wide runners.** It asserts on `serverStatus.connections.totalCreated`, a **server-global** counter on the shared mongo, so concurrently running neighbor tests (each with its own client pool) inflate it past the old ceiling of 50. The regression it guards against — a fresh client per operation — creates ≥160 connections (8 tasks × 20 ops), so a 120 ceiling keeps the signal while tolerating the noise.

Full suite green locally against the ulimit-configured container: 51/51.

Note for in-flight PRs (#229/#230/#241/#242/#244): the coverage job runs each branch's own tree, so they'll want a `main` merge after this lands to pick the fix up.