### PR TITLE
ci: fix testcontainer reaping that let containers accumulate

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -45,7 +45,27 @@ jobs:
     runs-on: [self-hosted, Linux]
     needs: [test-rust]
     if: always()
+    env:
+      MAX_CONTAINER_AGE_MIN: 90
     steps:
       - name: Remove testcontainers from this run
         run: |
           docker ps -aq --filter "label=github.run_id=${{ github.run_id }}" | xargs -r docker rm -f || true
+
+      - name: Sweep orphaned testcontainers from dead runs
+        run: |
+          # See ci.yml for the full rationale: containers live in `static
+          # OnceCell`s and are never dropped, so anything a dead run left behind
+          # can only be reaped by label + age.
+          now=$(date +%s)
+          reaped=0
+          for id in $(docker ps -q --filter "label=org.testcontainers.managed-by=testcontainers"); do
+            started=$(docker inspect -f '{{.State.StartedAt}}' "$id" 2>/dev/null) || continue
+            age_min=$(( (now - $(date -d "$started" +%s)) / 60 ))
+            if [ "$age_min" -ge "$MAX_CONTAINER_AGE_MIN" ]; then
+              echo "Reaping orphan $id (age ${age_min}m)"
+              docker rm -f "$id" || true
+              reaped=$((reaped + 1))
+            fi
+          done
+          echo "Swept ${reaped} orphaned testcontainer(s)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,34 +72,52 @@ jobs:
   cleanup-test-containers:
     name: Cleanup Test Containers
     runs-on: [self-hosted, Linux]
-    needs: [test-rust]
+    # EVERY job that stands up testcontainers must be listed here. `coverage`
+    # runs a second full ES + Postgres + Mongo suite after `test-rust`; when this
+    # job only needed `test-rust` it fired before `coverage` had even started, so
+    # coverage's containers survived every sweep.
+    needs: [test-rust, coverage]
     if: always()
     env:
-      # Reap any testcontainer older than this many minutes. Must comfortably
-      # exceed the longest CI job runtime so a *concurrent* run's live
-      # containers on the shared docker host are never killed mid-test.
+      # Orphan sweep only. Must comfortably exceed the longest CI job runtime so
+      # a *concurrent* run's live containers on the shared docker host are never
+      # killed mid-test.
       MAX_CONTAINER_AGE_MIN: 90
     steps:
-      - name: Reap leaked testcontainers
+      - name: Reap this run's testcontainers
         run: |
-          # testcontainers-rs cleans up on clean process exit, but a cancelled,
-          # timed-out, or OOM-killed test run leaks its containers. It stamps
-          # every container with `org.testcontainers.managed-by=testcontainers`
-          # (never github.run_id), so we reap by that label + age: anything
-          # older than MAX_CONTAINER_AGE_MIN is a leak from a dead run and is
-          # safe to remove without affecting a live concurrent job.
+          # testcontainers-rs removes a container only from `Drop for
+          # ContainerAsync`, and every suite parks its container in a `static
+          # OnceCell` — statics are never dropped, so even a fully green run
+          # leaks one container per test binary. The `watchdog` feature does not
+          # help: it fires on SIGTERM/SIGINT/SIGQUIT, not on normal exit or on
+          # the SIGKILL an OOM-kill delivers. Reaping here is the only cleanup.
+          #
+          # The test helpers stamp `github.run_id`, which is exactly what makes
+          # them reapable. No age guard: these are *this* run's containers, and
+          # by construction they are only minutes old.
+          docker ps -aq --filter "label=github.run_id=${{ github.run_id }}" \
+            | xargs -r docker rm -f || true
+
+      - name: Sweep orphaned testcontainers from dead runs
+        run: |
+          # Backstop for containers the run_id filter cannot see: leaks from runs
+          # that died before reaching this job, and the few suites that don't
+          # stamp github.run_id. testcontainers-rs unconditionally applies
+          # `org.testcontainers.managed-by=testcontainers` to every container, so
+          # that label plus an age guard is a safe net.
           now=$(date +%s)
           reaped=0
           for id in $(docker ps -q --filter "label=org.testcontainers.managed-by=testcontainers"); do
             started=$(docker inspect -f '{{.State.StartedAt}}' "$id" 2>/dev/null) || continue
             age_min=$(( (now - $(date -d "$started" +%s)) / 60 ))
             if [ "$age_min" -ge "$MAX_CONTAINER_AGE_MIN" ]; then
-              echo "Reaping $id (age ${age_min}m)"
+              echo "Reaping orphan $id (age ${age_min}m)"
               docker rm -f "$id" || true
               reaped=$((reaped + 1))
             fi
           done
-          echo "Reaped ${reaped} leaked testcontainer(s)."
+          echo "Swept ${reaped} orphaned testcontainer(s)."
 
   test-python:
     name: Test Python

--- a/.github/workflows/hts.yml
+++ b/.github/workflows/hts.yml
@@ -730,3 +730,46 @@ jobs:
             "./data/hts-${{ matrix.label }}.db" \
             "./utg.tgz" \
             "/tmp/hts-${{ matrix.label }}.log"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Reap leaked testcontainers
+  # ─────────────────────────────────────────────────────────────────────────────
+  cleanup-test-containers:
+    name: Cleanup Test Containers
+    runs-on: [self-hosted, Linux]
+    # Only `check` (cargo test -p helios-hts) stands up testcontainers; the
+    # integration-test job uses SQLite files and a locally-run binary. `check`'s
+    # own `#[ctor::dtor]` removes its Postgres container on a *clean* process
+    # exit, but a cancelled or OOM-killed run skips the dtor and leaks it — the
+    # same static-is-never-dropped problem as the rest of the suite. This job is
+    # the backstop for that case (this workflow runs nightly on its own cron, so
+    # it cannot rely on ci.yml's sweep to clean up after it).
+    needs: [check]
+    if: always()
+    env:
+      # Orphan sweep only. Must comfortably exceed the longest CI job runtime so
+      # a *concurrent* run's live containers on the shared docker host are never
+      # killed mid-test. hts test containers carry `io.helios.hts.test-pool`
+      # rather than `github.run_id`, so an age-guarded sweep is the safe option:
+      # it can never race a concurrent hts run (e.g. nightly + a release tag).
+      MAX_CONTAINER_AGE_MIN: 90
+    steps:
+      - name: Sweep orphaned testcontainers from dead runs
+        run: |
+          # testcontainers-rs unconditionally applies
+          # `org.testcontainers.managed-by=testcontainers` to every container it
+          # starts. Reap any carrying that label older than MAX_CONTAINER_AGE_MIN
+          # — old enough to be a leak from a dead run, never a live concurrent
+          # job. See ci.yml for the full rationale.
+          now=$(date +%s)
+          reaped=0
+          for id in $(docker ps -q --filter "label=org.testcontainers.managed-by=testcontainers"); do
+            started=$(docker inspect -f '{{.State.StartedAt}}' "$id" 2>/dev/null) || continue
+            age_min=$(( (now - $(date -d "$started" +%s)) / 60 ))
+            if [ "$age_min" -ge "$MAX_CONTAINER_AGE_MIN" ]; then
+              echo "Reaping orphan $id (age ${age_min}m)"
+              docker rm -f "$id" || true
+              reaped=$((reaped + 1))
+            fi
+          done
+          echo "Swept ${reaped} orphaned testcontainer(s)."

--- a/crates/persistence/tests/minio_s3_tests.rs
+++ b/crates/persistence/tests/minio_s3_tests.rs
@@ -102,6 +102,7 @@ async fn shared_minio() -> &'static SharedMinio {
             let root_password = std::env::var("MINIO_ROOT_PASSWORD")
                 .unwrap_or_else(|_| DEFAULT_MINIO_ROOT_PASSWORD.to_string());
 
+            let run_id = std::env::var("GITHUB_RUN_ID").unwrap_or_default();
             let container = GenericImage::new(image, tag)
                 .with_wait_for(WaitFor::message_on_stderr("API:"))
                 .with_exposed_port(9000.tcp())
@@ -110,6 +111,7 @@ async fn shared_minio() -> &'static SharedMinio {
                 .with_env_var("MINIO_ROOT_PASSWORD", root_password.clone())
                 .with_env_var("MINIO_CONSOLE_ADDRESS", ":9001")
                 .with_cmd(["server", "/data", "--console-address", ":9001"])
+                .with_label("github.run_id", &run_id)
                 .start()
                 .await
                 .expect("failed to start MinIO container");

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -704,7 +704,10 @@ mod postgres_integration {
     struct SharedPg {
         host: String,
         port: u16,
-        /// Kept alive for the duration of the test binary; dropped at process exit.
+        /// Kept alive for the duration of the test binary. NOTE: a `static` is
+        /// never dropped, so `Drop for ContainerAsync` — testcontainers' only
+        /// container-removal path — never runs. The container outlives the test
+        /// process and is reaped in CI by its `github.run_id` label.
         _container: testcontainers::ContainerAsync<Postgres>,
     }
 


### PR DESCRIPTION
## Problem

Zombie testcontainers (`postgres:11-alpine`, `mongo:5.0.6`, `es:7.16.1`) keep piling up on the shared self-hosted docker host. The `cleanup-test-containers` job added in #226 has never actually reaped a live run's containers.

## Root cause

Each test suite parks its container in a `static OnceCell`. **Statics are never dropped**, so testcontainers-rs's only removal path — `Drop for ContainerAsync` — never runs. The `watchdog` feature doesn't cover it (fires on SIGTERM/SIGINT/SIGQUIT only, not on normal exit or the SIGKILL an OOM-kill delivers), and testcontainers-rs ships no Ryuk reaper. So **CI-side reaping by label is the only cleanup mechanism** — which is exactly why the test helpers stamp `github.run_id`.

PR #226 replaced the `run_id` filter with an age guard of 90 minutes, on the belief that testcontainers "never sets github.run_id" (it does — 7 suites set it). Because the cleanup job runs immediately after `test-rust`, that run's own containers are only minutes old, so the age guard skips every one of them. It only ever caught leaks from *other, already-dead* runs. Every green run leaked its full suite.

## Three leak sources fixed

1. **`test-rust`** — reap this run's containers by `github.run_id` with **no age guard** (they're this run's own, and only minutes old).
2. **`coverage`** — `cargo llvm-cov --workspace --features postgres,mongodb` stands up a *second* Postgres + Mongo suite, but cleanup only `needs: [test-rust]` and fired before coverage even started. Added `coverage` to `needs`.
3. **`hts.yml`** — `cargo test -p helios-hts` spawns Postgres testcontainers and had **no cleanup job at all** (runs nightly on its own cron, so it can't lean on ci.yml's sweep). Added an age-guarded orphan sweep as a backstop.

An age-guarded orphan sweep (`org.testcontainers.managed-by=testcontainers`, applied unconditionally by testcontainers-rs) is kept in each job as a backstop for runs that died before reaching cleanup and for the couple of suites that don't stamp `run_id`.

Also: labeled the MinIO container (the one suite that wasn't) and corrected the misleading "dropped at process exit" comment in `postgres_tests.rs`.

## Note on the 90-minute age guard

The guard must outlast the longest **container-holding** job — the `cargo test --workspace` runs, not the multi-hour release build (which holds no testcontainers; sof's tests are in-process). 90 min is a comfortable ceiling today; each job's env comment documents this so it's bumped correctly if the test suite ever grows.