### PR TITLE
fix(hts): evict terminology caches on every CRUD write (#304)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         timeout-minutes: 15
         env:
           RUN_MINIO_S3_TESTS: "1"
-          EXPECTED_MINIO_SETTINGS_TESTS: "4"
+          EXPECTED_MINIO_SETTINGS_TESTS: "5"
           # The single self-hosted Windows runner is a virtualized guest whose
           # CPU does not advertise SSE4.1 + PCLMULQDQ. The AWS S3 SDK's default
           # integrity protection computes a CRC32 on every upload via the

--- a/crates/hts/src/backends/postgres/mod.rs
+++ b/crates/hts/src/backends/postgres/mod.rs
@@ -19,7 +19,7 @@ use tracing::info;
 use crate::error::HtsError;
 use crate::import::bundle_parser::{self, ParsedCodeSystem, ParsedConceptMap, ParsedValueSet};
 use crate::import::{BundleImportBackend, ImportStats};
-use crate::traits::TerminologyMetadata;
+use crate::traits::{TerminologyCaches, TerminologyMetadata};
 use crate::types::{ExpansionContains, LookupResponse, SubsumesResponse, TranslateResponse};
 use helios_persistence::tenant::TenantContext;
 
@@ -165,37 +165,6 @@ impl PostgresTerminologyBackend {
         })
     }
 
-    /// Drop every per-instance response cache. Invoked after a successful
-    /// `import_bundle` so stale `$lookup` / `resolve_code_system` results
-    /// don't shadow newly-imported codes. Mirrors SQLite's eviction at
-    /// backends/sqlite/mod.rs (`clear_response_caches` flow).
-    pub(super) fn clear_response_caches(&self) {
-        if let Ok(mut g) = self.lookup_response_cache.write() {
-            g.clear();
-        }
-        if let Ok(mut g) = self.cs_resolved_meta_cache.write() {
-            g.clear();
-        }
-        if let Ok(mut g) = self.inline_compose_cache.write() {
-            g.clear();
-        }
-        if let Ok(mut g) = self.subsumes_response_cache.write() {
-            g.clear();
-        }
-        if let Ok(mut g) = self.translate_response_cache.write() {
-            g.clear();
-        }
-        // Iter 7k+: process-global closure COUNT(*) memo (see
-        // backends/postgres/value_set.rs::CLOSURE_COUNT_CACHE).
-        if let Ok(mut g) = self::value_set::closure_count_cache().write() {
-            g.clear();
-        }
-        // Iter 7n: process-global `?fhir_vs=isa/X` per-root prefix cache.
-        if let Ok(mut g) = self::value_set::root_prefix_cache().write() {
-            g.clear();
-        }
-    }
-
     /// Borrow the underlying `deadpool-postgres` connection pool.
     pub fn pool(&self) -> &Pool {
         &self.pool
@@ -219,6 +188,59 @@ impl PostgresTerminologyBackend {
                 HtsError::StorageError(format!("concept_closure migration: {}", error_chain(&e)))
             })?;
         Ok(())
+    }
+}
+
+impl TerminologyCaches for PostgresTerminologyBackend {
+    /// Drop every per-instance response cache plus the two process-global
+    /// closure memos, so stale `$lookup` / `$translate` / `resolve_code_system`
+    /// answers cannot shadow content that has just changed.
+    ///
+    /// Invoked after a successful `import_bundle` / `import_parsed`, from
+    /// `delete_normalized`, and — since issue #304 — from the generic CRUD
+    /// write seam. The CRUD create/update path reaches this twice (once through
+    /// the importer, once through the seam); the method is idempotent, and a
+    /// second clear of already-empty maps is not worth branching to avoid.
+    ///
+    /// # Totality is enforced by the compiler
+    ///
+    /// The destructuring below names every field with no `..` rest pattern, so
+    /// adding a sixth cache to [`PostgresTerminologyBackend`] fails to compile
+    /// (E0027) until the author names it here. This mirrors the SQLite backend,
+    /// where the same shape closes a real six-of-sixteen eviction gap.
+    fn invalidate_caches(&self) {
+        // Exhaustive by construction: no `..`. See the doc comment above.
+        let Self {
+            // Not a cache: the connection pool itself.
+            pool: _,
+            inline_compose_cache,
+            lookup_response_cache,
+            cs_resolved_meta_cache,
+            subsumes_response_cache,
+            translate_response_cache,
+        } = self;
+
+        // Clear one `RwLock`-guarded map, ignoring a poisoned lock: a poisoned
+        // cache is already unusable, and failing a write because some unrelated
+        // reader panicked would be worse than leaving it be.
+        macro_rules! clear {
+            ($($cache:expr),* $(,)?) => {
+                $(if let Ok(mut guard) = $cache.write() { guard.clear(); })*
+            };
+        }
+
+        clear!(
+            inline_compose_cache,
+            lookup_response_cache,
+            cs_resolved_meta_cache,
+            subsumes_response_cache,
+            translate_response_cache,
+            // Iter 7k+: process-global closure COUNT(*) memo (see
+            // backends/postgres/value_set.rs::CLOSURE_COUNT_CACHE).
+            self::value_set::closure_count_cache(),
+            // Iter 7n: process-global `?fhir_vs=isa/X` per-root prefix cache.
+            self::value_set::root_prefix_cache(),
+        );
     }
 }
 
@@ -470,7 +492,7 @@ impl BundleImportBackend for PostgresTerminologyBackend {
 
         // Invalidate per-instance response caches — they may now shadow
         // newly-imported codes.
-        self.clear_response_caches();
+        self.invalidate_caches();
 
         Ok(stats)
     }
@@ -556,7 +578,7 @@ impl BundleImportBackend for PostgresTerminologyBackend {
 
         // Invalidate per-instance response caches — they may reference the
         // now-deleted resource.
-        self.clear_response_caches();
+        self.invalidate_caches();
 
         Ok(())
     }

--- a/crates/hts/src/backends/sqlite/mod.rs
+++ b/crates/hts/src/backends/sqlite/mod.rs
@@ -30,7 +30,7 @@ use tracing::info;
 
 use crate::error::HtsError;
 use crate::import::{BundleImportBackend, ImportStats};
-use crate::traits::TerminologyMetadata;
+use crate::traits::{TerminologyCaches, TerminologyMetadata};
 use crate::types::{LookupResponse, ValidateCodeResponse};
 use helios_persistence::tenant::TenantContext;
 
@@ -215,9 +215,16 @@ pub struct SqliteTerminologyBackend {
     /// pipeline (resolve VS, expand, search expansion, version-mismatch checks,
     /// finish_validate_code_response) is pure-functional in the request → so a
     /// per-instance memo skips spawn_blocking, pool acquisition, and the
-    /// resolve+expand SQL roundtrips. Cleared when a new backend instance is
-    /// created — no explicit invalidation required because hot-path bench loops
-    /// reuse one backend, and tests instantiate fresh ones per case.
+    /// resolve+expand SQL roundtrips. Invalidated by
+    /// [`TerminologyCaches::invalidate_caches`] on bundle import and on every
+    /// CRUD write.
+    ///
+    /// It previously carried the justification "no explicit invalidation
+    /// required because hot-path bench loops reuse one backend, and tests
+    /// instantiate fresh ones per case". That reasoning holds for the benchmark
+    /// and for tests, and fails for a server: a `PUT` that adds or retires a
+    /// code left this memo answering `$validate-code` from the superseded
+    /// content indefinitely (issue #304).
     pub(crate) validate_code_response_cache: Arc<RwLock<ValidateCodeResponseMap>>,
     /// CodeSystem URL → highest stored version, used by `$validate-code` for
     /// `x-unknown-system` detection (`build_validate_response_async`). Same
@@ -688,32 +695,89 @@ fn code_system_version_matches(actual: &str, pattern_segments: &[&str]) -> bool 
 
 // ── BundleImportBackend ────────────────────────────────────────────────────────
 
-impl SqliteTerminologyBackend {
-    /// Evict all in-memory indexes so the next expand re-reads fresh data.
+impl TerminologyCaches for SqliteTerminologyBackend {
+    /// Evict every in-memory index and response memo so the next read re-derives
+    /// from SQLite.
     ///
-    /// Per-instance CS metadata caches: highest stored version and existence
-    /// flags both flip when a new CS row is imported.  Flushed alongside the
-    /// global `cs_language_cache` invalidation that the sync writer already
-    /// triggers.
-    fn evict_import_caches(&self) {
-        if let Ok(mut guard) = self.implicit_index.write() {
-            guard.clear();
+    /// Called after a bundle import *and* after every CRUD write (issue #304).
+    /// Previously this cleared only the four concept indexes plus two CS
+    /// metadata caches, on the argument that the response memos needed no
+    /// invalidation because "hot-path bench loops reuse one backend, and tests
+    /// instantiate fresh ones per case". That is true of the benchmark and
+    /// false of a server: a `PUT /CodeSystem/{id}` that changes a display, or
+    /// adds a code, left `lookup_response_cache` and
+    /// `validate_code_response_cache` answering from the superseded content
+    /// indefinitely.
+    ///
+    /// # Totality is enforced by the compiler
+    ///
+    /// The destructuring below names every field with no `..` rest pattern, so
+    /// adding a seventeenth cache to [`SqliteTerminologyBackend`] fails to
+    /// compile (E0027) until the author names it here and decides whether it
+    /// needs clearing. The previous drift — six of sixteen caches cleared, the
+    /// gap invisible — is not reachable from this shape.
+    fn invalidate_caches(&self) {
+        // Exhaustive by construction: no `..`. See the doc comment above.
+        let Self {
+            // Not a cache: the connection pool itself.
+            pool: _,
+            // Not a cache: a dedup guard for in-flight background index builds.
+            // Clearing it would permit duplicate populate threads, not fresher
+            // data — the threads it guards write to caches that this method is
+            // about to empty anyway.
+            bg_index_pending: _,
+            implicit_index,
+            inline_compose_index,
+            property_result_cache,
+            plain_fts_cache,
+            cs_abstract_prop_cache,
+            cs_inactive_prop_cache,
+            cs_concept_abstract_cache,
+            cs_concept_inactive_cache,
+            cs_version_for_msg_cache,
+            cs_content_cache,
+            vs_version_for_msg_cache,
+            cs_resolved_meta_cache,
+            lookup_response_cache,
+            validate_code_response_cache,
+            cs_version_for_url_cache,
+            cs_exists_cache,
+        } = self;
+
+        // Clear one `RwLock`-guarded map, ignoring a poisoned lock: a poisoned
+        // cache is already unusable, and failing a write because some unrelated
+        // reader panicked would be worse than leaving it be.
+        macro_rules! clear {
+            ($($cache:expr),* $(,)?) => {
+                $(if let Ok(mut guard) = $cache.write() { guard.clear(); })*
+            };
         }
-        if let Ok(mut guard) = self.inline_compose_index.write() {
-            guard.clear();
-        }
-        if let Ok(mut guard) = self.property_result_cache.write() {
-            guard.clear();
-        }
-        if let Ok(mut guard) = self.plain_fts_cache.write() {
-            guard.clear();
-        }
-        if let Ok(mut guard) = self.cs_version_for_url_cache.write() {
-            guard.clear();
-        }
-        if let Ok(mut guard) = self.cs_exists_cache.write() {
-            guard.clear();
-        }
+
+        clear!(
+            implicit_index,
+            inline_compose_index,
+            property_result_cache,
+            plain_fts_cache,
+            cs_abstract_prop_cache,
+            cs_inactive_prop_cache,
+            cs_concept_abstract_cache,
+            cs_concept_inactive_cache,
+            cs_version_for_msg_cache,
+            cs_content_cache,
+            vs_version_for_msg_cache,
+            cs_resolved_meta_cache,
+            lookup_response_cache,
+            validate_code_response_cache,
+            cs_version_for_url_cache,
+            cs_exists_cache,
+        );
+
+        // Process-global caches shared by every backend instance in this
+        // process. `import_code_system` / `delete_code_system` already drop
+        // these on the paths they cover; doing it here too makes the hook total
+        // regardless of which resource type was written, and both are cheap.
+        invalidate_cs_id_cache();
+        invalidate_cs_language_cache();
     }
 }
 
@@ -740,7 +804,7 @@ impl BundleImportBackend for SqliteTerminologyBackend {
         .map_err(|e| HtsError::Internal(format!("Blocking task error: {e}")))?;
 
         if result.is_ok() {
-            self.evict_import_caches();
+            self.invalidate_caches();
         }
 
         result
@@ -761,7 +825,7 @@ impl BundleImportBackend for SqliteTerminologyBackend {
         .map_err(|e| HtsError::Internal(format!("Blocking task error: {e}")))?;
 
         if result.is_ok() {
-            self.evict_import_caches();
+            self.invalidate_caches();
         }
 
         result

--- a/crates/hts/src/import/fhir_bundle.rs
+++ b/crates/hts/src/import/fhir_bundle.rs
@@ -564,6 +564,19 @@ fn write_value_set(
         }
     };
 
+    // Drop any materialized expansion derived from the previous content of this
+    // ValueSet. `value_set_expansions` cascades on *row delete*, and the upsert
+    // below deliberately keeps the row, so without this an expansion computed
+    // from the old compose survives a re-import and is served forever. Mirrors
+    // what the PostgreSQL `write_value_set` already does. A no-op on first
+    // import; one indexed delete on re-import, negligible beside the insert work
+    // that follows.
+    conn.execute(
+        "DELETE FROM value_set_expansions WHERE value_set_id = ?1",
+        rusqlite::params![storage_id],
+    )
+    .map_err(|e| HtsError::StorageError(e.to_string()))?;
+
     // Upsert keyed on (url, version): a re-import refreshes the existing row
     // for the same version without disturbing sibling versions. The composite
     // UNIQUE index on (url, COALESCE(version,'')) guarantees one storage row
@@ -807,8 +820,33 @@ pub(crate) fn delete_code_system(conn: &Connection, id: &str) -> Result<(), HtsE
 /// Delete a ValueSet and its materialized expansion cache by FHIR resource `id`.
 #[cfg(feature = "sqlite")]
 pub(crate) fn delete_value_set(conn: &Connection, id: &str) -> Result<(), HtsError> {
+    // Multi-version: match the plain FHIR id *and* every synthetic storage id
+    // derived from it. `write_value_set` mints `<fhir-id>|<version>` via
+    // `storage_id_for`, so matching only `id = ?1` — as this did — silently
+    // no-ops for any ValueSet that carries a `version`. Two consequences, both
+    // reachable from the REST API: `DELETE /ValueSet/{id}` returned 204 while
+    // leaving the ValueSet fully expandable, and `PUT /ValueSet/{id}` skipped
+    // the delete-then-reimport, so the FK cascade never fired and
+    // `value_set_expansions` kept serving the pre-update codes. The existing
+    // round-trip tests missed both because their ValueSet fixtures carry no
+    // `version`.
+    //
+    // The second predicate compares the segment before the first `|` for exact
+    // equality rather than using `LIKE '<id>|%'`, so an id containing a LIKE
+    // wildcard cannot over-match, and no escaping is required. FHIR ids cannot
+    // contain `|`, so the split is unambiguous.
+    //
+    // Deliberately NOT matched: `json_extract(resource_json, '$.id')`, which is
+    // what `delete_code_system` uses. ValueSets legitimately share a FHIR id
+    // across *different* canonical URLs (the tx-ecosystem fixtures do this, and
+    // `write_value_set` mints a UUID storage id for the collision), so matching
+    // on the embedded id would delete unrelated ValueSets. The remaining gap —
+    // a ValueSet stored under such a minted UUID is still not reachable by id —
+    // needs URL-based resolution and is out of scope here.
     conn.execute(
-        "DELETE FROM value_sets WHERE id = ?1",
+        "DELETE FROM value_sets \
+         WHERE id = ?1 \
+            OR (instr(id, '|') > 0 AND substr(id, 1, instr(id, '|') - 1) = ?1)",
         rusqlite::params![id],
     )
     .map_err(|e| HtsError::StorageError(e.to_string()))?;

--- a/crates/hts/src/operations/crud.rs
+++ b/crates/hts/src/operations/crud.rs
@@ -29,7 +29,7 @@ mod inner {
 
     use crate::error::HtsError;
     use crate::state::AppState;
-    use crate::traits::{TerminologyBackend, TerminologyCaches};
+    use crate::traits::TerminologyBackend;
 
     #[cfg(feature = "sqlite")]
     use crate::import::ImportStats;
@@ -82,7 +82,7 @@ mod inner {
     ///   404'd stays absent until something clears it, so without this a
     ///   `POST /ValueSet` creating that exact URL is followed by a 404 for a
     ///   resource that demonstrably exists.
-    /// - [`TerminologyCaches::invalidate_caches`] — the backend's own per-instance
+    /// - [`crate::traits::TerminologyCaches::invalidate_caches`] — the backend's own per-instance
     ///   memos. Clearing only the handler tier is not enough: a `PUT` that changes
     ///   a display forces the handler to recompute, and the recomputation is then
     ///   served from the backend's stale `lookup_response_cache`.

--- a/crates/hts/src/operations/crud.rs
+++ b/crates/hts/src/operations/crud.rs
@@ -29,7 +29,7 @@ mod inner {
 
     use crate::error::HtsError;
     use crate::state::AppState;
-    use crate::traits::TerminologyBackend;
+    use crate::traits::{TerminologyBackend, TerminologyCaches};
 
     #[cfg(feature = "sqlite")]
     use crate::import::ImportStats;
@@ -60,6 +60,46 @@ mod inner {
             e,
             SE::Resource(ResourceError::Gone { .. }) | SE::Resource(ResourceError::NotFound { .. })
         )
+    }
+
+    // ── Cache invalidation seam ───────────────────────────────────────────────
+
+    /// Drop every cached answer derived from terminology content, across both
+    /// cache tiers.
+    ///
+    /// **Call this after every mutation, on every exit path.** It is the single
+    /// seam that keeps CRUD writes honest, and it exists because attaching
+    /// eviction to the write *mechanism* rather than to the write *verb* is what
+    /// produced issue #304: eviction lived inside `BundleImportBackend::
+    /// import_bundle`, the SQLite CRUD path writes through its own pooled
+    /// connection instead, and so no SQLite CRUD verb evicted anything.
+    ///
+    /// Two tiers, both required:
+    ///
+    /// - [`AppState::clear_expand_cache`] — the handler-level response caches
+    ///   (`$expand`, `$lookup`, both `$validate-code` directions) and, critically,
+    ///   the two *negative* caches. A URL recorded as absent by an `$expand` that
+    ///   404'd stays absent until something clears it, so without this a
+    ///   `POST /ValueSet` creating that exact URL is followed by a 404 for a
+    ///   resource that demonstrably exists.
+    /// - [`TerminologyCaches::invalidate_caches`] — the backend's own per-instance
+    ///   memos. Clearing only the handler tier is not enough: a `PUT` that changes
+    ///   a display forces the handler to recompute, and the recomputation is then
+    ///   served from the backend's stale `lookup_response_cache`.
+    ///
+    /// # Ordering
+    ///
+    /// Callers evict *after* the storage write, never before. Evicting first
+    /// leaves a window in which a concurrent reader repopulates from pre-write
+    /// state and that entry never expires. Evicting afterwards still leaves a
+    /// narrow race — a reader that began its query before the write commits may
+    /// insert just after this clear — but that window is bounded by one in-flight
+    /// request rather than unbounded. Closing it entirely needs a generation
+    /// counter compared at insert time across ~30 insertion sites, which is a
+    /// separate change.
+    fn evict_caches_after_write<B: TerminologyBackend>(state: &AppState<B>) {
+        state.clear_expand_cache();
+        state.backend().invalidate_caches();
     }
 
     // ── HTS re-index helper (generic / async path) ────────────────────────────
@@ -94,44 +134,63 @@ mod inner {
         Ok(())
     }
 
-    // ── Generic CRUD helpers ───────────────────────────────────────────────────
-
-    /// POST /<ResourceType> — create a new resource.
+    /// (Re-)index `content` into the HTS normalized tables.
     ///
-    /// 1. Stores raw JSON in `helios-persistence` (auto-generates version / ETag).
-    /// 2. Indexes the stored content into the HTS normalized tables.
-    /// 3. Returns **201 Created** with `Location` and `ETag` headers.
-    async fn create_resource<B: TerminologyBackend>(
+    /// Shared by create and update so both verbs cannot drift apart again.
+    /// `replace_id`, when supplied, names an existing resource whose normalized
+    /// rows are removed first — the update path, where the new content may have
+    /// *dropped* concepts that an upsert alone would leave behind.
+    ///
+    /// Two backend paths, matching how the state was wired:
+    ///
+    /// - SQLite: writes through `hts_pool` on a blocking thread, because
+    ///   `rusqlite` is synchronous.
+    /// - Everything else (PostgreSQL): wraps `content` in a one-entry Bundle and
+    ///   hands it to the async importer.
+    ///
+    /// This function does **not** evict caches — callers do that through
+    /// [`evict_caches_after_write`] on every exit path, including this one
+    /// failing. That split is deliberate: the SQLite update path deletes the old
+    /// normalized rows before re-importing, so a failure part-way through leaves
+    /// storage genuinely changed, and caches must be dropped anyway. The
+    /// invariant is that a cache may be colder than storage, never hotter.
+    // `replace_id` is consumed only by the SQLite delete-then-reimport branch;
+    // a postgres-only build would otherwise trip `unused_variables` under the
+    // workspace's deny-warnings clippy job.
+    #[cfg_attr(not(feature = "sqlite"), allow(unused_variables))]
+    async fn hts_reindex<B: TerminologyBackend>(
+        state: &AppState<B>,
         resource_type: &'static str,
-        state: AppState<B>,
-        body: Value,
-        format: ResponseFormat,
-    ) -> Result<Response, HtsError> {
-        let store = state
-            .active_resource_store()
-            .ok_or_else(|| HtsError::Internal("Resource store not initialized".into()))?;
-
+        content: Value,
+        ctx: &TenantContext,
+        replace_id: Option<String>,
+    ) -> Result<(), HtsError> {
         #[cfg(feature = "sqlite")]
-        let hts_pool = state.hts_pool.clone();
-        let terminology_importer = state.terminology_importer.clone();
-        let ctx = ctx();
-
-        // 1. Persist raw FHIR JSON (version_id = "1", ETag = W/"1").
-        let stored = store
-            .create(&ctx, resource_type, body, FhirVersion::default_enabled())
-            .await
-            .map_err(|e| HtsError::StorageError(e.to_string()))?;
-
-        // 2. Index into HTS normalized tables using the canonical content
-        //    (persistence layer injects the correct `id` into the JSON).
-        let content = stored.content().clone();
-
-        #[cfg(feature = "sqlite")]
-        if let Some(pool) = hts_pool {
-            tokio::task::spawn_blocking(move || {
+        if let Some(pool) = state.hts_pool.clone() {
+            let joined = tokio::task::spawn_blocking(move || {
                 let conn = pool
                     .get()
                     .map_err(|e| HtsError::StorageError(format!("HTS pool error: {e}")))?;
+
+                // Update path: drop the old normalized rows first (ON DELETE
+                // CASCADE propagates to concepts, designations, properties and
+                // hierarchy). For a CodeSystem, also evict the persistent
+                // expansion cache rows derived from it — those are DB state, not
+                // process memory, so no amount of in-process eviction covers them.
+                if let Some(ref resource_id) = replace_id {
+                    match resource_type {
+                        "CodeSystem" => {
+                            if let Some(url) = hts_get_cs_url(&conn, resource_id)? {
+                                hts_invalidate_expansion_cache(&conn, &url)?;
+                            }
+                            hts_delete_cs(&conn, resource_id)?;
+                        }
+                        "ValueSet" => hts_delete_vs(&conn, resource_id)?,
+                        "ConceptMap" => hts_delete_cm(&conn, resource_id)?,
+                        _ => {}
+                    }
+                }
+
                 let mut stats = ImportStats::default();
                 match resource_type {
                     "CodeSystem" => hts_import_cs(&conn, &content, &mut stats),
@@ -143,15 +202,60 @@ mod inner {
                 }
             })
             .await
-            .map_err(|e| HtsError::Internal(e.to_string()))??;
-        } else if let Some(importer) = terminology_importer {
-            hts_reindex_via_importer(&*importer, resource_type, content, &ctx).await?;
+            .map_err(|e| HtsError::Internal(e.to_string()))?;
+            return joined;
         }
 
-        #[cfg(not(feature = "sqlite"))]
-        if let Some(importer) = terminology_importer {
-            hts_reindex_via_importer(&*importer, resource_type, content, &ctx).await?;
+        // PostgreSQL: `import_bundle` upserts by URL, so no explicit delete is
+        // needed for the update path.
+        if let Some(importer) = state.terminology_importer.clone() {
+            return hts_reindex_via_importer(&*importer, resource_type, content, ctx).await;
         }
+
+        Ok(())
+    }
+
+    // ── Generic CRUD helpers ───────────────────────────────────────────────────
+
+    /// POST /<ResourceType> — create a new resource.
+    ///
+    /// 1. Stores raw JSON in `helios-persistence` (auto-generates version / ETag).
+    /// 2. Indexes the stored content into the HTS normalized tables.
+    /// 3. Evicts every cache derived from terminology content.
+    /// 4. Returns **201 Created** with `Location` and `ETag` headers.
+    ///
+    /// Step 3 is not optional: creating a resource has to un-cache the *absence*
+    /// recorded for its URL by any earlier `$expand` / `$lookup` that 404'd, or
+    /// the server keeps denying that a resource it just returned `201` for
+    /// exists (issue #304).
+    async fn create_resource<B: TerminologyBackend>(
+        resource_type: &'static str,
+        state: AppState<B>,
+        body: Value,
+        format: ResponseFormat,
+    ) -> Result<Response, HtsError> {
+        let store = state
+            .active_resource_store()
+            .ok_or_else(|| HtsError::Internal("Resource store not initialized".into()))?;
+
+        let ctx = ctx();
+
+        // 1. Persist raw FHIR JSON (version_id = "1", ETag = W/"1").
+        let stored = store
+            .create(&ctx, resource_type, body, FhirVersion::default_enabled())
+            .await
+            .map_err(|e| HtsError::StorageError(e.to_string()))?;
+
+        // 2. Index into HTS normalized tables using the canonical content
+        //    (persistence layer injects the correct `id` into the JSON).
+        let reindexed =
+            hts_reindex(&state, resource_type, stored.content().clone(), &ctx, None).await;
+
+        // 3. Evict regardless of whether the re-index succeeded: the resource is
+        //    already in the resource store, so any cached "does not exist" answer
+        //    is wrong either way.
+        evict_caches_after_write(&state);
+        reindexed?;
 
         let etag = stored.etag().to_string();
         let location = format!("/{}/{}", resource_type, stored.id());
@@ -210,7 +314,13 @@ mod inner {
     /// On success:
     /// 1. Updates raw JSON in `helios-persistence` (version_id incremented).
     /// 2. Deletes old HTS normalized data and re-imports the new content.
-    /// 3. Returns **200 OK** with the updated `ETag`.
+    /// 3. Evicts every cache derived from terminology content.
+    /// 4. Returns **200 OK** with the updated `ETag`.
+    ///
+    /// Step 3 is not optional: without it a `PUT` is indexed into storage and
+    /// then shadowed by pre-update bytes held in the handler-level `$expand` /
+    /// `$lookup` / `$validate-code` caches and the backend's own response memos
+    /// (issue #304).
     async fn update_resource<B: TerminologyBackend>(
         resource_type: &'static str,
         state: AppState<B>,
@@ -223,9 +333,6 @@ mod inner {
             .active_resource_store()
             .ok_or_else(|| HtsError::Internal("Resource store not initialized".into()))?;
 
-        #[cfg(feature = "sqlite")]
-        let hts_pool = state.hts_pool.clone();
-        let terminology_importer = state.terminology_importer.clone();
         let ctx = ctx();
 
         // 1. Read current version.
@@ -254,50 +361,21 @@ mod inner {
             .await
             .map_err(|e| HtsError::StorageError(e.to_string()))?;
 
-        // 4. Re-index normalized HTS tables.
-        let content = updated.content().clone();
-        let resource_id = updated.id().to_string();
+        // 4. Re-index normalized HTS tables, replacing the previous rows.
+        let reindexed = hts_reindex(
+            &state,
+            resource_type,
+            updated.content().clone(),
+            &ctx,
+            Some(updated.id().to_string()),
+        )
+        .await;
 
-        #[cfg(feature = "sqlite")]
-        if let Some(pool) = hts_pool {
-            tokio::task::spawn_blocking(move || {
-                let conn = pool
-                    .get()
-                    .map_err(|e| HtsError::StorageError(format!("HTS pool error: {e}")))?;
-                // Delete old normalized rows (ON DELETE CASCADE propagates).
-                // Invalidate expansion cache when a CodeSystem changes.
-                match resource_type {
-                    "CodeSystem" => {
-                        if let Some(url) = hts_get_cs_url(&conn, &resource_id)? {
-                            hts_invalidate_expansion_cache(&conn, &url)?;
-                        }
-                        hts_delete_cs(&conn, &resource_id)?;
-                    }
-                    "ValueSet" => hts_delete_vs(&conn, &resource_id)?,
-                    "ConceptMap" => hts_delete_cm(&conn, &resource_id)?,
-                    _ => {}
-                }
-                let mut stats = ImportStats::default();
-                match resource_type {
-                    "CodeSystem" => hts_import_cs(&conn, &content, &mut stats),
-                    "ValueSet" => hts_import_vs(&conn, &content, &mut stats),
-                    "ConceptMap" => hts_import_cm(&conn, &content, &mut stats),
-                    _ => Err(HtsError::InvalidRequest(format!(
-                        "Unsupported resource type for CRUD: {resource_type}"
-                    ))),
-                }
-            })
-            .await
-            .map_err(|e| HtsError::Internal(e.to_string()))??;
-        } else if let Some(importer) = terminology_importer {
-            // Postgres path: import_bundle upserts by URL so no explicit delete needed.
-            hts_reindex_via_importer(&*importer, resource_type, content, &ctx).await?;
-        }
-
-        #[cfg(not(feature = "sqlite"))]
-        if let Some(importer) = terminology_importer {
-            hts_reindex_via_importer(&*importer, resource_type, content, &ctx).await?;
-        }
+        // 5. Evict regardless of the re-index outcome. The SQLite path deletes
+        //    the old normalized rows before re-importing, so a failure in
+        //    between leaves storage changed and every cached answer stale.
+        evict_caches_after_write(&state);
+        reindexed?;
 
         let etag = updated.etag().to_string();
         let mut response = fhir_respond(updated.content().clone(), format);
@@ -347,10 +425,13 @@ mod inner {
             .map_err(|e| HtsError::StorageError(e.to_string()))?;
 
         // 3. Delete from HTS normalized tables.
+        #[allow(unused_mut, unused_assignments)]
+        let mut removed: Result<(), HtsError> = Ok(());
+
         #[cfg(feature = "sqlite")]
         if let Some(pool) = hts_pool {
             let resource_id = id.clone();
-            tokio::task::spawn_blocking(move || {
+            removed = tokio::task::spawn_blocking(move || {
                 let conn = pool
                     .get()
                     .map_err(|e| HtsError::StorageError(format!("HTS pool error: {e}")))?;
@@ -367,24 +448,27 @@ mod inner {
                 }
             })
             .await
-            .map_err(|e| HtsError::Internal(e.to_string()))??;
+            .map_err(|e| HtsError::Internal(e.to_string()))?;
         } else if let (Some(importer), Some(url)) =
             (terminology_importer.as_deref(), resource_url.as_deref())
         {
-            importer.delete_normalized(resource_type, url).await?;
+            removed = importer.delete_normalized(resource_type, url).await;
         }
 
         #[cfg(not(feature = "sqlite"))]
         if let (Some(importer), Some(url)) =
             (terminology_importer.as_deref(), resource_url.as_deref())
         {
-            importer.delete_normalized(resource_type, url).await?;
+            removed = importer.delete_normalized(resource_type, url).await;
         }
 
-        // Evict any cached $expand results so deleted ValueSets (and CodeSystems
-        // whose concepts would otherwise stay in cached expansions) are not served
-        // from the in-memory cache after deletion.
-        state.clear_expand_cache();
+        // Evict both cache tiers so a deleted ValueSet (and any CodeSystem whose
+        // concepts would otherwise linger in a cached expansion or response memo)
+        // stops being served from memory. Runs even when the normalized delete
+        // failed — the resource is already soft-deleted in the resource store, so
+        // holding on to cached answers about it is wrong either way.
+        evict_caches_after_write(&state);
+        removed?;
 
         Ok(StatusCode::NO_CONTENT.into_response())
     }
@@ -565,6 +649,7 @@ mod tests {
         Router,
         body::Body,
         http::{Request, StatusCode, header},
+        response::Response,
         routing::{delete, get, post, put},
     };
     use serde_json::{Value, json};
@@ -700,6 +785,441 @@ mod tests {
             .await
             .unwrap();
         serde_json::from_slice(&bytes).unwrap()
+    }
+
+    // ── Cache-invalidation harness (issue #304) ────────────────────────────────
+    //
+    // These tests need CRUD handlers and *operation* handlers sharing ONE
+    // `AppState`, because the whole defect lives in the caches that state owns.
+    // Building a router per step, or per request, would hand every request a
+    // fresh set of empty caches and the tests would pass on unfixed code.
+
+    /// Router wiring CRUD writes and the `$expand` / `$lookup` reads that read
+    /// through the caches, all over a single shared state.
+    fn ops_router(state: AppState<SqliteTerminologyBackend>) -> Router {
+        use crate::operations::expand::get_expand_handler;
+        use crate::operations::lookup::get_lookup_handler;
+
+        Router::new()
+            // Static operation paths before `/{id}`, mirroring `server.rs`.
+            .route(
+                "/ValueSet/$expand",
+                get(get_expand_handler::<SqliteTerminologyBackend>),
+            )
+            .route(
+                "/CodeSystem/$lookup",
+                get(get_lookup_handler::<SqliteTerminologyBackend>),
+            )
+            .route(
+                "/CodeSystem",
+                post(create_code_system::<SqliteTerminologyBackend>),
+            )
+            .route(
+                "/CodeSystem/{id}",
+                put(update_code_system::<SqliteTerminologyBackend>),
+            )
+            .route(
+                "/ValueSet",
+                post(create_value_set::<SqliteTerminologyBackend>),
+            )
+            .route(
+                "/ValueSet/{id}",
+                put(update_value_set::<SqliteTerminologyBackend>)
+                    .delete(delete_value_set::<SqliteTerminologyBackend>),
+            )
+            .with_state(state)
+    }
+
+    async fn send_json(app: &Router, method: &str, uri: &str, body: Value) -> Response {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn send(app: &Router, method: &str, uri: &str) -> Response {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    /// A CodeSystem with a caller-chosen concept list.
+    fn cs_with(id: &str, concept: Value) -> Value {
+        json!({
+            "resourceType": "CodeSystem",
+            "id": id,
+            "url": format!("http://example.org/cs/{id}"),
+            "version": "1.0",
+            "name": "TestCS",
+            "status": "active",
+            "content": "complete",
+            "concept": concept
+        })
+    }
+
+    /// A ValueSet enumerating `codes` from `system`, optionally versioned.
+    fn vs_including(id: &str, version: Option<&str>, system: &str, codes: &[&str]) -> Value {
+        let concept: Vec<Value> = codes.iter().map(|c| json!({ "code": c })).collect();
+        let mut vs = json!({
+            "resourceType": "ValueSet",
+            "id": id,
+            "url": format!("http://example.org/vs/{id}"),
+            "name": "TestVS",
+            "status": "active",
+            "compose": { "include": [{ "system": system, "concept": concept }] }
+        });
+        if let Some(v) = version {
+            vs["version"] = json!(v);
+        }
+        vs
+    }
+
+    /// Pull a named `valueString` out of a FHIR `Parameters` response.
+    fn param_str(params: &Value, name: &str) -> Option<String> {
+        params["parameter"]
+            .as_array()?
+            .iter()
+            .find(|p| p["name"] == name)
+            .and_then(|p| p["valueString"].as_str())
+            .map(str::to_owned)
+    }
+
+    /// The codes in an `$expand` response, in response order.
+    fn expansion_codes(body: &Value) -> Vec<String> {
+        body["expansion"]["contains"]
+            .as_array()
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|c| c["code"].as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Creating a ValueSet must un-cache the *absence* an earlier `$expand`
+    /// recorded for its URL.
+    ///
+    /// Before the fix `not_found_urls` was cleared only by `POST /import` and
+    /// the CRUD delete path, so the server kept answering 404 for a ValueSet it
+    /// had just returned `201 Created` for — permanently, since nothing expires
+    /// that set.
+    #[tokio::test]
+    async fn create_value_set_evicts_the_expand_negative_cache() {
+        let state = make_state();
+        let app = ops_router(state.clone());
+
+        // A CodeSystem to include, so the post-create expansion is non-empty.
+        assert_eq!(
+            send_json(&app, "POST", "/CodeSystem", cs_body("cs-neg"))
+                .await
+                .status(),
+            StatusCode::CREATED
+        );
+
+        let vs_url = "http://example.org/vs/vs-neg";
+        let expand_uri = format!("/ValueSet/$expand?url={vs_url}");
+
+        // 1. Absent → 404.
+        assert_eq!(
+            send(&app, "GET", &expand_uri).await.status(),
+            StatusCode::NOT_FOUND
+        );
+
+        // The load-bearing precondition: the 404 must actually have poisoned the
+        // negative cache. Without this assert the test would still pass if the
+        // caching path stopped being reached at all, and would then silently
+        // stop testing the defect it exists to catch.
+        let poisoned = { state.not_found_urls.read().unwrap().contains(vs_url) };
+        assert!(
+            poisoned,
+            "precondition: the 404 must record the URL in not_found_urls, \
+             otherwise this test cannot observe the bug"
+        );
+
+        // 2. Create exactly that ValueSet.
+        assert_eq!(
+            send_json(
+                &app,
+                "POST",
+                "/ValueSet",
+                vs_including("vs-neg", None, "http://example.org/cs/cs-neg", &["A"])
+            )
+            .await
+            .status(),
+            StatusCode::CREATED
+        );
+
+        // 3. It must expand now. Before the fix this stayed 404 forever.
+        let resp = send(&app, "GET", &expand_uri).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a just-created ValueSet must not still be reported absent"
+        );
+        assert_eq!(expansion_codes(&json_body(resp).await), vec!["A"]);
+
+        // Negative control: eviction must not amount to disabling 404s.
+        assert_eq!(
+            send(
+                &app,
+                "GET",
+                "/ValueSet/$expand?url=http://example.org/vs/never-created"
+            )
+            .await
+            .status(),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    /// Updating a CodeSystem must un-cache the absence recorded for a code the
+    /// update adds — the `$lookup` twin of the `$expand` negative cache.
+    #[tokio::test]
+    async fn update_code_system_evicts_the_lookup_negative_cache() {
+        let state = make_state();
+        let app = ops_router(state.clone());
+
+        assert_eq!(
+            send_json(
+                &app,
+                "POST",
+                "/CodeSystem",
+                cs_with("cs-lk", json!([{ "code": "A", "display": "Alpha" }]))
+            )
+            .await
+            .status(),
+            StatusCode::CREATED
+        );
+
+        let lookup_uri = "/CodeSystem/$lookup?system=http://example.org/cs/cs-lk&code=B";
+        assert_eq!(
+            send(&app, "GET", lookup_uri).await.status(),
+            StatusCode::NOT_FOUND
+        );
+
+        let poisoned = { !state.lookup_not_found_cache.read().unwrap().is_empty() };
+        assert!(
+            poisoned,
+            "precondition: the 404 must populate lookup_not_found_cache"
+        );
+
+        // Add code B.
+        assert_eq!(
+            send_json(
+                &app,
+                "PUT",
+                "/CodeSystem/cs-lk",
+                cs_with(
+                    "cs-lk",
+                    json!([
+                        { "code": "A", "display": "Alpha" },
+                        { "code": "B", "display": "Bravo" }
+                    ])
+                )
+            )
+            .await
+            .status(),
+            StatusCode::OK
+        );
+
+        assert_eq!(
+            send(&app, "GET", lookup_uri).await.status(),
+            StatusCode::OK,
+            "a code added by PUT must not still be reported unknown"
+        );
+    }
+
+    /// Updating a CodeSystem must also evict the **backend's** per-instance
+    /// response memo, not just the handler-level cache.
+    ///
+    /// This is the SQLite-specific half of #304 and it is deliberately not
+    /// covered by the tests above: `AppState::clear_expand_cache` alone makes
+    /// the handler recompute, and the recomputation is then served straight back
+    /// from `SqliteTerminologyBackend::lookup_response_cache`, whose key
+    /// (`system|code|version|lang|date|props`) is unchanged by a display edit.
+    /// The SQLite CRUD path writes through `hts_pool` and never reaches
+    /// `BundleImportBackend::import_bundle`, so before this fix nothing on any
+    /// CRUD verb cleared that memo. A Tier-1-only fix leaves this test red.
+    #[tokio::test]
+    async fn update_code_system_evicts_the_backend_response_memo() {
+        let state = make_state();
+        let app = ops_router(state.clone());
+
+        assert_eq!(
+            send_json(
+                &app,
+                "POST",
+                "/CodeSystem",
+                cs_with("cs-disp", json!([{ "code": "A", "display": "Alpha" }]))
+            )
+            .await
+            .status(),
+            StatusCode::CREATED
+        );
+
+        // Warm both cache tiers.
+        let warm = json_body(
+            send(
+                &app,
+                "GET",
+                "/CodeSystem/$lookup?system=http://example.org/cs/cs-disp&code=A",
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(param_str(&warm, "display").as_deref(), Some("Alpha"));
+
+        assert_eq!(
+            send_json(
+                &app,
+                "PUT",
+                "/CodeSystem/cs-disp",
+                cs_with("cs-disp", json!([{ "code": "A", "display": "Alpha v2" }]))
+            )
+            .await
+            .status(),
+            StatusCode::OK
+        );
+
+        let after = json_body(
+            send(
+                &app,
+                "GET",
+                "/CodeSystem/$lookup?system=http://example.org/cs/cs-disp&code=A",
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(
+            param_str(&after, "display").as_deref(),
+            Some("Alpha v2"),
+            "$lookup must reflect the updated display, not the backend's memo of the old one"
+        );
+    }
+
+    /// Deleting a *versioned* ValueSet must actually remove it.
+    ///
+    /// `write_value_set` stores versioned ValueSets under the synthetic id
+    /// `<fhir-id>|<version>`, but `delete_value_set` matched `id = ?1` only, so
+    /// the delete silently matched nothing: the handler returned `204` and the
+    /// ValueSet stayed fully expandable. Every pre-existing CRUD test missed
+    /// this because its ValueSet fixtures carry no `version`.
+    #[tokio::test]
+    async fn deleting_a_versioned_value_set_stops_it_expanding() {
+        let state = make_state();
+        let app = ops_router(state.clone());
+
+        assert_eq!(
+            send_json(&app, "POST", "/CodeSystem", cs_body("cs-ver"))
+                .await
+                .status(),
+            StatusCode::CREATED
+        );
+        assert_eq!(
+            send_json(
+                &app,
+                "POST",
+                "/ValueSet",
+                vs_including(
+                    "vs-ver",
+                    Some("1.0.0"),
+                    "http://example.org/cs/cs-ver",
+                    &["A"]
+                )
+            )
+            .await
+            .status(),
+            StatusCode::CREATED
+        );
+
+        let expand_uri = "/ValueSet/$expand?url=http://example.org/vs/vs-ver";
+        assert_eq!(
+            send(&app, "GET", expand_uri).await.status(),
+            StatusCode::OK,
+            "precondition: the versioned ValueSet expands before deletion"
+        );
+
+        assert_eq!(
+            send(&app, "DELETE", "/ValueSet/vs-ver").await.status(),
+            StatusCode::NO_CONTENT
+        );
+
+        assert_eq!(
+            send(&app, "GET", expand_uri).await.status(),
+            StatusCode::NOT_FOUND,
+            "a deleted ValueSet must not keep expanding"
+        );
+    }
+
+    /// Updating a ValueSet must not keep serving the previous expansion.
+    ///
+    /// Two independent defects could produce a stale answer here: the versioned
+    /// storage-id mismatch above (so the delete-then-reimport never deleted),
+    /// and `write_value_set` retaining `value_set_expansions` rows materialized
+    /// from the old compose. Both are fixed; this asserts the observable
+    /// behaviour rather than either mechanism.
+    #[tokio::test]
+    async fn updating_a_value_set_refreshes_its_expansion() {
+        let state = make_state();
+        let app = ops_router(state.clone());
+
+        let system = "http://example.org/cs/cs-upd";
+        assert_eq!(
+            send_json(&app, "POST", "/CodeSystem", cs_body("cs-upd"))
+                .await
+                .status(),
+            StatusCode::CREATED
+        );
+        assert_eq!(
+            send_json(
+                &app,
+                "POST",
+                "/ValueSet",
+                vs_including("vs-upd", Some("1.0.0"), system, &["A"])
+            )
+            .await
+            .status(),
+            StatusCode::CREATED
+        );
+
+        let expand_uri = "/ValueSet/$expand?url=http://example.org/vs/vs-upd";
+        // Materialize the expansion for the original compose.
+        let before = json_body(send(&app, "GET", expand_uri).await).await;
+        assert_eq!(expansion_codes(&before), vec!["A"]);
+
+        // Swap the enumerated concept A → B.
+        assert_eq!(
+            send_json(
+                &app,
+                "PUT",
+                "/ValueSet/vs-upd",
+                vs_including("vs-upd", Some("1.0.0"), system, &["B"])
+            )
+            .await
+            .status(),
+            StatusCode::OK
+        );
+
+        let after = json_body(send(&app, "GET", expand_uri).await).await;
+        assert_eq!(
+            expansion_codes(&after),
+            vec!["B"],
+            "the expansion must follow the updated compose"
+        );
     }
 
     // ── CodeSystem CRUD round-trip ─────────────────────────────────────────────

--- a/crates/hts/src/state.rs
+++ b/crates/hts/src/state.rs
@@ -184,9 +184,9 @@ pub struct AppState<B: TerminologyBackend> {
     /// In-process LRU-style cache for `$expand` responses.
     ///
     /// Eliminates redundant backend work when the same expansion is requested
-    /// repeatedly (e.g. by k6 virtual users running the same script).  The
-    /// cache is never invalidated during normal server operation; after a
-    /// bundle import call [`Self::clear_expand_cache`].
+    /// repeatedly (e.g. by k6 virtual users running the same script).  Evicted
+    /// by [`Self::clear_expand_cache`] after a bundle import and after every
+    /// CRUD write.
     pub expand_cache: ExpandCache,
 
     /// Negative cache for ValueSet URLs that are definitively absent.
@@ -272,11 +272,18 @@ impl<B: TerminologyBackend> AppState<B> {
     }
 
     /// Evict all cached `$expand` results and negative-cache entries, plus the
-    /// per-AppState `$validate-code` handler-response caches (CS and VS).
+    /// per-AppState `$lookup` and `$validate-code` handler-response caches.
     ///
-    /// Call this after a successful bundle import so that expansions and
-    /// validations reflecting the new terminology data are recomputed on the
+    /// Call this after any successful mutation of terminology content — bundle
+    /// import and CRUD create/update/delete alike — so that expansions,
+    /// lookups and validations reflecting the new data are recomputed on the
     /// next request.
+    ///
+    /// This is only the *handler* tier. The backend keeps its own per-instance
+    /// memos, which a handler recomputation would otherwise read straight back;
+    /// CRUD writes therefore go through
+    /// `operations::crud::evict_caches_after_write`, which clears both tiers.
+    /// See [`crate::traits::TerminologyCaches`].
     pub fn clear_expand_cache(&self) {
         if let Ok(mut cache) = self.expand_cache.write() {
             cache.clear();

--- a/crates/hts/src/traits/caches.rs
+++ b/crates/hts/src/traits/caches.rs
@@ -1,0 +1,53 @@
+//! In-process cache invalidation contract for terminology backends.
+//!
+//! Every backend memoises derived answers in process memory — assembled
+//! `$lookup` / `$validate-code` responses, concept indexes, resolved CodeSystem
+//! metadata. Those memos are correct only for as long as the underlying
+//! normalized tables do not change, so any code path that mutates terminology
+//! content has to tell the backend to drop them.
+//!
+//! # Why this is its own trait
+//!
+//! The obvious home for this hook is [`BundleImportBackend`], since that is
+//! where eviction used to live. It is the wrong home: the SQLite CRUD path
+//! deliberately bypasses `import_bundle` and writes through its own pooled
+//! connection, so hanging invalidation off the import trait is exactly how a
+//! whole backend ended up never evicting anything on `POST`/`PUT`/`DELETE`
+//! (issue #304). Invalidation belongs to the *mutation*, not to the mechanism
+//! that happened to perform it, so it gets a trait of its own that
+//! [`TerminologyBackend`] requires unconditionally.
+//!
+//! # Why there is no default implementation
+//!
+//! A defaulted no-op would let a new backend inherit silence: it would compile,
+//! serve stale answers, and nothing would point at the omission. Implementors
+//! must write the method, even if the honest body is empty with a comment
+//! explaining why that backend holds no state.
+//!
+//! [`BundleImportBackend`]: crate::import::BundleImportBackend
+//! [`TerminologyBackend`]: crate::traits::TerminologyBackend
+
+/// Drops every in-process cache a backend maintains.
+pub trait TerminologyCaches: Send + Sync {
+    /// Evict all in-process caches, so the next read re-derives from storage.
+    ///
+    /// Called after any successful mutation of terminology content — CRUD
+    /// create/update/delete and bundle import alike — and required to be
+    /// idempotent, because paths that already evict internally (the PostgreSQL
+    /// importer, for one) are also reached through the generic CRUD seam.
+    ///
+    /// This is deliberately total rather than scoped to the resource that
+    /// changed. An expansion answer is derived from a transitive closure —
+    /// ValueSet includes ValueSet includes CodeSystem, plus supplements and
+    /// hierarchy — and no cache entry records the set of resources it was
+    /// derived from, so there is no key material to invalidate against. The
+    /// implicit-ValueSet case makes the point concretely: creating a
+    /// *CodeSystem* with url `X` has to un-cache a 404 recorded against the
+    /// *ValueSet* url `X?fhir_vs=`, a different string entirely. A URL-matched
+    /// eviction would look precise and still serve the stale 404.
+    ///
+    /// Writes to a terminology server are rare (content publication) relative
+    /// to reads, so paying a cold cache per write is the right trade. See the
+    /// module docs for why this is not a defaulted method.
+    fn invalidate_caches(&self);
+}

--- a/crates/hts/src/traits/mod.rs
+++ b/crates/hts/src/traits/mod.rs
@@ -6,17 +6,20 @@
 //! - [`ValueSetOperations`] — `$expand`, `$validate-code` (value-set form)
 //! - [`ConceptMapOperations`] — `$translate`, `$closure`
 //! - [`TerminologyMetadata`] — introspection helpers used by `/metadata`
+//! - [`TerminologyCaches`] — in-process cache invalidation after a write
 //!
-//! The [`TerminologyBackend`] supertrait aggregates all four with the
+//! The [`TerminologyBackend`] supertrait aggregates all five with the
 //! `Send + Sync + 'static` bounds required for sharing in [`AppState`].
 //!
 //! [`AppState`]: crate::state::AppState
 
+mod caches;
 mod code_system;
 mod concept_map;
 mod metadata;
 mod value_set;
 
+pub use caches::TerminologyCaches;
 pub use code_system::{
     CodeSystemOperations, ConceptDesignation, ConceptExpansionFlags, SupplementInfo,
 };
@@ -33,6 +36,8 @@ pub use value_set::ValueSetOperations;
 /// - Fully operational (`CodeSystemOperations`, `ValueSetOperations`,
 ///   `ConceptMapOperations`)
 /// - Introspectable (`TerminologyMetadata`)
+/// - Able to drop its in-process caches when content changes
+///   ([`TerminologyCaches`])
 /// - Safe to share across async tasks (`Send + Sync + 'static`)
 ///
 /// [`AppState`]: crate::state::AppState
@@ -41,19 +46,26 @@ pub trait TerminologyBackend:
     + ValueSetOperations
     + ConceptMapOperations
     + TerminologyMetadata
+    + TerminologyCaches
     + Send
     + Sync
     + 'static
 {
 }
 
-/// Blanket impl: any type that satisfies all four sub-trait bounds automatically
+/// Blanket impl: any type that satisfies all five sub-trait bounds automatically
 /// implements `TerminologyBackend`.
+///
+/// Because this impl is blanket, a defaulted method added to
+/// `TerminologyBackend` itself could never be overridden per backend — which is
+/// why cache invalidation lives on its own [`TerminologyCaches`] sub-trait
+/// rather than here.
 impl<T> TerminologyBackend for T where
     T: CodeSystemOperations
         + ValueSetOperations
         + ConceptMapOperations
         + TerminologyMetadata
+        + TerminologyCaches
         + Send
         + Sync
         + 'static

--- a/crates/hts/tests/postgres_http_tests.rs
+++ b/crates/hts/tests/postgres_http_tests.rs
@@ -1063,3 +1063,129 @@ async fn reimport_changed_display_refreshes_filtered_expand_pg() {
         "stale display must not match after re-import: {body}"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Cache invalidation on CRUD writes (issue #304)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Creating a ValueSet must un-cache the *absence* recorded for its URL by an
+/// earlier `$expand` that 404'd.
+///
+/// The handler-level negative cache (`AppState::not_found_urls`) is
+/// backend-agnostic, so this defect was identical on PostgreSQL and SQLite:
+/// `clear_expand_cache()` was called only by `POST /import` and the CRUD delete
+/// path, never by create or update. The server therefore kept answering 404 for
+/// a ValueSet it had just returned `201 Created` for, indefinitely — nothing
+/// expires that set.
+///
+/// The SQLite twin of this test lives in `operations/crud.rs`; this one exists
+/// because the eviction seam is generic over the backend and the PostgreSQL CRUD
+/// path reaches it through a different re-index route (the async importer rather
+/// than the `hts_pool` blocking path).
+#[tokio::test(flavor = "multi_thread")]
+async fn create_value_set_evicts_the_expand_negative_cache() {
+    let app = TestAppPg::new().await;
+
+    let cs_url = "http://pg-cache-test.example/cs/neg";
+    let vs_url = "http://pg-cache-test.example/vs/neg";
+
+    let cs = serde_json::json!({
+        "resourceType": "CodeSystem",
+        "url": cs_url,
+        "version": "1.0",
+        "name": "NegCacheCS",
+        "status": "active",
+        "content": "complete",
+        "concept": [{"code": "A", "display": "Alpha"}]
+    })
+    .to_string();
+    let (status, body) = app.post_fhir("/CodeSystem", cs).await;
+    assert_eq!(status, StatusCode::CREATED, "POST CodeSystem: {body}");
+
+    let expand_uri = format!("/ValueSet/$expand?url={vs_url}");
+
+    // 1. Absent → 404, which records the URL as definitively missing.
+    let (status, _) = app.get_fhir(&expand_uri).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "precondition: the ValueSet must not exist yet"
+    );
+
+    // 2. Create exactly that ValueSet.
+    let vs = serde_json::json!({
+        "resourceType": "ValueSet",
+        "url": vs_url,
+        "name": "NegCacheVS",
+        "status": "active",
+        "compose": {"include": [{"system": cs_url, "concept": [{"code": "A"}]}]}
+    })
+    .to_string();
+    let (status, body) = app.post_fhir("/ValueSet", vs).await;
+    assert_eq!(status, StatusCode::CREATED, "POST ValueSet: {body}");
+
+    // 3. It must expand now. Before the fix this stayed 404 forever.
+    let (status, body) = app.get_fhir(&expand_uri).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a just-created ValueSet must not still be reported absent: {body}"
+    );
+    assert_eq!(
+        body["expansion"]["contains"][0]["code"], "A",
+        "expansion should carry the included code: {body}"
+    );
+}
+
+/// Updating a CodeSystem must not leave `$lookup` answering from pre-update
+/// content.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_code_system_refreshes_lookup_display() {
+    let app = TestAppPg::new().await;
+
+    let cs_url = "http://pg-cache-test.example/cs/display";
+    let make_cs = |display: &str| {
+        serde_json::json!({
+            "resourceType": "CodeSystem",
+            "url": cs_url,
+            "version": "1.0",
+            "name": "DisplayCS",
+            "status": "active",
+            "content": "complete",
+            "concept": [{"code": "A", "display": display}]
+        })
+        .to_string()
+    };
+
+    let (status, body) = app.post_fhir("/CodeSystem", make_cs("Alpha")).await;
+    assert_eq!(status, StatusCode::CREATED, "POST: {body}");
+    let id = body["id"].as_str().expect("id field missing").to_owned();
+
+    let lookup_uri = format!("/CodeSystem/$lookup?system={cs_url}&code=A");
+    let display_of = |body: &serde_json::Value| -> Option<String> {
+        body["parameter"]
+            .as_array()?
+            .iter()
+            .find(|p| p["name"] == "display")
+            .and_then(|p| p["valueString"].as_str())
+            .map(str::to_owned)
+    };
+
+    // Warm the caches.
+    let (status, body) = app.get_fhir(&lookup_uri).await;
+    assert_eq!(status, StatusCode::OK, "warm lookup: {body}");
+    assert_eq!(display_of(&body).as_deref(), Some("Alpha"));
+
+    let (status, body) = app
+        .put_fhir(&format!("/CodeSystem/{id}"), make_cs("Alpha v2"), None)
+        .await;
+    assert_eq!(status, StatusCode::OK, "PUT: {body}");
+
+    let (status, body) = app.get_fhir(&lookup_uri).await;
+    assert_eq!(status, StatusCode::OK, "post-update lookup: {body}");
+    assert_eq!(
+        display_of(&body).as_deref(),
+        Some("Alpha v2"),
+        "$lookup must reflect the updated display: {body}"
+    );
+}


### PR DESCRIPTION
Closes #304.

## What was wrong

HTS memoises `$expand` / `$lookup` / `$validate-code` answers in **two tiers**, and the REST CRUD write paths re-indexed into the normalized tables without dropping either. Only `DELETE` evicted, and only the handler tier.

The root cause is that eviction was attached to the write *mechanism* rather than the write *verb*: it lived inside `BundleImportBackend::import_bundle`. The SQLite CRUD path deliberately bypasses that — `crud.rs` branches on `state.hts_pool` first and writes through its own pooled connection — so **no SQLite CRUD verb, including `DELETE`, evicted the backend's caches at all**, while PostgreSQL CRUD was already covered via the importer.

| | Tier 1 (`AppState`) | Tier 2 (backend memos) |
|---|---|---|
| SQLite POST / PUT | ❌ | ❌ |
| SQLite DELETE | ✅ | ❌ |
| PG POST / PUT | ❌ | ✅ (via importer) |
| PG DELETE | ✅ | ✅ |
| `POST /import` (both) | ✅ | ✅ |

The issue describes the handler tier; the backend tier was the larger half, and a fix that only added `clear_expand_cache()` to create/update would have closed #304 falsely.

## Changes

- **`TerminologyCaches`**, a new sub-trait of `TerminologyBackend`, with a **required** (not defaulted) `invalidate_caches`, so a new backend cannot inherit silence. It is a separate trait because `TerminologyBackend` has a blanket impl, where a defaulted method could never be overridden per backend.
- **One `evict_caches_after_write` seam** in `operations/crud.rs`, called by create, update *and* delete — after the storage write, and on failure paths too. The invariant is that a cache may be colder than storage, never hotter; the SQLite update path deletes before re-importing, so a mid-way failure leaves storage genuinely changed.
- Create and update now share a single `hts_reindex` helper, so the two verbs cannot drift apart again.
- **SQLite eviction widened from 6 of 16 caches to all 16**, matching PostgreSQL. The gap included `lookup_response_cache` and `validate_code_response_cache`, whose in-code justification was explicitly benchmark-shaped — *"no explicit invalidation required because hot-path bench loops reuse one backend"*. True of the benchmark, false of a server; the comment is replaced with the real invariant.
- **Drift is now a compile error.** Both backends' eviction methods destructure `Self` exhaustively with no `..`, so adding a cache field fails with E0027 until the author names it and decides whether it needs clearing. That is what makes the 6-of-16 drift unrepeatable — a hand-maintained list is exactly what failed here.

## Two DB-tier defects fixed in the same family

Found while establishing that the regression tests are not vacuous. Both are "stale read after write", the same failure mode as the issue, one tier down:

- `delete_value_set` matched `id = ?1` only, but `write_value_set` stores versioned ValueSets under the synthetic id `<fhir-id>|<version>`. So `DELETE /ValueSet/{id}` **returned 204 while leaving the ValueSet fully expandable**, and `PUT /ValueSet/{id}` skipped the delete-then-reimport so the FK cascade never fired. Every existing ValueSet fixture omits `version`, which is why the round-trip tests passed. The new predicate compares the segment before the first `|` for exact equality rather than `LIKE`, so no wildcard escaping is needed; it deliberately does *not* match `resource_json.id` the way `delete_code_system` does, because ValueSets legitimately share a FHIR id across different canonical URLs.
- SQLite `write_value_set` never purged `value_set_expansions` on re-import, so a materialized expansion computed from the old compose survived. The PostgreSQL writer already did this.

## Tests

Five SQLite tests in `operations/crud.rs` and two PostgreSQL HTTP tests. The negative-cache tests **assert the poisoning precondition explicitly** (`not_found_urls` actually contains the URL after the 404), so they cannot pass by never reaching the cache — and they share one `AppState` across all requests, since a router built per step would hand every request empty caches and pass on unfixed code.

`update_code_system_evicts_the_backend_response_memo` is the one that isolates the SQLite bypass: a handler-tier-only fix leaves it **red**, because the handler recomputes and is then served straight back from the backend's stale `lookup_response_cache`, whose key is unchanged by a display edit.

## Performance

Non-event for the published numbers: the HTS benchmark performs **no writes in its measured window** — terminology is loaded before the server starts via the `hts import` CLI (`hts-benchmark.yml`), and every k6 scenario is `GET`/`POST` of read operations only. The new eviction is unreachable from every measured scenario, so no benchmark run is required to merge. For deployments that *do* write, a blanket clear costs one cold refill per hot key per write; terminology writes are content publication, not request traffic.

Scoped invalidation was considered and rejected for this PR: no cache entry records the resources it was derived from, and the implicit-ValueSet case shows URL matching would be wrong anyway — creating a *CodeSystem* with url `X` must un-cache a 404 recorded against the *ValueSet* url `X?fhir_vs=`.

## Not in scope (filed separately)

- `concept_closure` is dropped but not rebuilt when a hierarchical CodeSystem is re-imported at runtime, on **both** backends — `is-a` expansion and `$subsumes` degrade until restart. Symmetric, so not a parity gap, but higher severity than anything here; it needs a decision about rebuild cost on the import path.
- PG `delete_normalized` is skipped entirely when the stored resource has no `url`.
- Closing the residual eviction race (a reader that began before the write commits can insert just after the clear) needs a generation counter compared at ~30 insertion sites.

## Verification status

Written against source; **not compiled or run locally** — this environment has `cargo` but no C linker, so only `cargo fmt` works. CI is the first real signal.