### PR TITLE
feat(tenants): auto-register a tenant on its first write (#240)

### DIFF
--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -93,6 +93,10 @@ where
                 message: "Bundle must have a type".to_string(),
             })?;
 
+    // A batch/transaction may create the tenant's first resource — capture it
+    // in the registry (#240). Cache-guarded, so only the first write pays it.
+    state.ensure_tenant_registered(tenant.tenant_id()).await;
+
     match bundle_type {
         "batch" => process_batch(&state, tenant, &prefer, &bundle, principal.as_ref()).await,
         "transaction" => {

--- a/crates/rest/src/handlers/create.rs
+++ b/crates/rest/src/handlers/create.rs
@@ -104,6 +104,11 @@ where
         });
     }
 
+    // Organic tenants — a tenant id first seen on a write — get a registry row
+    // so their created_at is captured (#240). Guarded by a per-process cache, so
+    // only the first write for an id touches the registry; best-effort otherwise.
+    state.ensure_tenant_registered(tenant.tenant_id()).await;
+
     // Check for conditional create
     if let Some(search_params) = conditional.if_none_exist() {
         debug!(search_params = %search_params, "Processing conditional create");

--- a/crates/rest/src/handlers/update.rs
+++ b/crates/rest/src/handlers/update.rs
@@ -106,6 +106,9 @@ where
         });
     }
 
+    // Capture an organically-appearing tenant in the registry (#240).
+    state.ensure_tenant_registered(tenant.tenant_id()).await;
+
     // Validate ID in body matches URL (if present)
     if let Some(body_id) = resource.get("id").and_then(|v| v.as_str()) {
         if body_id != id {
@@ -263,6 +266,9 @@ where
         fhir_version = %fhir_version,
         "Processing conditional update request"
     );
+
+    // A conditional update can create — capture an organic tenant (#240).
+    state.ensure_tenant_registered(tenant.tenant_id()).await;
 
     // Validate resourceType
     if let Some(body_type) = resource.get("resourceType").and_then(|v| v.as_str()) {

--- a/crates/rest/src/state.rs
+++ b/crates/rest/src/state.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use dashmap::DashMap;
 use helios_audit::AuditSink;
 use helios_auth::AuthConfig;
 use helios_persistence::core::PurgableStorage;
@@ -116,6 +117,12 @@ pub struct AppState<S> {
 
     /// Bulk submit configuration.
     bulk_submit_config: Arc<BulkSubmitConfig>,
+
+    /// Tenant ids this process has already tried to auto-register (#240). A
+    /// positive, append-only in-memory cache so the write path never pays a
+    /// registry lookup: the first write for an id spawns a best-effort
+    /// `register_tenant`, and every later write just sees the id here and skips.
+    seen_tenants: Arc<DashMap<String, ()>>,
 }
 
 // Manually implement Clone since S is wrapped in Arc and doesn't need to be Clone
@@ -144,6 +151,7 @@ impl<S> Clone for AppState<S> {
             bulk_submit_output: self.bulk_submit_output.clone(),
             bulk_submit_file_auth: self.bulk_submit_file_auth.clone(),
             bulk_submit_config: Arc::clone(&self.bulk_submit_config),
+            seen_tenants: Arc::clone(&self.seen_tenants),
         }
     }
 }
@@ -181,6 +189,7 @@ impl<S: ResourceStorage> AppState<S> {
             bulk_submit_output: None,
             bulk_submit_file_auth: None,
             bulk_submit_config,
+            seen_tenants: Arc::new(DashMap::new()),
         }
     }
 
@@ -228,6 +237,7 @@ impl<S: ResourceStorage> AppState<S> {
             bulk_submit_output: None,
             bulk_submit_file_auth: None,
             bulk_submit_config,
+            seen_tenants: Arc::new(DashMap::new()),
         }
     }
 
@@ -386,6 +396,22 @@ impl<S: ResourceStorage> AppState<S> {
     /// Returns a clone of the storage Arc.
     pub fn storage_arc(&self) -> Arc<S> {
         Arc::clone(&self.storage)
+    }
+
+    /// Auto-registers the tenant a write is landing on (#240), best-effort.
+    /// Cheap on the hot path — a single in-memory probe guards it, so only the
+    /// first write for a given id this process touches the registry at all; no
+    /// per-write lookup. The registration itself is idempotent: a duplicate (a
+    /// concurrent registration won the race) or an unsupported backend surfaces
+    /// as an error that is simply dropped, so it never blocks or fails a write.
+    pub async fn ensure_tenant_registered(&self, tenant_id: &str) {
+        // `insert` returns the previous value; `Some` means this id was already
+        // handled. The insert is atomic, so a concurrent first-write for the
+        // same id skips here and the registration runs exactly once.
+        if self.seen_tenants.insert(tenant_id.to_string(), ()).is_some() {
+            return;
+        }
+        let _ = self.storage.register_tenant(tenant_id, None).await;
     }
 
     /// Returns a reference to the server configuration.

--- a/crates/rest/src/state.rs
+++ b/crates/rest/src/state.rs
@@ -120,8 +120,8 @@ pub struct AppState<S> {
 
     /// Tenant ids this process has already tried to auto-register (#240). A
     /// positive, append-only in-memory cache so the write path never pays a
-    /// registry lookup: the first write for an id spawns a best-effort
-    /// `register_tenant`, and every later write just sees the id here and skips.
+    /// registry lookup: the first write for an id registers it (best-effort),
+    /// and every later write just sees the id here and skips.
     seen_tenants: Arc<DashMap<String, ()>>,
 }
 
@@ -408,7 +408,11 @@ impl<S: ResourceStorage> AppState<S> {
         // `insert` returns the previous value; `Some` means this id was already
         // handled. The insert is atomic, so a concurrent first-write for the
         // same id skips here and the registration runs exactly once.
-        if self.seen_tenants.insert(tenant_id.to_string(), ()).is_some() {
+        if self
+            .seen_tenants
+            .insert(tenant_id.to_string(), ())
+            .is_some()
+        {
             return;
         }
         let _ = self.storage.register_tenant(tenant_id, None).await;

--- a/crates/rest/tests/admin_tenants.rs
+++ b/crates/rest/tests/admin_tenants.rs
@@ -138,9 +138,11 @@ async fn invalid_ids_are_rejected() {
 #[tokio::test]
 async fn list_includes_data_only_tenants_with_counts() {
     let server = create_test_server().await;
-    // A tenant that has data but was never registered.
+    // A tenant that has data but no registry row. Writes auto-register a tenant
+    // now (#240), so deregister it to get the pure data-only state back.
     seed_for(&server, "beta", "Patient").await;
     seed_for(&server, "beta", "Observation").await;
+    server.delete("/admin/tenants/beta").await;
     // A registered tenant with data.
     server
         .post("/admin/tenants")
@@ -160,6 +162,45 @@ async fn list_includes_data_only_tenants_with_counts() {
     assert_eq!(beta["registered"], false);
     assert_eq!(beta["resources"], 2);
     assert!(beta["created_at"].is_null());
+}
+
+#[tokio::test]
+async fn first_write_auto_registers_the_tenant() {
+    let server = create_test_server().await;
+    // A brand-new tenant that was never provisioned via POST /admin/tenants.
+    seed_for(&server, "organic-co", "Patient").await;
+
+    // Its first write captured it in the registry (#240): registered, with a
+    // created_at — no longer a `registered: false, created_at: null` row.
+    let list = server.get("/admin/tenants").await.json::<Value>();
+    let t = find(&list, "organic-co").expect("organic tenant auto-registered by its first write");
+    assert_eq!(t["registered"], true);
+    assert!(
+        t["created_at"].as_str().is_some_and(|s| !s.is_empty()),
+        "created_at captured: {t}"
+    );
+    assert_eq!(t["resources"], 1);
+}
+
+#[tokio::test]
+async fn writing_to_an_already_registered_tenant_does_not_clobber_it() {
+    let server = create_test_server().await;
+    // Provision explicitly, with a display name.
+    server
+        .post("/admin/tenants")
+        .json(&json!({ "id": "pre", "display_name": "Pre Co" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // The write's auto-registration finds a row already there: the duplicate is
+    // treated as success (never fails the write) and must not overwrite the name.
+    seed_for(&server, "pre", "Patient").await;
+
+    let list = server.get("/admin/tenants").await.json::<Value>();
+    let t = find(&list, "pre").expect("pre");
+    assert_eq!(t["registered"], true);
+    assert_eq!(t["display_name"], "Pre Co");
+    assert_eq!(t["resources"], 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #240. Follow-up to #213 / #220.

## The gap

Tenants provisioned via `POST /admin/tenants` get a registry row with `created_at` (and an optional display name). Tenants that appear **organically** — the first time a new tenant id is used on a write — never did: they showed up in `GET /admin/tenants` only as data-only rows (`registered: false, created_at: null`), merged in from `count_by_tenant`. #220 left this out deliberately to keep the hot write path untouched.

## What this does

On the resource write path, when a write lands for a tenant id with no registry row, register it automatically (no display name) so `created_at` is captured.

- **No per-write registry lookup.** `AppState` gains a per-process, append-only seen-tenants cache (`DashMap`). The hot path pays only a cheap in-memory probe; only the *first* write for an id this process touches the registry at all. (The registry is append-mostly, so a positive cache never needs invalidating — exactly the shape the issue called for.)
- **Idempotent + best-effort.** A duplicate (a concurrent registration won the race) or an unsupported backend surfaces as an error that is simply dropped — it never blocks or fails the write, and never overwrites an existing row's display name.
- **Where it's wired:** `create` (including conditional create), `update`, conditional update, and `batch`/`transaction`. **Patch is intentionally not** wired: it reads an existing resource first, so the tenant was already written to — and therefore already registered.

## Design note: inline, cache-guarded

The issue offered two shapes — a seen-tenants cache, or async/off-path registration. I took the cache and register **inline** (a single `await` on the first write per tenant), rather than a detached `tokio::spawn`. It's deterministic (no spawn-timing races in tests or in `GET /admin/tenants` right after a write) and the cost is one insert per tenant per process; the cache is what keeps it off every write.

## Tests

`crates/rest/tests/admin_tenants.rs`:
- `first_write_auto_registers_the_tenant` — a brand-new tenant's first write yields `registered: true` with a `created_at`.
- `writing_to_an_already_registered_tenant_does_not_clobber_it` — a write to a pre-provisioned tenant keeps its display name; the duplicate registration is a silent no-op.
- `list_includes_data_only_tenants_with_counts` — updated: since writes now auto-register, it deregisters the tenant to keep exercising the discovered-but-unregistered merge path (still reachable via deregister).

All 26 tenant tests green; `cargo build -p helios-hfs` clean.
