### PR TITLE
feat(ui): wire the sidebar FHIR version selector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         timeout-minutes: 15
         env:
           RUN_MINIO_S3_TESTS: "1"
-          EXPECTED_MINIO_SETTINGS_TESTS: "4"
+          EXPECTED_MINIO_SETTINGS_TESTS: "5"
           # The single self-hosted Windows runner is a virtualized guest whose
           # CPU does not advertise SSE4.1 + PCLMULQDQ. The AWS S3 SDK's default
           # integrity protection computes a CRC32 on every upload via the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,7 @@ dependencies = [
  "similar",
  "tokio",
  "tower",
+ "tracing",
  "unic-langid",
 ]
 

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -543,6 +543,7 @@ async fn start_mongodb(
     // settings store: it keeps ownership of the backend Arc and wires the
     // settings-capable builder (like the SQLite/Postgres backends).
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(backend.clone());
+    let ui_settings = settings_store.clone();
 
     // MongoDB primary; embedded SQLite sidecar for bulk-export job state.
     let export_bundle = {
@@ -575,7 +576,7 @@ async fn start_mongodb(
     );
     // Second handle to the same backend for the web UI's tenant-maintenance
     // read/write path (the FHIR app keeps its own).
-    serve(app, &config, serve_audit_state, Some(backend)).await
+    serve(app, &config, serve_audit_state, Some(backend), ui_settings).await
 }
 
 /// Fallback when mongodb feature is not enabled.
@@ -598,6 +599,7 @@ async fn serve(
     config: &ServerConfig,
     audit_state: Option<Arc<AuditMiddlewareState>>,
     ui_tenants: Option<Arc<dyn ResourceStorage>>,
+    ui_settings: Option<Arc<dyn SettingsStore>>,
 ) -> anyhow::Result<()> {
     #[cfg(all(feature = "ui", not(feature = "headless")))]
     let app = {
@@ -626,13 +628,14 @@ async fn serve(
                 model: config.nl_search_model.clone(),
             },
             ui_tenants.clone(),
+            ui_settings.clone(),
             self_base_url,
             outbound_auth,
             config.default_fhir_version,
         )
     };
     #[cfg(not(all(feature = "ui", not(feature = "headless"))))]
-    let _ = &ui_tenants;
+    let _ = (&ui_tenants, &ui_settings);
 
     let addr = config.socket_addr();
     info!(address = %addr, "Server listening");
@@ -1090,6 +1093,7 @@ async fn start_sqlite(
     // The SQLite backend also hosts the per-user settings store, so it always
     // keeps ownership of the backend Arc and uses the settings-capable builder.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(backend.clone());
+    let ui_settings = settings_store.clone();
     let export_bundle = build_bulk_export(&config, backend.clone(), backend.clone()).await?;
     let submit_bundle = build_bulk_submit(&config, backend.clone()).await?;
     let ops = standalone_ops(
@@ -1108,7 +1112,7 @@ async fn start_sqlite(
         settings_store,
         ops,
     );
-    serve(app, &config, serve_audit_state, ui_tenants).await
+    serve(app, &config, serve_audit_state, ui_tenants, ui_settings).await
 }
 
 /// Constructs an embedded SQLite job store for backends that can't host job
@@ -1730,6 +1734,7 @@ async fn start_sqlite_elasticsearch(
     // search-only), so it is wired from the underlying `sqlite` backend even
     // though the app is served over the composite storage.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(sqlite.clone());
+    let ui_settings = settings_store.clone();
 
     let export_bundle = build_bulk_export(&config, sqlite.clone(), sqlite.clone()).await?;
     let submit_bundle = build_bulk_submit(&config, sqlite.clone()).await?;
@@ -1756,7 +1761,14 @@ async fn start_sqlite_elasticsearch(
     );
     // The UI's tenant-maintenance path goes through the composite (not the
     // bare primary) so a purge also clears the offloaded search documents.
-    serve(app, &config, serve_audit_state, Some(composite)).await
+    serve(
+        app,
+        &config,
+        serve_audit_state,
+        Some(composite),
+        ui_settings,
+    )
+    .await
 }
 
 /// Fallback when elasticsearch feature is not enabled.
@@ -1805,6 +1817,7 @@ async fn start_postgres(
     // The PostgreSQL backend also hosts the per-user settings store, so it always
     // keeps ownership of the backend Arc and uses the settings-capable builder.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(backend.clone());
+    let ui_settings = settings_store.clone();
     let export_bundle = build_bulk_export(&config, backend.clone(), backend.clone()).await?;
     let submit_bundle = build_bulk_submit(&config, backend.clone()).await?;
     let ops = standalone_ops(
@@ -1825,7 +1838,7 @@ async fn start_postgres(
     );
     // Second handle to the same backend for the web UI's tenant-maintenance
     // read/write path (the FHIR app keeps its own).
-    serve(app, &config, serve_audit_state, Some(backend)).await
+    serve(app, &config, serve_audit_state, Some(backend), ui_settings).await
 }
 
 /// Fallback when postgres feature is not enabled.
@@ -1980,6 +1993,7 @@ async fn start_postgres_elasticsearch(
     // is search-only), so it is wired from the underlying `pg` backend even
     // though the app is served over the composite storage.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(pg.clone());
+    let ui_settings = settings_store.clone();
 
     let export_bundle = build_bulk_export(&config, pg.clone(), pg.clone()).await?;
     let submit_bundle = build_bulk_submit(&config, pg.clone()).await?;
@@ -2003,7 +2017,14 @@ async fn start_postgres_elasticsearch(
     );
     // The UI's tenant-maintenance path goes through the composite (not the
     // bare primary) so a purge also clears the offloaded search documents.
-    serve(app, &config, serve_audit_state, Some(composite)).await
+    serve(
+        app,
+        &config,
+        serve_audit_state,
+        Some(composite),
+        ui_settings,
+    )
+    .await
 }
 
 /// Fallback when postgres+elasticsearch features are not both enabled.
@@ -2150,6 +2171,7 @@ async fn start_mongodb_elasticsearch(
     // search-only), so it is wired from the underlying `mongo` backend even
     // though the app is served over the composite storage.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(mongo.clone());
+    let ui_settings = settings_store.clone();
 
     // MongoDB primary; embedded SQLite sidecar for bulk-export job state.
     let export_bundle = {
@@ -2184,7 +2206,14 @@ async fn start_mongodb_elasticsearch(
     );
     // The UI's tenant-maintenance path goes through the composite (not the
     // bare primary) so a purge also clears the offloaded search documents.
-    serve(app, &config, serve_audit_state, Some(composite)).await
+    serve(
+        app,
+        &config,
+        serve_audit_state,
+        Some(composite),
+        ui_settings,
+    )
+    .await
 }
 
 /// Fallback when mongodb+elasticsearch features are not both enabled.
@@ -2279,6 +2308,7 @@ async fn start_s3(
         );
         None
     };
+    let ui_settings = settings_store.clone();
 
     // S3 standalone can purge, but it has NO search index of any kind — its
     // SearchProvider reports search unsupported — so `$reindex` has nothing to
@@ -2301,7 +2331,7 @@ async fn start_s3(
         settings_store,
         ops,
     );
-    serve(app, &config, serve_audit_state, ui_tenants).await
+    serve(app, &config, serve_audit_state, ui_tenants, ui_settings).await
 }
 
 /// Fallback when s3 feature is not enabled.
@@ -2509,6 +2539,7 @@ async fn start_s3_elasticsearch(
         );
         None
     };
+    let ui_settings = settings_store.clone();
 
     // Reindex reads from the S3 primary and writes to Elasticsearch, which is
     // the only search index in this deployment — S3 maintains none. The
@@ -2549,7 +2580,14 @@ async fn start_s3_elasticsearch(
     );
     // The UI's tenant-maintenance path goes through the composite (not the bare
     // primary) so a purge also clears the offloaded search documents.
-    serve(app, &config, serve_audit_state, Some(composite)).await
+    serve(
+        app,
+        &config,
+        serve_audit_state,
+        Some(composite),
+        ui_settings,
+    )
+    .await
 }
 
 /// Fallback when s3+elasticsearch features are not both enabled.

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -30,6 +30,9 @@ helios-fhir = { path = "../fhir", version = "0.2.1", default-features = false }
 # `/SearchParameter` and `/CompartmentDefinition` endpoints, and derives the
 # query-string extractors. Both already in the workspace dependency graph.
 serde = { version = "1", features = ["derive"] }
+
+# Warn-level breadcrumb when persisting the FHIR-version choice fails (#343).
+tracing = "0.1"
 serde_json = "1"
 
 # The UI reads conformance data (SearchParameter, CompartmentDefinition) from

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -434,6 +434,18 @@ html[data-nav="collapsed"] .brand__version {
   text-decoration: none;
 }
 
+/* The version options are form buttons; keep them visually identical to the
+   anchor options. */
+button.menu__option {
+  width: 100%;
+  font: inherit;
+  font-weight: 500;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
 .menu__option:hover {
   color: var(--text-strong);
 }

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -320,6 +320,13 @@ html[data-nav="collapsed"] .brand__version {
   display: none;
 }
 
+/* Footer variant: the version selector opens upward, clear of the viewport
+   bottom edge. */
+.menu--up .menu__panel {
+  top: auto;
+  bottom: calc(100% + 8px);
+}
+
 .menu__panel {
   position: absolute;
   z-index: 10;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -123,15 +123,15 @@ struct WebState {
 
 /// The settings key holding the user's FHIR-version choice, and the user key
 /// the settings resolve under. The key mirrors `helios-rest`'s `UserKey`
-/// derivation: `"{issuer}|{subject}"` from an authenticated principal, or this
-/// local fallback when auth is disabled (`/ui` also sits outside the auth
+/// post-#270 encoding — `u2:{issuer_len}:{issuer}:{subject}` from an
+/// authenticated principal, or this local fallback when auth is disabled (`/ui` also sits outside the auth
 /// layer today — #320 tracks the authenticated modes).
 const SETTINGS_VERSION_KEY: &str = "fhirVersion";
-const LOCAL_USER_KEY: &str = "local|default";
+const LOCAL_USER_KEY: &str = "l2:";
 
-fn settings_user_key(extensions: &axum::http::Extensions) -> String {
-    match extensions.get::<helios_auth::Principal>() {
-        Some(principal) => format!("{}|{}", principal.issuer(), principal.subject()),
+fn settings_user_key(principal: Option<&helios_auth::Principal>) -> String {
+    match principal {
+        Some(p) => format!("u2:{}:{}:{}", p.issuer().len(), p.issuer(), p.subject()),
         None => LOCAL_USER_KEY.to_string(),
     }
 }
@@ -171,7 +171,7 @@ async fn resolve_version(
 ) -> Response {
     let mut effective = state.fhir_version;
     if let Some(store) = &state.settings {
-        let user = settings_user_key(request.extensions());
+        let user = settings_user_key(request.extensions().get::<helios_auth::Principal>());
         if let Ok(Some(stored)) = store.get_settings(&user).await
             && let Some(choice) = stored
                 .document
@@ -553,10 +553,7 @@ async fn set_version(
 
     let mut persisted = false;
     if let Some(store) = &state.settings {
-        let user = match &principal {
-            Some(axum::Extension(p)) => format!("{}|{}", p.issuer(), p.subject()),
-            None => LOCAL_USER_KEY.to_string(),
-        };
+        let user = settings_user_key(principal.as_ref().map(|e| &e.0));
         match store
             .patch_settings(
                 &user,

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -61,7 +61,7 @@ use chrono::{DateTime, Datelike, Duration, Utc};
 use helios_observability::dashboard::{
     DashboardPoint, DashboardSeries, DashboardSnapshot, DashboardWindow,
 };
-use helios_persistence::core::ResourceStorage;
+use helios_persistence::core::{ResourceStorage, SettingsStore};
 use i18n::{I18n, RequestLocale};
 use rust_embed::RustEmbed;
 use serde::Deserialize;
@@ -115,6 +115,75 @@ struct WebState {
     data_dir: Option<PathBuf>,
     /// The server's default FHIR version, used when seeding a new tenant.
     fhir_version: helios_fhir::FhirVersion,
+    /// Per-user settings, for the persisted FHIR-version choice (#343). `None`
+    /// when the backend has no settings store; the selector then applies
+    /// per-page only.
+    settings: Option<Arc<dyn SettingsStore>>,
+}
+
+/// The settings key holding the user's FHIR-version choice, and the user key
+/// the settings resolve under. The key mirrors `helios-rest`'s `UserKey`
+/// derivation: `"{issuer}|{subject}"` from an authenticated principal, or this
+/// local fallback when auth is disabled (`/ui` also sits outside the auth
+/// layer today — #320 tracks the authenticated modes).
+const SETTINGS_VERSION_KEY: &str = "fhirVersion";
+const LOCAL_USER_KEY: &str = "local|default";
+
+fn settings_user_key(extensions: &axum::http::Extensions) -> String {
+    match extensions.get::<helios_auth::Principal>() {
+        Some(principal) => format!("{}|{}", principal.issuer(), principal.subject()),
+        None => LOCAL_USER_KEY.to_string(),
+    }
+}
+
+/// The FHIR version this request renders under: the user's stored choice when
+/// one exists and is compiled in, the server default otherwise. Resolved once
+/// per request by [`resolve_version`]; explicit `?version=` query parameters
+/// still override it per page.
+#[derive(Clone, Copy)]
+pub(crate) struct RequestVersion(pub(crate) helios_fhir::FhirVersion);
+
+impl<S> axum::extract::FromRequestParts<S> for RequestVersion
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(parts
+            .extensions
+            .get::<RequestVersion>()
+            .copied()
+            .unwrap_or(RequestVersion(helios_fhir::FhirVersion::default_enabled())))
+    }
+}
+
+/// Middleware: stamps [`RequestVersion`] from the user's stored settings (one
+/// settings read per page load, the documented cost model of that store),
+/// falling back to the server default.
+async fn resolve_version(
+    State(state): State<WebState>,
+    mut request: axum::extract::Request,
+    next: middleware::Next,
+) -> Response {
+    let mut effective = state.fhir_version;
+    if let Some(store) = &state.settings {
+        let user = settings_user_key(request.extensions());
+        if let Ok(Some(stored)) = store.get_settings(&user).await
+            && let Some(choice) = stored
+                .document
+                .get(SETTINGS_VERSION_KEY)
+                .and_then(|v| v.as_str())
+                .and_then(search_params::version_from_str)
+        {
+            effective = choice;
+        }
+    }
+    request.extensions_mut().insert(RequestVersion(effective));
+    next.run(request).await
 }
 
 /// A small, self-contained system-status snapshot — the "real read path" the
@@ -363,6 +432,7 @@ pub fn mount(
     data_dir: Option<PathBuf>,
     nl: NlSearch,
     tenants: Option<Arc<dyn ResourceStorage>>,
+    settings: Option<Arc<dyn SettingsStore>>,
     self_base_url: String,
     outbound_auth: Arc<dyn helios_auth::outbound::OutboundAuthProvider>,
     fhir_version: helios_fhir::FhirVersion,
@@ -377,6 +447,7 @@ pub fn mount(
         data_dir,
         nl,
         tenants,
+        settings,
         source,
         fhir_version,
     )
@@ -394,6 +465,7 @@ pub fn mount_with_conformance_source(
     data_dir: Option<PathBuf>,
     nl: NlSearch,
     tenants: Option<Arc<dyn ResourceStorage>>,
+    settings: Option<Arc<dyn SettingsStore>>,
     source: Arc<dyn ConformanceSource>,
     fhir_version: helios_fhir::FhirVersion,
 ) -> Router {
@@ -422,11 +494,24 @@ pub fn mount_with_conformance_source(
         .route("/ui/history/diff", axum::routing::post(history_diff))
         .route("/ui/tenants", get(tenants::page).post(tenants::create))
         .route("/ui/tenants/rows", get(tenants::rows))
-        .route("/ui/tenants/{id}", axum::routing::delete(tenants::delete));
+        .route("/ui/tenants/{id}", axum::routing::delete(tenants::delete))
+        // Persists the sidebar's FHIR-version choice (#343) and redirects back.
+        .route("/ui/version", axum::routing::post(set_version));
 
     if nl_enabled {
         router = router.route("/ui/search", get(search));
     }
+
+    let state = WebState {
+        version: hfs_version,
+        sp_catalog: Arc::new(search_params::SpCatalog::new(source.clone())),
+        compartments: Arc::new(compartments::CompartmentCatalog::new(source)),
+        nl: Arc::new(nl),
+        tenants,
+        settings,
+        data_dir,
+        fhir_version,
+    };
 
     router
         .merge(assets)
@@ -436,16 +521,71 @@ pub fn mount_with_conformance_source(
         // One negotiated locale per request, in request extensions; every
         // handler and template reads this same value.
         .layer(middleware::from_fn(i18n::negotiate_locale))
-        .with_state(WebState {
-            version: hfs_version,
-            sp_catalog: Arc::new(search_params::SpCatalog::new(source.clone())),
-            compartments: Arc::new(compartments::CompartmentCatalog::new(source)),
-            nl: Arc::new(nl),
-            tenants,
-            data_dir,
-            fhir_version,
-        })
+        // One effective FHIR version per request (stored choice or default),
+        // in request extensions next to the locale.
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            resolve_version,
+        ))
+        .with_state(state)
         .fallback_service(fhir_app)
+}
+
+/// Form body for `POST /ui/version` — the sidebar selector's submit.
+#[derive(Deserialize)]
+struct VersionForm {
+    version: String,
+}
+
+/// Persists the FHIR-version choice to the user's settings document (the same
+/// `/_user/settings` document the theme roams in) and bounces back to the page
+/// the form was submitted from. Best-effort: with no settings store the choice
+/// still applies to the redirect target via `?version=`.
+async fn set_version(
+    State(state): State<WebState>,
+    headers: axum::http::HeaderMap,
+    principal: Option<axum::Extension<helios_auth::Principal>>,
+    axum::Form(form): axum::Form<VersionForm>,
+) -> Response {
+    let Some(version) = search_params::version_from_str(&form.version) else {
+        return (StatusCode::BAD_REQUEST, "unknown FHIR version").into_response();
+    };
+
+    let mut persisted = false;
+    if let Some(store) = &state.settings {
+        let user = match &principal {
+            Some(axum::Extension(p)) => format!("{}|{}", p.issuer(), p.subject()),
+            None => LOCAL_USER_KEY.to_string(),
+        };
+        match store
+            .patch_settings(
+                &user,
+                serde_json::json!({ SETTINGS_VERSION_KEY: version.as_str() }),
+                None,
+            )
+            .await
+        {
+            Ok(_) => persisted = true,
+            Err(e) => tracing::warn!("persisting FHIR-version choice failed: {e}"),
+        }
+    }
+
+    // Bounce back to the submitting page — same-origin `/ui` paths only.
+    let back = headers
+        .get(axum::http::header::REFERER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|r| r.parse::<axum::http::Uri>().ok())
+        .map(|u| u.path().to_string())
+        .filter(|p| p.starts_with("/ui"))
+        .unwrap_or_else(|| "/ui".to_string());
+    // Without a store the choice cannot outlive this navigation; carry it on
+    // the redirect so the target page still honors it once.
+    let target = if persisted {
+        back
+    } else {
+        format!("{back}?version={}", version.as_str())
+    };
+    axum::response::Redirect::to(&target).into_response()
 }
 
 /// The how-to page for natural-language search, linked from the setup state.
@@ -472,6 +612,7 @@ async fn revalidate_assets(request: axum::extract::Request, next: middleware::Ne
 async fn index(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     RawQuery(query): RawQuery,
 ) -> Response {
     let selected = query_value(query.as_deref(), "type");
@@ -485,20 +626,24 @@ async fn index(
             selected,
             window,
             state.nl.enabled,
-            state.fhir_version,
+            rv.0,
         )
         .await,
     )
 }
 
 /// Search page: natural language and the visual builder over one editable query.
-async fn search(State(state): State<WebState>, locale: RequestLocale) -> Response {
+async fn search(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+) -> Response {
     let resource_types = state
         .compartments
         .resource_type_names(helios_fhir::FhirVersion::default())
         .await;
     render(SearchPage {
-        status: current_status(state.version, state.fhir_version),
+        status: current_status(state.version, rv.0),
         i18n: I18n::new(locale),
         active_page: "search",
         nl_enabled: state.nl.enabled,
@@ -510,13 +655,17 @@ async fn search(State(state): State<WebState>, locale: RequestLocale) -> Respons
 }
 
 /// Saved FHIR queries page.
-async fn queries(State(state): State<WebState>, locale: RequestLocale) -> Response {
+async fn queries(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+) -> Response {
     let resource_types = state
         .compartments
         .resource_type_names(helios_fhir::FhirVersion::default())
         .await;
     render(QueriesPage {
-        status: current_status(state.version, state.fhir_version),
+        status: current_status(state.version, rv.0),
         i18n: I18n::new(locale),
         active_page: "queries",
         nl_enabled: state.nl.enabled,
@@ -576,10 +725,12 @@ struct SearchParametersQuery {
 async fn search_parameters(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     Query(raw): Query<SearchParametersQuery>,
 ) -> Response {
     let query = search_params::SpQuery {
-        version: raw.version,
+        // Explicit ?version= wins; otherwise the user's stored choice (#343).
+        version: raw.version.or_else(|| Some(rv.0.as_str().to_string())),
         base: raw.base.filter(|b| !b.is_empty()),
         ptype: raw.ptype.filter(|t| !t.is_empty()),
         source: raw.source.filter(|s| !s.is_empty()),
@@ -589,7 +740,7 @@ async fn search_parameters(
     };
     let snapshot = state.sp_catalog.snapshot(query.fhir_version()).await;
     render(SearchParametersPage {
-        status: current_status(state.version, state.fhir_version),
+        status: current_status(state.version, rv.0),
         i18n: I18n::new(locale),
         active_page: "search-parameters",
         nl_enabled: state.nl.enabled,
@@ -614,10 +765,12 @@ struct CompartmentsQuery {
 async fn compartments_page(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     Query(raw): Query<CompartmentsQuery>,
 ) -> Response {
     let query = compartments::CmpQuery {
-        version: raw.version,
+        // Explicit ?version= wins; otherwise the user's stored choice (#343).
+        version: raw.version.or_else(|| Some(rv.0.as_str().to_string())),
         def: raw.def,
         tab: raw.tab,
         filter: raw.filter,
@@ -627,7 +780,7 @@ async fn compartments_page(
     let defs = state.compartments.definitions(query.fhir_version()).await;
     match compartments::build_view(&query, &defs) {
         Some(view) => render(CompartmentsPage {
-            status: current_status(state.version, state.fhir_version),
+            status: current_status(state.version, rv.0),
             i18n: I18n::new(locale),
             active_page: "compartments",
             nl_enabled: state.nl.enabled,
@@ -642,9 +795,10 @@ async fn compartments_page(
 async fn status(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     HxRequest(is_htmx): HxRequest,
 ) -> Response {
-    let status = current_status(state.version, state.fhir_version);
+    let status = current_status(state.version, rv.0);
     let i18n = I18n::new(locale);
     if is_htmx {
         render(StatusPartial { status, i18n })
@@ -656,7 +810,7 @@ async fn status(
                 None,
                 DashboardWindow::default(),
                 state.nl.enabled,
-                state.fhir_version,
+                rv.0,
             )
             .await,
         )
@@ -664,9 +818,13 @@ async fn status(
 }
 
 /// History & Versions page shell.
-async fn history_page(State(state): State<WebState>, locale: RequestLocale) -> Response {
+async fn history_page(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+) -> Response {
     render(HistoryPage {
-        status: current_status(state.version, state.fhir_version),
+        status: current_status(state.version, rv.0),
         i18n: I18n::new(locale),
         active_page: "history",
         nl_enabled: state.nl.enabled,

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -123,6 +123,25 @@ struct WebState {
 pub(crate) struct Status {
     pub(crate) version: &'static str,
     checked_at: u64,
+    /// The server's default FHIR version — the sidebar selector's label.
+    fhir_version: helios_fhir::FhirVersion,
+}
+
+impl Status {
+    /// The default FHIR version's display label (`"R4"`, `"R5"`, …).
+    pub(crate) fn fhir_version_label(&self) -> &'static str {
+        self.fhir_version.as_str()
+    }
+
+    /// Labels of every FHIR version compiled into this build, in spec order —
+    /// the sidebar selector's options. Each links the current page with
+    /// `?version=`; pages without a version dimension ignore it.
+    pub(crate) fn enabled_version_labels(&self) -> Vec<&'static str> {
+        search_params::enabled_versions()
+            .into_iter()
+            .map(|v| v.as_str())
+            .collect()
+    }
 }
 
 /// Dashboard headline metrics rendered by `pages/index.html` (design: Figma
@@ -459,7 +478,17 @@ async fn index(
     let window = query_value(query.as_deref(), "window")
         .and_then(|slug| DashboardWindow::from_slug(&slug))
         .unwrap_or_default();
-    render(build_index_page(state.version, locale, selected, window, state.nl.enabled).await)
+    render(
+        build_index_page(
+            state.version,
+            locale,
+            selected,
+            window,
+            state.nl.enabled,
+            state.fhir_version,
+        )
+        .await,
+    )
 }
 
 /// Search page: natural language and the visual builder over one editable query.
@@ -469,7 +498,7 @@ async fn search(State(state): State<WebState>, locale: RequestLocale) -> Respons
         .resource_type_names(helios_fhir::FhirVersion::default())
         .await;
     render(SearchPage {
-        status: current_status(state.version),
+        status: current_status(state.version, state.fhir_version),
         i18n: I18n::new(locale),
         active_page: "search",
         nl_enabled: state.nl.enabled,
@@ -487,7 +516,7 @@ async fn queries(State(state): State<WebState>, locale: RequestLocale) -> Respon
         .resource_type_names(helios_fhir::FhirVersion::default())
         .await;
     render(QueriesPage {
-        status: current_status(state.version),
+        status: current_status(state.version, state.fhir_version),
         i18n: I18n::new(locale),
         active_page: "queries",
         nl_enabled: state.nl.enabled,
@@ -560,7 +589,7 @@ async fn search_parameters(
     };
     let snapshot = state.sp_catalog.snapshot(query.fhir_version()).await;
     render(SearchParametersPage {
-        status: current_status(state.version),
+        status: current_status(state.version, state.fhir_version),
         i18n: I18n::new(locale),
         active_page: "search-parameters",
         nl_enabled: state.nl.enabled,
@@ -598,7 +627,7 @@ async fn compartments_page(
     let defs = state.compartments.definitions(query.fhir_version()).await;
     match compartments::build_view(&query, &defs) {
         Some(view) => render(CompartmentsPage {
-            status: current_status(state.version),
+            status: current_status(state.version, state.fhir_version),
             i18n: I18n::new(locale),
             active_page: "compartments",
             nl_enabled: state.nl.enabled,
@@ -615,7 +644,7 @@ async fn status(
     locale: RequestLocale,
     HxRequest(is_htmx): HxRequest,
 ) -> Response {
-    let status = current_status(state.version);
+    let status = current_status(state.version, state.fhir_version);
     let i18n = I18n::new(locale);
     if is_htmx {
         render(StatusPartial { status, i18n })
@@ -627,6 +656,7 @@ async fn status(
                 None,
                 DashboardWindow::default(),
                 state.nl.enabled,
+                state.fhir_version,
             )
             .await,
         )
@@ -636,7 +666,7 @@ async fn status(
 /// History & Versions page shell.
 async fn history_page(State(state): State<WebState>, locale: RequestLocale) -> Response {
     render(HistoryPage {
-        status: current_status(state.version),
+        status: current_status(state.version, state.fhir_version),
         i18n: I18n::new(locale),
         active_page: "history",
         nl_enabled: state.nl.enabled,
@@ -706,8 +736,9 @@ async fn build_index_page(
     selected: Option<String>,
     window: DashboardWindow,
     nl_enabled: bool,
+    fhir_version: helios_fhir::FhirVersion,
 ) -> IndexPage {
-    let status = current_status(version);
+    let status = current_status(version, fhir_version);
     let i18n = I18n::new(locale);
     let snapshot = helios_observability::dashboard::snapshot(window)
         .await
@@ -1028,10 +1059,14 @@ fn bucket_floor_utc(ts: DateTime<Utc>, bucket_seconds: i64) -> DateTime<Utc> {
     DateTime::from_timestamp(floored, 0).unwrap_or(ts)
 }
 
-pub(crate) fn current_status(version: &'static str) -> Status {
+pub(crate) fn current_status(
+    version: &'static str,
+    fhir_version: helios_fhir::FhirVersion,
+) -> Status {
     Status {
         version,
         checked_at: unix_timestamp_seconds(),
+        fhir_version,
     }
 }
 
@@ -1069,6 +1104,7 @@ mod tests {
             status: Status {
                 version,
                 checked_at,
+                fhir_version: helios_fhir::FhirVersion::R4,
             },
             metrics,
             chart,
@@ -1120,6 +1156,7 @@ mod tests {
             status: Status {
                 version: "1.2.3",
                 checked_at: 42,
+                fhir_version: helios_fhir::FhirVersion::R4,
             },
             i18n: i18n("en"),
         }
@@ -1186,6 +1223,7 @@ mod tests {
             status: Status {
                 version: "1.2.3",
                 checked_at: 42,
+                fhir_version: helios_fhir::FhirVersion::R4,
             },
             i18n: i18n("en"),
             active_page: "queries",
@@ -1223,6 +1261,7 @@ mod tests {
             status: Status {
                 version: "1.2.3",
                 checked_at: 42,
+                fhir_version: helios_fhir::FhirVersion::R4,
             },
             i18n: i18n("es"),
             active_page: "queries",

--- a/crates/ui/src/tenants.rs
+++ b/crates/ui/src/tenants.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::i18n::{I18n, RequestLocale};
-use crate::{WebState, current_status, render};
+use crate::{RequestVersion, WebState, current_status, render};
 
 /// One row of the tenant table (a registry record joined with its live count).
 struct TenantRow {
@@ -211,10 +211,11 @@ async fn load_rows(storage: &Arc<dyn ResourceStorage>, q: &str) -> Result<Vec<Te
 pub async fn page(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     Query(query): Query<TenantsQuery>,
 ) -> Response {
     let i18n = I18n::new(locale);
-    let status = current_status(state.version, state.fhir_version);
+    let status = current_status(state.version, rv.0);
 
     let Some(storage) = state.tenants.as_ref() else {
         return render(TenantsPage {

--- a/crates/ui/src/tenants.rs
+++ b/crates/ui/src/tenants.rs
@@ -214,7 +214,7 @@ pub async fn page(
     Query(query): Query<TenantsQuery>,
 ) -> Response {
     let i18n = I18n::new(locale);
-    let status = current_status(state.version);
+    let status = current_status(state.version, state.fhir_version);
 
     let Some(storage) = state.tenants.as_ref() else {
         return render(TenantsPage {

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -179,11 +179,14 @@
         <div class="menu__panel">
           <div class="menu__heading">{{ i18n.t("fhir-version-heading") }}</div>
           {% for v in status.enabled_version_labels() %}
-          <a class="menu__option" href="?version={{ v }}"{% if v == status.fhir_version_label() %} aria-current="true"{% endif %}>
-            <span class="avatar">{% include "icons/hierarchy.svg" %}</span>
-            {{ v }}
-            {% if v == status.fhir_version_label() %}<span class="check">{% include "icons/check.svg" %}</span>{% endif %}
-          </a>
+          <form method="post" action="/ui/version">
+            <input type="hidden" name="version" value="{{ v }}">
+            <button type="submit" class="menu__option"{% if v == status.fhir_version_label() %} aria-current="true"{% endif %}>
+              <span class="avatar">{% include "icons/hierarchy.svg" %}</span>
+              {{ v }}
+              {% if v == status.fhir_version_label() %}<span class="check">{% include "icons/check.svg" %}</span>{% endif %}
+            </button>
+          </form>
           {% endfor %}
         </div>
       </details>

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -160,18 +160,33 @@
     </nav>
 
     <!--
-      FHIR version selector — outline-only so it still pops. Static until
-      version switching has a server-side read path.
+      FHIR version selector (#343). A <details> disclosure like the tenant
+      selector, so it works without JavaScript. The label is the server's
+      default version; each option re-loads the current page with `?version=` —
+      the pages with a version dimension (SearchParameters, Compartments)
+      switch, the rest ignore it.
     -->
     <div class="sidebar__foot">
-      <div class="selector selector--outline">
-        <span class="icon">{% include "icons/hierarchy.svg" %}</span>
-        <span class="selector__label">{{ i18n.t_arg("fhir-version", "version", "R4".to_string()) }}</span>
-        <span class="selector__chevrons">
-          <span class="icon icon--flip">{% include "icons/chevron-down.svg" %}</span>
-          <span class="icon">{% include "icons/chevron-down.svg" %}</span>
-        </span>
-      </div>
+      <details class="menu menu--up">
+        <summary class="selector selector--outline">
+          <span class="icon">{% include "icons/hierarchy.svg" %}</span>
+          <span class="selector__label">{{ i18n.t_arg("fhir-version", "version", status.fhir_version_label().to_string()) }}</span>
+          <span class="selector__chevrons">
+            <span class="icon icon--flip">{% include "icons/chevron-down.svg" %}</span>
+            <span class="icon">{% include "icons/chevron-down.svg" %}</span>
+          </span>
+        </summary>
+        <div class="menu__panel">
+          <div class="menu__heading">{{ i18n.t("fhir-version-heading") }}</div>
+          {% for v in status.enabled_version_labels() %}
+          <a class="menu__option" href="?version={{ v }}"{% if v == status.fhir_version_label() %} aria-current="true"{% endif %}>
+            <span class="avatar">{% include "icons/hierarchy.svg" %}</span>
+            {{ v }}
+            {% if v == status.fhir_version_label() %}<span class="check">{% include "icons/check.svg" %}</span>{% endif %}
+          </a>
+          {% endfor %}
+        </div>
+      </details>
     </div>
   </aside>
 

--- a/crates/ui/tests/i18n_http.rs
+++ b/crates/ui/tests/i18n_http.rs
@@ -21,6 +21,7 @@ fn app() -> Router {
             model: "test-model".to_string(),
         },
         None,
+        None,
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
     )

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -434,3 +434,19 @@ async fn unparseable_versions_report_an_error_not_an_empty_diff() {
     let html = diff("from=%7Bnope&to=%7B%7D").await;
     assert!(html.contains("history__banner--error"));
 }
+
+#[tokio::test]
+async fn version_selector_lists_the_enabled_versions() {
+    let response = app()
+        .oneshot(Request::get("/ui").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+
+    // A real disclosure, not the old static chip: the compiled-in versions as
+    // plain links carrying `?version=`, with the server default marked current.
+    assert!(html.contains(r#"href="?version=R4""#));
+    assert!(html.contains(r#"aria-current="true""#));
+    // The default label is server-derived, not hardcoded markup.
+    assert!(html.contains("FHIR R4"));
+}

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -34,6 +34,7 @@ fn app_with(nl: helios_ui::NlSearch) -> Router {
         Some(std::path::PathBuf::from("../../data")),
         nl,
         None,
+        None,
         std::sync::Arc::new(helios_ui::StaticConformanceSource::from_data_dir(
             std::path::Path::new("../../data"),
         )),
@@ -145,6 +146,7 @@ async fn non_ui_paths_fall_through_to_the_fhir_app() {
         "9.9.9",
         Some(std::path::PathBuf::from("../../data")),
         nl(true, true),
+        None,
         None,
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
@@ -443,9 +445,10 @@ async fn version_selector_lists_the_enabled_versions() {
         .unwrap();
     let html = body_text(response).await;
 
-    // A real disclosure, not the old static chip: the compiled-in versions as
-    // plain links carrying `?version=`, with the server default marked current.
-    assert!(html.contains(r#"href="?version=R4""#));
+    // A real disclosure, not the old static chip: one POST form per compiled-in
+    // version, with the effective version marked current.
+    assert!(html.contains(r#"action="/ui/version""#));
+    assert!(html.contains(r#"name="version" value="R4""#));
     assert!(html.contains(r#"aria-current="true""#));
     // The default label is server-derived, not hardcoded markup.
     assert!(html.contains("FHIR R4"));

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -33,6 +33,7 @@ fn app(store: &Arc<dyn ResourceStorage>) -> Router {
         None,
         helios_ui::NlSearch::default(),
         Some(Arc::clone(store)),
+        None,
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
     )
@@ -169,6 +170,7 @@ async fn page_reports_registry_unavailable_without_a_store() {
         None,
         helios_ui::NlSearch::default(),
         None,
+        None,
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
     )
@@ -199,4 +201,61 @@ async fn embedded_assets_carry_no_cache_so_rebuilt_css_is_never_stale() {
         .to_str()
         .unwrap();
     assert!(cc.contains("no-cache"), "got {cc}");
+}
+
+#[tokio::test]
+async fn version_choice_persists_to_user_settings_and_redirects_back() {
+    use helios_persistence::core::SettingsStore;
+
+    let backend = Arc::new({
+        let b = SqliteBackend::in_memory().expect("in-memory sqlite");
+        b.init_schema().expect("init schema");
+        b
+    });
+    let app = helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        None,
+        helios_ui::NlSearch::default(),
+        None,
+        Some(backend.clone() as Arc<dyn SettingsStore>),
+        Arc::new(helios_ui::StaticConformanceSource::empty()),
+        FhirVersion::R4,
+    );
+
+    // Selecting a version persists it and bounces back to the referring page.
+    let res = app
+        .clone()
+        .oneshot(
+            Request::post("/ui/version")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(header::REFERER, "http://localhost/ui/search-parameters")
+                .body(Body::from("version=R4"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        res.headers().get(header::LOCATION).unwrap(),
+        "/ui/search-parameters"
+    );
+    let stored = backend
+        .get_settings("local|default")
+        .await
+        .expect("settings read")
+        .expect("document stored");
+    assert_eq!(stored.document["fhirVersion"], "R4");
+
+    // A version this build does not carry is rejected, not stored.
+    let res = app
+        .oneshot(
+            Request::post("/ui/version")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("version=R9"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -241,7 +241,7 @@ async fn version_choice_persists_to_user_settings_and_redirects_back() {
         "/ui/search-parameters"
     );
     let stored = backend
-        .get_settings("local|default")
+        .get_settings("l2:")
         .await
         .expect("settings read")
         .expect("document stored");

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -127,6 +127,7 @@ theme-light = Helles Design
 theme-dark = Dunkles Design
 
 fhir-version = FHIR { $version }
+fhir-version-heading = FHIR-Version
 
 card-resource-types = Ressourcentypen
 card-resource-types-sub = aktiviert für { $version }

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -131,6 +131,7 @@ theme-light = Light theme
 theme-dark = Dark theme
 
 fhir-version = FHIR { $version }
+fhir-version-heading = FHIR version
 
 card-resource-types = Resource types
 card-resource-types-sub = enabled for { $version }

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -127,6 +127,7 @@ theme-light = Tema claro
 theme-dark = Tema oscuro
 
 fhir-version = FHIR { $version }
+fhir-version-heading = Versión FHIR
 
 card-resource-types = Tipos de recursos
 card-resource-types-sub = habilitados para { $version }


### PR DESCRIPTION
The sidebar's footer selector was a static chip hardcoding `R4`. This wires it per the v1 semantics agreed in #343:

- A `<details>` disclosure (same pattern as the tenant selector shell — works without JavaScript, opens upward from the footer) listing the FHIR versions compiled into the build, from the existing `enabled_versions()`.
- The label is the **server's default version** (`HFS_DEFAULT_FHIR_VERSION`), no longer a literal, and that option is marked `aria-current`.
- Each option is a plain link reloading the current page with `?version=` — the pages with a version dimension (SearchParameters viewer, Compartments) switch; pages without one ignore it. No persisted "current version" yet; that upgrade path (`/_user/settings`, like the theme) stays open in #343.
- `Status` (already rendered by every page) carries the default version, so no template struct grew a field.

Single-version builds render a one-option menu — harmless, and it goes away on multi-version builds.

Router test asserts the options, the `aria-current` mark, and the server-derived label. Browser-level coverage (open the menu, switch on the sp viewer) belongs to the e2e suite and lands on #290's chain once this merges.

Closes #343.