### PR TITLE
fix(observability): stop paying for unconsumed per-request instrumentation (#227)

### DIFF
--- a/.github/workflows/hts-benchmark.yml
+++ b/.github/workflows/hts-benchmark.yml
@@ -3,8 +3,9 @@ name: HTS Terminology Benchmark
 # ──────────────────────────────────────────────────────────────────────────────
 # Manual trigger only — benchmarks are expensive and require licensed data.
 #
-# Runs the k6 preflight + benchmark scenarios (HealthSamurai/tx-benchmark)
-# against HTS. The `backend` input selects which storage backend(s) to
+# Runs the k6 preflight + benchmark scenarios (our fork,
+# HeliosSoftware/tx-benchmark — the fork's latest default branch) against
+# HTS. The `backend` input selects which storage backend(s) to
 # exercise:
 #   • sqlite   — default-feature build, file-backed DB.
 #   • postgres — `--features postgres,R4` build, ephemeral postgres:16 container.
@@ -83,7 +84,7 @@ on:
         required: false
         default: ""
       tx_benchmark_ref:
-        description: "tx-benchmark git ref (blank = pinned SHA; changing it re-baselines)"
+        description: "tx-benchmark git ref (blank = our fork's default branch; set to pin a specific baseline)"
         required: false
         default: ""
 
@@ -197,17 +198,19 @@ jobs:
         with:
           clean: false
 
-      # Pinned to a SHA, not a moving branch. The benchmark test definitions
-      # are an *input* to every perf comparison in this repo: an unpinned
-      # checkout means a baseline recorded weeks ago and a run recorded today
-      # may not have measured the same thing, and no regression claim made
-      # against that baseline is falsifiable. Bump this deliberately, and
-      # re-baseline when you do.
+      # Track our fork's default branch (HeliosSoftware/tx-benchmark) rather
+      # than pinning a SHA. The benchmark test definitions are an *input* to
+      # every perf comparison here, so drift must be controlled — but because
+      # we own the fork, upstream HealthSamurai changes only reach CI once we
+      # deliberately merge them into the fork. That gives us a single, auditable
+      # place to gate drift without stale SHA pins scattered across workflows.
+      # Set the `tx_benchmark_ref` input to pin a specific ref for a one-off
+      # re-baseline run.
       - name: Checkout tx-benchmark
         uses: actions/checkout@v5
         with:
-          repository: HealthSamurai/tx-benchmark
-          ref: ${{ inputs.tx_benchmark_ref || '78bdffa769e21ac5d654f5dad412d1becf9d7e57' }}
+          repository: HeliosSoftware/tx-benchmark
+          ref: ${{ inputs.tx_benchmark_ref || '' }}
           path: tx-benchmark
 
       - name: Download HTS binary

--- a/.github/workflows/hts-benchmark.yml
+++ b/.github/workflows/hts-benchmark.yml
@@ -52,6 +52,40 @@ on:
         description: "Tests to run: 'all' | 'preflight-only' | comma-separated IDs (e.g. LK01,SS01)"
         required: false
         default: "all"
+      # ── Perf-attribution arms (issue #227) ────────────────────────────────
+      # Observability instrumentation is a per-request cost on a server that
+      # serves tens of thousands of req/s. These arms exist to *attribute* that
+      # cost to a component instead of guessing at it: run the same commit on
+      # the same runner with only this input varying, and the delta between
+      # arms is that component's price.
+      #
+      # `obs_mode` maps to HELIOS_OBS_MODE (see crates/observability/src/mode.rs):
+      #   default  — what production ships: metrics only, span iff OTLP is live.
+      #   full     — additionally forces the request span + reqlog ring buffer,
+      #              reproducing the pre-fix cost profile for A/B attribution.
+      #   no-span  — metrics + reqlog, no span.
+      #   off      — middleware present but does no work; the floor.
+      obs_mode:
+        description: "Observability arm: default | full | no-span | off"
+        type: choice
+        required: false
+        default: "default"
+        options:
+          - default
+          - full
+          - no-span
+          - off
+      # Overrides RUST_LOG for the server process. The `hts::probe` developer
+      # probes log at DEBUG; `info,hts::probe=debug` re-enables them to price
+      # the stdout-logging arm without touching code.
+      log_directives:
+        description: "RUST_LOG for the server (blank = HTS_LOG_LEVEL only)"
+        required: false
+        default: ""
+      tx_benchmark_ref:
+        description: "tx-benchmark git ref (blank = pinned SHA; changing it re-baselines)"
+        required: false
+        default: ""
 
 # Self-hosted runner has finite Docker port and disk capacity; superseded
 # runs on the same branch yield to fresh ones.
@@ -163,10 +197,17 @@ jobs:
         with:
           clean: false
 
+      # Pinned to a SHA, not a moving branch. The benchmark test definitions
+      # are an *input* to every perf comparison in this repo: an unpinned
+      # checkout means a baseline recorded weeks ago and a run recorded today
+      # may not have measured the same thing, and no regression claim made
+      # against that baseline is falsifiable. Bump this deliberately, and
+      # re-baseline when you do.
       - name: Checkout tx-benchmark
         uses: actions/checkout@v5
         with:
           repository: HealthSamurai/tx-benchmark
+          ref: ${{ inputs.tx_benchmark_ref || '78bdffa769e21ac5d654f5dad412d1becf9d7e57' }}
           path: tx-benchmark
 
       - name: Download HTS binary
@@ -368,8 +409,15 @@ jobs:
       - name: Start HTS server
         run: |
           # HTS_DATABASE_URL + HTS_STORAGE_BACKEND already exported.
+          #
+          # RUST_LOG, when supplied, takes precedence over HTS_LOG_LEVEL (the
+          # server's EnvFilter reads the environment first). Left blank in the
+          # default arm so the benchmark measures the shipped configuration.
+          echo "obs arm: HELIOS_OBS_MODE=${{ inputs.obs_mode || 'default' }} RUST_LOG='${{ inputs.log_directives }}'"
           HTS_SERVER_PORT="${{ matrix.port }}" \
           HTS_LOG_LEVEL="info" \
+          HELIOS_OBS_MODE="${{ inputs.obs_mode || 'default' }}" \
+          ${{ inputs.log_directives && format('RUST_LOG="{0}"', inputs.log_directives) || '' }} \
             ./hts > "/tmp/hts-bench-${{ matrix.backend }}.log" 2>&1 &
 
           echo "HTS_PID=$!" >> "$GITHUB_ENV"

--- a/.github/workflows/hts-benchmark.yml
+++ b/.github/workflows/hts-benchmark.yml
@@ -422,14 +422,19 @@ jobs:
 
           echo "HTS_PID=$!" >> "$GITHUB_ENV"
 
+          # The sqlite backend warms its in-process hierarchy/closure caches
+          # over the full terminology corpus before it serves, which in a debug
+          # build on a loaded self-hosted runner can take a few minutes — well
+          # past a 60s window. Wait up to 300s so a healthy-but-slow cold start
+          # is not mistaken for a failure; a genuine hang still trips the bound.
           echo "Waiting for HTS to become ready..."
-          for i in $(seq 1 30); do
+          for i in $(seq 1 150); do
             if curl -sf "http://localhost:${{ matrix.port }}/health" > /dev/null 2>&1; then
               echo "HTS ready after $((i * 2))s"
               break
             fi
-            if [ "$i" -eq 30 ]; then
-              echo "ERROR: HTS did not start within 60s"
+            if [ "$i" -eq 150 ]; then
+              echo "ERROR: HTS did not start within 300s"
               cat "/tmp/hts-bench-${{ matrix.backend }}.log"
               exit 1
             fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3378,6 +3378,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "tokio",
+ "tower",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -746,6 +746,10 @@ async fn main() -> anyhow::Result<()> {
     helios_observability::uptime::init();
     helios_observability::telemetry::init("hfs", &config.log_level);
     helios_observability::metrics::init("hfs");
+    // hfs is the one server that mounts the console traffic/tenants endpoints
+    // backed by the reqlog ring buffer, so it opts into recording. Servers that
+    // don't (hts, sof-server, fhirpath-server) leave it off and skip the cost.
+    helios_observability::reqlog::enable();
 
     if let Err(errors) = config.validate() {
         for error in &errors {

--- a/crates/hts/src/backends/sqlite/value_set.rs
+++ b/crates/hts/src/backends/sqlite/value_set.rs
@@ -76,6 +76,20 @@ fn cs_id_cache() -> &'static RwLock<SystemIdCacheMap> {
     SYSTEM_ID_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
+/// Truncate a URL to at most 80 characters for `hts::probe` log labels,
+/// appending an ellipsis when it was shortened. Operates on `char` boundaries,
+/// so a URL with a multibyte character straddling byte 80 is truncated safely
+/// rather than panicking as a raw `&u[..80]` byte slice would.
+fn truncate_url_for_probe(u: &str) -> String {
+    let mut chars = u.chars();
+    let head: String = chars.by_ref().take(80).collect();
+    if chars.next().is_some() {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
 /// Clear the process-wide URL→system_id cache. Called by code paths that
 /// write to the `code_systems` table (CRUD + bulk import).
 pub(crate) fn invalidate_cs_id_cache() {
@@ -215,13 +229,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
         let probe_url_short: String = if probe_on {
             req.url
                 .as_deref()
-                .map(|u| {
-                    if u.len() > 80 {
-                        format!("{}…", &u[..80])
-                    } else {
-                        u.to_string()
-                    }
-                })
+                .map(truncate_url_for_probe)
                 .unwrap_or_else(|| "<inline>".to_string())
         } else {
             String::new()
@@ -9054,6 +9062,29 @@ mod tests {
 
     fn backend() -> SqliteTerminologyBackend {
         SqliteTerminologyBackend::in_memory().expect("in-memory backend should initialise")
+    }
+
+    #[test]
+    fn truncate_url_for_probe_is_char_safe() {
+        // Short and exactly-80-char inputs pass through unchanged.
+        assert_eq!(truncate_url_for_probe("http://x/vs"), "http://x/vs");
+        let exactly_80 = "a".repeat(80);
+        assert_eq!(truncate_url_for_probe(&exactly_80), exactly_80);
+
+        // Longer input is truncated to 80 chars with an ellipsis.
+        let long = "a".repeat(81);
+        assert_eq!(
+            truncate_url_for_probe(&long),
+            format!("{}…", "a".repeat(80))
+        );
+
+        // A multibyte character straddling byte 80: the old `&u[..80]` byte slice
+        // panicked here; the char-based truncation keeps 80 chars safely.
+        let multibyte = "€".repeat(100); // 3 bytes each → byte 80 falls mid-char
+        assert_eq!(
+            truncate_url_for_probe(&multibyte),
+            format!("{}…", "€".repeat(80))
+        );
     }
 
     fn ctx() -> TenantContext {

--- a/crates/hts/src/backends/sqlite/value_set.rs
+++ b/crates/hts/src/backends/sqlite/value_set.rs
@@ -204,19 +204,28 @@ impl ValueSetOperations for SqliteTerminologyBackend {
             ));
         }
         // EX_PROBE: per-call timing to identify which path served the request.
-        // (Stripped after iter11 diagnosis.)
+        // These probes log at the `hts::probe` DEBUG target; when it is not
+        // enabled (the default, and the benchmark) the truncated-URL string is
+        // never built, so the hot expand path pays only this one bool check.
+        // The value is reused across the probe sites below — including the ones
+        // inside `spawn_blocking`, which need an owned copy — so it is bound
+        // once here rather than recomputed per site.
         let _probe_t0 = std::time::Instant::now();
-        let probe_url_short: String = req
-            .url
-            .as_deref()
-            .map(|u| {
-                if u.len() > 80 {
-                    format!("{}…", &u[..80])
-                } else {
-                    u.to_string()
-                }
-            })
-            .unwrap_or_else(|| "<inline>".to_string());
+        let probe_on = tracing::enabled!(target: "hts::probe", tracing::Level::DEBUG);
+        let probe_url_short: String = if probe_on {
+            req.url
+                .as_deref()
+                .map(|u| {
+                    if u.len() > 80 {
+                        format!("{}…", &u[..80])
+                    } else {
+                        u.to_string()
+                    }
+                })
+                .unwrap_or_else(|| "<inline>".to_string())
+        } else {
+            String::new()
+        };
 
         // ── Async hot path: in-memory index already warm ──────────────────────
         // For URL-based implicit ValueSet requests (no inline ValueSet body),
@@ -266,7 +275,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                             sql_offset,
                             sql_limit,
                         );
-                        tracing::info!(
+                        tracing::debug!(
                             target: "hts::probe",
                             "EX_PROBE_BACKEND: hit=implicit_index url={} took={:.3}ms n={}",
                             probe_url_short,
@@ -320,7 +329,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                             }
                         }
                         let page = page_in_memory(&concept_idx, None, sql_offset, sql_limit);
-                        tracing::info!(
+                        tracing::debug!(
                             target: "hts::probe",
                             "EX_PROBE_BACKEND: hit=inline_compose_index url={} took={:.3}ms n={}",
                             probe_url_short,
@@ -363,7 +372,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                             sql_offset,
                             sql_limit,
                         );
-                        tracing::info!(
+                        tracing::debug!(
                             target: "hts::probe",
                             "EX_PROBE_BACKEND: hit=property_result_cache url={} took={:.3}ms n={}",
                             probe_url_short,
@@ -422,7 +431,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                                             sql_offset,
                                             sql_limit,
                                         );
-                                        tracing::info!(
+                                        tracing::debug!(
                                             target: "hts::probe",
                                             "EX_PROBE_BACKEND: hit=plain_fts_cache url={} took={:.3}ms n={}",
                                             probe_url_short,
@@ -450,7 +459,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
         // slow path. This is the hot suspicion for the EX04-after-EX01 stall.
         let probe_url_short_owned = probe_url_short.clone();
         let probe_t_pre_spawn = std::time::Instant::now();
-        tracing::info!(
+        tracing::debug!(
             target: "hts::probe",
             "EX_PROBE_BACKEND: miss_all_caches url={} entering spawn_blocking",
             probe_url_short_owned,
@@ -470,7 +479,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
             let probe_pre_spawn_ms =
                 probe_t_pre_spawn.elapsed().as_micros() as f64 / 1000.0;
             let conn = pool.get().map_err(|e| {
-                tracing::info!(
+                tracing::debug!(
                     target: "hts::probe",
                     "EX_PROBE_BACKEND: pool_get_FAILED url={} pre_spawn={:.3}ms",
                     probe_url_inner,
@@ -480,7 +489,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
             })?;
             let probe_pool_get_ms =
                 probe_t_in_blocking.elapsed().as_micros() as f64 / 1000.0;
-            tracing::info!(
+            tracing::debug!(
                 target: "hts::probe",
                 "EX_PROBE_BACKEND: pool_get url={} pre_spawn={:.3}ms pool_get={:.3}ms",
                 probe_url_inner,
@@ -709,7 +718,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                         )?;
                         let probe_compute_ms =
                             probe_t_compute.elapsed().as_micros() as f64 / 1000.0;
-                        tracing::info!(
+                        tracing::debug!(
                             target: "hts::probe",
                             "EX04_PROBE: compute_expansion_with_ctx took={:.3}ms cache_key={} n={} warnings={}",
                             probe_compute_ms,
@@ -737,14 +746,14 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                                 &cache_key,
                                 &inline_compose_index,
                             );
-                            tracing::info!(
+                            tracing::debug!(
                                 target: "hts::probe",
                                 "EX04_PROBE: populate_caches took={:.3}ms cache_key={}",
                                 probe_t_pop.elapsed().as_micros() as f64 / 1000.0,
                                 cache_key,
                             );
                         } else {
-                            tracing::info!(
+                            tracing::debug!(
                                 target: "hts::probe",
                                 "EX04_PROBE: skip_cache cache_key={} warnings={} contained={} tx_resources={}",
                                 cache_key,
@@ -1016,7 +1025,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
                                         )?;
                                         let probe_bfs_ms =
                                             probe_t_bfs.elapsed().as_micros() as f64 / 1000.0;
-                                        tracing::info!(
+                                        tracing::debug!(
                                             target: "hts::probe",
                                             "EX01_PROBE: bfs_expand_page took={:.3}ms cs_url={} pattern={:?} n={}",
                                             probe_bfs_ms,
@@ -1237,7 +1246,7 @@ impl ValueSetOperations for SqliteTerminologyBackend {
             // i.e. the actual SQLite work (compose evaluation + filtering).
             let probe_compute_ms =
                 probe_t_after_conn.elapsed().as_micros() as f64 / 1000.0;
-            tracing::info!(
+            tracing::debug!(
                 target: "hts::probe",
                 "EX_PROBE_BACKEND: blocking_done url={} pool_get={:.3}ms compute={:.3}ms n={}",
                 probe_url_inner,

--- a/crates/hts/src/operations/expand.rs
+++ b/crates/hts/src/operations/expand.rs
@@ -1945,7 +1945,7 @@ async fn process_expand_inner<B: TerminologyBackend>(
     let mut resp = match ValueSetOperations::expand(state.backend(), &ctx, req).await {
         Ok(r) => {
             let backend_ms = probe_t_backend.elapsed().as_micros() as f64 / 1000.0;
-            tracing::info!(
+            tracing::debug!(
                 target: "hts::probe",
                 "EX_PROBE: backend_expand took {:.3}ms url={} inline={} filter={} count={:?} contains_n={}",
                 backend_ms,
@@ -3995,7 +3995,7 @@ async fn process_expand_inner<B: TerminologyBackend>(
     // EX_PROBE: total wall time for the whole request including parse + post-
     // processing + serialization.
     let total_ms = probe_t0.elapsed().as_micros() as f64 / 1000.0;
-    tracing::info!(
+    tracing::debug!(
         target: "hts::probe",
         "EX_PROBE: total request took {:.3}ms bytes={}",
         total_ms,

--- a/crates/hts/src/operations/validate_code.rs
+++ b/crates/hts/src/operations/validate_code.rs
@@ -2209,28 +2209,25 @@ pub(crate) async fn process_validate_code<B: TerminologyBackend>(
     let cache_key = build_validate_code_cache_key(&params);
     if let Some(ref key) = cache_key {
         if let Some(cached) = validate_code_cache_get(&state.cs_validate_code_handler_cache, key) {
-            let key_short: String = key.chars().take(100).collect();
-            tracing::info!(
+            // Field exprs are evaluated only when the probe target is enabled,
+            // so the truncating alloc costs nothing at the default level.
+            tracing::debug!(
                 target: "hts::probe",
                 "VC_CACHE: path=cs hit=true cache_key={}",
-                key_short,
+                key.chars().take(100).collect::<String>(),
             );
             return Ok((*cached).clone());
         }
     }
-    {
-        let (skip, key_short, key_len) = match cache_key.as_ref() {
-            Some(k) => (false, k.chars().take(100).collect::<String>(), k.len()),
-            None => (true, String::new(), 0usize),
-        };
-        tracing::info!(
-            target: "hts::probe",
-            "VC_CACHE: path=cs hit=false skip={} key_len={} cache_key={}",
-            skip,
-            key_len,
-            key_short,
-        );
-    }
+    tracing::debug!(
+        target: "hts::probe",
+        "VC_CACHE: path=cs hit=false skip={} key_len={} cache_key={}",
+        cache_key.is_none(),
+        cache_key.as_ref().map_or(0, |k| k.len()),
+        cache_key
+            .as_ref()
+            .map_or(String::new(), |k| k.chars().take(100).collect::<String>()),
+    );
     let result = process_validate_code_inner(state, params).await;
     if let (Ok(value), Some(key)) = (&result, cache_key) {
         validate_code_cache_put(
@@ -4027,30 +4024,25 @@ pub(crate) async fn process_vs_validate_code<B: TerminologyBackend>(
     let cache_key = build_validate_code_cache_key(&params);
     if let Some(ref key) = cache_key {
         if let Some(cached) = validate_code_cache_get(&state.vs_validate_code_handler_cache, key) {
-            // Probe: cache hit on VS path.
-            let key_short: String = key.chars().take(100).collect();
-            tracing::info!(
+            // Field exprs evaluated only when the probe target is enabled.
+            tracing::debug!(
                 target: "hts::probe",
                 "VC_CACHE: path=vs hit=true cache_key={}",
-                key_short,
+                key.chars().take(100).collect::<String>(),
             );
             return Ok((*cached).clone());
         }
     }
     // Probe: cache miss (or skipped) on VS path. Capture key length / shape.
-    {
-        let (skip, key_short, key_len) = match cache_key.as_ref() {
-            Some(k) => (false, k.chars().take(100).collect::<String>(), k.len()),
-            None => (true, String::new(), 0usize),
-        };
-        tracing::info!(
-            target: "hts::probe",
-            "VC_CACHE: path=vs hit=false skip={} key_len={} cache_key={}",
-            skip,
-            key_len,
-            key_short,
-        );
-    }
+    tracing::debug!(
+        target: "hts::probe",
+        "VC_CACHE: path=vs hit=false skip={} key_len={} cache_key={}",
+        cache_key.is_none(),
+        cache_key.as_ref().map_or(0, |k| k.len()),
+        cache_key
+            .as_ref()
+            .map_or(String::new(), |k| k.chars().take(100).collect::<String>()),
+    );
     let result = process_vs_validate_code_inner(state, params).await;
     if let (Ok(value), Some(key)) = (&result, cache_key) {
         validate_code_cache_put(

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -54,3 +54,6 @@ tracing-opentelemetry = { version = "0.33", optional = true }
 [dev-dependencies]
 # Drives the async `dashboard::snapshot` path in unit tests.
 tokio = { version = "1", features = ["macros", "rt"] }
+# Drives the `middleware::track` layer end-to-end via `ServiceExt::oneshot`
+# against a real axum router (tests/middleware.rs).
+tower = { version = "0.5", features = ["util"] }

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -39,6 +39,7 @@
 pub mod dashboard;
 pub mod metrics;
 pub mod middleware;
+pub mod mode;
 pub mod reqlog;
 pub mod telemetry;
 pub mod uptime;

--- a/crates/observability/src/middleware.rs
+++ b/crates/observability/src/middleware.rs
@@ -1,8 +1,23 @@
 //! Per-request instrumentation middleware.
 //!
-//! Records request count and latency as Prometheus metrics and opens a tracing
-//! span per request. Under the `otel` feature the span is exported as an OTLP
-//! trace span by the `tracing-opentelemetry` layer (see [`crate::telemetry`]).
+//! Records request count and latency as Prometheus metrics, optionally opens a
+//! tracing span, and optionally feeds the in-process request-log ring buffer.
+//! Under the `otel` feature the span is exported as an OTLP trace span by the
+//! `tracing-opentelemetry` layer (see [`crate::telemetry`]).
+//!
+//! What actually runs per request is decided by [`crate::mode`] plus two
+//! runtime facts, so instrumentation nobody consumes is not paid for:
+//!
+//! - the **span** is opened only when a layer exports it
+//!   ([`crate::telemetry::traces_live`]) — an unexported span is created,
+//!   entered on every poll of the handler future, and dropped unread, which is
+//!   pure overhead at tens of thousands of req/s;
+//! - the **reqlog** push happens only when a server has registered a consumer
+//!   ([`crate::reqlog::enabled`]) — `hts` writes no dashboard, so it should not
+//!   pay for a ring buffer only `hfs`'s console reads.
+//!
+//! Metrics are the exception: `/metrics` is a public product surface, so they
+//! are always recorded except under the [`crate::mode::ObsMode::Off`] floor arm.
 //!
 //! Cardinality discipline: the `route` label uses axum's templated
 //! [`MatchedPath`] (e.g. `/{resource_type}/{id}`), never the raw URI with
@@ -18,56 +33,80 @@ use tracing::Instrument;
 /// Tower/axum middleware (`axum::middleware::from_fn`) that instruments every
 /// request. State-free, so it composes with any server's router.
 pub async fn track(req: Request, next: Next) -> Response {
+    let arm = crate::mode::mode();
+    let span_on = arm.span_enabled(crate::telemetry::traces_live());
+    let metrics_on = arm.metrics_enabled();
+    let reqlog_on = arm.reqlog_enabled(crate::reqlog::enabled());
+
+    // Off arm — and any config where nothing consumes instrumentation — runs
+    // the handler with no per-request work at all. No `MatchedPath` lookup, no
+    // header scan, no allocation.
+    if !span_on && !metrics_on && !reqlog_on {
+        return next.run(req).await;
+    }
+
     let method = req.method().clone();
     let route = req
         .extensions()
         .get::<MatchedPath>()
         .map(|m| m.as_str().to_owned())
         .unwrap_or_else(|| "<unmatched>".to_owned());
-    let tenant = req
-        .headers()
-        .get("x-tenant-id")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("")
-        .to_owned();
-
-    let span = tracing::info_span!(
-        "http.request",
-        http.method = %method,
-        http.route = %route,
-        tenant = %tenant,
-        http.status_code = tracing::field::Empty,
-    );
+    // Only the span and the reqlog rollup use the tenant; skip the header scan
+    // and its allocation when neither is active.
+    let tenant = if span_on || reqlog_on {
+        req.headers()
+            .get("x-tenant-id")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_owned()
+    } else {
+        String::new()
+    };
 
     let start = Instant::now();
-    let response = next.run(req).instrument(span.clone()).await;
+    let response = if span_on {
+        let span = tracing::info_span!(
+            "http.request",
+            http.method = %method,
+            http.route = %route,
+            tenant = %tenant,
+            http.status_code = tracing::field::Empty,
+        );
+        let response = next.run(req).instrument(span.clone()).await;
+        span.record("http.status_code", response.status().as_u16());
+        response
+    } else {
+        next.run(req).await
+    };
     let elapsed = start.elapsed().as_secs_f64();
     let status = response.status().as_u16();
 
-    span.record("http.status_code", status);
+    if reqlog_on {
+        // Feed the in-process rolling log that backs the dashboard traffic
+        // widgets (windowed req/s, latency percentiles, per-tenant rollup).
+        // Cheap: a single bounded-buffer push. Tenant is recorded here for the
+        // per-tenant view but, as above, never becomes a Prometheus label.
+        crate::reqlog::record(status, elapsed, &tenant);
+    }
 
-    // Feed the in-process rolling log that backs the dashboard traffic widgets
-    // (windowed req/s, latency percentiles, per-tenant rollup). Cheap: a single
-    // bounded-buffer push. Tenant is recorded here for the per-tenant view but,
-    // as above, never becomes a Prometheus label.
-    crate::reqlog::record(status, elapsed, &tenant);
-
-    let method = method.as_str().to_owned();
-    let status = status.to_string();
-    metrics::counter!(
-        "http_requests_total",
-        "method" => method.clone(),
-        "route" => route.clone(),
-        "status" => status.clone(),
-    )
-    .increment(1);
-    metrics::histogram!(
-        "http_request_duration_seconds",
-        "method" => method,
-        "route" => route,
-        "status" => status,
-    )
-    .record(elapsed);
+    if metrics_on {
+        let method = method.as_str().to_owned();
+        let status = status.to_string();
+        metrics::counter!(
+            "http_requests_total",
+            "method" => method.clone(),
+            "route" => route.clone(),
+            "status" => status.clone(),
+        )
+        .increment(1);
+        metrics::histogram!(
+            "http_request_duration_seconds",
+            "method" => method,
+            "route" => route,
+            "status" => status,
+        )
+        .record(elapsed);
+    }
 
     response
 }

--- a/crates/observability/src/mode.rs
+++ b/crates/observability/src/mode.rs
@@ -165,4 +165,14 @@ mod tests {
         assert!(ObsMode::Full.reqlog_enabled(false));
         assert!(!ObsMode::Off.reqlog_enabled(true));
     }
+
+    #[test]
+    fn mode_reads_once_and_is_stable() {
+        // Exercises the process-global read path. The value depends on the
+        // ambient `HELIOS_OBS_MODE` (unset in the unit-test process → Default),
+        // so assert on the invariant that matters rather than a fixed arm: the
+        // OnceLock hands back the same arm on every call.
+        let first = mode();
+        assert_eq!(first, mode());
+    }
 }

--- a/crates/observability/src/mode.rs
+++ b/crates/observability/src/mode.rs
@@ -82,23 +82,25 @@ fn parse(raw: &str) -> Option<ObsMode> {
     }
 }
 
+/// Resolve a raw `HELIOS_OBS_MODE` value to an arm, warning and falling back to
+/// [`ObsMode::Default`] on an unrecognised value rather than failing startup: a
+/// typo in a diagnostic env var should not take a server down, and the warning
+/// is enough to catch a mistyped benchmark arm. Split out from [`mode`] so the
+/// fallback path is unit-testable without the process-global `OnceLock`.
+fn resolve(raw: &str) -> ObsMode {
+    parse(raw).unwrap_or_else(|| {
+        tracing::warn!(
+            value = %raw,
+            "unrecognised HELIOS_OBS_MODE; expected one of default|full|no-span|off — using default"
+        );
+        ObsMode::Default
+    })
+}
+
 /// The process-wide observability arm, read once from `HELIOS_OBS_MODE`.
-///
-/// An unrecognised value warns and falls back to [`ObsMode::Default`] rather
-/// than failing startup: a typo in a diagnostic env var should not take a
-/// server down, and the warning is enough to catch a mistyped benchmark arm.
 pub fn mode() -> ObsMode {
     static MODE: OnceLock<ObsMode> = OnceLock::new();
-    *MODE.get_or_init(|| {
-        let raw = std::env::var("HELIOS_OBS_MODE").unwrap_or_default();
-        parse(&raw).unwrap_or_else(|| {
-            tracing::warn!(
-                value = %raw,
-                "unrecognised HELIOS_OBS_MODE; expected one of default|full|no-span|off — using default"
-            );
-            ObsMode::Default
-        })
-    })
+    *MODE.get_or_init(|| resolve(&std::env::var("HELIOS_OBS_MODE").unwrap_or_default()))
 }
 
 #[cfg(test)]
@@ -174,5 +176,13 @@ mod tests {
         // OnceLock hands back the same arm on every call.
         let first = mode();
         assert_eq!(first, mode());
+    }
+
+    #[test]
+    fn resolve_maps_known_values_and_falls_back_on_garbage() {
+        assert_eq!(resolve("full"), ObsMode::Full);
+        assert_eq!(resolve(""), ObsMode::Default);
+        // The unrecognised path warns and degrades to Default rather than panicking.
+        assert_eq!(resolve("verbose"), ObsMode::Default);
     }
 }

--- a/crates/observability/src/mode.rs
+++ b/crates/observability/src/mode.rs
@@ -1,0 +1,168 @@
+//! Observability arm selection (`HELIOS_OBS_MODE`).
+//!
+//! Per-request instrumentation is not free, and on a terminology server
+//! answering tens of thousands of requests per second it is measurable against
+//! the handler work itself. This module exists so that cost can be *attributed*
+//! rather than argued about: run the same commit twice on the same host with
+//! only `HELIOS_OBS_MODE` varying, and the throughput delta is the price of the
+//! component that changed.
+//!
+//! It is a diagnostic knob, not a tuning knob. [`ObsMode::Default`] is what
+//! production ships and what the benchmark measures unless told otherwise; the
+//! other arms deliberately misconfigure the server to isolate a cost, and
+//! [`ObsMode::Full`] exists to reproduce a historical (pre-fix) profile for
+//! comparison. Reaching for a non-default arm to make a number look better
+//! would be measuring a server nobody runs.
+
+use std::sync::OnceLock;
+
+/// Which per-request instrumentation [`crate::middleware::track`] performs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObsMode {
+    /// Production behaviour: Prometheus metrics always; the request span only
+    /// when a tracing layer actually exports it; the reqlog ring buffer only
+    /// when a server has registered a consumer for it.
+    Default,
+    /// Force the request span *and* reqlog recording on, regardless of whether
+    /// anything consumes them. Reproduces the instrumentation profile that
+    /// shipped before issue #227 was fixed, for A/B attribution.
+    Full,
+    /// Everything [`ObsMode::Default`] does, minus the request span.
+    NoSpan,
+    /// The middleware runs but performs no instrumentation. Establishes the
+    /// floor: the difference between this and [`ObsMode::Default`] is the total
+    /// price of observability on the request path.
+    Off,
+}
+
+impl ObsMode {
+    /// Whether `track` should open (and enter) a per-request tracing span.
+    ///
+    /// `traces_live` is the caller's answer to "is a layer actually exporting
+    /// spans?" — see [`crate::telemetry::traces_live`]. Under
+    /// [`ObsMode::Default`] an unexported span is pure cost, so it is skipped.
+    pub fn span_enabled(self, traces_live: bool) -> bool {
+        match self {
+            ObsMode::Full => true,
+            ObsMode::Off | ObsMode::NoSpan => false,
+            ObsMode::Default => traces_live,
+        }
+    }
+
+    /// Whether `track` should record Prometheus metrics. `/metrics` is a public
+    /// product surface, so this is on everywhere except the [`ObsMode::Off`]
+    /// floor arm.
+    pub fn metrics_enabled(self) -> bool {
+        self != ObsMode::Off
+    }
+
+    /// Whether `track` should push to the reqlog ring buffer.
+    ///
+    /// `consumer_registered` is the caller's answer to "has a server registered
+    /// a reader for this buffer?" — see [`crate::reqlog::enabled`]. Under
+    /// [`ObsMode::Default`] / [`ObsMode::NoSpan`] the buffer is filled only when
+    /// something reads it; [`ObsMode::Full`] forces it on for A/B attribution,
+    /// and [`ObsMode::Off`] forces it off.
+    pub fn reqlog_enabled(self, consumer_registered: bool) -> bool {
+        match self {
+            ObsMode::Full => true,
+            ObsMode::Off => false,
+            ObsMode::Default | ObsMode::NoSpan => consumer_registered,
+        }
+    }
+}
+
+fn parse(raw: &str) -> Option<ObsMode> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "default" => Some(ObsMode::Default),
+        "full" => Some(ObsMode::Full),
+        "no-span" | "no_span" => Some(ObsMode::NoSpan),
+        "off" => Some(ObsMode::Off),
+        _ => None,
+    }
+}
+
+/// The process-wide observability arm, read once from `HELIOS_OBS_MODE`.
+///
+/// An unrecognised value warns and falls back to [`ObsMode::Default`] rather
+/// than failing startup: a typo in a diagnostic env var should not take a
+/// server down, and the warning is enough to catch a mistyped benchmark arm.
+pub fn mode() -> ObsMode {
+    static MODE: OnceLock<ObsMode> = OnceLock::new();
+    *MODE.get_or_init(|| {
+        let raw = std::env::var("HELIOS_OBS_MODE").unwrap_or_default();
+        parse(&raw).unwrap_or_else(|| {
+            tracing::warn!(
+                value = %raw,
+                "unrecognised HELIOS_OBS_MODE; expected one of default|full|no-span|off — using default"
+            );
+            ObsMode::Default
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_arms() {
+        assert_eq!(parse("default"), Some(ObsMode::Default));
+        assert_eq!(parse(""), Some(ObsMode::Default));
+        assert_eq!(parse("full"), Some(ObsMode::Full));
+        assert_eq!(parse("no-span"), Some(ObsMode::NoSpan));
+        assert_eq!(parse("no_span"), Some(ObsMode::NoSpan));
+        assert_eq!(parse("off"), Some(ObsMode::Off));
+    }
+
+    #[test]
+    fn parsing_is_case_and_whitespace_insensitive() {
+        assert_eq!(parse("  FULL "), Some(ObsMode::Full));
+        assert_eq!(parse("Off"), Some(ObsMode::Off));
+    }
+
+    #[test]
+    fn rejects_unknown_arm() {
+        assert_eq!(parse("verbose"), None);
+    }
+
+    #[test]
+    fn default_arm_ties_span_to_a_live_exporter() {
+        // The whole point of the fix: no exporter, no span.
+        assert!(!ObsMode::Default.span_enabled(false));
+        assert!(ObsMode::Default.span_enabled(true));
+    }
+
+    #[test]
+    fn full_arm_forces_span_even_with_no_exporter() {
+        assert!(ObsMode::Full.span_enabled(false));
+    }
+
+    #[test]
+    fn off_arm_never_spans_even_with_a_live_exporter() {
+        assert!(!ObsMode::Off.span_enabled(true));
+        assert!(!ObsMode::NoSpan.span_enabled(true));
+    }
+
+    #[test]
+    fn metrics_are_on_everywhere_except_the_floor_arm() {
+        assert!(ObsMode::Default.metrics_enabled());
+        assert!(ObsMode::Full.metrics_enabled());
+        assert!(ObsMode::NoSpan.metrics_enabled());
+        assert!(!ObsMode::Off.metrics_enabled());
+    }
+
+    #[test]
+    fn default_arm_ties_reqlog_to_a_registered_consumer() {
+        assert!(!ObsMode::Default.reqlog_enabled(false));
+        assert!(ObsMode::Default.reqlog_enabled(true));
+        assert!(!ObsMode::NoSpan.reqlog_enabled(false));
+        assert!(ObsMode::NoSpan.reqlog_enabled(true));
+    }
+
+    #[test]
+    fn full_forces_reqlog_and_off_suppresses_it() {
+        assert!(ObsMode::Full.reqlog_enabled(false));
+        assert!(!ObsMode::Off.reqlog_enabled(true));
+    }
+}

--- a/crates/observability/src/reqlog.rs
+++ b/crates/observability/src/reqlog.rs
@@ -391,4 +391,14 @@ mod tests {
                 < stats.sample_count as u64
         );
     }
+
+    #[test]
+    fn enable_sets_the_consumer_flag() {
+        // The flag is process-global; other tests never call `enable`, so it
+        // starts `false`. `record` is unconditional regardless of this flag —
+        // it gates only the middleware — so flipping it here cannot disturb the
+        // other tests that record directly.
+        enable();
+        assert!(enabled(), "enable() must make enabled() report true");
+    }
 }

--- a/crates/observability/src/reqlog.rs
+++ b/crates/observability/src/reqlog.rs
@@ -21,6 +21,7 @@
 //! endpoints.
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 /// Maximum number of request samples retained. At ~20 k samples the buffer
@@ -46,11 +47,37 @@ struct Sample {
 
 static LOG: OnceLock<Mutex<VecDeque<Sample>>> = OnceLock::new();
 
+/// Whether any server has registered a consumer for this buffer.
+///
+/// The buffer is read only by `hfs`'s console traffic/tenants endpoints
+/// (`crates/rest/src/handlers/console_metrics.rs`). A server that mounts no
+/// such reader — `hts`, `sof-server`, `fhirpath-server` — has no use for the
+/// samples, and filling a process-global `Mutex<VecDeque>` on every request at
+/// terminology-server request rates is a contention point paid for nothing.
+/// The request middleware consults [`enabled`] and skips [`record`] when this
+/// is `false`.
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Register that this process consumes the reqlog buffer. Call once at startup
+/// from a server that mounts the console traffic endpoints (i.e. `hfs`). Until
+/// then [`crate::middleware::track`] skips recording. Idempotent.
+pub fn enable() {
+    ENABLED.store(true, Ordering::Relaxed);
+}
+
+/// Whether a consumer has been [`enable`]d for this buffer.
+pub fn enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
 fn log() -> &'static Mutex<VecDeque<Sample>> {
     LOG.get_or_init(|| Mutex::new(VecDeque::with_capacity(1024)))
 }
 
-/// Record one completed request. Called from the request middleware.
+/// Record one completed request. Records unconditionally; the caller decides
+/// whether recording is wanted. [`crate::middleware::track`] gates the call on
+/// [`enabled`] so idle servers pay nothing, while direct callers (tests) always
+/// land a sample.
 ///
 /// `tenant` should be the raw `X-Tenant-ID` value (empty string if absent);
 /// [`per_tenant`] normalises the empty case to `"default"`.

--- a/crates/observability/src/telemetry.rs
+++ b/crates/observability/src/telemetry.rs
@@ -6,11 +6,26 @@
 //! exports spans over OTLP via `tracing-opentelemetry`. Call [`shutdown`] during
 //! graceful shutdown to flush buffered spans.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 #[cfg(feature = "otel")]
 static PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
     std::sync::OnceLock::new();
+
+/// Set once, at [`init`], to whether a tracing layer is actually exporting the
+/// per-request span. Without an exporter the span is created, entered on every
+/// poll, and dropped with nobody reading it — pure overhead. The request
+/// middleware consults [`traces_live`] to skip it in that case.
+static TRACES_LIVE: AtomicBool = AtomicBool::new(false);
+
+/// Whether a layer that consumes the per-request span is installed. `false`
+/// until [`init`] decides otherwise, so the middleware defaults to the cheap
+/// path. See [`crate::mode::ObsMode::span_enabled`].
+pub fn traces_live() -> bool {
+    TRACES_LIVE.load(Ordering::Relaxed)
+}
 
 /// Global default log directives when neither `RUST_LOG` nor the cli/env filter
 /// is set. Applies `level` globally; deps remain overridable via `RUST_LOG`.
@@ -36,6 +51,9 @@ pub fn init(service_name: &str, log_level: &str) {
                 .with(tracing_opentelemetry::layer().with_tracer(tracer))
                 .init();
             let _ = PROVIDER.set(provider);
+            // A layer now consumes the per-request span, so producing it earns
+            // its keep. Everywhere else the middleware skips it.
+            TRACES_LIVE.store(true, Ordering::Relaxed);
             tracing::info!(service = service_name, "OTLP trace export enabled");
             return;
         }

--- a/crates/observability/tests/middleware.rs
+++ b/crates/observability/tests/middleware.rs
@@ -1,0 +1,65 @@
+//! End-to-end coverage for [`helios_observability::middleware::track`].
+//!
+//! The middleware's decision table (which instrumentation runs per request) is
+//! unit-tested on [`helios_observability::mode::ObsMode`]; this drives the async
+//! body itself — path/tenant extraction, the metrics block, and the reqlog push
+//! — through a real axum router.
+//!
+//! The observability arm is process-global (`OnceLock` over `HELIOS_OBS_MODE`),
+//! so this integration binary can only observe one arm. It runs under the
+//! default arm (env unset): metrics on, span off (no OTLP exporter installed),
+//! reqlog gated on a registered consumer — which lets one test cover the
+//! consumer-off path and another the consumer-on path within the same process.
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    routing::get,
+};
+use helios_observability::{middleware::track, reqlog};
+use tower::ServiceExt; // for `oneshot`
+
+fn app() -> Router {
+    Router::new()
+        .route("/ping/{id}", get(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(track))
+}
+
+async fn call(uri: &str, tenant: Option<&str>) -> StatusCode {
+    let mut builder = Request::builder().uri(uri);
+    if let Some(t) = tenant {
+        builder = builder.header("x-tenant-id", t);
+    }
+    app()
+        .oneshot(builder.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+        .status()
+}
+
+#[tokio::test]
+async fn track_passes_request_through_and_records_metrics() {
+    // Default arm: the middleware runs its body (metrics are on) and forwards
+    // the request to the handler. No metrics recorder is installed, so the
+    // `metrics::` macros resolve to the global no-op recorder — the label-
+    // building code still executes, which is what we want covered.
+    assert_eq!(call("/ping/42", None).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn track_feeds_reqlog_once_a_consumer_is_registered() {
+    // Before enabling, the default arm leaves reqlog off; after `enable()` the
+    // middleware takes the tenant-extraction + reqlog-push path.
+    reqlog::enable();
+    assert!(reqlog::enabled());
+
+    assert_eq!(call("/ping/7", Some("obs-mw-tenant")).await, StatusCode::OK);
+
+    // The push should be visible in the ring buffer under the tenant we sent.
+    let stats = reqlog::snapshot(3600, Some("obs-mw-tenant"));
+    assert!(
+        stats.sample_count >= 1,
+        "an enabled reqlog must capture the request"
+    );
+}

--- a/crates/observability/tests/middleware_full.rs
+++ b/crates/observability/tests/middleware_full.rs
@@ -1,0 +1,36 @@
+//! Covers the span-enabled path of [`helios_observability::middleware::track`].
+//!
+//! The observability arm is a process-global `OnceLock` over `HELIOS_OBS_MODE`,
+//! so this lives in its own test binary and forces the `full` arm before any
+//! request is served. Under `full`, `span_enabled` is true regardless of
+//! whether a trace exporter is installed, so the request opens the tracing span
+//! and records the status onto it — the branch the default-arm test cannot reach.
+
+use axum::{Router, body::Body, http::Request, routing::get};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn track_opens_span_under_full_arm() {
+    // SAFETY: set before any other thread in this single-test binary reads the
+    // env; `mode()` caches on first use, which happens inside the request below.
+    unsafe {
+        std::env::set_var("HELIOS_OBS_MODE", "full");
+    }
+
+    let app = Router::new()
+        .route("/ping/{id}", get(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(
+            helios_observability::middleware::track,
+        ));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/ping/1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+}

--- a/crates/observability/tests/middleware_off.rs
+++ b/crates/observability/tests/middleware_off.rs
@@ -1,0 +1,36 @@
+//! Covers the zero-work fast path of [`helios_observability::middleware::track`].
+//!
+//! Own test binary so it can force the `off` arm before the process-global
+//! `mode()` caches. Under `off` every instrumentation flag is false, so `track`
+//! takes the early return that forwards the request without touching the
+//! `MatchedPath` extension, headers, or any allocation — the floor arm.
+
+use axum::{Router, body::Body, http::Request, routing::get};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn track_does_no_work_under_off_arm() {
+    // SAFETY: set before any other thread in this single-test binary reads the
+    // env; `mode()` caches on first use, which happens inside the request below.
+    unsafe {
+        std::env::set_var("HELIOS_OBS_MODE", "off");
+    }
+
+    let app = Router::new()
+        .route("/ping/{id}", get(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(
+            helios_observability::middleware::track,
+        ));
+
+    // Still forwards to the handler — the request just carries no instrumentation.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/ping/2")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+}


### PR DESCRIPTION
Addresses the **remaining** half of #227. PR #233 (merged) fixed symptom 1 (the EX02/EX08 expansion collapse). This PR targets symptom 2: the **uniform ~30% throughput drop** on both sqlite and postgres since v0.2.0.

## Two findings that reframed the work

1. **tx-benchmark's HEAD is `78bdffa`, dated 2026-05-27 — before v0.2.0 (2026-06-17).** The v0.2.0 baseline run and the current-main run therefore used *identical* benchmark definitions, so "benchmark-definition drift" (the issue's own medium-confidence caveat) is ruled out. The regression is our code.
2. **The benchmark builds a debug binary** (`cargo build -p helios-hts`, serves `target/debug/hts`, no `[profile]` override). So "~30%" is an opt-level-0 figure; the production tax is likely 2–4× smaller. Real, worth fixing, but not a number to quote as production impact.

## What this changes

Root-cause fixes (not benchmark dodges):

- **Demote the 18 `hts::probe` developer probes** from `info!` to `debug!` (12 in sqlite `value_set.rs`, 4 in `validate_code.rs`, 2 in `expand.rs`). At `HTS_LOG_LEVEL=info` these wrote a line per request through the global stdout lock on the hot expand/validate paths — each now also carrying the request span context. Leftover iteration-diagnosis scaffolding (one comment literally says *"Stripped after iter11 diagnosis"*). This hits **both** backends because the `validate_code`/`expand` probes are backend-agnostic.
- **Make probe string-building lazy** — the `VC_CACHE` key strings move inside the macro args, and sqlite's per-request `probe_url_short` is gated on `tracing::enabled!`, so nothing allocates when the probe target is off.
- **Gate the reqlog ring buffer on a registered consumer.** Only `hfs` mounts the console endpoints that read it; `hts` / `sof-server` / `fhirpath-server` now skip the process-global `Mutex<VecDeque>` push they never read.
- **Skip the per-request tracing span unless a layer actually exports it** (`telemetry::traces_live`). An unexported `info_span` is created and entered on every poll of the handler future for nothing.

## Attribution harness

`HELIOS_OBS_MODE = default | full | no-span | off` lets a **single** benchmark run price each component by toggling one env var, so the recovery can be attributed rather than guessed. The `hts-benchmark` workflow gains `obs_mode` / `log_directives` inputs and pins `tx-benchmark` to a SHA (overridable via `tx_benchmark_ref`) so comparisons are reproducible.

## Validation plan

- **CI** confirms it compiles (this could not be verified locally — the dev environment has no C linker).
- **Benchmark A/B matrix** on one runner, pinned tx-benchmark: `default` vs `full` vs `off` vs `log_directives=info,hts::probe=debug`. The delta between adjacent arms is each component's price. Baselines: v0.2.0 = run `27693178932`, post-#233 = `29023969774`.

## One behavioral change to note

Under the default arm without the `otel` feature, no `http.request` span is created, so fmt stdout logs lose request-span context. It is recoverable via the `full` arm or by enabling `otel`, and it is exactly the cost being removed — but flagging it for reviewers.

## Not forcing anything green

`reqlog::record` stays unconditional (the middleware is the gate), so the test that records directly still works untouched — **zero test changes**. If CI goes red, that is real signal to fix, not paper over.