### PR TITLE
fix(ui,hfs): conformance self-fetch and seeding work on Elasticsearch-search composites

### DIFF
--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -899,9 +899,15 @@ async fn main() -> anyhow::Result<()> {
 /// populated for each valid tenant. A failed seed logs and boots anyway: the
 /// in-memory registry still resolves searches; only API discovery is degraded.
 ///
-/// Only the self-indexing standalone backends (SQLite/Postgres/MongoDB) seed;
-/// the S3 primary has no search index to seed.
-#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mongodb"))]
+/// Standalone backends seed themselves; Elasticsearch composites seed through
+/// the composite so the writes also reach the search index. Standalone S3 is
+/// the one deployment that skips seeding — it has no search index at all.
+#[cfg(any(
+    feature = "sqlite",
+    feature = "postgres",
+    feature = "mongodb",
+    feature = "elasticsearch"
+))]
 async fn seed_conformance_resources<S>(backend: &S, config: &ServerConfig)
 where
     S: helios_persistence::core::ResourceStorage,
@@ -930,7 +936,12 @@ where
 /// registered tenant. Tenants are provisioned-only, so this is the complete set
 /// of valid tenants. Falls back to just the default tenant when the backend has
 /// no tenant registry (e.g. a minimal deployment).
-#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mongodb"))]
+#[cfg(any(
+    feature = "sqlite",
+    feature = "postgres",
+    feature = "mongodb",
+    feature = "elasticsearch"
+))]
 async fn provisioned_tenants<S>(backend: &S, config: &ServerConfig) -> Vec<String>
 where
     S: helios_persistence::core::ResourceStorage,
@@ -1603,8 +1614,8 @@ async fn start_sqlite_elasticsearch(
     sqlite.set_search_offloaded(true);
     let sqlite = Arc::new(sqlite);
     info!("SQLite search indexing disabled (offloaded to Elasticsearch)");
-    // Seed/refresh on the primary; the ES backend shares its registry Arc.
-    seed_conformance_resources(&*sqlite, &config).await;
+    // Refresh reads from the primary; the ES backend shares its registry Arc.
+    // Seeding waits for the composite below, so the writes also index into ES.
     spawn_sqlite_search_param_refresh(sqlite.clone(), &config);
 
     // Build Elasticsearch configuration from server config
@@ -1698,6 +1709,11 @@ async fn start_sqlite_elasticsearch(
 
     let serve_audit_state = audit_state.clone();
     let composite = Arc::new(composite);
+
+    // Seed through the composite: the primary's own indexing is offloaded, so
+    // seeding it directly would leave the conformance resources unsearchable
+    // (empty /SearchParameter and /CompartmentDefinition, and empty UI viewers).
+    seed_conformance_resources(&*composite, &config).await;
 
     // The per-user settings store lives on the SQLite primary (Elasticsearch is
     // search-only), so it is wired from the underlying `sqlite` backend even
@@ -1854,8 +1870,8 @@ async fn start_postgres_elasticsearch(
     backend.set_search_offloaded(true);
     let pg = Arc::new(backend);
     info!("PostgreSQL search indexing disabled (offloaded to Elasticsearch)");
-    // Seed/refresh on the primary; the ES backend shares its registry Arc.
-    seed_conformance_resources(&*pg, &config).await;
+    // Refresh reads from the primary; the ES backend shares its registry Arc.
+    // Seeding waits for the composite below, so the writes also index into ES.
     spawn_postgres_search_param_refresh(pg.clone(), &config);
 
     // Build Elasticsearch configuration from server config
@@ -1949,6 +1965,10 @@ async fn start_postgres_elasticsearch(
     let serve_audit_state = audit_state.clone();
     let composite = Arc::new(composite);
 
+    // Seed through the composite: the primary's own indexing is offloaded, so
+    // seeding it directly would leave the conformance resources unsearchable.
+    seed_conformance_resources(&*composite, &config).await;
+
     // The per-user settings store lives on the PostgreSQL primary (Elasticsearch
     // is search-only), so it is wired from the underlying `pg` backend even
     // though the app is served over the composite storage.
@@ -2024,8 +2044,8 @@ async fn start_mongodb_elasticsearch(
     // Offload search to Elasticsearch
     let mongo = Arc::new(backend);
     info!("MongoDB search indexing disabled (offloaded to Elasticsearch)");
-    // Seed/refresh on the primary; the ES backend shares its registry Arc.
-    seed_conformance_resources(&*mongo, &config).await;
+    // Refresh reads from the primary; the ES backend shares its registry Arc.
+    // Seeding waits for the composite below, so the writes also index into ES.
     spawn_mongodb_search_param_refresh(mongo.clone(), &config);
 
     // Build Elasticsearch configuration from server config
@@ -2118,6 +2138,10 @@ async fn start_mongodb_elasticsearch(
 
     let serve_audit_state = audit_state.clone();
     let composite = Arc::new(composite);
+
+    // Seed through the composite: the primary's own indexing is offloaded, so
+    // seeding it directly would leave the conformance resources unsearchable.
+    seed_conformance_resources(&*composite, &config).await;
 
     // The per-user settings store lives on the MongoDB primary (Elasticsearch is
     // search-only), so it is wired from the underlying `mongo` backend even
@@ -2468,6 +2492,10 @@ async fn start_s3_elasticsearch(
 
     let serve_audit_state = audit_state.clone();
     let composite = Arc::new(composite);
+
+    // Seed through the composite so the conformance resources land in the S3
+    // primary and get indexed into Elasticsearch — the only search index here.
+    seed_conformance_resources(&*composite, &config).await;
 
     // The per-user settings store lives on the S3 primary (Elasticsearch is
     // search-only), so it is wired from the underlying `s3` backend even though

--- a/crates/ui/src/compartments.rs
+++ b/crates/ui/src/compartments.rs
@@ -72,16 +72,22 @@ impl CompartmentCatalog {
         if let Some(cached) = self.cache.lock().expect("compartment lock").get(&version) {
             return cached.clone();
         }
-        let mut defs: Vec<CompartmentDef> =
-            match self.source.fetch("CompartmentDefinition", version).await {
-                Ok(resources) => resources
-                    .into_iter()
-                    .filter_map(|r| serde_json::from_value(r).ok())
-                    .collect(),
-                Err(_) => Vec::new(),
-            };
+        let fetched = self.source.fetch("CompartmentDefinition", version).await;
+        let fetch_ok = fetched.is_ok();
+        let mut defs: Vec<CompartmentDef> = match fetched {
+            Ok(resources) => resources
+                .into_iter()
+                .filter_map(|r| serde_json::from_value(r).ok())
+                .collect(),
+            Err(_) => Vec::new(),
+        };
         defs.sort_by(|a, b| a.code.cmp(&b.code));
         let built = Arc::new(defs);
+        // A failed fetch is served empty for this request only — caching it
+        // would pin the page to the failure until restart.
+        if !fetch_ok {
+            return built;
+        }
         self.cache
             .lock()
             .expect("compartment lock")

--- a/crates/ui/src/conformance.rs
+++ b/crates/ui/src/conformance.rs
@@ -57,9 +57,12 @@ impl ConformanceSource for HttpConformanceSource {
         resource_type: &str,
         _version: FhirVersion,
     ) -> Result<Vec<Value>, String> {
-        // A single page large enough to hold the whole conformance set: the UI
-        // needs the full list for its facets and rail, and paginates in-memory.
-        let url = format!("{}/{}?_count=100000", self.base_url, resource_type);
+        // A single page large enough to hold the whole conformance set (~1.4k
+        // SearchParameters per version): the UI needs the full list for its
+        // facets and rail, and paginates in-memory. Capped at 10000 — the
+        // Elasticsearch max_result_window — so the search also succeeds on
+        // backends that delegate search to ES.
+        let url = format!("{}/{}?_count=10000", self.base_url, resource_type);
         let request = self
             .client
             .get(&url)

--- a/crates/ui/src/search_params.rs
+++ b/crates/ui/src/search_params.rs
@@ -53,6 +53,12 @@ impl SpCatalog {
             return cached.clone();
         }
         let built = Arc::new(fetch_snapshot(&*self.source, version).await);
+        // A failed fetch (`spec_loaded == false`) is served degraded for this
+        // request only — caching it would pin the page to the failure until
+        // restart.
+        if !built.spec_loaded {
+            return built;
+        }
         // Another task may have raced us here; keep whichever landed first.
         self.versions
             .lock()


### PR DESCRIPTION
Standalone extraction per #323 — three production bugs the browser suite (#290) uncovered, all present on main today. Any composite deployment with Elasticsearch as the search backend currently renders the SearchParameter and Compartment viewers empty.

1. **`_count` past ES's window**: the UI self-fetch asked for `_count=100000`, past Elasticsearch's `max_result_window` (10000), so the search failed on ES-search composites. Capped at 10000 (~1.4k rows exist per version).
2. **Failures cached forever**: both conformance catalogs cached a failed fetch until restart. A failed fetch is now served degraded for that request and retried on the next.
3. **Seeding never reached ES**: startup seeded the bare primary before the composite was assembled; with the primary's indexing offloaded, the resources were stored but never indexed (and `s3-elasticsearch` did not seed at all). Seeding now runs through the composite on all four ES composites.

Verified by the backend matrix on #290: `sqlite-elasticsearch` went red → green with these commits.

Closes #323.