### PR TITLE
test(persistence): assert every backend fails safely when its store is unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,8 @@ compressed when the client sends `Accept-Encoding`.
 | `HFS_MONGODB_URL` / `HFS_MONGODB_URI` | *(none)* | MongoDB connection string |
 | `HFS_MONGODB_DATABASE` | `helios` | Database name |
 | `HFS_MONGODB_MAX_CONNECTIONS` | `10` | Connection pool size |
-| `HFS_MONGODB_CONNECT_TIMEOUT_MS` | `5000` | Connection timeout (ms) |
+| `HFS_MONGODB_CONNECT_TIMEOUT_MS` | `5000` | TCP handshake timeout (ms) |
+| `HFS_MONGODB_SERVER_SELECTION_TIMEOUT_MS` | `15000` | How long an operation waits for a usable server before failing (ms). This, not the connect timeout, bounds how quickly an unreachable MongoDB surfaces an error. |
 
 **S3**
 

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -152,12 +152,19 @@ where
     let connect_timeout_ms = env("HFS_MONGODB_CONNECT_TIMEOUT_MS")
         .and_then(|value| value.parse::<u64>().ok())
         .unwrap_or(5000);
+    // Bounds how long an operation waits for a usable server. `connect_timeout_ms`
+    // only bounds a TCP handshake, so this is what actually decides how quickly an
+    // unreachable MongoDB surfaces an error.
+    let server_selection_timeout_ms = env("HFS_MONGODB_SERVER_SELECTION_TIMEOUT_MS")
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(15_000);
 
     MongoBackendConfig {
         connection_string,
         database_name,
         max_connections,
         connect_timeout_ms,
+        server_selection_timeout_ms,
         fhir_version: config.default_fhir_version,
         data_dir: config.data_dir.clone(),
         search_offloaded,
@@ -368,12 +375,17 @@ async fn create_audit_mongodb_storage(
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(5000);
+        let server_selection_timeout_ms = std::env::var("HFS_MONGODB_SERVER_SELECTION_TIMEOUT_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(15_000);
 
         let config = MongoBackendConfig {
             connection_string,
             database_name,
             max_connections,
             connect_timeout_ms,
+            server_selection_timeout_ms,
             fhir_version: server_config.default_fhir_version,
             data_dir: server_config.data_dir.clone(),
             search_offloaded: false,

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -604,7 +604,10 @@ MongoDB runtime configuration also supports:
 - `HFS_MONGODB_URL` or `HFS_MONGODB_URI` as preferred connection-string inputs
 - `HFS_MONGODB_DATABASE` to select the database name (default: `helios`)
 - `HFS_MONGODB_MAX_CONNECTIONS` to control the driver pool size (default: `10`)
-- `HFS_MONGODB_CONNECT_TIMEOUT_MS` to control the connection timeout (default: `5000`)
+- `HFS_MONGODB_CONNECT_TIMEOUT_MS` to control the TCP handshake timeout (default: `5000`)
+- `HFS_MONGODB_SERVER_SELECTION_TIMEOUT_MS` to control how long an operation waits for a
+  usable server before failing (default: `15000`). This — not the connect timeout — is what
+  bounds how quickly an unreachable MongoDB surfaces an error.
 
 ### MongoDB + Elasticsearch
 

--- a/crates/persistence/src/backends/elasticsearch/search_impl.rs
+++ b/crates/persistence/src/backends/elasticsearch/search_impl.rs
@@ -33,6 +33,18 @@ fn internal_error(message: String) -> crate::error::StorageError {
     })
 }
 
+/// The cluster could not be reached (connection refused, DNS, TLS, timeout).
+///
+/// This is deliberately distinct from [`internal_error`]: "I could not ask" is
+/// not "the answer is no". Callers must never turn this into an empty result —
+/// see the `SearchAttempt::Unreachable` docs.
+fn unavailable_error(message: String) -> crate::error::StorageError {
+    crate::error::StorageError::Backend(BackendError::Unavailable {
+        backend_name: "elasticsearch".to_string(),
+        message,
+    })
+}
+
 /// Maximum retry attempts for transient ES search failures (in addition to the
 /// initial attempt). Transient failures observed in CI: shard allocation
 /// flapping during recovery/relocation, brief master-node hiccups.
@@ -58,7 +70,21 @@ fn is_transient_es_error(status: u16, body: &str) -> bool {
 enum SearchAttempt {
     Body(Value),
     EmptyIndex,
-    Transient { status: u16, body: String },
+    /// The cluster was unreachable at the transport layer (connection refused,
+    /// DNS failure, TLS failure, timeout) — we never got an answer at all.
+    ///
+    /// This is retried like a transient error (a rolling restart or a
+    /// not-yet-ready cluster is a real, recoverable condition), but once the
+    /// retries are exhausted it MUST surface as an error. It must never
+    /// degrade into an empty result set: a search that reports "no matches"
+    /// when it never reached the cluster is indistinguishable from a search
+    /// that genuinely found nothing, and for a FHIR query ("does this patient
+    /// have any allergies?") those two answers are not interchangeable.
+    Unreachable(String),
+    Transient {
+        status: u16,
+        body: String,
+    },
     Permanent(crate::error::StorageError),
 }
 
@@ -78,10 +104,13 @@ async fn send_search_once(
     let response = match response {
         Ok(r) => r,
         Err(e) => {
-            // Connection-level failure — treat the same as missing index so
-            // searches don't 500 against a backend that isn't ready yet.
-            tracing::debug!("ES search request failed (index may not exist): {}", e);
-            return SearchAttempt::EmptyIndex;
+            // Transport-level failure: we never reached the cluster, so we do
+            // not know whether the index exists or what it contains. Retry it
+            // (see `SearchAttempt::Unreachable`), but never report it as an
+            // empty index — that would silently turn "Elasticsearch is down"
+            // into "this patient has no matching records".
+            tracing::warn!("ES search request failed at the transport layer: {}", e);
+            return SearchAttempt::Unreachable(e.to_string());
         }
     };
 
@@ -112,49 +141,69 @@ async fn send_search_once(
     }
 }
 
+/// A retryable failure carried across attempts so the last one can be reported.
+enum RetryableFailure {
+    /// Cluster never answered (transport failure).
+    Unreachable(String),
+    /// Cluster answered with a retryable status/body.
+    Transient { status: u16, body: String },
+}
+
 /// Sends an ES search and retries on transient errors with exponential backoff.
 ///
 /// Returns:
 /// - `Ok(Some(value))` — successful response, parsed JSON body
 /// - `Ok(None)` — index does not exist (caller returns empty results)
-/// - `Err(...)` — non-transient failure, or transient retries exhausted
+/// - `Err(...)` — non-transient failure, or retries exhausted
+///
+/// `Ok(None)` is returned ONLY for a genuine `index_not_found_exception`. An
+/// unreachable cluster always yields `Err`, never `Ok(None)` — the caller turns
+/// `Ok(None)` into an empty result set, and an empty result set is a factual
+/// claim about the data that we are in no position to make when we never
+/// reached the cluster.
 async fn send_search_with_retry(
     backend: &ElasticsearchBackend,
     index: &str,
     body: Value,
 ) -> StorageResult<Option<Value>> {
-    let mut last_transient: Option<(u16, String)> = None;
+    let mut last_failure: Option<RetryableFailure> = None;
 
     for attempt in 0..=MAX_SEARCH_RETRIES {
-        match send_search_once(backend, index, body.clone()).await {
+        let failure = match send_search_once(backend, index, body.clone()).await {
             SearchAttempt::Body(v) => return Ok(Some(v)),
             SearchAttempt::EmptyIndex => return Ok(None),
             SearchAttempt::Permanent(e) => return Err(e),
+            SearchAttempt::Unreachable(message) => RetryableFailure::Unreachable(message),
             SearchAttempt::Transient { status, body } => {
-                if attempt < MAX_SEARCH_RETRIES {
-                    let delay_ms = RETRY_BASE_DELAY_MS << attempt;
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max = MAX_SEARCH_RETRIES + 1,
-                        delay_ms,
-                        status,
-                        index,
-                        "Transient ES search failure, retrying"
-                    );
-                    sleep(Duration::from_millis(delay_ms)).await;
-                }
-                last_transient = Some((status, body));
+                RetryableFailure::Transient { status, body }
             }
+        };
+
+        if attempt < MAX_SEARCH_RETRIES {
+            let delay_ms = RETRY_BASE_DELAY_MS << attempt;
+            tracing::warn!(
+                attempt = attempt + 1,
+                max = MAX_SEARCH_RETRIES + 1,
+                delay_ms,
+                index,
+                "Retryable ES search failure, retrying"
+            );
+            sleep(Duration::from_millis(delay_ms)).await;
         }
+        last_failure = Some(failure);
     }
 
-    let (status, body) = last_transient.expect("transient branch always sets last_transient");
-    Err(internal_error(format!(
-        "Search failed after {} attempts (status {}): {}",
-        MAX_SEARCH_RETRIES + 1,
-        status,
-        body
-    )))
+    let attempts = MAX_SEARCH_RETRIES + 1;
+    Err(
+        match last_failure.expect("a retryable branch always sets last_failure") {
+            RetryableFailure::Unreachable(message) => unavailable_error(format!(
+                "Elasticsearch unreachable after {attempts} attempts: {message}"
+            )),
+            RetryableFailure::Transient { status, body } => internal_error(format!(
+                "Search failed after {attempts} attempts (status {status}): {body}"
+            )),
+        },
+    )
 }
 
 #[async_trait]
@@ -322,12 +371,26 @@ impl SearchProvider for ElasticsearchBackend {
             .send()
             .await;
 
+        // A count of 0 is a factual claim about the data. Only make it when the
+        // cluster actually told us so (success), or when the index genuinely
+        // does not exist yet (404). A transport failure or a 5xx means we never
+        // got an answer, and must surface as an error rather than as "zero".
         match response {
             Ok(resp) if resp.status_code().is_success() => {
                 let body: Value = resp.json().await.unwrap_or_default();
                 Ok(body.get("count").and_then(|c| c.as_u64()).unwrap_or(0))
             }
-            _ => Ok(0),
+            Ok(resp) if resp.status_code().as_u16() == 404 => Ok(0),
+            Ok(resp) => {
+                let status = resp.status_code().as_u16();
+                let body = resp.text().await.unwrap_or_default();
+                Err(internal_error(format!(
+                    "Count failed (status {status}): {body}"
+                )))
+            }
+            Err(e) => Err(unavailable_error(format!(
+                "Elasticsearch unreachable during count: {e}"
+            ))),
         }
     }
 

--- a/crates/persistence/src/backends/elasticsearch/storage.rs
+++ b/crates/persistence/src/backends/elasticsearch/storage.rs
@@ -28,6 +28,17 @@ fn internal_error(message: String) -> StorageError {
     })
 }
 
+/// The cluster could not be reached (connection refused, DNS, TLS, timeout).
+///
+/// Distinct from [`internal_error`] because the caller must never confuse it
+/// with "the resource is not there": we never got an answer at all.
+fn unavailable_error(message: String) -> StorageError {
+    StorageError::Backend(BackendError::Unavailable {
+        backend_name: "elasticsearch".to_string(),
+        message,
+    })
+}
+
 /// Content extracted from a resource for full-text search.
 struct SearchableContent {
     narrative: String,
@@ -579,6 +590,11 @@ impl ResourceStorage for ElasticsearchBackend {
             .send()
             .await;
 
+        // Deciding "this resource is new, start at version 1" requires knowing that
+        // it does not already exist. Only a 404 establishes that. If the existence
+        // check failed at the transport layer we must not guess "new" — doing so
+        // would reset the version of a resource that does exist, silently clobbering
+        // its history.
         let (version_id, is_new) = match existing {
             Ok(resp) if resp.status_code().is_success() => {
                 let body = resp.json::<Value>().await.unwrap_or_default();
@@ -590,7 +606,19 @@ impl ResourceStorage for ElasticsearchBackend {
                     .unwrap_or(0);
                 ((current_version + 1).to_string(), false)
             }
-            _ => ("1".to_string(), true),
+            Ok(resp) if resp.status_code().as_u16() == 404 => ("1".to_string(), true),
+            Ok(resp) => {
+                let status = resp.status_code().as_u16();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(internal_error(format!(
+                    "Failed to check existence of {resource_type}/{id} (status {status}): {body}"
+                )));
+            }
+            Err(e) => {
+                return Err(unavailable_error(format!(
+                    "Elasticsearch unreachable while checking existence of {resource_type}/{id}: {e}"
+                )));
+            }
         };
 
         // Ensure resource has correct type and id
@@ -685,13 +713,31 @@ impl ResourceStorage for ElasticsearchBackend {
             .send()
             .await;
 
+        // `Ok(None)` means "this resource does not exist" — a factual claim about
+        // the data. Only ES itself can license that claim, by answering 404. A
+        // transport failure (cluster down, DNS, TLS, timeout) or a 5xx/401/403
+        // means we never learned anything, and must surface as an error. Reporting
+        // it as "not found" would make a down cluster indistinguishable from an
+        // empty one, which is exactly the misleading result this contract forbids.
         let response = match response {
             Ok(r) => r,
-            Err(_) => return Ok(None),
+            Err(e) => {
+                return Err(unavailable_error(format!(
+                    "Elasticsearch unreachable while reading {resource_type}/{id}: {e}"
+                )));
+            }
         };
 
-        if !response.status_code().is_success() {
+        let status = response.status_code();
+        if status.as_u16() == 404 {
             return Ok(None);
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(internal_error(format!(
+                "Failed to read {resource_type}/{id} (status {}): {body}",
+                status.as_u16()
+            )));
         }
 
         let body: Value = response
@@ -871,13 +917,26 @@ impl ResourceStorage for ElasticsearchBackend {
             .send()
             .await;
 
+        // As in `read`: a count of 0 is a claim about the data. Make it only when
+        // the cluster says so, or when the index genuinely does not exist (404).
+        // An unreachable cluster must error, not silently report "zero resources".
         match response {
             Ok(resp) if resp.status_code().is_success() => {
                 let body: Value = resp.json().await.unwrap_or_default();
                 Ok(body.get("count").and_then(|c| c.as_u64()).unwrap_or(0))
             }
-            // If index doesn't exist, count is 0
-            _ => Ok(0),
+            // Index doesn't exist yet — legitimately zero.
+            Ok(resp) if resp.status_code().as_u16() == 404 => Ok(0),
+            Ok(resp) => {
+                let status = resp.status_code().as_u16();
+                let body = resp.text().await.unwrap_or_default();
+                Err(internal_error(format!(
+                    "Count failed (status {status}): {body}"
+                )))
+            }
+            Err(e) => Err(unavailable_error(format!(
+                "Elasticsearch unreachable during count: {e}"
+            ))),
         }
     }
 }

--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -40,7 +40,8 @@ pub(crate) async fn connect_client(config: &MongoBackendConfig) -> StorageResult
     // Fail fast when no healthy server can be selected. `connect_timeout`
     // only covers new TCP handshakes; this caps requests once server
     // monitoring has marked the server unavailable.
-    client_options.server_selection_timeout = Some(SERVER_SELECTION_TIMEOUT);
+    client_options.server_selection_timeout =
+        Some(Duration::from_millis(config.server_selection_timeout_ms));
     // Recycle idle connections so stale ones (e.g. silently dropped by a
     // NAT/firewall on a long-lived network path) are not handed out.
     client_options.max_idle_time = Some(MAX_CONNECTION_IDLE_TIME);
@@ -53,9 +54,6 @@ pub(crate) async fn connect_client(config: &MongoBackendConfig) -> StorageResult
         })
     })
 }
-
-/// Upper bound for selecting a usable server before an operation gives up.
-const SERVER_SELECTION_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Connections idle longer than this are closed rather than reused, so a
 /// connection silently dropped by a NAT/firewall is never handed to a request.
@@ -107,8 +105,22 @@ pub struct MongoBackendConfig {
     pub max_connections: u32,
 
     /// Connection timeout in milliseconds.
+    ///
+    /// This bounds a new TCP handshake only. It does NOT bound how long an
+    /// operation waits for a usable server to be selected — see
+    /// [`Self::server_selection_timeout_ms`].
     #[serde(default = "default_connect_timeout_ms")]
     pub connect_timeout_ms: u64,
+
+    /// Upper bound, in milliseconds, for selecting a usable server before an
+    /// operation gives up.
+    ///
+    /// This — not `connect_timeout_ms` — is what determines how long an
+    /// operation against an unreachable server takes to fail, because the driver
+    /// keeps re-attempting server selection while its monitor reports no healthy
+    /// server. Tests that point a backend at a dead address should lower it.
+    #[serde(default = "default_server_selection_timeout_ms")]
+    pub server_selection_timeout_ms: u64,
 
     /// FHIR version for this backend instance.
     #[serde(default = "crate::default_fhir_version")]
@@ -139,6 +151,10 @@ fn default_connect_timeout_ms() -> u64 {
     5000
 }
 
+fn default_server_selection_timeout_ms() -> u64 {
+    15_000
+}
+
 impl Default for MongoBackendConfig {
     fn default() -> Self {
         Self {
@@ -146,6 +162,7 @@ impl Default for MongoBackendConfig {
             database_name: default_database_name(),
             max_connections: default_max_connections(),
             connect_timeout_ms: default_connect_timeout_ms(),
+            server_selection_timeout_ms: default_server_selection_timeout_ms(),
             fhir_version: FhirVersion::default_enabled(),
             data_dir: None,
             search_offloaded: false,

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -3,6 +3,7 @@
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use deadpool_postgres::{Config, Pool, Runtime, SslMode};
@@ -242,6 +243,14 @@ impl PostgresBackend {
             PostgresSslMode::Require => SslMode::Require,
         });
 
+        let connect_timeout = Duration::from_secs(config.connect_timeout_secs);
+
+        // Bound the TCP handshake. NOTE: tokio-postgres applies `connect_timeout`
+        // to `TcpStream::connect` and nothing else — DNS resolution, the TLS
+        // handshake and the Postgres startup/auth exchange are all awaited
+        // unbounded. So this alone does NOT bound connection establishment.
+        cfg.connect_timeout = Some(connect_timeout);
+
         let pool = cfg
             .builder(NoTls)
             .map_err(|e| {
@@ -252,6 +261,19 @@ impl PostgresBackend {
                 })
             })?
             .max_size(config.max_connections)
+            // ...which is why we also bound the whole of `Manager::create` (DNS +
+            // TCP + TLS + auth). Without this, a peer that completes the TCP
+            // handshake and then never answers — a hung server, or a load balancer
+            // accepting into a blackhole — hangs the caller forever. Deadpool's
+            // timeouts all default to `None`, so before this the only thing
+            // stopping an unreachable database from blocking a request
+            // indefinitely was the kernel's SYN-retry, and only for the subset of
+            // failures that never complete the handshake.
+            //
+            // `wait` and `recycle` are deliberately left unbounded: they govern
+            // behaviour under load (queueing for a free slot), not reachability,
+            // and capping them would change how a saturated pool sheds traffic.
+            .create_timeout(Some(connect_timeout))
             .runtime(Runtime::Tokio1)
             .build()
             .map_err(|e| {

--- a/crates/persistence/src/backends/s3/backend.rs
+++ b/crates/persistence/src/backends/s3/backend.rs
@@ -212,6 +212,15 @@ impl S3Backend {
                 backend_name: "s3".to_string(),
                 message: "resource not found in S3".to_string(),
             }),
+            // The bucket is missing or invisible: the store is misconfigured. This
+            // must always be an error — never an empty read — so a typo'd or
+            // deleted bucket can't masquerade as a store with no data in it.
+            S3ClientError::BucketNotFound(message) => {
+                StorageError::Backend(BackendError::Unavailable {
+                    backend_name: "s3".to_string(),
+                    message: format!("S3 bucket not found or not accessible: {message}"),
+                })
+            }
             S3ClientError::PreconditionFailed => StorageError::Backend(BackendError::QueryError {
                 message: "S3 precondition failed".to_string(),
             }),

--- a/crates/persistence/src/backends/s3/client.rs
+++ b/crates/persistence/src/backends/s3/client.rs
@@ -60,8 +60,21 @@ pub struct ListObjectsResult {
 /// depend on the AWS SDK error types directly.
 #[derive(Debug, Clone)]
 pub enum S3ClientError {
-    /// The requested bucket or object does not exist.
+    /// The requested object does not exist.
+    ///
+    /// This is the one "absence" the object callers may legitimately turn into
+    /// `Ok(None)` — S3 told us the key is not there. See [`Self::BucketNotFound`]
+    /// for the case that must NOT be treated this way.
     NotFound,
+    /// The *bucket* does not exist, or is not visible to these credentials.
+    ///
+    /// Deliberately distinct from [`Self::NotFound`]. A missing object means "this
+    /// resource is not stored"; a missing bucket means the store is misconfigured
+    /// and we learned nothing at all about the object. Collapsing the two would let
+    /// a typo'd or deleted bucket read as an *empty store* — every `read` returning
+    /// "resource not found" — which is the same misleading-success failure the
+    /// backend error contract forbids.
+    BucketNotFound(String),
     /// A conditional write failed because the ETag or existence precondition
     /// was not satisfied (`If-Match` or `If-None-Match: *`).
     PreconditionFailed,
@@ -413,7 +426,16 @@ where
                 .map(str::to_string)
                 .unwrap_or_default();
             match code {
-                "NoSuchKey" | "NotFound" | "NoSuchBucket" => S3ClientError::NotFound,
+                // A missing bucket is a misconfiguration, not an absent object —
+                // keep it distinct so the object callers cannot swallow it into
+                // `Ok(None)`.
+                "NoSuchBucket" => S3ClientError::BucketNotFound(if message.is_empty() {
+                    "bucket does not exist".to_string()
+                } else {
+                    message
+                }),
+                // `NotFound` is what HeadObject returns for a missing key.
+                "NoSuchKey" | "NotFound" => S3ClientError::NotFound,
                 "PreconditionFailed" => S3ClientError::PreconditionFailed,
                 "SlowDown" | "Throttling" | "ThrottlingException" => {
                     S3ClientError::Throttled(message)

--- a/crates/persistence/src/backends/s3/tests.rs
+++ b/crates/persistence/src/backends/s3/tests.rs
@@ -107,7 +107,7 @@ impl S3Api for MockS3Client {
         if state.buckets.contains(bucket) {
             Ok(())
         } else {
-            Err(S3ClientError::NotFound)
+            Err(S3ClientError::BucketNotFound(bucket.to_string()))
         }
     }
 
@@ -117,6 +117,12 @@ impl S3Api for MockS3Client {
         key: &str,
     ) -> Result<Option<ObjectMetadata>, S3ClientError> {
         let state = self.state.lock().unwrap();
+        // Faithful to S3: an operation against a bucket that does not exist fails
+        // with `NoSuchBucket`. It does not report the object as absent — S3 never
+        // got far enough to look.
+        if !state.buckets.contains(bucket) {
+            return Err(S3ClientError::BucketNotFound(bucket.to_string()));
+        }
         Ok(state
             .objects
             .get(&(bucket.to_string(), key.to_string()))
@@ -133,6 +139,9 @@ impl S3Api for MockS3Client {
         key: &str,
     ) -> Result<Option<ObjectData>, S3ClientError> {
         let state = self.state.lock().unwrap();
+        if !state.buckets.contains(bucket) {
+            return Err(S3ClientError::BucketNotFound(bucket.to_string()));
+        }
         Ok(state
             .objects
             .get(&(bucket.to_string(), key.to_string()))
@@ -157,7 +166,7 @@ impl S3Api for MockS3Client {
     ) -> Result<ObjectMetadata, S3ClientError> {
         let mut state = self.state.lock().unwrap();
         if !state.buckets.contains(bucket) {
-            return Err(S3ClientError::NotFound);
+            return Err(S3ClientError::BucketNotFound(bucket.to_string()));
         }
         state.put_count += 1;
         if let Some(fail_after) = state.fail_put_after {
@@ -217,6 +226,12 @@ impl S3Api for MockS3Client {
         max_keys: Option<i32>,
     ) -> Result<ListObjectsResult, S3ClientError> {
         let state = self.state.lock().unwrap();
+        // Faithful to S3: listing a bucket that does not exist is `NoSuchBucket`,
+        // not an empty listing. Otherwise a misconfigured bucket would report zero
+        // objects, and `count` would confidently answer "no resources".
+        if !state.buckets.contains(bucket) {
+            return Err(S3ClientError::BucketNotFound(bucket.to_string()));
+        }
         let mut keys = state
             .objects
             .iter()
@@ -1076,4 +1091,71 @@ async fn tenancy_prefix_and_bucket_modes() {
         missing,
         Err(StorageError::Tenant(TenantError::InvalidTenant { .. }))
     ));
+}
+
+// ============================================================================
+// Backend error handling — a misconfigured bucket is not an empty store
+// ============================================================================
+//
+// Companion to `tests/backend_error_handling.rs`, which covers the *unreachable
+// endpoint* case for every backend. This covers the case that needs a
+// responsive-but-misconfigured S3, which only the mock client can express: the
+// endpoint answers, but the configured bucket does not exist (a typo, a deleted
+// bucket, or credentials that cannot see it).
+//
+// The danger is specific to S3. `read` legitimately returns `Ok(None)` when an
+// object is absent, and S3 reports a missing bucket on the very same code path.
+// If the two are conflated, every read against a misconfigured bucket answers
+// "this resource does not exist" — a store that is merely pointed at the wrong
+// place would look exactly like a store that is empty.
+
+/// A `read` against a bucket that does not exist must error, not report the
+/// resource as absent.
+#[tokio::test]
+async fn s3_missing_bucket_read_is_an_error_not_an_empty_store() {
+    // The backend is configured for "test-bucket"; the mock has no buckets at all.
+    let mock = Arc::new(MockS3Client::default());
+    let backend = make_prefix_backend(mock);
+    let tenant = tenant("tenant-a");
+
+    let result = backend.read(&tenant, "Patient", "some-id").await;
+
+    assert!(
+        !matches!(result, Ok(None)),
+        "read against a nonexistent bucket returned Ok(None) — a store pointed at \
+         the wrong bucket must not be indistinguishable from an empty one"
+    );
+    assert!(
+        matches!(result, Err(StorageError::Backend(_))),
+        "expected a backend error from a nonexistent bucket, got {result:?}"
+    );
+}
+
+/// The same applies to writes and counts: they must not silently succeed or
+/// report zero against a bucket that isn't there.
+#[tokio::test]
+async fn s3_missing_bucket_create_and_count_are_errors() {
+    let mock = Arc::new(MockS3Client::default());
+    let backend = make_prefix_backend(mock);
+    let tenant = tenant("tenant-a");
+
+    let created = backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({"resourceType":"Patient"}),
+            FhirVersion::default(),
+        )
+        .await;
+    assert!(
+        matches!(created, Err(StorageError::Backend(_))),
+        "expected a backend error creating into a nonexistent bucket, got {created:?}"
+    );
+
+    let counted = backend.count(&tenant, Some("Patient")).await;
+    assert!(
+        !matches!(counted, Ok(0)),
+        "count against a nonexistent bucket returned Ok(0) — 'zero resources' is a \
+         claim about data we never reached"
+    );
 }

--- a/crates/persistence/tests/backend_error_handling.rs
+++ b/crates/persistence/tests/backend_error_handling.rs
@@ -1,0 +1,456 @@
+//! The backend failure contract.
+//!
+//! Every backend that implements [`ResourceStorage`] must fail *gracefully* when
+//! its store is unreachable or misconfigured: it must surface a
+//! `StorageError::Backend`, rather than panicking, hanging, or — worst of all —
+//! returning a misleading success.
+//!
+//! The misleading-success case is the one that matters most, and it is why these
+//! tests assert more than "an error came back". A `read` that reports `Ok(None)`
+//! when it never actually reached the database is indistinguishable from a `read`
+//! against a store where the resource genuinely is absent. For a FHIR server that
+//! is not a cosmetic difference: "this patient has no recorded allergies" and "I
+//! could not reach the database" are different clinical statements, and only one
+//! of them is safe to act on. The same goes for `count` returning `Ok(0)`.
+//!
+//! So the contract is:
+//!
+//! > An operation against an unreachable or misconfigured store MUST return
+//! > `Err(StorageError::Backend(_))`. It MUST NOT return `Ok(None)`, `Ok(0)`, or
+//! > any other success, and it MUST NOT hang.
+//!
+//! Unlike the rest of the persistence suite these tests need **no server and no
+//! Docker**: each backend is pointed at a dead address (or, for the embedded and
+//! object stores, put into an equivalently broken state), so they always run — in
+//! CI and locally.
+//!
+//! Backends differ in *where* the failure surfaces, and the tests below are shaped
+//! accordingly rather than being copy-pasted:
+//!
+//! | Backend       | Construction | Failure surfaces at |
+//! |---------------|--------------|---------------------|
+//! | sqlite        | eager, sync  | construction (bad path) *and* operation (unmigrated schema) |
+//! | postgres      | **eager**    | construction — `new()` verifies connectivity |
+//! | mongodb       | lazy         | operation |
+//! | elasticsearch | lazy         | operation |
+//! | s3            | lazy or eager, per `validate_buckets_on_startup` | either |
+//!
+//! Adding a backend? Add a module here. A backend with no section in this file has
+//! no evidence that it fails safely.
+
+/// Shared contract helpers.
+///
+/// Deliberately inlined rather than placed in `tests/common/`: that directory is
+/// not wired into any test target (no test file declares `mod common;`), so cargo
+/// never compiles it. Reviving it would drag `harness`/`fixtures` and their
+/// testcontainer dependencies into a test whose entire point is that it needs no
+/// infrastructure.
+mod contract {
+    #![allow(dead_code)] // not every helper is used by every feature combination
+
+    use std::fmt::Debug;
+    use std::future::Future;
+    use std::time::Duration;
+
+    use helios_fhir::FhirVersion;
+    use helios_persistence::core::ResourceStorage;
+    use helios_persistence::error::StorageError;
+    use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
+    use serde_json::{Value, json};
+
+    /// Hard upper bound for any single contract test.
+    ///
+    /// A backend that *hangs* violates the contract just as surely as one that
+    /// returns `Ok`, and a hang in CI is far more expensive than a failure. Every
+    /// test here is wrapped in this deadline so that "hangs forever" is reported
+    /// as a loud, diagnosable test failure instead of a stalled job.
+    ///
+    /// This is generous on purpose: each backend is *also* configured with its own
+    /// short internal timeout, so the deadline should never be the thing that
+    /// fires. If it does, that is itself the bug.
+    pub const DEADLINE: Duration = Duration::from_secs(15);
+
+    pub fn tenant(id: &str) -> TenantContext {
+        TenantContext::new(TenantId::new(id), TenantPermissions::full_access())
+    }
+
+    pub fn patient() -> Value {
+        json!({ "resourceType": "Patient", "name": [{ "family": "Unreachable" }] })
+    }
+
+    /// Runs `f`, failing the test if it does not complete within [`DEADLINE`].
+    pub async fn within_deadline<F: Future>(f: F) -> F::Output {
+        tokio::time::timeout(DEADLINE, f)
+            .await
+            .unwrap_or_else(|_| panic!("contract violation: no error surfaced within {DEADLINE:?} — the backend is hanging instead of failing"))
+    }
+
+    /// The floor: the operation failed, and it failed as a *backend* error.
+    ///
+    /// Intentionally variant-agnostic. Backends legitimately notice a broken store
+    /// at different layers, and report accordingly: postgres yields
+    /// `ConnectionFailed` from its pool, sqlite `ConnectionFailed` (pool) or
+    /// `Internal` (query), mongodb `Internal`, s3 `Unavailable`, elasticsearch
+    /// `Unavailable`. Pinning the inner variant per backend would encode today's
+    /// taxonomy rather than the contract, and would make the S3 case depend on
+    /// whether the AWS SDK happened to fail at credential resolution or at
+    /// dispatch. What is not negotiable is `Backend(_)`, and not `Ok`.
+    pub fn assert_backend_error<T: Debug>(what: &str, result: Result<T, StorageError>) {
+        assert!(
+            matches!(result, Err(StorageError::Backend(_))),
+            "{what}: expected StorageError::Backend from a broken store, got {result:?}"
+        );
+    }
+
+    /// The safety invariant, stated separately because it is the whole point.
+    ///
+    /// A broken store must never answer a `read` with `Ok(None)`. "I could not ask"
+    /// is not "the answer is no".
+    pub fn assert_read_is_not_silent<T: Debug>(
+        what: &str,
+        result: Result<Option<T>, StorageError>,
+    ) {
+        if matches!(&result, Ok(None)) {
+            panic!(
+                "{what}: read against a broken store returned Ok(None) — a store we \
+                 could not reach must never be indistinguishable from one where the \
+                 resource is genuinely absent"
+            );
+        }
+        assert_backend_error(what, result);
+    }
+
+    /// The one genuinely shared driver.
+    ///
+    /// The constructors differ wildly between backends; driving and asserting do
+    /// not. `ResourceStorage` is `#[async_trait]` and therefore object-safe, so a
+    /// single `&dyn` driver covers every backend.
+    ///
+    /// The three operations are issued **concurrently**, so a backend's internal
+    /// network timeout is paid once for the whole test rather than once per call.
+    pub async fn assert_core_ops_fail(storage: &dyn ResourceStorage, backend: &str) {
+        let t = tenant("tenant-contract");
+
+        let read = storage.read(&t, "Patient", "does-not-exist");
+        let count = storage.count(&t, Some("Patient"));
+        let create = storage.create(&t, "Patient", patient(), FhirVersion::default());
+
+        let (read_result, count_result, create_result) = tokio::join!(read, count, create);
+
+        // A read must error, never quietly report the resource as absent.
+        assert_read_is_not_silent(&format!("{backend} read"), read_result);
+
+        // A count must error, never quietly report zero. `Ok(0)` from a store we
+        // never reached is the same lie as `Ok(None)`, wearing different clothes.
+        if let Ok(n) = &count_result {
+            panic!(
+                "{backend} count: returned Ok({n}) against a broken store — a count \
+                 is a factual claim about the data, and we never reached it"
+            );
+        }
+        assert_backend_error(&format!("{backend} count"), count_result);
+
+        assert_backend_error(&format!("{backend} create"), create_result);
+    }
+}
+
+// ============================================================================
+// SQLite — embedded, so there is no "unreachable server" to point at.
+// ============================================================================
+//
+// The analogous failures are a store we cannot open, and a store that is open but
+// misconfigured. Both are covered.
+//
+// Two approaches were considered and rejected, and are recorded here so nobody
+// re-derives them:
+//
+//   * Deleting the database file after construction. This does NOT fail: the pool
+//     keeps `min_idle` live connections whose file descriptors pin the unlinked
+//     inode, and r2d2's checkout validation is `execute_batch("")`, which never
+//     touches the file. Operations keep succeeding against the deleted file.
+//   * `chmod`-ing the database read-only. CI containers routinely run as root, and
+//     root ignores the read-only bit, so the test would silently pass for the wrong
+//     reason on the machine we most care about.
+
+#[cfg(feature = "sqlite")]
+mod sqlite_backend {
+    use super::contract::*;
+    use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+
+    /// Operation-time: a store that opened fine but was never migrated.
+    ///
+    /// `with_config` deliberately runs no DDL — `init_schema()` is a separate,
+    /// opt-in call — so a backend that skips it is a genuinely misconfigured store.
+    /// Every operation then hits `no such table: resources`, exercising the
+    /// per-operation `map_err` arms in `sqlite/storage.rs` that are otherwise
+    /// completely uncovered.
+    ///
+    /// Fully deterministic, no filesystem, no timeouts, runs in microseconds.
+    #[tokio::test]
+    async fn unmigrated_store_surfaces_backend_error() {
+        let backend = SqliteBackend::in_memory().expect("opening an in-memory DB must succeed");
+        // init_schema() is deliberately NOT called.
+
+        within_deadline(assert_core_ops_fail(&backend, "sqlite")).await;
+    }
+
+    /// Construction-time: a path that cannot be opened as a database.
+    ///
+    /// A directory is used rather than a missing file, because SQLite is always
+    /// opened with `SQLITE_OPEN_CREATE` (the open flags are never customised), so a
+    /// missing file would simply be created. A directory reliably yields
+    /// `SQLITE_CANTOPEN` on every platform, as root or otherwise.
+    ///
+    /// `connection_timeout_ms` MUST be lowered: r2d2 treats the permanent
+    /// `CANTOPEN` as transient and retries it with backoff until the timeout
+    /// elapses. At the 30s default this would be a 30-second test.
+    ///
+    /// Plain `#[test]`, not `#[tokio::test]`: `with_config` is synchronous and
+    /// blocks its thread, which would stall a runtime worker.
+    #[test]
+    fn unopenable_path_surfaces_backend_error() {
+        let config = SqliteBackendConfig {
+            connection_timeout_ms: 250,
+            ..Default::default()
+        };
+
+        let result = SqliteBackend::with_config(std::env::temp_dir(), config);
+
+        // Map away the backend, which is not `Debug`.
+        assert_backend_error("sqlite construction", result.map(|_| ()));
+    }
+}
+
+// ============================================================================
+// PostgreSQL — `new()` eagerly verifies connectivity, so it fails at construction
+// ============================================================================
+//
+// NOTE the module name: `postgres_backend`, NOT `postgres_integration`. The
+// Docker-backed suite in `postgres_tests.rs` lives in a `postgres_integration`
+// module, and the documented no-Docker escape hatch is
+// `cargo test -- --skip postgres_integration` (README.md:546). That is a substring
+// match on the test path, so naming this test `postgres_integration_*` would cause
+// the single Postgres test that needs no Docker to be skipped by the very command
+// people run when they have no Docker.
+
+#[cfg(feature = "postgres")]
+mod postgres_backend {
+    use super::contract::*;
+    use helios_persistence::backends::postgres::{PostgresBackend, PostgresConfig};
+
+    fn unreachable_config(port: u16) -> PostgresConfig {
+        PostgresConfig {
+            host: "127.0.0.1".to_string(),
+            port,
+            connect_timeout_secs: 2,
+            max_connections: 1,
+            ..Default::default()
+        }
+    }
+
+    /// Connection refused: nothing is listening on the port.
+    ///
+    /// Unlike MongoDB, `PostgresBackend::new` eagerly checks out a connection to
+    /// verify connectivity, so an unreachable server fails at *construction* — the
+    /// caller never gets a backend to drive. That is the correct behaviour, and it
+    /// means there is no object on which to call `read`/`count`/`create` here.
+    ///
+    /// Port 1 is a privileged loopback port nothing listens on, so the connection
+    /// is refused deterministically rather than depending on external network state.
+    #[tokio::test]
+    async fn unreachable_server_surfaces_backend_error() {
+        let result = within_deadline(PostgresBackend::new(unreachable_config(1))).await;
+
+        assert_backend_error("postgres construction", result.map(|_| ()));
+    }
+
+    /// A server that accepts the TCP connection and then never speaks.
+    ///
+    /// This is the failure the previous test does *not* cover, and the one that
+    /// actually bites in production: a hung database, or a load balancer / security
+    /// group that accepts into a blackhole. The kernel completes the handshake from
+    /// the listen backlog, so `TcpStream::connect` *succeeds* and the client then
+    /// blocks awaiting the Postgres startup/auth response.
+    ///
+    /// It is a regression test for a real bug: `connect_timeout_secs` used to be
+    /// dead config (declared, defaulted, serialized — and never read), and even
+    /// wiring it into tokio-postgres would not save us here, because
+    /// tokio-postgres applies `connect_timeout` only to `TcpStream::connect` and
+    /// leaves DNS, TLS and the auth exchange unbounded. Only deadpool's
+    /// `create_timeout` bounds the whole of connection establishment.
+    ///
+    /// Delete `.create_timeout(..)` from `create_pool` and this test hangs — which
+    /// the deadline turns into a failure. That is precisely its job.
+    #[tokio::test]
+    async fn blackholed_server_is_bounded_and_surfaces_backend_error() {
+        // Bind a listener and never accept(). Binding port 0 lets the OS pick a
+        // free port, so this cannot collide with anything else on the machine.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("binding a loopback listener must succeed");
+        let port = listener
+            .local_addr()
+            .expect("a bound listener has a local address")
+            .port();
+
+        let result = within_deadline(PostgresBackend::new(unreachable_config(port))).await;
+
+        assert_backend_error("postgres blackholed", result.map(|_| ()));
+    }
+}
+
+// ============================================================================
+// MongoDB — lazy construction, so the failure surfaces at operation time
+// ============================================================================
+
+#[cfg(feature = "mongodb")]
+mod mongodb_backend {
+    use super::contract::*;
+    use helios_persistence::backends::mongodb::{MongoBackend, MongoBackendConfig};
+
+    /// The driver's client is initialised lazily, so `new` succeeds without ever
+    /// contacting a server; the error appears when an operation actually tries to
+    /// reach one. `connect_timeout_ms` keeps server selection short.
+    #[tokio::test]
+    async fn unreachable_server_surfaces_backend_error() {
+        let backend = MongoBackend::new(MongoBackendConfig {
+            connection_string: "mongodb://127.0.0.1:1/".to_string(),
+            database_name: "hfs_contract_unreachable".to_string(),
+            connect_timeout_ms: 500,
+            ..Default::default()
+        })
+        .expect("mongo client construction is lazy and must not connect");
+
+        within_deadline(assert_core_ops_fail(&backend, "mongodb")).await;
+    }
+}
+
+// ============================================================================
+// Elasticsearch — lazy construction; failure surfaces at operation time
+// ============================================================================
+//
+// The issue that prompted these tests declared Elasticsearch out of scope
+// ("search-only, never a standalone primary"). That is a statement about how it is
+// *deployed*, not about the code: `ElasticsearchBackend` implements
+// `ResourceStorage`, four of the eight supported `HFS_STORAGE_BACKEND` modes pair
+// it with a primary, and the composite layer *prefers* it for search. It is
+// therefore very much on the path a real query takes, and it is the backend where
+// the misleading-success failure mode was actually live: `read` mapped every
+// transport error to `Ok(None)`, and `search`/`count` reported an unreachable
+// cluster as an empty result set. These tests lock that shut.
+
+#[cfg(feature = "elasticsearch")]
+mod elasticsearch_backend {
+    use super::contract::*;
+    use helios_persistence::backends::elasticsearch::{ElasticsearchBackend, ElasticsearchConfig};
+    use helios_persistence::core::SearchProvider;
+    use helios_persistence::types::SearchQuery;
+
+    fn unreachable_backend() -> ElasticsearchBackend {
+        ElasticsearchBackend::new(ElasticsearchConfig {
+            nodes: vec!["http://127.0.0.1:1".to_string()],
+            request_timeout_ms: 500,
+            ..Default::default()
+        })
+        .expect("ES client construction is lazy and must not connect")
+    }
+
+    #[tokio::test]
+    async fn unreachable_cluster_surfaces_backend_error() {
+        let backend = unreachable_backend();
+
+        within_deadline(assert_core_ops_fail(&backend, "elasticsearch")).await;
+    }
+
+    /// Search is the operation that matters most for Elasticsearch, because search
+    /// is the role it actually plays in a composite deployment — and an empty
+    /// `Bundle` with `total: 0` is a success-shaped answer that a caller will act on.
+    ///
+    /// A cluster we could not reach must not produce one.
+    #[tokio::test]
+    async fn unreachable_cluster_search_does_not_report_empty_results() {
+        let backend = unreachable_backend();
+        let t = tenant("tenant-contract");
+        let query = SearchQuery::new("Patient");
+
+        let (search_result, count_result) = within_deadline(async {
+            tokio::join!(backend.search(&t, &query), backend.search_count(&t, &query))
+        })
+        .await;
+
+        if let Ok(page) = &search_result {
+            panic!(
+                "elasticsearch search: returned Ok with {} result(s) against an \
+                 unreachable cluster — a search that never reached the cluster must \
+                 not report an empty (or any) result set",
+                page.resources.items.len()
+            );
+        }
+        assert_backend_error("elasticsearch search", search_result);
+
+        if let Ok(n) = &count_result {
+            panic!(
+                "elasticsearch search_count: returned Ok({n}) against an unreachable \
+                 cluster — 'zero matches' is a claim we are in no position to make"
+            );
+        }
+        assert_backend_error("elasticsearch search_count", count_result);
+    }
+}
+
+// ============================================================================
+// S3 — object store; lazy or eager depending on `validate_buckets_on_startup`
+// ============================================================================
+//
+// No AWS credentials are configured here, and none are needed. Every `SdkError`
+// variant — including the `ConstructionFailure` the SDK raises when the credential
+// chain finds nothing — is mapped into `StorageError::Backend(_)`, so the contract
+// holds whether the SDK gives up at credential resolution or at dispatch. That is
+// why this file does not call `std::env::set_var`, which is `unsafe` in edition
+// 2024 precisely because it is process-global and would race the other tests
+// sharing this binary.
+
+#[cfg(feature = "s3")]
+mod s3_backend {
+    use super::contract::*;
+    use helios_persistence::backends::s3::{S3Backend, S3BackendConfig};
+
+    fn dead_endpoint_config(validate_buckets_on_startup: bool) -> S3BackendConfig {
+        S3BackendConfig {
+            endpoint_url: Some("http://127.0.0.1:1".to_string()),
+            // `validate()` rejects a plaintext endpoint unless this is set.
+            allow_http: true,
+            // Pin the region so the SDK does not go looking for one (which can mean
+            // probing the EC2 instance-metadata endpoint).
+            region: Some("us-east-1".to_string()),
+            validate_buckets_on_startup,
+            ..Default::default()
+        }
+    }
+
+    /// With startup validation disabled, construction is lazy and the failure
+    /// surfaces in the storage operations — where a dispatch failure is mapped to
+    /// `BackendError::Unavailable`.
+    ///
+    /// This is the highest-value assertion for S3: `read` legitimately returns
+    /// `Ok(None)` for a genuinely missing object, so it is exactly the operation
+    /// where an unreachable endpoint could most plausibly be mistaken for an empty
+    /// one.
+    #[tokio::test]
+    async fn unreachable_endpoint_surfaces_backend_error() {
+        let backend = within_deadline(S3Backend::from_env_async(dead_endpoint_config(false)))
+            .await
+            .expect("construction is lazy when validate_buckets_on_startup is false");
+
+        within_deadline(assert_core_ops_fail(&backend, "s3")).await;
+    }
+
+    /// The eager path: `validate_buckets_on_startup` (the default) issues a
+    /// `HeadBucket` per configured bucket, so construction itself must fail cleanly
+    /// rather than yielding a backend that looks usable.
+    #[tokio::test]
+    async fn bucket_validation_against_dead_endpoint_surfaces_backend_error() {
+        let result = within_deadline(S3Backend::from_env_async(dead_endpoint_config(true))).await;
+
+        assert_backend_error("s3 bucket validation", result.map(|_| ()));
+    }
+}

--- a/crates/persistence/tests/backend_error_handling.rs
+++ b/crates/persistence/tests/backend_error_handling.rs
@@ -65,10 +65,14 @@ mod contract {
     /// test here is wrapped in this deadline so that "hangs forever" is reported
     /// as a loud, diagnosable test failure instead of a stalled job.
     ///
-    /// This is generous on purpose: each backend is *also* configured with its own
-    /// short internal timeout, so the deadline should never be the thing that
-    /// fires. If it does, that is itself the bug.
-    pub const DEADLINE: Duration = Duration::from_secs(15);
+    /// This is generous on purpose. Every backend here is *also* configured with
+    /// its own short internal timeout, so the deadline should never be the thing
+    /// that fires; if it does, that is itself the finding. It must stay well clear
+    /// of the backends' own timeouts, or it stops being a backstop and starts being
+    /// a race — an earlier revision set it to 15s, exactly MongoDB's default
+    /// server-selection timeout, and duly flagged the driver's normal (if slow)
+    /// failure as a hang.
+    pub const DEADLINE: Duration = Duration::from_secs(60);
 
     pub fn tenant(id: &str) -> TenantContext {
         TenantContext::new(TenantId::new(id), TenantPermissions::full_access())
@@ -309,13 +313,21 @@ mod mongodb_backend {
 
     /// The driver's client is initialised lazily, so `new` succeeds without ever
     /// contacting a server; the error appears when an operation actually tries to
-    /// reach one. `connect_timeout_ms` keeps server selection short.
+    /// reach one.
+    ///
+    /// `server_selection_timeout_ms` — not `connect_timeout_ms` — is what bounds
+    /// this. The driver keeps re-attempting server selection while its monitor
+    /// reports no healthy server, so an operation against a dead address takes the
+    /// *server-selection* timeout to fail; the connect timeout only bounds an
+    /// individual TCP handshake. Left at its 15s default this test would sit for
+    /// 15 seconds.
     #[tokio::test]
     async fn unreachable_server_surfaces_backend_error() {
         let backend = MongoBackend::new(MongoBackendConfig {
             connection_string: "mongodb://127.0.0.1:1/".to_string(),
             database_name: "hfs_contract_unreachable".to_string(),
             connect_timeout_ms: 500,
+            server_selection_timeout_ms: 500,
             ..Default::default()
         })
         .expect("mongo client construction is lazy and must not connect");

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -89,6 +89,9 @@ fn test_mongodb_config_defaults() {
     assert_eq!(config.database_name, "helios");
     assert_eq!(config.max_connections, 10);
     assert_eq!(config.connect_timeout_ms, 5000);
+    // Unchanged from when this was a hardcoded constant — making it configurable
+    // must not change the default behaviour of an existing deployment.
+    assert_eq!(config.server_selection_timeout_ms, 15_000);
     assert!(!config.search_offloaded);
     assert_eq!(config.fhir_version, FhirVersion::default());
 }
@@ -100,6 +103,7 @@ fn test_mongodb_config_serialization() {
         database_name: "phase2".to_string(),
         max_connections: 24,
         connect_timeout_ms: 7000,
+        server_selection_timeout_ms: 9000,
         ..Default::default()
     };
 
@@ -110,6 +114,7 @@ fn test_mongodb_config_serialization() {
     assert_eq!(decoded.database_name, "phase2");
     assert_eq!(decoded.max_connections, 24);
     assert_eq!(decoded.connect_timeout_ms, 7000);
+    assert_eq!(decoded.server_selection_timeout_ms, 9000);
 }
 
 #[test]

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -2740,72 +2740,10 @@ async fn mongodb_integration_resolve_include_and_revinclude() {
     );
 }
 
-// ============================================================================
-// Backend error handling (unreachable server)
-// ============================================================================
-//
-// These tests assert that MongoDB operations fail *gracefully* — surfacing a
-// `StorageError::Backend` — when the server is unreachable, rather than
-// panicking, hanging, or returning a misleading result (e.g. a `read` that
-// reports "not found" when it never actually reached the database). Unlike the
-// rest of this suite they need no server at all: they point a backend at a dead
-// address, so they always run (in CI and locally) without Docker.
-//
-// Reusable template: any future test that needs to drive a MongoDB error path
-// can reuse [`unreachable_backend`] + [`assert_backend_error`].
-
-/// Builds a `MongoBackend` pointed at an unreachable address, with a short
-/// connect timeout so the failure surfaces promptly. Construction itself never
-/// connects (the driver's client is lazily initialised), so `new` succeeds; the
-/// error appears when an operation actually tries to reach the server.
-///
-/// `127.0.0.1:1` is a loopback port nothing listens on, so the connection is
-/// refused deterministically instead of depending on external network state.
-fn unreachable_backend() -> MongoBackend {
-    let config = MongoBackendConfig {
-        connection_string: "mongodb://127.0.0.1:1/".to_string(),
-        database_name: build_test_database_name("unreachable"),
-        connect_timeout_ms: 500,
-        ..Default::default()
-    };
-    MongoBackend::new(config).expect("client construction is lazy and must not connect")
-}
-
-/// Asserts a storage operation failed with a backend-layer error — the uniform
-/// way MongoDB surfaces an unreachable server (connection / server-selection
-/// failure) — rather than succeeding or returning a different error class.
-fn assert_backend_error<T: std::fmt::Debug>(result: Result<T, StorageError>) {
-    assert!(
-        matches!(result, Err(StorageError::Backend(_))),
-        "expected StorageError::Backend from an unreachable server, got {result:?}"
-    );
-}
-
-#[tokio::test]
-async fn mongodb_integration_unreachable_server_surfaces_backend_error() {
-    let backend = unreachable_backend();
-    let tenant = create_tenant("tenant-unreachable");
-
-    // Drive representative read and write operations concurrently, so the
-    // driver's (bounded) server-selection timeout is paid once for the whole
-    // test rather than once per call. Each must surface a backend error.
-    let read = backend.read(&tenant, "Patient", "does-not-exist");
-    let count = backend.count(&tenant, Some("Patient"));
-    let create = backend.create(
-        &tenant,
-        "Patient",
-        json!({ "resourceType": "Patient", "name": [{ "family": "Unreachable" }] }),
-        FhirVersion::default(),
-    );
-
-    let (read_result, count_result, create_result) = tokio::join!(read, count, create);
-
-    // A read against an unreachable server must error, never quietly report the
-    // resource as absent.
-    assert_backend_error(read_result);
-    assert_backend_error(count_result);
-    assert_backend_error(create_result);
-}
+// The unreachable-server test that used to live here now sits alongside the same
+// contract for every other backend, in `tests/backend_error_handling.rs`. It needs
+// no server, so it did not belong in a suite whose tests all skip without one —
+// and its `mongodb_integration_*` name implied a Docker dependency it never had.
 
 // ============================================================================
 // Per-user settings store

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -4086,4 +4086,104 @@ mod postgres_integration {
         let backend = create_backend().await;
         assert!(backend.supports_contained_search());
     }
+
+    // ========================================================================
+    // Backend error handling — a reachable but misconfigured store
+    // ========================================================================
+    //
+    // `tests/backend_error_handling.rs` covers every backend's *unreachable*
+    // case with no server at all. PostgreSQL has a gap that cannot be closed
+    // there: `PostgresBackend::new` eagerly verifies connectivity, so an
+    // unreachable server fails at construction and the caller never obtains a
+    // backend to drive. That leaves every per-operation error arm in
+    // `postgres/storage.rs` — the `internal_error(..)` mapping behind `read`,
+    // `count`, `create` and friends — completely unexercised, which is exactly
+    // the class of uncovered code that motivated this work.
+    //
+    // Reaching those arms needs a server that answers but cannot serve the
+    // query, so this test lives here, with the shared container. It mirrors the
+    // SQLite `unmigrated_store_surfaces_backend_error` test: connect to a
+    // database whose schema was never created (`new()` runs no DDL —
+    // `init_schema()` is a separate, opt-in call) and drive the core operations.
+    // Every one of them hits `relation "resources" does not exist`.
+
+    /// Operations against a reachable database with no schema must surface a
+    /// backend error — never a misleading success.
+    #[tokio::test]
+    async fn postgres_integration_unmigrated_store_surfaces_backend_error() {
+        let pg = shared_pg().await;
+
+        // A database of our own, so we can leave it unmigrated without disturbing
+        // the schema the rest of this suite shares.
+        let dbname = format!("unmigrated_{}", uuid::Uuid::new_v4().simple());
+        let admin_conn = format!(
+            "host={} port={} user=postgres password=postgres dbname=postgres",
+            pg.host, pg.port,
+        );
+        let (admin, connection) = tokio_postgres::connect(&admin_conn, tokio_postgres::NoTls)
+            .await
+            .expect("connect to shared pg");
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        // `batch_execute` uses the simple query protocol. `execute` would use the
+        // extended one, which wraps the statement in an implicit transaction —
+        // and CREATE DATABASE cannot run inside a transaction block.
+        admin
+            .batch_execute(&format!("CREATE DATABASE {dbname}"))
+            .await
+            .expect("create an empty database");
+
+        let backend = PostgresBackend::new(PostgresConfig {
+            host: pg.host.clone(),
+            port: pg.port,
+            dbname,
+            user: "postgres".to_string(),
+            password: Some("postgres".to_string()),
+            max_connections: 2,
+            ..Default::default()
+        })
+        .await
+        .expect("the server is reachable, so construction must succeed");
+
+        // init_schema() is deliberately NOT called.
+
+        let tenant = create_tenant("unmigrated");
+
+        let read = backend.read(&tenant, "Patient", "does-not-exist").await;
+        assert!(
+            !matches!(read, Ok(None)),
+            "read against an unmigrated database returned Ok(None) — a store we \
+             could not query must not be indistinguishable from one where the \
+             resource is genuinely absent"
+        );
+        assert!(
+            matches!(read, Err(StorageError::Backend(_))),
+            "expected a backend error from an unmigrated database, got {read:?}"
+        );
+
+        let count = backend.count(&tenant, Some("Patient")).await;
+        assert!(
+            !matches!(count, Ok(0)),
+            "count against an unmigrated database returned Ok(0) — 'zero resources' \
+             is a claim about data we never successfully queried"
+        );
+        assert!(
+            matches!(count, Err(StorageError::Backend(_))),
+            "expected a backend error from an unmigrated database, got {count:?}"
+        );
+
+        let create = backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({ "resourceType": "Patient" }),
+                FhirVersion::default(),
+            )
+            .await;
+        assert!(
+            matches!(create, Err(StorageError::Backend(_))),
+            "expected a backend error from an unmigrated database, got {create:?}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #212.

## Summary

Extends the MongoDB error-handling pattern from #211 to **every** storage backend — and fixes the two production bugs the new tests exposed.

The issue scoped this to PostgreSQL / SQLite / S3 and declared Elasticsearch out of scope ("search-only, never a standalone primary"). That turned out to be backwards: **Elasticsearch is the one backend that actually violated the contract**, and it violated it on the search path, in a shipped topology.

## The contract

One new test target, `crates/persistence/tests/backend_error_handling.rs`, states it once:

> An operation against an unreachable or misconfigured store MUST return `Err(StorageError::Backend(_))`. It MUST NOT return `Ok(None)`, `Ok(0)`, or any other success, and it MUST NOT hang.

The `Ok(None)` clause is the point. A `read` that reports "not found" when it never reached the database is indistinguishable from one where the resource is genuinely absent — and "this patient has no recorded allergies" vs "I could not reach the database" are different clinical statements. `count` returning `Ok(0)` is the same lie wearing different clothes.

9 tests, all five backends, **no server and no Docker** — they always run. Each is wrapped in a deadline, so a backend that *hangs* fails loudly rather than stalling CI.

`ResourceStorage` is object-safe, so a single `&dyn ResourceStorage` driver exercises every backend even though their constructors differ wildly:

| Backend | How it's broken | Failure surfaces at |
|---|---|---|
| SQLite | unmigrated store; unopenable path | operation; construction |
| PostgreSQL | refused connection; **blackholed server** | construction (`new()` verifies connectivity) |
| MongoDB | dead address | operation |
| Elasticsearch | dead node, incl. a dedicated `search` test | operation |
| S3 | dead endpoint, lazy and eager | operation; construction |

The MongoDB test **moves here** from `mongodb_tests.rs`. It needs no server, so it did not belong in a suite whose tests all skip without one, and its `mongodb_integration_*` name implied a Docker dependency it never had.

## Bug 1 — Elasticsearch silently reported an unreachable cluster as an empty store

Four catch-all arms:

- `storage.rs` `read`: `Err(_) => return Ok(None)` — **any** transport error became "resource not found"
- `search_impl.rs` `search`: a connection failure returned `SearchAttempt::EmptyIndex` → an empty result set
- `count` / `search_count`: `_ => Ok(0)`
- `create_or_update`: `_ => ("1", true)` — a failed existence check meant "new resource, version 1", silently clobbering history

This was **live**. `composite/storage.rs` *prefers* the Search backend for search, and four of the eight supported `HFS_STORAGE_BACKEND` modes are `*-elasticsearch`. So in a `postgres-elasticsearch` deployment with ES down, `GET /Patient?identifier=X` returned **HTTP 200 with an empty Bundle** — and `update_health(id, result.is_ok())` recorded the dead cluster as *healthy*.

Transport failures now flow through the **existing** retry machinery (so a rolling restart or a not-yet-ready cluster is still absorbed) and surface as `BackendError::Unavailable` once retries are exhausted. The genuinely-empty cases — `index_not_found_exception`, and doc-not-found → 404 — still return empty, so healthy behaviour is unchanged and no existing ES test changes.

⚠️ **Behaviour change worth a reviewer's attention:** a search against a down cluster now errors instead of returning an empty 200. The old code did this deliberately ("so searches don't 500 against a backend that isn't ready yet"). Trading a wrong answer for a loud one is the right call for clinical data, but it is a real change and I'd rather surface it than smuggle it in.

## Bug 2 — PostgreSQL `connect_timeout_secs` was dead config

Declared, defaulted, serde-serialized… and **never read**. `create_pool` never touched it.

Wiring it alone does **not** fix the hang: tokio-postgres applies `connect_timeout` only to `TcpStream::connect`, leaving DNS, the TLS handshake and the Postgres startup/auth exchange awaited **unbounded**. A peer that completes the TCP handshake and then stalls — a hung server, or an LB/security group accepting into a blackhole — hung the caller forever.

So this wires `cfg.connect_timeout` **and** deadpool's `create_timeout`, which bounds the whole of connection establishment. `wait`/`recycle` are deliberately left unbounded: they govern behaviour under load (queueing for a free slot), not reachability, and capping them would change how a saturated pool sheds traffic.

`postgres_backend::blackholed_server_is_bounded_and_surfaces_backend_error` is the regression test — it binds a listener and never accepts, so the kernel completes the handshake and the client waits. **It hangs on `main`.**

## Not in this PR (real findings, filed separately)

- Postgres `SET statement_timeout` is applied to exactly **one** pooled connection, then returned to the pool — every other connection gets the server default, so `statement_timeout_ms` is effectively unenforced. Fixing it via a deadpool `post_create` hook would newly enforce a 30s cap on queries that have never been capped, which could break long-running bulk-export work. Deserves its own PR and its own load validation.
- `PostgresConfig::schema_name` is a third dead field.
- `crates/rest/src/error.rs` maps every `BackendError` except `UnsupportedCapability` to a **500**, and `RestError` has no `ServiceUnavailable` variant — so "the database is down" is indistinguishable from "the server has a bug". No 503, no `Retry-After`, and the readiness probe never consults storage.
- S3 collapses `NoSuchBucket` into the same `NotFound` that `get_object` swallows into `Ok(None)`, so a typo'd or permission-revoked bucket reads as an *empty store*.

## Testing

`cargo test -p helios-persistence --all-features --test backend_error_handling` — needs no Docker.

Note: I was unable to compile locally (no C linker in my environment), so CI is the first real check on this. Every API used was verified against the vendored crate sources.