### PR TITLE
feat(ui): wire the sidebar tenant selector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         timeout-minutes: 15
         env:
           RUN_MINIO_S3_TESTS: "1"
-          EXPECTED_MINIO_SETTINGS_TESTS: "4"
+          EXPECTED_MINIO_SETTINGS_TESTS: "5"
           # The single self-hosted Windows runner is a virtualized guest whose
           # CPU does not advertise SSE4.1 + PCLMULQDQ. The AWS S3 SDK's default
           # integrity protection computes a CRC32 on every upload via the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,7 @@ dependencies = [
  "similar",
  "tokio",
  "tower",
+ "tracing",
  "unic-langid",
 ]
 

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -629,6 +629,7 @@ async fn serve(
             },
             ui_tenants.clone(),
             ui_settings.clone(),
+            config.default_tenant.clone(),
             self_base_url,
             outbound_auth,
             config.default_fhir_version,

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -543,6 +543,7 @@ async fn start_mongodb(
     // settings store: it keeps ownership of the backend Arc and wires the
     // settings-capable builder (like the SQLite/Postgres backends).
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(backend.clone());
+    let ui_settings = settings_store.clone();
 
     // MongoDB primary; embedded SQLite sidecar for bulk-export job state.
     let export_bundle = {
@@ -575,7 +576,7 @@ async fn start_mongodb(
     );
     // Second handle to the same backend for the web UI's tenant-maintenance
     // read/write path (the FHIR app keeps its own).
-    serve(app, &config, serve_audit_state, Some(backend)).await
+    serve(app, &config, serve_audit_state, Some(backend), ui_settings).await
 }
 
 /// Fallback when mongodb feature is not enabled.
@@ -598,6 +599,7 @@ async fn serve(
     config: &ServerConfig,
     audit_state: Option<Arc<AuditMiddlewareState>>,
     ui_tenants: Option<Arc<dyn ResourceStorage>>,
+    ui_settings: Option<Arc<dyn SettingsStore>>,
 ) -> anyhow::Result<()> {
     #[cfg(all(feature = "ui", not(feature = "headless")))]
     let app = {
@@ -626,13 +628,14 @@ async fn serve(
                 model: config.nl_search_model.clone(),
             },
             ui_tenants.clone(),
+            ui_settings.clone(),
             self_base_url,
             outbound_auth,
             config.default_fhir_version,
         )
     };
     #[cfg(not(all(feature = "ui", not(feature = "headless"))))]
-    let _ = &ui_tenants;
+    let _ = (&ui_tenants, &ui_settings);
 
     let addr = config.socket_addr();
     info!(address = %addr, "Server listening");
@@ -1090,6 +1093,7 @@ async fn start_sqlite(
     // The SQLite backend also hosts the per-user settings store, so it always
     // keeps ownership of the backend Arc and uses the settings-capable builder.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(backend.clone());
+    let ui_settings = settings_store.clone();
     let export_bundle = build_bulk_export(&config, backend.clone(), backend.clone()).await?;
     let submit_bundle = build_bulk_submit(&config, backend.clone()).await?;
     let ops = standalone_ops(
@@ -1108,7 +1112,7 @@ async fn start_sqlite(
         settings_store,
         ops,
     );
-    serve(app, &config, serve_audit_state, ui_tenants).await
+    serve(app, &config, serve_audit_state, ui_tenants, ui_settings).await
 }
 
 /// Constructs an embedded SQLite job store for backends that can't host job
@@ -1730,6 +1734,7 @@ async fn start_sqlite_elasticsearch(
     // search-only), so it is wired from the underlying `sqlite` backend even
     // though the app is served over the composite storage.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(sqlite.clone());
+    let ui_settings = settings_store.clone();
 
     let export_bundle = build_bulk_export(&config, sqlite.clone(), sqlite.clone()).await?;
     let submit_bundle = build_bulk_submit(&config, sqlite.clone()).await?;
@@ -1756,7 +1761,14 @@ async fn start_sqlite_elasticsearch(
     );
     // The UI's tenant-maintenance path goes through the composite (not the
     // bare primary) so a purge also clears the offloaded search documents.
-    serve(app, &config, serve_audit_state, Some(composite)).await
+    serve(
+        app,
+        &config,
+        serve_audit_state,
+        Some(composite),
+        ui_settings,
+    )
+    .await
 }
 
 /// Fallback when elasticsearch feature is not enabled.
@@ -1805,6 +1817,7 @@ async fn start_postgres(
     // The PostgreSQL backend also hosts the per-user settings store, so it always
     // keeps ownership of the backend Arc and uses the settings-capable builder.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(backend.clone());
+    let ui_settings = settings_store.clone();
     let export_bundle = build_bulk_export(&config, backend.clone(), backend.clone()).await?;
     let submit_bundle = build_bulk_submit(&config, backend.clone()).await?;
     let ops = standalone_ops(
@@ -1825,7 +1838,7 @@ async fn start_postgres(
     );
     // Second handle to the same backend for the web UI's tenant-maintenance
     // read/write path (the FHIR app keeps its own).
-    serve(app, &config, serve_audit_state, Some(backend)).await
+    serve(app, &config, serve_audit_state, Some(backend), ui_settings).await
 }
 
 /// Fallback when postgres feature is not enabled.
@@ -1980,6 +1993,7 @@ async fn start_postgres_elasticsearch(
     // is search-only), so it is wired from the underlying `pg` backend even
     // though the app is served over the composite storage.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(pg.clone());
+    let ui_settings = settings_store.clone();
 
     let export_bundle = build_bulk_export(&config, pg.clone(), pg.clone()).await?;
     let submit_bundle = build_bulk_submit(&config, pg.clone()).await?;
@@ -2003,7 +2017,14 @@ async fn start_postgres_elasticsearch(
     );
     // The UI's tenant-maintenance path goes through the composite (not the
     // bare primary) so a purge also clears the offloaded search documents.
-    serve(app, &config, serve_audit_state, Some(composite)).await
+    serve(
+        app,
+        &config,
+        serve_audit_state,
+        Some(composite),
+        ui_settings,
+    )
+    .await
 }
 
 /// Fallback when postgres+elasticsearch features are not both enabled.
@@ -2150,6 +2171,7 @@ async fn start_mongodb_elasticsearch(
     // search-only), so it is wired from the underlying `mongo` backend even
     // though the app is served over the composite storage.
     let settings_store: Option<Arc<dyn SettingsStore>> = Some(mongo.clone());
+    let ui_settings = settings_store.clone();
 
     // MongoDB primary; embedded SQLite sidecar for bulk-export job state.
     let export_bundle = {
@@ -2184,7 +2206,14 @@ async fn start_mongodb_elasticsearch(
     );
     // The UI's tenant-maintenance path goes through the composite (not the
     // bare primary) so a purge also clears the offloaded search documents.
-    serve(app, &config, serve_audit_state, Some(composite)).await
+    serve(
+        app,
+        &config,
+        serve_audit_state,
+        Some(composite),
+        ui_settings,
+    )
+    .await
 }
 
 /// Fallback when mongodb+elasticsearch features are not both enabled.
@@ -2279,6 +2308,7 @@ async fn start_s3(
         );
         None
     };
+    let ui_settings = settings_store.clone();
 
     // S3 standalone can purge, but it has NO search index of any kind — its
     // SearchProvider reports search unsupported — so `$reindex` has nothing to
@@ -2301,7 +2331,7 @@ async fn start_s3(
         settings_store,
         ops,
     );
-    serve(app, &config, serve_audit_state, ui_tenants).await
+    serve(app, &config, serve_audit_state, ui_tenants, ui_settings).await
 }
 
 /// Fallback when s3 feature is not enabled.
@@ -2509,6 +2539,7 @@ async fn start_s3_elasticsearch(
         );
         None
     };
+    let ui_settings = settings_store.clone();
 
     // Reindex reads from the S3 primary and writes to Elasticsearch, which is
     // the only search index in this deployment — S3 maintains none. The
@@ -2549,7 +2580,14 @@ async fn start_s3_elasticsearch(
     );
     // The UI's tenant-maintenance path goes through the composite (not the bare
     // primary) so a purge also clears the offloaded search documents.
-    serve(app, &config, serve_audit_state, Some(composite)).await
+    serve(
+        app,
+        &config,
+        serve_audit_state,
+        Some(composite),
+        ui_settings,
+    )
+    .await
 }
 
 /// Fallback when s3+elasticsearch features are not both enabled.

--- a/crates/observability/src/dashboard.rs
+++ b/crates/observability/src/dashboard.rs
@@ -153,7 +153,7 @@ pub trait DashboardProvider: Send + Sync {
     /// Compute a fresh snapshot over `window`. Called per dashboard page load, so
     /// implementations keep the query fan-out bounded (a handful of resource
     /// types) and degrade gracefully — returning zeros — rather than erroring.
-    async fn snapshot(&self, window: DashboardWindow) -> DashboardSnapshot;
+    async fn snapshot(&self, window: DashboardWindow, tenant: &str) -> DashboardSnapshot;
 }
 
 static PROVIDER: RwLock<Option<Arc<dyn DashboardProvider>>> = RwLock::new(None);
@@ -179,7 +179,7 @@ struct CacheEntry {
     computing: bool,
 }
 
-type SnapCache = Arc<RwLock<std::collections::HashMap<DashboardWindow, CacheEntry>>>;
+type SnapCache = Arc<RwLock<std::collections::HashMap<(DashboardWindow, String), CacheEntry>>>;
 
 static CACHE: std::sync::LazyLock<SnapCache> = std::sync::LazyLock::new(SnapCache::default);
 
@@ -202,9 +202,17 @@ const COLD_WAIT: std::time::Duration = std::time::Duration::from_millis(800);
 /// page loads O(1) even on backends where computing the snapshot walks storage
 /// (the S3 primary reads one object per resource — minutes once conformance
 /// seeding has populated the store, #326).
-pub async fn snapshot(window: DashboardWindow) -> Option<DashboardSnapshot> {
+pub async fn snapshot(window: DashboardWindow, tenant: &str) -> Option<DashboardSnapshot> {
     let provider = provider()?;
-    snapshot_via(CACHE.clone(), provider, window, CACHE_TTL, COLD_WAIT).await
+    snapshot_via(
+        CACHE.clone(),
+        provider,
+        window,
+        tenant,
+        CACHE_TTL,
+        COLD_WAIT,
+    )
+    .await
 }
 
 /// [`snapshot`] with the cache, provider, and timings injected, so the serve
@@ -213,14 +221,16 @@ async fn snapshot_via(
     cache: SnapCache,
     provider: Arc<dyn DashboardProvider>,
     window: DashboardWindow,
+    tenant: &str,
     ttl: std::time::Duration,
     cold_wait: std::time::Duration,
 ) -> Option<DashboardSnapshot> {
+    let key = (window, tenant.to_string());
     // One pass under the lock: serve fresh hits, note staleness, and claim the
     // compute slot if nobody holds it.
     let (cached, spawn_compute) = {
         let mut guard = cache.write().ok()?;
-        let entry = guard.entry(window).or_insert(CacheEntry {
+        let entry = guard.entry(key.clone()).or_insert(CacheEntry {
             value: None,
             computing: false,
         });
@@ -238,10 +248,12 @@ async fn snapshot_via(
 
     if spawn_compute {
         let cache = cache.clone();
+        let key = key.clone();
+        let tenant = tenant.to_string();
         tokio::spawn(async move {
-            let value = provider.snapshot(window).await;
+            let value = provider.snapshot(window, &tenant).await;
             if let Ok(mut guard) = cache.write()
-                && let Some(entry) = guard.get_mut(&window)
+                && let Some(entry) = guard.get_mut(&key)
             {
                 entry.value = Some((std::time::Instant::now(), value));
                 entry.computing = false;
@@ -259,7 +271,7 @@ async fn snapshot_via(
     while std::time::Instant::now() < deadline {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         if let Ok(guard) = cache.read()
-            && let Some(value) = guard.get(&window).and_then(|e| e.value.as_ref())
+            && let Some(value) = guard.get(&key).and_then(|e| e.value.as_ref())
         {
             return Some(value.1.clone());
         }
@@ -292,7 +304,7 @@ mod tests {
 
     #[async_trait]
     impl DashboardProvider for Counting {
-        async fn snapshot(&self, window: DashboardWindow) -> DashboardSnapshot {
+        async fn snapshot(&self, window: DashboardWindow, _tenant: &str) -> DashboardSnapshot {
             let hit = self.hits.fetch_add(1, Ordering::SeqCst) + 1;
             if !self.delay.is_zero() {
                 tokio::time::sleep(self.delay).await;
@@ -316,6 +328,7 @@ mod tests {
             cache.clone(),
             provider.clone(),
             DashboardWindow::LastHour,
+            "default",
             ttl,
             cold,
         )
@@ -327,6 +340,7 @@ mod tests {
             cache,
             provider.clone(),
             DashboardWindow::LastHour,
+            "default",
             ttl,
             cold,
         )
@@ -351,6 +365,7 @@ mod tests {
             cache.clone(),
             provider.clone(),
             DashboardWindow::LastDay,
+            "default",
             ttl,
             cold,
         )
@@ -362,6 +377,7 @@ mod tests {
             cache.clone(),
             provider.clone(),
             DashboardWindow::LastDay,
+            "default",
             ttl,
             cold,
         )
@@ -376,9 +392,16 @@ mod tests {
                 break;
             }
         }
-        let refreshed = snapshot_via(cache, provider.clone(), DashboardWindow::LastDay, ttl, cold)
-            .await
-            .expect("refreshed value");
+        let refreshed = snapshot_via(
+            cache,
+            provider.clone(),
+            DashboardWindow::LastDay,
+            "default",
+            ttl,
+            cold,
+        )
+        .await
+        .expect("refreshed value");
         assert!(
             refreshed.total_resources >= 2,
             "got {}",
@@ -397,6 +420,7 @@ mod tests {
             cache.clone(),
             provider.clone(),
             DashboardWindow::LastMonth,
+            "default",
             ttl,
             cold,
         )
@@ -411,6 +435,7 @@ mod tests {
             cache,
             provider.clone(),
             DashboardWindow::LastMonth,
+            "default",
             ttl,
             cold,
         )
@@ -430,7 +455,7 @@ mod tests {
 
     #[async_trait]
     impl DashboardProvider for Fixed {
-        async fn snapshot(&self, window: DashboardWindow) -> DashboardSnapshot {
+        async fn snapshot(&self, window: DashboardWindow, _tenant: &str) -> DashboardSnapshot {
             DashboardSnapshot {
                 fhir_version: "R4".to_string(),
                 total_resources: 42,
@@ -453,7 +478,7 @@ mod tests {
     async fn registered_provider_snapshot_round_trips() {
         set_provider(Arc::new(Fixed));
 
-        let snap = snapshot(DashboardWindow::LastHour)
+        let snap = snapshot(DashboardWindow::LastHour, "default")
             .await
             .expect("provider registered");
         assert_eq!(snap.total_resources, 42);

--- a/crates/rest/src/dashboard.rs
+++ b/crates/rest/src/dashboard.rs
@@ -174,10 +174,11 @@ where
     Ok(series)
 }
 
-/// [`DashboardProvider`] backed by a live storage backend, scoped to the
-/// server's default tenant. Registered once in [`crate::build_app`].
+/// [`DashboardProvider`] backed by a live storage backend. Registered once in
+/// [`crate::build_app`]; the tenant to chart arrives per call (#344), with the
+/// server default as the fallback for an empty id.
 pub(crate) struct StorageDashboardProvider<S> {
-    tenant: TenantContext,
+    default_tenant: String,
     fhir_version: String,
     types: Vec<String>,
     storage: Arc<S>,
@@ -188,12 +189,8 @@ impl<S> StorageDashboardProvider<S> {
     /// version, charting [`DEFAULT_DASHBOARD_TYPES`]. The window is chosen per
     /// request by the UI, so it is not fixed here.
     pub(crate) fn new(storage: Arc<S>, config: &ServerConfig) -> Self {
-        let tenant = TenantContext::new(
-            TenantId::new(config.default_tenant.clone()),
-            TenantPermissions::full_access(),
-        );
         Self {
-            tenant,
+            default_tenant: config.default_tenant.clone(),
             fhir_version: config.default_fhir_version.to_string(),
             types: DEFAULT_DASHBOARD_TYPES
                 .iter()
@@ -209,7 +206,16 @@ impl<S> DashboardProvider for StorageDashboardProvider<S>
 where
     S: ResourceStorage + Send + Sync + 'static,
 {
-    async fn snapshot(&self, window: DashboardWindow) -> DashboardSnapshot {
+    async fn snapshot(&self, window: DashboardWindow, tenant: &str) -> DashboardSnapshot {
+        let tenant_id = if tenant.is_empty() {
+            self.default_tenant.as_str()
+        } else {
+            tenant
+        };
+        let tenant = TenantContext::new(
+            TenantId::new(tenant_id.to_string()),
+            TenantPermissions::full_access(),
+        );
         let now = Utc::now();
         let type_refs: Vec<&str> = self.types.iter().map(|t| t.as_str()).collect();
 
@@ -217,7 +223,7 @@ where
         // the operator dashboard should render even if a count query hiccups.
         let series = match resource_count_series(
             self.storage.as_ref(),
-            &self.tenant,
+            &tenant,
             &type_refs,
             SeriesWindow::from_dashboard_window(window),
             now,
@@ -231,18 +237,18 @@ where
             }
         };
 
-        let total_resources =
-            self.storage
-                .count(&self.tenant, None)
-                .await
-                .unwrap_or_else(|error| {
-                    warn!(%error, "dashboard snapshot: total count query failed");
-                    0
-                });
+        let total_resources = self
+            .storage
+            .count(&tenant, None)
+            .await
+            .unwrap_or_else(|error| {
+                warn!(%error, "dashboard snapshot: total count query failed");
+                0
+            });
 
         let distinct_types = self
             .storage
-            .count_all_types(&self.tenant)
+            .count_all_types(&tenant)
             .await
             .map(|types| types.len())
             .unwrap_or_else(|error| {
@@ -280,7 +286,7 @@ mod tests {
         };
 
         let provider = StorageDashboardProvider::new(Arc::new(backend), &config);
-        let snapshot = provider.snapshot(DashboardWindow::default()).await;
+        let snapshot = provider.snapshot(DashboardWindow::default(), "").await;
 
         // One series per charted type, each a dense 30-day window of zeros.
         assert_eq!(snapshot.series.len(), DEFAULT_DASHBOARD_TYPES.len());

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -30,6 +30,9 @@ helios-fhir = { path = "../fhir", version = "0.2.1", default-features = false }
 # `/SearchParameter` and `/CompartmentDefinition` endpoints, and derives the
 # query-string extractors. Both already in the workspace dependency graph.
 serde = { version = "1", features = ["derive"] }
+
+# Warn-level breadcrumb when persisting the FHIR-version choice fails (#343).
+tracing = "0.1"
 serde_json = "1"
 
 # The UI reads conformance data (SearchParameter, CompartmentDefinition) from

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -434,6 +434,18 @@ html[data-nav="collapsed"] .brand__version {
   text-decoration: none;
 }
 
+/* The version options are form buttons; keep them visually identical to the
+   anchor options. */
+button.menu__option {
+  width: 100%;
+  font: inherit;
+  font-weight: 500;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
 .menu__option:hover {
   color: var(--text-strong);
 }

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -320,6 +320,13 @@ html[data-nav="collapsed"] .brand__version {
   display: none;
 }
 
+/* Footer variant: the version selector opens upward, clear of the viewport
+   bottom edge. */
+.menu--up .menu__panel {
+  top: auto;
+  bottom: calc(100% + 8px);
+}
+
 .menu__panel {
   position: absolute;
   z-index: 10;

--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -30,6 +30,13 @@
   "use strict";
 
   var SETTINGS = "/_user/settings";
+  /* The effective tenant, stamped by the server (#344); FHIR calls carry it. */
+  var TENANT = (document.querySelector('meta[name="hfs-tenant"]') || {}).content || "";
+  function fhirHeaders() {
+    var h = { Accept: "application/fhir+json" };
+    if (TENANT) h["X-Tenant-ID"] = TENANT;
+    return h;
+  }
   var MAX_RETRIES = 2;
   var MAX_RECENT = 10;
 
@@ -391,7 +398,7 @@
           encodeURIComponent(slot.dataset.countFor) +
           "?_summary=count&_total=accurate",
         {
-          headers: { Accept: "application/fhir+json" },
+          headers: fhirHeaders(),
           credentials: "same-origin",
         }
       )
@@ -604,7 +611,7 @@
       window.open(path, "_blank", "noopener");
     } else {
       fetch(path, {
-        headers: { Accept: "application/fhir+json" },
+        headers: fhirHeaders(),
         credentials: "same-origin",
       })
         .then(function (response) {

--- a/crates/ui/src/compartments.rs
+++ b/crates/ui/src/compartments.rs
@@ -53,9 +53,12 @@ pub(crate) struct CompartmentResource {
 /// Lazily-fetched, process-lifetime CompartmentDefinitions, one set per enabled
 /// FHIR version. Fetched from the server's own endpoint once per version and
 /// cached; sorted by compartment code.
+/// Cache key: the tenant the definitions were fetched for, and the version.
+type TenantVersion = (String, FhirVersion);
+
 pub(crate) struct CompartmentCatalog {
     source: Arc<dyn ConformanceSource>,
-    cache: Mutex<HashMap<(String, FhirVersion), Arc<Vec<CompartmentDef>>>>,
+    cache: Mutex<HashMap<TenantVersion, Arc<Vec<CompartmentDef>>>>,
 }
 
 impl CompartmentCatalog {

--- a/crates/ui/src/compartments.rs
+++ b/crates/ui/src/compartments.rs
@@ -55,7 +55,7 @@ pub(crate) struct CompartmentResource {
 /// cached; sorted by compartment code.
 pub(crate) struct CompartmentCatalog {
     source: Arc<dyn ConformanceSource>,
-    cache: Mutex<HashMap<FhirVersion, Arc<Vec<CompartmentDef>>>>,
+    cache: Mutex<HashMap<(String, FhirVersion), Arc<Vec<CompartmentDef>>>>,
 }
 
 impl CompartmentCatalog {
@@ -68,24 +68,32 @@ impl CompartmentCatalog {
 
     /// The definitions for a version, fetching on first use. A failed fetch
     /// yields an empty set (the page degrades to a warning).
-    pub async fn definitions(&self, version: FhirVersion) -> Arc<Vec<CompartmentDef>> {
-        if let Some(cached) = self.cache.lock().expect("compartment lock").get(&version) {
+    pub async fn definitions(
+        &self,
+        tenant: &str,
+        version: FhirVersion,
+    ) -> Arc<Vec<CompartmentDef>> {
+        let key = (tenant.to_string(), version);
+        if let Some(cached) = self.cache.lock().expect("compartment lock").get(&key) {
             return cached.clone();
         }
-        let mut defs: Vec<CompartmentDef> =
-            match self.source.fetch("CompartmentDefinition", version).await {
-                Ok(resources) => resources
-                    .into_iter()
-                    .filter_map(|r| serde_json::from_value(r).ok())
-                    .collect(),
-                Err(_) => Vec::new(),
-            };
+        let mut defs: Vec<CompartmentDef> = match self
+            .source
+            .fetch("CompartmentDefinition", version, tenant)
+            .await
+        {
+            Ok(resources) => resources
+                .into_iter()
+                .filter_map(|r| serde_json::from_value(r).ok())
+                .collect(),
+            Err(_) => Vec::new(),
+        };
         defs.sort_by(|a, b| a.code.cmp(&b.code));
         let built = Arc::new(defs);
         self.cache
             .lock()
             .expect("compartment lock")
-            .entry(version)
+            .entry(key)
             .or_insert_with(|| built.clone())
             .clone()
     }
@@ -93,8 +101,8 @@ impl CompartmentCatalog {
     /// Every resource type of the version, from the first CompartmentDefinition
     /// (each enumerates the full set — 145 in R4). Used by the queries page's
     /// resource picker rail.
-    pub async fn resource_type_names(&self, version: FhirVersion) -> Vec<String> {
-        self.definitions(version)
+    pub async fn resource_type_names(&self, tenant: &str, version: FhirVersion) -> Vec<String> {
+        self.definitions(tenant, version)
             .await
             .first()
             .map(|def| def.resource.iter().map(|r| r.code.clone()).collect())

--- a/crates/ui/src/conformance.rs
+++ b/crates/ui/src/conformance.rs
@@ -23,7 +23,12 @@ use serde_json::Value;
 pub trait ConformanceSource: Send + Sync {
     /// Returns every resource of `resource_type` the server holds for `version`,
     /// or an `Err` message when the fetch fails (the caller degrades the page).
-    async fn fetch(&self, resource_type: &str, version: FhirVersion) -> Result<Vec<Value>, String>;
+    async fn fetch(
+        &self,
+        resource_type: &str,
+        version: FhirVersion,
+        tenant: &str,
+    ) -> Result<Vec<Value>, String>;
 }
 
 /// Reads conformance resources from the server's own FHIR API over HTTP.
@@ -56,14 +61,20 @@ impl ConformanceSource for HttpConformanceSource {
         &self,
         resource_type: &str,
         _version: FhirVersion,
+        tenant: &str,
     ) -> Result<Vec<Value>, String> {
         // A single page large enough to hold the whole conformance set: the UI
         // needs the full list for its facets and rail, and paginates in-memory.
         let url = format!("{}/{}?_count=100000", self.base_url, resource_type);
-        let request = self
+        let mut request = self
             .client
             .get(&url)
             .header("Accept", "application/fhir+json");
+        // Scope the self-call to the effective tenant (#344); an empty id means
+        // the server default and needs no header.
+        if !tenant.is_empty() {
+            request = request.header("X-Tenant-ID", tenant);
+        }
         let request = self
             .outbound_auth
             .authorize(request, &self.base_url)
@@ -149,7 +160,12 @@ impl StaticConformanceSource {
 
 #[async_trait]
 impl ConformanceSource for StaticConformanceSource {
-    async fn fetch(&self, resource_type: &str, version: FhirVersion) -> Result<Vec<Value>, String> {
+    async fn fetch(
+        &self,
+        resource_type: &str,
+        version: FhirVersion,
+        _tenant: &str,
+    ) -> Result<Vec<Value>, String> {
         Ok(self
             .map
             .get(&(resource_type.to_string(), version))

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -115,6 +115,9 @@ struct WebState {
     data_dir: Option<PathBuf>,
     /// The server's default FHIR version, used when seeding a new tenant.
     fhir_version: helios_fhir::FhirVersion,
+    /// The server's default tenant id — the fallback when no stored choice
+    /// exists (#344).
+    default_tenant: String,
     /// Per-user settings, for the persisted FHIR-version choice (#343). `None`
     /// when the backend has no settings store; the selector then applies
     /// per-page only.
@@ -127,6 +130,7 @@ struct WebState {
 /// local fallback when auth is disabled (`/ui` also sits outside the auth
 /// layer today — #320 tracks the authenticated modes).
 const SETTINGS_VERSION_KEY: &str = "fhirVersion";
+const SETTINGS_TENANT_KEY: &str = "tenantId";
 const LOCAL_USER_KEY: &str = "local|default";
 
 fn settings_user_key(extensions: &axum::http::Extensions) -> String {
@@ -138,7 +142,7 @@ fn settings_user_key(extensions: &axum::http::Extensions) -> String {
 
 /// The FHIR version this request renders under: the user's stored choice when
 /// one exists and is compiled in, the server default otherwise. Resolved once
-/// per request by [`resolve_version`]; explicit `?version=` query parameters
+/// per request by [`resolve_prefs`]; explicit `?version=` query parameters
 /// still override it per page.
 #[derive(Clone, Copy)]
 pub(crate) struct RequestVersion(pub(crate) helios_fhir::FhirVersion);
@@ -161,28 +165,81 @@ where
     }
 }
 
-/// Middleware: stamps [`RequestVersion`] from the user's stored settings (one
-/// settings read per page load, the documented cost model of that store),
-/// falling back to the server default.
-async fn resolve_version(
+/// The tenant this request renders under (#344): the user's stored choice when
+/// it is still a provisioned tenant, the server default otherwise. Carries the
+/// registry display name for the selector label.
+#[derive(Clone)]
+pub(crate) struct RequestTenant {
+    pub(crate) id: String,
+    pub(crate) display: Option<String>,
+}
+
+impl<S> axum::extract::FromRequestParts<S> for RequestTenant
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(parts
+            .extensions
+            .get::<RequestTenant>()
+            .cloned()
+            .unwrap_or(RequestTenant {
+                id: "default".to_string(),
+                display: None,
+            }))
+    }
+}
+
+/// Middleware: stamps [`RequestVersion`] and [`RequestTenant`] from the user's
+/// stored settings — one settings read per page load, the documented cost model
+/// of that store — falling back to the server defaults. A stored tenant that is
+/// no longer provisioned falls back too, keeping the provisioned-only model.
+async fn resolve_prefs(
     State(state): State<WebState>,
     mut request: axum::extract::Request,
     next: middleware::Next,
 ) -> Response {
-    let mut effective = state.fhir_version;
-    if let Some(store) = &state.settings {
-        let user = settings_user_key(request.extensions());
-        if let Ok(Some(stored)) = store.get_settings(&user).await
-            && let Some(choice) = stored
-                .document
-                .get(SETTINGS_VERSION_KEY)
-                .and_then(|v| v.as_str())
-                .and_then(search_params::version_from_str)
+    let mut version = state.fhir_version;
+    let mut tenant = RequestTenant {
+        id: state.default_tenant.clone(),
+        display: None,
+    };
+    let document = match &state.settings {
+        Some(store) => {
+            let user = settings_user_key(request.extensions());
+            match store.get_settings(&user).await {
+                Ok(stored) => stored.map(|s| s.document),
+                Err(_) => None,
+            }
+        }
+        None => None,
+    };
+    if let Some(document) = &document {
+        if let Some(choice) = document
+            .get(SETTINGS_VERSION_KEY)
+            .and_then(|v| v.as_str())
+            .and_then(search_params::version_from_str)
         {
-            effective = choice;
+            version = choice;
+        }
+        if let Some(choice) = document.get(SETTINGS_TENANT_KEY).and_then(|v| v.as_str())
+            && choice != tenant.id
+            && let Some(registry) = &state.tenants
+            && let Ok(Some(record)) = registry.get_tenant(choice).await
+        {
+            tenant = RequestTenant {
+                id: record.id,
+                display: record.display_name,
+            };
         }
     }
-    request.extensions_mut().insert(RequestVersion(effective));
+    request.extensions_mut().insert(RequestVersion(version));
+    request.extensions_mut().insert(tenant);
     next.run(request).await
 }
 
@@ -192,8 +249,13 @@ async fn resolve_version(
 pub(crate) struct Status {
     pub(crate) version: &'static str,
     checked_at: u64,
-    /// The server's default FHIR version — the sidebar selector's label.
+    /// The effective FHIR version for this request — the sidebar selector's
+    /// label (#343).
     fhir_version: helios_fhir::FhirVersion,
+    /// The effective tenant for this request — the tenant selector's label
+    /// (#344).
+    tenant_id: String,
+    tenant_display: Option<String>,
 }
 
 impl Status {
@@ -210,6 +272,34 @@ impl Status {
             .into_iter()
             .map(|v| v.as_str())
             .collect()
+    }
+
+    /// The effective tenant id, for the `hfs-tenant` meta tag browser calls
+    /// read (#344).
+    pub(crate) fn tenant_id(&self) -> &str {
+        &self.tenant_id
+    }
+
+    /// The effective tenant's display label: its registry display name, or the
+    /// id when none is set.
+    pub(crate) fn tenant_label(&self) -> &str {
+        self.tenant_display.as_deref().unwrap_or(&self.tenant_id)
+    }
+
+    /// Up-to-two-letter avatar initials from the tenant label.
+    pub(crate) fn tenant_initials(&self) -> String {
+        let letters: String = self
+            .tenant_label()
+            .split([' ', '-', '_', '/'])
+            .filter(|w| !w.is_empty())
+            .take(2)
+            .filter_map(|w| w.chars().next())
+            .collect();
+        if letters.is_empty() {
+            "?".to_string()
+        } else {
+            letters.to_uppercase()
+        }
     }
 }
 
@@ -433,6 +523,7 @@ pub fn mount(
     nl: NlSearch,
     tenants: Option<Arc<dyn ResourceStorage>>,
     settings: Option<Arc<dyn SettingsStore>>,
+    default_tenant: String,
     self_base_url: String,
     outbound_auth: Arc<dyn helios_auth::outbound::OutboundAuthProvider>,
     fhir_version: helios_fhir::FhirVersion,
@@ -448,6 +539,7 @@ pub fn mount(
         nl,
         tenants,
         settings,
+        default_tenant,
         source,
         fhir_version,
     )
@@ -466,6 +558,7 @@ pub fn mount_with_conformance_source(
     nl: NlSearch,
     tenants: Option<Arc<dyn ResourceStorage>>,
     settings: Option<Arc<dyn SettingsStore>>,
+    default_tenant: String,
     source: Arc<dyn ConformanceSource>,
     fhir_version: helios_fhir::FhirVersion,
 ) -> Router {
@@ -496,7 +589,11 @@ pub fn mount_with_conformance_source(
         .route("/ui/tenants/rows", get(tenants::rows))
         .route("/ui/tenants/{id}", axum::routing::delete(tenants::delete))
         // Persists the sidebar's FHIR-version choice (#343) and redirects back.
-        .route("/ui/version", axum::routing::post(set_version));
+        .route("/ui/version", axum::routing::post(set_version))
+        // The tenant selector (#344): lazily-loaded options and the persisted
+        // choice, mirroring /ui/version.
+        .route("/ui/tenant/options", get(tenant_options))
+        .route("/ui/tenant", axum::routing::post(set_tenant));
 
     if nl_enabled {
         router = router.route("/ui/search", get(search));
@@ -511,6 +608,7 @@ pub fn mount_with_conformance_source(
         settings,
         data_dir,
         fhir_version,
+        default_tenant,
     };
 
     router
@@ -523,10 +621,7 @@ pub fn mount_with_conformance_source(
         .layer(middleware::from_fn(i18n::negotiate_locale))
         // One effective FHIR version per request (stored choice or default),
         // in request extensions next to the locale.
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            resolve_version,
-        ))
+        .layer(middleware::from_fn_with_state(state.clone(), resolve_prefs))
         .with_state(state)
         .fallback_service(fhir_app)
 }
@@ -588,6 +683,123 @@ async fn set_version(
     axum::response::Redirect::to(&target).into_response()
 }
 
+/// One option row of the tenant selector menu.
+struct TenantOption {
+    id: String,
+    label: String,
+    initials: String,
+    current: bool,
+}
+
+/// The tenant selector's options, loaded when the menu opens (htmx) so pages
+/// do not pay a registry listing per load.
+#[derive(Template)]
+#[template(path = "partials/tenant-options.html")]
+struct TenantOptionsPartial {
+    options: Vec<TenantOption>,
+}
+
+fn initials_of(label: &str) -> String {
+    let letters: String = label
+        .split([' ', '-', '_', '/'])
+        .filter(|w| !w.is_empty())
+        .take(2)
+        .filter_map(|w| w.chars().next())
+        .collect();
+    if letters.is_empty() {
+        "?".to_string()
+    } else {
+        letters.to_uppercase()
+    }
+}
+
+/// `GET /ui/tenant/options` — the registry's provisioned tenants as selector
+/// options, with the effective tenant marked current.
+async fn tenant_options(State(state): State<WebState>, rt: RequestTenant) -> Response {
+    let mut options = Vec::new();
+    if let Some(registry) = &state.tenants
+        && let Ok(records) = registry.list_tenants().await
+    {
+        for record in records {
+            let label = record
+                .display_name
+                .clone()
+                .unwrap_or_else(|| record.id.clone());
+            options.push(TenantOption {
+                current: record.id == rt.id,
+                initials: initials_of(&label),
+                id: record.id,
+                label,
+            });
+        }
+    }
+    if !options.iter().any(|o| o.current) {
+        let label = rt.display.clone().unwrap_or_else(|| rt.id.clone());
+        options.insert(
+            0,
+            TenantOption {
+                current: true,
+                initials: initials_of(&label),
+                id: rt.id.clone(),
+                label,
+            },
+        );
+    }
+    render(TenantOptionsPartial { options })
+}
+
+/// Form body for `POST /ui/tenant` — the tenant selector's submit.
+#[derive(Deserialize)]
+struct TenantForm {
+    tenant: String,
+}
+
+/// Persists the tenant choice to the user's settings document and bounces back
+/// to the referring page. Only provisioned tenants are accepted (#252's model);
+/// anything else is rejected rather than stored.
+async fn set_tenant(
+    State(state): State<WebState>,
+    headers: axum::http::HeaderMap,
+    principal: Option<axum::Extension<helios_auth::Principal>>,
+    axum::Form(form): axum::Form<TenantForm>,
+) -> Response {
+    let choice = form.tenant.trim();
+    let known = choice == state.default_tenant
+        || match &state.tenants {
+            Some(registry) => matches!(registry.get_tenant(choice).await, Ok(Some(_))),
+            None => false,
+        };
+    if !known {
+        return (StatusCode::BAD_REQUEST, "unknown tenant").into_response();
+    }
+
+    if let Some(store) = &state.settings {
+        let user = match &principal {
+            Some(axum::Extension(p)) => format!("{}|{}", p.issuer(), p.subject()),
+            None => LOCAL_USER_KEY.to_string(),
+        };
+        if let Err(e) = store
+            .patch_settings(
+                &user,
+                serde_json::json!({ SETTINGS_TENANT_KEY: choice }),
+                None,
+            )
+            .await
+        {
+            tracing::warn!("persisting tenant choice failed: {e}");
+        }
+    }
+
+    let back = headers
+        .get(axum::http::header::REFERER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|r| r.parse::<axum::http::Uri>().ok())
+        .map(|u| u.path().to_string())
+        .filter(|p| p.starts_with("/ui"))
+        .unwrap_or_else(|| "/ui".to_string());
+    axum::response::Redirect::to(&back).into_response()
+}
+
 /// The how-to page for natural-language search, linked from the setup state.
 const NL_SEARCH_DOCS: &str =
     "https://heliossoftware.github.io/hfs/components/natural-language-search.html";
@@ -613,6 +825,7 @@ async fn index(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
+    rt: RequestTenant,
     RawQuery(query): RawQuery,
 ) -> Response {
     let selected = query_value(query.as_deref(), "type");
@@ -627,6 +840,7 @@ async fn index(
             window,
             state.nl.enabled,
             rv.0,
+            &rt,
         )
         .await,
     )
@@ -637,13 +851,14 @@ async fn search(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
+    rt: RequestTenant,
 ) -> Response {
     let resource_types = state
         .compartments
-        .resource_type_names(helios_fhir::FhirVersion::default())
+        .resource_type_names(&rt.id, helios_fhir::FhirVersion::default())
         .await;
     render(SearchPage {
-        status: current_status(state.version, rv.0),
+        status: current_status(state.version, rv.0, &rt),
         i18n: I18n::new(locale),
         active_page: "search",
         nl_enabled: state.nl.enabled,
@@ -659,13 +874,14 @@ async fn queries(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
+    rt: RequestTenant,
 ) -> Response {
     let resource_types = state
         .compartments
-        .resource_type_names(helios_fhir::FhirVersion::default())
+        .resource_type_names(&rt.id, helios_fhir::FhirVersion::default())
         .await;
     render(QueriesPage {
-        status: current_status(state.version, rv.0),
+        status: current_status(state.version, rv.0, &rt),
         i18n: I18n::new(locale),
         active_page: "queries",
         nl_enabled: state.nl.enabled,
@@ -685,11 +901,12 @@ struct ParamsCatalogQuery {
 /// `DomainResource`-level ones), from the default-version snapshot.
 async fn query_params_catalog(
     State(state): State<WebState>,
+    rt: RequestTenant,
     Query(raw): Query<ParamsCatalogQuery>,
 ) -> Response {
     let snapshot = state
         .sp_catalog
-        .snapshot(helios_fhir::FhirVersion::default())
+        .snapshot(&rt.id, helios_fhir::FhirVersion::default())
         .await;
     let resource_type = raw.resource_type.unwrap_or_default();
     let mut params: Vec<ParamOption> = snapshot
@@ -726,6 +943,7 @@ async fn search_parameters(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
+    rt: RequestTenant,
     Query(raw): Query<SearchParametersQuery>,
 ) -> Response {
     let query = search_params::SpQuery {
@@ -738,9 +956,12 @@ async fn search_parameters(
         page: raw.page.unwrap_or(1),
         sel: raw.sel.filter(|s| !s.is_empty()),
     };
-    let snapshot = state.sp_catalog.snapshot(query.fhir_version()).await;
+    let snapshot = state
+        .sp_catalog
+        .snapshot(&rt.id, query.fhir_version())
+        .await;
     render(SearchParametersPage {
-        status: current_status(state.version, rv.0),
+        status: current_status(state.version, rv.0, &rt),
         i18n: I18n::new(locale),
         active_page: "search-parameters",
         nl_enabled: state.nl.enabled,
@@ -766,6 +987,7 @@ async fn compartments_page(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
+    rt: RequestTenant,
     Query(raw): Query<CompartmentsQuery>,
 ) -> Response {
     let query = compartments::CmpQuery {
@@ -777,10 +999,13 @@ async fn compartments_page(
         id: raw.id,
         target: raw.target,
     };
-    let defs = state.compartments.definitions(query.fhir_version()).await;
+    let defs = state
+        .compartments
+        .definitions(&rt.id, query.fhir_version())
+        .await;
     match compartments::build_view(&query, &defs) {
         Some(view) => render(CompartmentsPage {
-            status: current_status(state.version, rv.0),
+            status: current_status(state.version, rv.0, &rt),
             i18n: I18n::new(locale),
             active_page: "compartments",
             nl_enabled: state.nl.enabled,
@@ -796,9 +1021,10 @@ async fn status(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
+    rt: RequestTenant,
     HxRequest(is_htmx): HxRequest,
 ) -> Response {
-    let status = current_status(state.version, rv.0);
+    let status = current_status(state.version, rv.0, &rt);
     let i18n = I18n::new(locale);
     if is_htmx {
         render(StatusPartial { status, i18n })
@@ -811,6 +1037,7 @@ async fn status(
                 DashboardWindow::default(),
                 state.nl.enabled,
                 rv.0,
+                &rt,
             )
             .await,
         )
@@ -822,9 +1049,10 @@ async fn history_page(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
+    rt: RequestTenant,
 ) -> Response {
     render(HistoryPage {
-        status: current_status(state.version, rv.0),
+        status: current_status(state.version, rv.0, &rt),
         i18n: I18n::new(locale),
         active_page: "history",
         nl_enabled: state.nl.enabled,
@@ -895,10 +1123,11 @@ async fn build_index_page(
     window: DashboardWindow,
     nl_enabled: bool,
     fhir_version: helios_fhir::FhirVersion,
+    tenant: &RequestTenant,
 ) -> IndexPage {
-    let status = current_status(version, fhir_version);
+    let status = current_status(version, fhir_version, tenant);
     let i18n = I18n::new(locale);
-    let snapshot = helios_observability::dashboard::snapshot(window)
+    let snapshot = helios_observability::dashboard::snapshot(window, &tenant.id)
         .await
         .unwrap_or_else(|| sample_snapshot(window));
     let (metrics, chart, legend, windows) = build_dashboard(&snapshot, selected.as_deref());
@@ -1220,11 +1449,14 @@ fn bucket_floor_utc(ts: DateTime<Utc>, bucket_seconds: i64) -> DateTime<Utc> {
 pub(crate) fn current_status(
     version: &'static str,
     fhir_version: helios_fhir::FhirVersion,
+    tenant: &RequestTenant,
 ) -> Status {
     Status {
         version,
         checked_at: unix_timestamp_seconds(),
         fhir_version,
+        tenant_id: tenant.id.clone(),
+        tenant_display: tenant.display.clone(),
     }
 }
 
@@ -1263,6 +1495,8 @@ mod tests {
                 version,
                 checked_at,
                 fhir_version: helios_fhir::FhirVersion::R4,
+                tenant_id: "default".to_string(),
+                tenant_display: None,
             },
             metrics,
             chart,
@@ -1315,6 +1549,8 @@ mod tests {
                 version: "1.2.3",
                 checked_at: 42,
                 fhir_version: helios_fhir::FhirVersion::R4,
+                tenant_id: "default".to_string(),
+                tenant_display: None,
             },
             i18n: i18n("en"),
         }
@@ -1382,6 +1618,8 @@ mod tests {
                 version: "1.2.3",
                 checked_at: 42,
                 fhir_version: helios_fhir::FhirVersion::R4,
+                tenant_id: "default".to_string(),
+                tenant_display: None,
             },
             i18n: i18n("en"),
             active_page: "queries",
@@ -1420,6 +1658,8 @@ mod tests {
                 version: "1.2.3",
                 checked_at: 42,
                 fhir_version: helios_fhir::FhirVersion::R4,
+                tenant_id: "default".to_string(),
+                tenant_display: None,
             },
             i18n: i18n("es"),
             active_page: "queries",

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -123,15 +123,15 @@ struct WebState {
 
 /// The settings key holding the user's FHIR-version choice, and the user key
 /// the settings resolve under. The key mirrors `helios-rest`'s `UserKey`
-/// derivation: `"{issuer}|{subject}"` from an authenticated principal, or this
-/// local fallback when auth is disabled (`/ui` also sits outside the auth
+/// post-#270 encoding — `u2:{issuer_len}:{issuer}:{subject}` from an
+/// authenticated principal, or this local fallback when auth is disabled (`/ui` also sits outside the auth
 /// layer today — #320 tracks the authenticated modes).
 const SETTINGS_VERSION_KEY: &str = "fhirVersion";
-const LOCAL_USER_KEY: &str = "local|default";
+const LOCAL_USER_KEY: &str = "l2:";
 
-fn settings_user_key(extensions: &axum::http::Extensions) -> String {
-    match extensions.get::<helios_auth::Principal>() {
-        Some(principal) => format!("{}|{}", principal.issuer(), principal.subject()),
+fn settings_user_key(principal: Option<&helios_auth::Principal>) -> String {
+    match principal {
+        Some(p) => format!("u2:{}:{}:{}", p.issuer().len(), p.issuer(), p.subject()),
         None => LOCAL_USER_KEY.to_string(),
     }
 }
@@ -171,7 +171,7 @@ async fn resolve_version(
 ) -> Response {
     let mut effective = state.fhir_version;
     if let Some(store) = &state.settings {
-        let user = settings_user_key(request.extensions());
+        let user = settings_user_key(request.extensions().get::<helios_auth::Principal>());
         if let Ok(Some(stored)) = store.get_settings(&user).await
             && let Some(choice) = stored
                 .document
@@ -553,10 +553,7 @@ async fn set_version(
 
     let mut persisted = false;
     if let Some(store) = &state.settings {
-        let user = match &principal {
-            Some(axum::Extension(p)) => format!("{}|{}", p.issuer(), p.subject()),
-            None => LOCAL_USER_KEY.to_string(),
-        };
+        let user = settings_user_key(principal.as_ref().map(|e| &e.0));
         match store
             .patch_settings(
                 &user,

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -61,7 +61,7 @@ use chrono::{DateTime, Datelike, Duration, Utc};
 use helios_observability::dashboard::{
     DashboardPoint, DashboardSeries, DashboardSnapshot, DashboardWindow,
 };
-use helios_persistence::core::ResourceStorage;
+use helios_persistence::core::{ResourceStorage, SettingsStore};
 use i18n::{I18n, RequestLocale};
 use rust_embed::RustEmbed;
 use serde::Deserialize;
@@ -115,6 +115,75 @@ struct WebState {
     data_dir: Option<PathBuf>,
     /// The server's default FHIR version, used when seeding a new tenant.
     fhir_version: helios_fhir::FhirVersion,
+    /// Per-user settings, for the persisted FHIR-version choice (#343). `None`
+    /// when the backend has no settings store; the selector then applies
+    /// per-page only.
+    settings: Option<Arc<dyn SettingsStore>>,
+}
+
+/// The settings key holding the user's FHIR-version choice, and the user key
+/// the settings resolve under. The key mirrors `helios-rest`'s `UserKey`
+/// derivation: `"{issuer}|{subject}"` from an authenticated principal, or this
+/// local fallback when auth is disabled (`/ui` also sits outside the auth
+/// layer today — #320 tracks the authenticated modes).
+const SETTINGS_VERSION_KEY: &str = "fhirVersion";
+const LOCAL_USER_KEY: &str = "local|default";
+
+fn settings_user_key(extensions: &axum::http::Extensions) -> String {
+    match extensions.get::<helios_auth::Principal>() {
+        Some(principal) => format!("{}|{}", principal.issuer(), principal.subject()),
+        None => LOCAL_USER_KEY.to_string(),
+    }
+}
+
+/// The FHIR version this request renders under: the user's stored choice when
+/// one exists and is compiled in, the server default otherwise. Resolved once
+/// per request by [`resolve_version`]; explicit `?version=` query parameters
+/// still override it per page.
+#[derive(Clone, Copy)]
+pub(crate) struct RequestVersion(pub(crate) helios_fhir::FhirVersion);
+
+impl<S> axum::extract::FromRequestParts<S> for RequestVersion
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(parts
+            .extensions
+            .get::<RequestVersion>()
+            .copied()
+            .unwrap_or(RequestVersion(helios_fhir::FhirVersion::default_enabled())))
+    }
+}
+
+/// Middleware: stamps [`RequestVersion`] from the user's stored settings (one
+/// settings read per page load, the documented cost model of that store),
+/// falling back to the server default.
+async fn resolve_version(
+    State(state): State<WebState>,
+    mut request: axum::extract::Request,
+    next: middleware::Next,
+) -> Response {
+    let mut effective = state.fhir_version;
+    if let Some(store) = &state.settings {
+        let user = settings_user_key(request.extensions());
+        if let Ok(Some(stored)) = store.get_settings(&user).await
+            && let Some(choice) = stored
+                .document
+                .get(SETTINGS_VERSION_KEY)
+                .and_then(|v| v.as_str())
+                .and_then(search_params::version_from_str)
+        {
+            effective = choice;
+        }
+    }
+    request.extensions_mut().insert(RequestVersion(effective));
+    next.run(request).await
 }
 
 /// A small, self-contained system-status snapshot — the "real read path" the
@@ -363,6 +432,7 @@ pub fn mount(
     data_dir: Option<PathBuf>,
     nl: NlSearch,
     tenants: Option<Arc<dyn ResourceStorage>>,
+    settings: Option<Arc<dyn SettingsStore>>,
     self_base_url: String,
     outbound_auth: Arc<dyn helios_auth::outbound::OutboundAuthProvider>,
     fhir_version: helios_fhir::FhirVersion,
@@ -377,6 +447,7 @@ pub fn mount(
         data_dir,
         nl,
         tenants,
+        settings,
         source,
         fhir_version,
     )
@@ -394,6 +465,7 @@ pub fn mount_with_conformance_source(
     data_dir: Option<PathBuf>,
     nl: NlSearch,
     tenants: Option<Arc<dyn ResourceStorage>>,
+    settings: Option<Arc<dyn SettingsStore>>,
     source: Arc<dyn ConformanceSource>,
     fhir_version: helios_fhir::FhirVersion,
 ) -> Router {
@@ -422,11 +494,24 @@ pub fn mount_with_conformance_source(
         .route("/ui/history/diff", axum::routing::post(history_diff))
         .route("/ui/tenants", get(tenants::page).post(tenants::create))
         .route("/ui/tenants/rows", get(tenants::rows))
-        .route("/ui/tenants/{id}", axum::routing::delete(tenants::delete));
+        .route("/ui/tenants/{id}", axum::routing::delete(tenants::delete))
+        // Persists the sidebar's FHIR-version choice (#343) and redirects back.
+        .route("/ui/version", axum::routing::post(set_version));
 
     if nl_enabled {
         router = router.route("/ui/search", get(search));
     }
+
+    let state = WebState {
+        version: hfs_version,
+        sp_catalog: Arc::new(search_params::SpCatalog::new(source.clone())),
+        compartments: Arc::new(compartments::CompartmentCatalog::new(source)),
+        nl: Arc::new(nl),
+        tenants,
+        settings,
+        data_dir,
+        fhir_version,
+    };
 
     router
         .merge(assets)
@@ -436,16 +521,71 @@ pub fn mount_with_conformance_source(
         // One negotiated locale per request, in request extensions; every
         // handler and template reads this same value.
         .layer(middleware::from_fn(i18n::negotiate_locale))
-        .with_state(WebState {
-            version: hfs_version,
-            sp_catalog: Arc::new(search_params::SpCatalog::new(source.clone())),
-            compartments: Arc::new(compartments::CompartmentCatalog::new(source)),
-            nl: Arc::new(nl),
-            tenants,
-            data_dir,
-            fhir_version,
-        })
+        // One effective FHIR version per request (stored choice or default),
+        // in request extensions next to the locale.
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            resolve_version,
+        ))
+        .with_state(state)
         .fallback_service(fhir_app)
+}
+
+/// Form body for `POST /ui/version` — the sidebar selector's submit.
+#[derive(Deserialize)]
+struct VersionForm {
+    version: String,
+}
+
+/// Persists the FHIR-version choice to the user's settings document (the same
+/// `/_user/settings` document the theme roams in) and bounces back to the page
+/// the form was submitted from. Best-effort: with no settings store the choice
+/// still applies to the redirect target via `?version=`.
+async fn set_version(
+    State(state): State<WebState>,
+    headers: axum::http::HeaderMap,
+    principal: Option<axum::Extension<helios_auth::Principal>>,
+    axum::Form(form): axum::Form<VersionForm>,
+) -> Response {
+    let Some(version) = search_params::version_from_str(&form.version) else {
+        return (StatusCode::BAD_REQUEST, "unknown FHIR version").into_response();
+    };
+
+    let mut persisted = false;
+    if let Some(store) = &state.settings {
+        let user = match &principal {
+            Some(axum::Extension(p)) => format!("{}|{}", p.issuer(), p.subject()),
+            None => LOCAL_USER_KEY.to_string(),
+        };
+        match store
+            .patch_settings(
+                &user,
+                serde_json::json!({ SETTINGS_VERSION_KEY: version.as_str() }),
+                None,
+            )
+            .await
+        {
+            Ok(_) => persisted = true,
+            Err(e) => tracing::warn!("persisting FHIR-version choice failed: {e}"),
+        }
+    }
+
+    // Bounce back to the submitting page — same-origin `/ui` paths only.
+    let back = headers
+        .get(axum::http::header::REFERER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|r| r.parse::<axum::http::Uri>().ok())
+        .map(|u| u.path().to_string())
+        .filter(|p| p.starts_with("/ui"))
+        .unwrap_or_else(|| "/ui".to_string());
+    // Without a store the choice cannot outlive this navigation; carry it on
+    // the redirect so the target page still honors it once.
+    let target = if persisted {
+        back
+    } else {
+        format!("{back}?version={}", version.as_str())
+    };
+    axum::response::Redirect::to(&target).into_response()
 }
 
 /// The how-to page for natural-language search, linked from the setup state.
@@ -472,6 +612,7 @@ async fn revalidate_assets(request: axum::extract::Request, next: middleware::Ne
 async fn index(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     RawQuery(query): RawQuery,
 ) -> Response {
     let selected = query_value(query.as_deref(), "type");
@@ -485,20 +626,24 @@ async fn index(
             selected,
             window,
             state.nl.enabled,
-            state.fhir_version,
+            rv.0,
         )
         .await,
     )
 }
 
 /// Search page: natural language and the visual builder over one editable query.
-async fn search(State(state): State<WebState>, locale: RequestLocale) -> Response {
+async fn search(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+) -> Response {
     let resource_types = state
         .compartments
         .resource_type_names(helios_fhir::FhirVersion::default())
         .await;
     render(SearchPage {
-        status: current_status(state.version, state.fhir_version),
+        status: current_status(state.version, rv.0),
         i18n: I18n::new(locale),
         active_page: "search",
         nl_enabled: state.nl.enabled,
@@ -510,13 +655,17 @@ async fn search(State(state): State<WebState>, locale: RequestLocale) -> Respons
 }
 
 /// Saved FHIR queries page.
-async fn queries(State(state): State<WebState>, locale: RequestLocale) -> Response {
+async fn queries(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+) -> Response {
     let resource_types = state
         .compartments
         .resource_type_names(helios_fhir::FhirVersion::default())
         .await;
     render(QueriesPage {
-        status: current_status(state.version, state.fhir_version),
+        status: current_status(state.version, rv.0),
         i18n: I18n::new(locale),
         active_page: "queries",
         nl_enabled: state.nl.enabled,
@@ -576,10 +725,12 @@ struct SearchParametersQuery {
 async fn search_parameters(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     Query(raw): Query<SearchParametersQuery>,
 ) -> Response {
     let query = search_params::SpQuery {
-        version: raw.version,
+        // Explicit ?version= wins; otherwise the user's stored choice (#343).
+        version: raw.version.or_else(|| Some(rv.0.as_str().to_string())),
         base: raw.base.filter(|b| !b.is_empty()),
         ptype: raw.ptype.filter(|t| !t.is_empty()),
         source: raw.source.filter(|s| !s.is_empty()),
@@ -589,7 +740,7 @@ async fn search_parameters(
     };
     let snapshot = state.sp_catalog.snapshot(query.fhir_version()).await;
     render(SearchParametersPage {
-        status: current_status(state.version, state.fhir_version),
+        status: current_status(state.version, rv.0),
         i18n: I18n::new(locale),
         active_page: "search-parameters",
         nl_enabled: state.nl.enabled,
@@ -614,10 +765,12 @@ struct CompartmentsQuery {
 async fn compartments_page(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     Query(raw): Query<CompartmentsQuery>,
 ) -> Response {
     let query = compartments::CmpQuery {
-        version: raw.version,
+        // Explicit ?version= wins; otherwise the user's stored choice (#343).
+        version: raw.version.or_else(|| Some(rv.0.as_str().to_string())),
         def: raw.def,
         tab: raw.tab,
         filter: raw.filter,
@@ -627,7 +780,7 @@ async fn compartments_page(
     let defs = state.compartments.definitions(query.fhir_version()).await;
     match compartments::build_view(&query, &defs) {
         Some(view) => render(CompartmentsPage {
-            status: current_status(state.version, state.fhir_version),
+            status: current_status(state.version, rv.0),
             i18n: I18n::new(locale),
             active_page: "compartments",
             nl_enabled: state.nl.enabled,
@@ -642,9 +795,10 @@ async fn compartments_page(
 async fn status(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     HxRequest(is_htmx): HxRequest,
 ) -> Response {
-    let status = current_status(state.version, state.fhir_version);
+    let status = current_status(state.version, rv.0);
     let i18n = I18n::new(locale);
     if is_htmx {
         render(StatusPartial { status, i18n })
@@ -656,7 +810,7 @@ async fn status(
                 None,
                 DashboardWindow::default(),
                 state.nl.enabled,
-                state.fhir_version,
+                rv.0,
             )
             .await,
         )
@@ -664,9 +818,13 @@ async fn status(
 }
 
 /// History & Versions page shell.
-async fn history_page(State(state): State<WebState>, locale: RequestLocale) -> Response {
+async fn history_page(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+) -> Response {
     render(HistoryPage {
-        status: current_status(state.version, state.fhir_version),
+        status: current_status(state.version, rv.0),
         i18n: I18n::new(locale),
         active_page: "history",
         nl_enabled: state.nl.enabled,

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -123,6 +123,25 @@ struct WebState {
 pub(crate) struct Status {
     pub(crate) version: &'static str,
     checked_at: u64,
+    /// The server's default FHIR version — the sidebar selector's label.
+    fhir_version: helios_fhir::FhirVersion,
+}
+
+impl Status {
+    /// The default FHIR version's display label (`"R4"`, `"R5"`, …).
+    pub(crate) fn fhir_version_label(&self) -> &'static str {
+        self.fhir_version.as_str()
+    }
+
+    /// Labels of every FHIR version compiled into this build, in spec order —
+    /// the sidebar selector's options. Each links the current page with
+    /// `?version=`; pages without a version dimension ignore it.
+    pub(crate) fn enabled_version_labels(&self) -> Vec<&'static str> {
+        search_params::enabled_versions()
+            .into_iter()
+            .map(|v| v.as_str())
+            .collect()
+    }
 }
 
 /// Dashboard headline metrics rendered by `pages/index.html` (design: Figma
@@ -459,7 +478,17 @@ async fn index(
     let window = query_value(query.as_deref(), "window")
         .and_then(|slug| DashboardWindow::from_slug(&slug))
         .unwrap_or_default();
-    render(build_index_page(state.version, locale, selected, window, state.nl.enabled).await)
+    render(
+        build_index_page(
+            state.version,
+            locale,
+            selected,
+            window,
+            state.nl.enabled,
+            state.fhir_version,
+        )
+        .await,
+    )
 }
 
 /// Search page: natural language and the visual builder over one editable query.
@@ -469,7 +498,7 @@ async fn search(State(state): State<WebState>, locale: RequestLocale) -> Respons
         .resource_type_names(helios_fhir::FhirVersion::default())
         .await;
     render(SearchPage {
-        status: current_status(state.version),
+        status: current_status(state.version, state.fhir_version),
         i18n: I18n::new(locale),
         active_page: "search",
         nl_enabled: state.nl.enabled,
@@ -487,7 +516,7 @@ async fn queries(State(state): State<WebState>, locale: RequestLocale) -> Respon
         .resource_type_names(helios_fhir::FhirVersion::default())
         .await;
     render(QueriesPage {
-        status: current_status(state.version),
+        status: current_status(state.version, state.fhir_version),
         i18n: I18n::new(locale),
         active_page: "queries",
         nl_enabled: state.nl.enabled,
@@ -560,7 +589,7 @@ async fn search_parameters(
     };
     let snapshot = state.sp_catalog.snapshot(query.fhir_version()).await;
     render(SearchParametersPage {
-        status: current_status(state.version),
+        status: current_status(state.version, state.fhir_version),
         i18n: I18n::new(locale),
         active_page: "search-parameters",
         nl_enabled: state.nl.enabled,
@@ -598,7 +627,7 @@ async fn compartments_page(
     let defs = state.compartments.definitions(query.fhir_version()).await;
     match compartments::build_view(&query, &defs) {
         Some(view) => render(CompartmentsPage {
-            status: current_status(state.version),
+            status: current_status(state.version, state.fhir_version),
             i18n: I18n::new(locale),
             active_page: "compartments",
             nl_enabled: state.nl.enabled,
@@ -615,7 +644,7 @@ async fn status(
     locale: RequestLocale,
     HxRequest(is_htmx): HxRequest,
 ) -> Response {
-    let status = current_status(state.version);
+    let status = current_status(state.version, state.fhir_version);
     let i18n = I18n::new(locale);
     if is_htmx {
         render(StatusPartial { status, i18n })
@@ -627,6 +656,7 @@ async fn status(
                 None,
                 DashboardWindow::default(),
                 state.nl.enabled,
+                state.fhir_version,
             )
             .await,
         )
@@ -636,7 +666,7 @@ async fn status(
 /// History & Versions page shell.
 async fn history_page(State(state): State<WebState>, locale: RequestLocale) -> Response {
     render(HistoryPage {
-        status: current_status(state.version),
+        status: current_status(state.version, state.fhir_version),
         i18n: I18n::new(locale),
         active_page: "history",
         nl_enabled: state.nl.enabled,
@@ -706,8 +736,9 @@ async fn build_index_page(
     selected: Option<String>,
     window: DashboardWindow,
     nl_enabled: bool,
+    fhir_version: helios_fhir::FhirVersion,
 ) -> IndexPage {
-    let status = current_status(version);
+    let status = current_status(version, fhir_version);
     let i18n = I18n::new(locale);
     let snapshot = helios_observability::dashboard::snapshot(window)
         .await
@@ -1028,10 +1059,14 @@ fn bucket_floor_utc(ts: DateTime<Utc>, bucket_seconds: i64) -> DateTime<Utc> {
     DateTime::from_timestamp(floored, 0).unwrap_or(ts)
 }
 
-pub(crate) fn current_status(version: &'static str) -> Status {
+pub(crate) fn current_status(
+    version: &'static str,
+    fhir_version: helios_fhir::FhirVersion,
+) -> Status {
     Status {
         version,
         checked_at: unix_timestamp_seconds(),
+        fhir_version,
     }
 }
 
@@ -1069,6 +1104,7 @@ mod tests {
             status: Status {
                 version,
                 checked_at,
+                fhir_version: helios_fhir::FhirVersion::R4,
             },
             metrics,
             chart,
@@ -1120,6 +1156,7 @@ mod tests {
             status: Status {
                 version: "1.2.3",
                 checked_at: 42,
+                fhir_version: helios_fhir::FhirVersion::R4,
             },
             i18n: i18n("en"),
         }
@@ -1186,6 +1223,7 @@ mod tests {
             status: Status {
                 version: "1.2.3",
                 checked_at: 42,
+                fhir_version: helios_fhir::FhirVersion::R4,
             },
             i18n: i18n("en"),
             active_page: "queries",
@@ -1223,6 +1261,7 @@ mod tests {
             status: Status {
                 version: "1.2.3",
                 checked_at: 42,
+                fhir_version: helios_fhir::FhirVersion::R4,
             },
             i18n: i18n("es"),
             active_page: "queries",

--- a/crates/ui/src/search_params.rs
+++ b/crates/ui/src/search_params.rs
@@ -28,7 +28,7 @@ pub(crate) const PAGE_SIZE: usize = 50;
 /// once per version and cached for the process lifetime.
 pub(crate) struct SpCatalog {
     source: Arc<dyn ConformanceSource>,
-    versions: Mutex<HashMap<FhirVersion, Arc<VersionSnapshot>>>,
+    versions: Mutex<HashMap<(String, FhirVersion), Arc<VersionSnapshot>>>,
 }
 
 pub(crate) struct VersionSnapshot {
@@ -47,24 +47,29 @@ impl SpCatalog {
         }
     }
 
-    /// Returns the snapshot for a version, fetching it on first use.
-    pub async fn snapshot(&self, version: FhirVersion) -> Arc<VersionSnapshot> {
-        if let Some(cached) = self.versions.lock().expect("catalog lock").get(&version) {
+    /// Returns the snapshot for a tenant + version, fetching it on first use.
+    pub async fn snapshot(&self, tenant: &str, version: FhirVersion) -> Arc<VersionSnapshot> {
+        let key = (tenant.to_string(), version);
+        if let Some(cached) = self.versions.lock().expect("catalog lock").get(&key) {
             return cached.clone();
         }
-        let built = Arc::new(fetch_snapshot(&*self.source, version).await);
+        let built = Arc::new(fetch_snapshot(&*self.source, version, tenant).await);
         // Another task may have raced us here; keep whichever landed first.
         self.versions
             .lock()
             .expect("catalog lock")
-            .entry(version)
+            .entry(key)
             .or_insert_with(|| built.clone())
             .clone()
     }
 }
 
-async fn fetch_snapshot(source: &dyn ConformanceSource, version: FhirVersion) -> VersionSnapshot {
-    match source.fetch("SearchParameter", version).await {
+async fn fetch_snapshot(
+    source: &dyn ConformanceSource,
+    version: FhirVersion,
+    tenant: &str,
+) -> VersionSnapshot {
+    match source.fetch("SearchParameter", version, tenant).await {
         Ok(resources) => build_snapshot(version, resources, true),
         Err(_) => build_snapshot(version, Vec::new(), false),
     }

--- a/crates/ui/src/search_params.rs
+++ b/crates/ui/src/search_params.rs
@@ -26,9 +26,12 @@ pub(crate) const PAGE_SIZE: usize = 50;
 /// model, one per enabled FHIR version. The data comes from the server's own
 /// `GET /SearchParameter` endpoint (storage is the source of truth), fetched
 /// once per version and cached for the process lifetime.
+/// Cache key: the tenant the snapshot was fetched for, and the version.
+type TenantVersion = (String, FhirVersion);
+
 pub(crate) struct SpCatalog {
     source: Arc<dyn ConformanceSource>,
-    versions: Mutex<HashMap<(String, FhirVersion), Arc<VersionSnapshot>>>,
+    versions: Mutex<HashMap<TenantVersion, Arc<VersionSnapshot>>>,
 }
 
 pub(crate) struct VersionSnapshot {

--- a/crates/ui/src/tenants.rs
+++ b/crates/ui/src/tenants.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::i18n::{I18n, RequestLocale};
-use crate::{RequestVersion, WebState, current_status, render};
+use crate::{RequestTenant, RequestVersion, WebState, current_status, render};
 
 /// One row of the tenant table (a registry record joined with its live count).
 struct TenantRow {
@@ -212,10 +212,11 @@ pub async fn page(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
+    rt: RequestTenant,
     Query(query): Query<TenantsQuery>,
 ) -> Response {
     let i18n = I18n::new(locale);
-    let status = current_status(state.version, rv.0);
+    let status = current_status(state.version, rv.0, &rt);
 
     let Some(storage) = state.tenants.as_ref() else {
         return render(TenantsPage {

--- a/crates/ui/src/tenants.rs
+++ b/crates/ui/src/tenants.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::i18n::{I18n, RequestLocale};
-use crate::{WebState, current_status, render};
+use crate::{RequestVersion, WebState, current_status, render};
 
 /// One row of the tenant table (a registry record joined with its live count).
 struct TenantRow {
@@ -211,10 +211,11 @@ async fn load_rows(storage: &Arc<dyn ResourceStorage>, q: &str) -> Result<Vec<Te
 pub async fn page(
     State(state): State<WebState>,
     locale: RequestLocale,
+    rv: RequestVersion,
     Query(query): Query<TenantsQuery>,
 ) -> Response {
     let i18n = I18n::new(locale);
-    let status = current_status(state.version, state.fhir_version);
+    let status = current_status(state.version, rv.0);
 
     let Some(storage) = state.tenants.as_ref() else {
         return render(TenantsPage {

--- a/crates/ui/src/tenants.rs
+++ b/crates/ui/src/tenants.rs
@@ -214,7 +214,7 @@ pub async fn page(
     Query(query): Query<TenantsQuery>,
 ) -> Response {
     let i18n = I18n::new(locale);
-    let status = current_status(state.version);
+    let status = current_status(state.version, state.fhir_version);
 
     let Some(storage) = state.tenants.as_ref() else {
         return render(TenantsPage {

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -179,11 +179,14 @@
         <div class="menu__panel">
           <div class="menu__heading">{{ i18n.t("fhir-version-heading") }}</div>
           {% for v in status.enabled_version_labels() %}
-          <a class="menu__option" href="?version={{ v }}"{% if v == status.fhir_version_label() %} aria-current="true"{% endif %}>
-            <span class="avatar">{% include "icons/hierarchy.svg" %}</span>
-            {{ v }}
-            {% if v == status.fhir_version_label() %}<span class="check">{% include "icons/check.svg" %}</span>{% endif %}
-          </a>
+          <form method="post" action="/ui/version">
+            <input type="hidden" name="version" value="{{ v }}">
+            <button type="submit" class="menu__option"{% if v == status.fhir_version_label() %} aria-current="true"{% endif %}>
+              <span class="avatar">{% include "icons/hierarchy.svg" %}</span>
+              {{ v }}
+              {% if v == status.fhir_version_label() %}<span class="check">{% include "icons/check.svg" %}</span>{% endif %}
+            </button>
+          </form>
           {% endfor %}
         </div>
       </details>

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -160,18 +160,33 @@
     </nav>
 
     <!--
-      FHIR version selector — outline-only so it still pops. Static until
-      version switching has a server-side read path.
+      FHIR version selector (#343). A <details> disclosure like the tenant
+      selector, so it works without JavaScript. The label is the server's
+      default version; each option re-loads the current page with `?version=` —
+      the pages with a version dimension (SearchParameters, Compartments)
+      switch, the rest ignore it.
     -->
     <div class="sidebar__foot">
-      <div class="selector selector--outline">
-        <span class="icon">{% include "icons/hierarchy.svg" %}</span>
-        <span class="selector__label">{{ i18n.t_arg("fhir-version", "version", "R4".to_string()) }}</span>
-        <span class="selector__chevrons">
-          <span class="icon icon--flip">{% include "icons/chevron-down.svg" %}</span>
-          <span class="icon">{% include "icons/chevron-down.svg" %}</span>
-        </span>
-      </div>
+      <details class="menu menu--up">
+        <summary class="selector selector--outline">
+          <span class="icon">{% include "icons/hierarchy.svg" %}</span>
+          <span class="selector__label">{{ i18n.t_arg("fhir-version", "version", status.fhir_version_label().to_string()) }}</span>
+          <span class="selector__chevrons">
+            <span class="icon icon--flip">{% include "icons/chevron-down.svg" %}</span>
+            <span class="icon">{% include "icons/chevron-down.svg" %}</span>
+          </span>
+        </summary>
+        <div class="menu__panel">
+          <div class="menu__heading">{{ i18n.t("fhir-version-heading") }}</div>
+          {% for v in status.enabled_version_labels() %}
+          <a class="menu__option" href="?version={{ v }}"{% if v == status.fhir_version_label() %} aria-current="true"{% endif %}>
+            <span class="avatar">{% include "icons/hierarchy.svg" %}</span>
+            {{ v }}
+            {% if v == status.fhir_version_label() %}<span class="check">{% include "icons/check.svg" %}</span>{% endif %}
+          </a>
+          {% endfor %}
+        </div>
+      </details>
     </div>
   </aside>
 

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}{{ i18n.t("app-title") }}{% endblock %}</title>
   <link rel="stylesheet" href="/ui/assets/app.css">
+  <!-- The effective tenant for browser-issued FHIR calls (#344). -->
+  <meta name="hfs-tenant" content="{{ status.tenant_id() }}">
   <!-- No `defer`: these attributes must land on <html> before first paint,
        or the stored theme / collapsed-nav flashes its default first. -->
   <script src="/ui/assets/theme.js"></script>
@@ -39,38 +41,29 @@
     </div>
 
     <!--
-      Tenant selector. A <details> disclosure so the dropdown works without
-      JavaScript. The tenant list is sample data until the handler grows a
-      read path into helios-persistence (README: "Left for follow-up work").
+      Tenant selector (#344). A <details> disclosure — works without
+      JavaScript. The label is the effective tenant (the user's stored choice,
+      validated against the registry, else the server default). The options are
+      lazily fetched from the registry by htmx when the menu first opens; with
+      JavaScript disabled the panel offers the tenant-maintenance page instead.
     -->
     <details class="menu">
       <summary class="selector">
-        <span class="avatar">AH</span>
-        <span class="selector__label">Acme Health</span>
+        <span class="avatar">{{ status.tenant_initials() }}</span>
+        <span class="selector__label">{{ status.tenant_label() }}</span>
         <span class="selector__chevrons">
           <span class="icon icon--flip">{% include "icons/chevron-down.svg" %}</span>
           <span class="icon">{% include "icons/chevron-down.svg" %}</span>
         </span>
       </summary>
       <div class="menu__panel">
-        <label class="menu__search">
-          {% include "icons/search.svg" %}
-          <input type="search" placeholder="{{ i18n.t("tenant-search-placeholder") }}">
-        </label>
         <div class="menu__heading">{{ i18n.t("tenant-heading") }}</div>
-        <a class="menu__option" href="#">
-          <span class="avatar">{% include "icons/building.svg" %}</span>
-          {{ i18n.t("tenant-all") }}
-        </a>
-        <a class="menu__option" href="#" aria-current="true">
-          <span class="avatar">AH</span>
-          Acme Health
-          <span class="check">{% include "icons/check.svg" %}</span>
-        </a>
-        <a class="menu__option" href="#">
-          <span class="avatar">MM</span>
-          Mercy Medical
-        </a>
+        <div hx-get="/ui/tenant/options" hx-trigger="toggle once from:closest details" hx-swap="outerHTML">
+          <a class="menu__option" href="/ui/tenants">
+            <span class="avatar">{% include "icons/building.svg" %}</span>
+            {{ i18n.t("nav-tenants") }}
+          </a>
+        </div>
       </div>
     </details>
 

--- a/crates/ui/templates/partials/tenant-options.html
+++ b/crates/ui/templates/partials/tenant-options.html
@@ -1,0 +1,13 @@
+{# The tenant selector's option list (#344), swapped into the menu panel when
+   it first opens. One POST form per provisioned tenant, mirroring the FHIR
+   version selector; the effective tenant is marked current. #}
+{% for o in options %}
+<form method="post" action="/ui/tenant">
+  <input type="hidden" name="tenant" value="{{ o.id }}">
+  <button type="submit" class="menu__option"{% if o.current %} aria-current="true"{% endif %}>
+    <span class="avatar">{{ o.initials }}</span>
+    {{ o.label }}
+    {% if o.current %}<span class="check">{% include "icons/check.svg" %}</span>{% endif %}
+  </button>
+</form>
+{% endfor %}

--- a/crates/ui/tests/i18n_http.rs
+++ b/crates/ui/tests/i18n_http.rs
@@ -22,6 +22,7 @@ fn app() -> Router {
         },
         None,
         None,
+        "default".to_string(),
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
     )

--- a/crates/ui/tests/i18n_http.rs
+++ b/crates/ui/tests/i18n_http.rs
@@ -21,6 +21,7 @@ fn app() -> Router {
             model: "test-model".to_string(),
         },
         None,
+        None,
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
     )

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -35,6 +35,7 @@ fn app_with(nl: helios_ui::NlSearch) -> Router {
         nl,
         None,
         None,
+        "default".to_string(),
         std::sync::Arc::new(helios_ui::StaticConformanceSource::from_data_dir(
             std::path::Path::new("../../data"),
         )),
@@ -148,6 +149,7 @@ async fn non_ui_paths_fall_through_to_the_fhir_app() {
         nl(true, true),
         None,
         None,
+        "default".to_string(),
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
     )

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -434,3 +434,19 @@ async fn unparseable_versions_report_an_error_not_an_empty_diff() {
     let html = diff("from=%7Bnope&to=%7B%7D").await;
     assert!(html.contains("history__banner--error"));
 }
+
+#[tokio::test]
+async fn version_selector_lists_the_enabled_versions() {
+    let response = app()
+        .oneshot(Request::get("/ui").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+
+    // A real disclosure, not the old static chip: the compiled-in versions as
+    // plain links carrying `?version=`, with the server default marked current.
+    assert!(html.contains(r#"href="?version=R4""#));
+    assert!(html.contains(r#"aria-current="true""#));
+    // The default label is server-derived, not hardcoded markup.
+    assert!(html.contains("FHIR R4"));
+}

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -34,6 +34,7 @@ fn app_with(nl: helios_ui::NlSearch) -> Router {
         Some(std::path::PathBuf::from("../../data")),
         nl,
         None,
+        None,
         std::sync::Arc::new(helios_ui::StaticConformanceSource::from_data_dir(
             std::path::Path::new("../../data"),
         )),
@@ -145,6 +146,7 @@ async fn non_ui_paths_fall_through_to_the_fhir_app() {
         "9.9.9",
         Some(std::path::PathBuf::from("../../data")),
         nl(true, true),
+        None,
         None,
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
@@ -443,9 +445,10 @@ async fn version_selector_lists_the_enabled_versions() {
         .unwrap();
     let html = body_text(response).await;
 
-    // A real disclosure, not the old static chip: the compiled-in versions as
-    // plain links carrying `?version=`, with the server default marked current.
-    assert!(html.contains(r#"href="?version=R4""#));
+    // A real disclosure, not the old static chip: one POST form per compiled-in
+    // version, with the effective version marked current.
+    assert!(html.contains(r#"action="/ui/version""#));
+    assert!(html.contains(r#"name="version" value="R4""#));
     assert!(html.contains(r#"aria-current="true""#));
     // The default label is server-derived, not hardcoded markup.
     assert!(html.contains("FHIR R4"));

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -33,6 +33,7 @@ fn app(store: &Arc<dyn ResourceStorage>) -> Router {
         None,
         helios_ui::NlSearch::default(),
         Some(Arc::clone(store)),
+        None,
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
     )
@@ -169,6 +170,7 @@ async fn page_reports_registry_unavailable_without_a_store() {
         None,
         helios_ui::NlSearch::default(),
         None,
+        None,
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
     )
@@ -199,4 +201,61 @@ async fn embedded_assets_carry_no_cache_so_rebuilt_css_is_never_stale() {
         .to_str()
         .unwrap();
     assert!(cc.contains("no-cache"), "got {cc}");
+}
+
+#[tokio::test]
+async fn version_choice_persists_to_user_settings_and_redirects_back() {
+    use helios_persistence::core::SettingsStore;
+
+    let backend = Arc::new({
+        let b = SqliteBackend::in_memory().expect("in-memory sqlite");
+        b.init_schema().expect("init schema");
+        b
+    });
+    let app = helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        None,
+        helios_ui::NlSearch::default(),
+        None,
+        Some(backend.clone() as Arc<dyn SettingsStore>),
+        Arc::new(helios_ui::StaticConformanceSource::empty()),
+        FhirVersion::R4,
+    );
+
+    // Selecting a version persists it and bounces back to the referring page.
+    let res = app
+        .clone()
+        .oneshot(
+            Request::post("/ui/version")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(header::REFERER, "http://localhost/ui/search-parameters")
+                .body(Body::from("version=R4"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        res.headers().get(header::LOCATION).unwrap(),
+        "/ui/search-parameters"
+    );
+    let stored = backend
+        .get_settings("local|default")
+        .await
+        .expect("settings read")
+        .expect("document stored");
+    assert_eq!(stored.document["fhirVersion"], "R4");
+
+    // A version this build does not carry is rejected, not stored.
+    let res = app
+        .oneshot(
+            Request::post("/ui/version")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("version=R9"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -34,6 +34,7 @@ fn app(store: &Arc<dyn ResourceStorage>) -> Router {
         helios_ui::NlSearch::default(),
         Some(Arc::clone(store)),
         None,
+        "default".to_string(),
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
     )
@@ -171,6 +172,7 @@ async fn page_reports_registry_unavailable_without_a_store() {
         helios_ui::NlSearch::default(),
         None,
         None,
+        "default".to_string(),
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
     )
@@ -219,6 +221,7 @@ async fn version_choice_persists_to_user_settings_and_redirects_back() {
         helios_ui::NlSearch::default(),
         None,
         Some(backend.clone() as Arc<dyn SettingsStore>),
+        "default".to_string(),
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
     );
@@ -253,6 +256,98 @@ async fn version_choice_persists_to_user_settings_and_redirects_back() {
             Request::post("/ui/version")
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .body(Body::from("version=R9"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn tenant_choice_persists_and_the_selector_follows_it() {
+    use helios_persistence::core::SettingsStore;
+
+    let backend = Arc::new({
+        let b = SqliteBackend::in_memory().expect("in-memory sqlite");
+        b.init_schema().expect("init schema");
+        b
+    });
+    backend
+        .register_tenant("acme", Some("Acme Health"))
+        .await
+        .expect("register tenant");
+    let app = || {
+        helios_ui::mount_with_conformance_source(
+            Router::new(),
+            "9.9.9",
+            None,
+            helios_ui::NlSearch::default(),
+            Some(backend.clone() as Arc<dyn ResourceStorage>),
+            Some(backend.clone() as Arc<dyn SettingsStore>),
+            "default".to_string(),
+            Arc::new(helios_ui::StaticConformanceSource::empty()),
+            FhirVersion::R4,
+        )
+    };
+
+    // The options fragment lists the registered tenant, with the effective
+    // (default) tenant present and marked current.
+    let res = app()
+        .oneshot(
+            Request::get("/ui/tenant/options")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let html = body_text(res).await;
+    assert!(html.contains(r#"name="tenant" value="acme""#));
+    assert!(html.contains("Acme Health"));
+    assert!(html.contains(r#"aria-current="true""#));
+    assert!(!html.contains("<html"), "fragment, not a page");
+
+    // Choosing a provisioned tenant persists it and bounces back.
+    let res = app()
+        .oneshot(
+            Request::post("/ui/tenant")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(header::REFERER, "http://localhost/ui/queries")
+                .body(Body::from("tenant=acme"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER);
+    assert_eq!(res.headers().get(header::LOCATION).unwrap(), "/ui/queries");
+    let stored = backend
+        .get_settings("local|default")
+        .await
+        .expect("settings read")
+        .expect("document stored");
+    assert_eq!(stored.document["tenantId"], "acme");
+
+    // The stored choice now drives the selector label on every page.
+    let res = app()
+        .oneshot(Request::get("/ui").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let html = body_text(res).await;
+    assert!(
+        html.contains("Acme Health"),
+        "label follows the stored tenant"
+    );
+    assert!(
+        html.contains(r#"content="acme""#),
+        "meta tag carries the id"
+    );
+
+    // An unprovisioned tenant is rejected, not stored.
+    let res = app()
+        .oneshot(
+            Request::post("/ui/tenant")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("tenant=made-up"))
                 .unwrap(),
         )
         .await

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -241,7 +241,7 @@ async fn version_choice_persists_to_user_settings_and_redirects_back() {
         "/ui/search-parameters"
     );
     let stored = backend
-        .get_settings("local|default")
+        .get_settings("l2:")
         .await
         .expect("settings read")
         .expect("document stored");

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -127,6 +127,7 @@ theme-light = Helles Design
 theme-dark = Dunkles Design
 
 fhir-version = FHIR { $version }
+fhir-version-heading = FHIR-Version
 
 card-resource-types = Ressourcentypen
 card-resource-types-sub = aktiviert für { $version }

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -131,6 +131,7 @@ theme-light = Light theme
 theme-dark = Dark theme
 
 fhir-version = FHIR { $version }
+fhir-version-heading = FHIR version
 
 card-resource-types = Resource types
 card-resource-types-sub = enabled for { $version }

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -127,6 +127,7 @@ theme-light = Tema claro
 theme-dark = Tema oscuro
 
 fhir-version = FHIR { $version }
+fhir-version-heading = Versión FHIR
 
 card-resource-types = Tipos de recursos
 card-resource-types-sub = habilitados para { $version }


### PR DESCRIPTION
Implements #344 per the design settled in the issue (choice in user settings; no claim gating; dashboard keeps it simple and shows the selected tenant; list from the registry — reusing the per-tenant read paths from the console-metrics work).

- **The choice roams**: selecting a tenant POSTs to `/ui/tenant`, which merge-patches `{ "tenantId": … }` into the `/_user/settings` document (next to `fhirVersion` and the theme) and bounces back. Only **provisioned** tenants are accepted; a stored tenant that has since been deregistered falls back to the server default — the provisioned-only model from #252 holds.
- **One resolve per request**: the `resolve_prefs` middleware reads settings once and stamps both the effective version and tenant. The selector label (registry display name + initials), the dashboard, the conformance viewers, and the queries/search pages all render under the effective tenant.
- **Dashboard follows the selection**: `DashboardProvider::snapshot` now takes the tenant per call and the snapshot cache keys by `(window, tenant)`.
- **Propagation**: the UI's conformance self-fetch sends `X-Tenant-ID`, the SearchParameter/Compartment catalogs cache per `(tenant, version)`, and browser-issued FHIR calls read the tenant from a server-stamped meta tag (`saved-queries.js`). Remaining browser call sites can pick the same helper up incrementally, per the "wire now, polish later" call.
- **Options load lazily**: the menu fetches `/ui/tenant/options` from the registry when first opened (htmx), so pages don't pay a registry listing per load; without JavaScript the panel links to the tenant-maintenance page.

Tests: full round-trip against a real SQLite registry + settings store — options fragment with current mark, persist + 303 to referrer, the label following the stored choice on subsequent loads, the meta tag carrying the id, and unprovisioned tenants rejected with 400.

Built on #346 (its commits appear here until it merges) and includes #329's dashboard-cache commits for the same reason; both diffs disappear as those land.

Closes #344.