### PR TITLE
fix(hts): create concepts_search_fts and make its ranked query valid

### DIFF
--- a/crates/hts/src/backends/sqlite/mod.rs
+++ b/crates/hts/src/backends/sqlite/mod.rs
@@ -369,7 +369,8 @@ impl SqliteTerminologyBackend {
                 let _ = conn.execute_batch(
                     "DELETE FROM concepts_fts;
                      DELETE FROM concepts_fts_built;
-                     DELETE FROM concepts_word_fts;",
+                     DELETE FROM concepts_word_fts;
+                     DELETE FROM concepts_search_fts;",
                 );
 
                 // Update query-planner statistics for large tables.
@@ -461,7 +462,8 @@ impl SqliteTerminologyBackend {
         let _ = conn.execute_batch(
             "DELETE FROM concepts_fts;
              DELETE FROM concepts_fts_built;
-             DELETE FROM concepts_word_fts;",
+             DELETE FROM concepts_word_fts;
+             DELETE FROM concepts_search_fts;",
         );
         let _ = conn.execute_batch(
             "ANALYZE concept_hierarchy; ANALYZE concepts; ANALYZE concept_closure; \

--- a/crates/hts/src/backends/sqlite/schema.rs
+++ b/crates/hts/src/backends/sqlite/schema.rs
@@ -227,6 +227,19 @@ CREATE VIRTUAL TABLE IF NOT EXISTS concepts_word_fts
 USING fts5(system_id UNINDEXED, code, display,
            tokenize='unicode61 remove_diacritics 1');
 
+-- ── FTS5 search index over preferred terms and synonym designations ──────────
+-- Backs the ranked typeahead/text-filter path (fts_candidates_ranked_for_system).
+-- Unlike concepts_fts (display only) this also indexes every designation value,
+-- so a synonym hit surfaces its concept. One row per (concept, term): preferred
+-- terms use the concept id as rowid, designation rows use -cd.id so the two
+-- never collide. bm25() ranks hits; system_id is UNINDEXED (post-filter only).
+-- Trigram like concepts_fts, which serves the same MATCH expression as the
+-- fallback when this index is empty — callers guard on filter length >= 3.
+-- Populated at startup by prebuild_concepts_fts; cleared on startup.
+CREATE VIRTUAL TABLE IF NOT EXISTS concepts_search_fts
+USING fts5(system_id UNINDEXED, code, term,
+           tokenize='trigram case_sensitive 0');
+
 -- ── FTS build tracker ─────────────────────────────────────────────────────────
 -- O(1) lookup to check whether concepts_fts is populated for a given system_id.
 -- Replaces the slow FTS content scan (O(N_total_concepts)) used previously.
@@ -645,7 +658,9 @@ mod tests {
             "concept_map_elements",
             "implicit_expansion_cache",
             "implicit_expansion_fts",
+            "concepts_fts",
             "concepts_word_fts",
+            "concepts_search_fts",
             "concepts_fts_built",
         ];
 

--- a/crates/hts/src/backends/sqlite/value_set.rs
+++ b/crates/hts/src/backends/sqlite/value_set.rs
@@ -5004,11 +5004,22 @@ fn fts_candidates_ranked_for_system(
         .unwrap_or(false);
 
     let ranked_codes: Vec<(String, f64)> = if search_populated {
+        // A concept contributes one row per term (preferred display + each
+        // designation), so scores are collapsed per code with MIN — bm25 is
+        // negative and lower is better, i.e. the concept's best-matching term
+        // wins. The CTE must be MATERIALIZED: bm25() is an FTS5 auxiliary
+        // function and SQLite rejects it in an aggregate context, so without
+        // the fence it gets flattened into the GROUP BY and the query fails
+        // with "unable to use function bm25 in the requested context".
         let mut stmt = conn
             .prepare_cached(
-                "SELECT code, MIN(bm25(concepts_search_fts)) AS rank
-                 FROM concepts_search_fts
-                 WHERE concepts_search_fts MATCH ?1 AND system_id = ?2
+                "WITH hits AS MATERIALIZED (
+                     SELECT code, bm25(concepts_search_fts) AS rank
+                     FROM concepts_search_fts
+                     WHERE concepts_search_fts MATCH ?1 AND system_id = ?2
+                 )
+                 SELECT code, MIN(rank) AS rank
+                 FROM hits
                  GROUP BY code
                  ORDER BY rank ASC
                  LIMIT ?3",
@@ -12100,5 +12111,40 @@ mod tests {
             .await
             .unwrap();
         assert!(!v_out.result, "code C must not be found in vs-import");
+    }
+
+    /// Regression for #272. `concepts_search_fts` was queried and populated but
+    /// never created, so this path failed with "no such table". Because the
+    /// EXISTS probe swallows that error and falls back to `concepts_fts`, the
+    /// ranked query below had never actually executed — and it aggregated
+    /// `bm25()`, which FTS5 rejects outside a MATCH scan. Exercise it for real.
+    #[test]
+    fn concepts_search_fts_ranked_query_runs() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::backends::sqlite::schema::apply(&conn).expect("schema should apply");
+
+        conn.execute_batch(
+            "INSERT INTO code_systems(id, url, created_at, updated_at)
+                 VALUES ('sys1', 'http://example.org/cs', '2026-01-01', '2026-01-01');
+             INSERT INTO concepts(id, system_id, code, display) VALUES
+                 (1, 'sys1', 'data-exchange',  'Data Exchange'),
+                 (2, 'sys1', 'data-exchange1', 'Data Exchange1'),
+                 (3, 'sys1', 'unrelated',      'Something Else');
+             INSERT INTO concept_designations(id, concept_id, value)
+                 VALUES (7, 3, 'Data synonym');",
+        )
+        .expect("fixture should insert");
+
+        populate_concepts_search_fts_for_system(&conn, "sys1").expect("populate should succeed");
+
+        let hits =
+            fts_candidates_ranked_for_system(&conn, "sys1", "http://example.org/cs", "data", None)
+                .expect("ranked search must not error");
+
+        let mut codes: Vec<&str> = hits.iter().map(|c| c.code.as_str()).collect();
+        codes.sort_unstable();
+        // `unrelated` matches on its designation alone — the reason this index
+        // exists separately from concepts_fts, which indexes display only.
+        assert_eq!(codes, ["data-exchange", "data-exchange1", "unrelated"]);
     }
 }


### PR DESCRIPTION
Fixes #272 — `main` is red on **Test Rust**, which blocks every open PR (PR CI builds the branch merged with `main`).

## What was broken

`crates/hts/src/backends/sqlite/value_set.rs` queries and populates `concepts_search_fts`, but `schema.rs` never created it, so the text-filter path failed with `no such table: concepts_search_fts`. `f6008b29d` (IG Publisher `$validate-code`) never touched `schema.rs` at all — the DDL was simply never written, not lost in a merge.

## Two bugs, not one

The issue proposed either adding the DDL or repointing the queries at `concepts_fts`. **The populate path already exists** (preferred displays + synonym designations, negative rowids for designation rows to avoid colliding with concept ids), so a separate search index was genuinely intended. Adding the DDL is the right call.

But adding the table alone does **not** turn the test green. The EXISTS probe swallows the missing-table error via `unwrap_or(false)` and falls back to `concepts_fts`, so the ranked query had **never once executed** — and it is invalid SQL:

```sql
SELECT code, MIN(bm25(concepts_search_fts)) AS rank ... GROUP BY code
```

`bm25()` is an FTS5 auxiliary function and SQLite rejects it in an aggregate context. Creating the table just swaps `no such table` for `unable to use function bm25 in the requested context`. (A plain subquery doesn't help — SQLite flattens it and it fails too.)

Fixed by fencing the scan in a `MATERIALIZED` CTE, so `bm25` is computed during the MATCH scan and aggregated outside it. `MIN` is still correct: a concept contributes one row per term, and bm25 is negative-lower-is-better, so `MIN` keeps each concept's best-matching term.

## Also fixed: a latent restart bug

The startup clear deleted `concepts_fts`, `concepts_fts_built`, and `concepts_word_fts` but not `concepts_search_fts`, which `prebuild_concepts_fts` inserts into with **explicit rowids**. On a restart against a persistent DB that's a duplicate-rowid error, which hits the `ROLLBACK` path and silently rolls back the *entire* prebuild transaction — leaving `concepts_fts` and `concepts_word_fts` empty too, and quietly forfeiting the FTS fast path. Added to both clear sites.

## Choices worth reviewing

- **Trigram, case-insensitive** — matches `concepts_fts`, which serves the *same* quoted MATCH expression as the fallback. A different tokenizer would make results flip depending on whether the index happened to be populated. The sole call site already guards on `filter_lower.len() >= 3`, exactly the trigram minimum.
- **`code` is indexed** (only `system_id` is `UNINDEXED`) — `concepts_fts` indexes `code`, and since prebuild populates this index for every system at startup, this branch is now the one that runs in practice. Not indexing `code` would silently drop filter-by-code matching.

## Postgres

Unaffected — it never references `concepts_search_fts`. That commit only added the BCP-13 hook there. I also audited every table referenced by the SQLite backend against `schema.rs`: `concepts_search_fts` was the only one missing.

## Verification

No C linker in my environment, so CI is the real gate. I validated the SQL directly against SQLite by extracting the actual `SCHEMA` const and the patched query from source and running them on the failing test's exact fixture: schema applies and stays idempotent, `search_populated` is now true, and `filter=data` returns `data-exchange` + its three children — so the expansion nests, which is what the test asserts.

Tests added:
- `concepts_search_fts_ranked_query_runs` — exercises the ranked query directly (previously dead code), including a concept that matches on a **designation alone**, which is the whole reason this index exists separately from `concepts_fts`.
- `concepts_fts` and `concepts_search_fts` added to `all_tables_exist_after_migration` — that test would have caught this at commit time.