### PR TITLE
ci(macos): drop `-undefined dynamic_lookup` from macOS linker flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,13 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-Wl,-dead_strip", "-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]' >> ~/.cargo/config.toml
+          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
+          # loadable-bundle linker mode, not valid for executables/test
+          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
+          # map against the shared cache ("syscall to map cache into shared
+          # region failed" -> SystemConfiguration.framework fails to load ->
+          # SIGABRT). Match the Linux side: only bump the main-thread stack.
+          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
 
       - name: Run tests with all features
         run: |
@@ -162,7 +168,13 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-Wl,-dead_strip", "-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]' >> ~/.cargo/config.toml
+          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
+          # loadable-bundle linker mode, not valid for executables/test
+          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
+          # map against the shared cache ("syscall to map cache into shared
+          # region failed" -> SystemConfiguration.framework fails to load ->
+          # SIGABRT). Match the Linux side: only bump the main-thread stack.
+          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
 
       - name: Build pysof wheel
         working-directory: crates/pysof
@@ -214,7 +226,13 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-Wl,-dead_strip", "-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]' >> ~/.cargo/config.toml
+          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
+          # loadable-bundle linker mode, not valid for executables/test
+          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
+          # map against the shared cache ("syscall to map cache into shared
+          # region failed" -> SystemConfiguration.framework fails to load ->
+          # SIGABRT). Match the Linux side: only bump the main-thread stack.
+          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -284,7 +302,13 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-Wl,-dead_strip", "-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]' >> ~/.cargo/config.toml
+          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
+          # loadable-bundle linker mode, not valid for executables/test
+          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
+          # map against the shared cache ("syscall to map cache into shared
+          # region failed" -> SystemConfiguration.framework fails to load ->
+          # SIGABRT). Match the Linux side: only bump the main-thread stack.
+          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
 
       - name: Install cargo-audit
         run: cargo install cargo-audit
@@ -378,7 +402,13 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-Wl,-dead_strip", "-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]' >> ~/.cargo/config.toml
+          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
+          # loadable-bundle linker mode, not valid for executables/test
+          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
+          # map against the shared cache ("syscall to map cache into shared
+          # region failed" -> SystemConfiguration.framework fails to load ->
+          # SIGABRT). Match the Linux side: only bump the main-thread stack.
+          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
@@ -752,7 +782,13 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-Wl,-dead_strip", "-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]' >> ~/.cargo/config.toml
+          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
+          # loadable-bundle linker mode, not valid for executables/test
+          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
+          # map against the shared cache ("syscall to map cache into shared
+          # region failed" -> SystemConfiguration.framework fails to load ->
+          # SIGABRT). Match the Linux side: only bump the main-thread stack.
+          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
 
       - name: Build Release (Windows)
         if: matrix.os == 'Windows'


### PR DESCRIPTION
## Problem

The macOS `test-rust` job (and other self-hosted-runner jobs) intermittently abort at **runtime** — not at compile time — with:

```
dyld cache '(null)' not loaded: syscall to map cache into shared region failed
dyld[…]: Library not loaded: /System/Library/Frameworks/SystemConfiguration.framework/…
  Reason: tried: '…/SystemConfiguration' (no such file, no dyld cache)
process didn't exit successfully: … (signal: 6, SIGABRT)
```

Observed on PR #244: https://github.com/HeliosSoftware/hfs/actions/runs/29596368102/job/87937639611

## Root cause

The "Configure Rust linker (macOS)" step wrote these rustflags into `~/.cargo/config.toml`:

```
["-C","link-arg=-Wl,-dead_strip","-C","link-arg=-undefined","-C","link-arg=dynamic_lookup"]
```

`-undefined dynamic_lookup` is a **loadable-bundle** linker mode — it is not valid for executables or test binaries. On Apple Silicon it yields Mach-O binaries dyld cannot map against the shared cache, which surfaces as `syscall to map cache into shared region failed`. That then cascades into "SystemConfiguration.framework not loaded", because that framework only exists **inside** the dyld shared cache on modern macOS — once the cache fails to map, any binary referencing it (here `helios-rest`, via `reqwest`) aborts with SIGABRT.

Introduced in `52ec228e6` ("Removed lld for macOS"). Linux and Windows link fine with no equivalent flag, confirming it was never needed.

## Fix

Replace the flags in all **6** jobs with just the 8 MB main-thread stack bump that mirrors the Linux config, and add a comment so the bad flag does not return:

```
rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]
```

## Note

This crash class can also appear intermittently on self-hosted Apple Silicon runners due to shared-region map exhaustion across many uniquely-signed binaries in a single boot. Removing the bad flag is the correct, highest-leverage fix; if sporadic "map cache into shared region failed" persists afterward, that points to runner-host state (cleared by a reboot), independent of this workflow bug.

https://claude.ai/code/session_01Vnu2A87mWaKnbeFuWZSwkd