### PR TITLE
ci: fix duplicate shell key breaking ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,8 @@ jobs:
         # `runs-on: [self-hosted]` is unpinned, so this job can land on a Windows
         # runner, where `run:` defaults to PowerShell and cannot parse this bash
         # script (`set -o pipefail`, `| tee`, `if ! grep`, `\` continuations).
-        # Pin bash explicitly — Git Bash ships with Git for Windows on the runner.
-        shell: bash
+        # Pin Git Bash explicitly via its 8.3 short path (see line 139) — the
+        # plain `shell: bash` alias is unreliable on this self-hosted runner.
         run: |
           set -o pipefail
           cargo test -p helios-persistence --all-features \


### PR DESCRIPTION
## Problem

The run for [`Merge pull request #257`](https://github.com/HeliosSoftware/hfs/actions/runs/29876762948) failed with *"This run likely failed because of a workflow file issue"* and **zero jobs scheduled**.

Root cause: the merge of PR #257 reintroduced the older `shell: bash` line on top of the newer 8.3-short-path Git Bash shell fix (commit `433decf64`), leaving **two `shell:` keys** in the same step (`Verify S3 conditional writes against MinIO (per-user settings) (Windows)`). GitHub rejects a workflow file with a duplicate mapping key, so the entire `ci.yml` run aborts before any job runs.

```
.github/workflows/ci.yml:147:9: key "shell" is duplicated in element of "steps" section. previously defined at line:139,col:9 [syntax-check]
```

## Fix

Drop the stale `shell: bash` duplicate and keep the pinned `C:\Progra~1\Git\bin\bash.exe` shell (the intended state after `433decf64`). Verified with `actionlint` — no more syntax-check / duplicate-key errors.