### PR TITLE
fix(hts): create the concepts_search_fts FTS5 table it uses (#274)

### DIFF
--- a/crates/hts/src/backends/sqlite/mod.rs
+++ b/crates/hts/src/backends/sqlite/mod.rs
@@ -369,7 +369,8 @@ impl SqliteTerminologyBackend {
                 let _ = conn.execute_batch(
                     "DELETE FROM concepts_fts;
                      DELETE FROM concepts_fts_built;
-                     DELETE FROM concepts_word_fts;",
+                     DELETE FROM concepts_word_fts;
+                     DELETE FROM concepts_search_fts;",
                 );
 
                 // Update query-planner statistics for large tables.
@@ -461,7 +462,8 @@ impl SqliteTerminologyBackend {
         let _ = conn.execute_batch(
             "DELETE FROM concepts_fts;
              DELETE FROM concepts_fts_built;
-             DELETE FROM concepts_word_fts;",
+             DELETE FROM concepts_word_fts;
+             DELETE FROM concepts_search_fts;",
         );
         let _ = conn.execute_batch(
             "ANALYZE concept_hierarchy; ANALYZE concepts; ANALYZE concept_closure; \

--- a/crates/hts/src/backends/sqlite/schema.rs
+++ b/crates/hts/src/backends/sqlite/schema.rs
@@ -227,6 +227,19 @@ CREATE VIRTUAL TABLE IF NOT EXISTS concepts_word_fts
 USING fts5(system_id UNINDEXED, code, display,
            tokenize='unicode61 remove_diacritics 1');
 
+-- ── FTS5 ranked search index (preferred display + synonym designations) ───────
+-- Backs the typeahead ranker `fts_candidates_ranked_for_system`: `term` carries
+-- both the concept's preferred display and every designation value, so a query
+-- matches a concept by any of its synonyms, and bm25(concepts_search_fts) ranks
+-- them. Only `term` is tokenised; `code` is retrieved (SELECT/GROUP BY) and
+-- `system_id` is a post-filter, so both are UNINDEXED. Same trigram tokenizer as
+-- `concepts_fts`, which is the fallback when this index is empty, so substring
+-- matching behaves consistently between the two. Populated lazily per system_id
+-- (`populate_concepts_search_fts_for_system`); cleared on startup.
+CREATE VIRTUAL TABLE IF NOT EXISTS concepts_search_fts
+USING fts5(system_id UNINDEXED, code UNINDEXED, term,
+           tokenize='trigram case_sensitive 0');
+
 -- ── FTS build tracker ─────────────────────────────────────────────────────────
 -- O(1) lookup to check whether concepts_fts is populated for a given system_id.
 -- Replaces the slow FTS content scan (O(N_total_concepts)) used previously.


### PR DESCRIPTION
Fixes #274.

## The bug

`crates/hts/src/backends/sqlite/value_set.rs` reads from and writes to a `concepts_search_fts` FTS5 table (the typeahead ranker `fts_candidates_ranked_for_system` and its populate path `populate_concepts_search_fts_for_system`), but the table's `CREATE VIRTUAL TABLE` **existed nowhere in the repository**:

```
$ grep -rn "CREATE VIRTUAL TABLE.*concepts_search_fts" .
(no matches)
```

So the first text-filtered expansion of any system fails hard with `no such table: concepts_search_fts`, surfaced as an OperationOutcome exception. `main` currently fails `value_set_ops::expand_is_a_filter_with_text_filter_still_nests` on exactly this.

## Why CI didn't catch it — semantic merge conflict

| PR | added | green because |
|----|-------|---------------|
| **#194** | the code that uses the table (no DDL) | nothing in its tests reached the build path |
| **#233** | `expand_is_a_filter_with_text_filter_still_nests`, which does reach it | its CI ran against a base predating #194 |

Both merged green; the combination on `main` is broken.

## The fix

Add the table next to its siblings in `schema.rs`, and clear it at startup in the same two blocks that reset `concepts_fts` / `concepts_word_fts`.

The shape is derived from how `value_set.rs` uses it, not guessed:
- **`term`** is the only tokenised column — the INSERTs fill it from both the concept's `display` and every designation `value`, which is what lets a query match a concept by any synonym and rank with `bm25`.
- **`code`** is retrieved (`SELECT code … GROUP BY code`) and **`system_id`** is a post-filter (`WHERE system_id = ?`), so both are `UNINDEXED`.
- Same `trigram case_sensitive 0` tokenizer as `concepts_fts`, its empty-index fallback, so substring matching is consistent between the two.

```sql
CREATE VIRTUAL TABLE IF NOT EXISTS concepts_search_fts
USING fts5(system_id UNINDEXED, code UNINDEXED, term,
           tokenize='trigram case_sensitive 0');
```

## Verification

Against a real SQLite (3.45): the DDL applies, both populate INSERTs run, the `EXISTS` populated-probe returns true, and a trigram `MATCH` on a designation value returns the owning concept's code ranked by `bm25`.

@sandhums (author of #194) — please sanity-check the column/tokenizer choice against your intent for the search ranker; the behaviour is inferred from the queries, but you'd know if `term` was meant to carry anything else.

Found while rebasing #261 (issue #200) onto main; #261's CI is blocked on this because GitHub tests the PR *merged into main*.