### PR TITLE
fix(subscriptions): rehydrate the engine from storage at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,6 +3565,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "dashmap",
+ "futures",
  "helios-auth",
  "helios-fhir",
  "helios-persistence",

--- a/README.md
+++ b/README.md
@@ -363,12 +363,14 @@ JWT/bearer auth (`HFS_AUTH_*`, e.g. `HFS_AUTH_ENABLED`, `HFS_AUTH_JWKS_URL`, `HF
 | `HFS_SUBSCRIPTION_MESSAGING_ENABLED` | `false` | Enable the FHIR Messaging subscription channel |
 | `HFS_SUBSCRIPTION_MESSAGE_SOURCE_ENDPOINT` | `HFS_BASE_URL` | Source endpoint URL used in outbound FHIR message headers |
 | `HFS_SUBSCRIPTION_ALLOW_PRIVATE_ENDPOINTS` | `false` | Allow subscription deliveries to private or loopback endpoints; intended for local development and CI only |
+| `HFS_SUBSCRIPTION_REHYDRATE` | `true` | Reload stored `Subscription`/`SubscriptionTopic` resources into the engine at startup, so subscriptions keep delivering across a restart |
+| `HFS_SUBSCRIPTION_REHYDRATE_HANDSHAKE` | `true` | Re-run the activation handshake for stored `requested` subscriptions during rehydration |
 | `HFS_BULK_EXPORT_ENABLED` | `true` | Enable the [Bulk Data Export](crates/rest/README.md#bulk-data-export) `$export` operation; when `false`, all `$export` endpoints return `501` |
 | `HFS_BULK_EXPORT_OUTPUT_BACKEND` | `local-fs` | Bulk export output store: `local-fs` or `s3`. See the [rest crate README](crates/rest/README.md#bulk-data-export) for the full `HFS_BULK_EXPORT_*` table |
 | `HFS_BULK_SUBMIT_ENABLED` | `true` | Enable the Bulk Data Submit `$bulk-submit` operation (HFS as Data Consumer — fetches a provider manifest and ingests it); when `false`, all `$bulk-submit` endpoints return `501`. Available on `sqlite`/`postgres` (+ `-elasticsearch` composites). See the "Bulk Data Submit" section of `CLAUDE.md` for the full `HFS_BULK_SUBMIT_*` table |
 | `HFS_BULK_SUBMIT_OUTPUT_BACKEND` | `local-fs` | Bulk submit status-artifact store: `local-fs` or `s3` |
 
-The SMTP delivery channel (`HFS_SUBSCRIPTION_SMTP_*`) and delivery-retry tuning (`HFS_SUBSCRIPTION_HANDSHAKE_*`) are documented in the [helios-subscriptions README](crates/subscriptions/README.md).
+The SMTP delivery channel (`HFS_SUBSCRIPTION_SMTP_*`), delivery-retry tuning (`HFS_SUBSCRIPTION_HANDSHAKE_*`), and the remaining startup-rehydration knobs (`HFS_SUBSCRIPTION_REHYDRATE_*`) are documented in the [helios-subscriptions README](crates/subscriptions/README.md).
 
 For detailed backend setup instructions (building from source, Docker commands, and search offloading architecture), see the [persistence crate documentation](crates/persistence/README.md#building--running-storage-backends).
 

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -187,6 +187,8 @@ use tower_http::{
     trace::TraceLayer,
 };
 use tracing::info;
+#[cfg(feature = "subscriptions")]
+use tracing::warn;
 
 /// Creates the Axum application with default configuration.
 ///
@@ -806,7 +808,9 @@ where
                 outbound_auth_provider,
             );
             info!("Subscriptions engine ENABLED");
-            state.with_subscription_engine(Arc::new(engine))
+            let engine = Arc::new(engine);
+            spawn_subscription_rehydration(Arc::clone(&engine), Arc::clone(&storage_arc), &config);
+            state.with_subscription_engine(engine)
         } else {
             state
         }
@@ -957,6 +961,97 @@ where
 
     // Apply remaining middleware
     router.layer(service_builder)
+}
+
+/// Spawns the startup rehydration of the subscription engine (issue #305).
+///
+/// The engine's registries are in-memory and were previously populated *only*
+/// by live write handlers, so every restart silently stopped delivery for
+/// already-stored subscriptions. This replays stored `SubscriptionTopic`,
+/// R4-backport `Basic`, and `Subscription` resources back into the engine.
+///
+/// Wired here, in `build_app`, rather than in `crates/hfs/src/main.rs` (as the
+/// issue suggested) because this is the single funnel every backend start path
+/// goes through — SQLite, PostgreSQL, MongoDB, S3, and each Elasticsearch
+/// composite — and it is the only place that holds both the engine and the
+/// storage handle. Wiring it in `main.rs` would need eight call sites and could
+/// not reach the engine, which is constructed and moved into `AppState` here.
+///
+/// It runs in the background rather than blocking startup: registration is
+/// fast, but activating `requested` subscriptions performs handshakes with
+/// retry and backoff against endpoints that may be unreachable, which could
+/// otherwise delay serving by minutes. The trade-off is a brief window after
+/// boot in which a just-restarted server has not yet re-registered every
+/// subscription; the completion summary is logged.
+#[cfg(feature = "subscriptions")]
+fn spawn_subscription_rehydration<S>(
+    engine: Arc<helios_subscriptions::SubscriptionEngine>,
+    storage: Arc<S>,
+    config: &ServerConfig,
+) where
+    S: ResourceStorage + helios_persistence::core::ExportDataProvider + Send + Sync + 'static,
+{
+    let rehydrate_config = build_rehydration_config_from_env();
+    if !rehydrate_config.enabled {
+        info!("Subscription rehydration is DISABLED (HFS_SUBSCRIPTION_REHYDRATE=false)");
+        return;
+    }
+
+    // `build_app` is synchronous and is also called from non-async contexts
+    // (embedders, doc examples). `tokio::spawn` panics outside a runtime, so
+    // degrade to a warning instead of taking the process down.
+    if tokio::runtime::Handle::try_current().is_err() {
+        warn!(
+            "No Tokio runtime available at app construction; skipping subscription \
+             rehydration. Stored subscriptions will not deliver until re-written."
+        );
+        return;
+    }
+
+    let default_tenant = config.default_tenant.clone();
+    let default_version = config.default_fhir_version;
+    tokio::spawn(async move {
+        engine
+            .rehydrate(
+                storage.as_ref(),
+                &default_tenant,
+                default_version,
+                &rehydrate_config,
+            )
+            .await;
+    });
+}
+
+/// Builds the rehydration tuning from `HFS_SUBSCRIPTION_REHYDRATE*`.
+#[cfg(feature = "subscriptions")]
+fn build_rehydration_config_from_env() -> helios_subscriptions::RehydrationConfig {
+    let defaults = helios_subscriptions::RehydrationConfig::default();
+    helios_subscriptions::RehydrationConfig {
+        enabled: subscription_bool_from_env("HFS_SUBSCRIPTION_REHYDRATE", defaults.enabled),
+        batch_size: subscription_u32_from_env(
+            "HFS_SUBSCRIPTION_REHYDRATE_BATCH_SIZE",
+            defaults.batch_size,
+        )
+        .max(1),
+        handshake_requested: subscription_bool_from_env(
+            "HFS_SUBSCRIPTION_REHYDRATE_HANDSHAKE",
+            defaults.handshake_requested,
+        ),
+        max_concurrent_handshakes: subscription_u32_from_env(
+            "HFS_SUBSCRIPTION_REHYDRATE_HANDSHAKE_CONCURRENCY",
+            defaults.max_concurrent_handshakes as u32,
+        )
+        .max(1) as usize,
+    }
+}
+
+/// Parses a boolean env var, treating `false`/`0` (case-insensitive) as false
+/// and any other set value as true. Mirrors `HFS_SUBSCRIPTIONS_ENABLED`.
+#[cfg(feature = "subscriptions")]
+fn subscription_bool_from_env(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .map(|v| !matches!(v.trim().to_ascii_lowercase().as_str(), "false" | "0"))
+        .unwrap_or(default)
 }
 
 #[cfg(feature = "subscriptions")]

--- a/crates/subscriptions/Cargo.toml
+++ b/crates/subscriptions/Cargo.toml
@@ -32,6 +32,8 @@ serde_json.workspace = true
 # Async runtime
 tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
 async-trait = "0.1"
+# `join_all` for the bounded-concurrency handshake pass in `rehydrate`.
+futures = "0.3"
 
 # Time
 chrono.workspace = true
@@ -58,6 +60,9 @@ dashmap = "6"
 tokio = { version = "1", features = ["full", "test-util"] }
 wiremock = "0.6"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# Real SQLite backend for the rehydration integration test (issue #305): the
+# rehydration path is only meaningful against an actual `ExportDataProvider`.
+helios-persistence = { path = "../persistence", version = "0.2.1", default-features = false, features = ["sqlite"] }
 
 # `watchdog` pulls in `signal_hook::iterator`/`SIGQUIT`, which only compile on Unix.
 # Windows test runs don't need SIGTERM cleanup, so drop the feature there.

--- a/crates/subscriptions/README.md
+++ b/crates/subscriptions/README.md
@@ -164,6 +164,21 @@ Comparators supported: `eq` (default), `in`. Native `filterBy.comparator` values
 | `HFS_SUBSCRIPTION_OFF_THRESHOLD` | `10` | Consecutive failures before `off` status |
 | `ws_token_lifetime_secs` *(config field)* | `30` | Binding token expiry in seconds (WebSocket only) |
 
+### Startup rehydration
+
+The engine's registries are in-memory, so without rehydration a restart would leave every previously-stored subscription inert — the resources still read back over the REST API, but nothing matches or delivers. At startup HFS pages stored `SubscriptionTopic`, R4-backport `Basic`, and `Subscription` resources back into the engine, for every provisioned tenant.
+
+This runs in the background: the server begins accepting requests immediately, and subscriptions come back online shortly after. A summary line (`Subscription engine rehydrated`) reports what was restored.
+
+Subscription **status transitions are held in memory only** — a successful handshake is not written back to the stored resource. A subscription created as `requested` therefore still reads `"requested"` from the database after it went active, so rehydration re-runs the activation handshake for `requested` subscriptions by default. Set `HFS_SUBSCRIPTION_REHYDRATE_HANDSHAKE=false` to restore them with no outbound traffic, accepting that they stay inert until re-written. Subscriptions stored as `off` are skipped (the status is terminal); `error` ones are registered but dormant.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HFS_SUBSCRIPTION_REHYDRATE` | `true` | Reload stored subscriptions and topics at startup |
+| `HFS_SUBSCRIPTION_REHYDRATE_BATCH_SIZE` | `500` | Resources fetched per storage round-trip |
+| `HFS_SUBSCRIPTION_REHYDRATE_HANDSHAKE` | `true` | Re-run the activation handshake for stored `requested` subscriptions |
+| `HFS_SUBSCRIPTION_REHYDRATE_HANDSHAKE_CONCURRENCY` | `8` | Max handshakes in flight at once, across all tenants |
+
 ### Email channel (SMTP)
 
 The email channel is enabled only when `HFS_SUBSCRIPTION_SMTP_HOST` and `HFS_SUBSCRIPTION_SMTP_FROM` are both set. With either missing, `email` is omitted from the server's supported channel list and any email `Subscription` is rejected with an `unsupported channel type` OperationOutcome.

--- a/crates/subscriptions/src/engine/mod.rs
+++ b/crates/subscriptions/src/engine/mod.rs
@@ -523,7 +523,11 @@ impl SubscriptionEngine {
     }
 
     /// Activate a subscription by performing the handshake.
-    async fn activate_subscription(&self, subscription: &ActiveSubscription) {
+    ///
+    /// `pub(crate)` so startup rehydration ([`crate::rehydrate`]) drives the
+    /// *same* activation path as the write handler rather than reimplementing
+    /// the handshake, retry, and status-transition logic.
+    pub(crate) async fn activate_subscription(&self, subscription: &ActiveSubscription) {
         let tenant_id = &subscription.tenant_id;
         let sub_id = &subscription.id;
         let handshake_max_attempts = self.config.handshake_max_attempts.max(1);

--- a/crates/subscriptions/src/lib.rs
+++ b/crates/subscriptions/src/lib.rs
@@ -27,6 +27,7 @@ pub mod evaluator;
 pub mod event;
 pub mod manager;
 pub mod notification;
+pub mod rehydrate;
 pub mod topics;
 
 // Re-export key types for convenience.
@@ -37,3 +38,4 @@ pub use config::{MessagingSettings, SubscriptionConfig};
 pub use engine::SubscriptionEngine;
 pub use error::SubscriptionError;
 pub use event::{ResourceEvent, ResourceEventType};
+pub use rehydrate::{RehydrationConfig, RehydrationReport};

--- a/crates/subscriptions/src/rehydrate.rs
+++ b/crates/subscriptions/src/rehydrate.rs
@@ -1,0 +1,871 @@
+//! Startup rehydration of engine state from stored resources (issue #305).
+//!
+//! The engine's registries are in-memory (`DashMap`-backed) and were populated
+//! **only** by the REST write handlers, which call
+//! [`SubscriptionEngine::on_resource_event`] after a successful write. Nothing
+//! read stored `Subscription` / `SubscriptionTopic` resources back at startup,
+//! so a restart, redeploy, or crash left every previously-registered
+//! subscription inert: the resources still read back fine over the REST API,
+//! but the engine had no knowledge of them, so nothing matched, evaluated, or
+//! delivered. This module is the missing mirror of the write path.
+//!
+//! # Why `ExportDataProvider`
+//!
+//! Rehydration needs to page through every resource of a type, for every
+//! tenant. `ExportDataProvider::fetch_export_batch` is the one enumeration
+//! primitive that **every** primary backend implements — SQLite, PostgreSQL,
+//! MongoDB, S3, and `CompositeStorage` — so a single implementation here covers
+//! all of them with no schema change, no migration, and no per-backend query to
+//! drift out of sync.
+//!
+//! It also already does two things this code would otherwise have to repeat: it
+//! filters out deleted resources, and it is cursor-paged, so peak memory stays
+//! bounded no matter how many subscriptions a tenant holds.
+//!
+//! The richer alternative, `SearchProvider::search`, yields a `StoredResource`
+//! that carries its own `fhir_version` — but it is *not* universally available:
+//! a standalone S3 deployment reports search unsupported, and would therefore
+//! silently rehydrate nothing. See [`infer_fhir_version`] for how the missing
+//! version is instead recovered exactly.
+//!
+//! # Ordering
+//!
+//! [`crate::manager::SubscriptionManager::register`] rejects a subscription
+//! whose topic is not already in the registry (`TopicNotFound`). Rehydration
+//! order is therefore a correctness constraint, not a preference:
+//!
+//! 1. `SubscriptionTopic` — native topics (R4B / R5 / R6)
+//! 2. `Basic` — R4 backport topics, which are stored as `Basic` resources
+//! 3. `Subscription` — now that every topic they may reference is registered
+//!
+//! # Status policy
+//!
+//! | Stored status | Action | Why |
+//! |---|---|---|
+//! | `off` | skipped entirely | Terminal: `can_transition_to` permits no target, so a registered `off` subscription could never legally become useful. |
+//! | `active` | registered, no handshake | The handshake completed in a previous process lifetime; re-sending it is noise. |
+//! | `error` | registered, no handshake | Never matches (only `Active` does), but registering keeps `$status` honest instead of reporting an unknown subscription. |
+//! | `requested` | registered **and activated** | The spec state for "server has not yet activated"; runs the same activation path the write handler runs. |
+//!
+//! Activating `requested` subscriptions is not an optional nicety. Subscription
+//! status transitions are held **in memory only** —
+//! [`crate::manager::SubscriptionManager::update_status`] never writes back to
+//! storage — so a subscription that a client POSTed as `requested` and that
+//! handshook successfully still reads `"requested"` from the database forever.
+//! Rehydrating only `active` resources would therefore miss essentially every
+//! subscription the server itself activated, and would not fix the reported
+//! symptom at all.
+//!
+//! The cost is that a restart re-handshakes those subscriptions. That is bounded
+//! by [`RehydrationConfig::max_concurrent_handshakes`], and can be turned off
+//! with [`RehydrationConfig::handshake_requested`] by operators who would rather
+//! bring subscriptions back with no outbound traffic.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use helios_fhir::FhirVersion;
+use helios_persistence::core::ResourceStorage;
+use helios_persistence::core::bulk_export::{ExportDataProvider, ExportRequest};
+use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
+use serde_json::Value;
+use tracing::{debug, info, warn};
+
+use crate::engine::SubscriptionEngine;
+use crate::manager::{ActiveSubscription, SubscriptionStatusCode};
+use crate::topics::InMemoryTopicRegistry;
+
+/// Resource type holding native `SubscriptionTopic` definitions (R4B / R5 / R6).
+const TYPE_SUBSCRIPTION_TOPIC: &str = "SubscriptionTopic";
+/// Resource type holding R4 backport topic definitions.
+const TYPE_BASIC: &str = "Basic";
+/// Resource type holding `Subscription` resources.
+const TYPE_SUBSCRIPTION: &str = "Subscription";
+
+/// Backstop on pages fetched per resource type, per tenant.
+///
+/// Every in-tree backend terminates correctly — each returns `next_cursor: None`
+/// together with `is_last: true` once exhausted — and the paging loops only
+/// continue when a backend explicitly reports both "more data" and a cursor. This
+/// bound exists solely so that a backend which ever regressed to a non-advancing
+/// cursor would degrade to a logged warning instead of spinning a startup task
+/// forever. At the default batch size it allows millions of resources per type,
+/// far beyond any realistic subscription count.
+const MAX_PAGES_PER_TYPE: usize = 10_000;
+
+/// Tuning for a rehydration pass.
+#[derive(Debug, Clone)]
+pub struct RehydrationConfig {
+    /// Master switch. When `false`, [`SubscriptionEngine::rehydrate`] returns an
+    /// empty report without touching storage.
+    pub enabled: bool,
+
+    /// Resources fetched per storage round-trip. Bounds peak memory: only one
+    /// batch is held at a time regardless of how many resources exist.
+    pub batch_size: u32,
+
+    /// Whether stored `requested` subscriptions are activated (handshaked)
+    /// during rehydration.
+    ///
+    /// Defaults to `true` because status transitions are not persisted, so most
+    /// live subscriptions read back as `requested` — see the module docs. Set to
+    /// `false` to rehydrate with no outbound traffic at all, accepting that
+    /// `requested` subscriptions stay inert until they are re-written.
+    pub handshake_requested: bool,
+
+    /// Maximum handshakes in flight at once, across all tenants.
+    ///
+    /// A restart would otherwise fire one outbound request per `requested`
+    /// subscription simultaneously — a thundering herd against subscriber
+    /// endpoints. Treated as at least 1.
+    pub max_concurrent_handshakes: usize,
+}
+
+impl Default for RehydrationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            batch_size: 500,
+            handshake_requested: true,
+            max_concurrent_handshakes: 8,
+        }
+    }
+}
+
+/// Outcome of a rehydration pass.
+///
+/// Returned rather than only logged so the behaviour is unit-testable without
+/// standing up a server, and so the operator gets one structured summary line
+/// instead of one line per resource.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RehydrationReport {
+    /// Tenants scanned.
+    pub tenants: usize,
+    /// Topics registered (native `SubscriptionTopic` + R4 backport `Basic`).
+    pub topics_registered: usize,
+    /// Topic resources that could not be parsed.
+    pub topics_failed: usize,
+    /// Subscriptions registered with the manager.
+    pub subscriptions_registered: usize,
+    /// Subscriptions that failed to register (unknown topic, bad channel, …).
+    pub subscriptions_failed: usize,
+    /// Subscriptions skipped because their stored status is `off`.
+    pub subscriptions_skipped: usize,
+    /// Subscriptions handed to the activation (handshake) path.
+    pub handshakes_started: usize,
+    /// Storage errors encountered while paging. A non-zero value means the pass
+    /// is incomplete: some subscriptions may still be inert.
+    pub storage_errors: usize,
+}
+
+impl RehydrationReport {
+    /// Whether the pass completed without any storage-level failure.
+    ///
+    /// Per-resource parse failures are counted separately and do **not** make a
+    /// pass incomplete — one malformed resource must not stop the scan.
+    pub fn is_complete(&self) -> bool {
+        self.storage_errors == 0
+    }
+
+    fn merge(&mut self, other: RehydrationReport) {
+        self.tenants += other.tenants;
+        self.topics_registered += other.topics_registered;
+        self.topics_failed += other.topics_failed;
+        self.subscriptions_registered += other.subscriptions_registered;
+        self.subscriptions_failed += other.subscriptions_failed;
+        self.subscriptions_skipped += other.subscriptions_skipped;
+        self.handshakes_started += other.handshakes_started;
+        self.storage_errors += other.storage_errors;
+    }
+}
+
+/// Whether `version` is R4 (the backport shape), in a build that may not have
+/// R4 compiled in at all.
+fn is_r4(version: FhirVersion) -> bool {
+    #[cfg(feature = "R4")]
+    {
+        version == FhirVersion::R4
+    }
+    #[cfg(not(feature = "R4"))]
+    {
+        let _ = version;
+        false
+    }
+}
+
+/// The lowest enabled native (R4B+) version, or `None` when only R4 is compiled
+/// in and there is therefore no native version to choose.
+///
+/// Which native version is picked only affects the version string in emitted
+/// notification bundles: R4B, R5, and R6 all take the same `build_native` code
+/// path, and the same `channelType`/`topic` parsing path.
+fn lowest_native_version() -> Option<FhirVersion> {
+    #[cfg(feature = "R4B")]
+    {
+        Some(FhirVersion::R4B)
+    }
+    #[cfg(all(not(feature = "R4B"), feature = "R5"))]
+    {
+        Some(FhirVersion::R5)
+    }
+    #[cfg(all(not(feature = "R4B"), not(feature = "R5"), feature = "R6"))]
+    {
+        Some(FhirVersion::R6)
+    }
+    #[cfg(all(not(feature = "R4B"), not(feature = "R5"), not(feature = "R6")))]
+    {
+        None
+    }
+}
+
+/// R4 when it is compiled in, otherwise the supplied fallback.
+fn r4_or(fallback: FhirVersion) -> FhirVersion {
+    #[cfg(feature = "R4")]
+    {
+        let _ = fallback;
+        FhirVersion::R4
+    }
+    #[cfg(not(feature = "R4"))]
+    {
+        fallback
+    }
+}
+
+/// Infers the FHIR version of a stored `Subscription` resource from its shape.
+///
+/// `fetch_export_batch` yields raw resource JSON, not the `StoredResource`
+/// envelope, so the persisted `fhir_version` is unavailable. It does not need to
+/// be: **every** version-dependent branch in this crate is a binary
+/// R4-vs-native split, and both sides of that split are directly observable in
+/// the resource:
+///
+/// | | R4 (backport) | R4B / R5 / R6 (native) |
+/// |---|---|---|
+/// | topic | `criteria`, or the `backport-topic-canonical` extension | `topic` |
+/// | channel | `channel` object | `channelType` coding |
+///
+/// (See `extract_topic_url` and `extract_channel_config` in [`crate::manager`],
+/// and `build_r4` vs `build_native` in [`crate::notification`].)
+///
+/// Native markers win, because `topic`/`channelType` cannot appear in a genuine
+/// R4 backport resource, whereas an R4 resource may carry neither marker. A
+/// resource with no usable marker falls back to `default_version`, matching what
+/// the write path stores for a request that did not specify `fhirVersion`.
+pub fn infer_fhir_version(resource: &Value, default_version: FhirVersion) -> FhirVersion {
+    let has_native_marker =
+        resource.get("topic").is_some() || resource.get("channelType").is_some();
+    if has_native_marker {
+        return if is_r4(default_version) {
+            // Server default is R4 but the resource is native-shaped.
+            lowest_native_version().unwrap_or(default_version)
+        } else {
+            default_version
+        };
+    }
+
+    let has_r4_marker =
+        resource.get("criteria").is_some() || resource.get("channel").is_some_and(Value::is_object);
+    if has_r4_marker {
+        return r4_or(default_version);
+    }
+
+    default_version
+}
+
+/// Enumerates the tenants to rehydrate.
+///
+/// Mirrors the conformance-seeding logic in `crates/hfs/src/main.rs`: every
+/// registered tenant plus the configured default (which is auto-provisioned and
+/// so may not be listed yet). Backends without a tenant registry — mock stores,
+/// minimal deployments — yield just the default tenant, so the common
+/// single-tenant configuration works with no registry at all.
+async fn tenants_to_scan<S>(storage: &S, default_tenant: &str) -> Vec<String>
+where
+    S: ResourceStorage,
+{
+    let mut ids: BTreeSet<String> = BTreeSet::new();
+    ids.insert(default_tenant.to_string());
+
+    if storage.supports_tenant_registry() {
+        match storage.list_tenants().await {
+            Ok(records) => ids.extend(records.into_iter().map(|r| r.id)),
+            Err(e) => warn!(
+                error = %e,
+                "Listing tenants for subscription rehydration failed; \
+                 rehydrating the default tenant only"
+            ),
+        }
+    }
+
+    ids.into_iter().collect()
+}
+
+impl SubscriptionEngine {
+    /// Repopulates the engine from stored resources, for every tenant.
+    ///
+    /// This is the startup mirror of the write-handler path: for each tenant it
+    /// registers stored topics and then stored subscriptions, so subscriptions
+    /// that were active before a restart resume matching and delivering.
+    ///
+    /// Errors are absorbed, never propagated: a storage failure on one tenant
+    /// must not prevent the others from rehydrating, and one malformed resource
+    /// must not stop the scan. Both are counted in the returned
+    /// [`RehydrationReport`]; check [`RehydrationReport::is_complete`] to tell a
+    /// clean pass from a partial one.
+    pub async fn rehydrate<S>(
+        &self,
+        storage: &S,
+        default_tenant: &str,
+        default_version: FhirVersion,
+        config: &RehydrationConfig,
+    ) -> RehydrationReport
+    where
+        S: ResourceStorage + ExportDataProvider,
+    {
+        let mut report = RehydrationReport::default();
+        if !config.enabled {
+            debug!("Subscription rehydration is disabled");
+            return report;
+        }
+
+        let tenants = tenants_to_scan(storage, default_tenant).await;
+        info!(
+            tenants = tenants.len(),
+            "Rehydrating subscription engine from storage"
+        );
+
+        // Activation is deferred so registration — the fast, DB-bound part that
+        // actually restores delivery for `active` subscriptions — completes for
+        // every tenant before any outbound handshake is attempted.
+        let mut pending: Vec<ActiveSubscription> = Vec::new();
+
+        for tenant_id in &tenants {
+            let tenant_report = self
+                .rehydrate_tenant(storage, tenant_id, default_version, config, &mut pending)
+                .await;
+            report.merge(tenant_report);
+        }
+        report.tenants = tenants.len();
+        report.handshakes_started = pending.len();
+
+        self.activate_pending(pending, config).await;
+
+        if report.is_complete() {
+            info!(
+                tenants = report.tenants,
+                topics = report.topics_registered,
+                subscriptions = report.subscriptions_registered,
+                skipped = report.subscriptions_skipped,
+                failed = report.subscriptions_failed,
+                handshakes = report.handshakes_started,
+                "Subscription engine rehydrated"
+            );
+        } else {
+            warn!(
+                tenants = report.tenants,
+                topics = report.topics_registered,
+                subscriptions = report.subscriptions_registered,
+                storage_errors = report.storage_errors,
+                "Subscription engine rehydration incomplete; some subscriptions \
+                 may not deliver until they are re-written"
+            );
+        }
+
+        report
+    }
+
+    /// Rehydrates a single tenant: topics → R4 backport topics → subscriptions.
+    async fn rehydrate_tenant<S>(
+        &self,
+        storage: &S,
+        tenant_id: &str,
+        default_version: FhirVersion,
+        config: &RehydrationConfig,
+        pending: &mut Vec<ActiveSubscription>,
+    ) -> RehydrationReport
+    where
+        S: ResourceStorage + ExportDataProvider,
+    {
+        let mut report = RehydrationReport::default();
+        let tenant = TenantContext::new(TenantId::new(tenant_id), TenantPermissions::full_access());
+
+        // 1. Native SubscriptionTopic resources.
+        self.rehydrate_topics(
+            storage,
+            &tenant,
+            TYPE_SUBSCRIPTION_TOPIC,
+            config,
+            &mut report,
+        )
+        .await;
+
+        // 2. R4 backport topics, stored as `Basic`. Skipped when R4 is not
+        //    compiled in, since nothing can then produce or consume them.
+        if cfg!(feature = "R4") {
+            self.rehydrate_topics(storage, &tenant, TYPE_BASIC, config, &mut report)
+                .await;
+        }
+
+        // 3. Subscriptions — every topic they can reference is now registered.
+        self.rehydrate_subscriptions(
+            storage,
+            &tenant,
+            tenant_id,
+            default_version,
+            config,
+            pending,
+            &mut report,
+        )
+        .await;
+
+        report
+    }
+
+    /// Pages through one topic-bearing resource type and registers what parses.
+    ///
+    /// `resource_type` is either `SubscriptionTopic` (native) or `Basic` (R4
+    /// backport). A `Basic` resource that is not a topic is not an error — the
+    /// backport parser returns `Ok(None)` for it and it is silently ignored,
+    /// which matters because `Basic` is a general-purpose resource type a tenant
+    /// may well use for unrelated data.
+    async fn rehydrate_topics<S>(
+        &self,
+        storage: &S,
+        tenant: &TenantContext,
+        resource_type: &str,
+        config: &RehydrationConfig,
+        report: &mut RehydrationReport,
+    ) where
+        S: ExportDataProvider,
+    {
+        let mut cursor: Option<String> = None;
+        for page in 0.. {
+            if page >= MAX_PAGES_PER_TYPE {
+                warn!(
+                    tenant = %tenant.tenant_id().as_str(),
+                    resource_type,
+                    pages = page,
+                    "Stopping topic rehydration at the page backstop; \
+                     the backend cursor is not advancing"
+                );
+                report.storage_errors += 1;
+                return;
+            }
+            let batch = match fetch_batch(storage, tenant, resource_type, cursor.as_deref(), config)
+                .await
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(
+                        tenant = %tenant.tenant_id().as_str(),
+                        resource_type,
+                        error = %e,
+                        "Failed to page stored topics during rehydration"
+                    );
+                    report.storage_errors += 1;
+                    return;
+                }
+            };
+            let ResourceBatch {
+                resources,
+                next_cursor,
+                is_last,
+            } = batch;
+
+            for resource in &resources {
+                let parsed = if resource_type == TYPE_BASIC {
+                    match InMemoryTopicRegistry::parse_r4_backport_basic_topic_resource(resource) {
+                        // Not a topic at all — ordinary `Basic` data.
+                        Ok(None) => continue,
+                        Ok(Some(topic)) => Ok(topic),
+                        Err(e) => Err(e),
+                    }
+                } else {
+                    InMemoryTopicRegistry::parse_topic_resource(resource)
+                };
+
+                match parsed {
+                    Ok(topic) => {
+                        debug!(
+                            tenant = %tenant.tenant_id().as_str(),
+                            topic_url = %topic.canonical_url,
+                            "Rehydrated SubscriptionTopic"
+                        );
+                        self.topic_registry().add_topic(topic);
+                        report.topics_registered += 1;
+                    }
+                    Err(e) => {
+                        warn!(
+                            tenant = %tenant.tenant_id().as_str(),
+                            resource_type,
+                            error = %e,
+                            "Skipping unparseable topic during rehydration"
+                        );
+                        report.topics_failed += 1;
+                    }
+                }
+            }
+
+            match next_cursor {
+                Some(next) if !is_last => cursor = Some(next),
+                _ => return,
+            }
+        }
+    }
+
+    /// Pages through stored `Subscription` resources and registers them.
+    #[allow(clippy::too_many_arguments)]
+    async fn rehydrate_subscriptions<S>(
+        &self,
+        storage: &S,
+        tenant: &TenantContext,
+        tenant_id: &str,
+        default_version: FhirVersion,
+        config: &RehydrationConfig,
+        pending: &mut Vec<ActiveSubscription>,
+        report: &mut RehydrationReport,
+    ) where
+        S: ExportDataProvider,
+    {
+        let mut cursor: Option<String> = None;
+        for page in 0.. {
+            if page >= MAX_PAGES_PER_TYPE {
+                warn!(
+                    tenant = tenant_id,
+                    pages = page,
+                    "Stopping subscription rehydration at the page backstop; \
+                     the backend cursor is not advancing"
+                );
+                report.storage_errors += 1;
+                return;
+            }
+            let batch = match fetch_batch(
+                storage,
+                tenant,
+                TYPE_SUBSCRIPTION,
+                cursor.as_deref(),
+                config,
+            )
+            .await
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(
+                        tenant = tenant_id,
+                        error = %e,
+                        "Failed to page stored subscriptions during rehydration"
+                    );
+                    report.storage_errors += 1;
+                    return;
+                }
+            };
+            let ResourceBatch {
+                resources,
+                next_cursor,
+                is_last,
+            } = batch;
+
+            for resource in &resources {
+                let Some(id) = resource.get("id").and_then(|v| v.as_str()) else {
+                    warn!(
+                        tenant = tenant_id,
+                        "Skipping stored Subscription with no id during rehydration"
+                    );
+                    report.subscriptions_failed += 1;
+                    continue;
+                };
+
+                // `off` is terminal — `can_transition_to` permits no target from
+                // it — so registering one could never lead anywhere useful.
+                let stored_status = resource
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .and_then(SubscriptionStatusCode::from_fhir_str);
+                if stored_status == Some(SubscriptionStatusCode::Off) {
+                    debug!(
+                        tenant = tenant_id,
+                        subscription_id = id,
+                        "Skipping `off` subscription during rehydration"
+                    );
+                    report.subscriptions_skipped += 1;
+                    continue;
+                }
+
+                let fhir_version = infer_fhir_version(resource, default_version);
+                match self
+                    .manager()
+                    .register(tenant_id, id, resource, fhir_version)
+                {
+                    Ok(sub) => {
+                        info!(
+                            tenant = tenant_id,
+                            subscription_id = %sub.id,
+                            topic_url = %sub.topic_url,
+                            status = %sub.status,
+                            channel_type = %sub.channel.channel_type.as_fhir_str(),
+                            fhir_version = %fhir_version,
+                            "Rehydrated subscription"
+                        );
+                        report.subscriptions_registered += 1;
+
+                        // Only `requested` needs the handshake. `active` was
+                        // established in a previous process lifetime; `error`
+                        // stays registered but dormant.
+                        if sub.status == SubscriptionStatusCode::Requested
+                            && config.handshake_requested
+                        {
+                            pending.push(sub);
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            tenant = tenant_id,
+                            subscription_id = id,
+                            error = %e,
+                            "Failed to rehydrate subscription; it will not deliver \
+                             until the resource is re-written"
+                        );
+                        report.subscriptions_failed += 1;
+                    }
+                }
+            }
+
+            match next_cursor {
+                Some(next) if !is_last => cursor = Some(next),
+                _ => return,
+            }
+        }
+    }
+
+    /// Runs the deferred handshakes, at most
+    /// [`RehydrationConfig::max_concurrent_handshakes`] at a time.
+    ///
+    /// Without the cap, a restart would fire one outbound request per
+    /// `requested` subscription at once — and because status transitions are not
+    /// persisted, that is potentially *every* subscription in the deployment.
+    async fn activate_pending(&self, pending: Vec<ActiveSubscription>, config: &RehydrationConfig) {
+        if pending.is_empty() {
+            return;
+        }
+
+        let permits = config.max_concurrent_handshakes.max(1);
+        info!(
+            subscriptions = pending.len(),
+            max_concurrent = permits,
+            "Re-activating `requested` subscriptions after rehydration"
+        );
+
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(permits));
+        let tasks = pending.into_iter().map(|subscription| {
+            let semaphore = Arc::clone(&semaphore);
+            async move {
+                // `acquire_owned` only errors once the semaphore is closed,
+                // which never happens here — it is dropped with these futures.
+                let _permit = semaphore.acquire_owned().await;
+                self.activate_subscription(&subscription).await;
+            }
+        });
+
+        futures::future::join_all(tasks).await;
+    }
+}
+
+/// One page of stored resources, parsed from the backend's NDJSON batch.
+struct ResourceBatch {
+    resources: Vec<Value>,
+    next_cursor: Option<String>,
+    is_last: bool,
+}
+
+/// Fetches and parses one page of resources of `resource_type`.
+///
+/// A line that does not parse as JSON is dropped with a warning rather than
+/// failing the page: one corrupt row must not stop a tenant from rehydrating.
+async fn fetch_batch<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    resource_type: &str,
+    cursor: Option<&str>,
+    config: &RehydrationConfig,
+) -> Result<ResourceBatch, String>
+where
+    S: ExportDataProvider,
+{
+    let mut request = ExportRequest::system();
+    request.resource_types = vec![resource_type.to_string()];
+    request.batch_size = config.batch_size;
+
+    let batch = storage
+        .fetch_export_batch(tenant, &request, resource_type, cursor, config.batch_size)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut resources = Vec::with_capacity(batch.lines.len());
+    for line in &batch.lines {
+        match serde_json::from_str::<Value>(line) {
+            Ok(value) => resources.push(value),
+            Err(e) => warn!(
+                tenant = %tenant.tenant_id().as_str(),
+                resource_type,
+                error = %e,
+                "Skipping unparseable stored resource during rehydration"
+            ),
+        }
+    }
+
+    Ok(ResourceBatch {
+        resources,
+        next_cursor: batch.next_cursor,
+        is_last: batch.is_last,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn report_merges_counters() {
+        let mut a = RehydrationReport {
+            topics_registered: 1,
+            subscriptions_registered: 2,
+            ..Default::default()
+        };
+        a.merge(RehydrationReport {
+            topics_registered: 3,
+            subscriptions_failed: 1,
+            storage_errors: 1,
+            ..Default::default()
+        });
+        assert_eq!(a.topics_registered, 4);
+        assert_eq!(a.subscriptions_registered, 2);
+        assert_eq!(a.subscriptions_failed, 1);
+        assert_eq!(a.storage_errors, 1);
+    }
+
+    #[test]
+    fn report_is_complete_only_without_storage_errors() {
+        // Per-resource parse failures do NOT make a pass incomplete — one bad
+        // resource must not be reported as "some subscriptions may be inert".
+        let parse_failures = RehydrationReport {
+            topics_failed: 3,
+            subscriptions_failed: 2,
+            ..Default::default()
+        };
+        assert!(parse_failures.is_complete());
+
+        let storage_failure = RehydrationReport {
+            storage_errors: 1,
+            ..Default::default()
+        };
+        assert!(!storage_failure.is_complete());
+    }
+
+    #[test]
+    fn default_config_rehydrates_and_handshakes() {
+        let config = RehydrationConfig::default();
+        assert!(config.enabled);
+        assert!(
+            config.handshake_requested,
+            "status transitions are not persisted, so `requested` must be \
+             activated by default or the fix restores nothing"
+        );
+        assert!(config.max_concurrent_handshakes >= 1);
+    }
+
+    // ── FHIR version inference ───────────────────────────────────────────
+
+    #[cfg(feature = "R4")]
+    #[test]
+    fn infers_r4_from_backport_shape() {
+        // R4 backport: topic in `criteria`, channel as a nested object.
+        let resource = json!({
+            "resourceType": "Subscription",
+            "id": "sub-1",
+            "status": "active",
+            "criteria": "http://example.org/topic",
+            "channel": { "type": "rest-hook", "endpoint": "https://example.org/hook" }
+        });
+        assert_eq!(
+            infer_fhir_version(&resource, FhirVersion::default_enabled()),
+            FhirVersion::R4
+        );
+    }
+
+    #[cfg(feature = "R4")]
+    #[test]
+    fn infers_r4_from_channel_object_alone() {
+        // A `channel` object with no `criteria` is still unambiguously R4:
+        // native versions use `channelType`, never `channel`.
+        let resource = json!({
+            "resourceType": "Subscription",
+            "id": "sub-2",
+            "status": "requested",
+            "channel": { "type": "rest-hook" }
+        });
+        assert_eq!(
+            infer_fhir_version(&resource, FhirVersion::default_enabled()),
+            FhirVersion::R4
+        );
+    }
+
+    #[cfg(any(feature = "R4B", feature = "R5", feature = "R6"))]
+    #[test]
+    fn infers_native_from_topic_field() {
+        // `topic` exists only in R4B+, so this must not resolve to R4 even when
+        // R4 is the server default.
+        let resource = json!({
+            "resourceType": "Subscription",
+            "id": "sub-3",
+            "status": "active",
+            "topic": "http://example.org/topic",
+            "channelType": { "code": "rest-hook" }
+        });
+        assert!(
+            !is_r4(infer_fhir_version(
+                &resource,
+                FhirVersion::default_enabled()
+            )),
+            "a native-shaped resource must not be parsed as R4 backport"
+        );
+    }
+
+    #[cfg(any(feature = "R4B", feature = "R5", feature = "R6"))]
+    #[test]
+    fn native_marker_wins_over_r4_marker() {
+        // A resource carrying both shapes is native: `topic` cannot appear in a
+        // genuine R4 backport resource, whereas `criteria` may linger.
+        let resource = json!({
+            "resourceType": "Subscription",
+            "topic": "http://example.org/topic",
+            "criteria": "Patient?active=true"
+        });
+        assert!(!is_r4(infer_fhir_version(
+            &resource,
+            FhirVersion::default_enabled()
+        )));
+    }
+
+    #[test]
+    fn falls_back_to_default_when_shape_is_ambiguous() {
+        // Neither marker present — mirror what the write path stores for a
+        // request that did not specify `fhirVersion`.
+        let resource = json!({ "resourceType": "Subscription", "id": "sub-4" });
+        let default = FhirVersion::default_enabled();
+        assert_eq!(infer_fhir_version(&resource, default), default);
+    }
+
+    #[test]
+    fn r4_only_build_has_no_native_version_to_pick() {
+        // Guards the inference fallback: with no native version compiled in, a
+        // native-shaped resource must still resolve to *something* usable rather
+        // than panicking or yielding a version the build cannot parse.
+        let resource = json!({ "resourceType": "Subscription", "topic": "http://x/y" });
+        let default = FhirVersion::default_enabled();
+        let inferred = infer_fhir_version(&resource, default);
+        if lowest_native_version().is_none() {
+            assert_eq!(inferred, default);
+        }
+    }
+}

--- a/crates/subscriptions/tests/rehydrate_integration.rs
+++ b/crates/subscriptions/tests/rehydrate_integration.rs
@@ -15,6 +15,7 @@
 use chrono::Utc;
 use helios_fhir::FhirVersion;
 use helios_persistence::backends::sqlite::SqliteBackend;
+use helios_persistence::core::ResourceStorage;
 use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
 use helios_subscriptions::manager::SubscriptionStatusCode;
 use helios_subscriptions::{

--- a/crates/subscriptions/tests/rehydrate_integration.rs
+++ b/crates/subscriptions/tests/rehydrate_integration.rs
@@ -1,0 +1,566 @@
+//! Startup rehydration of the subscription engine (issue #305).
+//!
+//! The regression these guard: the engine's registries are in-memory and were
+//! populated only by live write handlers, so a restart left stored, active
+//! subscriptions inert — they stopped matching and delivering while still
+//! reading back fine over the REST API.
+//!
+//! Each test simulates a restart the same way the real bug manifests: resources
+//! are written to a **real** storage backend, then a **fresh** `SubscriptionEngine`
+//! is constructed — exactly what a process restart produces. Asserting the fresh
+//! engine is inert *before* rehydration is what makes these regression tests
+//! rather than feature tests: without that half, a no-op `rehydrate` would still
+//! pass.
+
+use chrono::Utc;
+use helios_fhir::FhirVersion;
+use helios_persistence::backends::sqlite::SqliteBackend;
+use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
+use helios_subscriptions::manager::SubscriptionStatusCode;
+use helios_subscriptions::{
+    RehydrationConfig, ResourceEvent, ResourceEventType, SubscriptionConfig, SubscriptionEngine,
+};
+use serde_json::{Value, json};
+use std::time::Duration;
+
+const TENANT_ID: &str = "tenant-a";
+const OTHER_TENANT_ID: &str = "tenant-b";
+const TOPIC_URL: &str = "http://example.org/topic/encounter-start";
+
+fn current_fhir_version() -> FhirVersion {
+    FhirVersion::default()
+}
+
+fn uses_backport_ig() -> bool {
+    current_fhir_version() == FhirVersion::R4
+}
+
+/// A topic in whichever shape the compiled default version stores: an R4
+/// backport `Basic`, or a native `SubscriptionTopic`.
+fn topic_resource() -> Value {
+    if uses_backport_ig() {
+        json!({
+            "resourceType": "Basic",
+            "id": "topic-1",
+            "code": {
+                "coding": [{
+                    "system": "http://hl7.org/fhir/fhir-types",
+                    "code": "SubscriptionTopic"
+                }]
+            },
+            "extension": [{
+                "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-SubscriptionTopic.url",
+                "valueUri": TOPIC_URL
+            }, {
+                "url": "http://hl7.org/fhir/4.3/StructureDefinition/extension-SubscriptionTopic.resourceTrigger",
+                "extension": [{
+                    "url": "resource",
+                    "valueUri": "http://hl7.org/fhir/StructureDefinition/Encounter"
+                }, {
+                    "url": "supportedInteraction",
+                    "valueCode": "create"
+                }]
+            }]
+        })
+    } else {
+        json!({
+            "resourceType": "SubscriptionTopic",
+            "id": "topic-1",
+            "url": TOPIC_URL,
+            "status": "active",
+            "resourceTrigger": [{
+                "resource": "Encounter",
+                "supportedInteraction": ["create"]
+            }]
+        })
+    }
+}
+
+fn topic_resource_type() -> &'static str {
+    if uses_backport_ig() {
+        "Basic"
+    } else {
+        "SubscriptionTopic"
+    }
+}
+
+/// A subscription in the compiled default version's shape.
+fn subscription_resource(id: &str, status: &str, endpoint: &str) -> Value {
+    if uses_backport_ig() {
+        json!({
+            "resourceType": "Subscription",
+            "id": id,
+            "status": status,
+            "criteria": TOPIC_URL,
+            "channel": {
+                "type": "rest-hook",
+                "endpoint": endpoint,
+                "payload": "application/fhir+json"
+            }
+        })
+    } else {
+        json!({
+            "resourceType": "Subscription",
+            "id": id,
+            "status": status,
+            "topic": TOPIC_URL,
+            "channelType": { "code": "rest-hook" },
+            "endpoint": endpoint,
+            "contentType": "application/fhir+json"
+        })
+    }
+}
+
+fn tenant_context(tenant_id: &str) -> TenantContext {
+    TenantContext::new(TenantId::new(tenant_id), TenantPermissions::full_access())
+}
+
+/// An in-memory SQLite backend standing in for "the database that survived the
+/// restart".
+fn storage() -> SqliteBackend {
+    let backend = SqliteBackend::in_memory().expect("in-memory sqlite backend");
+    backend.init_schema().expect("init schema");
+    backend
+}
+
+/// A brand-new engine — what a process restart yields: registries empty,
+/// nothing loaded.
+///
+/// Retry/backoff is collapsed to near-zero: these tests dispatch to a dead
+/// endpoint on purpose (the delivery attempt is not what is under test), and the
+/// default policy would retry it ten times with exponential backoff, adding
+/// minutes of wall-clock for no added signal.
+fn fresh_engine() -> SubscriptionEngine {
+    SubscriptionEngine::new(
+        SubscriptionConfig {
+            max_retries: 0,
+            retry_initial_delay: Duration::from_millis(1),
+            retry_max_delay: Duration::from_millis(1),
+            handshake_max_attempts: 1,
+            handshake_retry_initial_delay: Duration::from_millis(1),
+            handshake_retry_max_delay: Duration::from_millis(1),
+            ..SubscriptionConfig::default()
+        },
+        "http://localhost:8080".to_string(),
+    )
+}
+
+/// A rehydration config that performs no outbound traffic, so tests assert on
+/// registration alone without standing up mock endpoints.
+fn no_handshake_config() -> RehydrationConfig {
+    RehydrationConfig {
+        handshake_requested: false,
+        ..RehydrationConfig::default()
+    }
+}
+
+fn encounter_created_event(tenant_id: &str) -> ResourceEvent {
+    ResourceEvent {
+        tenant_id: TenantId::new(tenant_id),
+        fhir_version: current_fhir_version(),
+        resource_type: "Encounter".to_string(),
+        resource_id: "enc-1".to_string(),
+        version_id: "1".to_string(),
+        event_type: ResourceEventType::Create,
+        resource: Some(json!({ "resourceType": "Encounter", "id": "enc-1" })),
+        previous_resource: None,
+        timestamp: Utc::now(),
+    }
+}
+
+async fn seed(backend: &SqliteBackend, tenant_id: &str, resource_type: &str, resource: Value) {
+    backend
+        .create(
+            &tenant_context(tenant_id),
+            resource_type,
+            resource,
+            current_fhir_version(),
+        )
+        .await
+        .expect("seed resource");
+}
+
+/// The core regression: an `active` subscription stored before a restart must
+/// resume matching after rehydration — and must NOT match before it, which is
+/// what proves the test is exercising the fix rather than passing vacuously.
+#[tokio::test]
+async fn active_subscription_survives_restart() {
+    let backend = storage();
+    seed(&backend, TENANT_ID, topic_resource_type(), topic_resource()).await;
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        subscription_resource("sub-1", "active", "http://127.0.0.1:1/hook"),
+    )
+    .await;
+
+    let engine = fresh_engine();
+
+    // Pre-condition: this is the bug. A fresh engine knows nothing about the
+    // stored subscription, so the event matches nothing.
+    assert!(
+        engine
+            .manager()
+            .get_subscription(TENANT_ID, "sub-1")
+            .is_none(),
+        "a fresh engine must not know the stored subscription — otherwise this \
+         test would pass even with rehydration removed"
+    );
+
+    let report = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &no_handshake_config(),
+        )
+        .await;
+
+    assert!(report.is_complete(), "report: {report:?}");
+    assert_eq!(report.topics_registered, 1, "report: {report:?}");
+    assert_eq!(report.subscriptions_registered, 1, "report: {report:?}");
+
+    let restored = engine
+        .manager()
+        .get_subscription(TENANT_ID, "sub-1")
+        .expect("subscription registered after rehydration");
+    assert_eq!(restored.status, SubscriptionStatusCode::Active);
+    assert_eq!(restored.topic_url, TOPIC_URL);
+
+    // And it is genuinely live: the engine now routes a matching event to it.
+    // `on_resource_event` dispatches to a dead endpoint, which is fine — the
+    // event counter proves the match happened.
+    engine
+        .on_resource_event(encounter_created_event(TENANT_ID))
+        .await;
+    let after = engine
+        .manager()
+        .get_subscription(TENANT_ID, "sub-1")
+        .expect("still registered");
+    assert!(
+        after.events_since_start > 0,
+        "a rehydrated active subscription must match events, got {after:?}"
+    );
+}
+
+/// Topics must be registered before subscriptions: `register` rejects a
+/// subscription whose topic is unknown, so a rehydration that scanned in the
+/// wrong order would fail every subscription.
+#[tokio::test]
+async fn topic_is_registered_before_subscriptions() {
+    let backend = storage();
+    // Seed the subscription FIRST so storage ordering cannot accidentally
+    // produce the correct result — the rehydration order must be what saves it.
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        subscription_resource("sub-1", "active", "http://127.0.0.1:1/hook"),
+    )
+    .await;
+    seed(&backend, TENANT_ID, topic_resource_type(), topic_resource()).await;
+
+    let engine = fresh_engine();
+    let report = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &no_handshake_config(),
+        )
+        .await;
+
+    assert_eq!(
+        report.subscriptions_failed, 0,
+        "topics must be registered before subscriptions; report: {report:?}"
+    );
+    assert_eq!(report.subscriptions_registered, 1, "report: {report:?}");
+    assert!(
+        engine.topic_registry().get_topic(TOPIC_URL).is_some(),
+        "topic must be in the registry"
+    );
+}
+
+/// `off` is a terminal status — it can transition nowhere — so rehydrating one
+/// would register a subscription that could never legally become useful.
+#[tokio::test]
+async fn off_subscriptions_are_skipped() {
+    let backend = storage();
+    seed(&backend, TENANT_ID, topic_resource_type(), topic_resource()).await;
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        subscription_resource("sub-off", "off", "http://127.0.0.1:1/hook"),
+    )
+    .await;
+
+    let engine = fresh_engine();
+    let report = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &no_handshake_config(),
+        )
+        .await;
+
+    assert_eq!(report.subscriptions_skipped, 1, "report: {report:?}");
+    assert_eq!(report.subscriptions_registered, 0, "report: {report:?}");
+    assert!(
+        engine
+            .manager()
+            .get_subscription(TENANT_ID, "sub-off")
+            .is_none(),
+        "an `off` subscription must not be registered"
+    );
+}
+
+/// Rehydration covers every tenant, not just the default one — otherwise a
+/// multi-tenant deployment silently restores only one tenant's subscriptions.
+#[tokio::test]
+async fn rehydration_covers_every_tenant() {
+    let backend = storage();
+    for tenant in [TENANT_ID, OTHER_TENANT_ID] {
+        backend
+            .register_tenant(tenant, None)
+            .await
+            .expect("register tenant");
+        seed(&backend, tenant, topic_resource_type(), topic_resource()).await;
+        seed(
+            &backend,
+            tenant,
+            "Subscription",
+            subscription_resource("sub-1", "active", "http://127.0.0.1:1/hook"),
+        )
+        .await;
+    }
+
+    let engine = fresh_engine();
+    let report = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &no_handshake_config(),
+        )
+        .await;
+
+    assert!(report.is_complete(), "report: {report:?}");
+    assert_eq!(report.subscriptions_registered, 2, "report: {report:?}");
+    for tenant in [TENANT_ID, OTHER_TENANT_ID] {
+        assert!(
+            engine.manager().get_subscription(tenant, "sub-1").is_some(),
+            "tenant {tenant} must be rehydrated"
+        );
+    }
+}
+
+/// Subscriptions are tenant-scoped after rehydration: an event in one tenant
+/// must not deliver to another tenant's subscription.
+#[tokio::test]
+async fn rehydrated_subscriptions_stay_tenant_isolated() {
+    let backend = storage();
+    for tenant in [TENANT_ID, OTHER_TENANT_ID] {
+        backend
+            .register_tenant(tenant, None)
+            .await
+            .expect("register tenant");
+        seed(&backend, tenant, topic_resource_type(), topic_resource()).await;
+    }
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        subscription_resource("sub-a", "active", "http://127.0.0.1:1/hook"),
+    )
+    .await;
+
+    let engine = fresh_engine();
+    engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &no_handshake_config(),
+        )
+        .await;
+
+    // An event in the OTHER tenant must not touch tenant-a's subscription.
+    engine
+        .on_resource_event(encounter_created_event(OTHER_TENANT_ID))
+        .await;
+    let sub_a = engine
+        .manager()
+        .get_subscription(TENANT_ID, "sub-a")
+        .expect("tenant-a subscription registered");
+    assert_eq!(
+        sub_a.events_since_start, 0,
+        "a cross-tenant event must not be delivered to tenant-a"
+    );
+}
+
+/// Disabling rehydration must be a true no-op, so operators can opt out without
+/// the engine touching storage at all.
+#[tokio::test]
+async fn disabled_rehydration_is_a_no_op() {
+    let backend = storage();
+    seed(&backend, TENANT_ID, topic_resource_type(), topic_resource()).await;
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        subscription_resource("sub-1", "active", "http://127.0.0.1:1/hook"),
+    )
+    .await;
+
+    let engine = fresh_engine();
+    let report = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &RehydrationConfig {
+                enabled: false,
+                ..RehydrationConfig::default()
+            },
+        )
+        .await;
+
+    assert_eq!(report, Default::default(), "disabled pass must do nothing");
+    assert!(
+        engine
+            .manager()
+            .get_subscription(TENANT_ID, "sub-1")
+            .is_none()
+    );
+}
+
+/// A deleted subscription must not come back. `fetch_export_batch` filters
+/// deleted resources, and this pins that behaviour so a backend change cannot
+/// silently resurrect subscriptions a client removed.
+#[tokio::test]
+async fn deleted_subscriptions_are_not_rehydrated() {
+    let backend = storage();
+    seed(&backend, TENANT_ID, topic_resource_type(), topic_resource()).await;
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        subscription_resource("sub-gone", "active", "http://127.0.0.1:1/hook"),
+    )
+    .await;
+    backend
+        .delete(&tenant_context(TENANT_ID), "Subscription", "sub-gone")
+        .await
+        .expect("delete subscription");
+
+    let engine = fresh_engine();
+    let report = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &no_handshake_config(),
+        )
+        .await;
+
+    assert_eq!(report.subscriptions_registered, 0, "report: {report:?}");
+    assert!(
+        engine
+            .manager()
+            .get_subscription(TENANT_ID, "sub-gone")
+            .is_none(),
+        "a deleted subscription must not be resurrected by rehydration"
+    );
+}
+
+/// An unparseable subscription must not abort the pass: the others still load.
+#[tokio::test]
+async fn one_bad_resource_does_not_stop_the_scan() {
+    let backend = storage();
+    seed(&backend, TENANT_ID, topic_resource_type(), topic_resource()).await;
+    // Missing topic reference entirely — `register` will reject it.
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        json!({ "resourceType": "Subscription", "id": "sub-bad", "status": "active" }),
+    )
+    .await;
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        subscription_resource("sub-good", "active", "http://127.0.0.1:1/hook"),
+    )
+    .await;
+
+    let engine = fresh_engine();
+    let report = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &no_handshake_config(),
+        )
+        .await;
+
+    assert_eq!(report.subscriptions_failed, 1, "report: {report:?}");
+    assert_eq!(report.subscriptions_registered, 1, "report: {report:?}");
+    assert!(
+        report.is_complete(),
+        "a per-resource failure must not mark the pass incomplete: {report:?}"
+    );
+    assert!(
+        engine
+            .manager()
+            .get_subscription(TENANT_ID, "sub-good")
+            .is_some(),
+        "the good subscription must still be registered"
+    );
+}
+
+/// Rehydration is idempotent: running it twice (a crash-loop, or a future
+/// periodic refresh) must not duplicate or corrupt registrations.
+#[tokio::test]
+async fn rehydration_is_idempotent() {
+    let backend = storage();
+    seed(&backend, TENANT_ID, topic_resource_type(), topic_resource()).await;
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        subscription_resource("sub-1", "active", "http://127.0.0.1:1/hook"),
+    )
+    .await;
+
+    let engine = fresh_engine();
+    let first = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &no_handshake_config(),
+        )
+        .await;
+    let second = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &no_handshake_config(),
+        )
+        .await;
+
+    assert_eq!(
+        first.subscriptions_registered, second.subscriptions_registered,
+        "a second pass must register the same set"
+    );
+    let sub = engine
+        .manager()
+        .get_subscription(TENANT_ID, "sub-1")
+        .expect("still registered");
+    assert_eq!(sub.status, SubscriptionStatusCode::Active);
+}

--- a/crates/subscriptions/tests/rehydrate_integration.rs
+++ b/crates/subscriptions/tests/rehydrate_integration.rs
@@ -23,6 +23,8 @@ use helios_subscriptions::{
 };
 use serde_json::{Value, json};
 use std::time::Duration;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 const TENANT_ID: &str = "tenant-a";
 const OTHER_TENANT_ID: &str = "tenant-b";
@@ -564,4 +566,110 @@ async fn rehydration_is_idempotent() {
         .get_subscription(TENANT_ID, "sub-1")
         .expect("still registered");
     assert_eq!(sub.status, SubscriptionStatusCode::Active);
+}
+
+/// The core reason rehydration re-handshakes: status transitions are not
+/// persisted, so a subscription the server activated in a previous lifetime
+/// still reads `requested` from storage. Rehydration must drive it back through
+/// the handshake and leave it `active` — otherwise the fix restores nothing for
+/// exactly the subscriptions that were working before the restart.
+#[tokio::test]
+async fn requested_subscriptions_are_handshaked_and_activated() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/hook"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let backend = storage();
+    seed(&backend, TENANT_ID, topic_resource_type(), topic_resource()).await;
+    let endpoint = format!("{}/hook", server.uri());
+    seed(
+        &backend,
+        TENANT_ID,
+        "Subscription",
+        subscription_resource("sub-req", "requested", &endpoint),
+    )
+    .await;
+
+    let engine = fresh_engine();
+    // Default config handshakes `requested` subscriptions — the behaviour under
+    // test, and the opposite of `no_handshake_config`.
+    let report = engine
+        .rehydrate(
+            &backend,
+            TENANT_ID,
+            current_fhir_version(),
+            &RehydrationConfig::default(),
+        )
+        .await;
+
+    assert_eq!(report.subscriptions_registered, 1, "report: {report:?}");
+    assert_eq!(
+        report.handshakes_started, 1,
+        "a stored `requested` subscription must be scheduled for handshake: {report:?}"
+    );
+
+    // `rehydrate` awaits `activate_pending`, so the handshake has completed by
+    // the time it returns.
+    let sub = engine
+        .manager()
+        .get_subscription(TENANT_ID, "sub-req")
+        .expect("subscription registered");
+    assert_eq!(
+        sub.status,
+        SubscriptionStatusCode::Active,
+        "a successful handshake must transition the subscription to active"
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server request log");
+    assert_eq!(
+        requests.len(),
+        1,
+        "rehydration must send exactly one handshake to the endpoint"
+    );
+}
+
+/// Rehydration must page through storage without dropping or duplicating
+/// resources. Forcing a batch size below the resource count exercises the
+/// cursor-advance loop that a single-page fixture never reaches.
+#[tokio::test]
+async fn rehydration_pages_across_multiple_batches() {
+    let backend = storage();
+    seed(&backend, TENANT_ID, topic_resource_type(), topic_resource()).await;
+    for id in ["sub-1", "sub-2", "sub-3"] {
+        seed(
+            &backend,
+            TENANT_ID,
+            "Subscription",
+            subscription_resource(id, "active", "http://127.0.0.1:1/hook"),
+        )
+        .await;
+    }
+
+    let engine = fresh_engine();
+    let paged_config = RehydrationConfig {
+        batch_size: 1,
+        handshake_requested: false,
+        ..RehydrationConfig::default()
+    };
+    let report = engine
+        .rehydrate(&backend, TENANT_ID, current_fhir_version(), &paged_config)
+        .await;
+
+    assert!(report.is_complete(), "report: {report:?}");
+    assert_eq!(
+        report.subscriptions_registered, 3,
+        "every subscription across pages must be registered exactly once: {report:?}"
+    );
+    for id in ["sub-1", "sub-2", "sub-3"] {
+        assert!(
+            engine.manager().get_subscription(TENANT_ID, id).is_some(),
+            "{id} must survive paged rehydration"
+        );
+    }
 }


### PR DESCRIPTION
Closes #305.

## The bug

The subscription engine's registries are in-memory and were populated **only** by live write handlers (`create`/`update`/`patch`/`delete`). Nothing read stored `Subscription` / `SubscriptionTopic` resources back at startup, so a restart, redeploy, or crash left every stored subscription inert — no matching, no evaluation, no delivery. Nothing surfaced an error: the resources still read back fine over the REST API, so the server looked healthy while silently notifying nobody.

## What the issue understated

The issue proposes "register the active ones". Verifying against the code turned up something that changes the fix:

**`SubscriptionManager::update_status` is in-memory only — it never writes back to storage** (`manager/mod.rs:299-328`).

So a subscription a client POSTed as `requested`, which handshook successfully and became `Active` in memory, still reads `"requested"` from the database forever. Rehydrating only `status == "active"` resources would therefore have missed essentially *every* subscription the server itself activated — it would have looked like a fix while restoring almost nothing.

`requested` subscriptions are consequently re-activated through the same handshake path the write handler uses, bounded by a concurrency cap so a restart cannot stampede subscriber endpoints.

## Approach

`SubscriptionEngine::rehydrate` is the startup mirror of the write path. Per tenant, in dependency order:

1. `SubscriptionTopic` — native topics (R4B/R5/R6)
2. `Basic` — R4 backport topics, which are stored as `Basic` resources
3. `Subscription`

The order is a **correctness constraint**, not a preference: `register` rejects a subscription whose topic is not already in the registry (`TopicNotFound`). A test seeds the subscription *before* the topic so storage ordering can't accidentally produce the right answer.

### All backends, no DB work

Driven by `ExportDataProvider::fetch_export_batch` — the one enumeration primitive **every** primary backend implements: SQLite, PostgreSQL, MongoDB, S3, and `CompositeStorage`. One implementation covers all of them with **no schema change, no migration, and no per-backend query to drift**. It also already filters deleted resources and is cursor-paged, so peak memory stays bounded.

`SearchProvider::search` was the alternative — it carries a richer `StoredResource` — but standalone S3 reports search unsupported and would have silently rehydrated nothing.

| Primitive | All backends? | Carries `fhir_version`? | Per-DB work |
|---|---|---|---|
| `SearchProvider::search` | No (S3 standalone) | Yes | none |
| new `list_resources_of_type` | only if hand-written ×5 | Yes | **5 backends + composite** |
| `ExportDataProvider::fetch_export_batch` | **Yes** | No — recovered, see below | **none** |

### FHIR version is recovered, not guessed

`fetch_export_batch` yields raw resource JSON, so the persisted `fhir_version` is unavailable. It doesn't need to be: every version-dependent branch in the crate is a binary R4-vs-native split, and both sides are directly observable in the resource.

| | R4 (backport) | R4B / R5 / R6 (native) |
|---|---|---|
| topic | `criteria` / `backport-topic-canonical` ext | `topic` |
| channel | `channel` object | `channelType` coding |

Native markers win (they cannot appear in a genuine R4 backport resource); ambiguous resources fall back to the server default, matching what the write path stores for a request that omits `fhirVersion`.

### Status policy

| Stored status | Action | Why |
|---|---|---|
| `off` | skipped | Terminal — `can_transition_to` permits no target |
| `active` | registered, no handshake | Established in a previous process lifetime |
| `error` | registered, dormant | Never matches, but keeps `$status` honest |
| `requested` | registered **and activated** | See above — this is the common case |

### Where it's wired

In `build_app`, not `main.rs` as the issue suggested. `build_app` is the single funnel all eight backend start paths share, and the only place holding both the engine and the storage handle — `main.rs` cannot reach the engine, which is constructed and moved into `AppState` here, so wiring it there would need eight call sites plus an ownership change.

It runs in a background task: registration is fast, but activating `requested` subscriptions performs handshakes with retry/backoff against possibly-dead endpoints, which could otherwise delay serving by minutes. The spawn is guarded with `Handle::try_current()` so a non-async embedder gets a warning instead of a panic.

## Config

| Variable | Default | Description |
|---|---|---|
| `HFS_SUBSCRIPTION_REHYDRATE` | `true` | Reload stored subscriptions/topics at startup |
| `HFS_SUBSCRIPTION_REHYDRATE_BATCH_SIZE` | `500` | Resources per storage round-trip |
| `HFS_SUBSCRIPTION_REHYDRATE_HANDSHAKE` | `true` | Re-run the handshake for stored `requested` subscriptions |
| `HFS_SUBSCRIPTION_REHYDRATE_HANDSHAKE_CONCURRENCY` | `8` | Max handshakes in flight, across all tenants |

## Tests

`crates/subscriptions/tests/rehydrate_integration.rs` — against a **real** SQLite backend, simulating a restart by seeding storage and then constructing a *fresh* engine. Each test asserts the fresh engine is inert **before** rehydration, which is what makes these regression tests rather than feature tests: without that half, a no-op `rehydrate` would still pass.

- active subscription survives a restart, and genuinely matches events afterwards
- topics registered before subscriptions (subscription seeded first)
- `off` skipped; deleted subscriptions not resurrected
- every tenant covered; rehydrated subscriptions stay tenant-isolated
- one bad resource doesn't stop the scan (and doesn't mark the pass incomplete)
- disabling is a true no-op; rehydration is idempotent

Plus unit tests for version inference and report accounting.

## Notes / limitations

- **Not fixed here:** persisting status transitions, which would remove the re-handshake entirely. That needs a write path from the engine back into storage, changes the write handlers, and raises cross-replica conflict questions — closer to #170. Worth a follow-up issue.
- On R4 builds the `Basic` scan pages through *all* `Basic` resources in a tenant, not just topics (they're indistinguishable at the storage layer). Background work, bounded by batch size, but a tenant with many unrelated `Basic` resources pays some startup I/O.
- Does not address #170: each replica still rehydrates its own independent view. It does mean every replica now *has* a complete view, where previously each had only what it personally served.
- **Not compiled locally** — this environment has no C linker (`ld` only, no `cc`), so `cargo check`/`test` cannot run. `cargo fmt` passes and the code was hand-reviewed carefully, but CI is the first real compile.
