### PR TITLE
ci(hts-benchmark): same-session observability A/B for instrumentation cost (#297)

### DIFF
--- a/.github/scripts/obs-ab/report.py
+++ b/.github/scripts/obs-ab/report.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Same-session observability A/B reporter (issue #297).
+
+Consumes the per-(arm, round) k6 summaries written by run-arms.sh under
+``results/${RUN_ID}__${arm-slug}__r${round}/hts/${TEST}_vu${VU}.json`` and
+produces:
+
+  * a medians-only Markdown table on stdout (destined for
+    ``$GITHUB_STEP_SUMMARY``; kept small to stay under the 1 MiB limit), and
+  * a detailed CSV artifact (``--csv-out``) carrying spread, sign-consistency
+    and the noise flag for every cell.
+
+Method (why it is shaped this way):
+
+  * Deltas are PAIRED WITHIN A ROUND — ``median_r( B[r] - A[r] )`` — not a
+    difference of independent per-arm medians. Because the arms are interleaved
+    round-robin, pairing within a round cancels the slow within-session drift
+    that the two-dispatch #292 A/B could not, to first order.
+  * Every cell carries spread (min/median/max) and a flag, so a bare point
+    estimate is never presented as fact. The flag is deliberately conservative:
+      - INCONCLUSIVE  <2 paired rounds, or too few requests to trust (the
+                      low-rps EX family at 30 s lands here).
+      - VOID          the two arms' error rates differ materially — a partly
+                      failing arm's throughput is not comparable.
+      - SIGNAL        sign-consistent across (nearly) all rounds AND the median
+                      delta clears twice the within-arm noise.
+      - NOISE         sign flips across rounds, or the delta is within noise.
+      - WEAK          directionally consistent but under the SIGNAL bar.
+  * Only ``off→default`` is a single-component isolate (the cost of metrics; in
+    the benchmark span and reqlog are inert under Default). Later adjacencies
+    bundle components and are labelled as such — the "per-component" reading
+    stops after the first hop, by construction of the current arm switch.
+
+The numbers are from a DEBUG build: use them to rank components and confirm
+direction, never as release magnitudes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import json
+import os
+import statistics as stats
+from typing import Optional
+
+# A cell with fewer than this many observed requests (min across the paired
+# rounds/arms) is treated as too small to difference — the low-rps EX tests at
+# 30 s produce ~tens–hundreds and land here rather than being quoted.
+LOW_SAMPLE = 300
+# Error-rate gap (fraction) beyond which a paired cell is voided as not
+# comparable.
+ERR_VOID = 0.01
+
+# What each adjacency attributes, given the arm switch semantics. Keyed by
+# (from_arm, to_arm). Anything not listed is labelled "bundled".
+ADJACENCY_MEANING = {
+    ("off", "default"): "metrics (clean isolate)",
+    ("default", "no-span"): "reqlog (span still off in bench)",
+    ("no-span", "full"): "span",
+    ("default", "full"): "span + reqlog (bundled)",
+    ("full", "full+probe"): "probe stdout logs (RUST_LOG)",
+    ("default", "full+probe"): "span + reqlog + probe logs (bundled)",
+}
+
+
+def slug(arm: str) -> str:
+    return arm.replace("+", "-")
+
+
+def load_cell(path: str) -> Optional[dict]:
+    try:
+        with open(path) as fh:
+            d = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    m = d.get("metrics", {})
+    dur = m.get("http_req_duration", {})
+    reqs = m.get("http_reqs", {})
+    failed = m.get("http_req_failed", {})
+    return {
+        "p50": dur.get("med"),
+        "rps": reqs.get("rate"),
+        "count": reqs.get("count"),
+        "err": failed.get("rate", 0.0) or 0.0,
+    }
+
+
+def collect(results_dir: str, run_id: str, arms: list[str], rounds: int):
+    """-> data[(test, vu)][arm][round] = cell, plus sorted (test, vu) keys."""
+    data: dict = {}
+    for arm in arms:
+        for rnd in range(1, rounds + 1):
+            base = os.path.join(results_dir, f"{run_id}__{slug(arm)}__r{rnd}", "hts")
+            for path in glob.glob(os.path.join(base, "*_vu*.json")):
+                name = os.path.basename(path)[: -len(".json")]
+                if "_vu" not in name:
+                    continue
+                test, vu = name.rsplit("_vu", 1)
+                try:
+                    vu = int(vu)
+                except ValueError:
+                    continue
+                cell = load_cell(path)
+                if cell is None or cell["p50"] is None:
+                    continue
+                data.setdefault((test, vu), {}).setdefault(arm, {})[rnd] = cell
+    return data
+
+
+def cv_pct(values: list[float]) -> Optional[float]:
+    vals = [v for v in values if v is not None]
+    if len(vals) < 2:
+        return None
+    mean = stats.mean(vals)
+    if mean <= 0:
+        return None
+    return stats.pstdev(vals) / mean * 100.0
+
+
+def summarize_arm(rounds_map: dict, key: str):
+    vals = [c[key] for c in rounds_map.values() if c.get(key) is not None]
+    if not vals:
+        return None
+    return {
+        "median": stats.median(vals),
+        "min": min(vals),
+        "max": max(vals),
+        "n": len(vals),
+    }
+
+
+def paired_delta(a: dict, b: dict, key: str):
+    """Per-round paired deltas of `key` for rounds present in BOTH arms."""
+    common = sorted(set(a) & set(b))
+    abs_d, pct_d = [], []
+    for r in common:
+        av, bv = a[r].get(key), b[r].get(key)
+        if av is None or bv is None:
+            continue
+        abs_d.append(bv - av)
+        if av != 0:
+            pct_d.append((bv - av) / av * 100.0)
+    return common, abs_d, pct_d
+
+
+def sign_string(deltas: list[float], eps: float = 1e-9):
+    signs = [1 if d > eps else (-1 if d < -eps else 0) for d in deltas]
+    n = len(signs)
+    pos = signs.count(1)
+    neg = signs.count(-1)
+    k = max(pos, neg)
+    dom = "+" if pos >= neg else "-"
+    consistent = n >= 2 and k >= n - 1 and pos != neg
+    return f"{k}/{n} {dom}", consistent
+
+
+def flag_for(pct_deltas, abs_deltas, cvp, min_count, err_gap, n_pair):
+    if n_pair < 2 or min_count is None or min_count < LOW_SAMPLE:
+        return "INCONCLUSIVE"
+    if err_gap is not None and err_gap > ERR_VOID:
+        return "VOID"
+    if cvp is None:
+        return "INCONCLUSIVE"
+    median_pct = abs(stats.median(pct_deltas)) if pct_deltas else 0.0
+    _, consistent = sign_string(abs_deltas)
+    if consistent and median_pct > 2 * cvp:
+        return "SIGNAL"
+    if (not consistent) or median_pct <= cvp:
+        return "NOISE"
+    return "WEAK"
+
+
+def fmt(x, nd=1):
+    return "—" if x is None else f"{x:,.{nd}f}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--results-dir", required=True)
+    ap.add_argument("--run-id", required=True)
+    ap.add_argument("--arms", required=True, help="space/comma list, ladder order")
+    ap.add_argument("--rounds", type=int, required=True)
+    ap.add_argument("--backend", default="")
+    ap.add_argument("--commit", default="")
+    ap.add_argument("--build", default="debug (opt-level 0)")
+    ap.add_argument("--csv-out", default="")
+    args = ap.parse_args()
+
+    arms = [a for a in args.arms.replace(",", " ").split() if a]
+    data = collect(args.results_dir, args.run_id, arms, args.rounds)
+
+    out = []
+    out.append(f"## HTS observability A/B — same session ({args.backend})")
+    out.append("")
+    out.append("| | |")
+    out.append("|---|---|")
+    out.append(f"| **Commit** | `{args.commit[:7]}` |")
+    out.append(f"| **Backend** | `{args.backend}` |")
+    out.append(f"| **Arms** | `{' → '.join(arms)}` |")
+    out.append(f"| **Rounds** | {args.rounds} (interleaved; deltas paired within a round) |")
+    out.append(f"| **Build** | **{args.build} — ratios/direction only, NOT release magnitude** |")
+    out.append("")
+    out.append(
+        "> In the benchmark `default` = metrics-only (no OTLP exporter → span off; "
+        "no reqlog consumer → reqlog off). Only `off→default` isolates a single "
+        "component (metrics); later hops bundle span/reqlog/probe-logs. Primary "
+        "metric below is **VU=1 p50** (purest per-request cost); RPS is the headline."
+    )
+    out.append("")
+
+    if not data:
+        out.append("_No results collected — every arm may have failed to start._")
+        print("\n".join(out))
+        return 0
+
+    # Adjacency legend actually present in this ladder.
+    out.append("**Adjacencies:** " + " · ".join(
+        f"`{a}→{b}` = {ADJACENCY_MEANING.get((a, b), 'bundled')}"
+        for a, b in zip(arms, arms[1:])
+    ))
+    out.append("")
+
+    csv_rows = []
+    vus = sorted({vu for (_t, vu) in data})
+    for vu in vus:
+        out.append(f"### VU = {vu}")
+        out.append("")
+        header = ["Test"] + [f"{a} p50" for a in arms]
+        for a, b in zip(arms, arms[1:]):
+            header.append(f"Δ {a}→{b}")
+        out.append("| " + " | ".join(header) + " |")
+        out.append("|" + "---|" * len(header))
+
+        for (test, cvu) in sorted(k for k in data if k[1] == vu):
+            per_arm = data[(test, cvu)]
+            row = [test]
+            arm_stats = {}
+            for a in arms:
+                s = summarize_arm(per_arm.get(a, {}), "p50")
+                arm_stats[a] = s
+                row.append(fmt(s["median"] if s else None))
+
+            for a, b in zip(arms, arms[1:]):
+                am = per_arm.get(a, {})
+                bm = per_arm.get(b, {})
+                common, abs_d, pct_d = paired_delta(am, bm, "p50")
+                if not abs_d:
+                    row.append("—")
+                    continue
+                med_abs = stats.median(abs_d)
+                med_pct = stats.median(pct_d) if pct_d else 0.0
+                cvp = max(
+                    [c for c in (cv_pct([am[r]["p50"] for r in common if r in am]),
+                                 cv_pct([bm[r]["p50"] for r in common if r in bm])) if c is not None]
+                    or [None]
+                ) if common else None
+                counts = [am[r]["count"] for r in common if am[r].get("count") is not None] + \
+                         [bm[r]["count"] for r in common if bm[r].get("count") is not None]
+                min_count = min(counts) if counts else None
+                erra = stats.median([am[r]["err"] for r in common if r in am])
+                errb = stats.median([bm[r]["err"] for r in common if r in bm])
+                err_gap = abs(errb - erra)
+                sig, _ = sign_string(abs_d)
+                flag = flag_for(pct_d, abs_d, cvp, min_count, err_gap, len(common))
+                row.append(f"{med_pct:+.1f}% [{flag}]")
+
+                csv_rows.append({
+                    "vu": vu, "test": test, "from": a, "to": b,
+                    "meaning": ADJACENCY_MEANING.get((a, b), "bundled"),
+                    "median_dp50_ms": round(med_abs, 3),
+                    "median_dp50_pct": round(med_pct, 2),
+                    "min_dp50_ms": round(min(abs_d), 3),
+                    "max_dp50_ms": round(max(abs_d), 3),
+                    "pooled_cv_pct": None if cvp is None else round(cvp, 2),
+                    "sign": sig, "min_count": min_count,
+                    "err_from": round(erra, 4), "err_to": round(errb, 4),
+                    "rounds_paired": len(common), "flag": flag,
+                    "from_p50_median": None if not arm_stats[a] else round(arm_stats[a]["median"], 3),
+                    "to_p50_median": None if not arm_stats[b] else round(arm_stats[b]["median"], 3),
+                })
+            out.append("| " + " | ".join(row) + " |")
+        out.append("")
+
+    out.append(
+        "_Flags: SIGNAL = sign-consistent across rounds and > 2× within-arm noise; "
+        "WEAK = consistent but under that bar; NOISE = sign flips or within noise; "
+        "INCONCLUSIVE = < 2 paired rounds or < "
+        f"{LOW_SAMPLE} requests (low-rps tests); VOID = arms' error rates differ. "
+        "Full per-round spread is in the CSV artifact._"
+    )
+    print("\n".join(out))
+
+    if args.csv_out and csv_rows:
+        os.makedirs(os.path.dirname(args.csv_out) or ".", exist_ok=True)
+        with open(args.csv_out, "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(csv_rows[0].keys()))
+            w.writeheader()
+            w.writerows(csv_rows)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/obs-ab/run-arms.sh
+++ b/.github/scripts/obs-ab/run-arms.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+#
+# Same-session observability A/B driver (issue #297).
+#
+# Runs the k6 tx-benchmark scenarios against the HTS server once per
+# (round × arm), restarting the server between arms so each arm's
+# HELIOS_OBS_MODE / RUST_LOG takes effect (the arm switch is read once into a
+# process-global OnceLock, so it can only change across a restart). The
+# terminology database is imported ONCE by the caller and left untouched: only
+# the app process is restarted, so every arm measures the same warmed data with
+# no cross-run drift.
+#
+# Two properties the whole comparison rests on, enforced here:
+#   1. Interleaving. Arms are rotated per round (round-robin, not blocked
+#      off×N,default×N,…) so slow within-session drift on the shared runner
+#      spreads across all arms as honest variance instead of aliasing onto the
+#      arm axis. The reporter pairs deltas WITHIN a round.
+#   2. Warm start. Every restart leaves the in-process memo caches
+#      (hierarchy/closure/$lookup/expansion) cold. A discarded warm-up pass
+#      that exercises the exact measured request population primes them before
+#      the measured pass, so an arm's first scenarios are not taxed with
+#      cache-fill cost that has nothing to do with instrumentation.
+#
+# Results are namespaced per arm+round:
+#   results/${RUN_ID}__${arm-slug}__r${round}/hts/${TEST}_vu${VU}.json
+# The RUN_ID itself carries the arm+round, which also namespaces k6's internal
+# handleSummary() output (results/${RUN_ID}/hts/benchmark/) — without that,
+# successive arms silently overwrite each other's k6 summaries.
+#
+# Required environment (exported by the workflow):
+#   HTS_BIN            path to the hts binary
+#   PORT               server port for this backend leg
+#   BACKEND            sqlite | postgres (for log/artifact naming)
+#   RUN_ID            github.run_id (the base run identifier)
+#   ARMS              space-separated arm list, in ladder order
+#                     (e.g. "off default full full+probe")
+#   ROUNDS            repeats per arm (integer >= 1)
+#   TESTS_CSV         comma-separated test IDs (e.g. "LK01,VC01,EX01")
+#   VUS_CSV           comma-separated VU levels (e.g. "1" or "1,10,50")
+#   DURATION          measured duration per scenario (e.g. "30s")
+#   WARMUP_DURATION   discarded warm-up duration per test (e.g. "10s")
+#   LOG_DIR           directory for per-arm server logs (e.g. "/tmp")
+#   HTS_DATABASE_URL, HTS_STORAGE_BACKEND  already exported by the caller
+#
+# Run from the tx-benchmark checkout (working-directory), so k6 script paths
+# (k6/<FAMILY>/<TEST>.js) and results/ resolve correctly.
+set -uo pipefail
+
+# Fail the job if a whole arm never came up, but only AFTER every salvageable
+# arm has run and its artifacts exist — one broken arm must not discard the
+# others' good data.
+ANY_ARM_FAILED=0
+
+# ── arm → (HELIOS_OBS_MODE, RUST_LOG) ───────────────────────────────────────
+# `full+probe` is Full plus the developer probe stdout logs re-enabled via
+# RUST_LOG; every other arm leaves RUST_LOG unset so HTS_LOG_LEVEL=info stands.
+arm_obs_mode() {
+  case "$1" in
+    off)        echo "off" ;;
+    default)    echo "default" ;;
+    no-span)    echo "no-span" ;;
+    full)       echo "full" ;;
+    full+probe) echo "full" ;;
+    *)          echo "" ;;
+  esac
+}
+arm_rust_log() {
+  case "$1" in
+    full+probe) echo "info,hts::probe=debug" ;;
+    *)          echo "" ;;
+  esac
+}
+# The ObsMode Debug string the server logs at boot, for the active-arm assertion.
+arm_expected_mode_log() {
+  case "$1" in
+    off)        echo "Off" ;;
+    default)    echo "Default" ;;
+    no-span)    echo "NoSpan" ;;
+    full)       echo "Full" ;;
+    full+probe) echo "Full" ;;
+    *)          echo "" ;;
+  esac
+}
+# Filesystem-safe slug — NEVER let RUST_LOG (which contains `hts::probe`, i.e.
+# colons) reach a path; colons in result paths have already bitten this repo.
+arm_slug() {
+  printf '%s' "$1" | tr '+' '-'
+}
+
+# ── server lifecycle ────────────────────────────────────────────────────────
+SERVER_PID=""
+
+wait_port_free() {
+  for _ in $(seq 1 100); do
+    if ! fuser "${PORT}/tcp" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "WARN: port ${PORT} still bound after 20s"
+  return 1
+}
+
+stop_server() {
+  local pid="${1:-}"
+  [ -z "$pid" ] && return 0
+  kill "$pid" 2>/dev/null || true
+  # Block until the process actually exits — a fire-and-forget kill is how a
+  # previous arm's server ends up still holding the port when the next binds.
+  for _ in $(seq 1 100); do
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.2
+  done
+  kill -9 "$pid" 2>/dev/null || true
+  fuser -k "${PORT}/tcp" 2>/dev/null || true
+  wait_port_free || true
+}
+
+# start_server <arm> <logfile>; sets SERVER_PID. Returns non-zero on a failed
+# readiness/active-arm check (caller isolates the arm rather than aborting).
+start_server() {
+  local arm="$1" logfile="$2"
+  local obs rustlog expected started_epoch
+  obs="$(arm_obs_mode "$arm")"
+  rustlog="$(arm_rust_log "$arm")"
+  expected="$(arm_expected_mode_log "$arm")"
+  started_epoch=$(date +%s)
+
+  echo "  starting server: HELIOS_OBS_MODE=${obs} RUST_LOG='${rustlog}'  -> ${logfile}"
+  # RUST_LOG (when set) overrides HTS_LOG_LEVEL in the server's EnvFilter; unset
+  # for every non-probe arm so only the probe arm changes the log configuration.
+  HTS_SERVER_PORT="$PORT" \
+  HTS_LOG_LEVEL="info" \
+  HELIOS_OBS_MODE="$obs" \
+  RUST_LOG="$rustlog" \
+    "$HTS_BIN" >"$logfile" 2>&1 &
+  SERVER_PID=$!
+
+  # Readiness — generous bound: inside the arm loop a cold start (and, on
+  # sqlite pre-#295, an FTS rebuild) can take minutes.
+  local ready=0
+  for _ in $(seq 1 150); do
+    if curl -sf "http://localhost:${PORT}/health" >/dev/null 2>&1; then
+      ready=1
+      break
+    fi
+    kill -0 "$SERVER_PID" 2>/dev/null || { echo "  ERROR: server process exited during startup"; break; }
+    sleep 2
+  done
+  if [ "$ready" -ne 1 ]; then
+    echo "  ERROR: server for arm '${arm}' did not become ready"
+    tail -50 "$logfile" || true
+    return 1
+  fi
+
+  # Zombie / wrong-arm guard: confirm we are talking to the process we just
+  # started (a survivor on the port would serve every request of this arm under
+  # the WRONG mode). /health carries uptime_seconds; it must be smaller than the
+  # time we spent waiting.
+  local elapsed uptime
+  elapsed=$(( $(date +%s) - started_epoch + 15 ))
+  uptime=$(curl -sf "http://localhost:${PORT}/health" 2>/dev/null \
+           | jq -r '.uptime_seconds // empty' 2>/dev/null || true)
+  if [ -n "$uptime" ] && [ "$uptime" -gt "$elapsed" ] 2>/dev/null; then
+    echo "  ERROR: /health uptime_seconds=${uptime}s exceeds ${elapsed}s — a stale server may be answering on port ${PORT}"
+    return 1
+  fi
+
+  # Active-arm assertion: the server stamps its resolved ObsMode into the
+  # startup line (main.rs). If it does not match, the arm is inert (e.g. a
+  # server built without the arm switch) and its numbers are meaningless.
+  if [ -n "$expected" ]; then
+    if ! grep -Eq "obs_mode=${expected}\b" "$logfile"; then
+      echo "  ERROR: server did not report obs_mode=${expected}; arm '${arm}' is not active."
+      grep -i 'obs_mode' "$logfile" | head -3 || echo "    (no obs_mode line found in startup log)"
+      return 1
+    fi
+    echo "  active arm confirmed: obs_mode=${expected}"
+  fi
+  return 0
+}
+
+# ── k6 passes ───────────────────────────────────────────────────────────────
+IFS=',' read -ra TESTS <<< "$TESTS_CSV"
+IFS=',' read -ra VUS <<< "$VUS_CSV"
+
+script_for() {  # <TEST> -> k6 script path, or empty if absent
+  local t="${1// /}" fam
+  fam="${t:0:2}"
+  local s="k6/${fam}/${t}.js"
+  [ -f "$s" ] && printf '%s' "$s" || printf ''
+}
+
+# Discarded warm-up: touch the exact measured request population once at VU=1 so
+# the per-URL memo caches are primed identically for every arm before the
+# measured pass. Output goes to a throwaway RUN_ID that is deleted afterwards.
+warmup_pass() {
+  local warm_run="warmup-${1}"
+  rm -rf "results/${warm_run}"
+  mkdir -p "results/${warm_run}/hts/benchmark"
+  for TEST in "${TESTS[@]}"; do
+    local s; s="$(script_for "$TEST")"
+    [ -z "$s" ] && continue
+    k6 run \
+      --env BASE_URL="http://localhost:${PORT}" \
+      --env SERVER_NAME=hts \
+      --env RUN_ID="$warm_run" \
+      --env TEST_ID="${TEST// /}" \
+      --env VUS=1 \
+      --duration "$WARMUP_DURATION" \
+      --vus 1 \
+      "$s" >/dev/null 2>&1 || true
+  done
+  rm -rf "results/${warm_run}"
+}
+
+# Measured pass: namespaced per arm+round so nothing (ours or k6's internal
+# handleSummary) collides across arms.
+measured_pass() {
+  local arm="$1" round="$2" slug run_arm
+  slug="$(arm_slug "$arm")"
+  run_arm="${RUN_ID}__${slug}__r${round}"
+  mkdir -p "results/${run_arm}/hts/benchmark"
+  for TEST in "${TESTS[@]}"; do
+    TEST="${TEST// /}"
+    local s; s="$(script_for "$TEST")"
+    [ -z "$s" ] && { echo "    skip ${TEST} — script not found"; continue; }
+    for VU in "${VUS[@]}"; do
+      VU="${VU// /}"
+      echo "    ${arm} r${round}: ${TEST} vu${VU}"
+      k6 run \
+        --env BASE_URL="http://localhost:${PORT}" \
+        --env SERVER_NAME=hts \
+        --env RUN_ID="$run_arm" \
+        --env TEST_ID="$TEST" \
+        --env VUS="$VU" \
+        --duration "$DURATION" \
+        --vus "$VU" \
+        --summary-export "results/${run_arm}/hts/${TEST}_vu${VU}.json" \
+        "$s" || true
+    done
+  done
+}
+
+# ── main loop: rounds × (rotated) arms ──────────────────────────────────────
+read -ra ARM_ARR <<< "$ARMS"
+NARMS=${#ARM_ARR[@]}
+
+echo "Arms: ${ARMS}"
+echo "Rounds: ${ROUNDS}  Tests: ${TESTS_CSV}  VUs: ${VUS_CSV}  Duration: ${DURATION}"
+echo ""
+
+for (( round=1; round<=ROUNDS; round++ )); do
+  echo "═══ round ${round}/${ROUNDS} ═══"
+  # Rotate the arm order by (round-1) so no arm is permanently first
+  # (first-after-restart pays the most cold-start; rotation shares it).
+  for (( j=0; j<NARMS; j++ )); do
+    idx=$(( (j + round - 1) % NARMS ))
+    arm="${ARM_ARR[$idx]}"
+    slug="$(arm_slug "$arm")"
+    logfile="${LOG_DIR}/hts-bench-${BACKEND}-${slug}-r${round}.log"
+
+    stop_server "$SERVER_PID"; SERVER_PID=""
+    if ! start_server "$arm" "$logfile"; then
+      echo "  arm '${arm}' round ${round} FAILED to start/verify — recording and continuing"
+      ANY_ARM_FAILED=1
+      continue
+    fi
+    warmup_pass "${slug}-r${round}"
+    measured_pass "$arm" "$round"
+  done
+done
+
+stop_server "$SERVER_PID"; SERVER_PID=""
+
+echo ""
+if [ "$ANY_ARM_FAILED" -ne 0 ]; then
+  echo "One or more arms failed to start/verify; see per-arm logs. Reporting on whatever completed."
+fi
+# Do not exit non-zero here: the report + artifact-upload steps must still run
+# so partial data and logs are preserved. The workflow inspects ARM_FAILED.
+echo "ARM_FAILED=${ANY_ARM_FAILED}" >> "${GITHUB_ENV:-/dev/null}"

--- a/.github/workflows/hts-benchmark.yml
+++ b/.github/workflows/hts-benchmark.yml
@@ -53,36 +53,38 @@ on:
         description: "Tests to run: 'all' | 'preflight-only' | comma-separated IDs (e.g. LK01,SS01)"
         required: false
         default: "all"
-      # ── Perf-attribution arms (issue #227) ────────────────────────────────
+      # ── Same-session observability A/B (issues #227 / #297) ───────────────
       # Observability instrumentation is a per-request cost on a server that
-      # serves tens of thousands of req/s. These arms exist to *attribute* that
-      # cost to a component instead of guessing at it: run the same commit on
-      # the same runner with only this input varying, and the delta between
-      # arms is that component's price.
+      # serves tens of thousands of req/s. To attribute that cost instead of
+      # guessing, the benchmark runs once per (round × arm) against ONE warmed
+      # database, restarting ONLY the server between arms — so the delta between
+      # adjacent arms is the price of the instrumentation that changed, with no
+      # cross-run drift. Arms are interleaved (rotated per round) and the
+      # reporter pairs deltas within a round, then medians across rounds.
       #
-      # `obs_mode` maps to HELIOS_OBS_MODE (see crates/observability/src/mode.rs):
-      #   default  — what production ships: metrics only, span iff OTLP is live.
-      #   full     — additionally forces the request span + reqlog ring buffer,
-      #              reproducing the pre-fix cost profile for A/B attribution.
-      #   no-span  — metrics + reqlog, no span.
-      #   off      — middleware present but does no work; the floor.
-      obs_mode:
-        description: "Observability arm: default | full | no-span | off"
-        type: choice
+      # An "arm" maps to a (HELIOS_OBS_MODE, RUST_LOG) pair
+      # (crates/observability/src/mode.rs):
+      #   off         middleware present, does no work — the floor.
+      #   default     what production ships: metrics; span iff OTLP is live
+      #               (off in this bench); reqlog iff a consumer is registered
+      #               (off in this bench). → in the benchmark, metrics-only.
+      #   no-span     metrics + reqlog, no span (degenerate here = default).
+      #   full        forces span + reqlog on — the pre-#227 cost profile.
+      #   full+probe  full, plus hts::probe DEBUG stdout logs via RUST_LOG.
+      #
+      # Only `off→default` isolates a single component (metrics). Later hops
+      # bundle span/reqlog/probe-logs — the report labels them as such. A
+      # single-arm list (the default) reproduces the ordinary one-shot
+      # benchmark; the A/B is the multi-arm ladder, e.g.:
+      #   obs_arms="off default full full+probe"  rounds=3  vus=1
+      obs_arms:
+        description: "Space/comma arm list in ladder order, e.g. 'off default full full+probe'"
         required: false
         default: "default"
-        options:
-          - default
-          - full
-          - no-span
-          - off
-      # Overrides RUST_LOG for the server process. The `hts::probe` developer
-      # probes log at DEBUG; `info,hts::probe=debug` re-enables them to price
-      # the stdout-logging arm without touching code.
-      log_directives:
-        description: "RUST_LOG for the server (blank = HTS_LOG_LEVEL only)"
+      rounds:
+        description: "Repeats per arm (interleaved; deltas paired & medianed across them)"
         required: false
-        default: ""
+        default: "1"
       tx_benchmark_ref:
         description: "tx-benchmark git ref (blank = our fork's default branch; set to pin a specific baseline)"
         required: false
@@ -404,47 +406,9 @@ jobs:
           echo "Importing licensed terminology (directory auto-detects SNOMED RF2 / LOINC / RxNorm)..."
           ./hts import "$LICENSED_DIR" --batch-size 500
 
-      # ── Server ───────────────────────────────────────────────────────────
-
-      - name: Kill any leftover process on port ${{ matrix.port }}
-        run: fuser -k "${{ matrix.port }}/tcp" 2>/dev/null || true
-
-      - name: Start HTS server
-        run: |
-          # HTS_DATABASE_URL + HTS_STORAGE_BACKEND already exported.
-          #
-          # RUST_LOG, when supplied, takes precedence over HTS_LOG_LEVEL (the
-          # server's EnvFilter reads the environment first). Left blank in the
-          # default arm so the benchmark measures the shipped configuration.
-          echo "obs arm: HELIOS_OBS_MODE=${{ inputs.obs_mode || 'default' }} RUST_LOG='${{ inputs.log_directives }}'"
-          HTS_SERVER_PORT="${{ matrix.port }}" \
-          HTS_LOG_LEVEL="info" \
-          HELIOS_OBS_MODE="${{ inputs.obs_mode || 'default' }}" \
-          ${{ inputs.log_directives && format('RUST_LOG="{0}"', inputs.log_directives) || '' }} \
-            ./hts > "/tmp/hts-bench-${{ matrix.backend }}.log" 2>&1 &
-
-          echo "HTS_PID=$!" >> "$GITHUB_ENV"
-
-          # The sqlite backend warms its in-process hierarchy/closure caches
-          # over the full terminology corpus before it serves, which in a debug
-          # build on a loaded self-hosted runner can take a few minutes — well
-          # past a 60s window. Wait up to 300s so a healthy-but-slow cold start
-          # is not mistaken for a failure; a genuine hang still trips the bound.
-          echo "Waiting for HTS to become ready..."
-          for i in $(seq 1 150); do
-            if curl -sf "http://localhost:${{ matrix.port }}/health" > /dev/null 2>&1; then
-              echo "HTS ready after $((i * 2))s"
-              break
-            fi
-            if [ "$i" -eq 150 ]; then
-              echo "ERROR: HTS did not start within 300s"
-              cat "/tmp/hts-bench-${{ matrix.backend }}.log"
-              exit 1
-            fi
-            sleep 2
-          done
-
       # ── Tools (k6) ───────────────────────────────────────────────────────
+      # The server is started, restarted per arm, and stopped by the arm-loop
+      # script below — not here — so one warmed database is shared across arms.
 
       - name: Install k6
         uses: grafana/setup-k6-action@v1
@@ -455,135 +419,108 @@ jobs:
         id: preflight
         working-directory: tx-benchmark
         run: |
-          mkdir -p "results/${{ github.run_id }}/hts"
+          set -uo pipefail
+          # Preflight runs on its own short-lived default-arm server to discover
+          # the passing test list the arm loop measures, and to validate the
+          # import worked before the long loop. HTS_DATABASE_URL /
+          # HTS_STORAGE_BACKEND are already exported.
+          fuser -k "${{ matrix.port }}/tcp" 2>/dev/null || true
+          HTS_SERVER_PORT="${{ matrix.port }}" HTS_LOG_LEVEL="info" HELIOS_OBS_MODE="default" \
+            "$GITHUB_WORKSPACE/hts" > "/tmp/hts-preflight-${{ matrix.backend }}.log" 2>&1 &
+          PF_PID=$!
+          for i in $(seq 1 150); do
+            curl -sf "http://localhost:${{ matrix.port }}/health" >/dev/null 2>&1 && break
+            if [ "$i" -eq 150 ]; then
+              echo "ERROR: preflight server did not become ready within 300s"
+              cat "/tmp/hts-preflight-${{ matrix.backend }}.log"
+              kill "$PF_PID" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 2
+          done
 
+          mkdir -p "results/${{ github.run_id }}/hts"
           k6 run \
             --env BASE_URL="http://localhost:${{ matrix.port }}" \
             --env SERVER_NAME=hts \
             --env RUN_ID="${{ github.run_id }}" \
-            preflight/run.js 2>&1 | tee "/tmp/preflight-stdout-${{ matrix.backend }}.txt"
+            preflight/run.js 2>&1 | tee "/tmp/preflight-stdout-${{ matrix.backend }}.txt" || true
 
-          # Extract passing test IDs for the benchmark step
+          # Extract passing test IDs for the arm loop.
           PREFLIGHT_JSON="results/${{ github.run_id }}/hts/preflight.json"
           if [ -f "$PREFLIGHT_JSON" ]; then
             PASSING=$(jq -r '.tests | to_entries[]
                              | select(.value.status == "pass")
                              | .key' "$PREFLIGHT_JSON" \
                       | paste -sd ',' -)
-            echo "passing_tests=$PASSING" >> "$GITHUB_OUTPUT"
-            echo "Passing tests: $PASSING"
           else
             # Preflight JSON was not written (path collision with colons on some runners)
             PASSING="FS01,LK01,LK02,LK03,LK05,VC01,VC02,VC03,EX01,EX02,EX03,EX04,EX05,EX07,EX08,SS01,CM01,CM02"
-            echo "passing_tests=$PASSING" >> "$GITHUB_OUTPUT"
             echo "Warning: preflight.json not found — using fallback test list: $PASSING"
           fi
+          echo "passing_tests=$PASSING" >> "$GITHUB_OUTPUT"
+          echo "Passing tests: $PASSING"
 
-      # ── Benchmark ────────────────────────────────────────────────────────
+          # Stop the preflight server; the arm loop owns the port from here.
+          kill "$PF_PID" 2>/dev/null || true
+          for _ in $(seq 1 50); do kill -0 "$PF_PID" 2>/dev/null || break; sleep 0.2; done
+          kill -9 "$PF_PID" 2>/dev/null || true
+          fuser -k "${{ matrix.port }}/tcp" 2>/dev/null || true
 
-      - name: Run benchmark
+      # ── Arm loop (arms × rounds against one warmed DB) ────────────────────
+
+      - name: Run observability A/B (arms × rounds)
         if: inputs.tests != 'preflight-only'
         working-directory: tx-benchmark
+        env:
+          HTS_BIN: ${{ github.workspace }}/hts
+          PORT: ${{ matrix.port }}
+          BACKEND: ${{ matrix.backend }}
+          RUN_ID: ${{ github.run_id }}
+          ARMS: ${{ inputs.obs_arms || 'default' }}
+          ROUNDS: ${{ inputs.rounds || '1' }}
+          VUS_CSV: ${{ inputs.vus || '1,10,50' }}
+          DURATION: ${{ inputs.duration || '30s' }}
+          WARMUP_DURATION: "10s"
+          LOG_DIR: /tmp
+          TESTS_INPUT: ${{ inputs.tests || 'all' }}
+          PASSING_TESTS: ${{ steps.preflight.outputs.passing_tests }}
         run: |
-          IFS=',' read -ra VUS_LIST <<< "${{ inputs.vus || '1,10,50' }}"
-          DURATION="${{ inputs.duration || '30s' }}"
-
-          # Resolve test list
-          INPUT_TESTS="${{ inputs.tests || 'all' }}"
-          if [ "$INPUT_TESTS" = "all" ]; then
-            TESTS_CSV="${{ steps.preflight.outputs.passing_tests }}"
+          set -uo pipefail
+          # Accept comma- or space-separated arm lists.
+          export ARMS="$(echo "$ARMS" | tr ',' ' ')"
+          if [ "$TESTS_INPUT" = "all" ]; then
+            export TESTS_CSV="$PASSING_TESTS"
           else
-            TESTS_CSV="$INPUT_TESTS"
+            export TESTS_CSV="$TESTS_INPUT"
           fi
+          bash "$GITHUB_WORKSPACE/.github/scripts/obs-ab/run-arms.sh"
 
-          IFS=',' read -ra TESTS <<< "$TESTS_CSV"
+      # ── Report ────────────────────────────────────────────────────────────
 
-          echo "Running ${#TESTS[@]} test(s) × ${#VUS_LIST[@]} VU level(s) × $DURATION each"
-          echo ""
-
-          # handleSummary() in k6/lib/runner.js writes to results/${RUN_ID}/${server}/benchmark/
-          mkdir -p "results/${{ github.run_id }}/hts/benchmark"
-
-          for TEST in "${TESTS[@]}"; do
-            TEST="${TEST// /}"
-            [ -z "$TEST" ] && continue
-            FAMILY="${TEST:0:2}"
-            SCRIPT="k6/${FAMILY}/${TEST}.js"
-            [ -f "$SCRIPT" ] || { echo "Skip $TEST — script not found"; continue; }
-
-            for VU in "${VUS_LIST[@]}"; do
-              echo "--- $TEST  VUs=$VU ---"
-              k6 run \
-                --env BASE_URL="http://localhost:${{ matrix.port }}" \
-                --env SERVER_NAME=hts \
-                --env RUN_ID="${{ github.run_id }}" \
-                --env TEST_ID="$TEST" \
-                --env VUS="$VU" \
-                --duration "$DURATION" \
-                --vus "$VU" \
-                --summary-export "results/${{ github.run_id }}/hts/${TEST}_vu${VU}.json" \
-                "$SCRIPT" || true
-            done
-          done
-
-      # ── Summary ──────────────────────────────────────────────────────────
-
-      - name: Generate step summary
+      - name: Generate report
+        if: always() && inputs.tests != 'preflight-only'
         working-directory: tx-benchmark
         run: |
-          RESULTS_DIR="results/${{ github.run_id }}/hts"
-
+          set -uo pipefail
           {
-            echo "## HTS Benchmark — \`${{ github.ref_name }}\` (${{ matrix.backend }})"
-            echo ""
-            echo "| | |"
-            echo "|---|---|"
-            echo "| **Commit**  | \`$(echo '${{ github.sha }}' | cut -c1-7)\` |"
-            echo "| **Backend** | \`${{ matrix.backend }}\` |"
-            echo "| **Duration**| ${{ inputs.duration || '30s' }} per scenario |"
-            echo "| **VUs**     | ${{ inputs.vus || '1,10,50' }} |"
-            echo ""
-
-            # Preflight table from stdout
-            echo "### Preflight"
+            echo "### Preflight (${{ matrix.backend }})"
             echo '```'
-            cat "/tmp/preflight-stdout-${{ matrix.backend }}.txt" | grep -E '✓|✗|~|Preflight' || true
+            grep -E '✓|✗|~|Preflight' "/tmp/preflight-stdout-${{ matrix.backend }}.txt" 2>/dev/null || echo "(no preflight output captured)"
             echo '```'
             echo ""
-
-            # Benchmark results table
-            python3 - <<'PYEOF'
-          import json, glob, os, sys
-
-          results_dir = "results/${{ github.run_id }}/hts"
-          files = sorted(glob.glob(f"{results_dir}/*_vu*.json"))
-
-          if not files:
-              print("### Benchmark\n\n_No results (preflight-only mode or no passing tests)._")
-              sys.exit(0)
-
-          rows = []
-          for f in files:
-              name = os.path.basename(f).replace('.json', '')
-              test, vu = name.rsplit('_vu', 1)
-              with open(f) as fh:
-                  d = json.load(fh)
-              m = d.get('metrics', {})
-              rps  = m.get('http_reqs', {}).get('rate', 0)
-              p50  = m.get('http_req_duration', {}).get('med', 0)
-              p95  = m.get('http_req_duration', {}).get('p(95)', 0)
-              p99  = m.get('http_req_duration', {}).get('p(99)', 0)
-              err  = m.get('http_req_failed', {}).get('rate', 0) * 100
-              rows.append((test, int(vu), rps, p50, p95, p99, err))
-
-          print("### Benchmark results\n")
-          print("| Test | VUs | RPS | p50 ms | p95 ms | p99 ms | Err% |")
-          print("|------|----:|----:|-------:|-------:|-------:|-----:|")
-          for test, vu, rps, p50, p95, p99, err in sorted(rows):
-              err_fmt = f"**{err:.1f}%**" if err > 1 else f"{err:.1f}%"
-              print(f"| {test} | {vu} | {rps:,.0f} | {p50:.1f} | {p95:.1f} | {p99:.1f} | {err_fmt} |")
-          PYEOF
           } >> "$GITHUB_STEP_SUMMARY"
+
+          ARMS="$(echo "${{ inputs.obs_arms || 'default' }}" | tr ',' ' ')"
+          python3 "$GITHUB_WORKSPACE/.github/scripts/obs-ab/report.py" \
+            --results-dir results \
+            --run-id "${{ github.run_id }}" \
+            --arms "$ARMS" \
+            --rounds "${{ inputs.rounds || '1' }}" \
+            --backend "${{ matrix.backend }}" \
+            --commit "${{ github.sha }}" \
+            --csv-out "results/${{ github.run_id }}/obs-ab-${{ matrix.backend }}.csv" \
+            >> "$GITHUB_STEP_SUMMARY"
 
       # ── Artifacts ────────────────────────────────────────────────────────
 
@@ -595,28 +532,39 @@ jobs:
           path: tx-benchmark/results/
           retention-days: 90
 
-      - name: Upload server log
+      - name: Upload server logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: hts-bench-server-log-${{ matrix.backend }}-${{ github.run_id }}
-          path: /tmp/hts-bench-${{ matrix.backend }}.log
+          # One log per arm+round (a crashed arm's log is its only forensic
+          # trail), plus the preflight server's log.
+          name: hts-bench-server-logs-${{ matrix.backend }}-${{ github.run_id }}
+          path: |
+            /tmp/hts-bench-${{ matrix.backend }}-*.log
+            /tmp/hts-preflight-${{ matrix.backend }}.log
           retention-days: 7
           if-no-files-found: ignore
 
       # ── Cleanup ──────────────────────────────────────────────────────────
 
-      - name: Stop HTS server
+      - name: Stop any leftover HTS server
         if: always()
-        run: |
-          if [ -n "${HTS_PID:-}" ]; then
-            kill "$HTS_PID" 2>/dev/null || true
-          fi
-          fuser -k "${{ matrix.port }}/tcp" 2>/dev/null || true
+        run: fuser -k "${{ matrix.port }}/tcp" 2>/dev/null || true
 
       - name: Stop ephemeral Postgres
         if: always() && matrix.backend == 'postgres'
         run: |
           if [ -n "${PG_CONTAINER:-}" ]; then
             docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          fi
+
+      # Turn the job red if any arm never started/verified — but only after the
+      # report and artifacts above have preserved whatever did complete. ARM_FAILED
+      # is written to $GITHUB_ENV by run-arms.sh.
+      - name: Fail if any arm did not run
+        if: always() && inputs.tests != 'preflight-only'
+        run: |
+          if [ "${ARM_FAILED:-0}" != "0" ]; then
+            echo "::error::One or more observability arms failed to start or verify — see the per-arm server logs artifact."
+            exit 1
           fi

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,3 +15,4 @@ ignore:
   - "crates/fhir/src/r5.rs"
   - "crates/fhir/src/r6.rs"
   - "crates/hfs/src/main.rs"
+  - "crates/hts/src/main.rs"

--- a/crates/hts/src/main.rs
+++ b/crates/hts/src/main.rs
@@ -30,6 +30,13 @@ async fn main() -> anyhow::Result<()> {
                 host = %config.host,
                 storage_backend = %config.storage_backend,
                 database_url = %config.database_url,
+                // Eagerly resolve the HELIOS_OBS_MODE OnceLock at boot and stamp
+                // it into the startup line. The same-session A/B benchmark (#297)
+                // greps this to assert each arm's server actually resolved to the
+                // arm it set — a server that silently ignored the env var (e.g.
+                // built without the observability arm switch) is caught here
+                // rather than producing a clean-looking table of ~zero deltas.
+                obs_mode = ?helios_observability::mode::mode(),
                 "Starting Helios Terminology Server"
             );
             run_server(config).await


### PR DESCRIPTION
Closes #297. Builds on #292 (now merged to `main`), which shipped the `HELIOS_OBS_MODE` arm switch this orchestration drives.

## What & why

#292 measured the observability instrumentation cost with **two separate workflow dispatches ~2h apart** on the shared self-hosted runner: coherent signal on log-heavy paths (VC +28–43%) but noise on the expensive low-rps expansion tests (EX01 −26%, EX07 −18%) — cross-run drift limited confidence in the aggregate.

This runs the arms **back-to-back in one job against one warmed database**, restarting only the server between arms, so the per-arm delta isolates instrumentation cost with no cross-run drift.

## Design (from a 5-persona review)

- **Interleaved rounds + paired within-round deltas.** Arms are rotated per round; the reporter differences arms *within a round*, so slow within-session drift on the shared runner spreads as honest variance instead of aliasing onto the arm axis (the flaw a blocked `off×N,default×N` design would keep).
- **Per-arm restart** (`HELIOS_OBS_MODE` is read once into a `OnceLock`) with hygiene: kill → wait for exit → confirm port free; a **zombie/wrong-arm guard** via `/health uptime_seconds`; and a **positive active-arm assertion** grepping the server's startup `obs_mode=` line (new one-line log in `main.rs`).
- **Discarded warm-up pass per arm** primes the in-process memo caches with the exact measured request population — the one real confound once on-disk closures/FTS are already warm at first `/health`.
- **`RUN_ID` carries arm+round**, namespacing both our exports and k6's internal `handleSummary()` output (otherwise arms silently overwrite each other).
- **Honest reporting.** Primary = VU=1 p50 (RPS headline); medians with min/median/max spread, sign-consistency, and a conservative `SIGNAL/WEAK/NOISE/INCONCLUSIVE/VOID` flag so low-rps EX noise is labelled noise, not quoted. **Only `off→default` is a single-component isolate (metrics)**; later hops are labelled **bundled** (span+reqlog / probe-logs) — the issue's "each adjacency = one component" is not literally true and the report says so. Prominent **debug-build** caveat. Medians-only markdown to the step summary (1 MiB safe) + a detailed CSV artifact.

## Usage

Routine benchmark (unchanged): dispatch with defaults (`obs_arms=default`, `rounds=1`).

A/B run:
```
obs_arms = off default full full+probe
rounds   = 3
vus      = 1
```

## Scope / DB coverage

Workflow-orchestration + reporting only, plus one startup-log line in `main.rs`. The arm loop is **backend-agnostic**: Postgres only for now (per the issue); the sqlite leg slots into the existing backend matrix once #295 (every-boot FTS rebuild) lands — no further code change.

## Validation

`bash -n`, `python3 -m py_compile`, and `yaml.safe_load` all pass. The reporter's flag logic is verified against synthetic k6 JSON (consistent large delta → SIGNAL; differing error rate → VOID; low-sample EX → INCONCLUSIVE). End-to-end validation requires a `workflow_dispatch` on the self-hosted runner with licensed terminology.