### PR TITLE
fix(s3): disambiguate a missing bucket from a missing object on the HEAD paths (#284)

### DIFF
--- a/crates/persistence/src/backends/s3/client.rs
+++ b/crates/persistence/src/backends/s3/client.rs
@@ -1,6 +1,9 @@
 //! S3 API abstraction — trait definition, request/response types, AWS SDK
 //! client implementation, and SDK error mapping.
 
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+
 use async_trait::async_trait;
 use aws_config::{BehaviorVersion, Region, SdkConfig};
 use aws_sdk_s3::Client;
@@ -164,6 +167,19 @@ pub trait S3Api: Send + Sync {
 pub struct AwsS3Client {
     /// Underlying AWS SDK S3 client.
     client: Client,
+    /// Buckets this process has already proven to exist.
+    ///
+    /// A `HeadObject` returns a *bodyless* 404 for both a missing object and a
+    /// missing bucket, so `head_object` must confirm the bucket before it can
+    /// safely report an object as absent (see #284). That confirmation is a
+    /// second round-trip, so we cache the positive result: once a bucket is
+    /// known-good it stays that way for the process lifetime, and the probe is
+    /// skipped. Startup `validate_buckets` seeds this for every configured
+    /// bucket, so in the common configuration the probe never fires on the hot
+    /// path. Only *presence* is cached — a missing bucket is never remembered —
+    /// so this can only ever let us skip a redundant probe, never hide a
+    /// misconfigured store.
+    known_buckets: Arc<RwLock<HashSet<String>>>,
 }
 
 /// S3-compatible endpoint overrides for [`AwsS3Client`].
@@ -205,6 +221,29 @@ impl AwsS3Client {
         let s3_config = builder.build();
         Self {
             client: Client::from_conf(s3_config),
+            known_buckets: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    /// Returns `true` if this bucket has already been proven to exist during
+    /// this process's lifetime (startup validation or an earlier probe).
+    fn bucket_known_good(&self, bucket: &str) -> bool {
+        // A poisoned lock just means "not cached" — we re-probe rather than
+        // panic. The probe is correct on its own; the cache is only an
+        // optimisation, so degrading to it is always safe.
+        self.known_buckets
+            .read()
+            .map(|set| set.contains(bucket))
+            .unwrap_or(false)
+    }
+
+    /// Records that `bucket` exists, so later `head_object` 404s on it can skip
+    /// the disambiguating `HeadBucket` probe.
+    fn remember_bucket(&self, bucket: &str) {
+        if let Ok(mut set) = self.known_buckets.write() {
+            if !set.contains(bucket) {
+                set.insert(bucket.to_string());
+            }
         }
     }
 
@@ -230,7 +269,20 @@ impl S3Api for AwsS3Client {
             .bucket(bucket)
             .send()
             .await
-            .map_err(map_sdk_error)?;
+            .map_err(|err| match map_sdk_error(err) {
+                // A `HeadBucket` response is bodyless, so `map_sdk_error` sees no
+                // `<Code>` and falls through to `404 => NotFound`. But a
+                // `HeadBucket` 404 is unambiguous: there is no object in the
+                // request that could be the thing that is missing, so the only
+                // thing a 404 can mean is that the *bucket* is absent (or
+                // invisible to these credentials). Report it as such so
+                // `validate_buckets` names the bucket rather than a phantom
+                // "resource". A 403 stays `Unavailable` (access-denied is the
+                // common cause and must not be reported as a missing bucket).
+                S3ClientError::NotFound => S3ClientError::BucketNotFound(bucket.to_string()),
+                other => other,
+            })?;
+        self.remember_bucket(bucket);
         Ok(())
     }
 
@@ -247,14 +299,36 @@ impl S3Api for AwsS3Client {
             .send()
             .await
         {
-            Ok(out) => Ok(Some(ObjectMetadata {
-                etag: out.e_tag().map(|s| s.to_string()),
-                last_modified: None,
-                size: out.content_length().unwrap_or_default(),
-            })),
+            Ok(out) => {
+                // A successful HEAD proves the bucket exists; cache it so a
+                // later 404 on this bucket can skip the disambiguating probe.
+                self.remember_bucket(bucket);
+                Ok(Some(ObjectMetadata {
+                    etag: out.e_tag().map(|s| s.to_string()),
+                    last_modified: None,
+                    size: out.content_length().unwrap_or_default(),
+                }))
+            }
             Err(err) => {
                 let mapped = map_sdk_error(err);
                 if matches!(mapped, S3ClientError::NotFound) {
+                    // A bodyless HEAD 404 cannot carry `<Code>NoSuchBucket</Code>`,
+                    // so "missing object" and "missing bucket" are the same wire
+                    // signal here (#284). Reporting `Ok(None)` unconditionally would
+                    // let a typo'd or deleted bucket masquerade as an empty store —
+                    // exactly what the backend error contract forbids. Confirm the
+                    // bucket exists before concluding the object is merely absent.
+                    //
+                    // The probe is skipped once the bucket is known-good (from
+                    // startup validation or an earlier call), so it costs at most
+                    // one extra `HeadBucket` per bucket per process, not one per
+                    // request.
+                    if self.bucket_known_good(bucket) {
+                        return Ok(None);
+                    }
+                    // `head_bucket` returns `BucketNotFound` for a missing bucket
+                    // (propagated to the caller) and caches the bucket on success.
+                    self.head_bucket(bucket).await?;
                     Ok(None)
                 } else {
                     Err(mapped)

--- a/crates/persistence/src/backends/s3/tests.rs
+++ b/crates/persistence/src/backends/s3/tests.rs
@@ -185,27 +185,20 @@ impl MockS3Client {
 
 #[async_trait]
 impl S3Api for MockS3Client {
-    // NOTE: the two HEAD operations below deliberately do NOT report
-    // `BucketNotFound`, even though a missing bucket is exactly what they are up
-    // against. A HEAD response has no body, so real S3 cannot return
-    // `<Code>NoSuchBucket</Code>` on these paths — the SDK sees a bare 404 and
-    // synthesizes `NotFound`, which `map_sdk_error` maps to
-    // `S3ClientError::NotFound`. Making the mock answer `BucketNotFound` here
-    // would let it claim a distinction the real client cannot make, and these
-    // tests would then vouch for behaviour that does not exist in production.
-    //
-    // That gap is real and tracked in #284: `head_object` in `S3Client` swallows
-    // `NotFound` into `Ok(None)`, so a missing bucket still reads as a missing
-    // object on the `create` existence check and on the bulk-submit state read,
-    // and `validate_buckets` reports a missing bucket as "resource not found in
-    // S3". Until that is fixed, the mock stays honest about it rather than
-    // papering over it.
+    // The two HEAD operations below report `BucketNotFound` for a missing
+    // bucket, mirroring the real client after #284. A HEAD response is bodyless,
+    // so real S3 cannot tag it `<Code>NoSuchBucket</Code>` directly — but the
+    // real `AwsS3Client` now disambiguates anyway: `head_bucket` treats its own
+    // (unambiguous) 404 as `BucketNotFound`, and `head_object`, on a bodyless
+    // 404, issues a follow-up `HeadBucket` to tell a missing object apart from a
+    // missing bucket. So the mock is not inventing a distinction the real client
+    // lacks — it is modelling the outcome the real client now produces.
     async fn head_bucket(&self, bucket: &str) -> Result<(), S3ClientError> {
         let state = self.state.lock().unwrap();
         if state.buckets.contains(bucket) {
             Ok(())
         } else {
-            Err(S3ClientError::NotFound)
+            Err(S3ClientError::BucketNotFound(bucket.to_string()))
         }
     }
 
@@ -215,10 +208,13 @@ impl S3Api for MockS3Client {
         key: &str,
     ) -> Result<Option<ObjectMetadata>, S3ClientError> {
         let state = self.state.lock().unwrap();
-        // No bucket check: a missing bucket has no objects, so the lookup below
-        // already yields `Ok(None)` — which is exactly what `S3Client::head_object`
-        // produces against real S3, since it swallows the bodyless 404's
-        // `NotFound` into `Ok(None)`.
+        // A missing bucket is an error, never `Ok(None)`: the real client reaches
+        // this verdict via a follow-up `HeadBucket` on a bodyless 404; the mock
+        // reaches it directly from its in-memory bucket set. Either way, a
+        // misconfigured store must not read as an absent object.
+        if !state.buckets.contains(bucket) {
+            return Err(S3ClientError::BucketNotFound(bucket.to_string()));
+        }
         Ok(state
             .objects
             .get(&(bucket.to_string(), key.to_string()))
@@ -1371,12 +1367,13 @@ async fn purge_tenant_data_sweeps_resources_and_history() {
 // "this resource does not exist" — a store that is merely pointed at the wrong
 // place would look exactly like a store that is empty.
 //
-// Scope, so these tests are not read as more than they are: they cover the
-// operations that reach S3 via GET / PUT / LIST, whose error responses carry a
-// body and can therefore say `NoSuchBucket`. The HEAD paths cannot (#284) — see
-// the note on `MockS3Client::head_bucket` — so `create` below is covered only
-// because its `PutObject` fails, not because its `head_object` existence check
-// notices the missing bucket. It does not.
+// The GET / PUT / LIST paths tell the two apart from the error body's
+// `NoSuchBucket` code. The HEAD paths cannot — a HEAD response is bodyless — so
+// #284's fix has the real client disambiguate for itself: `head_bucket` treats
+// its own 404 as `BucketNotFound`, and `head_object` issues a follow-up
+// `HeadBucket` on a 404. The tests below therefore assert the existence checks
+// fail at the *check* (no write attempted), not merely because a later write
+// happens to fail.
 
 /// A `read` against a bucket that does not exist must error, not report the
 /// resource as absent.
@@ -1403,14 +1400,15 @@ async fn s3_missing_bucket_read_is_an_error_not_an_empty_store() {
 /// The same applies to writes and counts: they must not silently succeed or
 /// report zero against a bucket that isn't there.
 ///
-/// `create` fails at its `PutObject`, not at its `head_object` existence check —
-/// the check reports `Ok(None)` ("no such object, go ahead and create") because a
-/// bodyless HEAD 404 cannot say `NoSuchBucket`. The contract holds here, but by
-/// way of the write that follows rather than by the check noticing anything.
+/// `create` now fails at its `head_object` existence check, before any write:
+/// the check confirms the bucket and gets `BucketNotFound`, so no `PutObject` is
+/// ever attempted. The `put_count == 0` assertion is what distinguishes this
+/// from the old behaviour, where the check reported `Ok(None)` and the error
+/// only surfaced because the following write failed.
 #[tokio::test]
 async fn s3_missing_bucket_create_and_count_are_errors() {
     let mock = Arc::new(MockS3Client::default());
-    let backend = make_prefix_backend(mock);
+    let backend = make_prefix_backend(mock.clone());
     let tenant = tenant("tenant-a");
 
     let created = backend
@@ -1425,12 +1423,129 @@ async fn s3_missing_bucket_create_and_count_are_errors() {
         matches!(created, Err(StorageError::Backend(_))),
         "expected a backend error creating into a nonexistent bucket, got {created:?}"
     );
+    assert_eq!(
+        mock.put_count(),
+        0,
+        "create into a nonexistent bucket must fail at the existence check, not \
+         at a subsequent write — no PutObject should have been attempted"
+    );
 
     let counted = backend.count(&tenant, Some("Patient")).await;
     assert!(
         !matches!(counted, Ok(0)),
         "count against a nonexistent bucket returned Ok(0) — 'zero resources' is a \
          claim about data we never reached"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #284: a missing bucket must never masquerade as a missing object on the HEAD
+// paths. These pin the client seam (so the mock stays in step with the real
+// `AwsS3Client`) and both `head_object` existence-check callers. The real
+// client is exercised end-to-end against a live server in `minio_s3_tests.rs`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `head_object` against a bucket that does not exist is a bucket-level error,
+/// not `Ok(None)`. (Acceptance criterion 1.)
+#[tokio::test]
+async fn head_object_missing_bucket_is_bucket_not_found() {
+    let mock = MockS3Client::default();
+    let result = mock.head_object("test-bucket", "some-key").await;
+    assert!(
+        matches!(&result, Err(S3ClientError::BucketNotFound(b)) if b == "test-bucket"),
+        "head_object against a nonexistent bucket must surface BucketNotFound, got {result:?}"
+    );
+}
+
+/// A genuinely absent object in an existing bucket is still `Ok(None)` — the
+/// #284 fix must not turn an ordinary miss into an error.
+#[tokio::test]
+async fn head_object_absent_object_in_existing_bucket_is_ok_none() {
+    let mock = MockS3Client::with_buckets(&["test-bucket"]);
+    let result = mock.head_object("test-bucket", "absent-key").await;
+    assert!(
+        matches!(result, Ok(None)),
+        "an absent object in an existing bucket must remain Ok(None), got {result:?}"
+    );
+}
+
+/// A present object still reports its metadata — guards against the new bucket
+/// check short-circuiting a real hit.
+#[tokio::test]
+async fn head_object_present_object_is_ok_some() {
+    let mock = MockS3Client::with_buckets(&["test-bucket"]);
+    mock.put_object("test-bucket", "k", b"body".to_vec(), None, None, None)
+        .await
+        .expect("seed object");
+    let result = mock.head_object("test-bucket", "k").await;
+    assert!(
+        matches!(result, Ok(Some(_))),
+        "a present object must report Ok(Some(_)), got {result:?}"
+    );
+}
+
+/// `head_bucket` against a nonexistent bucket is `BucketNotFound`, so
+/// `validate_buckets` can name the bucket. (Underpins acceptance criterion 2.)
+#[tokio::test]
+async fn head_bucket_missing_is_bucket_not_found() {
+    let mock = MockS3Client::default();
+    let result = mock.head_bucket("test-bucket").await;
+    assert!(
+        matches!(&result, Err(S3ClientError::BucketNotFound(b)) if b == "test-bucket"),
+        "head_bucket against a nonexistent bucket must be BucketNotFound, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn head_bucket_existing_is_ok() {
+    let mock = MockS3Client::with_buckets(&["test-bucket"]);
+    assert!(mock.head_bucket("test-bucket").await.is_ok());
+}
+
+/// `validate_buckets` against a nonexistent bucket reports the bucket as
+/// missing, not "resource not found in S3". (Acceptance criterion 2.)
+#[tokio::test]
+async fn s3_validate_buckets_missing_bucket_is_bucket_flavored_error() {
+    let backend = make_prefix_backend(Arc::new(MockS3Client::default()));
+    let err = backend
+        .validate_buckets()
+        .await
+        .expect_err("validate_buckets must fail against a nonexistent bucket");
+    match &err {
+        StorageError::Backend(BackendError::Unavailable { message, .. }) => {
+            assert!(
+                message.contains("bucket"),
+                "expected a bucket-flavored message, got {message:?}"
+            );
+            assert!(
+                !message.contains("resource not found in S3"),
+                "validate_buckets must not report a missing bucket as a missing resource, \
+                 got {message:?}"
+            );
+        }
+        other => panic!("expected Backend(Unavailable), got {other:?}"),
+    }
+}
+
+/// The bulk-submit duplicate check (the second `head_object` existence-check
+/// caller) also errors at the *check* against a missing bucket, before writing
+/// any state. (Acceptance criterion 4, for `create_submission`.)
+#[tokio::test]
+async fn s3_bulk_submit_missing_bucket_errors_at_the_check() {
+    let mock = Arc::new(MockS3Client::default());
+    let backend = make_prefix_backend(mock.clone());
+    let tenant = tenant("tenant-a");
+    let id = SubmissionId::new("client-a", "sub-1");
+
+    let result = backend.create_submission(&tenant, &id, None).await;
+    assert!(
+        matches!(result, Err(StorageError::Backend(_))),
+        "create_submission into a nonexistent bucket must be a backend error, got {result:?}"
+    );
+    assert_eq!(
+        mock.put_count(),
+        0,
+        "the duplicate check must fail before any submission state is written"
     );
 }
 

--- a/crates/persistence/tests/minio_s3_tests.rs
+++ b/crates/persistence/tests/minio_s3_tests.rs
@@ -23,7 +23,9 @@ use helios_persistence::core::history::{
     HistoryParams, InstanceHistoryProvider, SystemHistoryProvider, TypeHistoryProvider,
 };
 use helios_persistence::core::{ResourceStorage, SettingsStore, VersionedStorage};
-use helios_persistence::error::{ConcurrencyError, ResourceError, SearchError, StorageError};
+use helios_persistence::error::{
+    BackendError, ConcurrencyError, ResourceError, SearchError, StorageError,
+};
 use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
 use helios_persistence::types::{CursorValue, PageCursor, Pagination, PaginationMode};
 use serde_json::json;
@@ -1109,4 +1111,106 @@ async fn test_minio_settings_concurrent_patches_never_lose_an_update() {
         );
     }
     assert_eq!(stored.version, writers as i64);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #284: a missing bucket must never read as an empty store on the real client.
+//
+// These are the end-to-end anchor for the mock-level tests in
+// `src/backends/s3/tests.rs`: they exercise the real `AwsS3Client` HEAD-path
+// disambiguation (a bodyless 404 → follow-up `HeadBucket`; a `HeadBucket` 404 →
+// `BucketNotFound`) against a genuine S3 API, so the mock cannot silently drift
+// from production behaviour. A dead-endpoint test (`backend_error_handling.rs`)
+// cannot cover this — it needs a responsive server whose configured bucket is
+// simply absent.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Builds an S3 backend pointed at a bucket that is deliberately never created.
+/// `validate_on_startup=false` lets construction succeed so the missing bucket
+/// is hit at operation time; `true` makes construction itself validate it.
+async fn make_absent_bucket_backend(validate_on_startup: bool) -> Result<S3Backend, StorageError> {
+    let shared = shared_minio().await;
+    ensure_backend_env_credentials(shared);
+
+    let bucket = format!("hfs-absent-{}", Uuid::new_v4().simple());
+    let config = S3BackendConfig {
+        tenancy_mode: S3TenancyMode::PrefixPerTenant { bucket },
+        prefix: Some(format!("integration/{}", Uuid::new_v4())),
+        region: Some("us-east-1".to_string()),
+        endpoint_url: Some(shared.endpoint_url.clone()),
+        force_path_style: true,
+        allow_http: true,
+        validate_buckets_on_startup: validate_on_startup,
+        ..Default::default()
+    };
+    S3Backend::from_env_async(config).await
+}
+
+/// Against a responsive server whose bucket is missing, `read`/`create`/`count`
+/// must error — never `Ok(None)` / `Ok(_)` / `Ok(0)`. This proves the real
+/// client's HEAD-path disambiguation (not just the mock's) refuses to let a
+/// misconfigured store masquerade as an empty one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_minio_missing_bucket_reads_and_writes_are_errors() {
+    if skip_if_disabled("test_minio_missing_bucket_reads_and_writes_are_errors") {
+        return;
+    }
+
+    let backend = make_absent_bucket_backend(false)
+        .await
+        .expect("construction must succeed when startup validation is off");
+    let tenant = tenant("minio-tenant-absent");
+
+    let read = backend.read(&tenant, "Patient", "some-id").await;
+    assert!(
+        matches!(read, Err(StorageError::Backend(_))),
+        "read against a missing bucket must be a backend error, not Ok(None): {read:?}"
+    );
+
+    let id = format!("p-{}", Uuid::new_v4());
+    let created = backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({"resourceType":"Patient","id":id}),
+            FhirVersion::default(),
+        )
+        .await;
+    assert!(
+        matches!(created, Err(StorageError::Backend(_))),
+        "create into a missing bucket must be a backend error: {created:?}"
+    );
+
+    let counted = backend.count(&tenant, Some("Patient")).await;
+    assert!(
+        !matches!(counted, Ok(0)),
+        "count against a missing bucket must not report zero resources: {counted:?}"
+    );
+}
+
+/// `validate_buckets` (via startup validation) reports a missing bucket as a
+/// bucket-level error, not "resource not found in S3" — exercising the real
+/// `head_bucket` → `BucketNotFound` mapping end to end.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_minio_validate_buckets_missing_bucket_is_bucket_flavored() {
+    if skip_if_disabled("test_minio_validate_buckets_missing_bucket_is_bucket_flavored") {
+        return;
+    }
+
+    let err = make_absent_bucket_backend(true)
+        .await
+        .expect_err("startup validation must fail against a missing bucket");
+    match &err {
+        StorageError::Backend(BackendError::Unavailable { message, .. }) => {
+            assert!(
+                message.contains("bucket"),
+                "expected a bucket-flavored message, got {message:?}"
+            );
+            assert!(
+                !message.contains("resource not found in S3"),
+                "a missing bucket must not be reported as a missing resource: {message:?}"
+            );
+        }
+        other => panic!("expected Backend(Unavailable), got {other:?}"),
+    }
 }


### PR DESCRIPTION
Closes #284. Stacked on #275 (`test/212-backend-error-contract`) — that PR introduced `S3ClientError::BucketNotFound` and the honest mock this builds on, so this targets that branch rather than `main`. Retarget to `main` once #275 merges.

## Problem

A HEAD response carries no body, so real S3 cannot tag it `<Code>NoSuchBucket</Code>`. The SDK sees a bare 404 and `map_sdk_error`'s status fallback (`404 => NotFound`) collapsed **both** "missing object" and "missing bucket" into `S3ClientError::NotFound` — which `head_object` swallows into `Ok(None)`. So a typo'd/deleted/invisible bucket read as an **empty store** on every existence check, and `validate_buckets` reported a missing bucket as `"resource not found in S3"`. #212/#275 fixed this for the body-bearing GET/PUT/LIST paths via the `NoSuchBucket` error *code*; the HEAD paths have no such code to read.

This was latent (each check happens to be followed by a write that fails correctly), but the safety rested on that coincidence — which the backend error contract forbids.

## Fix (all inside `AwsS3Client`; `S3Api` trait + callers unchanged)

- **`head_bucket`** maps its own bodyless 404 → `BucketNotFound`. A HeadBucket 404 is unambiguous (no object in the request could be the missing thing), so it needs no probe. A **403 stays `Unavailable`** — access-denied is the common cause and must not be reported as a missing bucket. *Fixes `validate_buckets` (acceptance #2).*
- **`head_object`**, on a bodyless 404, confirms the bucket with a follow-up `HeadBucket` before concluding the object is absent. A missing bucket now surfaces `BucketNotFound` **at the check**, so `create`/`create_submission` no longer depend on the subsequent write (acceptance #1, #4).
- **Bucket-existence cache** so the follow-up stays off the hot path (`create` 404s on every new resource). Startup `validate_buckets` seeds it for every configured bucket → in the default config the probe never fires per-request; with startup validation off it fires at most once per bucket per process. **Positive-only** — it can never hide a missing bucket, only skip a redundant probe.
- **`get_object` deliberately unchanged**: a GET error response carries a body, so a missing bucket already surfaces `NoSuchBucket` → `BucketNotFound` without a probe. The ambiguity is unique to the bodyless HEAD verb.

## "All DB" scope

Reviewed across backends: the body-less-404 ambiguity is **unique to S3**. SQLite (`QueryReturnedNoRows` vs coded errors), Postgres (SQLSTATE), MongoDB (server-selection errors), and Elasticsearch (`index_not_found_exception` vs transport failure) all already separate "misconfigured/unreachable store" from "absent resource" via structured codes — the broad contract (#212/#275) is already applied to each. No analogue change is needed elsewhere.

## Tests

- `MockS3Client`'s HEAD ops now mirror the fixed real client (missing bucket → `BucketNotFound`); the #284 notes documenting the old gap are removed. The mock earns the distinction because the real client can now make it too.
- **Unit:** client-seam variants (missing bucket → error; absent object in existing bucket still `Ok(None)`; present object still `Ok(Some)`); `validate_buckets` bucket-flavored message; `create`/`create_submission` failing at the check with **`put_count == 0`** (proves no write was attempted).
- **MinIO integration** (`RUN_MINIO_S3_TESTS=1`): the real client end-to-end against a responsive server with an absent bucket — the anchor that keeps the mock from drifting from production. `backend_error_handling.rs` covers only the dead-endpoint case, which cannot distinguish the two flavors.

## Acceptance criteria
- [x] `head_object` against a nonexistent bucket → bucket-level error, not `Ok(None)`
- [x] `validate_buckets` → "bucket not found"-flavored error, not "resource not found in S3"
- [x] `MockS3Client` HEAD ops mirror the real client; the #284 note is removed
- [x] `create`/`bulk_submit` existence checks no longer depend on a subsequent write

## Follow-up (out of scope, noted for a reviewer)
The bucket name currently reaches the client verbatim via `ServiceUnavailable` (503) — a pre-existing message-hygiene gap from #275's `BucketNotFound`, not introduced here. Worth scrubbing the client-facing body (log server-side) and reconsidering `transient` vs a non-retryable classification for a missing bucket. Left out to keep this change focused on the HEAD ambiguity.

## CI note
Base ≠ `main`, so this repo's CI does not run while stacked; verified locally as far as the toolchain allows (rustfmt clean; no C linker in this environment so compile/test run in CI once rebased on a CI-eligible base).