### PR TITLE
fix(hts): incremental sqlite concept FTS (stop full rebuild on every boot) (#295)

### DIFF
--- a/crates/hts/src/backends/sqlite/mod.rs
+++ b/crates/hts/src/backends/sqlite/mod.rs
@@ -369,29 +369,24 @@ impl SqliteTerminologyBackend {
             // per-code-system when new data is imported (see
             // fhir_bundle::write_code_system).
             if prebuild_fts {
-                // Clear the concept FTS index — it is always rebuilt
-                // synchronously by prebuild_concepts_fts below, so stale rows
-                // from a previous run must be removed first.
-                let _ = conn.execute_batch(
-                    "DELETE FROM concepts_fts;
-                     DELETE FROM concepts_fts_built;
-                     DELETE FROM concepts_word_fts;
-                     DELETE FROM concepts_search_fts;",
-                );
-
-                // Update query-planner statistics for large tables.
-                let _ = conn.execute_batch(
-                    "ANALYZE concept_hierarchy; ANALYZE concepts; ANALYZE concept_closure; \
-                     ANALYZE concept_properties; ANALYZE concept_designations; \
-                     ANALYZE code_systems; ANALYZE value_sets; ANALYZE concept_maps;",
-                );
-
-                // Pre-populate the concepts_fts trigram index for every code
-                // system so that text-filtered $expand requests always use the
-                // fast FTS path. This runs synchronously before the server
-                // accepts requests; for large systems (SNOMED 638K, LOINC 181K)
-                // it can take 10–25 s total.
-                value_set::prebuild_concepts_fts(&conn);
+                // Incrementally build the concepts_fts trigram index for any
+                // system not already tracked in concepts_fts_built (issue #295).
+                // No blanket wipe: per-system invalidation on (re)import keeps
+                // the tracker authoritative, so this only builds what is
+                // genuinely missing and is a no-op on a warm reopen. For a first
+                // load of large systems (SNOMED 638K, LOINC 181K) it still
+                // tokenises the full corpus once. Runs synchronously before the
+                // server accepts requests.
+                let built = value_set::prebuild_concepts_fts(&conn);
+                if built > 0 {
+                    // Update query-planner statistics only when a build ran;
+                    // stats persist on disk across reopens.
+                    let _ = conn.execute_batch(
+                        "ANALYZE concept_hierarchy; ANALYZE concepts; ANALYZE concept_closure; \
+                         ANALYZE concept_properties; ANALYZE concept_designations; \
+                         ANALYZE code_systems; ANALYZE value_sets; ANALYZE concept_maps;",
+                    );
+                }
 
                 // Pre-warm the in-memory concept index from any implicit-expansion
                 // entries that are already persisted in implicit_expansion_cache.
@@ -442,9 +437,12 @@ impl SqliteTerminologyBackend {
     ///    `migrate_concept_closure` only touches systems that have hierarchy
     ///    edges but no closure rows, so unchanged systems cost nothing while a
     ///    re-imported SNOMED/LOINC system is rebuilt.
-    /// 2. Clears and rebuilds the `concepts_fts` index on the final data and
-    ///    refreshes the in-memory implicit/inline-compose indexes and planner
-    ///    statistics.
+    /// 2. Incrementally builds the `concepts_fts` index for any system not yet
+    ///    recorded in `concepts_fts_built` (missing or invalidated by a
+    ///    bootstrap re-import), and refreshes the in-memory
+    ///    implicit/inline-compose indexes — plus planner statistics only when a
+    ///    build actually ran. Unchanged systems cost nothing, so a warm restart
+    ///    does no FTS work before the server binds (issue #295).
     ///
     /// # Errors
     ///
@@ -463,20 +461,22 @@ impl SqliteTerminologyBackend {
             HtsError::StorageError(format!("Failed to rebuild concept closure: {e}"))
         })?;
 
-        // Rebuild FTS + planner stats on the final data. Mirrors the block in
-        // `new_inner` that is skipped under `new_without_fts_prebuild`.
-        let _ = conn.execute_batch(
-            "DELETE FROM concepts_fts;
-             DELETE FROM concepts_fts_built;
-             DELETE FROM concepts_word_fts;
-             DELETE FROM concepts_search_fts;",
-        );
-        let _ = conn.execute_batch(
-            "ANALYZE concept_hierarchy; ANALYZE concepts; ANALYZE concept_closure; \
-             ANALYZE concept_properties; ANALYZE concept_designations; \
-             ANALYZE code_systems; ANALYZE value_sets; ANALYZE concept_maps;",
-        );
-        value_set::prebuild_concepts_fts(&conn);
+        // Incrementally (re)build FTS for exactly the systems whose index is
+        // missing or was invalidated by a bootstrap re-import — NOT a blanket
+        // wipe + full rebuild on every boot (issue #295). When nothing changed
+        // (a warm restart, or an `hts import`-prepared DB) this is a near-instant
+        // no-op, so the server binds without re-tokenising the whole corpus.
+        // Only refresh planner statistics when we actually built something:
+        // ANALYZE stats persist on disk across restarts, so a no-op boot needs
+        // none.
+        let built = value_set::prebuild_concepts_fts(&conn);
+        if built > 0 {
+            let _ = conn.execute_batch(
+                "ANALYZE concept_hierarchy; ANALYZE concepts; ANALYZE concept_closure; \
+                 ANALYZE concept_properties; ANALYZE concept_designations; \
+                 ANALYZE code_systems; ANALYZE value_sets; ANALYZE concept_maps;",
+            );
+        }
         value_set::prebuild_implicit_index(&conn, &self.implicit_index);
         value_set::prebuild_inline_compose_index(&conn, &self.inline_compose_index);
         Ok(())

--- a/crates/hts/src/backends/sqlite/value_set.rs
+++ b/crates/hts/src/backends/sqlite/value_set.rs
@@ -8569,23 +8569,65 @@ fn populate_implicit_cache(
         .map_err(|e| HtsError::StorageError(e.to_string()))
 }
 
-/// Pre-populate `concepts_fts` for every code system currently in the DB.
+/// Incrementally populate the concept FTS indexes for every code system that is
+/// not yet recorded in `concepts_fts_built`. Systems already tracked are skipped
+/// entirely, so a warm restart — or a server start after `hts import` /
+/// `HTS_BOOTSTRAP_DIR` already built the index — does zero rebuild work instead
+/// of re-tokenising the whole corpus on every boot (issue #295). Returns the
+/// number of concept rows newly indexed (`0` = nothing needed building).
 ///
-/// Called once at server startup (after clearing `concepts_fts`) so that
-/// filtered `$expand` requests always use the fast FTS path rather than
-/// triggering a blocking per-system build on the first filtered request.
-/// Uses a single bulk INSERT inside one transaction — much faster than
-/// building per-system (1 transaction per system × 1217 systems would take
-/// several minutes; the bulk approach finishes in under 30 s).
-pub(crate) fn prebuild_concepts_fts(conn: &Connection) {
+/// # Invariant
+///
+/// `concepts_fts_built` contains a system's row **iff** that system's rows in
+/// all three FTS tables (`concepts_fts`, `concepts_word_fts`,
+/// `concepts_search_fts`) are current for its concepts and designations. This
+/// function only ever *adds* untracked systems; the other half of the invariant
+/// — clearing a system's FTS rows *and* its tracker row together when its
+/// concepts change — is upheld by `import::fhir_bundle::write_code_system`,
+/// which deletes both in the same transaction as the concept upserts. Removing
+/// either the per-import invalidation or the `NOT IN (…concepts_fts_built)`
+/// guard below breaks correctness: the former serves stale FTS after a
+/// re-import, the latter double-inserts rows (FTS5 has no row uniqueness),
+/// worst on the churning `-cd.id` designation rows.
+///
+/// Runs the build in a single `BEGIN IMMEDIATE` transaction (bulk INSERTs are
+/// far faster than the per-system path — 1 txn × 1217 systems would take
+/// minutes). Cheap up-front gate skips the transaction when nothing is stale.
+pub(crate) fn prebuild_concepts_fts(conn: &Connection) -> usize {
+    // Fast path: is there any concept-bearing code system whose FTS is not yet
+    // built? Iterates `code_systems` (~1217 rows) and only probes `concepts`
+    // for the untracked ones, so a fully-built DB confirms "nothing to do" with
+    // a cheap scan of a small table and no full `concepts` scan.
+    let needs_build: bool = conn
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM code_systems cs
+                 WHERE cs.id NOT IN (SELECT system_id FROM concepts_fts_built)
+                   AND EXISTS (SELECT 1 FROM concepts c WHERE c.system_id = cs.id)
+             )",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(false);
+
+    if !needs_build {
+        // Mark any concept-less systems so the lazy ensure_concepts_fts path is
+        // O(1) for them too. Cheap upsert; no-op once every system is tracked.
+        let _ = conn.execute_batch(
+            "INSERT OR IGNORE INTO concepts_fts_built (system_id) SELECT id FROM code_systems",
+        );
+        return 0;
+    }
+
     if let Err(e) = conn.execute_batch("BEGIN IMMEDIATE") {
         tracing::warn!("prebuild_concepts_fts: could not begin transaction: {e}");
-        return;
+        return 0;
     }
 
     let fts_result = conn.execute(
         "INSERT INTO concepts_fts(rowid, system_id, code, display)
-         SELECT id, system_id, code, display FROM concepts",
+         SELECT id, system_id, code, display FROM concepts
+         WHERE system_id NOT IN (SELECT system_id FROM concepts_fts_built)",
         [],
     );
 
@@ -8594,30 +8636,32 @@ pub(crate) fn prebuild_concepts_fts(conn: &Connection) {
         Err(e) => {
             let _ = conn.execute_batch("ROLLBACK");
             tracing::warn!("prebuild_concepts_fts: trigram INSERT failed: {e}");
-            return;
+            return 0;
         }
     };
 
     // Also populate the word-prefix FTS (unicode61) used for short filter terms.
     if let Err(e) = conn.execute(
         "INSERT INTO concepts_word_fts(rowid, system_id, code, display)
-         SELECT id, system_id, code, display FROM concepts",
+         SELECT id, system_id, code, display FROM concepts
+         WHERE system_id NOT IN (SELECT system_id FROM concepts_fts_built)",
         [],
     ) {
         let _ = conn.execute_batch("ROLLBACK");
         tracing::warn!("prebuild_concepts_fts: word-prefix INSERT failed: {e}");
-        return;
+        return 0;
     }
 
     if let Err(e) = conn.execute(
         "INSERT INTO concepts_search_fts(rowid, system_id, code, term)
          SELECT id, system_id, code, display FROM concepts
-         WHERE display IS NOT NULL AND display != ''",
+         WHERE display IS NOT NULL AND display != ''
+           AND system_id NOT IN (SELECT system_id FROM concepts_fts_built)",
         [],
     ) {
         let _ = conn.execute_batch("ROLLBACK");
         tracing::warn!("prebuild_concepts_fts: search FTS preferred-term INSERT failed: {e}");
-        return;
+        return 0;
     }
 
     if let Err(e) = conn.execute(
@@ -8625,29 +8669,33 @@ pub(crate) fn prebuild_concepts_fts(conn: &Connection) {
          SELECT -cd.id, c.system_id, c.code, cd.value
          FROM concept_designations cd
          JOIN concepts c ON c.id = cd.concept_id
-         WHERE cd.value IS NOT NULL AND cd.value != ''",
+         WHERE cd.value IS NOT NULL AND cd.value != ''
+           AND c.system_id NOT IN (SELECT system_id FROM concepts_fts_built)",
         [],
     ) {
         let _ = conn.execute_batch("ROLLBACK");
         tracing::warn!("prebuild_concepts_fts: search FTS designation INSERT failed: {e}");
-        return;
+        return 0;
     }
 
-    // Populate the O(1) tracker so ensure_concepts_fts avoids FTS content scans.
+    // Mark the systems we just built (and any concept-less ones) so subsequent
+    // boots and the lazy path skip them. Done last so the guards above still see
+    // the pre-build tracked set.
     if let Err(e) = conn.execute_batch(
-        "INSERT OR IGNORE INTO concepts_fts_built (system_id)
-         SELECT DISTINCT id FROM code_systems",
+        "INSERT OR IGNORE INTO concepts_fts_built (system_id) SELECT DISTINCT system_id FROM concepts;
+         INSERT OR IGNORE INTO concepts_fts_built (system_id) SELECT id FROM code_systems;",
     ) {
         let _ = conn.execute_batch("ROLLBACK");
         tracing::warn!("prebuild_concepts_fts: tracker INSERT failed: {e}");
-        return;
+        return 0;
     }
 
     let _ = conn.execute_batch("COMMIT");
     tracing::info!(
         rows = n,
-        "concepts_fts pre-populated (trigram + word-prefix)"
+        "concepts_fts built incrementally (trigram + word-prefix + search)"
     );
+    n
 }
 
 /// Pre-warm the in-memory concept index from any implicit-expansion URLs
@@ -12149,5 +12197,120 @@ mod tests {
         // `unrelated` matches on its designation alone — the reason this index
         // exists separately from concepts_fts, which indexes display only.
         assert_eq!(codes, ["data-exchange", "data-exchange1", "unrelated"]);
+    }
+
+    fn count(conn: &Connection, sql: &str) -> i64 {
+        conn.query_row(sql, [], |r| r.get(0)).unwrap()
+    }
+
+    /// #295: the startup FTS build must be incremental and idempotent — it
+    /// builds untracked systems once, then does nothing (and never duplicates
+    /// rows) on a warm reopen. This is what makes a restart a no-op instead of a
+    /// full-corpus re-tokenise.
+    #[test]
+    fn prebuild_concepts_fts_is_incremental_and_idempotent() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::backends::sqlite::schema::apply(&conn).expect("schema should apply");
+        conn.execute_batch(
+            "INSERT INTO code_systems(id, url, created_at, updated_at)
+                 VALUES ('sys1', 'http://example.org/cs', '2026-01-01', '2026-01-01');
+             INSERT INTO concepts(id, system_id, code, display) VALUES
+                 (1, 'sys1', 'a', 'Alpha term'),
+                 (2, 'sys1', 'b', 'Beta term');
+             INSERT INTO concept_designations(id, concept_id, value) VALUES (5, 1, 'Alpha synonym');",
+        )
+        .expect("fixture should insert");
+
+        // First build: indexes both concepts and marks the system built.
+        let built = prebuild_concepts_fts(&conn);
+        assert_eq!(built, 2, "both concepts indexed on first build");
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM concepts_fts"), 2);
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM concepts_word_fts"), 2);
+        // 2 preferred-term rows + 1 designation row.
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM concepts_search_fts"), 3);
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM concepts_fts_built WHERE system_id = 'sys1'"
+            ),
+            1
+        );
+
+        // Second build over unchanged data: no work, and crucially no duplicate
+        // rows (FTS5 has no row uniqueness, so a missing guard would double them).
+        let rebuilt = prebuild_concepts_fts(&conn);
+        assert_eq!(rebuilt, 0, "warm reopen builds nothing");
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM concepts_fts"), 2);
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM concepts_search_fts"), 3);
+    }
+
+    /// #295: after a re-import invalidates ONE system (the four DELETEs that
+    /// `write_code_system` performs), the incremental build rebuilds only that
+    /// system — reflecting its new content — and leaves every other system's
+    /// rows untouched (no rebuild, no duplication).
+    #[test]
+    fn prebuild_concepts_fts_rebuilds_only_invalidated_system() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::backends::sqlite::schema::apply(&conn).expect("schema should apply");
+        conn.execute_batch(
+            "INSERT INTO code_systems(id, url, created_at, updated_at) VALUES
+                 ('sys1', 'http://example.org/cs1', '2026-01-01', '2026-01-01'),
+                 ('sys2', 'http://example.org/cs2', '2026-01-01', '2026-01-01');
+             INSERT INTO concepts(id, system_id, code, display) VALUES
+                 (1, 'sys1', 'a', 'Old display'),
+                 (2, 'sys2', 'z', 'Untouched');",
+        )
+        .expect("fixture should insert");
+
+        assert_eq!(prebuild_concepts_fts(&conn), 2, "both systems built");
+        let sys2_rowid: i64 = count(
+            &conn,
+            "SELECT rowid FROM concepts_fts WHERE system_id = 'sys2'",
+        );
+
+        // Simulate write_code_system re-importing sys1 with a changed display:
+        // the four per-system invalidations, then the concept content change.
+        conn.execute_batch(
+            "DELETE FROM concepts_fts        WHERE system_id = 'sys1';
+             DELETE FROM concepts_word_fts   WHERE system_id = 'sys1';
+             DELETE FROM concepts_search_fts WHERE system_id = 'sys1';
+             DELETE FROM concepts_fts_built  WHERE system_id = 'sys1';
+             UPDATE concepts SET display = 'New display' WHERE system_id = 'sys1';",
+        )
+        .expect("invalidation should apply");
+
+        // Only sys1 is untracked now, so only its one concept is rebuilt.
+        assert_eq!(prebuild_concepts_fts(&conn), 1, "only sys1 rebuilt");
+
+        // sys1 reflects the new display; the stale one is gone.
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM concepts_fts WHERE system_id = 'sys1' AND display = 'New display'"
+            ),
+            1
+        );
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM concepts_fts WHERE display = 'Old display'"
+            ),
+            0
+        );
+        // sys2 was never touched: same single row, same rowid, no duplicate.
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM concepts_fts WHERE system_id = 'sys2'"
+            ),
+            1
+        );
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT rowid FROM concepts_fts WHERE system_id = 'sys2'"
+            ),
+            sys2_rowid
+        );
     }
 }

--- a/crates/hts/src/import/fhir_bundle.rs
+++ b/crates/hts/src/import/fhir_bundle.rs
@@ -434,6 +434,36 @@ fn write_code_system(
         rusqlite::params![system_id],
     );
 
+    // Invalidate this system's concept FTS so a later filtered $expand rebuilds
+    // it from the freshly-imported concepts/designations instead of serving
+    // stale display/synonym rows. The `concepts_fts_built` tracker row MUST be
+    // cleared alongside the content: it is the authoritative "FTS current for
+    // this system" flag (both the lazy ensure_concepts_fts path and the
+    // startup incremental prebuild_concepts_fts short-circuit on it), so leaving
+    // it set would freeze stale FTS results until the next full rebuild.
+    // Runs in the same transaction as the concept upserts above, so the content
+    // and the tracker flip atomically — no window where a concurrent reader
+    // sees "built" with stale rows (issue #295). The three content tables carry
+    // an explicit system_id column, so the delete is exact: designation rows
+    // (negative `-cd.id` rowids in concepts_search_fts) are removed too, and no
+    // other system's rows are touched.
+    let _ = conn.execute(
+        "DELETE FROM concepts_fts WHERE system_id = ?1",
+        rusqlite::params![system_id],
+    );
+    let _ = conn.execute(
+        "DELETE FROM concepts_word_fts WHERE system_id = ?1",
+        rusqlite::params![system_id],
+    );
+    let _ = conn.execute(
+        "DELETE FROM concepts_search_fts WHERE system_id = ?1",
+        rusqlite::params![system_id],
+    );
+    let _ = conn.execute(
+        "DELETE FROM concepts_fts_built WHERE system_id = ?1",
+        rusqlite::params![system_id],
+    );
+
     // Invalidate any cached implicit-ValueSet expansions for this code system.
     // The implicit_expansion_cache is otherwise persistent across restarts; stale
     // entries from a previous version of this system must be evicted on re-import.
@@ -725,12 +755,50 @@ pub(crate) fn invalidate_expansion_cache_for_system(
 /// `/CodeSystem/version` removes every stored version of that resource.
 #[cfg(feature = "sqlite")]
 pub(crate) fn delete_code_system(conn: &Connection, id: &str) -> Result<(), HtsError> {
+    // Collect the storage ids being removed (a multi-version CodeSystem can own
+    // several rows sharing one FHIR id) so we can clear their concept FTS rows.
+    // The concepts_fts* tables have no foreign key to cascade from, so — now that
+    // startup no longer wipes and rebuilds the whole index (issue #295) —
+    // deleting a CodeSystem would otherwise orphan its FTS rows and its
+    // concepts_fts_built marker. Mirrors the per-system invalidation in
+    // write_code_system.
+    let system_ids: Vec<String> = conn
+        .prepare(
+            "SELECT id FROM code_systems \
+             WHERE id = ?1 OR json_extract(resource_json, '$.id') = ?1",
+        )
+        .and_then(|mut s| {
+            s.query_map(rusqlite::params![id], |r| r.get::<_, String>(0))
+                .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        })
+        .unwrap_or_default();
+
     conn.execute(
         "DELETE FROM code_systems \
          WHERE id = ?1 OR json_extract(resource_json, '$.id') = ?1",
         rusqlite::params![id],
     )
     .map_err(|e| HtsError::StorageError(e.to_string()))?;
+
+    for sid in &system_ids {
+        let _ = conn.execute(
+            "DELETE FROM concepts_fts WHERE system_id = ?1",
+            rusqlite::params![sid],
+        );
+        let _ = conn.execute(
+            "DELETE FROM concepts_word_fts WHERE system_id = ?1",
+            rusqlite::params![sid],
+        );
+        let _ = conn.execute(
+            "DELETE FROM concepts_search_fts WHERE system_id = ?1",
+            rusqlite::params![sid],
+        );
+        let _ = conn.execute(
+            "DELETE FROM concepts_fts_built WHERE system_id = ?1",
+            rusqlite::params![sid],
+        );
+    }
+
     crate::backends::sqlite::invalidate_cs_id_cache();
     crate::backends::sqlite::invalidate_cs_language_cache();
     Ok(())
@@ -897,6 +965,89 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.display.as_deref(), Some("Concept A"));
+    }
+
+    /// #295 (Leg A): re-importing a CodeSystem must invalidate that system's
+    /// concept FTS — both the content rows and the `concepts_fts_built` tracker
+    /// — so a subsequent build reflects the new data instead of serving stale
+    /// display/synonym rows. Proven directly: after a re-import the tracker row
+    /// is gone (which forces a rebuild) and the stale display is no longer
+    /// indexed; a rebuild then indexes the new display.
+    #[tokio::test]
+    async fn reimport_invalidates_concept_fts() {
+        let b = backend();
+        let ctx = ctx();
+
+        // Same id/url/version each time → a stable storage system_id, so the
+        // concept is updated in place (the case per-system invalidation covers).
+        let cs_bundle = |display: &str| {
+            format!(
+                r#"{{"resourceType":"Bundle","type":"collection","entry":[
+                    {{"resource":{{"resourceType":"CodeSystem","id":"cs-x",
+                        "url":"http://example.org/csx","version":"1.0",
+                        "status":"active","content":"complete",
+                        "concept":[{{"code":"A","display":"{display}"}}]}}}}]}}"#
+            )
+        };
+
+        let tracker_rows = |b: &SqliteTerminologyBackend| -> i64 {
+            let conn = b.pool().get().unwrap();
+            conn.query_row(
+                "SELECT COUNT(*) FROM concepts_fts_built cfb \
+                 JOIN code_systems cs ON cfb.system_id = cs.id \
+                 WHERE cs.url = 'http://example.org/csx'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        let fts_display_count = |b: &SqliteTerminologyBackend, display: &str| -> i64 {
+            let conn = b.pool().get().unwrap();
+            conn.query_row(
+                "SELECT COUNT(*) FROM concepts_fts WHERE display = ?1",
+                [display],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+
+        // Import + build FTS.
+        b.import_bundle(&ctx, cs_bundle("Original A").as_bytes())
+            .await
+            .unwrap();
+        b.finalize_after_bootstrap().unwrap();
+        assert_eq!(tracker_rows(&b), 1, "system tracked after first build");
+        assert_eq!(
+            fts_display_count(&b, "Original A"),
+            1,
+            "original display indexed"
+        );
+
+        // Re-import the same system with a changed display.
+        b.import_bundle(&ctx, cs_bundle("Changed A").as_bytes())
+            .await
+            .unwrap();
+
+        // Leg A must have cleared this system's tracker row AND its FTS content.
+        assert_eq!(
+            tracker_rows(&b),
+            0,
+            "re-import must clear the concepts_fts_built tracker row"
+        );
+        assert_eq!(
+            fts_display_count(&b, "Original A"),
+            0,
+            "stale FTS content must be removed on re-import"
+        );
+
+        // A rebuild reflects the new display.
+        b.finalize_after_bootstrap().unwrap();
+        assert_eq!(tracker_rows(&b), 1, "system re-tracked after rebuild");
+        assert_eq!(
+            fts_display_count(&b, "Changed A"),
+            1,
+            "new display indexed after rebuild"
+        );
     }
 
     #[tokio::test]

--- a/crates/hts/src/main.rs
+++ b/crates/hts/src/main.rs
@@ -556,26 +556,24 @@ async fn run_import(args: ImportArgs) -> anyhow::Result<i32> {
             let backend = SqliteTerminologyBackend::new(&database_url)?;
             let result = run_import_for_path(&backend, &ctx, &args, rxnorm_dir).await?;
 
-            // Pre-build concept closures now so server startup only needs to
-            // rebuild the FTS index (~10–25 s) instead of also running
-            // migrate_concept_closure (~40 s for SNOMED). Without this, the
-            // combined startup time can exceed the 60-second health-check timeout.
+            // Finalize the database now — build concept closures AND the
+            // concepts FTS index — so the on-disk DB ships fully serve-ready.
+            // Server startup then finds everything already built (tracked in
+            // concepts_fts_built + closure rows present) and its
+            // finalize_after_bootstrap is a near-instant no-op, instead of
+            // re-tokenising the whole corpus inside the health-check window
+            // (issue #295). Previously only closures were pre-built here, which
+            // left the full FTS rebuild to block server startup on every boot.
+            // Runs on a blocking thread (heavy synchronous SQLite work).
             if !args.dry_run {
-                info!("Building concept closures (this may take ~40 s for SNOMED CT)…");
-                let pool = backend.pool().clone();
-                tokio::task::spawn_blocking(move || {
-                    let conn = pool.get().map_err(|e| {
-                        rusqlite::Error::SqliteFailure(
-                            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
-                            Some(format!("pool error: {e}")),
-                        )
-                    })?;
-                    helios_hts::backends::sqlite::schema::migrate_concept_closure(&conn)
-                })
-                .await
-                .map_err(|e| anyhow::anyhow!("task join error: {e}"))?
-                .map_err(|e| anyhow::anyhow!("failed to build concept closures: {e}"))?;
-                info!("Concept closures ready");
+                info!(
+                    "Building concept closures + FTS index (this may take ~40–60 s for SNOMED CT)…"
+                );
+                tokio::task::spawn_blocking(move || backend.finalize_after_bootstrap())
+                    .await
+                    .map_err(|e| anyhow::anyhow!("task join error: {e}"))?
+                    .map_err(|e| anyhow::anyhow!("failed to finalize terminology database: {e}"))?;
+                info!("Concept closures + FTS index ready");
             }
 
             result

--- a/crates/hts/tests/postgres_http_tests.rs
+++ b/crates/hts/tests/postgres_http_tests.rs
@@ -980,3 +980,86 @@ async fn translate_r6_arm_returns_snomed_code() {
         .unwrap_or(false);
     assert!(result, "R6 arm should translate to SNOMED code");
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Re-import refreshes filtered $expand — PostgreSQL parity for issue #295
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// #295 parity: the fix that makes SQLite rebuild its concept FTS on re-import
+/// is a no-op for PostgreSQL, which searches a live `pg_trgm` GIN index on
+/// `concepts.display` that the engine maintains transactionally on every write.
+/// This test pins that invariant — a re-imported display is reflected by a
+/// filtered `$expand` with no application-side index maintenance and no restart.
+#[tokio::test(flavor = "multi_thread")]
+async fn reimport_changed_display_refreshes_filtered_expand_pg() {
+    let app = TestAppPg::new().await;
+
+    let bundle = |display: &str| {
+        serde_json::json!({
+            "resourceType": "Bundle",
+            "type": "collection",
+            "entry": [{"resource": {
+                "resourceType": "CodeSystem",
+                "url": "http://pg-295.example/cs/reindex",
+                "version": "1.0.0",
+                "status": "active",
+                "content": "complete",
+                "concept": [{"code": "x", "display": display}]
+            }}]
+        })
+        .to_string()
+    };
+
+    let expand = |filter: &str| {
+        serde_json::json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "filter", "valueString": filter},
+                {"name": "valueSet", "resource": {
+                    "resourceType": "ValueSet",
+                    "url": "http://pg-295.example/vs/reindex",
+                    "status": "active",
+                    "compose": {"include": [{"system": "http://pg-295.example/cs/reindex"}]}
+                }}
+            ]
+        })
+        .to_string()
+    };
+
+    let contains_x = |body: &serde_json::Value| -> bool {
+        body["expansion"]["contains"]
+            .as_array()
+            .is_some_and(|arr| arr.iter().any(|c| c["code"].as_str() == Some("x")))
+    };
+
+    app.import_bundle_ok(&bundle("originalword marker")).await;
+    let (status, body) = app
+        .post_fhir("/ValueSet/$expand", expand("originalword"))
+        .await;
+    assert_eq!(status, StatusCode::OK, "initial expand failed: {body}");
+    assert!(contains_x(&body), "original display should match: {body}");
+
+    app.import_bundle_ok(&bundle("changedword marker")).await;
+
+    let (status, body) = app
+        .post_fhir("/ValueSet/$expand", expand("changedword"))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "post-reimport expand failed: {body}"
+    );
+    assert!(
+        contains_x(&body),
+        "changed display should match after re-import: {body}"
+    );
+
+    let (status, body) = app
+        .post_fhir("/ValueSet/$expand", expand("originalword"))
+        .await;
+    assert_eq!(status, StatusCode::OK, "stale-filter expand failed: {body}");
+    assert!(
+        !contains_x(&body),
+        "stale display must not match after re-import: {body}"
+    );
+}

--- a/crates/hts/tests/terminology_import.rs
+++ b/crates/hts/tests/terminology_import.rs
@@ -9,6 +9,7 @@ mod common;
 
 use axum::http::StatusCode;
 use common::{TestApp, bundles};
+use serde_json::Value;
 
 // ── R4 import ─────────────────────────────────────────────────────────────────
 
@@ -123,6 +124,89 @@ async fn reimport_same_bundle_is_idempotent() {
     assert!(
         status2 == StatusCode::OK || status2 == StatusCode::MULTI_STATUS,
         "second import should succeed, got {status2}: {body2}"
+    );
+}
+
+// ── Re-import refreshes filtered $expand (issue #295) ─────────────────────────
+
+/// #295: a filtered `$expand` reads the concept FTS index. Re-importing a
+/// CodeSystem with a changed concept display must invalidate that system's FTS
+/// so the filter reflects the new display and no longer matches the old one.
+///
+/// This is the end-to-end guard for the per-system FTS invalidation in
+/// `write_code_system`: before the fix the FTS index was rebuilt only by an
+/// unconditional wipe at server startup, so a live re-import left stale
+/// display/synonym rows searchable until the next restart.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn reimport_changed_display_refreshes_filtered_expand() {
+    let app = TestApp::new();
+
+    // Same (url, version) both times so the storage system_id is stable and the
+    // concept is updated in place — the case the per-system invalidation covers.
+    let bundle = |display: &str| {
+        format!(
+            r#"{{"resourceType":"Bundle","type":"collection","entry":[
+                {{"resource":{{"resourceType":"CodeSystem",
+                    "url":"http://hts.test/cs/reindex","version":"1.0.0",
+                    "status":"active","content":"complete",
+                    "concept":[{{"code":"x","display":"{display}"}}]}}}}]}}"#
+        )
+    };
+
+    // Full-system include + text filter → the FTS-backed filtered expand path.
+    let expand = |filter: &str| {
+        format!(
+            r#"{{"resourceType":"Parameters","parameter":[
+                {{"name":"filter","valueString":"{filter}"}},
+                {{"name":"valueSet","resource":{{"resourceType":"ValueSet",
+                    "url":"http://hts.test/vs/reindex","status":"active",
+                    "compose":{{"include":[{{"system":"http://hts.test/cs/reindex"}}]}}}}}}]}}"#
+        )
+    };
+
+    let contains_x = |body: &Value| -> bool {
+        body["expansion"]["contains"]
+            .as_array()
+            .is_some_and(|arr| arr.iter().any(|c| c["code"].as_str() == Some("x")))
+    };
+
+    // Import with the original display; the filter on "originalword" matches.
+    app.import_bundle_ok(&bundle("originalword marker")).await;
+    let (status, body) = app
+        .post_fhir("/ValueSet/$expand", expand("originalword"))
+        .await;
+    assert_eq!(status, StatusCode::OK, "initial expand failed: {body}");
+    assert!(
+        contains_x(&body),
+        "original display should match its filter: {body}"
+    );
+
+    // Re-import the same system with a changed display.
+    app.import_bundle_ok(&bundle("changedword marker")).await;
+
+    // The new display now matches…
+    let (status, body) = app
+        .post_fhir("/ValueSet/$expand", expand("changedword"))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "post-reimport expand failed: {body}"
+    );
+    assert!(
+        contains_x(&body),
+        "changed display should match after re-import (FTS rebuilt): {body}"
+    );
+
+    // …and the old display no longer matches (stale FTS rows were invalidated).
+    let (status, body) = app
+        .post_fhir("/ValueSet/$expand", expand("originalword"))
+        .await;
+    assert_eq!(status, StatusCode::OK, "stale-filter expand failed: {body}");
+    assert!(
+        !contains_x(&body),
+        "stale display must not match after re-import: {body}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #295. The sqlite HTS server rebuilt the **entire** concept FTS index (`concepts_fts`, `concepts_word_fts`, `concepts_search_fts`) over all concepts on **every** startup, synchronously **before** `TcpListener::bind()`. `finalize_after_bootstrap()` did an unconditional `DELETE` of all FTS + `prebuild_concepts_fts` over the full corpus. With a full terminology corpus this exceeds the readiness window in a **debug** build, so the server never binds and `/health` (which just returns 200 once bound) never answers — breaking the sqlite HTS benchmark leg. `concepts_search_fts` (added in #273) pushed it over the edge.

Root cause is architectural: FTS was the one index without the invalidate-on-import → incremental-startup-rebuild → prebuild-in-CLI-import lifecycle that **concept closures already have**. This PR gives FTS that same lifecycle, so the per-boot rebuild is *removed*, not deferred or hidden.

## What changed (SQLite)

- **Import invalidates per-system** — `write_code_system` now deletes the re-imported system's rows from `concepts_fts`, `concepts_word_fts`, `concepts_search_fts` **and** its `concepts_fts_built` tracker row, in the **same transaction** as the concept upserts (mirrors the adjacent closure/implicit invalidation). This makes `concepts_fts_built` the authoritative "FTS current for this system" flag.
- **Incremental startup build** — `prebuild_concepts_fts` builds only systems missing from `concepts_fts_built` (a `NOT IN (…)` guard on every INSERT — mandatory now the wipe is gone, since FTS5 has no row uniqueness), skips the whole transaction via a cheap up-front gate when nothing is stale, and returns the count built.
- **No more blanket wipe** — `finalize_after_bootstrap` and `new_inner` drop the unconditional `DELETE FROM concepts_fts…` and only run `ANALYZE` when a build actually ran (stats persist across restarts).
- **CLI `hts import` ships an index-ready DB** — it now finalizes (closures **+** FTS) at the end of the untimed import, so the server-start finalize is a sub-second no-op. Previously only closures were pre-built here, leaving the full FTS rebuild to block startup.
- **Delete cleans up** — `delete_code_system` clears the deleted system's FTS rows + tracker (the FTS5 tables have no FK to cascade from), preventing orphans now that boot no longer wipes.

Net effect: a warm restart, and the benchmark's `hts import` → serve flow, do **zero** FTS work before the server binds. Filtered `$expand` correctness is unchanged (and strengthened — a live `$import` that changes a display is now reflected without a restart), via the existing lazy `ensure_concepts_fts` fallback.

## All-DB consistency

**Postgres needs no code change.** It searches a live `pg_trgm` GIN index on `concepts.display` (`postgres/schema.rs`) that the engine maintains transactionally on every write — already incremental, no per-boot rebuild, no tracker. This PR adds a Postgres **parity test** to pin that invariant as executable.

## Not a masking workaround

The banned pattern hides a cost while leaving the work unchanged (e.g. widening the readiness window, which #292 tried and the issue explicitly rejects). This PR does the opposite: it **removes** the per-boot rebuild and moves the genuinely-once cost onto the once event (import), exactly as closures already do. No `sleep`, no timeout bump, no backgrounding-past-the-probe. The correctness contract is strengthened, and the new tests fail loudly if a future change reintroduces a per-boot rebuild or drops the invalidation.

## Design provenance

Approach vetted by a 5-persona review (SQLite internals, SRE/readiness, performance/benchmark, FHIR-terminology correctness, architecture) — all five converged on this incremental + prebuild-on-import shape and rejected background-after-bind (write-lock contention would pollute the first EX0x benchmark iterations, plus a half-built `concepts_search_fts` hazard via the non-tracker `EXISTS` probe).

## Tests

- `value_set.rs` — incremental build is idempotent / no duplicate rows; rebuilds only the invalidated system.
- `fhir_bundle.rs` — re-import clears the FTS tracker + content (direct Leg A guard).
- `terminology_import.rs` — end-to-end: re-import changes a display → filtered `$expand` reflects the new display, stale one gone.
- `postgres_http_tests.rs` — Postgres parity for the same re-import → filtered `$expand` behavior.

## Verification note

Built and formatted with `cargo fmt`; the local environment has no C linker so `cargo check`/`test` can't link here — relying on CI to compile and run the suite (incl. the Postgres testcontainer parity test). Draft until CI (and ideally a benchmark preflight run on the sqlite leg) is green.