### PR TITLE
fix(rest,persistence): stamp bundle writes with the negotiated FHIR version

### DIFF
--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -2307,6 +2307,7 @@ impl BundleProvider for MongoBackend {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> Result<BundleResult, TransactionError> {
         let db = self
             .get_database()
@@ -2334,6 +2335,7 @@ impl BundleProvider for MongoBackend {
                     &mut session,
                     tenant,
                     entry,
+                    fhir_version,
                     &mut pending_search_parameter_changes,
                 )
                 .await;
@@ -2401,6 +2403,7 @@ impl BundleProvider for MongoBackend {
         &self,
         _tenant: &TenantContext,
         _entries: Vec<BundleEntry>,
+        _fhir_version: helios_fhir::FhirVersion,
     ) -> StorageResult<BundleResult> {
         Err(StorageError::Backend(BackendError::UnsupportedCapability {
             backend_name: "mongodb".to_string(),
@@ -2416,6 +2419,7 @@ impl MongoBackend {
         session: &mut ClientSession,
         tenant: &TenantContext,
         entry: &BundleEntry,
+        fhir_version: helios_fhir::FhirVersion,
         pending_search_parameter_changes: &mut Vec<PendingSearchParameterChange>,
     ) -> StorageResult<BundleEntryResult> {
         match entry.method {
@@ -2498,6 +2502,7 @@ impl MongoBackend {
                         tenant,
                         &resource_type,
                         resource,
+                        fhir_version,
                         pending_search_parameter_changes,
                     )
                     .await?;
@@ -2554,6 +2559,7 @@ impl MongoBackend {
                                 tenant,
                                 &resource_type,
                                 resource_with_id,
+                                fhir_version,
                                 pending_search_parameter_changes,
                             )
                             .await?;
@@ -2626,6 +2632,7 @@ impl MongoBackend {
         tenant: &TenantContext,
         resource_type: &str,
         resource: Value,
+        fhir_version: helios_fhir::FhirVersion,
         pending_search_parameter_changes: &mut Vec<PendingSearchParameterChange>,
     ) -> StorageResult<StoredResource> {
         let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
@@ -2667,7 +2674,6 @@ impl MongoBackend {
         let now = Utc::now();
         let now_bson = chrono_to_bson(now);
         let version_id = "1".to_string();
-        let fhir_version = FhirVersion::default_enabled();
         let fhir_version_str = fhir_version.as_mime_param().to_string();
 
         resources

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -2549,13 +2549,14 @@ impl BundleProvider for PostgresBackend {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> Result<BundleResult, TransactionError> {
         use crate::core::transaction::{Transaction, TransactionOptions, TransactionProvider};
         use std::collections::HashMap;
 
         // Start a transaction
         let mut tx = self
-            .begin_transaction(tenant, TransactionOptions::new())
+            .begin_transaction(tenant, TransactionOptions::new().fhir_version(fhir_version))
             .await
             .map_err(|e| TransactionError::RolledBack {
                 reason: format!("Failed to begin transaction: {}", e),
@@ -2636,12 +2637,13 @@ impl BundleProvider for PostgresBackend {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> StorageResult<BundleResult> {
         let mut results = Vec::with_capacity(entries.len());
 
         // Process each entry independently
         for entry in &entries {
-            let result = self.process_batch_entry(tenant, entry).await;
+            let result = self.process_batch_entry(tenant, entry, fhir_version).await;
             results.push(result);
         }
 
@@ -2756,8 +2758,12 @@ impl PostgresBackend {
         &self,
         tenant: &TenantContext,
         entry: &BundleEntry,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> BundleEntryResult {
-        match self.process_batch_entry_inner(tenant, entry).await {
+        match self
+            .process_batch_entry_inner(tenant, entry, fhir_version)
+            .await
+        {
             Ok(result) => result,
             Err(e) => BundleEntryResult::error(
                 500,
@@ -2773,6 +2779,7 @@ impl PostgresBackend {
         &self,
         tenant: &TenantContext,
         entry: &BundleEntry,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> StorageResult<BundleEntryResult> {
         match entry.method {
             BundleMethod::Get => {
@@ -2808,12 +2815,7 @@ impl PostgresBackend {
                     })?;
 
                 let created = self
-                    .create(
-                        tenant,
-                        &resource_type,
-                        resource,
-                        FhirVersion::default_enabled(),
-                    )
+                    .create(tenant, &resource_type, resource, fhir_version)
                     .await?;
                 Ok(BundleEntryResult::created(created))
             }
@@ -2826,13 +2828,7 @@ impl PostgresBackend {
 
                 let (resource_type, id) = self.parse_url(&entry.url)?;
                 let (stored, _created) = self
-                    .create_or_update(
-                        tenant,
-                        &resource_type,
-                        &id,
-                        resource,
-                        FhirVersion::default_enabled(),
-                    )
+                    .create_or_update(tenant, &resource_type, &id, resource, fhir_version)
                     .await?;
                 Ok(BundleEntryResult::ok(stored))
             }

--- a/crates/persistence/src/backends/postgres/transaction.rs
+++ b/crates/persistence/src/backends/postgres/transaction.rs
@@ -48,6 +48,8 @@ pub struct PostgresTransaction {
     search_extractor: Arc<SearchParameterExtractor>,
     /// When true, search indexing is offloaded to a secondary backend.
     search_offloaded: bool,
+    /// The FHIR version writes in this transaction are stamped with.
+    fhir_version: FhirVersion,
 }
 
 impl std::fmt::Debug for PostgresTransaction {
@@ -66,6 +68,7 @@ impl PostgresTransaction {
         tenant: TenantContext,
         search_extractor: Arc<SearchParameterExtractor>,
         search_offloaded: bool,
+        fhir_version: FhirVersion,
     ) -> StorageResult<Self> {
         // Start the transaction
         client.execute("BEGIN", &[]).await.map_err(|e| {
@@ -80,6 +83,7 @@ impl PostgresTransaction {
             tenant,
             search_extractor,
             search_offloaded,
+            fhir_version,
         })
     }
 
@@ -191,8 +195,7 @@ impl Transaction for PostgresTransaction {
 
         let now = Utc::now();
         let version_id = "1";
-        let fhir_version = FhirVersion::default_enabled();
-        let fhir_version_str = fhir_version.as_mime_param();
+        let fhir_version_str = self.fhir_version.as_mime_param();
         let is_deleted = false;
 
         // Insert the resource
@@ -228,7 +231,7 @@ impl Transaction for PostgresTransaction {
             now,
             now,
             None,
-            fhir_version,
+            self.fhir_version,
         ))
     }
 
@@ -557,7 +560,7 @@ impl TransactionProvider for PostgresBackend {
     async fn begin_transaction(
         &self,
         tenant: &TenantContext,
-        _options: TransactionOptions,
+        options: TransactionOptions,
     ) -> StorageResult<Self::Transaction> {
         let client = self.get_client().await?;
         PostgresTransaction::new(
@@ -565,6 +568,7 @@ impl TransactionProvider for PostgresBackend {
             tenant.clone(),
             std::sync::Arc::new(self.tenant_extractor(tenant.tenant_id().as_str())),
             self.is_search_offloaded(),
+            options.fhir_version.unwrap_or(self.config().fhir_version),
         )
         .await
     }

--- a/crates/persistence/src/backends/s3/bundle.rs
+++ b/crates/persistence/src/backends/s3/bundle.rs
@@ -8,7 +8,6 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use helios_fhir::FhirVersion;
 use serde_json::{Value, json};
 use uuid::Uuid;
 
@@ -41,6 +40,7 @@ impl BundleProvider for S3Backend {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> Result<BundleResult, TransactionError> {
         let mut entries = entries;
         let mut reference_map: HashMap<String, String> = HashMap::new();
@@ -91,7 +91,7 @@ impl BundleProvider for S3Backend {
         // Phase 3: Execute ALL entries concurrently.
         let futs: Vec<_> = entries
             .iter()
-            .map(|entry| self.execute_bundle_entry(tenant, entry))
+            .map(|entry| self.execute_bundle_entry(tenant, entry, fhir_version))
             .collect();
 
         let outcomes = futures::future::join_all(futs).await;
@@ -150,10 +150,11 @@ impl BundleProvider for S3Backend {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> crate::error::StorageResult<BundleResult> {
         let futs: Vec<_> = entries
             .iter()
-            .map(|entry| self.process_batch_entry(tenant, entry))
+            .map(|entry| self.process_batch_entry(tenant, entry, fhir_version))
             .collect();
 
         let results = futures::future::join_all(futs).await;
@@ -173,8 +174,9 @@ impl S3Backend {
         &self,
         tenant: &TenantContext,
         entry: &BundleEntry,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> BundleEntryResult {
-        match self.execute_bundle_entry(tenant, entry).await {
+        match self.execute_bundle_entry(tenant, entry, fhir_version).await {
             Ok((result, _)) => result,
             Err(err) => Self::bundle_error_result(&err),
         }
@@ -186,6 +188,7 @@ impl S3Backend {
         &self,
         tenant: &TenantContext,
         entry: &BundleEntry,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> crate::error::StorageResult<(BundleEntryResult, Option<CompensationAction>)> {
         match entry.method {
             BundleMethod::Get => {
@@ -233,12 +236,7 @@ impl S3Backend {
                     .to_string();
 
                 let created = self
-                    .create(
-                        tenant,
-                        &resource_type,
-                        resource,
-                        FhirVersion::default_enabled(),
-                    )
+                    .create(tenant, &resource_type, resource, fhir_version)
                     .await?;
 
                 Ok((
@@ -278,13 +276,7 @@ impl S3Backend {
                     ))
                 } else {
                     let (stored, created) = self
-                        .create_or_update(
-                            tenant,
-                            &resource_type,
-                            &id,
-                            resource,
-                            FhirVersion::default_enabled(),
-                        )
+                        .create_or_update(tenant, &resource_type, &id, resource, fhir_version)
                         .await?;
 
                     let result = if created {

--- a/crates/persistence/src/backends/s3/tests.rs
+++ b/crates/persistence/src/backends/s3/tests.rs
@@ -744,7 +744,10 @@ async fn bundle_batch_mixed_results() {
         },
     ];
 
-    let result = backend.process_batch(&tenant, entries).await.unwrap();
+    let result = backend
+        .process_batch(&tenant, entries, FhirVersion::default())
+        .await
+        .unwrap();
     assert_eq!(result.entries.len(), 2);
     assert_eq!(result.entries[0].status, 201);
     assert_eq!(result.entries[1].status, 404);
@@ -776,7 +779,10 @@ async fn bundle_transaction_success_and_reference_resolution() {
         },
     ];
 
-    let result = backend.process_transaction(&tenant, entries).await.unwrap();
+    let result = backend
+        .process_transaction(&tenant, entries, FhirVersion::default())
+        .await
+        .unwrap();
     assert_eq!(result.entries.len(), 2);
 
     let obs = backend
@@ -814,7 +820,9 @@ async fn bundle_transaction_failure_rolls_back() {
         },
     ];
 
-    let result = backend.process_transaction(&tenant, entries).await;
+    let result = backend
+        .process_transaction(&tenant, entries, FhirVersion::default())
+        .await;
     assert!(matches!(result, Err(TransactionError::BundleError { .. })));
 
     let read = backend.read(&tenant, "Patient", "rollback-me").await;
@@ -848,7 +856,9 @@ async fn bundle_transaction_reports_rollback_failure() {
         },
     ];
 
-    let result = backend.process_transaction(&tenant, entries).await;
+    let result = backend
+        .process_transaction(&tenant, entries, FhirVersion::default())
+        .await;
     match result {
         Err(TransactionError::BundleError { message, .. }) => {
             assert!(message.contains("rollback failed"));

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -2881,13 +2881,14 @@ impl BundleProvider for SqliteBackend {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> Result<BundleResult, TransactionError> {
         use crate::core::transaction::{Transaction, TransactionOptions, TransactionProvider};
         use std::collections::HashMap;
 
         // Start a transaction
         let mut tx = self
-            .begin_transaction(tenant, TransactionOptions::new())
+            .begin_transaction(tenant, TransactionOptions::new().fhir_version(fhir_version))
             .await
             .map_err(|e| TransactionError::RolledBack {
                 reason: format!("Failed to begin transaction: {}", e),
@@ -2972,12 +2973,13 @@ impl BundleProvider for SqliteBackend {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> StorageResult<BundleResult> {
         let mut results = Vec::with_capacity(entries.len());
 
         // Process each entry independently
         for entry in &entries {
-            let result = self.process_batch_entry(tenant, entry).await;
+            let result = self.process_batch_entry(tenant, entry, fhir_version).await;
             results.push(result);
         }
 
@@ -3096,8 +3098,12 @@ impl SqliteBackend {
         &self,
         tenant: &TenantContext,
         entry: &BundleEntry,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> BundleEntryResult {
-        match self.process_batch_entry_inner(tenant, entry).await {
+        match self
+            .process_batch_entry_inner(tenant, entry, fhir_version)
+            .await
+        {
             Ok(result) => result,
             Err(e) => BundleEntryResult::error(
                 500,
@@ -3113,6 +3119,7 @@ impl SqliteBackend {
         &self,
         tenant: &TenantContext,
         entry: &BundleEntry,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> StorageResult<BundleEntryResult> {
         match entry.method {
             BundleMethod::Get => {
@@ -3147,14 +3154,8 @@ impl SqliteBackend {
                         )
                     })?;
 
-                // Use default FHIR version for bundle operations
                 let created = self
-                    .create(
-                        tenant,
-                        &resource_type,
-                        resource,
-                        FhirVersion::default_enabled(),
-                    )
+                    .create(tenant, &resource_type, resource, fhir_version)
                     .await?;
                 Ok(BundleEntryResult::created(created))
             }
@@ -3166,15 +3167,8 @@ impl SqliteBackend {
                 })?;
 
                 let (resource_type, id) = self.parse_url(&entry.url)?;
-                // Use default FHIR version for bundle operations
                 let (stored, _created) = self
-                    .create_or_update(
-                        tenant,
-                        &resource_type,
-                        &id,
-                        resource,
-                        FhirVersion::default_enabled(),
-                    )
+                    .create_or_update(tenant, &resource_type, &id, resource, fhir_version)
                     .await?;
                 Ok(BundleEntryResult::ok(stored))
             }
@@ -5971,11 +5965,60 @@ mod tests {
             },
         ];
 
-        let result = backend.process_batch(&tenant, entries).await.unwrap();
+        let result = backend
+            .process_batch(&tenant, entries, helios_fhir::FhirVersion::default())
+            .await
+            .unwrap();
 
         assert_eq!(result.entries.len(), 2);
         assert_eq!(result.entries[0].status, 201);
         assert_eq!(result.entries[1].status, 201);
+    }
+
+    /// #350: bundle-created resources must be stamped with the bundle's
+    /// negotiated version, not the compile-time default.
+    #[cfg(feature = "R5")]
+    #[tokio::test]
+    async fn test_bundle_writes_stamp_the_negotiated_version() {
+        use crate::core::transaction::BundleProvider;
+
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        let entry = |id: &str| BundleEntry {
+            method: BundleMethod::Post,
+            url: "Patient".to_string(),
+            resource: Some(json!({"resourceType": "Patient", "id": id})),
+            if_match: None,
+            if_none_match: None,
+            if_none_exist: None,
+            full_url: None,
+        };
+
+        let tx_result = backend
+            .process_transaction(&tenant, vec![entry("tx-r5")], helios_fhir::FhirVersion::R5)
+            .await
+            .unwrap();
+        assert_eq!(tx_result.entries[0].status, 201);
+
+        let batch_result = backend
+            .process_batch(
+                &tenant,
+                vec![entry("batch-r5")],
+                helios_fhir::FhirVersion::R5,
+            )
+            .await
+            .unwrap();
+        assert_eq!(batch_result.entries[0].status, 201);
+
+        for id in ["tx-r5", "batch-r5"] {
+            let stored = backend.read(&tenant, "Patient", id).await.unwrap().unwrap();
+            assert_eq!(
+                stored.fhir_version(),
+                helios_fhir::FhirVersion::R5,
+                "{id} should be stamped R5"
+            );
+        }
     }
 
     #[tokio::test]
@@ -6029,7 +6072,10 @@ mod tests {
             },
         ];
 
-        let result = backend.process_batch(&tenant, entries).await.unwrap();
+        let result = backend
+            .process_batch(&tenant, entries, helios_fhir::FhirVersion::default())
+            .await
+            .unwrap();
 
         assert_eq!(result.entries.len(), 3);
         assert_eq!(result.entries[0].status, 200); // Read existing
@@ -6065,7 +6111,10 @@ mod tests {
             full_url: None,
         }];
 
-        let result = backend.process_batch(&tenant, entries).await.unwrap();
+        let result = backend
+            .process_batch(&tenant, entries, helios_fhir::FhirVersion::default())
+            .await
+            .unwrap();
 
         assert_eq!(result.entries.len(), 1);
         assert_eq!(result.entries[0].status, 204);
@@ -6120,7 +6169,9 @@ mod tests {
             },
         ];
 
-        let result = backend.process_transaction(&tenant, entries).await;
+        let result = backend
+            .process_transaction(&tenant, entries, helios_fhir::FhirVersion::default())
+            .await;
 
         // Should fail
         assert!(result.is_err());
@@ -6158,7 +6209,10 @@ mod tests {
             },
         ];
 
-        let result = backend.process_transaction(&tenant, entries).await.unwrap();
+        let result = backend
+            .process_transaction(&tenant, entries, helios_fhir::FhirVersion::default())
+            .await
+            .unwrap();
 
         assert_eq!(result.entries.len(), 2);
         assert_eq!(result.entries[0].status, 201);

--- a/crates/persistence/src/backends/sqlite/transaction.rs
+++ b/crates/persistence/src/backends/sqlite/transaction.rs
@@ -45,6 +45,8 @@ pub struct SqliteTransaction {
     search_extractor: Arc<SearchParameterExtractor>,
     /// When true, search indexing is offloaded to a secondary backend.
     search_offloaded: bool,
+    /// The FHIR version writes in this transaction are stamped with.
+    fhir_version: FhirVersion,
 }
 
 impl std::fmt::Debug for SqliteTransaction {
@@ -63,6 +65,7 @@ impl SqliteTransaction {
         tenant: TenantContext,
         search_extractor: Arc<SearchParameterExtractor>,
         search_offloaded: bool,
+        fhir_version: FhirVersion,
     ) -> StorageResult<Self> {
         // Start the transaction
         conn.execute("BEGIN IMMEDIATE", []).map_err(|e| {
@@ -77,6 +80,7 @@ impl SqliteTransaction {
             tenant,
             search_extractor,
             search_offloaded,
+            fhir_version,
         })
     }
 
@@ -214,9 +218,7 @@ impl Transaction for SqliteTransaction {
         let last_updated = now.to_rfc3339();
         let version_id = "1";
 
-        // Use default FHIR version for transaction operations
-        let fhir_version = FhirVersion::default_enabled();
-        let fhir_version_str = fhir_version.as_mime_param();
+        let fhir_version_str = self.fhir_version.as_mime_param();
 
         // Insert the resource
         conn.execute(
@@ -246,7 +248,7 @@ impl Transaction for SqliteTransaction {
             now,
             now,
             None,
-            fhir_version,
+            self.fhir_version,
         ))
     }
 
@@ -545,7 +547,7 @@ impl TransactionProvider for SqliteBackend {
     async fn begin_transaction(
         &self,
         tenant: &TenantContext,
-        _options: TransactionOptions,
+        options: TransactionOptions,
     ) -> StorageResult<Self::Transaction> {
         let conn = self.get_connection()?;
         SqliteTransaction::new(
@@ -553,6 +555,7 @@ impl TransactionProvider for SqliteBackend {
             tenant.clone(),
             Arc::new(self.tenant_extractor(tenant.tenant_id().as_str())),
             self.is_search_offloaded(),
+            options.fhir_version.unwrap_or(self.config().fhir_version),
         )
     }
 }

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -674,7 +674,12 @@ impl CompositeStorage {
     }
 
     /// Syncs bundle results to secondaries by extracting resource info from responses.
-    async fn sync_bundle_results(&self, tenant: &TenantContext, result: &BundleResult) {
+    async fn sync_bundle_results(
+        &self,
+        tenant: &TenantContext,
+        result: &BundleResult,
+        fhir_version: FhirVersion,
+    ) {
         for entry_result in &result.entries {
             // Only sync successful mutating operations that have a resource body
             if let Some(ref resource_json) = entry_result.resource {
@@ -690,12 +695,6 @@ impl CompositeStorage {
                 if resource_type.is_empty() || resource_id.is_empty() {
                     continue;
                 }
-
-                let fhir_version = resource_json
-                    .get("meta")
-                    .and_then(|m| m.get("profile"))
-                    .map(|_| FhirVersion::default_enabled())
-                    .unwrap_or_else(FhirVersion::default_enabled);
 
                 if let Err(e) = self
                     .sync_to_secondaries(SyncEvent::Create {
@@ -1673,6 +1672,7 @@ impl BundleProvider for CompositeStorage {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> Result<BundleResult, TransactionError> {
         let provider =
             self.bundle_provider
@@ -1682,10 +1682,13 @@ impl BundleProvider for CompositeStorage {
                     message: "BundleProvider not available on composite primary".to_string(),
                 })?;
 
-        let result = provider.process_transaction(tenant, entries).await?;
+        let result = provider
+            .process_transaction(tenant, entries, fhir_version)
+            .await?;
 
         // Sync successful entries to secondaries by reading resources from primary
-        self.sync_bundle_results(tenant, &result).await;
+        self.sync_bundle_results(tenant, &result, fhir_version)
+            .await;
 
         Ok(result)
     }
@@ -1694,6 +1697,7 @@ impl BundleProvider for CompositeStorage {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> StorageResult<BundleResult> {
         let provider = self.bundle_provider.as_ref().ok_or_else(|| {
             StorageError::Backend(BackendError::UnsupportedCapability {
@@ -1702,10 +1706,13 @@ impl BundleProvider for CompositeStorage {
             })
         })?;
 
-        let result = provider.process_batch(tenant, entries).await?;
+        let result = provider
+            .process_batch(tenant, entries, fhir_version)
+            .await?;
 
         // Sync successful entries to secondaries
-        self.sync_bundle_results(tenant, &result).await;
+        self.sync_bundle_results(tenant, &result, fhir_version)
+            .await;
 
         Ok(result)
     }
@@ -3673,7 +3680,9 @@ mod tests {
         use crate::core::BundleProvider;
         let composite = make_composite_no_secondary();
         let tenant = make_tenant();
-        let result = composite.process_batch(&tenant, vec![]).await;
+        let result = composite
+            .process_batch(&tenant, vec![], helios_fhir::FhirVersion::default())
+            .await;
         assert!(result.is_err());
         match result.unwrap_err() {
             StorageError::Backend(BackendError::UnsupportedCapability { capability, .. }) => {
@@ -3688,7 +3697,9 @@ mod tests {
         use crate::core::BundleProvider;
         let composite = make_composite_no_secondary();
         let tenant = make_tenant();
-        let result = composite.process_transaction(&tenant, vec![]).await;
+        let result = composite
+            .process_transaction(&tenant, vec![], helios_fhir::FhirVersion::default())
+            .await;
         assert!(result.is_err());
     }
 

--- a/crates/persistence/src/core/transaction.rs
+++ b/crates/persistence/src/core/transaction.rs
@@ -61,6 +61,11 @@ pub struct TransactionOptions {
     pub timeout_ms: u64,
     /// Whether this is a read-only transaction.
     pub read_only: bool,
+    /// The FHIR version resources written in this transaction are stamped
+    /// with. A transaction serves one request, and a request negotiates one
+    /// version, so it rides on the transaction rather than on every write.
+    /// `None` falls back to the backend's configured version.
+    pub fhir_version: Option<helios_fhir::FhirVersion>,
 }
 
 impl TransactionOptions {
@@ -91,6 +96,12 @@ impl TransactionOptions {
     pub fn read_only(mut self) -> Self {
         self.read_only = true;
         self.locking_strategy = LockingStrategy::None;
+        self
+    }
+
+    /// Sets the FHIR version writes in this transaction are stamped with.
+    pub fn fhir_version(mut self, version: helios_fhir::FhirVersion) -> Self {
+        self.fhir_version = Some(version);
         self
     }
 }
@@ -390,6 +401,8 @@ pub trait BundleProvider: ResourceStorage {
     ///
     /// * `tenant` - The tenant context
     /// * `entries` - The bundle entries to process
+    /// * `fhir_version` - The version created/updated resources are stamped
+    ///   with — the request's negotiated version (one bundle, one version)
     ///
     /// # Returns
     ///
@@ -398,6 +411,7 @@ pub trait BundleProvider: ResourceStorage {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> Result<BundleResult, TransactionError>;
 
     /// Processes a batch bundle (independent operations).
@@ -409,6 +423,8 @@ pub trait BundleProvider: ResourceStorage {
     ///
     /// * `tenant` - The tenant context
     /// * `entries` - The bundle entries to process
+    /// * `fhir_version` - The version created/updated resources are stamped
+    ///   with — the request's negotiated version (one bundle, one version)
     ///
     /// # Returns
     ///
@@ -417,6 +433,7 @@ pub trait BundleProvider: ResourceStorage {
         &self,
         tenant: &TenantContext,
         entries: Vec<BundleEntry>,
+        fhir_version: helios_fhir::FhirVersion,
     ) -> StorageResult<BundleResult>;
 }
 

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -168,7 +168,10 @@ async fn mongodb_integration_transaction_bundle_topology_behavior() {
 
     let tenant = create_tenant("tenant-bundle-topology");
 
-    match backend.process_transaction(&tenant, vec![]).await {
+    match backend
+        .process_transaction(&tenant, vec![], FhirVersion::default())
+        .await
+    {
         Ok(bundle_result) => assert!(bundle_result.entries.is_empty()),
         Err(TransactionError::UnsupportedIsolationLevel { .. }) => {
             eprintln!(
@@ -184,7 +187,9 @@ async fn test_mongodb_bundle_provider_batch_not_supported() {
     let backend = MongoBackend::new(MongoBackendConfig::default()).unwrap();
     let tenant = create_tenant("tenant-bundle-batch");
 
-    let result = backend.process_batch(&tenant, vec![]).await;
+    let result = backend
+        .process_batch(&tenant, vec![], FhirVersion::default())
+        .await;
     assert!(matches!(
         result,
         Err(StorageError::Backend(
@@ -199,7 +204,10 @@ async fn process_transaction_or_skip(
     entries: Vec<BundleEntry>,
     test_name: &str,
 ) -> Option<BundleResult> {
-    match backend.process_transaction(tenant, entries).await {
+    match backend
+        .process_transaction(tenant, entries, FhirVersion::default())
+        .await
+    {
         Ok(result) => Some(result),
         Err(TransactionError::UnsupportedIsolationLevel { .. }) => {
             eprintln!(
@@ -952,7 +960,10 @@ async fn mongodb_integration_transaction_bundle_conditional_headers() {
         full_url: None,
     }];
 
-    match backend.process_transaction(&tenant, bad_if_match).await {
+    match backend
+        .process_transaction(&tenant, bad_if_match, FhirVersion::default())
+        .await
+    {
         Err(TransactionError::UnsupportedIsolationLevel { .. }) => {
             eprintln!(
                 "Skipping mongodb_integration_transaction_bundle_conditional_headers/if-match-bad (MongoDB topology does not support transactions)"
@@ -1029,7 +1040,10 @@ async fn mongodb_integration_transaction_bundle_rolls_back_on_failure() {
         },
     ];
 
-    match backend.process_transaction(&tenant, entries).await {
+    match backend
+        .process_transaction(&tenant, entries, FhirVersion::default())
+        .await
+    {
         Err(TransactionError::UnsupportedIsolationLevel { .. }) => {
             eprintln!(
                 "Skipping mongodb_integration_transaction_bundle_rolls_back_on_failure (MongoDB topology does not support transactions)"

--- a/crates/persistence/tests/s3_tests.rs
+++ b/crates/persistence/tests/s3_tests.rs
@@ -170,7 +170,10 @@ async fn test_aws_bundle_bulk_export_and_submit() {
         resource: Some(json!({"resourceType":"Patient","id":format!("b-{}", Uuid::new_v4())})),
         ..Default::default()
     }];
-    let bundle = backend.process_batch(&tenant, entries).await.unwrap();
+    let bundle = backend
+        .process_batch(&tenant, entries, FhirVersion::default())
+        .await
+        .unwrap();
     assert_eq!(bundle.entries.len(), 1);
     assert_eq!(bundle.entries[0].status, 201);
 

--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 use tracing::{debug, error, warn};
 
 use crate::error::{RestError, RestResult};
-use crate::extractors::TenantExtractor;
+use crate::extractors::{FhirVersionExtractor, TenantExtractor};
 use crate::handlers::extract_patient_from_resource;
 use crate::middleware::prefer::PreferHeader;
 use crate::state::AppState;
@@ -52,6 +52,7 @@ use crate::state::AppState;
 pub async fn batch_handler<S>(
     State(state): State<AppState<S>>,
     tenant: TenantExtractor,
+    version: FhirVersionExtractor,
     prefer: PreferHeader,
     request: Request,
 ) -> RestResult<Response>
@@ -61,6 +62,11 @@ where
     // Extract the Principal from request extensions (set by auth middleware).
     // If present, per-entry scope checks will be enforced.
     let principal = request.extensions().get::<Principal>().cloned();
+
+    // One bundle, one version: every entry the bundle creates or updates is
+    // stamped with the request's negotiated version, exactly as a
+    // single-resource endpoint would stamp it (#350).
+    let fhir_version = version.storage_version_or(state.config().default_fhir_version);
 
     // Parse the body as JSON
     let bundle: Value = serde_json::from_slice(
@@ -94,9 +100,27 @@ where
             })?;
 
     match bundle_type {
-        "batch" => process_batch(&state, tenant, &prefer, &bundle, principal.as_ref()).await,
+        "batch" => {
+            process_batch(
+                &state,
+                tenant,
+                fhir_version,
+                &prefer,
+                &bundle,
+                principal.as_ref(),
+            )
+            .await
+        }
         "transaction" => {
-            process_transaction(&state, tenant, &prefer, &bundle, principal.as_ref()).await
+            process_transaction(
+                &state,
+                tenant,
+                fhir_version,
+                &prefer,
+                &bundle,
+                principal.as_ref(),
+            )
+            .await
         }
         _ => Err(RestError::BadRequest {
             message: format!(
@@ -111,6 +135,7 @@ where
 async fn process_batch<S>(
     state: &AppState<S>,
     tenant: TenantExtractor,
+    fhir_version: FhirVersion,
     prefer: &PreferHeader,
     bundle: &Value,
     principal: Option<&Principal>,
@@ -134,7 +159,8 @@ where
     let mut response_entries = Vec::with_capacity(entries.len());
 
     for (index, entry) in entries.iter().enumerate() {
-        let result = process_batch_entry(state, &tenant, entry, index, principal).await;
+        let result =
+            process_batch_entry(state, &tenant, fhir_version, entry, index, principal).await;
         let correlation_details = EntryAuditCorrelation::from_bundle(&correlation, index);
         emit_batch_entry_audit(
             state,
@@ -172,6 +198,7 @@ where
 async fn process_transaction<S>(
     state: &AppState<S>,
     tenant: TenantExtractor,
+    fhir_version: FhirVersion,
     prefer: &PreferHeader,
     bundle: &Value,
     principal: Option<&Principal>,
@@ -243,7 +270,7 @@ where
     // Call the persistence layer
     let result = state
         .storage()
-        .process_transaction(tenant.context(), entries_for_processing)
+        .process_transaction(tenant.context(), entries_for_processing, fhir_version)
         .await;
 
     match result {
@@ -319,6 +346,7 @@ where
 async fn process_batch_entry<S>(
     state: &AppState<S>,
     tenant: &TenantExtractor,
+    fhir_version: FhirVersion,
     entry: &Value,
     index: usize,
     principal: Option<&Principal>,
@@ -389,15 +417,9 @@ where
                 }
             };
 
-            // Use default FHIR version for batch operations
             match state
                 .storage()
-                .create(
-                    tenant.context(),
-                    &resource_type,
-                    resource,
-                    FhirVersion::default_enabled(),
-                )
+                .create(tenant.context(), &resource_type, resource, fhir_version)
                 .await
             {
                 Ok(stored) => BundleEntryResult::created(stored),
@@ -416,7 +438,6 @@ where
                 }
             };
 
-            // Use default FHIR version for batch operations
             match state
                 .storage()
                 .create_or_update(
@@ -424,7 +445,7 @@ where
                     &resource_type,
                     &id,
                     resource,
-                    FhirVersion::default_enabled(),
+                    fhir_version,
                 )
                 .await
             {


### PR DESCRIPTION
## Summary

Fixes #350 (defect 1 — the main report): transaction/batch Bundles ignored the request's `fhirVersion` MIME parameter and persisted every entry as the compile-time default (R4 in the all-features release build), while single-resource endpoints honored the same negotiation. A bundle POST followed by a version-negotiated GET returned 406.

**Stacked on #359** (`fix/355-config-default-version`) — the bundle fallback when nothing is negotiated is the *configured* server default from that PR, not the compile-time one. Merge #359 first; this diff then shrinks to the bundle threading.

## Design

One bundle serves one request, and a request negotiates one version — so the version rides once per bundle rather than once per write:

- `batch_handler` gains the same `FhirVersionExtractor` as `create_handler`: Content-Type `fhirVersion`, else `ServerConfig.default_fhir_version`.
- `BundleProvider::process_transaction` / `process_batch` take `fhir_version`; all five backends (sqlite, postgres, mongodb, s3, composite) stamp entry creates/updates with it instead of `FhirVersion::default_enabled()`.
- `TransactionOptions` carries an optional `fhir_version`; `SqliteTransaction` / `PostgresTransaction` stamp writes with it and fall back to the backend's configured version. Existing direct `Transaction` users compile and behave unchanged.
- `CompositeStorage` forwards the version to its primary and to secondary sync — which previously re-derived it from a `meta.profile` inspection that could only ever produce the compile-time default.

## Verification

- New regression test `test_bundle_writes_stamp_the_negotiated_version` (sqlite, R5-gated): transaction and batch entries stored via the composite-facing path read back as R5. Fails before this change (stamped R4).
- helios-persistence 728 lib tests + helios-rest 400 lib tests green; `--all-features --tests` compile clean across persistence/rest/hfs; fmt clean.
- Container-backed suites (postgres, mongo, s3/MinIO) exercise the updated call sites in CI.

Closes #350