### PR TITLE
perf(hts): attribute + trim the uniform throughput residual since v0.2.0 (#298)

### DIFF
--- a/.github/scripts/obs-ab/report.py
+++ b/.github/scripts/obs-ab/report.py
@@ -55,7 +55,14 @@ ERR_VOID = 0.01
 
 # What each adjacency attributes, given the arm switch semantics. Keyed by
 # (from_arm, to_arm). Anything not listed is labelled "bundled".
+#
+# `baseline` is not an instrumentation switch — it is a different binary, built
+# from the workflow's `baseline_ref`. Any adjacency touching it prices ALL code
+# change across that revision range, so it must never be read as the cost of
+# whatever component the neighbouring arm names.
 ADJACENCY_MEANING = {
+    ("baseline", "off"): "all code change since baseline_ref, instrumentation excluded",
+    ("baseline", "default"): "all code change since baseline_ref, instrumentation included",
     ("off", "default"): "metrics (clean isolate)",
     ("default", "no-span"): "reqlog (span still off in bench)",
     ("no-span", "full"): "span",
@@ -186,6 +193,11 @@ def main() -> int:
     ap.add_argument("--commit", default="")
     ap.add_argument("--build", default="debug (opt-level 0)")
     ap.add_argument("--csv-out", default="")
+    ap.add_argument(
+        "--baseline-ref",
+        default="",
+        help="git ref the `baseline` version arm was built from, if present",
+    )
     args = ap.parse_args()
 
     arms = [a for a in args.arms.replace(",", " ").split() if a]
@@ -201,6 +213,11 @@ def main() -> int:
     out.append(f"| **Arms** | `{' → '.join(arms)}` |")
     out.append(f"| **Rounds** | {args.rounds} (interleaved; deltas paired within a round) |")
     out.append(f"| **Build** | **{args.build} — ratios/direction only, NOT release magnitude** |")
+    if "baseline" in arms:
+        out.append(
+            f"| **Baseline arm** | separate binary built from "
+            f"`{args.baseline_ref or '(ref not recorded)'}` |"
+        )
     out.append("")
     out.append(
         "> In the benchmark `default` = metrics-only (no OTLP exporter → span off; "
@@ -208,6 +225,18 @@ def main() -> int:
         "component (metrics); later hops bundle span/reqlog/probe-logs. Primary "
         "metric below is **VU=1 p50** (purest per-request cost); RPS is the headline."
     )
+    if "baseline" in arms:
+        out.append("")
+        out.append(
+            "> **Reading the `baseline` arm.** It is a different *binary*, not a "
+            "different switch, so any delta against it prices every code change in "
+            "the range — not one component. The database is imported once by the "
+            "CURRENT binary and restored pristine before each arm, so the corpus is "
+            "held identical: this measures old serving code over new data, and is "
+            "**not** a reproduction of that release. Deltas against `off` and "
+            "`default` bracket the same range with instrumentation excluded and "
+            "included respectively."
+        )
     out.append("")
 
     if not data:

--- a/.github/scripts/obs-ab/run-arms.sh
+++ b/.github/scripts/obs-ab/run-arms.sh
@@ -181,9 +181,15 @@ start_server() {
   # startup line (main.rs). If it does not match, the arm is inert (e.g. a
   # server built without the arm switch) and its numbers are meaningless.
   if [ -n "$expected" ]; then
-    if ! grep -Eq "obs_mode=${expected}\b" "$logfile"; then
+    # Strip ANSI colour escapes before matching: a server writing to this file
+    # may still colourize (older builds, or a forced-colour env), which would
+    # otherwise split `obs_mode=Off` with escape sequences and fail the match.
+    local plainlog
+    plainlog="$(sed -E 's/\x1b\[[0-9;]*m//g' "$logfile")"
+    if ! printf '%s' "$plainlog" | grep -Eq "obs_mode=${expected}\b"; then
       echo "  ERROR: server did not report obs_mode=${expected}; arm '${arm}' is not active."
-      grep -i 'obs_mode' "$logfile" | head -3 || echo "    (no obs_mode line found in startup log)"
+      printf '%s' "$plainlog" | grep -i 'obs_mode' | head -3 \
+        || echo "    (no obs_mode line found in startup log)"
       return 1
     fi
     echo "  active arm confirmed: obs_mode=${expected}"

--- a/.github/scripts/obs-ab/run-arms.sh
+++ b/.github/scripts/obs-ab/run-arms.sh
@@ -127,13 +127,24 @@ start_server() {
   started_epoch=$(date +%s)
 
   echo "  starting server: HELIOS_OBS_MODE=${obs} RUST_LOG='${rustlog}'  -> ${logfile}"
-  # RUST_LOG (when set) overrides HTS_LOG_LEVEL in the server's EnvFilter; unset
-  # for every non-probe arm so only the probe arm changes the log configuration.
-  HTS_SERVER_PORT="$PORT" \
-  HTS_LOG_LEVEL="info" \
-  HELIOS_OBS_MODE="$obs" \
-  RUST_LOG="$rustlog" \
-    "$HTS_BIN" >"$logfile" 2>&1 &
+  # RUST_LOG (when set) overrides HTS_LOG_LEVEL in the server's EnvFilter. It
+  # must be genuinely UNSET for the non-probe arms, not set to "" — a set-but-
+  # empty RUST_LOG makes the tracing EnvFilter enable nothing, which suppresses
+  # the startup `obs_mode=` line this script greps to confirm the active arm.
+  # `env -u RUST_LOG` guarantees it is absent (even if inherited); the probe arm
+  # sets it explicitly.
+  if [ -n "$rustlog" ]; then
+    HTS_SERVER_PORT="$PORT" \
+    HTS_LOG_LEVEL="info" \
+    HELIOS_OBS_MODE="$obs" \
+    RUST_LOG="$rustlog" \
+      "$HTS_BIN" >"$logfile" 2>&1 &
+  else
+    HTS_SERVER_PORT="$PORT" \
+    HTS_LOG_LEVEL="info" \
+    HELIOS_OBS_MODE="$obs" \
+      env -u RUST_LOG "$HTS_BIN" >"$logfile" 2>&1 &
+  fi
   SERVER_PID=$!
 
   # Readiness — generous bound: inside the arm loop a cold start (and, on

--- a/.github/scripts/obs-ab/run-arms.sh
+++ b/.github/scripts/obs-ab/run-arms.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Same-session observability A/B driver (issue #297).
+# Same-session observability A/B driver (issue #297), extended with
+# version arms (issue #298).
 #
 # Runs the k6 tx-benchmark scenarios against the HTS server once per
 # (round × arm), restarting the server between arms so each arm's
@@ -9,6 +10,37 @@
 # terminology database is imported ONCE by the caller and left untouched: only
 # the app process is restarted, so every arm measures the same warmed data with
 # no cross-run drift.
+#
+# ── Version arms ────────────────────────────────────────────────────────────
+# An arm is normally an env-var switch on ONE binary. The `baseline` arm is
+# different: it runs a *second binary*, built by the caller from an older git
+# ref (the workflow's `baseline_ref` input, e.g. v0.2.0), and passed here as
+# BASELINE_BIN. That is what lets a run separate two questions #298 has to keep
+# apart — how much of the regression the current branch already recovered
+# (baseline→default) versus how much was never observability's fault at all
+# (off→default, measured on one binary).
+#
+# A version arm breaks the "restart the app, keep the database" invariant,
+# because a different binary runs a DIFFERENT startup migration set against the
+# shared database. Concretely, between v0.2.0 and HEAD the HTS schema gained
+# `authority_rank` on code_systems/value_sets and the `concepts_search_fts`
+# index, and both binaries run migrations + prebuild_concepts_fts on EVERY boot
+# (crates/hts/src/backends/sqlite/mod.rs). An old binary would leave HEAD's
+# extra index stale, and a new binary would then re-migrate on top — so arm N+1
+# would measure a database that arm N mutated. DB_SNAPSHOT closes that hole:
+# when set, every arm is restored from one pristine post-import copy before its
+# server starts, so all arms see byte-identical data regardless of order.
+#
+# Restoring resets the file, but not the comparison: the discarded warm-up pass
+# below re-primes the OS page cache and the in-process memo caches for every arm
+# identically, which is exactly what it already had to do after each restart.
+#
+# The confound a version arm CANNOT remove: the database is imported once, by
+# the CURRENT binary's importer. `baseline` therefore measures old serving code
+# over a newly-imported corpus, not the corpus v0.2.0 would have built for
+# itself (#261 changed which of the duplicate THO CodeSystems win, for one). It
+# isolates per-request serving cost with the data held constant — which is the
+# question — and is NOT a reproduction of the v0.2.0 release.
 #
 # Two properties the whole comparison rests on, enforced here:
 #   1. Interleaving. Arms are rotated per round (round-robin, not blocked
@@ -33,7 +65,8 @@
 #   BACKEND            sqlite | postgres (for log/artifact naming)
 #   RUN_ID            github.run_id (the base run identifier)
 #   ARMS              space-separated arm list, in ladder order
-#                     (e.g. "off default full full+probe")
+#                     (e.g. "off default full full+probe", or
+#                      "baseline off default" for a version comparison)
 #   ROUNDS            repeats per arm (integer >= 1)
 #   TESTS_CSV         comma-separated test IDs (e.g. "LK01,VC01,EX01")
 #   VUS_CSV           comma-separated VU levels (e.g. "1" or "1,10,50")
@@ -41,6 +74,12 @@
 #   WARMUP_DURATION   discarded warm-up duration per test (e.g. "10s")
 #   LOG_DIR           directory for per-arm server logs (e.g. "/tmp")
 #   HTS_DATABASE_URL, HTS_STORAGE_BACKEND  already exported by the caller
+#
+# Required ONLY when ARMS contains a version arm (`baseline`); the run aborts
+# up front if either is missing, rather than reporting meaningless numbers:
+#   BASELINE_BIN      path to the hts binary built from `baseline_ref`
+#   DB_SNAPSHOT       pristine post-import DB copy, restored before every arm
+#                     (sqlite only; see "Version arms" above)
 #
 # Run from the tx-benchmark checkout (working-directory), so k6 script paths
 # (k6/<FAMILY>/<TEST>.js) and results/ resolve correctly.
@@ -54,6 +93,11 @@ ANY_ARM_FAILED=0
 # ── arm → (HELIOS_OBS_MODE, RUST_LOG) ───────────────────────────────────────
 # `full+probe` is Full plus the developer probe stdout logs re-enabled via
 # RUST_LOG; every other arm leaves RUST_LOG unset so HTS_LOG_LEVEL=info stands.
+#
+# `baseline` is a VERSION arm: it runs BASELINE_BIN instead, and sets no
+# HELIOS_OBS_MODE at all — the ref it is built from (v0.2.0) predates the
+# switch, so the variable would be ignored anyway, and leaving it unset is the
+# honest reproduction of how that build shipped.
 arm_obs_mode() {
   case "$1" in
     off)        echo "off" ;;
@@ -61,7 +105,15 @@ arm_obs_mode() {
     no-span)    echo "no-span" ;;
     full)       echo "full" ;;
     full+probe) echo "full" ;;
+    baseline)   echo "" ;;
     *)          echo "" ;;
+  esac
+}
+# Which binary an arm runs. Version arms are the only ones that differ.
+arm_binary() {
+  case "$1" in
+    baseline) printf '%s' "${BASELINE_BIN:-}" ;;
+    *)        printf '%s' "$HTS_BIN" ;;
   esac
 }
 arm_rust_log() {
@@ -78,6 +130,9 @@ arm_expected_mode_log() {
     no-span)    echo "NoSpan" ;;
     full)       echo "Full" ;;
     full+probe) echo "Full" ;;
+    # A pre-#292 build logs no obs_mode= line; asserting one would fail every
+    # baseline arm. The binary-identity check in start_server covers it instead.
+    baseline)   echo "" ;;
     *)          echo "" ;;
   esac
 }
@@ -101,6 +156,27 @@ wait_port_free() {
   return 1
 }
 
+# Restore the pristine post-import database, so an arm can never inherit schema
+# or index state left behind by a different binary version (see "Version arms").
+# No-op unless DB_SNAPSHOT is set, i.e. unless a version arm is in the ladder.
+# Must run while no server holds the file — callers invoke it after stop_server.
+restore_db() {
+  [ -z "${DB_SNAPSHOT:-}" ] && return 0
+  if [ ! -f "$DB_SNAPSHOT" ]; then
+    echo "  ERROR: DB_SNAPSHOT=${DB_SNAPSHOT} does not exist"
+    return 1
+  fi
+  # The -wal/-shm sidecars belong to the OLD database file. Leaving them next to
+  # a restored copy is corruption, not staleness: sqlite would replay a WAL
+  # against a file it was never written for.
+  rm -f "${HTS_DATABASE_URL}-wal" "${HTS_DATABASE_URL}-shm"
+  cp -f "$DB_SNAPSHOT" "$HTS_DATABASE_URL" || {
+    echo "  ERROR: failed to restore ${HTS_DATABASE_URL} from ${DB_SNAPSHOT}"
+    return 1
+  }
+  return 0
+}
+
 stop_server() {
   local pid="${1:-}"
   [ -z "$pid" ] && return 0
@@ -120,30 +196,45 @@ stop_server() {
 # readiness/active-arm check (caller isolates the arm rather than aborting).
 start_server() {
   local arm="$1" logfile="$2"
-  local obs rustlog expected started_epoch
+  local obs rustlog expected started_epoch bin
   obs="$(arm_obs_mode "$arm")"
   rustlog="$(arm_rust_log "$arm")"
   expected="$(arm_expected_mode_log "$arm")"
+  bin="$(arm_binary "$arm")"
   started_epoch=$(date +%s)
 
-  echo "  starting server: HELIOS_OBS_MODE=${obs} RUST_LOG='${rustlog}'  -> ${logfile}"
+  if [ -z "$bin" ] || [ ! -x "$bin" ]; then
+    echo "  ERROR: arm '${arm}' has no runnable binary (got '${bin}')."
+    echo "         A 'baseline' arm requires BASELINE_BIN — set the workflow's baseline_ref input."
+    return 1
+  fi
+
+  echo "  starting server: bin=${bin} HELIOS_OBS_MODE=${obs} RUST_LOG='${rustlog}'  -> ${logfile}"
   # RUST_LOG (when set) overrides HTS_LOG_LEVEL in the server's EnvFilter. It
   # must be genuinely UNSET for the non-probe arms, not set to "" — a set-but-
   # empty RUST_LOG makes the tracing EnvFilter enable nothing, which suppresses
   # the startup `obs_mode=` line this script greps to confirm the active arm.
   # `env -u RUST_LOG` guarantees it is absent (even if inherited); the probe arm
   # sets it explicitly.
+  #
+  # An empty $obs means a version arm, which must run with HELIOS_OBS_MODE
+  # genuinely absent rather than set-but-empty — the build it targets predates
+  # the variable, and an empty value is not what production would have seen.
   if [ -n "$rustlog" ]; then
     HTS_SERVER_PORT="$PORT" \
     HTS_LOG_LEVEL="info" \
     HELIOS_OBS_MODE="$obs" \
     RUST_LOG="$rustlog" \
-      "$HTS_BIN" >"$logfile" 2>&1 &
-  else
+      "$bin" >"$logfile" 2>&1 &
+  elif [ -n "$obs" ]; then
     HTS_SERVER_PORT="$PORT" \
     HTS_LOG_LEVEL="info" \
     HELIOS_OBS_MODE="$obs" \
-      env -u RUST_LOG "$HTS_BIN" >"$logfile" 2>&1 &
+      env -u RUST_LOG "$bin" >"$logfile" 2>&1 &
+  else
+    HTS_SERVER_PORT="$PORT" \
+    HTS_LOG_LEVEL="info" \
+      env -u RUST_LOG -u HELIOS_OBS_MODE "$bin" >"$logfile" 2>&1 &
   fi
   SERVER_PID=$!
 
@@ -164,10 +255,30 @@ start_server() {
     return 1
   fi
 
+  # Binary-identity guard: confirm the process we started is running the binary
+  # this arm asked for. This is the ONLY assertion a version arm gets — a
+  # pre-#292 build emits no obs_mode= line for the check below to match — and it
+  # is the one that matters most there, because a `baseline` arm silently
+  # running the current binary would report "no regression" and be believed.
+  local actual_exe
+  actual_exe="$(readlink -f "/proc/${SERVER_PID}/exe" 2>/dev/null || true)"
+  if [ -n "$actual_exe" ] && [ "$actual_exe" != "$(readlink -f "$bin")" ]; then
+    echo "  ERROR: arm '${arm}' expected binary $(readlink -f "$bin") but pid ${SERVER_PID} is running ${actual_exe}"
+    return 1
+  fi
+
   # Zombie / wrong-arm guard: confirm we are talking to the process we just
   # started (a survivor on the port would serve every request of this arm under
-  # the WRONG mode). /health carries uptime_seconds; it must be smaller than the
-  # time we spent waiting.
+  # the WRONG mode). Two independent checks, because neither alone covers every
+  # build: the port-owner check works on any version, while uptime_seconds is
+  # absent from /health on pre-v0.2.1 builds and simply skips there.
+  local port_pids
+  port_pids="$(fuser -n tcp "$PORT" 2>/dev/null | tr -s ' ' '\n' | grep -E '^[0-9]+$' || true)"
+  if [ -n "$port_pids" ] && ! printf '%s\n' "$port_pids" | grep -qx "$SERVER_PID"; then
+    echo "  ERROR: port ${PORT} is held by pid(s) $(echo "$port_pids" | tr '\n' ' ')— not the server we started (${SERVER_PID})"
+    return 1
+  fi
+
   local elapsed uptime
   elapsed=$(( $(date +%s) - started_epoch + 15 ))
   uptime=$(curl -sf "http://localhost:${PORT}/health" 2>/dev/null \
@@ -263,6 +374,28 @@ measured_pass() {
 read -ra ARM_ARR <<< "$ARMS"
 NARMS=${#ARM_ARR[@]}
 
+# Fail before the first import-expensive round rather than mid-ladder: a version
+# arm without its binary, or without the snapshot that keeps arms independent,
+# produces numbers that look fine and mean nothing.
+HAS_VERSION_ARM=0
+for a in "${ARM_ARR[@]}"; do
+  [ "$a" = "baseline" ] && HAS_VERSION_ARM=1
+done
+if [ "$HAS_VERSION_ARM" -eq 1 ]; then
+  if [ -z "${BASELINE_BIN:-}" ] || [ ! -x "${BASELINE_BIN:-}" ]; then
+    echo "ERROR: arm list contains 'baseline' but BASELINE_BIN is unset or not executable."
+    echo "       Set the workflow's baseline_ref input (e.g. v0.2.0)."
+    exit 1
+  fi
+  if [ -z "${DB_SNAPSHOT:-}" ]; then
+    echo "ERROR: arm list contains 'baseline' but DB_SNAPSHOT is unset — arms would"
+    echo "       inherit each other's schema migrations. Refusing to produce numbers."
+    exit 1
+  fi
+  echo "Version arm active: baseline -> ${BASELINE_BIN}"
+  echo "DB restored from ${DB_SNAPSHOT} before every arm."
+fi
+
 echo "Arms: ${ARMS}"
 echo "Rounds: ${ROUNDS}  Tests: ${TESTS_CSV}  VUs: ${VUS_CSV}  Duration: ${DURATION}"
 echo ""
@@ -278,6 +411,13 @@ for (( round=1; round<=ROUNDS; round++ )); do
     logfile="${LOG_DIR}/hts-bench-${BACKEND}-${slug}-r${round}.log"
 
     stop_server "$SERVER_PID"; SERVER_PID=""
+    # Between stopping the last server and starting this one is the only window
+    # in which the database file is unheld and can be safely rolled back.
+    if ! restore_db; then
+      echo "  arm '${arm}' round ${round} SKIPPED — could not restore the pristine DB"
+      ANY_ARM_FAILED=1
+      continue
+    fi
     if ! start_server "$arm" "$logfile"; then
       echo "  arm '${arm}' round ${round} FAILED to start/verify — recording and continuing"
       ANY_ARM_FAILED=1

--- a/.github/workflows/hts-benchmark.yml
+++ b/.github/workflows/hts-benchmark.yml
@@ -85,6 +85,27 @@ on:
         description: "Repeats per arm (interleaved; deltas paired & medianed across them)"
         required: false
         default: "1"
+      # ── Version arm (issue #298) ─────────────────────────────────────────
+      # Every arm above is an env-var switch on ONE binary, so it can only
+      # price instrumentation. To price *code* — how much of the regression
+      # since v0.2.0 the current branch has actually recovered — set this to a
+      # git ref and add `baseline` to obs_arms. A second binary is built from
+      # that ref and run as the `baseline` arm, interleaved and paired like any
+      # other, e.g.:
+      #   obs_arms="baseline off default"  baseline_ref=v0.2.0  rounds=3
+      # Then baseline→default is what the branch costs vs the old release, and
+      # off→default is what observability costs today — the two numbers #298
+      # needs kept apart.
+      #
+      # sqlite only: arms must be rolled back to a pristine database between
+      # binary versions (see .github/scripts/obs-ab/run-arms.sh), which is a
+      # file copy for sqlite and a full re-clone for postgres. A postgres leg
+      # with baseline_ref set fails fast rather than reporting cross-migrated
+      # numbers.
+      baseline_ref:
+        description: "Git ref for the `baseline` version arm (e.g. v0.2.0). Blank = no version arm. sqlite only."
+        required: false
+        default: ""
       tx_benchmark_ref:
         description: "tx-benchmark git ref (blank = our fork's default branch; set to pin a specific baseline)"
         required: false
@@ -119,6 +140,16 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
+      # A version arm needs the database rolled back between binary versions
+      # (run-arms.sh). For sqlite that is a file copy; for postgres it would be
+      # a full re-clone of a multi-GB database, which is not implemented. Fail
+      # here rather than after the ~hour of import that precedes the arm loop.
+      - name: Reject unsupported baseline_ref / backend combination
+        if: inputs.baseline_ref != '' && (inputs.backend == 'all' || inputs.backend == 'postgres')
+        run: |
+          echo "::error::baseline_ref is supported on the sqlite backend only (got backend='${{ inputs.backend }}'). Re-dispatch with backend=sqlite."
+          exit 1
+
       - name: Resolve matrix from backend input
         id: matrix
         run: |
@@ -180,6 +211,42 @@ jobs:
           path: target/debug/hts
           retention-days: 1
 
+      # ── Version arm: a second binary from an older ref (issue #298) ────────
+      # Checked out into its own directory with its own target dir. Sharing
+      # either with the main build would be self-defeating: two source trees in
+      # one target dir make cargo rebuild the world on every alternation, and
+      # the artifact paths would collide.
+      - name: Checkout baseline ref
+        if: inputs.baseline_ref != ''
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.baseline_ref }}
+          path: baseline-src
+          clean: false
+
+      - name: Build baseline binary (${{ inputs.baseline_ref }})
+        if: inputs.baseline_ref != ''
+        working-directory: baseline-src
+        run: |
+          set -euo pipefail
+          echo "Building baseline from ref: ${{ inputs.baseline_ref }} ($(git rev-parse --short HEAD))"
+          # Same feature selection as the current-binary build above, so the two
+          # arms differ by source revision and nothing else.
+          if [ "${{ matrix.backend }}" = "postgres" ]; then
+            cargo build -p helios-hts --target-dir "$GITHUB_WORKSPACE/baseline-target" \
+              --no-default-features --features "postgres,R4"
+          else
+            cargo build -p helios-hts --target-dir "$GITHUB_WORKSPACE/baseline-target"
+          fi
+
+      - name: Upload baseline binary
+        if: inputs.baseline_ref != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: hts-bench-baseline-${{ matrix.backend }}-${{ github.run_id }}
+          path: baseline-target/debug/hts
+          retention-days: 1
+
   # ────────────────────────────────────────────────────────────────────────────
   # Run preflight + benchmark per backend.
   # ────────────────────────────────────────────────────────────────────────────
@@ -223,6 +290,17 @@ jobs:
 
       - name: Make binary executable
         run: chmod +x ./hts
+
+      - name: Download baseline HTS binary
+        if: inputs.baseline_ref != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: hts-bench-baseline-${{ matrix.backend }}-${{ github.run_id }}
+          path: baseline-bin
+
+      - name: Make baseline binary executable
+        if: inputs.baseline_ref != ''
+        run: chmod +x ./baseline-bin/hts
 
       # ── Postgres: remote Docker host discovery ───────────────────────────
       # The container binds to `-p 0:5432` so the remote Docker daemon picks
@@ -406,9 +484,42 @@ jobs:
           echo "Importing licensed terminology (directory auto-detects SNOMED RF2 / LOINC / RxNorm)..."
           ./hts import "$LICENSED_DIR" --batch-size 500
 
+      # ── Pristine DB snapshot (version arm only) ──────────────────────────
+      # With a version arm in the ladder the database can no longer simply be
+      # shared: the two binaries run different startup migration sets against
+      # it (HEAD adds authority_rank and concepts_search_fts), so whichever arm
+      # ran first would leave the next one measuring a mutated database. Take
+      # one pristine copy here; run-arms.sh restores it before every arm.
+      - name: Snapshot pristine database
+        if: inputs.baseline_ref != ''
+        run: |
+          set -euo pipefail
+          DB="$HTS_DATABASE_URL"
+          if [ ! -f "$DB" ]; then
+            echo "::error::Expected sqlite database at $DB after import"
+            exit 1
+          fi
+          # The importer has exited, so sqlite should already have checkpointed
+          # and removed the WAL. If one survived (unclean exit), fold it in —
+          # copying the .db alone would silently drop its most recent writes.
+          if [ -f "$DB-wal" ]; then
+            echo "WAL present after import; checkpointing before snapshot"
+            sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);" || {
+              echo "::error::Could not checkpoint $DB-wal; snapshot would be incomplete"
+              exit 1
+            }
+          fi
+          cp "$DB" "$DB.pristine"
+          echo "DB_SNAPSHOT=$DB.pristine" >> "$GITHUB_ENV"
+          echo "Snapshot: $(du -h "$DB.pristine" | cut -f1) at $DB.pristine"
+          # The snapshot doubles this leg's database footprint, and disk
+          # exhaustion on the shared runner is a recurring failure here.
+          df -h "$(dirname "$DB")" | tail -1
+
       # ── Tools (k6) ───────────────────────────────────────────────────────
       # The server is started, restarted per arm, and stopped by the arm-loop
-      # script below — not here — so one warmed database is shared across arms.
+      # script below — not here — so one warmed database is shared across arms
+      # (or restored from the snapshot above, when a version arm is present).
 
       - name: Install k6
         uses: grafana/setup-k6-action@v1
@@ -474,6 +585,10 @@ jobs:
         working-directory: tx-benchmark
         env:
           HTS_BIN: ${{ github.workspace }}/hts
+          # Empty unless a version arm was requested; run-arms.sh refuses to run
+          # a `baseline` arm without it rather than silently reusing HTS_BIN.
+          # DB_SNAPSHOT reaches the script via $GITHUB_ENV (snapshot step above).
+          BASELINE_BIN: ${{ inputs.baseline_ref != '' && format('{0}/baseline-bin/hts', github.workspace) || '' }}
           PORT: ${{ matrix.port }}
           BACKEND: ${{ matrix.backend }}
           RUN_ID: ${{ github.run_id }}
@@ -519,6 +634,7 @@ jobs:
             --rounds "${{ inputs.rounds || '1' }}" \
             --backend "${{ matrix.backend }}" \
             --commit "${{ github.sha }}" \
+            --baseline-ref "${{ inputs.baseline_ref }}" \
             --csv-out "results/${{ github.run_id }}/obs-ab-${{ matrix.backend }}.csv" \
             >> "$GITHUB_STEP_SUMMARY"
 
@@ -550,6 +666,12 @@ jobs:
       - name: Stop any leftover HTS server
         if: always()
         run: fuser -k "${{ matrix.port }}/tcp" 2>/dev/null || true
+
+      # The snapshot is a full second copy of a multi-GB database; leaving it on
+      # a shared self-hosted runner is how the next run hits "no space left".
+      - name: Remove pristine DB snapshot
+        if: always() && inputs.baseline_ref != ''
+        run: rm -f "${DB_SNAPSHOT:-}" || true
 
       - name: Stop ephemeral Postgres
         if: always() && matrix.backend == 'postgres'

--- a/crates/hts/src/backends/mod.rs
+++ b/crates/hts/src/backends/mod.rs
@@ -10,6 +10,9 @@
 //!
 //! [`TerminologyBackend`]: crate::traits::TerminologyBackend
 
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
@@ -61,7 +64,21 @@ pub use postgres::PostgresTerminologyBackend;
 /// `$validate-code` resolving against the authoritative row while `$lookup`
 /// reads `resource_json` from the truncated copy. That incoherence is what
 /// let this bug class persist.
-pub(crate) fn cs_precedence_order_by(alias: &str) -> String {
+pub(crate) fn cs_precedence_order_by(alias: &str) -> Cow<'static, str> {
+    // This clause is spliced into a `format!`-built SQL string at ~40 hot-path
+    // resolver call sites, once (or more) per request. Only three aliases are
+    // ever passed (`"code_systems"`, `"s"`, `"value_sets"` is vs-only), so cache
+    // their rendered form and rebuild only for an unexpected alias. The cached
+    // value is produced by the same `build_cs_precedence_order_by` as the
+    // fallback, so the SQL text is identical whichever branch is taken.
+    match alias {
+        "code_systems" => Cow::Borrowed(CS_ORDER_BY_CODE_SYSTEMS.as_str()),
+        "s" => Cow::Borrowed(CS_ORDER_BY_S.as_str()),
+        other => Cow::Owned(build_cs_precedence_order_by(other)),
+    }
+}
+
+fn build_cs_precedence_order_by(alias: &str) -> String {
     format!(
         "(CASE COALESCE({alias}.content, 'complete') \
               WHEN 'complete'    THEN 0 \
@@ -79,6 +96,10 @@ pub(crate) fn cs_precedence_order_by(alias: &str) -> String {
     )
 }
 
+static CS_ORDER_BY_CODE_SYSTEMS: LazyLock<String> =
+    LazyLock::new(|| build_cs_precedence_order_by("code_systems"));
+static CS_ORDER_BY_S: LazyLock<String> = LazyLock::new(|| build_cs_precedence_order_by("s"));
+
 /// Precedence among `value_sets` rows sharing one canonical URL.
 ///
 /// The ValueSet analogue of [`cs_precedence_order_by`]. `value_sets` has no
@@ -88,13 +109,25 @@ pub(crate) fn cs_precedence_order_by(alias: &str) -> String {
 ///
 /// This matters for the same reason: `hl7.fhir.r4.core` re-ships 603 THO
 /// ValueSets under canonical URLs it does not own.
-pub(crate) fn vs_precedence_order_by(alias: &str) -> String {
+pub(crate) fn vs_precedence_order_by(alias: &str) -> Cow<'static, str> {
+    // Only `"value_sets"` is ever passed; cache it and rebuild for any other.
+    // Same builder feeds cache and fallback, so the SQL text is identical.
+    match alias {
+        "value_sets" => Cow::Borrowed(VS_ORDER_BY_VALUE_SETS.as_str()),
+        other => Cow::Owned(build_vs_precedence_order_by(other)),
+    }
+}
+
+fn build_vs_precedence_order_by(alias: &str) -> String {
     format!(
         "COALESCE({alias}.authority_rank, 0), \
          COALESCE({alias}.version, '') DESC, \
          {alias}.id",
     )
 }
+
+static VS_ORDER_BY_VALUE_SETS: LazyLock<String> =
+    LazyLock::new(|| build_vs_precedence_order_by("value_sets"));
 
 /// True when `ver` is the sentinel `current` (case-insensitive).
 ///
@@ -105,4 +138,73 @@ pub(crate) fn vs_precedence_order_by(alias: &str) -> String {
 /// `sqlite/code_system.rs` / `postgres/code_system.rs`.
 pub(super) fn code_system_version_is_current(ver: &str) -> bool {
     ver.eq_ignore_ascii_case("current")
+}
+
+#[cfg(test)]
+mod precedence_tests {
+    use super::*;
+
+    // Locks the exact ORDER BY text. The precedence order is the single arbiter
+    // of which same-canonical-URL row wins (content > has-concepts > authority >
+    // version > id); a silent change to this string would re-open the
+    // resolution-incoherence bug class #200 closed. These literals are the
+    // clause as it shipped, so both the cached fast path and the owned fallback
+    // are asserted byte-for-byte.
+    const CS_EXPECTED_CODE_SYSTEMS: &str = "(CASE COALESCE(code_systems.content, 'complete') \
+              WHEN 'complete'    THEN 0 \
+              WHEN 'supplement'  THEN 0 \
+              WHEN 'fragment'    THEN 1 \
+              WHEN 'example'     THEN 1 \
+              WHEN 'not-present' THEN 2 \
+              ELSE 1 END), \
+         (CASE WHEN EXISTS \
+             (SELECT 1 FROM concepts hc WHERE hc.system_id = code_systems.id) \
+             THEN 0 ELSE 1 END), \
+         COALESCE(code_systems.authority_rank, 0), \
+         COALESCE(code_systems.version, '') DESC, \
+         code_systems.id";
+
+    #[test]
+    fn cs_precedence_cached_and_fallback_match_shipped_sql() {
+        // Cached fast paths (the only aliases used in the codebase).
+        assert_eq!(
+            &*cs_precedence_order_by("code_systems"),
+            CS_EXPECTED_CODE_SYSTEMS
+        );
+        assert_eq!(
+            &*cs_precedence_order_by("s"),
+            CS_EXPECTED_CODE_SYSTEMS
+                .replace("code_systems", "s")
+                .as_str()
+        );
+        // Fallback (unexpected alias) renders through the same builder, so it is
+        // byte-identical to the cached form with the alias substituted.
+        assert_eq!(
+            &*cs_precedence_order_by("cs"),
+            CS_EXPECTED_CODE_SYSTEMS
+                .replace("code_systems", "cs")
+                .as_str()
+        );
+        // The cached value equals a fresh build — no drift between the two paths.
+        assert_eq!(
+            &*cs_precedence_order_by("code_systems"),
+            build_cs_precedence_order_by("code_systems").as_str()
+        );
+    }
+
+    #[test]
+    fn vs_precedence_cached_and_fallback_match_shipped_sql() {
+        const VS_EXPECTED: &str = "COALESCE(value_sets.authority_rank, 0), \
+         COALESCE(value_sets.version, '') DESC, \
+         value_sets.id";
+        assert_eq!(&*vs_precedence_order_by("value_sets"), VS_EXPECTED);
+        assert_eq!(
+            &*vs_precedence_order_by("s"),
+            VS_EXPECTED.replace("value_sets", "s").as_str()
+        );
+        assert_eq!(
+            &*vs_precedence_order_by("value_sets"),
+            build_vs_precedence_order_by("value_sets").as_str()
+        );
+    }
 }

--- a/crates/observability/src/middleware.rs
+++ b/crates/observability/src/middleware.rs
@@ -57,23 +57,19 @@ static METRIC_HANDLES: LazyLock<RwLock<HashMap<LabelTriple, (Counter, Histogram)
 /// Build the counter+histogram handles for one label triple. Only called on a
 /// cache miss (or for uncacheable exotic labels), so the `route` allocation here
 /// is amortized to once per distinct series.
-fn build_handles(
-    method: &Cow<'static, str>,
-    route: &Arc<str>,
-    status: &Cow<'static, str>,
-) -> (Counter, Histogram) {
+fn build_handles(method: &str, route: &Arc<str>, status: &str) -> (Counter, Histogram) {
     let route = route.to_string();
     let counter = metrics::counter!(
         "http_requests_total",
-        "method" => method.clone(),
+        "method" => method.to_string(),
         "route" => route.clone(),
-        "status" => status.clone(),
+        "status" => status.to_string(),
     );
     let histogram = metrics::histogram!(
         "http_request_duration_seconds",
-        "method" => method.clone(),
+        "method" => method.to_string(),
         "route" => route,
-        "status" => status.clone(),
+        "status" => status.to_string(),
     );
     (counter, histogram)
 }

--- a/crates/observability/src/middleware.rs
+++ b/crates/observability/src/middleware.rs
@@ -25,10 +25,67 @@
 //! per-tenant latency in traces) and is never a metric label, to avoid
 //! unbounded Prometheus series.
 
+use std::borrow::Cow;
 use std::time::Instant;
 
 use axum::{extract::MatchedPath, extract::Request, middleware::Next, response::Response};
 use tracing::Instrument;
+
+/// Map an HTTP method to a metric label without allocating for the standard
+/// verbs.
+///
+/// The `metrics` label value is a `SharedString` (`Cow<'static, str>`), so a
+/// `Cow::Borrowed(&'static str)` clones for free — the always-on metrics path
+/// records two metrics per request (a counter and a histogram) and would
+/// otherwise heap-allocate the method string twice. Exotic methods keep their
+/// exact spelling via an owned fallback, so the emitted label value is
+/// byte-for-byte what `method.as_str()` produced before.
+fn method_label(method: &axum::http::Method) -> Cow<'static, str> {
+    match method.as_str() {
+        "GET" => Cow::Borrowed("GET"),
+        "POST" => Cow::Borrowed("POST"),
+        "PUT" => Cow::Borrowed("PUT"),
+        "DELETE" => Cow::Borrowed("DELETE"),
+        "PATCH" => Cow::Borrowed("PATCH"),
+        "HEAD" => Cow::Borrowed("HEAD"),
+        "OPTIONS" => Cow::Borrowed("OPTIONS"),
+        "CONNECT" => Cow::Borrowed("CONNECT"),
+        "TRACE" => Cow::Borrowed("TRACE"),
+        other => Cow::Owned(other.to_owned()),
+    }
+}
+
+/// Map an HTTP status code to a metric label without allocating for the common
+/// codes. Same rationale as [`method_label`]; the owned fallback for an
+/// uncommon code renders identically to `status.to_string()`.
+fn status_label(status: u16) -> Cow<'static, str> {
+    match status {
+        200 => Cow::Borrowed("200"),
+        201 => Cow::Borrowed("201"),
+        202 => Cow::Borrowed("202"),
+        204 => Cow::Borrowed("204"),
+        301 => Cow::Borrowed("301"),
+        302 => Cow::Borrowed("302"),
+        304 => Cow::Borrowed("304"),
+        400 => Cow::Borrowed("400"),
+        401 => Cow::Borrowed("401"),
+        403 => Cow::Borrowed("403"),
+        404 => Cow::Borrowed("404"),
+        405 => Cow::Borrowed("405"),
+        406 => Cow::Borrowed("406"),
+        409 => Cow::Borrowed("409"),
+        410 => Cow::Borrowed("410"),
+        412 => Cow::Borrowed("412"),
+        415 => Cow::Borrowed("415"),
+        422 => Cow::Borrowed("422"),
+        429 => Cow::Borrowed("429"),
+        500 => Cow::Borrowed("500"),
+        501 => Cow::Borrowed("501"),
+        502 => Cow::Borrowed("502"),
+        503 => Cow::Borrowed("503"),
+        other => Cow::Owned(other.to_string()),
+    }
+}
 
 /// Tower/axum middleware (`axum::middleware::from_fn`) that instruments every
 /// request. State-free, so it composes with any server's router.
@@ -90,8 +147,14 @@ pub async fn track(req: Request, next: Next) -> Response {
     }
 
     if metrics_on {
-        let method = method.as_str().to_owned();
-        let status = status.to_string();
+        // Labels are `Cow<'static, str>`: the standard method/status values are
+        // `Cow::Borrowed`, so cloning them for the second metric is free. Only
+        // `route` (a matched-path template that is not `'static`) still owns a
+        // clone. This keeps the always-on metrics path — recorded on every
+        // request in every mode except `Off` — from heap-allocating the method
+        // and status strings four times per request. Label values are unchanged.
+        let method = method_label(&method);
+        let status = status_label(status);
         metrics::counter!(
             "http_requests_total",
             "method" => method.clone(),
@@ -109,4 +172,46 @@ pub async fn track(req: Request, next: Next) -> Response {
     }
 
     response
+}
+
+#[cfg(test)]
+mod label_tests {
+    use super::*;
+    use axum::http::Method;
+
+    // The label helpers must be byte-identical to the pre-optimization
+    // `method.as_str().to_owned()` / `status.to_string()` for every value, so
+    // the Prometheus series they feed are unchanged — only the allocation goes.
+    #[test]
+    fn method_label_matches_as_str_for_all_verbs() {
+        for m in [
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::PATCH,
+            Method::HEAD,
+            Method::OPTIONS,
+            Method::CONNECT,
+            Method::TRACE,
+        ] {
+            assert_eq!(method_label(&m).as_ref(), m.as_str());
+            assert!(matches!(method_label(&m), Cow::Borrowed(_)));
+        }
+        // Non-standard method keeps its exact spelling via the owned fallback.
+        let custom = Method::from_bytes(b"REPORT").unwrap();
+        assert_eq!(method_label(&custom).as_ref(), "REPORT");
+        assert!(matches!(method_label(&custom), Cow::Owned(_)));
+    }
+
+    #[test]
+    fn status_label_matches_to_string() {
+        for code in [200u16, 201, 204, 304, 400, 404, 409, 412, 422, 500, 503] {
+            assert_eq!(status_label(code).as_ref(), code.to_string());
+            assert!(matches!(status_label(code), Cow::Borrowed(_)));
+        }
+        // Uncommon code falls back to an owned render, identical to to_string().
+        assert_eq!(status_label(418).as_ref(), "418");
+        assert!(matches!(status_label(418), Cow::Owned(_)));
+    }
 }

--- a/crates/observability/src/middleware.rs
+++ b/crates/observability/src/middleware.rs
@@ -26,10 +26,93 @@
 //! unbounded Prometheus series.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, RwLock};
 use std::time::Instant;
 
 use axum::{extract::MatchedPath, extract::Request, middleware::Next, response::Response};
+use metrics::{Counter, Histogram};
 use tracing::Instrument;
+
+/// Label triple identifying one `(method, route, status)` metric series.
+type LabelTriple = (Cow<'static, str>, Arc<str>, Cow<'static, str>);
+
+/// Cache of resolved `(counter, histogram)` handles, keyed by label triple.
+///
+/// `metrics::counter!`/`histogram!` rebuild a `Key` (hashing the metric name and
+/// every label) and allocate a `Vec<Label>` on *every* call, then look the metric
+/// up in the recorder's registry. On the always-on metrics path — two metrics per
+/// request, every request in every mode except `Off` — that is pure repeated work:
+/// the handle for a given label triple never changes. Cache it and the hot path
+/// becomes a read-locked map lookup plus two atomic updates.
+///
+/// Bounded by construction: it is only populated for the statically-known method
+/// and status labels ([`method_label`]/[`status_label`] return `Cow::Borrowed`
+/// for those) crossed with the finite set of matched-path route templates. An
+/// exotic method/status (owned) bypasses the cache entirely, so a client cannot
+/// grow it without bound.
+static METRIC_HANDLES: LazyLock<RwLock<HashMap<LabelTriple, (Counter, Histogram)>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Build the counter+histogram handles for one label triple. Only called on a
+/// cache miss (or for uncacheable exotic labels), so the `route` allocation here
+/// is amortized to once per distinct series.
+fn build_handles(
+    method: &Cow<'static, str>,
+    route: &Arc<str>,
+    status: &Cow<'static, str>,
+) -> (Counter, Histogram) {
+    let route = route.to_string();
+    let counter = metrics::counter!(
+        "http_requests_total",
+        "method" => method.clone(),
+        "route" => route.clone(),
+        "status" => status.clone(),
+    );
+    let histogram = metrics::histogram!(
+        "http_request_duration_seconds",
+        "method" => method.clone(),
+        "route" => route,
+        "status" => status.clone(),
+    );
+    (counter, histogram)
+}
+
+/// Record one request into the counter + histogram, reusing cached handles.
+fn record_metrics(
+    method: Cow<'static, str>,
+    route: Arc<str>,
+    status: Cow<'static, str>,
+    elapsed: f64,
+) {
+    // Only the bounded, statically-known labels are cacheable; exotic (owned)
+    // method/status values are recorded directly so the cache cannot grow without
+    // bound. Route is always bounded (a matched-path template or "<unmatched>").
+    let cacheable = matches!(method, Cow::Borrowed(_)) && matches!(status, Cow::Borrowed(_));
+    if cacheable {
+        let key: LabelTriple = (method.clone(), route.clone(), status.clone());
+        if let Some((counter, histogram)) = METRIC_HANDLES.read().unwrap().get(&key) {
+            counter.increment(1);
+            histogram.record(elapsed);
+            return;
+        }
+        let (counter, histogram) = build_handles(&method, &route, &status);
+        counter.increment(1);
+        histogram.record(elapsed);
+        // `entry().or_insert` tolerates a race: two threads that both miss build
+        // handles aliasing the same series, both record correctly, and the loser's
+        // handles are simply dropped.
+        METRIC_HANDLES
+            .write()
+            .unwrap()
+            .entry(key)
+            .or_insert((counter, histogram));
+        return;
+    }
+    let (counter, histogram) = build_handles(&method, &route, &status);
+    counter.increment(1);
+    histogram.record(elapsed);
+}
 
 /// Map an HTTP method to a metric label without allocating for the standard
 /// verbs.
@@ -103,11 +186,13 @@ pub async fn track(req: Request, next: Next) -> Response {
     }
 
     let method = req.method().clone();
-    let route = req
+    // `Arc<str>` (not `String`): the metric-handle cache key holds a clone of the
+    // route, and an `Arc` clone is a refcount bump rather than a fresh allocation.
+    let route: Arc<str> = req
         .extensions()
         .get::<MatchedPath>()
-        .map(|m| m.as_str().to_owned())
-        .unwrap_or_else(|| "<unmatched>".to_owned());
+        .map(|m| Arc::from(m.as_str()))
+        .unwrap_or_else(|| Arc::from("<unmatched>"));
     // Only the span and the reqlog rollup use the tenant; skip the header scan
     // and its allocation when neither is active.
     let tenant = if span_on || reqlog_on {
@@ -147,28 +232,7 @@ pub async fn track(req: Request, next: Next) -> Response {
     }
 
     if metrics_on {
-        // Labels are `Cow<'static, str>`: the standard method/status values are
-        // `Cow::Borrowed`, so cloning them for the second metric is free. Only
-        // `route` (a matched-path template that is not `'static`) still owns a
-        // clone. This keeps the always-on metrics path — recorded on every
-        // request in every mode except `Off` — from heap-allocating the method
-        // and status strings four times per request. Label values are unchanged.
-        let method = method_label(&method);
-        let status = status_label(status);
-        metrics::counter!(
-            "http_requests_total",
-            "method" => method.clone(),
-            "route" => route.clone(),
-            "status" => status.clone(),
-        )
-        .increment(1);
-        metrics::histogram!(
-            "http_request_duration_seconds",
-            "method" => method,
-            "route" => route,
-            "status" => status,
-        )
-        .record(elapsed);
+        record_metrics(method_label(&method), route, status_label(status), elapsed);
     }
 
     response
@@ -213,5 +277,43 @@ mod label_tests {
         // Uncommon code falls back to an owned render, identical to to_string().
         assert_eq!(status_label(418).as_ref(), "418");
         assert!(matches!(status_label(418), Cow::Owned(_)));
+    }
+
+    // The handle cache must stay bounded: statically-known labels are cached,
+    // exotic (owned) method/status values are recorded but never inserted, so a
+    // client sending junk methods cannot grow it without bound. (No recorder is
+    // installed in tests, so the metric ops are harmless no-ops.)
+    #[test]
+    fn cache_holds_known_labels_and_skips_exotic() {
+        // Unique routes so this test cannot collide with any other.
+        let good_route: Arc<str> = Arc::from("/__test_cacheable__");
+        record_metrics(
+            Cow::Borrowed("GET"),
+            good_route.clone(),
+            Cow::Borrowed("200"),
+            0.001,
+        );
+        let good_key: LabelTriple = (Cow::Borrowed("GET"), good_route, Cow::Borrowed("200"));
+        assert!(
+            METRIC_HANDLES.read().unwrap().contains_key(&good_key),
+            "a statically-known label triple should be cached"
+        );
+
+        let junk_route: Arc<str> = Arc::from("/__test_exotic__");
+        record_metrics(
+            Cow::Owned("PROPFIND".to_owned()),
+            junk_route.clone(),
+            Cow::Borrowed("200"),
+            0.001,
+        );
+        let junk_key: LabelTriple = (
+            Cow::Owned("PROPFIND".to_owned()),
+            junk_route,
+            Cow::Borrowed("200"),
+        );
+        assert!(
+            !METRIC_HANDLES.read().unwrap().contains_key(&junk_key),
+            "an exotic (owned) method must bypass the cache"
+        );
     }
 }

--- a/crates/observability/src/telemetry.rs
+++ b/crates/observability/src/telemetry.rs
@@ -6,6 +6,7 @@
 //! exports spans over OTLP via `tracing-opentelemetry`. Call [`shutdown`] during
 //! graceful shutdown to flush buffered spans.
 
+use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
@@ -58,6 +59,10 @@ fn env_filter_from(rust_log: Option<&str>, log_level: &str) -> EnvFilter {
 /// once per process.
 pub fn init(service_name: &str, log_level: &str) {
     let filter = env_filter_from(std::env::var("RUST_LOG").ok().as_deref(), log_level);
+    // Only colorize when stdout is a real terminal. Emitting ANSI escapes into a
+    // redirected file / journald / CloudWatch corrupts the text — and it made the
+    // obs-A/B harness unable to grep the `obs_mode=` stamp out of the arm logs.
+    let use_ansi = std::io::stdout().is_terminal();
 
     #[cfg(feature = "otel")]
     {
@@ -66,7 +71,7 @@ pub fn init(service_name: &str, log_level: &str) {
             let tracer = provider.tracer("helios");
             tracing_subscriber::registry()
                 .with(filter)
-                .with(fmt::layer())
+                .with(fmt::layer().with_ansi(use_ansi))
                 .with(tracing_opentelemetry::layer().with_tracer(tracer))
                 .init();
             let _ = PROVIDER.set(provider);
@@ -80,7 +85,7 @@ pub fn init(service_name: &str, log_level: &str) {
 
     tracing_subscriber::registry()
         .with(filter)
-        .with(fmt::layer())
+        .with(fmt::layer().with_ansi(use_ansi))
         .init();
     let _ = service_name;
 }

--- a/crates/observability/src/telemetry.rs
+++ b/crates/observability/src/telemetry.rs
@@ -33,12 +33,31 @@ fn default_directives(level: &str) -> String {
     level.to_string()
 }
 
+/// Build the `EnvFilter`, honoring `RUST_LOG` only when it is set to a
+/// non-empty value.
+///
+/// `EnvFilter::try_from_default_env()` treats a *set-but-empty* `RUST_LOG`
+/// (`RUST_LOG=""`, as opposed to unset) as a valid filter that enables nothing,
+/// silently silencing all output — including a server's startup line. That is a
+/// footgun for operators, and it broke the obs-A/B benchmark harness, which
+/// launches its non-probe arms with an empty `RUST_LOG` and then greps the
+/// startup log to confirm which arm is active. Treat empty/whitespace-only
+/// `RUST_LOG` as unset and fall back to the process default level; an unparseable
+/// value also falls back, as before.
+fn env_filter_from(rust_log: Option<&str>, log_level: &str) -> EnvFilter {
+    match rust_log {
+        Some(v) if !v.trim().is_empty() => {
+            EnvFilter::try_new(v).unwrap_or_else(|_| EnvFilter::new(default_directives(log_level)))
+        }
+        _ => EnvFilter::new(default_directives(log_level)),
+    }
+}
+
 /// Initialize logging/tracing for a server process. `service_name` is used as
 /// the OTel resource service name (overridable by `OTEL_SERVICE_NAME`). Call
 /// once per process.
 pub fn init(service_name: &str, log_level: &str) {
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(default_directives(log_level)));
+    let filter = env_filter_from(std::env::var("RUST_LOG").ok().as_deref(), log_level);
 
     #[cfg(feature = "otel")]
     {
@@ -105,4 +124,38 @@ fn build_otlp_tracer(service_name: &str) -> Option<opentelemetry_sdk::trace::Sdk
 
     opentelemetry::global::set_tracer_provider(provider.clone());
     Some(provider)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EnvFilter, env_filter_from};
+
+    // Empty / whitespace / unset RUST_LOG must all fall back to the process
+    // default level, so the startup line (and everything at that level) is
+    // still emitted. A set-but-empty RUST_LOG previously enabled nothing.
+    #[test]
+    fn empty_or_unset_rust_log_falls_back_to_default_level() {
+        for rust_log in [None, Some(""), Some("   ")] {
+            assert_eq!(
+                env_filter_from(rust_log, "info").to_string(),
+                "info",
+                "RUST_LOG={rust_log:?} should behave as unset"
+            );
+        }
+    }
+
+    #[test]
+    fn non_empty_rust_log_is_honored() {
+        assert_eq!(env_filter_from(Some("debug"), "info").to_string(), "debug");
+        assert_eq!(
+            env_filter_from(Some("warn,hts=trace"), "info").to_string(),
+            EnvFilter::new("warn,hts=trace").to_string()
+        );
+    }
+
+    #[test]
+    fn unparseable_rust_log_falls_back_to_default_level() {
+        // `@@@` is not a valid directive; fall back rather than panic.
+        assert_eq!(env_filter_from(Some("@@@"), "info").to_string(), "info");
+    }
 }


### PR DESCRIPTION
## Issue

Advances #298: attribute the remaining **~24%** of the uniform HTS throughput drop since v0.2.0 (the part left after #233 fixed the EX02/EX08 collapse and #292 removed the span/reqlog per-request instrumentation), and fix or file each cause.

## Summary

Two things, one measured end to end:

1. The always-on Prometheus metrics recording that #292 deliberately left on **was** a large uniform per-request cost. This PR removes most of it: `off→default` overhead at vu50 goes **11.3% → ~2.9%**.
2. **The "~24% non-observability residual" in #298 does not exist.** A version-arm A/B against a binary built from `v0.2.0` (run `30015496998`, 3 rounds, vu1+vu50, all tests, err 0.0, 0.5–1M samples/cell) puts the full vu50 throughput gap to v0.2.0 at **−6.5%** — and decomposes it as **~4.8% remaining metrics + ~1.7% all other code change**. With instrumentation stripped from both binaries, current code is within **1.7%** of v0.2.0 in aggregate, and ~11% *faster* on validate-code.

The issue's premise assumed #292 had removed observability's cost; it had not — metrics alone measured ~11.3% at vu50 on `main`. What #298 called a non-observability residual was largely still-present metrics cost. Once that is measured and trimmed (this PR), nothing large is left underneath it: the genuine non-obs code delta is ~1.7%, spread thin and partly offset by validate-code gains — below the threshold that would justify a bisect.

Sizing this was a *measurement*, not a guess, so this PR also adds the harness that took it (see "Benchmark tooling — version arms").

### Version-arm result (run `30015496998`, sqlite, 3 rounds, all tests)

Aggregate throughput vs the `v0.2.0` binary, same corpus, arms interleaved and paired:

| Comparison | vu1 | vu50 | what it is |
|---|---:|---:|---|
| `off / baseline` | −1.9% | **−1.7%** | all code change since v0.2.0, instrumentation excluded |
| `default / baseline` | −7.7% | −6.5% | code change + today's (already-trimmed) metrics |
| `off → default` | −5.9% | −4.9% | today's remaining metrics cost |

Per-test at vu50 the code-only delta (`off/baseline`) ranges −6.4% (CM01) to **+11.8%** (VC01) — validate-code is materially *faster* than v0.2.0 (likely #233 + the FTS/closure work). No test shows anything near a 24% code regression.

**Debug build (opt-level 0):** the metrics rows overstate release magnitude (constant per-request cost is amplified); the `off/baseline` code row is structural and less sensitive to profile. A release-profile confirmation is the one open item (see Follow-ups).

## Root-cause analysis

The regression fingerprint is **uniform across every benchmark family (LK/VC/CM/SS/EX) and equal across both backends** — the signature of **backend-agnostic per-request overhead on the shared request path**, in an opt-level-0 debug build that amplifies constant per-request work. Prime suspect: the **always-on Prometheus metrics recording** in the observability `track` middleware (added to HTS `server.rs` in `4efd2d819`; HTS had *no* per-request middleware at v0.2.0). In `ObsMode::Default` — what the benchmark measures — every request paid ~4 heap allocations, a rebuilt metric `Key`, a `Vec<Label>`, and a label-hashed registry lookup.

## Measured results

All figures are the **within-run paired `off→default` delta** — the arms are interleaved and differenced inside a single run, which is what makes the ratio comparable across runs even though absolute p50 is not (the runner drifts ~10%).

### Step 1 — label allocations (VU=1, 3 rounds, p50)

| Test | `main` overhead | + label fix | Δ |
|------|----------------:|------------:|---|
| VC01 | 19.3% `SIGNAL` | 16.8% `SIGNAL` | −2.5pp |
| VC02 | 18.4% `SIGNAL` | 14.9% `SIGNAL` | −3.5pp |
| LK03 | 18.5% `SIGNAL` | 11.3% `SIGNAL` | **−7.2pp** |
| LK02 | 13.4% `SIGNAL` | 7.3% `WEAK` | **−6.1pp** |
| LK01 | 11.5% `SIGNAL` | 8.6% `WEAK` | −2.8pp |
| SS01 | 9.5% `WEAK` | 2.1% `NOISE` | **−7.4pp** |
| CM01 | 6.2% `SIGNAL` | 6.8% `WEAK` | ~flat |
| **mean** | **~13.8%** | **~9.7%** | **≈⅓ less** |

Runs `29948736549` (baseline) / `29948738546` (treatment). Both arms clean — err 0.0, 69k–108k samples/cell, no false-zero.

### Step 2 — vu50 sizing, and handle caching

vu50 is the load level the "~24% throughput" figure actually came from.

| Build | `off→default` overhead @ vu50 | Run |
|---|---:|---|
| `main` | **~11.3%** (8–15%, all `SIGNAL`, CV 0.2–1.1%) | `29957052096` |
| + label fix | **~9.4%** | `29957054469` |
| + handle caching (this PR) | **~2.9%** | `29972539614` |

At vu1 the same run measures ~4.9% mean, and total throughput across the suite differs by only **−2.1% @ vu50 / −1.3% @ vu1** between metrics-off and metrics-on.

**Findings:**
1. **Root cause confirmed.** On `main`, metrics-on is 6–19% slower per request than the idle middleware, `SIGNAL` on 5/7 tests, uniform across families — a genuine uniform per-request cost, as hypothesized.
2. **Both fixes work, cumulatively.** Label interning removed the allocations; handle caching removed the residual `Key` rebuild + registry hashing. Together: **11.3% → ~2.9% at vu50**, without removing a single metric.
3. **Observability is now largely exhausted as an explanation.** ~2–3% is what is left to win by turning instrumentation off entirely. The remaining residual is elsewhere.
4. **The precedence-caching change is marginal** — no measurable effect (`off`-arm absolute p50 unchanged, 0.15–0.29 ms). Kept as a harmless allocation cleanup; **no throughput is claimed from it**, matching the DB-review prediction that the cached resolvers short-circuit before the `format!`.

**Caveats (honest):** debug build (opt-level 0) amplifies constant per-request costs — direction holds, magnitude will shrink in release, and no release-profile sizing has been run. Steps 1 and 2 are separate dispatches; only the paired ratio is compared across them, never absolute p50.

## Changes

- **`perf(observability)`** — standard HTTP methods & common status codes become `Cow::Borrowed(&'static str)` metric labels (clone-free), removing ~4 allocations/request on the always-on metrics path. Label values byte-identical (unit test).
- **`perf(observability)`** — cache resolved `(Counter, Histogram)` handles keyed by `(method, route, status)`, so the hot path is a read-locked map lookup plus two atomic updates instead of a rebuilt `Key` + `Vec<Label>` + registry lookup. Bounded by construction: only the statically-known borrowed labels are cached, so an exotic method/status bypasses the cache and cannot grow it without bound. Test `cache_holds_known_labels_and_skips_exotic`.
- **`perf(hts)`** — cache the precedence `ORDER BY` in a `LazyLock`, return `Cow::Borrowed` instead of `format!`-rebuilding per resolve; unexpected aliases rebuild via the same shared builder (byte-equivalence test). Backend-agnostic (SQLite + Postgres).
- **`fix(observability)` ×2 — obs-A/B harness fixes (required to measure any of this; #297 was DOA on first dispatch, `main` too):**
  - An empty `RUST_LOG` (`""`, set-but-unset) made `EnvFilter::try_from_default_env()` enable *nothing*, silencing the startup line — a real operator footgun. Now treated as unset; harness uses `env -u RUST_LOG`.
  - The `fmt` layer colourized unconditionally, writing ANSI escapes into redirected log files (corrupting journald/CloudWatch capture) and splitting the `obs_mode=` stamp so the harness grep couldn't match. Now gated on `stdout().is_terminal()`; harness strips ANSI as belt-and-suspenders.

Metrics are made **cheaper, not removed** throughout — deleting a product surface to win a benchmark would be masking the cost, not fixing it.

### Benchmark tooling — version arms

Every arm in the #297 ladder is an env-var switch on one binary, so the harness could price *instrumentation* and nothing else. It could not answer the question this PR raises: how much of the gap to v0.2.0 is already recovered, versus never observability's fault.

This PR adds a **`baseline` arm** — a second binary built from the new `baseline_ref` input (e.g. `v0.2.0`), interleaved and paired like any other arm. `baseline off default` brackets it: `baseline→off` is all code change with instrumentation excluded; `off→default` is what observability costs today.

A version arm breaks the ladder's "restart the app, keep the database" invariant, because the two binaries run **different startup migrations** against the shared DB (HEAD adds `authority_rank` and `concepts_search_fts`; both boots run `prebuild_concepts_fts`). Whichever arm ran first would leave the next measuring a mutated database. So the workflow snapshots the post-import DB once and restores it before **every** arm, making arms order-independent rather than merely warm. The run aborts up front if a baseline arm is requested without its binary or its snapshot, rather than reporting numbers that look fine and mean nothing.

Guards, since a baseline arm silently running the current binary would report "no regression" and be believed: assert `/proc/<pid>/exe` is the binary the arm asked for, and assert the port is held by the pid we started. The existing `obs_mode=` assertion cannot cover a pre-#292 build, and `/health` had no `uptime_seconds` before v0.2.1.

**Scoped to sqlite** — rolling back Postgres would be a full re-clone of a multi-GB database, so a Postgres leg with `baseline_ref` set fails fast in the matrix resolver instead of reporting cross-migrated numbers.

**Confound stated rather than hidden** (it prints in the run summary): the corpus is imported once by the *current* binary, so `baseline` measures old serving code over new data. That holds the data constant to isolate per-request serving cost — it is **not** a reproduction of the v0.2.0 release.

Validated end-to-end by smoke run `30012060180` (all three arms started and verified; v0.2.0 still builds on current stable), then run in anger as `30015496998` — the source of the Summary table above.

## Follow-ups (not in this PR)

- **Release-profile sizing.** Every number here is debug. The `off→default` metrics rows will shrink in release; a `build_profile` workflow input would let us quote a release magnitude. The `off/baseline` code delta (~1.7%) is already small enough that release is unlikely to change the conclusion.
- **#298 scope.** The version-arm run answers the issue's core question: the non-observability residual is ~1.7% at vu50, not ~24%. The remaining lever is metrics, which this PR addresses. Recommend re-scoping or closing the "bisect the 24%" framing rather than continuing it — there is no large code regression to bisect toward.
- **Not done:** materializing the `EXISTS` "has-concepts" precedence tier — index-backed already, ~20 write-path sync points, would re-open the #200 incoherence class if it drifts. File only if a future A/B proves that tier hot.

Refs #298, #297.
