### PR TITLE
fix(hts): name accepted $translate spellings in the missing-concept 400 (#288)

### DIFF
--- a/crates/hts/src/operations/translate.rs
+++ b/crates/hts/src/operations/translate.rs
@@ -104,9 +104,16 @@ pub(crate) async fn process_translate<B: TerminologyBackend>(
     }
 
     // Need at least one of source code (forward) or target code (reverse).
+    // Name every accepted spelling so a client that sent a valid-but-unread
+    // shape (e.g. the R5 `sourceCoding`) can self-correct — the old message
+    // listed only the scalar forms and gave no hint the Coding/CodeableConcept
+    // spellings this handler accepts even exist. See #288.
     if source_code.is_none() && target_code.is_none() {
         return Err(HtsError::InvalidRequest(
-            "Missing required parameter: code or sourceCode (or targetCode for reverse)".into(),
+            "Missing source concept: provide code (with system), coding, or codeableConcept \
+             (R5 aliases sourceCode/sourceSystem, sourceCoding, sourceCodeableConcept accepted); \
+             for a reverse translation supply targetCode, targetCoding, or targetCodeableConcept"
+                .into(),
         ));
     }
 
@@ -704,6 +711,48 @@ mod tests {
 
         let resp = post_json(app, "/ConceptMap/$translate", body).await;
         assert_eq!(resp.status(), 400);
+    }
+
+    /// When no source concept is supplied, the 400 OperationOutcome must name
+    /// every accepted spelling — including the Coding/CodeableConcept ones — so a
+    /// client that sent a spec-legal-but-unread shape (e.g. R5 `sourceCoding`) has
+    /// a hint about what HTS accepts. Regression test for #288: the old message
+    /// listed only `code`/`sourceCode`/`targetCode`. Assert substring-contains per
+    /// spelling (not exact-equality) so rewording the prose doesn't spuriously
+    /// break CI while still guaranteeing each alias stays discoverable.
+    #[tokio::test]
+    async fn translate_missing_code_diagnostics_names_accepted_spellings() {
+        let app = make_app();
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "system", "valueUri": "http://example.org/src"}
+            ]
+        });
+
+        let resp = post_json(app, "/ConceptMap/$translate", body).await;
+        assert_eq!(resp.status(), 400);
+
+        let json = body_json(resp).await;
+        assert_eq!(json["resourceType"], "OperationOutcome");
+        assert_eq!(json["issue"][0]["code"], "invalid");
+        let diag = json["issue"][0]["diagnostics"]
+            .as_str()
+            .expect("diagnostics string");
+        for spelling in [
+            "sourceCoding",
+            "coding",
+            "sourceCodeableConcept",
+            "codeableConcept",
+            "sourceCode",
+            "targetCoding",
+            "targetCode",
+        ] {
+            assert!(
+                diag.contains(spelling),
+                "diagnostics must name the accepted `{spelling}` spelling, got: {diag}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes the residual gap in #288. The issue's headline complaint — `ConceptMap/$translate` rejecting the R5-spec `sourceCoding` parameter (and the R4-era `coding`), accepting only `code`+`system` — **was already resolved on `main` by #287** (commit `472cace42`). `process_translate` now accepts `code`/`coding`/`codeableConcept`, their R5 `source*` aliases, and the `target*` forms, with tests. That covers proposed-work items 1, 2, and 4.

This PR is the finishing touch: **item 3** — *"make the `OperationOutcome` name the parameters that are accepted."*

### Before

```
Missing required parameter: code or sourceCode (or targetCode for reverse)
```

A client that sent a spec-legal `sourceCoding` and still got a 400 saw a message that never mentioned `sourceCoding` (or `coding`, or `codeableConcept`) — no hint that a supported alternative existed.

### After

```
Missing source concept: provide code (with system), coding, or codeableConcept
(R5 aliases sourceCode/sourceSystem, sourceCoding, sourceCodeableConcept accepted);
for a reverse translation supply targetCode, targetCoding, or targetCodeableConcept
```

The message now enumerates every spelling the handler actually accepts, grouped by shape.

## Scope

- **Pure in-handler change.** Only the `HtsError::InvalidRequest` diagnostics string in `process_translate` changes. `process_translate` is the single shared entry point for the POST, GET, and instance-level (`/ConceptMap/{id}/$translate`) handlers, so one edit covers every route.
- **No backend/DB code touched** — nothing in `backends/{sqlite,postgres}` or the persistence layer is affected, so there is no per-database work to replicate.
- Deliberately does **not** re-touch the acceptance logic (`coding_pair`, the scalar-wins precedence) or the existing tests from #287.

## Test

Adds `translate_missing_code_diagnostics_names_accepted_spellings`, which asserts the 400 `OperationOutcome` (`issue[0].code == "invalid"`) and that its `diagnostics` names each accepted spelling. Uses substring-contains rather than exact-equality so rewording the prose can't spuriously break CI while still guaranteeing no accepted alias is silently dropped.

> Note: built and formatted locally; the test suite is validated in CI (this dev environment has no C linker).

## Refs

- Item 3 of #288.
- Acceptance fix already merged: #287 (`472cace42`).
- Related: #183 / #184 (migration off public `tx.fhir.org` onto our own HTS).
