### PR TITLE
ci(cluster): add two-instance cluster smoke workflow skeleton

### DIFF
--- a/.github/workflows/cluster-smoke.yml
+++ b/.github/workflows/cluster-smoke.yml
@@ -1,0 +1,308 @@
+name: HFS Cluster Smoke
+
+# T3 tier of docs/cluster-testing-strategy.md (§3, §7): two hfs processes on
+# separate ports sharing one Postgres, behind an nginx round-robin front.
+#
+# This is the workflow_dispatch skeleton for the cluster-capable-state work
+# (discussion #223). It lands on main ahead of the feature phases because a
+# workflow is only dispatchable once it exists on the default branch; dispatch
+# it with ref=<feature-branch> to run the branch's version of this file and of
+# the smoke script. The skeleton asserts only behavior that is already
+# cluster-safe (shared-Postgres CRUD visibility A→B, round-robin through the
+# front) — it calibrates the two-instance harness. Phase 1 adds the SoF
+# $export A→B round-trip; Phase 3 adds the WebSocket fan-out A→B case; the
+# nightly kill-9 recovery cases (A1/E1) get a schedule trigger when they land.
+#
+# Cloned from bulk-export-smoke.yml: same self-hosted runners, remote Docker
+# host (containers are reached at $DOCKER_HOST_IP, the hfs binaries run on the
+# runner), same container lifecycle and artifact conventions.
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 1
+  CARGO_PROFILE_DEV_DEBUG: 0
+  DOCKER_HOST: ${{ secrets.DOCKER_HOST }}
+  DOCKER_HOST_IP: ${{ secrets.DOCKER_HOST_IP }}
+
+jobs:
+  build:
+    name: Build HFS for cluster smoke
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Configure Rust to use LLD
+        run: |
+          mkdir -p ~/.cargo
+          rm -f ~/.cargo/config.toml
+          echo '[target.x86_64-unknown-linux-gnu]' >> ~/.cargo/config.toml
+          echo 'linker = "clang"' >> ~/.cargo/config.toml
+          echo 'rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,-zstack-size=8388608"]' >> ~/.cargo/config.toml
+
+      - name: Build HFS binary
+        run: |
+          cargo build -p helios-hfs --no-default-features \
+            --features R4,postgres
+
+      - name: Upload HFS binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: hfs-cluster-smoke-binary
+          path: target/debug/hfs
+          retention-days: 1
+
+  cluster-smoke:
+    name: Cluster smoke (R4 / postgres)
+    needs: build
+    runs-on: [self-hosted, Linux]
+    env:
+      RESULTS_DIR: cluster-smoke-results/R4/postgres
+      FHIR_VERSION: R4
+      HFS_PORT_A: "18200"
+      HFS_PORT_B: "18201"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Download HFS binary
+        uses: actions/download-artifact@v8
+        with:
+          name: hfs-cluster-smoke-binary
+          path: target/debug
+
+      - name: Make executables available
+        run: |
+          chmod +x target/debug/hfs
+          chmod +x crates/hfs/tests/cluster/run_external_cluster_smoke.sh
+
+      - name: Determine runner and Docker host IP
+        run: |
+          RUNNER_IP=$(hostname -I | awk '{print $1}')
+          if [ -n "${DOCKER_HOST_IP:-}" ]; then
+            EFFECTIVE_DOCKER_HOST_IP="$DOCKER_HOST_IP"
+          else
+            EFFECTIVE_DOCKER_HOST_IP="$RUNNER_IP"
+          fi
+          echo "RUNNER_IP=$RUNNER_IP" >> "$GITHUB_ENV"
+          echo "DOCKER_HOST_IP=$EFFECTIVE_DOCKER_HOST_IP" >> "$GITHUB_ENV"
+          echo "Runner IP: $RUNNER_IP"
+          echo "Docker host IP: $EFFECTIVE_DOCKER_HOST_IP"
+
+      - name: Start PostgreSQL
+        run: |
+          PG_CONTAINER="pg-cluster-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
+          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker run -d --name "$PG_CONTAINER" -p 0:5432 \
+            -e POSTGRES_USER=helios \
+            -e POSTGRES_PASSWORD=helios \
+            -e POSTGRES_DB=helios \
+            postgres:16
+          echo "PG_CONTAINER=$PG_CONTAINER" >> "$GITHUB_ENV"
+
+          for i in {1..30}; do
+            if docker exec "$PG_CONTAINER" pg_isready -U helios >/dev/null 2>&1; then
+              PG_PORT=$(docker port "$PG_CONTAINER" 5432 | head -1 | sed 's/.*://')
+              if timeout 2 bash -c "cat < /dev/null > /dev/tcp/$DOCKER_HOST_IP/$PG_PORT" 2>/dev/null; then
+                echo "PG_PORT=$PG_PORT" >> "$GITHUB_ENV"
+                echo "PG_URL=postgresql://helios:helios@$DOCKER_HOST_IP:$PG_PORT/helios" >> "$GITHUB_ENV"
+                echo "PostgreSQL is ready on port $PG_PORT"
+                exit 0
+              fi
+            fi
+            echo "Attempt $i/30: PostgreSQL not ready yet..."
+            sleep 2
+          done
+
+          docker logs "$PG_CONTAINER"
+          exit 1
+
+      - name: Start nginx round-robin front
+        run: |
+          mkdir -p "$RESULTS_DIR"
+          NGINX_CONTAINER="nginx-cluster-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
+          docker rm -f "$NGINX_CONTAINER" 2>/dev/null || true
+
+          # Upstreams are the two hfs processes on the runner. X-Hfs-Upstream
+          # lets the smoke script prove round-robin. The Upgrade/Connection
+          # plumbing is already in place for the Phase 3 WebSocket fan-out case.
+          cat > "$RESULTS_DIR/nginx.conf" <<EOF
+          events {}
+          http {
+            map \$http_upgrade \$connection_upgrade {
+              default upgrade;
+              ''      close;
+            }
+            upstream hfs_cluster {
+              server $RUNNER_IP:$HFS_PORT_A;
+              server $RUNNER_IP:$HFS_PORT_B;
+            }
+            server {
+              listen 80;
+              location / {
+                proxy_pass http://hfs_cluster;
+                proxy_http_version 1.1;
+                proxy_set_header Host \$host;
+                proxy_set_header Upgrade \$http_upgrade;
+                proxy_set_header Connection \$connection_upgrade;
+                add_header X-Hfs-Upstream \$upstream_addr always;
+              }
+            }
+          }
+          EOF
+
+          # The Docker host may be remote, so inject the config with docker cp
+          # (a bind mount would resolve paths on the Docker host, not here).
+          docker create --name "$NGINX_CONTAINER" -p 0:80 nginx:1.27
+          docker cp "$RESULTS_DIR/nginx.conf" "$NGINX_CONTAINER:/etc/nginx/nginx.conf"
+          docker start "$NGINX_CONTAINER"
+          echo "NGINX_CONTAINER=$NGINX_CONTAINER" >> "$GITHUB_ENV"
+
+          # hfs is not up yet, so accept any HTTP answer (502 included) as
+          # proof that nginx itself is serving.
+          for i in {1..30}; do
+            NGINX_PORT=$(docker port "$NGINX_CONTAINER" 80 2>/dev/null | head -1 | sed 's/.*://')
+            if [ -n "$NGINX_PORT" ] \
+                && curl -s -o /dev/null "http://$DOCKER_HOST_IP:$NGINX_PORT/health"; then
+              echo "NGINX_PORT=$NGINX_PORT" >> "$GITHUB_ENV"
+              echo "FRONT_URL=http://$DOCKER_HOST_IP:$NGINX_PORT" >> "$GITHUB_ENV"
+              echo "nginx front is ready on port $NGINX_PORT"
+              exit 0
+            fi
+            echo "Attempt $i/30: nginx not ready yet..."
+            sleep 2
+          done
+
+          docker logs "$NGINX_CONTAINER"
+          exit 1
+
+      - name: Start HFS instances A and B
+        run: |
+          HFS_DEFAULT_TENANT="cluster-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "HFS_DEFAULT_TENANT=$HFS_DEFAULT_TENANT" >> "$GITHUB_ENV"
+
+          # One logical cluster: both instances share the database and the
+          # public base URL (the nginx front), differing only in port.
+          COMMON_ENV=(
+            HFS_BASE_URL="$FRONT_URL"
+            HFS_DEFAULT_FHIR_VERSION="$FHIR_VERSION"
+            HFS_DEFAULT_TENANT="$HFS_DEFAULT_TENANT"
+            HFS_STORAGE_BACKEND=postgres
+            HFS_DATABASE_URL="$PG_URL"
+            HFS_PG_HOST="$DOCKER_HOST_IP"
+            HFS_PG_PORT="$PG_PORT"
+            HFS_PG_DBNAME=helios
+            HFS_PG_USER=helios
+            HFS_PG_PASSWORD=helios
+          )
+
+          HFS_LOG_A="$RESULTS_DIR/hfs-a.log"
+          HFS_LOG_B="$RESULTS_DIR/hfs-b.log"
+          echo "HFS_LOG_A=$HFS_LOG_A" >> "$GITHUB_ENV"
+          echo "HFS_LOG_B=$HFS_LOG_B" >> "$GITHUB_ENV"
+
+          env "${COMMON_ENV[@]}" \
+            ./target/debug/hfs --log-level info --port "$HFS_PORT_A" --host 0.0.0.0 > "$HFS_LOG_A" 2>&1 &
+          echo "HFS_PID_A=$!" >> "$GITHUB_ENV"
+
+          env "${COMMON_ENV[@]}" \
+            ./target/debug/hfs --log-level info --port "$HFS_PORT_B" --host 0.0.0.0 > "$HFS_LOG_B" 2>&1 &
+          echo "HFS_PID_B=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for both HFS instances to be ready
+        run: |
+          wait_ready() {
+            local name="$1" pid="$2" port="$3" log="$4"
+            for i in {1..45}; do
+              if ! kill -0 "$pid" 2>/dev/null; then
+                echo "HFS instance $name exited"
+                cat "$log"
+                return 1
+              fi
+              if curl -sf "http://localhost:$port/health" >/dev/null 2>&1; then
+                echo "HFS instance $name is ready on port $port"
+                return 0
+              fi
+              echo "Attempt $i/45: HFS instance $name not ready yet..."
+              sleep 2
+            done
+            tail -100 "$log"
+            return 1
+          }
+          wait_ready A "$HFS_PID_A" "$HFS_PORT_A" "$HFS_LOG_A"
+          wait_ready B "$HFS_PID_B" "$HFS_PORT_B" "$HFS_LOG_B"
+
+      - name: Run cluster smoke checks
+        run: |
+          BASE_URL_A="http://localhost:$HFS_PORT_A" \
+          BASE_URL_B="http://localhost:$HFS_PORT_B" \
+          FRONT_URL="$FRONT_URL" \
+          FHIR_VERSION="$FHIR_VERSION" \
+          RESULTS_DIR="$RESULTS_DIR" \
+          SMOKE_RUN_SUFFIX="${{ github.run_id }}-${{ github.run_attempt }}" \
+          ./crates/hfs/tests/cluster/run_external_cluster_smoke.sh
+
+      - name: Stop HFS instances gracefully
+        if: always()
+        run: |
+          for pid in "${HFS_PID_A:-}" "${HFS_PID_B:-}"; do
+            if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+              kill -INT "$pid" 2>/dev/null || true
+              for _ in {1..50}; do
+                if kill -0 "$pid" 2>/dev/null; then
+                  sleep 0.2
+                else
+                  break
+                fi
+              done
+              kill -9 "$pid" 2>/dev/null || true
+            fi
+          done
+
+      - name: Collect container logs
+        if: always()
+        run: |
+          mkdir -p "$RESULTS_DIR/backend-logs"
+          if [ -n "${PG_CONTAINER:-}" ]; then
+            docker logs "$PG_CONTAINER" > "$RESULTS_DIR/backend-logs/postgres.log" 2>&1 || true
+          fi
+          if [ -n "${NGINX_CONTAINER:-}" ]; then
+            docker logs "$NGINX_CONTAINER" > "$RESULTS_DIR/backend-logs/nginx.log" 2>&1 || true
+          fi
+
+      - name: Append smoke report to summary
+        if: always()
+        run: |
+          if [ -f "$RESULTS_DIR/summary.md" ]; then
+            cat "$RESULTS_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Cluster Smoke" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No summary produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload cluster smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cluster-smoke-R4-postgres-${{ github.run_id }}-${{ github.run_attempt }}
+          path: cluster-smoke-results/R4/postgres/
+          retention-days: 30
+
+      - name: Cleanup containers
+        if: always()
+        run: |
+          if [ -n "${PG_CONTAINER:-}" ]; then
+            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          fi
+          if [ -n "${NGINX_CONTAINER:-}" ]; then
+            docker rm -f "$NGINX_CONTAINER" 2>/dev/null || true
+          fi

--- a/crates/hfs/tests/cluster/run_external_cluster_smoke.sh
+++ b/crates/hfs/tests/cluster/run_external_cluster_smoke.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cluster smoke skeleton (T3 tier of docs/cluster-testing-strategy.md).
+#
+# Drives two hfs instances that share one Postgres, plus an nginx round-robin
+# front. This skeleton only asserts behavior that is already cluster-safe on
+# main (shared-Postgres CRUD visibility), calibrating the two-instance harness
+# before any cluster-capable-state phase depends on it — the same
+# calibrate-against-known-good principle the T2 harness uses
+# (docs/cluster-testing-methodology.md §5). Phase 1+ extends this script with
+# the real cross-instance assertions (SoF $export A→B, WS fan-out A→B).
+
+BASE_URL_A="${BASE_URL_A:-http://localhost:18200}"
+BASE_URL_B="${BASE_URL_B:-http://localhost:18201}"
+FRONT_URL="${FRONT_URL:?FRONT_URL (nginx round-robin front) must be set}"
+FHIR_VERSION="${FHIR_VERSION:-R4}"
+RESULTS_DIR="${RESULTS_DIR:-cluster-smoke-results}"
+SMOKE_RUN_SUFFIX="${SMOKE_RUN_SUFFIX:-local-$(date +%s)-$$}"
+
+HTTP_DIR="$RESULTS_DIR/http"
+SUMMARY_FILE="$RESULTS_DIR/summary.md"
+
+mkdir -p "$HTTP_DIR"
+
+log() {
+  echo "[cluster-smoke] $*"
+}
+
+fail() {
+  local msg="$1"
+  echo "[cluster-smoke] ERROR: $msg" >&2
+  mkdir -p "$(dirname "$SUMMARY_FILE")"
+  echo "- FAIL: $msg" >> "$SUMMARY_FILE"
+  for hfs_log in "${HFS_LOG_A:-}" "${HFS_LOG_B:-}"; do
+    if [ -n "$hfs_log" ] && [ -f "$hfs_log" ]; then
+      echo "---- $hfs_log (tail) ----" >&2
+      tail -n 120 "$hfs_log" >&2 || true
+      echo "-------------------------" >&2
+    fi
+  done
+  exit 1
+}
+
+pass() {
+  local msg="$1"
+  log "PASS: $msg"
+  echo "- PASS: $msg" >> "$SUMMARY_FILE"
+}
+
+case "$FHIR_VERSION" in
+  R4) FHIR_MIME_VERSION="4.0" ;;
+  R4B) FHIR_MIME_VERSION="4.3" ;;
+  R5) FHIR_MIME_VERSION="5.0" ;;
+  *) fail "unsupported FHIR_VERSION: $FHIR_VERSION (expected R4, R4B, or R5)" ;;
+esac
+
+FHIR_CT="application/fhir+json; fhirVersion=$FHIR_MIME_VERSION"
+
+ID_SUFFIX="$(printf '%s' "$SMOKE_RUN_SUFFIX-$FHIR_VERSION" | tr -cs '[:alnum:]-' '-' | sed -e 's/^-*//' -e 's/-*$//')"
+if [ -z "$ID_SUFFIX" ]; then
+  ID_SUFFIX="cluster-smoke"
+fi
+PATIENT_ID="cluster-smoke-patient-$ID_SUFFIX"
+
+cat > "$SUMMARY_FILE" <<EOF
+## Cluster Smoke Test
+
+- Instance A: \`$BASE_URL_A\`
+- Instance B: \`$BASE_URL_B\`
+- Front (nginx): \`$FRONT_URL\`
+- FHIR version: \`$FHIR_VERSION\`
+- Run suffix: \`$SMOKE_RUN_SUFFIX\`
+
+EOF
+
+curl_json() {
+  local method="$1"
+  local url="$2"
+  local body_file="$3"
+  local output_file="$4"
+  shift 4
+
+  if [ -n "$body_file" ]; then
+    curl -sS -o "$output_file" -w "%{http_code}" \
+      -X "$method" "$url" \
+      -H "Content-Type: $FHIR_CT" \
+      -H "Accept: $FHIR_CT" \
+      "$@" \
+      --data-binary @"$body_file"
+  else
+    curl -sS -o "$output_file" -w "%{http_code}" \
+      -X "$method" "$url" \
+      -H "Accept: $FHIR_CT" \
+      "$@"
+  fi
+}
+
+# --- 1. Health: both instances and the front answer -------------------------
+
+for name in A B front; do
+  case "$name" in
+    A) url="$BASE_URL_A" ;;
+    B) url="$BASE_URL_B" ;;
+    front) url="$FRONT_URL" ;;
+  esac
+  status="$(curl -sS -o "$HTTP_DIR/health-$name.txt" -w "%{http_code}" "$url/health")" \
+    || fail "health check request to $name ($url) failed"
+  if [ "$status" != "200" ]; then
+    fail "health check on $name returned HTTP $status, expected 200"
+  fi
+done
+pass "health endpoint answers on instance A, instance B, and the nginx front"
+
+# --- 2. Round-robin: the front alternates between both upstreams ------------
+# nginx stamps X-Hfs-Upstream with \$upstream_addr; over several requests we
+# must observe at least two distinct upstream addresses.
+
+: > "$HTTP_DIR/upstreams.txt"
+for i in $(seq 1 8); do
+  curl -sS -D - -o /dev/null "$FRONT_URL/health" \
+    | tr -d '\r' \
+    | awk -F': ' 'tolower($1) == "x-hfs-upstream" { print $2 }' \
+    >> "$HTTP_DIR/upstreams.txt" \
+    || fail "round-robin probe $i via the front failed"
+done
+DISTINCT_UPSTREAMS="$(sort -u "$HTTP_DIR/upstreams.txt" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [ "$DISTINCT_UPSTREAMS" -lt 2 ]; then
+  cat "$HTTP_DIR/upstreams.txt" >&2 || true
+  fail "front only reached $DISTINCT_UPSTREAMS distinct upstream(s) over 8 requests, expected 2"
+fi
+pass "nginx front round-robins across both instances ($DISTINCT_UPSTREAMS distinct upstreams)"
+
+# --- 3. Cross-instance visibility (calibration): write on A, read on B ------
+# Plain CRUD on a shared Postgres primary is already cluster-safe; this proves
+# the harness (two processes, one database) is wired correctly.
+
+PATIENT_FILE="$HTTP_DIR/patient.json"
+cat > "$PATIENT_FILE" <<EOF
+{
+  "resourceType": "Patient",
+  "id": "$PATIENT_ID",
+  "name": [{"family": "ClusterSmoke", "given": ["Skeleton"]}]
+}
+EOF
+
+status="$(curl_json PUT "$BASE_URL_A/Patient/$PATIENT_ID" "$PATIENT_FILE" "$HTTP_DIR/put-a.json")"
+if [ "$status" != "200" ] && [ "$status" != "201" ]; then
+  cat "$HTTP_DIR/put-a.json" >&2 || true
+  fail "PUT Patient on instance A returned HTTP $status, expected 200/201"
+fi
+
+status="$(curl_json GET "$BASE_URL_B/Patient/$PATIENT_ID" "" "$HTTP_DIR/get-b.json")"
+if [ "$status" != "200" ]; then
+  cat "$HTTP_DIR/get-b.json" >&2 || true
+  fail "GET Patient on instance B returned HTTP $status, expected 200 (created via A)"
+fi
+if ! grep -q "\"$PATIENT_ID\"" "$HTTP_DIR/get-b.json"; then
+  cat "$HTTP_DIR/get-b.json" >&2 || true
+  fail "Patient read via instance B does not contain id $PATIENT_ID"
+fi
+pass "Patient created via instance A is readable via instance B"
+
+status="$(curl_json GET "$FRONT_URL/Patient/$PATIENT_ID" "" "$HTTP_DIR/get-front.json")"
+if [ "$status" != "200" ]; then
+  cat "$HTTP_DIR/get-front.json" >&2 || true
+  fail "GET Patient via the front returned HTTP $status, expected 200"
+fi
+pass "Patient is readable through the nginx front"
+
+log "all cluster smoke checks passed"
+echo "" >> "$SUMMARY_FILE"
+echo "All checks passed." >> "$SUMMARY_FILE"


### PR DESCRIPTION
## Summary

Adds the `workflow_dispatch` skeleton for the T3 (two-process) smoke tier of the cluster-capable-state work ([discussion #223](https://github.com/HeliosSoftware/hfs/discussions/223)): two `hfs` instances sharing one Postgres behind an nginx round-robin front.

This lands on `main` ahead of the feature phases because a `workflow_dispatch` workflow is only dispatchable once it exists on the default branch. Once merged, it can be dispatched with `ref=feat/cluster-capable-state` (or any branch) and will run that ref's version of both the workflow and the smoke script — so all iteration happens on the feature branch from here.

The smoke script deliberately asserts only behavior that is **already cluster-safe today** (shared-Postgres CRUD visibility, round-robin through the front), so this is green on `main` as-is. That calibrates the two-instance harness against known-good behavior before any cluster phase depends on it — the same calibrate-first principle the T2 harness plan uses. The real cross-instance assertions arrive with their features: Phase 1 adds the SoF `$export` A→B round-trip, Phase 3 adds the WebSocket fan-out A→B case, and the nightly kill-9 recovery cases add a `schedule` trigger when they land.

## Changes

- **`.github/workflows/cluster-smoke.yml`** — cloned from `bulk-export-smoke.yml` conventions (self-hosted runners, remote Docker host, container lifecycle, artifact/summary layout):
  - Build job compiles `helios-hfs` with `R4,postgres` (the strategy's Postgres-primary T3 substrate).
  - Smoke job starts one Postgres container, an nginx front, and two `hfs` processes on ports 18200/18201 sharing `HFS_DATABASE_URL` and the front as `HFS_BASE_URL`.
  - nginx config is injected via `docker create` + `docker cp` + `docker start` rather than a bind mount, so it works when `DOCKER_HOST` points at a remote machine. The config already carries WebSocket `Upgrade`/`Connection` plumbing (for Phase 3) and stamps `X-Hfs-Upstream` so round-robin is provable.
  - nginx upstreams point back at the runner (`$RUNNER_IP:1820x`) — the same container→runner pattern the Inferno workflows already rely on (`HFS_BASE_URL=http://$RUNNER_IP:$HFS_PORT`).
- **`crates/hfs/tests/cluster/run_external_cluster_smoke.sh`** — three checks: `/health` on A, B, and the front; ≥2 distinct `X-Hfs-Upstream` values over 8 requests through the front; `PUT Patient` on A → `GET` on B → `GET` via the front. Follows the summary/PASS-FAIL/artifact conventions of the existing smoke scripts.

## Testing

- `bash -n` on the smoke script and on all 11 workflow run steps (extracted from the YAML).
- `actionlint`: only two style-level SC2129 notes (grouped `>> $GITHUB_ENV` redirects), matching the pattern the existing smoke workflows use.
- Generated nginx config validated with `nginx -t` (nginx:1.27).
- Harness mechanics exercised locally end-to-end against two stub HTTP backends: the `docker create`/`cp`/`start` injection path, ephemeral-port discovery, and round-robin (8 requests split 4/4 across both upstreams, header extraction logic run verbatim).
- Not yet exercised: the real `hfs` + Postgres + runner/Docker-host topology — that is exactly what the first dispatch of this workflow validates.

## Notes

- The workflow header references `docs/cluster-testing-strategy.md` / `docs/cluster-testing-methodology.md`, which land with the feature branch (`feat/cluster-capable-state`), not this PR. The reference is informational; nothing in the workflow reads those files.
- Fixed ports 18200/18201 don't collide with the ranges used by the other smoke workflows (18088–18092, 18100+index).
- No triggers besides `workflow_dispatch`, so merging this runs nothing automatically and costs nothing until dispatched.
