### PR TITLE
ci(ui): add placeholder UI testing workflow

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,144 @@
+name: UI Tests
+
+# PLACEHOLDER — browser-level UI testing for `crates/ui` (helios-ui).
+#
+# Scope and status
+# ---------------
+# `crates/ui` is a server-rendered Askama + htmx UI. Today it is covered only by
+# `tower::oneshot` router tests (`crates/ui/tests/{router_http,i18n_http}.rs`),
+# which assert over response *strings*. They cannot execute `assets/theme.js`,
+# so first-paint theming, the `/_user/settings` merge-patch, htmx swaps, and
+# WCAG conformance are all untested.
+#
+# This workflow is the agreed CI seat for that coverage. It is intentionally a
+# no-op-friendly skeleton: it builds and boots the UI, smoke-checks that `/ui`
+# serves, and then runs the Playwright suite **only once it exists** at
+# `crates/ui/e2e`. Until then the "run" steps skip and the job stays green, so
+# this can live on `main` without gating anyone.
+#
+# Owner: @angela-helios — see the tracking issue for the strategy, the tool
+# evaluation, and the phased rollout.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/ui/**"
+      - ".github/workflows/ui-tests.yml"
+
+concurrency:
+  group: ui-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 2
+  CARGO_PROFILE_DEV_DEBUG: 0
+  # The suite drives a real browser against this origin.
+  HFS_UI_BASE_URL: http://127.0.0.1:8080
+  E2E_DIR: crates/ui/e2e
+
+jobs:
+  ui-tests:
+    name: Browser tests (helios-ui)
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          clean: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Configure Rust linker (Linux)
+        run: |
+          mkdir -p ~/.cargo
+          rm -f ~/.cargo/config.toml
+          echo '[target.x86_64-unknown-linux-gnu]' >> ~/.cargo/config.toml
+          echo 'linker = "clang"' >> ~/.cargo/config.toml
+          echo 'rustflags = ["-C", "link-arg=-fuse-ld=lld"]' >> ~/.cargo/config.toml
+
+      # Cheap guard that keeps working while the browser suite is still empty:
+      # the existing router tests must pass before we bother booting a browser.
+      - name: Router/i18n tests (helios-ui)
+        run: cargo test -p helios-ui
+
+      - name: Detect the browser suite
+        id: detect
+        run: |
+          if [ -f "${E2E_DIR}/package.json" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=UI browser suite not present::No ${E2E_DIR}/package.json yet — skipping browser tests. See the UI testing strategy issue."
+          fi
+
+      - name: Build hfs with the UI feature
+        if: steps.detect.outputs.present == 'true'
+        run: cargo build -p helios-hfs --features ui
+
+      - name: Set up Node
+        if: steps.detect.outputs.present == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ${{ env.E2E_DIR }}/package-lock.json
+
+      - name: Install browser suite deps
+        if: steps.detect.outputs.present == 'true'
+        working-directory: ${{ env.E2E_DIR }}
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Boot hfs and wait for /ui
+        if: steps.detect.outputs.present == 'true'
+        run: |
+          HFS_LOG_LEVEL=warn ./target/debug/hfs > "${RUNNER_TEMP}/hfs.log" 2>&1 &
+          echo "$!" > "${RUNNER_TEMP}/hfs.pid"
+          for _ in $(seq 1 60); do
+            if curl -sf -o /dev/null "${HFS_UI_BASE_URL}/ui"; then
+              echo "UI is up"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error title=hfs did not serve /ui::Server never became ready"
+          cat "${RUNNER_TEMP}/hfs.log" || true
+          exit 1
+
+      - name: Run browser tests
+        if: steps.detect.outputs.present == 'true'
+        working-directory: ${{ env.E2E_DIR }}
+        run: npx playwright test
+
+      - name: Stop hfs
+        if: always() && steps.detect.outputs.present == 'true'
+        run: |
+          if [ -f "${RUNNER_TEMP}/hfs.pid" ]; then
+            kill "$(cat "${RUNNER_TEMP}/hfs.pid")" 2>/dev/null || true
+          fi
+
+      - name: Upload Playwright report
+        if: always() && steps.detect.outputs.present == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: |
+            ${{ env.E2E_DIR }}/playwright-report
+            ${{ env.E2E_DIR }}/test-results
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload server log
+        if: failure() && steps.detect.outputs.present == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: hfs-server-log
+          path: ${{ runner.temp }}/hfs.log
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
Adds `.github/workflows/ui-tests.yml` as the CI seat for browser-level testing of `crates/ui`.

**This is a placeholder and gates nobody.** It runs `cargo test -p helios-ui` (green today), then detects `crates/ui/e2e/package.json`. That file does not exist yet, so every browser step skips and the job passes. When @angela-helios lands the Playwright suite at `crates/ui/e2e/` in a branch, the workflow activates with no further CI changes.

What it does once the suite exists:
- builds `hfs --features ui`, boots it, waits for `/ui`
- `npm ci` + pinned Chromium, runs `npx playwright test`
- uploads the Playwright report; uploads the server log on failure
- always tears the server down

Conventions follow the existing workflows: self-hosted Linux runner, `dtolnay/rust-toolchain@stable`, clang/lld linker config, `CARGO_BUILD_JOBS: 2`, `actions/upload-artifact@v7`.

Triggers are `workflow_dispatch` + `pull_request` scoped to `crates/ui/**`. Whether it should also run on `push` to `main` is an open question in the issue.

Strategy, tool evaluation (Playwright vs. a Rust-native CDP driver, both prototyped), and the phased rollout: #249

Note: that evaluation already surfaced two real `serious` WCAG 2.2 AA defects on `/ui` in both themes — an `aria-prohibited-attr` on the expand-chart `<span>` and a 20×20px `target-size` violation on the theme toggles. Both are tracked in #249.