### PR TITLE
ci: use 8.3 short path for Git Bash on Windows MinIO verify step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,14 @@ jobs:
       # so point Windows at Git Bash explicitly and keep plain `shell: bash` for
       # the Unix agents. The two steps run the identical script; exactly one fires
       # per run via the `runner.os` guard.
+      #
+      # The Windows path MUST use the 8.3 short name `C:\Progra~1` rather than
+      # `C:\Program Files`. The runner parses a custom `shell:` string by
+      # splitting on the FIRST space into (executable, args). A space inside the
+      # executable path splits it as ("C:\Program", "Files\...bash.exe ..."), and
+      # resolving that broken "C:\Program" fragment throws "Second path fragment
+      # must not be a drive or UNC name" before the script ever runs. The
+      # space-free short path avoids the mis-split entirely.
       - name: Verify S3 conditional writes against MinIO (per-user settings)
         if: runner.os != 'Windows'
         shell: bash
@@ -128,7 +136,7 @@ jobs:
           fi
       - name: Verify S3 conditional writes against MinIO (per-user settings) (Windows)
         if: runner.os == 'Windows'
-        shell: 'C:\Program Files\Git\bin\bash.exe --noprofile --norc -eo pipefail {0}'
+        shell: 'C:\Progra~1\Git\bin\bash.exe --noprofile --norc -eo pipefail {0}'
         env:
           RUN_MINIO_S3_TESTS: "1"
           EXPECTED_MINIO_SETTINGS_TESTS: "4"


### PR DESCRIPTION
## Problem

The **Test Rust** job's step *"Verify S3 conditional writes against MinIO (per-user settings) (Windows)"* fails on the self-hosted Windows agent before running a single line:

```
##[error]Second path fragment must not be a drive or UNC name. (Parameter 'expression')
```

Example failing run: https://github.com/HeliosSoftware/hfs/actions/runs/29833160253/job/88642676004

## Root cause

That step (added in `312de5a2f`) uses a custom shell:

```yaml
shell: 'C:\Program Files\Git\bin\bash.exe --noprofile --norc -eo pipefail {0}'
```

The Actions runner parses a custom `shell:` string by splitting on the **first space** into `(executable, args)`. The space in `Program Files` mis-parses the executable as `C:\Program`; the runner's `Which`-style resolution then `Path.Combine`s that drive-rooted `C:\Program` fragment, which throws the error above. The shell never launches.

## Fix

Use the space-free DOS 8.3 short path so the shell string splits cleanly:

```yaml
shell: 'C:\Progra~1\Git\bin\bash.exe --noprofile --norc -eo pipefail {0}'
```

Also expanded the adjacent comment to document *why* the short path is required, so it isn't reverted to `C:\Program Files` in a future edit. No other workflow step uses this pattern.

## Validation

YAML validates locally. The actual behavior can only be confirmed on the self-hosted Windows agent, so the real check is this PR's Windows CI run going green.