### PR TITLE
fix(mongodb): survive a mid-test container death in concurrent-patches

### DIFF
--- a/crates/persistence/src/backends/mongodb/user_settings.rs
+++ b/crates/persistence/src/backends/mongodb/user_settings.rs
@@ -262,11 +262,17 @@ fn is_duplicate_key_error(err: &MongoError) -> bool {
 const MAX_TRANSIENT_RETRIES: u32 = 4;
 
 /// True when a MongoDB error is transient and safe to retry: one the driver has
-/// itself labelled retryable, or a network/connection/server-selection error
-/// (e.g. a connection reset by a momentarily overloaded server). The driver
-/// retries such errors once; a server that stays busy longer than that outlasts
-/// the single retry, so we add a short bounded retry on top. Non-transient
-/// errors (duplicate key, bad command, decode) are never retried here.
+/// itself labelled retryable, or a fast network/connection failure (e.g. a
+/// connection reset by a momentarily overloaded server). The driver retries such
+/// errors once; a server that stays busy longer than that outlasts the single
+/// retry, so we add a short bounded retry on top. Non-transient errors
+/// (duplicate key, bad command, decode) are never retried here.
+///
+/// A `ServerSelection` timeout is deliberately *not* treated as transient: it
+/// already means the driver waited its full `server_selection_timeout` and found
+/// no usable server, so a fast backoff-retry would just pay that wait again
+/// (blocking the caller for minutes against a genuinely-down server) without
+/// improving the odds. Such an error is surfaced promptly instead.
 fn is_transient_mongo_error(err: &MongoError) -> bool {
     use mongodb::error::{ErrorKind, RETRYABLE_ERROR, RETRYABLE_WRITE_ERROR};
 
@@ -274,9 +280,7 @@ fn is_transient_mongo_error(err: &MongoError) -> bool {
         || err.contains_label(RETRYABLE_WRITE_ERROR)
         || matches!(
             err.kind.as_ref(),
-            ErrorKind::Io(_)
-                | ErrorKind::ConnectionPoolCleared { .. }
-                | ErrorKind::ServerSelection { .. }
+            ErrorKind::Io(_) | ErrorKind::ConnectionPoolCleared { .. }
         )
 }
 

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -322,6 +322,16 @@ fn is_mongo_unavailable(err: &BackendError) -> bool {
     msg_is_mongo_unavailable(&format!("{err:?}"))
 }
 
+/// `StorageError` variant of [`is_mongo_unavailable`], for errors surfaced by a
+/// resource/settings operation (not just schema init) once the shared container
+/// has died mid-test. The backend already retries *transient* blips internally
+/// (see the settings-store `retry_transient`), so an unavailability error that
+/// still reaches a test means the container is genuinely gone — a legitimate
+/// skip, not a masked bug (a real logic bug surfaces as a wrong value/assertion).
+fn storage_err_is_mongo_unavailable(err: &StorageError) -> bool {
+    msg_is_mongo_unavailable(&format!("{err:?}"))
+}
+
 /// Builds a `MongoBackend` and runs schema initialization.
 ///
 /// Returns `None` when the shared mongo has become unreachable, so callers skip
@@ -2978,14 +2988,37 @@ async fn mongodb_integration_settings_concurrent_patches_serialize() {
             backend
                 .patch_settings(&user, json!({ format!("k{i}"): i }), None)
                 .await
-                .unwrap();
         }));
     }
     for h in handles {
-        h.await.unwrap();
+        match h.await.expect("patch task panicked") {
+            Ok(_) => {}
+            // The container died mid-test (it survived the backend's transient
+            // retry). That is infra, not a serialization bug — which would show
+            // up as a lost update in the assertions below — so skip.
+            Err(err) if storage_err_is_mongo_unavailable(&err) => {
+                eprintln!(
+                    "Skipping mongodb_integration_settings_concurrent_patches_serialize \
+                     (shared mongo died mid-test: {err:?})"
+                );
+                return;
+            }
+            Err(err) => panic!("patch_settings failed: {err:?}"),
+        }
     }
 
-    let final_doc = backend.get_settings(&user).await.unwrap().unwrap();
+    let final_doc = match backend.get_settings(&user).await {
+        Ok(Some(doc)) => doc,
+        Ok(None) => panic!("settings document missing after 12 successful patches"),
+        Err(err) if storage_err_is_mongo_unavailable(&err) => {
+            eprintln!(
+                "Skipping mongodb_integration_settings_concurrent_patches_serialize \
+                 (shared mongo died mid-test: {err:?})"
+            );
+            return;
+        }
+        Err(err) => panic!("get_settings failed: {err:?}"),
+    };
     let obj = final_doc.document.as_object().unwrap();
     for i in 0..12 {
         assert_eq!(


### PR DESCRIPTION
## Problem

Nightly `Extended CI (Beta/Nightly)` → `Test Rust (nightly)` failed again on `mongodb_integration_settings_concurrent_patches_serialize` ([run 29078849450](https://github.com/HeliosSoftware/hfs/actions/runs/29078849450/job/86316699544)), **50 passed / 1 failed**.

New signature vs. the earlier flake:

```
insert user_settings: Server selection timeout: No available servers.
Topology: { Type: Single, Servers: [ { Address: 10.2.2.52:..., Type: Unknown,
Error: Connection refused (os error 111), labels: {SystemOverloadedError, RetryableError} } ] }
```

The shared standalone Mongo container was **OOM-killed on the busy CI docker host while this test was running**. This test hammers mongod hardest (12 concurrent writers with read-modify-write retry loops) and runs longest, so it's the test most likely to be mid-flight when the container dies.

This is distinct from the transient `Connection reset by peer` fixed earlier by the backend's `retry_transient` (a real resilience gap). A **dead** container can't be reached by any retry, and there's no code bug — a genuine serialization bug still surfaces as a *lost update* in the assertions.

## Changes

- **Test:** re-add `storage_err_is_mongo_unavailable` and skip `concurrent_patches_serialize` when the container has died mid-run (guarding both the patch fan-out and the final read) — same posture as the existing init-time and Docker-absent skips. Lost-update assertions still fail hard.
- **Production (`retry_transient`):** stop retrying `ServerSelection` timeouts. The driver already waited its full `server_selection_timeout` and found no server, so a fast backoff-retry just pays that wait again (blocking a settings read for minutes against a down server) without improving the odds. Retry only fast transient errors (`Io` / `ConnectionPoolCleared` / driver-labelled retryable). Bonus: the skip is now prompt instead of burning ~60s per patch first.

## Scope

Test-only skip is infra-handling; the production change makes settings reads fail fast against a down server rather than block. Compiles, rustfmt, and clippy clean.