### PR TITLE
fix(sof): handle phantom FhirVersion variants from feature unification

### DIFF
--- a/crates/sof/src/lib.rs
+++ b/crates/sof/src/lib.rs
@@ -757,6 +757,16 @@ pub fn get_fhir_version_string() -> &'static str {
         helios_fhir::FhirVersion::R5 => "5.0.0",
         #[cfg(feature = "R6")]
         helios_fhir::FhirVersion::R6 => "6.0.0",
+        // A `FhirVersion` variant can exist without helios-sof enabling the
+        // matching feature: another crate in the build graph (e.g. helios-audit,
+        // whose R5/R6 features alias to helios-fhir/R4B for the BALP baseline)
+        // can turn on a helios-fhir version feature that helios-sof did not.
+        // `newest_version` always comes from helios-sof's own features, so this
+        // arm is genuinely unreachable at runtime.
+        #[allow(unreachable_patterns)]
+        _ => unreachable!(
+            "get_newest_enabled_fhir_version only returns versions enabled for helios-sof"
+        ),
     }
 }
 
@@ -1042,6 +1052,14 @@ pub fn parse_view_definition_for_version(
                 })?;
             Ok(SofViewDefinition::R6(view_def))
         }
+        // The requested `FhirVersion` variant may exist (because another crate
+        // enabled a helios-fhir version feature) while helios-sof was not built
+        // with support for it. Report that rather than failing to compile.
+        #[allow(unreachable_patterns)]
+        _ => Err(SofError::InvalidViewDefinition(format!(
+            "helios-sof was not compiled with support for FHIR version {:?}",
+            version
+        ))),
     }
 }
 
@@ -1100,6 +1118,13 @@ pub fn create_bundle_from_resources_for_version(
                 })?;
             Ok(SofBundle::R6(bundle))
         }
+        // See the note in `parse_view_definition_for_version`: the variant can
+        // exist without helios-sof having the matching feature enabled.
+        #[allow(unreachable_patterns)]
+        _ => Err(SofError::InvalidViewDefinition(format!(
+            "helios-sof was not compiled with support for FHIR version {:?}",
+            version
+        ))),
     }
 }
 
@@ -2320,6 +2345,13 @@ fn parse_json_to_fhir_resource(
                 })?;
             Ok(helios_fhir::FhirResource::R6(Box::new(resource)))
         }
+        // See the note in `parse_view_definition_for_version`: the variant can
+        // exist without helios-sof having the matching feature enabled.
+        #[allow(unreachable_patterns)]
+        _ => Err(SofError::InvalidSourceContent(format!(
+            "helios-sof was not compiled with support for FHIR version {:?}",
+            version
+        ))),
     }
 }
 


### PR DESCRIPTION
## Problem

The CI job **Build HTS binary (sqlite / R5)** ([failed run](https://github.com/HeliosSoftware/hfs/actions/runs/29800186645/job/88540020767)) fails to compile `helios-sof` with four `E0004` non-exhaustive-match errors:

```
error[E0004]: non-exhaustive patterns: `FhirVersion::R4B` not covered
  --> crates/sof/src/lib.rs:751 / 1012 / 1070 / 2290
```

## Root cause

The job builds:

```
cargo build -p helios-hts --no-default-features --features "sqlite,R5"
```

`helios-audit`'s `R5` feature deliberately aliases to `R4B` (`R5 = ["helios-fhir/R5", "R4B"]`) so BALP AuditEvents use the R4-family model. Through Cargo's global **feature unification**, this enables `helios-fhir/R4B` across the whole build graph — so the `FhirVersion::R4B` enum variant exists everywhere.

But `helios-sof` only receives its own `R5` feature (via `helios-persistence`), so its `#[cfg(feature = "R4B")]` match arms are compiled out. The variant exists with no arm to cover it → the build breaks.

## Fix

Add a catch-all arm to each of the four version matches in `crates/sof/src/lib.rs`, each marked `#[allow(unreachable_patterns)]` so it stays silent (no warning under `-D warnings`) when `helios-sof` *does* have all version features enabled (workspace / `--all-features` builds):

- `get_fhir_version_string` → `unreachable!()`, since its input always comes from `get_newest_enabled_fhir_version()`, which only returns sof's own enabled versions.
- The three fallible parsers → return a `SofError` reporting that sof was not compiled with support for that version.

The fix is robust to the same phantom-variant divergence for any FHIR version, not just R4B.

## Verification

- `cargo build -p helios-hts --no-default-features --features "sqlite,R5"` → builds to Finished (was failing).
- `cargo build -p helios-sof --features "R4,R4B,R5,R6"` → no `unreachable_patterns` warning.
- `cargo build -p helios-sof --features "R4B"` → clean.