### PR TITLE
ci(macos): drop `-stack_size` rustflag (breaks proc-macro dylib links)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,19 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
-          # loadable-bundle linker mode, not valid for executables/test
-          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
-          # map against the shared cache ("syscall to map cache into shared
-          # region failed" -> SystemConfiguration.framework fails to load ->
-          # SIGABRT). Match the Linux side: only bump the main-thread stack.
-          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
+          # No custom rustflags on macOS. Two flags that were tried here both
+          # broke the build:
+          #   * `-undefined dynamic_lookup` is a loadable-bundle linker mode,
+          #     invalid for executables/test binaries. On Apple Silicon it
+          #     yields Mach-O binaries dyld cannot map against the shared cache
+          #     ("syscall to map cache into shared region failed" ->
+          #     SystemConfiguration.framework fails to load -> SIGABRT).
+          #   * `-stack_size` is rejected by ld64 on any non-main-executable
+          #     link ("-stack_size option can only be used when linking a main
+          #     executable"), and cargo applies rustflags to proc-macro/cdylib
+          #     links too (e.g. serde_derive), so it fails the build outright.
+          # The main-thread stack already defaults to 8 MB on macOS, matching
+          # the Linux `-zstack-size=8388608`, so no override is needed.
 
       - name: Run tests with all features
         run: |
@@ -202,13 +208,19 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
-          # loadable-bundle linker mode, not valid for executables/test
-          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
-          # map against the shared cache ("syscall to map cache into shared
-          # region failed" -> SystemConfiguration.framework fails to load ->
-          # SIGABRT). Match the Linux side: only bump the main-thread stack.
-          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
+          # No custom rustflags on macOS. Two flags that were tried here both
+          # broke the build:
+          #   * `-undefined dynamic_lookup` is a loadable-bundle linker mode,
+          #     invalid for executables/test binaries. On Apple Silicon it
+          #     yields Mach-O binaries dyld cannot map against the shared cache
+          #     ("syscall to map cache into shared region failed" ->
+          #     SystemConfiguration.framework fails to load -> SIGABRT).
+          #   * `-stack_size` is rejected by ld64 on any non-main-executable
+          #     link ("-stack_size option can only be used when linking a main
+          #     executable"), and cargo applies rustflags to proc-macro/cdylib
+          #     links too (e.g. serde_derive), so it fails the build outright.
+          # The main-thread stack already defaults to 8 MB on macOS, matching
+          # the Linux `-zstack-size=8388608`, so no override is needed.
 
       - name: Build pysof wheel
         working-directory: crates/pysof
@@ -260,13 +272,19 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
-          # loadable-bundle linker mode, not valid for executables/test
-          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
-          # map against the shared cache ("syscall to map cache into shared
-          # region failed" -> SystemConfiguration.framework fails to load ->
-          # SIGABRT). Match the Linux side: only bump the main-thread stack.
-          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
+          # No custom rustflags on macOS. Two flags that were tried here both
+          # broke the build:
+          #   * `-undefined dynamic_lookup` is a loadable-bundle linker mode,
+          #     invalid for executables/test binaries. On Apple Silicon it
+          #     yields Mach-O binaries dyld cannot map against the shared cache
+          #     ("syscall to map cache into shared region failed" ->
+          #     SystemConfiguration.framework fails to load -> SIGABRT).
+          #   * `-stack_size` is rejected by ld64 on any non-main-executable
+          #     link ("-stack_size option can only be used when linking a main
+          #     executable"), and cargo applies rustflags to proc-macro/cdylib
+          #     links too (e.g. serde_derive), so it fails the build outright.
+          # The main-thread stack already defaults to 8 MB on macOS, matching
+          # the Linux `-zstack-size=8388608`, so no override is needed.
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -336,13 +354,19 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
-          # loadable-bundle linker mode, not valid for executables/test
-          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
-          # map against the shared cache ("syscall to map cache into shared
-          # region failed" -> SystemConfiguration.framework fails to load ->
-          # SIGABRT). Match the Linux side: only bump the main-thread stack.
-          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
+          # No custom rustflags on macOS. Two flags that were tried here both
+          # broke the build:
+          #   * `-undefined dynamic_lookup` is a loadable-bundle linker mode,
+          #     invalid for executables/test binaries. On Apple Silicon it
+          #     yields Mach-O binaries dyld cannot map against the shared cache
+          #     ("syscall to map cache into shared region failed" ->
+          #     SystemConfiguration.framework fails to load -> SIGABRT).
+          #   * `-stack_size` is rejected by ld64 on any non-main-executable
+          #     link ("-stack_size option can only be used when linking a main
+          #     executable"), and cargo applies rustflags to proc-macro/cdylib
+          #     links too (e.g. serde_derive), so it fails the build outright.
+          # The main-thread stack already defaults to 8 MB on macOS, matching
+          # the Linux `-zstack-size=8388608`, so no override is needed.
 
       - name: Install cargo-audit
         run: cargo install cargo-audit
@@ -436,13 +460,19 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
-          # loadable-bundle linker mode, not valid for executables/test
-          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
-          # map against the shared cache ("syscall to map cache into shared
-          # region failed" -> SystemConfiguration.framework fails to load ->
-          # SIGABRT). Match the Linux side: only bump the main-thread stack.
-          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
+          # No custom rustflags on macOS. Two flags that were tried here both
+          # broke the build:
+          #   * `-undefined dynamic_lookup` is a loadable-bundle linker mode,
+          #     invalid for executables/test binaries. On Apple Silicon it
+          #     yields Mach-O binaries dyld cannot map against the shared cache
+          #     ("syscall to map cache into shared region failed" ->
+          #     SystemConfiguration.framework fails to load -> SIGABRT).
+          #   * `-stack_size` is rejected by ld64 on any non-main-executable
+          #     link ("-stack_size option can only be used when linking a main
+          #     executable"), and cargo applies rustflags to proc-macro/cdylib
+          #     links too (e.g. serde_derive), so it fails the build outright.
+          # The main-thread stack already defaults to 8 MB on macOS, matching
+          # the Linux `-zstack-size=8388608`, so no override is needed.
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
@@ -816,13 +846,19 @@ jobs:
           rm -f ~/.cargo/config.toml
           echo '[target.aarch64-apple-darwin]' >> ~/.cargo/config.toml
           echo 'linker = "clang"' >> ~/.cargo/config.toml
-          # NOTE: do NOT pass `-undefined dynamic_lookup` here. That is a
-          # loadable-bundle linker mode, not valid for executables/test
-          # binaries. On Apple Silicon it yields Mach-O binaries dyld cannot
-          # map against the shared cache ("syscall to map cache into shared
-          # region failed" -> SystemConfiguration.framework fails to load ->
-          # SIGABRT). Match the Linux side: only bump the main-thread stack.
-          echo 'rustflags = ["-C", "link-arg=-Wl,-stack_size,0x800000"]' >> ~/.cargo/config.toml
+          # No custom rustflags on macOS. Two flags that were tried here both
+          # broke the build:
+          #   * `-undefined dynamic_lookup` is a loadable-bundle linker mode,
+          #     invalid for executables/test binaries. On Apple Silicon it
+          #     yields Mach-O binaries dyld cannot map against the shared cache
+          #     ("syscall to map cache into shared region failed" ->
+          #     SystemConfiguration.framework fails to load -> SIGABRT).
+          #   * `-stack_size` is rejected by ld64 on any non-main-executable
+          #     link ("-stack_size option can only be used when linking a main
+          #     executable"), and cargo applies rustflags to proc-macro/cdylib
+          #     links too (e.g. serde_derive), so it fails the build outright.
+          # The main-thread stack already defaults to 8 MB on macOS, matching
+          # the Linux `-zstack-size=8388608`, so no override is needed.
 
       - name: Build Release (Windows)
         if: matrix.os == 'Windows'


### PR DESCRIPTION
## Follow-up to #293

#293 removed `-undefined dynamic_lookup` (which caused the dyld `syscall to map cache into shared region failed` / SIGABRT crash) and replaced it with `-Wl,-stack_size,0x800000` to preserve the Linux side's 8 MB stack intent. That replacement introduced a **new** build failure on macOS:

```
ld: -stack_size option can only be used when linking a main executable
error: could not compile `serde_derive` (lib) due to 1 previous error
```

## Cause

`ld64` rejects `-stack_size` on any link target that isn't a **main executable**. Cargo applies `rustflags` to *every* link invocation — including proc-macro and cdylib crates like `serde_derive`, which link as `-dynamiclib`. So the flag fails the build before a single test runs. On Linux the equivalent `-zstack-size` is silently accepted for shared objects, which is why the same pattern was never a problem there.

## Fix

Drop the custom `rustflags` on macOS entirely. The macOS main-thread stack **already defaults to 8 MB** — the exact value the Linux side sets explicitly via `-zstack-size=8388608` — so no override is needed. (The `-stack_size` linker arg only affects the main thread anyway; `cargo test` runs tests on spawned worker threads, so it never influenced the test suite.)

The step now writes only `linker = "clang"` (the macOS default) plus a comment documenting both flags that must not come back.

## Verification

Confirmed on PR #244's runner: with #293 merged, the dyld crash is gone and the build now fails only on this `-stack_size` error — this PR removes that last flag. The same fix is already pushed to the #244 branch, which is re-running CI now.

https://claude.ai/code/session_01Vnu2A87mWaKnbeFuWZSwkd