### PR TITLE
fix(hts): create the missing concepts_search_fts table and unbreak its bm25 query

### DIFF
--- a/crates/hts/src/backends/sqlite/mod.rs
+++ b/crates/hts/src/backends/sqlite/mod.rs
@@ -369,7 +369,8 @@ impl SqliteTerminologyBackend {
                 let _ = conn.execute_batch(
                     "DELETE FROM concepts_fts;
                      DELETE FROM concepts_fts_built;
-                     DELETE FROM concepts_word_fts;",
+                     DELETE FROM concepts_word_fts;
+                     DELETE FROM concepts_search_fts;",
                 );
 
                 // Update query-planner statistics for large tables.
@@ -461,7 +462,8 @@ impl SqliteTerminologyBackend {
         let _ = conn.execute_batch(
             "DELETE FROM concepts_fts;
              DELETE FROM concepts_fts_built;
-             DELETE FROM concepts_word_fts;",
+             DELETE FROM concepts_word_fts;
+             DELETE FROM concepts_search_fts;",
         );
         let _ = conn.execute_batch(
             "ANALYZE concept_hierarchy; ANALYZE concepts; ANALYZE concept_closure; \

--- a/crates/hts/src/backends/sqlite/schema.rs
+++ b/crates/hts/src/backends/sqlite/schema.rs
@@ -227,6 +227,17 @@ CREATE VIRTUAL TABLE IF NOT EXISTS concepts_word_fts
 USING fts5(system_id UNINDEXED, code, display,
            tokenize='unicode61 remove_diacritics 1');
 
+-- ── FTS5 ranked search index for typeahead concept search ────────────────────
+-- Preferred displays plus synonym designations (rowid = concept id for display
+-- rows, -designation id for synonym rows; see
+-- populate_concepts_search_fts_for_system). Queried with bm25() by
+-- fts_candidates_ranked_for_system; falls back to concepts_fts when empty.
+-- system_id is UNINDEXED (stored for post-filter only). Populated lazily in
+-- ensure_concepts_fts alongside concepts_fts; cleared on startup.
+CREATE VIRTUAL TABLE IF NOT EXISTS concepts_search_fts
+USING fts5(system_id UNINDEXED, code, term,
+           tokenize='trigram case_sensitive 0');
+
 -- ── FTS build tracker ─────────────────────────────────────────────────────────
 -- O(1) lookup to check whether concepts_fts is populated for a given system_id.
 -- Replaces the slow FTS content scan (O(N_total_concepts)) used previously.

--- a/crates/hts/src/backends/sqlite/value_set.rs
+++ b/crates/hts/src/backends/sqlite/value_set.rs
@@ -5006,9 +5006,16 @@ fn fts_candidates_ranked_for_system(
     let ranked_codes: Vec<(String, f64)> = if search_populated {
         let mut stmt = conn
             .prepare_cached(
-                "SELECT code, MIN(bm25(concepts_search_fts)) AS rank
-                 FROM concepts_search_fts
-                 WHERE concepts_search_fts MATCH ?1 AND system_id = ?2
+                // MATERIALIZED stops SQLite flattening the CTE into the
+                // aggregate query — FTS5 aux functions like bm25() cannot run
+                // in an aggregate context ("unable to use function bm25 in
+                // the requested context").
+                "WITH ranked AS MATERIALIZED (
+                     SELECT code, bm25(concepts_search_fts) AS rank
+                     FROM concepts_search_fts
+                     WHERE concepts_search_fts MATCH ?1 AND system_id = ?2
+                 )
+                 SELECT code, MIN(rank) AS rank FROM ranked
                  GROUP BY code
                  ORDER BY rank ASC
                  LIMIT ?3",


### PR DESCRIPTION
## Summary

`main` is currently red: `expand_is_a_filter_with_text_filter_still_nests` (added by #233) fails under `--all-features` with `no such table: concepts_search_fts`. The table was introduced by f6008b29 (IG Publisher `$validate-code` compatibility) but **no schema ever creates it**, and its ranked `bm25` query is additionally illegal SQLite. This PR creates the table, wires its startup clearing, and fixes the query.

## Why

f6008b29 added a ranked typeahead search path over `concepts_search_fts` (preferred displays + synonym designations). Two latent bugs shipped with it:

1. The table is populated and queried but never created. The *read* path silently fell back to `concepts_fts` (`unwrap_or(false)` swallows the missing-table error), but the *populate* path inside `ensure_concepts_fts` hard-fails on the first filtered expand of any system.
2. The ranked query uses `MIN(bm25(concepts_search_fts)) … GROUP BY`, which SQLite rejects (`unable to use function bm25 in the requested context`) — FTS5 auxiliary functions cannot run in an aggregate context, and a plain subquery gets flattened back into one.

Nothing hit either bug until #233 (branched before f6008b29 landed, green on its own CI) merged: its new test is the first to walk `ensure_concepts_fts → populate_concepts_search_fts_for_system` on a text-filtered expand. main's own CI run for the merge died on runner disk space, so the failure first surfaced on PR merge refs.

## Changes

- **`schema.rs`** — create `concepts_search_fts` (`system_id UNINDEXED, code, term`, trigram tokenizer to match `concepts_fts`, so the same quoted `MATCH` expression behaves identically in the ranked branch and its fallback).
- **`mod.rs`** — clear `concepts_search_fts` on startup alongside `concepts_fts`/`concepts_word_fts` in both rebuild blocks, preserving the re-import contract.
- **`value_set.rs`** — rewrite the ranked query with a `MATERIALIZED` CTE so `bm25()` runs in plain query context before the `MIN … GROUP BY` aggregation. The previously dead ranked branch now actually executes.

## Testing

- `cargo test -p helios-hts --all-features` — green (all 12 test binaries, including the previously failing `value_set_ops`; reproduced the failure on clean `origin/main` first).
- CI-style clippy (`-D warnings` + repo allowances) and `cargo fmt` clean.
- Query shape validated directly in `sqlite3`: the flattened forms fail, the materialized CTE returns ranked rows.

## Notes

- `CREATE VIRTUAL TABLE IF NOT EXISTS` in the startup schema batch means existing SQLite terminology databases get the table on next boot; no migration needed.
- This unblocks every open PR whose merge ref includes #233 (their `Test Rust` currently fails on this test regardless of their own changes).
