### PR TITLE
fix(sof): guard version matches against foreign helios-fhir feature activation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         timeout-minutes: 15
         env:
           RUN_MINIO_S3_TESTS: "1"
-          EXPECTED_MINIO_SETTINGS_TESTS: "4"
+          EXPECTED_MINIO_SETTINGS_TESTS: "5"
           # The single self-hosted Windows runner is a virtualized guest whose
           # CPU does not advertise SSE4.1 + PCLMULQDQ. The AWS S3 SDK's default
           # integrity protection computes a CRC32 on every upload via the

--- a/crates/sof/src/cli.rs
+++ b/crates/sof/src/cli.rs
@@ -422,6 +422,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let vd: helios_fhir::r6::ViewDefinition = serde_json::from_str(&view_content)?;
             SofViewDefinition::R6(vd)
         }
+        // A `FhirVersion` variant can exist without helios-sof enabling the
+        // matching feature: another crate in the build graph (e.g. helios-audit,
+        // whose R5/R6 features alias to helios-fhir/R4B for the BALP baseline)
+        // can turn on a helios-fhir version feature that helios-sof did not.
+        // Unlike the guarded matches over `get_newest_enabled_fhir_version()`,
+        // this arm is reachable: `--fhir-version` accepts any variant clap can
+        // see, so reject the unsupported version instead of panicking.
+        #[allow(unreachable_patterns)]
+        other => {
+            return Err(format!(
+                "FHIR version {other:?} is not enabled for SQL-on-FHIR in this build"
+            )
+            .into());
+        }
     };
 
     // Check if we should use streaming mode for NDJSON

--- a/crates/sof/src/handlers.rs
+++ b/crates/sof/src/handlers.rs
@@ -766,6 +766,16 @@ fn parse_parameters(json: serde_json::Value) -> ServerResult<RunParameters> {
                 .map_err(|e| ServerError::BadRequest(format!("Invalid R6 Parameters: {}", e)))?;
             Ok(RunParameters::R6(params))
         }
+        // A `FhirVersion` variant can exist without helios-sof enabling the
+        // matching feature: another crate in the build graph (e.g. helios-audit,
+        // whose R5/R6 features alias to helios-fhir/R4B for the BALP baseline)
+        // can turn on a helios-fhir version feature that helios-sof did not.
+        // `newest_version` always comes from helios-sof's own features, so this
+        // arm is genuinely unreachable at runtime.
+        #[allow(unreachable_patterns)]
+        _ => unreachable!(
+            "get_newest_enabled_fhir_version only returns versions enabled for helios-sof"
+        ),
     }
 }
 

--- a/crates/sof/src/models.rs
+++ b/crates/sof/src/models.rs
@@ -632,6 +632,13 @@ pub fn extract_all_parameters(params: RunParameters) -> Result<ExtractedParamete
         RunParameters::R5(_) => params_json.get("R5"),
         #[cfg(feature = "R6")]
         RunParameters::R6(_) => params_json.get("R6"),
+        // A variant can exist without helios-sof enabling the matching feature
+        // (another crate in the build graph can turn on a helios-fhir version
+        // feature that helios-sof did not), but `RunParameters` values are only
+        // ever built by helios-sof's own feature-gated constructors, so this
+        // arm is genuinely unreachable at runtime.
+        #[allow(unreachable_patterns)]
+        _ => unreachable!("RunParameters is only constructed for versions enabled in helios-sof"),
     }
     .unwrap_or(&params_json);
 


### PR DESCRIPTION
## Summary

Fixes #356 (split out of #350, reported by @dougc95): `helios-audit`'s R5/R6 features enable `helios-fhir/R4B` (BALP baseline) without anything forwarding `helios-sof/R4B`, so the `FhirVersion::R4B` variant exists while sof's cfg-gated match arms are compiled out — single-version builds (`--no-default-features --features R5,postgres`) fail with E0004.

## Changes

sof already guards five such matches with a documented `#[allow(unreachable_patterns)]` catch-all for exactly this scenario. This adds the guard to the three sites missing it:

- `cli.rs` — the one **reachable** case: `--fhir-version` accepts any variant clap can see, so it returns an error for versions not enabled in this build instead of panicking.
- `handlers.rs` — `get_newest_enabled_fhir_version()` only returns sof-enabled versions; `unreachable!` guard matching the existing sites.
- `models.rs` — `RunParameters` values are only built by sof's own feature-gated constructors; same guard. (This third site was surfaced by actually building the failing combination — the issue listed only the first two.)

## Verification

- `cargo check -p helios-sof --no-default-features --features R5,helios-fhir/R4B` — was E0004 ×3, now clean.
- `cargo check -p helios-hfs --no-default-features --features R5,postgres` (the exact combination from #350's report) — now compiles.
- Default build: clippy, fmt, and the 127 sof unit tests unchanged and green.