### PR TITLE
fix(s3): stop tenant data being read as tenant registry records (#271)

### DIFF
--- a/crates/persistence/src/backends/s3/keyspace.rs
+++ b/crates/persistence/src/backends/s3/keyspace.rs
@@ -477,19 +477,33 @@ mod tests {
 
     /// Traversal in a tenant id cannot walk the registry key out of its
     /// namespace.
+    ///
+    /// What makes this safe is that `/` is escaped, so the id can never
+    /// contribute a separator and the key always stays a single leaf under
+    /// `tenants/`. A `..` surviving *within* that leaf is harmless: the leaf
+    /// always has `.json` appended, so no path segment is ever exactly `.` or
+    /// `..`, and S3 keys carry no path semantics anyway. Assert the property
+    /// that actually holds — one leaf, no separator — rather than the absence of
+    /// the characters.
     #[test]
     fn registry_key_cannot_be_escaped_by_traversal() {
         let ks = S3Keyspace::new(None);
-        for id in ["..", "../..", "a/../../b"] {
+        for id in ["..", ".", "../..", "a/../../b", "../../../etc/passwd"] {
             let key = ks.tenant_registry_key(id);
+            let leaf = key
+                .strip_prefix("tenants/")
+                .unwrap_or_else(|| panic!("{id:?} escaped the registry namespace: {key}"));
             assert!(
-                key.starts_with("tenants/"),
-                "{id:?} escaped the registry namespace: {key}"
+                !leaf.contains('/'),
+                "{id:?} injected a separator into the key: {key}"
             );
-            assert!(
-                !key.contains(".."),
-                "{id:?} left a traversal segment in the key: {key}"
-            );
+            // No path segment is ever a bare traversal token.
+            for segment in key.split('/') {
+                assert!(
+                    segment != ".." && segment != ".",
+                    "{id:?} produced a traversal segment: {key}"
+                );
+            }
         }
     }
 

--- a/crates/persistence/src/backends/s3/keyspace.rs
+++ b/crates/persistence/src/backends/s3/keyspace.rs
@@ -78,11 +78,49 @@ impl S3Keyspace {
     /// Key for a tenant's registry record — one JSON object per registered
     /// tenant. The registry spans tenants, so this is only meaningful on an
     /// un-tenanted keyspace (no `with_tenant_prefix`).
+    ///
+    /// The id is escaped with [`registry_object_id`], **not** [`sanitize`]: this
+    /// key establishes tenant identity and ownership, so a lossy mapping here
+    /// would let two tenants share one record (see that function's docs).
     pub fn tenant_registry_key(&self, tenant_id: &str) -> String {
+        self.join(&[
+            "tenants",
+            &format!("{}.json", registry_object_id(tenant_id)),
+        ])
+    }
+
+    /// The pre-fix key shape for a registry record, which escaped `/`, `\`, and
+    /// space to `_` via [`sanitize`] and so collided for ids differing only in
+    /// those characters.
+    ///
+    /// Read-only, for falling back to records written before the escaping fix so
+    /// an upgrade does not orphan them. Never write through this. Once existing
+    /// deployments have re-registered (or a backfill has run) this and its call
+    /// sites in `list_tenants`/`get_tenant`/`deregister_tenant` can be deleted.
+    pub fn legacy_tenant_registry_key(&self, tenant_id: &str) -> String {
         self.join(&["tenants", &format!("{}.json", sanitize(tenant_id))])
     }
 
     /// Prefix covering all tenant registry records.
+    ///
+    /// # Why tenant data cannot be mistaken for a registry record
+    ///
+    /// The guarantee is **structural, not lexical**, mirroring
+    /// [`user_settings_key`](Self::user_settings_key). A registry record sits
+    /// *directly* under this segment as a `{escaped-id}.json` leaf, whereas every
+    /// tenant-scoped key lives under a `resources/`, `history/`, or `bulk/`
+    /// **sub**-prefix of its tenant segment. So a tenant named `tenants` writes
+    /// `tenants/resources/…`, never a `tenants/{leaf}.json`.
+    ///
+    /// That invariant is only worth anything if the reader enforces it: S3
+    /// listings are recursive, so `list_tenants` must keep **direct children
+    /// only**. Before that filter existed a tenant named `tenants` injected
+    /// phantom rows into the registry and, once it accumulated a history event,
+    /// made `list_tenants` fail permanently (issue #271).
+    ///
+    /// Do **not** weaken this to "no tenant may be named `tenants`". The admin
+    /// API does reserve that name, but the JWT tenant extractor validates
+    /// nothing, so the safety of this namespace must not depend on it.
     pub fn tenant_registry_prefix(&self) -> String {
         self.join(&["tenants/"])
     }
@@ -325,4 +363,161 @@ fn sanitize(value: &str) -> String {
             _ => c,
         })
         .collect()
+}
+
+/// Escapes a tenant id into a single, injective S3 key segment.
+///
+/// Unlike [`sanitize`], distinct ids always produce distinct segments, so this
+/// is safe for a key that establishes identity. `%` is escaped first so the
+/// mapping stays reversible and no other escape can be forged; `/`, `\`, and
+/// space — the characters `sanitize` collapses — follow.
+///
+/// Percent-encoding rather than a hash (as `settings_object_id` uses) because a
+/// tenant id is validated and non-secret, and keeping the bucket greppable by
+/// tenant is worth more here than fixed-length keys. Ids reaching this point are
+/// length-capped upstream, so S3's 1024-byte key limit is not a concern.
+///
+/// Only `/` is reachable through the admin API's charset — `\` and space are
+/// already rejected there — so in practice this changes the key of exactly the
+/// hierarchical ids that were previously colliding.
+fn registry_object_id(tenant_id: &str) -> String {
+    let mut out = String::with_capacity(tenant_id.len());
+    for c in tenant_id.chars() {
+        match c {
+            '%' => out.push_str("%25"),
+            '/' => out.push_str("%2F"),
+            '\\' => out.push_str("%5C"),
+            ' ' => out.push_str("%20"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry key establishes tenant identity: ids that a lossy sanitiser
+    /// would collapse together must map to distinct objects. A collision here
+    /// lets one tenant read, overwrite, and deregister another's record.
+    #[test]
+    fn tenant_registry_key_is_injective_for_ids_a_sanitiser_would_collide() {
+        let ks = S3Keyspace::new(None);
+        // `sanitize()` maps '/', '\\', and ' ' all to '_', so these four collided.
+        let keys = [
+            ks.tenant_registry_key("a/b"),
+            ks.tenant_registry_key("a_b"),
+            ks.tenant_registry_key("a\\b"),
+            ks.tenant_registry_key("a b"),
+        ];
+        for (i, a) in keys.iter().enumerate() {
+            for b in keys.iter().skip(i + 1) {
+                assert_ne!(a, b, "registry keys must be injective");
+            }
+        }
+        // The escape itself must not be forgeable: a literal '%2F' cannot be
+        // made to collide with an encoded '/'.
+        assert_ne!(
+            ks.tenant_registry_key("a/b"),
+            ks.tenant_registry_key("a%2Fb")
+        );
+    }
+
+    /// Every registry record is a direct child of the registry prefix. This is
+    /// the invariant `list_tenants` relies on to tell records apart from the
+    /// data of a tenant that happens to be named `tenants` (issue #271).
+    #[test]
+    fn tenant_registry_keys_are_direct_children_of_the_registry_prefix() {
+        for base in [None, Some("hfs".to_string())] {
+            let ks = S3Keyspace::new(base);
+            let prefix = ks.tenant_registry_prefix();
+            for id in ["acme", "a/b", "tenants", "resources", "__system__", ".."] {
+                let key = ks.tenant_registry_key(id);
+                let rest = key
+                    .strip_prefix(&prefix)
+                    .expect("registry key must sit under the registry prefix");
+                assert!(
+                    !rest.contains('/'),
+                    "registry key for {id:?} must be a direct child, got {rest:?}"
+                );
+            }
+        }
+    }
+
+    /// A tenant whose id names the registry segment still writes its data one
+    /// or more segments deeper, so no key it can produce is mistaken for a
+    /// registry record. This is the structural half of the #271 fix — it holds
+    /// regardless of whether tenant-id validation ran.
+    #[test]
+    fn a_tenant_named_tenants_cannot_forge_a_registry_record() {
+        let base = S3Keyspace::new(None);
+        let prefix = base.tenant_registry_prefix();
+        let hostile = base.with_tenant_prefix("tenants");
+
+        let data_keys = [
+            hostile.current_resource_key("Patient", "p1"),
+            hostile.history_version_key("Patient", "p1", "1"),
+            hostile.history_system_prefix(),
+            hostile.resources_prefix(),
+            hostile.history_root_prefix(),
+        ];
+        for key in data_keys {
+            assert!(
+                key.starts_with(&prefix),
+                "precondition: hostile tenant data shares the registry prefix"
+            );
+            let rest = &key[prefix.len()..];
+            assert!(
+                rest.contains('/'),
+                "tenant data must be nested deeper than a registry record, got {rest:?}"
+            );
+        }
+    }
+
+    /// Traversal in a tenant id cannot walk the registry key out of its
+    /// namespace.
+    #[test]
+    fn registry_key_cannot_be_escaped_by_traversal() {
+        let ks = S3Keyspace::new(None);
+        for id in ["..", "../..", "a/../../b"] {
+            let key = ks.tenant_registry_key(id);
+            assert!(
+                key.starts_with("tenants/"),
+                "{id:?} escaped the registry namespace: {key}"
+            );
+            assert!(
+                !key.contains(".."),
+                "{id:?} left a traversal segment in the key: {key}"
+            );
+        }
+    }
+
+    /// The legacy key shape is what pre-fix records were written under, and is
+    /// read as a fallback. It must agree with the new shape for every id that
+    /// `sanitize` did not rewrite, so the fallback is a no-op for them.
+    #[test]
+    fn legacy_registry_key_differs_only_for_ids_sanitize_rewrote() {
+        let ks = S3Keyspace::new(None);
+        for id in [
+            "acme",
+            "acme-research",
+            "tenant_123",
+            "acme.org",
+            "__system__",
+        ] {
+            assert_eq!(
+                ks.tenant_registry_key(id),
+                ks.legacy_tenant_registry_key(id),
+                "unaffected id {id:?} must keep its existing key"
+            );
+        }
+        for id in ["a/b", "a\\b", "a b"] {
+            assert_ne!(
+                ks.tenant_registry_key(id),
+                ks.legacy_tenant_registry_key(id),
+                "previously-colliding id {id:?} must move to a new key"
+            );
+        }
+    }
 }

--- a/crates/persistence/src/backends/s3/storage.rs
+++ b/crates/persistence/src/backends/s3/storage.rs
@@ -785,13 +785,51 @@ impl ResourceStorage for S3Backend {
             if !item.key.ends_with(".json") {
                 continue;
             }
-            if let Some((record, _)) = self
+            // Registry records are direct children of the registry prefix; every
+            // tenant-scoped key is nested at least one segment deeper (see
+            // `S3Keyspace::tenant_registry_prefix`). S3 listings are recursive, so
+            // without this a tenant named `tenants` has its own resource and
+            // history objects read back as registry records (issue #271).
+            let Some(relative) = item.key.strip_prefix(&prefix) else {
+                continue;
+            };
+            if relative.contains('/') {
+                continue;
+            }
+            match self
                 .get_json_object::<crate::core::TenantRecord>(&location.bucket, &item.key)
-                .await?
+                .await
             {
-                out.push(record);
+                Ok(Some((record, _))) => out.push(record),
+                Ok(None) => {}
+                // Degrade per record only for a payload we cannot parse — a
+                // foreign object, a truncated write, a future schema change.
+                // One such object must not make the whole tenant list fail
+                // permanently, which is the unrecoverable half of #271.
+                //
+                // Transport and permission failures still propagate: silently
+                // dropping a tenant because S3 hiccuped would under-report the
+                // registry, which is worse than returning an error the caller
+                // can retry.
+                Err(StorageError::Backend(BackendError::SerializationError { message })) => {
+                    tracing::warn!(
+                        key = %item.key,
+                        error = %message,
+                        "skipping unparseable tenant registry record"
+                    );
+                }
+                Err(e) => return Err(e),
             }
         }
+        // A tenant registered before the `sanitize` fix and re-registered after it
+        // would have a record under both key shapes; report it once, keeping the
+        // earliest registration. Group by id first — `dedup_by` only collapses
+        // adjacent entries, and the display order below is by timestamp.
+        out.sort_by(|a, b| {
+            a.id.cmp(&b.id)
+                .then_with(|| a.created_at.cmp(&b.created_at))
+        });
+        out.dedup_by(|a, b| a.id == b.id);
         out.sort_by(|a, b| {
             a.created_at
                 .cmp(&b.created_at)
@@ -805,8 +843,22 @@ impl ResourceStorage for S3Backend {
             return Ok(None);
         };
         let key = location.keyspace.tenant_registry_key(id);
-        Ok(self
+        if let Some((record, _)) = self
             .get_json_object::<crate::core::TenantRecord>(&location.bucket, &key)
+            .await?
+        {
+            return Ok(Some(record));
+        }
+        // Fall back to the pre-escaping key so records written before the
+        // `sanitize` fix stay readable. Only ids containing `/`, `\`, or space
+        // differ between the two shapes, so this is a miss-only extra GET for
+        // every other tenant.
+        let legacy = location.keyspace.legacy_tenant_registry_key(id);
+        if legacy == key {
+            return Ok(None);
+        }
+        Ok(self
+            .get_json_object::<crate::core::TenantRecord>(&location.bucket, &legacy)
             .await?
             .map(|(record, _)| record))
     }
@@ -840,21 +892,31 @@ impl ResourceStorage for S3Backend {
         let location = self
             .registry_location()
             .ok_or_else(|| self.tenant_registry_unsupported())?;
+        // Delete both key shapes so deregistering a tenant registered before the
+        // `sanitize` fix actually removes its record. S3 deletes are silently
+        // idempotent, so probe each first to report whether anything was removed.
         let key = location.keyspace.tenant_registry_key(id);
-        // S3 deletes are silently idempotent; probe first so the caller can
-        // distinguish "removed" from "was never registered".
-        if self
-            .get_json_object::<crate::core::TenantRecord>(&location.bucket, &key)
-            .await?
-            .is_none()
-        {
-            return Ok(false);
+        let legacy = location.keyspace.legacy_tenant_registry_key(id);
+        let mut candidates = vec![key.clone()];
+        if legacy != key {
+            candidates.push(legacy);
         }
-        self.client
-            .delete_object(&location.bucket, &key)
-            .await
-            .map_err(|e| self.map_client_error(e))?;
-        Ok(true)
+        let mut removed = false;
+        for candidate in candidates {
+            if self
+                .get_json_object::<crate::core::TenantRecord>(&location.bucket, &candidate)
+                .await?
+                .is_none()
+            {
+                continue;
+            }
+            self.client
+                .delete_object(&location.bucket, &candidate)
+                .await
+                .map_err(|e| self.map_client_error(e))?;
+            removed = true;
+        }
+        Ok(removed)
     }
 
     async fn purge_tenant_data(&self, id: &str) -> StorageResult<u64> {

--- a/crates/persistence/src/backends/s3/storage.rs
+++ b/crates/persistence/src/backends/s3/storage.rs
@@ -857,10 +857,16 @@ impl ResourceStorage for S3Backend {
         if legacy == key {
             return Ok(None);
         }
+        // The legacy key is ambiguous: `sanitize` mapped `a/b` to `a_b`, which is
+        // also the *canonical* key of a tenant literally named `a_b`. So the key
+        // alone cannot establish ownership — the record body decides. Without
+        // this check the fallback would re-open the very cross-tenant read the
+        // escaping change closes.
         Ok(self
             .get_json_object::<crate::core::TenantRecord>(&location.bucket, &legacy)
             .await?
-            .map(|(record, _)| record))
+            .map(|(record, _)| record)
+            .filter(|record| record.id == id))
     }
 
     async fn register_tenant(
@@ -895,6 +901,12 @@ impl ResourceStorage for S3Backend {
         // Delete both key shapes so deregistering a tenant registered before the
         // `sanitize` fix actually removes its record. S3 deletes are silently
         // idempotent, so probe each first to report whether anything was removed.
+        //
+        // The probe is not just a nicety here: the legacy key is ambiguous —
+        // `sanitize` mapped `a/b` to `a_b`, which is also the *canonical* key of
+        // a tenant named `a_b` — so the record body must confirm ownership
+        // before deleting. Skipping that would make deregistering `a/b` silently
+        // destroy `a_b`'s registration.
         let key = location.keyspace.tenant_registry_key(id);
         let legacy = location.keyspace.legacy_tenant_registry_key(id);
         let mut candidates = vec![key.clone()];
@@ -903,11 +915,13 @@ impl ResourceStorage for S3Backend {
         }
         let mut removed = false;
         for candidate in candidates {
-            if self
+            let Some((record, _)) = self
                 .get_json_object::<crate::core::TenantRecord>(&location.bucket, &candidate)
                 .await?
-                .is_none()
-            {
+            else {
+                continue;
+            };
+            if record.id != id {
                 continue;
             }
             self.client

--- a/crates/persistence/src/backends/s3/tests.rs
+++ b/crates/persistence/src/backends/s3/tests.rs
@@ -1871,3 +1871,291 @@ async fn settings_key_respects_the_configured_global_prefix() {
     let stored = backend.get_settings("u1").await.unwrap().unwrap();
     assert_eq!(stored.document, json!({"theme": "dark"}));
 }
+
+// ---------------------------------------------------------------------------
+// Issue #271 — a tenant whose id names the registry namespace
+// ---------------------------------------------------------------------------
+
+/// A tenant named `tenants` writes under `tenants/resources/…`, which shares the
+/// registry's list prefix. Its resources must not be read back as registry
+/// records.
+#[tokio::test]
+async fn list_tenants_ignores_data_written_by_a_tenant_named_tenants() {
+    let mock = Arc::new(MockS3Client::with_buckets(&["test-bucket"]));
+    let backend = make_prefix_backend(mock);
+
+    let acme = backend.register_tenant("acme", None).await.unwrap();
+
+    let hostile = tenant("tenants");
+    backend
+        .create(
+            &hostile,
+            "Patient",
+            json!({"resourceType":"Patient","id":"p1","active":true}),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let listed = backend.list_tenants().await.unwrap();
+    assert_eq!(
+        listed,
+        vec![acme],
+        "a resource under `tenants/` must not surface as a registry record"
+    );
+}
+
+/// The permanent-failure half of #271: a history index event has no
+/// `created_at`, so deserializing it as a `TenantRecord` fails. That must skip
+/// the object, not abort the listing — otherwise the admin tenant list and the
+/// UI tenants page return 500 forever with no operator recovery path.
+#[tokio::test]
+async fn list_tenants_survives_history_events_under_the_registry_prefix() {
+    let mock = Arc::new(MockS3Client::with_buckets(&["test-bucket"]));
+    let backend = make_prefix_backend(mock);
+
+    let acme = backend.register_tenant("acme", None).await.unwrap();
+
+    // Create, update, and delete so both type- and system-level history index
+    // events exist under `tenants/history/…`.
+    let hostile = tenant("tenants");
+    let created = backend
+        .create(
+            &hostile,
+            "Patient",
+            json!({"resourceType":"Patient","id":"p1"}),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+    backend
+        .update(
+            &hostile,
+            &created,
+            json!({"resourceType":"Patient","id":"p1","active":true}),
+        )
+        .await
+        .unwrap();
+    backend.delete(&hostile, "Patient", "p1").await.unwrap();
+
+    let listed = backend
+        .list_tenants()
+        .await
+        .expect("history events under the registry prefix must not fail the listing");
+    assert_eq!(listed, vec![acme]);
+}
+
+/// A bucket already poisoned before the upgrade must recover on read alone.
+///
+/// The hostile objects are written *raw* through the mock client rather than via
+/// the backend API, so this keeps testing the real corrupted-bucket shape even if
+/// the registry is later relocated.
+#[tokio::test]
+async fn list_tenants_recovers_from_an_already_poisoned_bucket() {
+    let mock = Arc::new(MockS3Client::with_buckets(&["test-bucket"]));
+
+    // A resource object: deserializes cleanly into a TenantRecord (both `id` and
+    // `created_at` are present), so pre-fix it injected a phantom tenant row.
+    mock.put_object(
+        "test-bucket",
+        "tenants/resources/Patient/p1/current.json",
+        serde_json::to_vec(&json!({
+            "id": "p1",
+            "created_at": "2026-01-01T00:00:00Z",
+            "resource": {"resourceType": "Patient", "id": "p1"}
+        }))
+        .unwrap(),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // A history index event: no `created_at`, so pre-fix it hard-failed the call.
+    mock.put_object(
+        "test-bucket",
+        "tenants/history/system/1700000000000_Patient_p1_1_abc.json",
+        serde_json::to_vec(&json!({
+            "id": "p1",
+            "resource_type": "Patient",
+            "version_id": "1"
+        }))
+        .unwrap(),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let backend = make_prefix_backend(mock);
+    let acme = backend.register_tenant("acme", None).await.unwrap();
+
+    let listed = backend
+        .list_tenants()
+        .await
+        .expect("a poisoned bucket must recover on upgrade, without bucket surgery");
+    assert_eq!(listed, vec![acme]);
+}
+
+/// `sanitize()` mapped `/` to `_`, so `a/b` and `a_b` shared one registry
+/// object. That is a cross-tenant read and delete, not a cosmetic listing bug,
+/// so `get_tenant` and `deregister_tenant` are asserted too.
+#[tokio::test]
+async fn registry_distinguishes_ids_a_sanitiser_would_collide() {
+    let mock = Arc::new(MockS3Client::with_buckets(&["test-bucket"]));
+    let backend = make_prefix_backend(mock);
+
+    let slashed = backend
+        .register_tenant("a/b", Some("Slashed"))
+        .await
+        .unwrap();
+    let underscored = backend
+        .register_tenant("a_b", Some("Underscored"))
+        .await
+        .unwrap();
+
+    assert_eq!(backend.list_tenants().await.unwrap().len(), 2);
+
+    let got_slashed = backend.get_tenant("a/b").await.unwrap().unwrap();
+    let got_underscored = backend.get_tenant("a_b").await.unwrap().unwrap();
+    assert_eq!(got_slashed, slashed);
+    assert_eq!(got_underscored, underscored);
+    assert_eq!(got_slashed.display_name.as_deref(), Some("Slashed"));
+
+    // Deregistering one must leave the other intact.
+    assert!(backend.deregister_tenant("a/b").await.unwrap());
+    assert!(backend.get_tenant("a/b").await.unwrap().is_none());
+    assert_eq!(
+        backend.get_tenant("a_b").await.unwrap(),
+        Some(underscored),
+        "deregistering `a/b` must not remove `a_b`"
+    );
+}
+
+/// A record written under the pre-fix key shape stays readable after upgrade, so
+/// the escaping change does not orphan existing registrations.
+#[tokio::test]
+async fn registry_reads_records_written_under_the_legacy_key() {
+    let mock = Arc::new(MockS3Client::with_buckets(&["test-bucket"]));
+
+    // `a/b` as the old code would have written it: sanitized to `a_b.json`.
+    mock.put_object(
+        "test-bucket",
+        "tenants/a_b.json",
+        serde_json::to_vec(&json!({
+            "id": "a/b",
+            "display_name": "Legacy",
+            "created_at": "2026-01-01T00:00:00Z"
+        }))
+        .unwrap(),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let backend = make_prefix_backend(mock);
+
+    let found = backend
+        .get_tenant("a/b")
+        .await
+        .unwrap()
+        .expect("a pre-fix record must remain readable after upgrade");
+    assert_eq!(found.display_name.as_deref(), Some("Legacy"));
+
+    let listed = backend.list_tenants().await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, "a/b");
+
+    assert!(
+        backend.deregister_tenant("a/b").await.unwrap(),
+        "deregister must remove a record stored under the legacy key"
+    );
+    assert!(backend.get_tenant("a/b").await.unwrap().is_none());
+}
+
+/// Every sibling namespace of the registry, exercised end to end: writing data
+/// as a tenant with that name must never corrupt or fail the registry listing.
+#[tokio::test]
+async fn list_tenants_survives_tenants_named_after_control_plane_namespaces() {
+    for hostile_id in [
+        "tenants",
+        "resources",
+        "history",
+        "bulk",
+        "_system.user-settings",
+    ] {
+        let mock = Arc::new(MockS3Client::with_buckets(&["test-bucket"]));
+        let backend = make_prefix_backend(mock);
+
+        let acme = backend.register_tenant("acme", None).await.unwrap();
+
+        let hostile = tenant(hostile_id);
+        backend
+            .create(
+                &hostile,
+                "Patient",
+                json!({"resourceType":"Patient","id":"p1"}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        backend.delete(&hostile, "Patient", "p1").await.unwrap();
+
+        let listed = backend
+            .list_tenants()
+            .await
+            .unwrap_or_else(|e| panic!("tenant named {hostile_id:?} broke list_tenants: {e}"));
+        assert_eq!(
+            listed,
+            vec![acme.clone()],
+            "tenant named {hostile_id:?} corrupted the registry listing"
+        );
+    }
+}
+
+/// A malformed object sitting *directly* under the registry prefix — a foreign
+/// object, a truncated write, or a future schema change — must be skipped, not
+/// abort the listing. The direct-child filter cannot catch this one, so it is
+/// what keeps a single bad object from making the admin tenant list permanently
+/// unavailable.
+#[tokio::test]
+async fn list_tenants_skips_an_unreadable_record_instead_of_failing() {
+    let mock = Arc::new(MockS3Client::with_buckets(&["test-bucket"]));
+
+    // Well-formed JSON, but not a TenantRecord (no `created_at`).
+    mock.put_object(
+        "test-bucket",
+        "tenants/not-a-record.json",
+        serde_json::to_vec(&json!({"something": "else"})).unwrap(),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Not JSON at all.
+    mock.put_object(
+        "test-bucket",
+        "tenants/truncated.json",
+        b"{\"id\": \"half-writ".to_vec(),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let backend = make_prefix_backend(mock);
+    let acme = backend.register_tenant("acme", None).await.unwrap();
+
+    let listed = backend
+        .list_tenants()
+        .await
+        .expect("one unreadable record must not fail the whole listing");
+    assert_eq!(listed, vec![acme]);
+}

--- a/crates/rest/src/handlers/admin_tenants.rs
+++ b/crates/rest/src/handlers/admin_tenants.rs
@@ -40,6 +40,12 @@ use crate::state::AppState;
 /// into schema names / storage keys.
 const MAX_TENANT_ID_LEN: usize = 128;
 
+/// Tenant ids that name a control-plane namespace in a storage backend's
+/// keyspace. Currently the S3 sibling prefixes of `tenants/` (see
+/// `S3Keyspace`); `__system__` is checked separately as the shared-tenant
+/// sentinel.
+const RESERVED_TENANT_IDS: &[&str] = &["tenants", "resources", "history", "bulk"];
+
 /// Request body for `POST /admin/tenants`.
 #[derive(Debug, Deserialize)]
 pub struct CreateTenantBody {
@@ -103,6 +109,20 @@ fn validate_tenant_id(id: &str) -> RestResult<()> {
     if id == SYSTEM_TENANT {
         return Err(RestError::BadRequest {
             message: "'__system__' is reserved for internal shared resources".to_string(),
+        });
+    }
+    // Names that collide with a control-plane namespace in the S3 keyspace.
+    //
+    // Defense in depth and a UX guardrail only — it is *not* what makes the
+    // keyspace safe. The S3 backend is safe structurally (registry records are
+    // direct `{id}.json` children of `tenants/`, tenant data is always nested
+    // deeper), because this check is reachable from the admin API alone: the JWT
+    // tenant extractor validates nothing. See `S3Keyspace::tenant_registry_prefix`
+    // and issue #271 — do not conclude from this list that the reader-side filter
+    // is redundant.
+    if RESERVED_TENANT_IDS.contains(&id) {
+        return Err(RestError::BadRequest {
+            message: format!("'{id}' is reserved for internal use"),
         });
     }
     // Allow the characters that are safe across routing (header / URL prefix /

--- a/crates/rest/tests/admin_tenants.rs
+++ b/crates/rest/tests/admin_tenants.rs
@@ -138,6 +138,36 @@ async fn invalid_ids_are_rejected() {
     }
 }
 
+/// Ids naming a control-plane namespace are refused at creation (issue #271).
+///
+/// This is a guardrail, not the fix: the backend is safe structurally, because
+/// this check only covers the admin API and the JWT tenant extractor validates
+/// nothing.
+#[tokio::test]
+async fn control_plane_namespace_ids_are_reserved() {
+    let server = create_test_server().await;
+    for reserved in ["tenants", "resources", "history", "bulk"] {
+        let res = server
+            .post("/admin/tenants")
+            .json(&json!({ "id": reserved }))
+            .await;
+        res.assert_status(StatusCode::BAD_REQUEST);
+    }
+}
+
+/// Hierarchical ids stay valid — `TenantId` treats `/` as the hierarchy
+/// separator and `SharedSchemaStrategy` accepts `acme/research`. Tightening the
+/// charset here would contradict a shipped feature.
+#[tokio::test]
+async fn hierarchical_ids_are_still_accepted() {
+    let server = create_test_server().await;
+    server
+        .post("/admin/tenants")
+        .json(&json!({ "id": "acme/research" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+}
+
 #[tokio::test]
 async fn list_includes_data_only_tenants_with_counts() {
     let server = create_test_server().await;


### PR DESCRIPTION
Fixes the S3 tenant registry so a tenant whose id names a keyspace segment cannot corrupt or disable the registry listing.

## What was wrong

In `PrefixPerTenant` mode a tenant named `tenants` writes under the registry's own list prefix — `tenants/resources/…`, `tenants/history/…` — and `list_objects_all` is a flat, recursive listing. So `list_tenants()` read that tenant's data back as registry records:

- `tenants/resources/Patient/p1/current.json` deserializes **cleanly** into a `TenantRecord` (`StoredResource` has both `id` and `created_at`; `display_name` is `Option`), so a phantom tenant appeared in the admin list with an id the writer chose.
- A history index event has no `created_at`, so the `?` on the per-item deserialize aborted the whole call. `GET /admin/tenants` and the UI tenants page then returned **500 permanently**, from that tenant's first write onward, with no recovery short of deleting objects from the bucket.

## Approach

The fix is in the **reader**, not in tenant-id validation.

Registry records are `{id}.json` leaves directly under `tenants/`, while every tenant-scoped key is nested at least one segment deeper (`resources/`, `history/`, `bulk/`). I verified this holds for every key shape in `S3Keyspace`. So filtering to direct children is a **structural** guarantee, not a heuristic — and critically, it holds whether or not tenant-id validation ran. That matters because the admin API is only one of three ways a tenant id reaches storage; the JWT tenant extractor validates nothing.

This is the same argument the existing `user_settings_key` doc comment already makes for its namespace. I've documented it on `tenant_registry_prefix` in the same style, since it's the thing a future refactor would unknowingly break.

Two changes:

1. **Keep only direct children** of the registry prefix.
2. **Skip an unparseable record instead of failing the listing.** This is the durable half — it also covers truncated writes, foreign objects, and future schema drift. Transport and permission errors still propagate, because silently dropping a tenant when S3 hiccups would under-report the registry, which is worse than an error the caller can retry.

**Read-path only: no objects move, no migration, and an already-poisoned bucket recovers the moment it upgrades.**

## Second defect found while in here

`tenant_registry_key` escaped the id with `sanitize()`, which maps `/`, `\`, and space all to `_`. So tenants `a/b` and `a_b` **shared one registry object** — `get_tenant("a_b")` could return `a/b`'s record, and deregistering either removed both. `sanitize`'s own doc comment forbids precisely this use:

> Never use it to derive a key that establishes identity or ownership: two principals colliding on one key is a cross-user data leak.

Hierarchical ids are a first-class feature (`TenantId::is_descendant_of`), so this is reachable through supported behaviour, not an exotic name. Registry keys now use an injective percent-encoding.

Blast radius is small and bounded: only `/` is reachable through the admin charset (`\` and space are already rejected), so this moves exactly the ids that were already colliding. `get_tenant`/`deregister_tenant` fall back to the old key shape so an upgrade cannot orphan existing records, and `list_tenants` de-duplicates by id if both shapes exist.

**This is a separate commit (73584e8 covers both; the injectivity part is separable) — say the word and I'll split it out if you'd rather ship the #271 reader fix alone.**

## Scope decisions

- **Not** relocating the registry to a `_system.`-prefixed namespace. It would orphan every existing record and, because the admin handler unions registry with *discovered* tenants, would turn a loud 500 into a **silent** list of `registered: false` rows that an operator might not notice for days. There is also no S3 data-migration precedent in this repo. Worth doing as a follow-up with a real migration plan; not as the bug fix.
- **Not** banning `/` in tenant ids. `shared_schema.rs:433` asserts `acme/research` is valid and `TenantId` treats `/` as the hierarchy separator — that would contradict a shipped feature. A regression test now pins it.
- Reserved ids (`tenants`, `resources`, `history`, `bulk`) are added at the admin API as a guardrail and a clearer error, explicitly **not** as the fix. The comment says so, so nobody later concludes the reader-side filter is redundant.

## Other backends

The keyspace collision is **S3-only**. SQLite, Postgres, and Mongo keep the registry in a dedicated table/collection where a tenant id is a column value, never a namespace — no key derivation, nothing to collide. No schema migration is needed anywhere, so none was added.

## Tests

`keyspace.rs` had **zero** tests; it now has five, modelled on the existing `settings_object_id_is_injective_for_keys_a_sanitiser_would_collide` precedent:

- registry keys are injective for ids `sanitize` would collide, and the escape is not forgeable
- registry keys are direct children, with and without a base prefix
- a tenant named `tenants` cannot forge a registry record (asserts the structural invariant directly)
- traversal ids (`..`, `a/../../b`) cannot escape the namespace
- the legacy key shape is identical for every id `sanitize` did not rewrite, so the fallback is a no-op for them

Behavioural tests in `s3/tests.rs` (mock client, run unconditionally in CI — no containers or credentials):

- `list_tenants_ignores_data_written_by_a_tenant_named_tenants` — the phantom-row half
- `list_tenants_survives_history_events_under_the_registry_prefix` — the permanent-500 half; creates, updates, **and deletes** so both type- and system-level events exist
- `list_tenants_recovers_from_an_already_poisoned_bucket` — hostile objects written **raw through the mock**, not via the backend API, so it keeps testing the real corrupted-bucket shape even if the registry is later relocated
- `list_tenants_skips_an_unreadable_record_instead_of_failing` — a malformed object as a *direct* child, which the direct-child filter cannot catch; this is what actually exercises the skip-and-warn branch
- `registry_distinguishes_ids_a_sanitiser_would_collide` — asserts `get_tenant` and `deregister_tenant`, not just `list`, because the collision is a cross-tenant read/delete
- `registry_reads_records_written_under_the_legacy_key` — upgrade path
- `list_tenants_survives_tenants_named_after_control_plane_namespaces` — parameterized over `tenants`, `resources`, `history`, `bulk`, `_system.user-settings`

Plus REST tests for the reserved ids and for hierarchical ids still being accepted.

## Verification status — please read

**Nothing here has been compiled or run.** There is no C linker in my environment, so `cargo test` and `cargo check` cannot execute at all. `cargo fmt` passes, which confirms only that it parses. Every signature was matched by reading the source (I corrected one wrong `update()` call that way), but **CI is the first real check** and I would not merge this until it is green.

## Follow-ups I am not doing here

1. **`__system__` is reachable from the network.** `is_valid_tenant_id` (`resolver.rs:283`) allows alnum + `-` + `_`, so `__system__` passes it; `HeaderTenantExtractor` never consults the reserved-path list, and `JwtTenantExtractor` validates nothing. `X-Tenant-ID: __system__` therefore resolves to the shared system tenant, while the admin API carefully rejects that same id. Same shape as this bug, and it deserves its own issue — I'd treat it as higher priority than #271.
2. Three disagreeing tenant-id validators: routing rejects `.` and `/` at 64 chars, admin-create permits them at 128, JWT validates nothing. A tenant created as `a/b` today can never be routed to.
3. `RESERVED_SYSTEM_PATHS` is duplicated verbatim in `resolver.rs:18` and `tenant_prefix.rs:11`.
4. `database_per_tenant.rs:389` has the same non-injective `sanitize_tenant_id` pattern this PR fixes in S3.
5. Registry relocation under a single reserved namespace, with a real migration.

Closes #271
