### PR TITLE
fix(fhirpath): resolve choice elements against the evaluation context's FHIR version (#309)

### DIFF
--- a/crates/fhirpath/src/evaluator.rs
+++ b/crates/fhirpath/src/evaluator.rs
@@ -2069,17 +2069,6 @@ fn evaluate_invocation(
                         // Check if this field exists directly in the object
                         let exists_directly = obj.contains_key(name.as_str());
 
-                        // Check if it would be found through polymorphic access
-                        let _found_polymorphically = if !exists_directly {
-                            crate::polymorphic_access::access_polymorphic_element(
-                                obj,
-                                name.as_str(),
-                            )
-                            .is_some()
-                        } else {
-                            false
-                        };
-
                         // If the field exists directly but could also be a polymorphic field name
                         if exists_directly
                             && could_be_typed_polymorphic_field(name.as_str(), obj, context)
@@ -2096,10 +2085,14 @@ fn evaluate_invocation(
                         return Ok(result.clone()); // Direct access succeeded
                     }
 
-                    // Try polymorphic access for FHIR choice elements
-                    if let Some(result) =
-                        crate::polymorphic_access::access_polymorphic_element(obj, name.as_str())
-                    {
+                    // Try polymorphic access for FHIR choice elements. The context's
+                    // FHIR version selects the choice-element metadata table — using
+                    // the build default here resolved R5/R6 data against R4 (#309).
+                    if let Some(result) = crate::polymorphic_access::access_polymorphic_element(
+                        obj,
+                        name.as_str(),
+                        context.fhir_version,
+                    ) {
                         return Ok(result); // Return polymorphic result
                     }
 
@@ -7986,6 +7979,7 @@ fn apply_type_operation(
             op,
             &type_name_for_poly,
             namespace_for_poly_opt,
+            context,
         );
 
         if op == "as" && context.is_strict_mode && actual_value != &EvaluationResult::Empty {

--- a/crates/fhirpath/src/polymorphic_access.rs
+++ b/crates/fhirpath/src/polymorphic_access.rs
@@ -1198,4 +1198,169 @@ mod tests {
         assert!(is_polymorphic_base_in_version("value", FhirVersion::R4));
         assert!(is_polymorphic_base_in_version("value", FhirVersion::R5));
     }
+
+    // ---------------------------------------------------------------------
+    // Version-agnostic coverage of the choice-element machinery.
+    //
+    // The cross-version tests above must be gated on two versions being
+    // compiled in, so they vanish from single-version builds — including the
+    // R4-only build CI measures coverage with, which left the functions this
+    // fix changed (`is_choice_element_with_context`, `is_choice_element`,
+    // `is_polymorphic_base_in_version`, and the dotted-path branch of
+    // `access_polymorphic_element`) with no direct test at all.
+    //
+    // The tests below assert only facts that hold in *every* supported
+    // version, verified against the generated `FIELD_TYPES` tables for R4,
+    // R4B, R5 and R6: `value`, `effective` and `onset` are polymorphic bases
+    // in all four, and `identifier` is a base in none. They therefore hold at
+    // `default_enabled()` whichever single version that resolves to.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn access_polymorphic_element_resolves_a_dotted_choice_path() {
+        let obs = create_observation_with_quantity();
+
+        // `value` is a choice base, so `value.unit` must reach the `unit`
+        // inside `valueQuantity` without the caller naming the typed variant.
+        let unit = access_polymorphic_element(&obs, "value.unit", test_version())
+            .expect("value.unit should resolve through valueQuantity");
+        assert_eq!(unit, EvaluationResult::string("lbs".to_string()));
+    }
+
+    #[test]
+    fn access_polymorphic_element_resolves_a_dotted_non_choice_path() {
+        let mut identifier = HashMap::new();
+        identifier.insert(
+            "system".to_string(),
+            EvaluationResult::string("http://example.org/mrn".to_string()),
+        );
+
+        let mut obs = create_observation_with_quantity();
+        obs.insert(
+            "identifier".to_string(),
+            EvaluationResult::Object {
+                map: identifier,
+                type_info: None,
+            },
+        );
+
+        // `identifier` is not a choice base in any supported version, so this
+        // takes the plain nested-object branch rather than the choice branch.
+        assert!(!is_choice_element("identifier", test_version()));
+
+        let system = access_polymorphic_element(&obs, "identifier.system", test_version())
+            .expect("identifier.system should resolve as a plain nested field");
+        assert_eq!(
+            system,
+            EvaluationResult::string("http://example.org/mrn".to_string())
+        );
+    }
+
+    #[test]
+    fn access_polymorphic_element_returns_none_for_an_unresolvable_dotted_path() {
+        let obs = create_observation_with_quantity();
+
+        // Choice branch: `value` resolves, but `valueQuantity` has no `nonesuch`.
+        assert_eq!(
+            access_polymorphic_element(&obs, "value.nonesuch", test_version()),
+            None
+        );
+
+        // Non-choice branch: the object has no `identifier` at all.
+        assert_eq!(
+            access_polymorphic_element(&obs, "identifier.system", test_version()),
+            None
+        );
+    }
+
+    #[test]
+    fn is_choice_element_with_context_honours_the_bracket_form() {
+        // An explicit `[x]` is decisive, whatever the metadata or version says.
+        let no_choices: &[&str] = &[];
+        assert!(is_choice_element_with_context(
+            "value[x]",
+            None,
+            test_version()
+        ));
+        assert!(is_choice_element_with_context(
+            "anything[x]",
+            Some(no_choices),
+            test_version()
+        ));
+    }
+
+    #[test]
+    fn is_choice_element_with_context_prefers_supplied_metadata() {
+        let metadata: &[&str] = &["value", "effective"];
+
+        // The base name itself, and a typed variant of a known base.
+        assert!(is_choice_element_with_context(
+            "value",
+            Some(metadata),
+            test_version()
+        ));
+        assert!(is_choice_element_with_context(
+            "valueQuantity",
+            Some(metadata),
+            test_version()
+        ));
+
+        // Metadata is authoritative when present: `onset` is a choice base in
+        // the generated table, but this caller did not declare it, so the
+        // table must not be consulted as a second chance.
+        assert!(!is_choice_element_with_context(
+            "onset",
+            Some(metadata),
+            test_version()
+        ));
+
+        // A prefix match without an uppercase boundary is not a typed variant.
+        assert!(!is_choice_element_with_context(
+            "values",
+            Some(metadata),
+            test_version()
+        ));
+    }
+
+    #[test]
+    fn is_choice_element_falls_back_to_the_generated_table() {
+        // With no metadata the answer comes from `version`'s FIELD_TYPES table.
+        for base in ["value", "effective", "onset"] {
+            assert!(
+                is_choice_element(base, test_version()),
+                "{base} is a polymorphic base in every supported version"
+            );
+        }
+
+        assert!(!is_choice_element("identifier", test_version()));
+        assert!(!is_choice_element_with_context(
+            "identifier",
+            None,
+            test_version()
+        ));
+    }
+
+    #[test]
+    fn type_operation_unwraps_a_singleton_collection() {
+        let obs = create_observation_with_quantity();
+        let quantity = obs
+            .get("valueQuantity")
+            .expect("fixture has valueQuantity")
+            .clone();
+
+        // A one-item collection must behave exactly as the item itself does.
+        let singleton = EvaluationResult::collection(vec![quantity.clone()]);
+        assert_eq!(
+            apply_polymorphic_type_operation(&singleton, "is", "Quantity", None, &ctx()).unwrap(),
+            apply_polymorphic_type_operation(&quantity, "is", "Quantity", None, &ctx()).unwrap(),
+            "a singleton collection should delegate to its single item"
+        );
+
+        // A multi-item collection is not a singleton, so the result is Empty.
+        let pair = EvaluationResult::collection(vec![quantity.clone(), quantity]);
+        assert_eq!(
+            apply_polymorphic_type_operation(&pair, "is", "Quantity", None, &ctx()).unwrap(),
+            EvaluationResult::Empty
+        );
+    }
 }

--- a/crates/fhirpath/src/polymorphic_access.rs
+++ b/crates/fhirpath/src/polymorphic_access.rs
@@ -2,6 +2,7 @@
 //!
 //! Handles accessing polymorphic FHIR elements (e.g., value[x]) in FHIRPath expressions.
 
+use helios_fhir::FhirVersion;
 use helios_fhirpath_support::{EvaluationError, EvaluationResult};
 use std::collections::HashMap;
 
@@ -36,6 +37,10 @@ use std::collections::HashMap;
 ///
 /// * `obj` - A reference to a HashMap representing a FHIR resource or part of a resource
 /// * `field_name` - The name of the field to access, which may be a choice element base name
+/// * `version` - The FHIR version of the data being evaluated. Choice-element
+///   metadata is version-specific (`Observation.valueAttachment` exists in R5/R6
+///   but not R4), so this must be the *evaluation context's* version — never
+///   `FhirVersion::default_enabled()`. See issue #309.
 ///
 /// # Returns
 ///
@@ -45,11 +50,12 @@ use std::collections::HashMap;
 /// # Examples
 ///
 /// // For a FHIR Observation with valueQuantity:
-/// // access_polymorphic_element(observation, "value") -> Some(valueQuantity)
-/// // access_polymorphic_element(observation, "value.unit") -> Some(unit)
+/// // access_polymorphic_element(observation, "value", version) -> Some(valueQuantity)
+/// // access_polymorphic_element(observation, "value.unit", version) -> Some(unit)
 pub fn access_polymorphic_element(
     obj: &HashMap<String, EvaluationResult>,
     field_name: &str,
+    version: FhirVersion,
 ) -> Option<EvaluationResult> {
     // First, try direct access - field might already be the right name
     if let Some(value) = obj.get(field_name) {
@@ -63,9 +69,9 @@ pub fn access_polymorphic_element(
         let rest = &parts[1..].join(".");
 
         // Handle path with potential choice element as the first part
-        if is_choice_element(first_part) {
+        if is_choice_element(first_part, version) {
             // Try to resolve the choice element
-            let matches = get_polymorphic_fields(obj, first_part);
+            let matches = get_polymorphic_fields(obj, first_part, version);
 
             // Process each matching field
             for (_, value) in &matches {
@@ -75,7 +81,7 @@ pub fn access_polymorphic_element(
                 } = value
                 {
                     // Recursively resolve the rest of the path
-                    if let Some(result) = access_polymorphic_element(inner_obj, rest) {
+                    if let Some(result) = access_polymorphic_element(inner_obj, rest, version) {
                         return Some(result);
                     }
                 }
@@ -96,7 +102,9 @@ pub fn access_polymorphic_element(
                             } = value
                             {
                                 // Try to resolve the rest of the path
-                                if let Some(result) = access_polymorphic_element(inner_obj, rest) {
+                                if let Some(result) =
+                                    access_polymorphic_element(inner_obj, rest, version)
+                                {
                                     return Some(result);
                                 }
                             }
@@ -112,7 +120,7 @@ pub fn access_polymorphic_element(
                     type_info: _,
                 } = value
                 {
-                    return access_polymorphic_element(inner_obj, rest);
+                    return access_polymorphic_element(inner_obj, rest, version);
                 }
             }
         }
@@ -124,7 +132,7 @@ pub fn access_polymorphic_element(
     // Check if this could be a choice element
     // Even without metadata, we can try to find polymorphic fields
     // based on the pattern of fields in the object
-    let matching_fields = get_polymorphic_fields(obj, field_name);
+    let matching_fields = get_polymorphic_fields(obj, field_name, version);
 
     // If we found any matches, it's likely a choice element
     if !matching_fields.is_empty() {
@@ -151,6 +159,7 @@ pub fn access_polymorphic_element(
 ///
 /// * `obj` - A reference to a HashMap representing a FHIR resource or part of a resource
 /// * `base_name` - The base name of the choice element to search for
+/// * `version` - The FHIR version of the data being evaluated (see issue #309)
 ///
 /// # Returns
 ///
@@ -158,6 +167,7 @@ pub fn access_polymorphic_element(
 fn get_polymorphic_fields(
     obj: &HashMap<String, EvaluationResult>,
     base_name: &str,
+    version: FhirVersion,
 ) -> Vec<(String, EvaluationResult)> {
     let mut matches = Vec::new();
 
@@ -170,9 +180,15 @@ fn get_polymorphic_fields(
     // typed variants that are both declared in the spec and present in the
     // data. More accurate than the JSON-key prefix scan below, which can
     // match unrelated fields whose names happen to start with `base_name`.
+    //
+    // The table MUST be the one for `version` — the evaluation context's FHIR
+    // version — not `default_enabled()`. Choice-element type sets differ
+    // between versions (`Observation.valueAttachment` is R5/R6 only,
+    // `Person.deceased[x]` is R5+ only), and consulting the wrong table makes
+    // the variant present in the data invisible here. See issue #309.
     let mut consulted_field_types = false;
     if let Some(EvaluationResult::String(resource_type, _, _)) = obj.get("resourceType")
-        && let Some(table) = helios_fhir::field_types(helios_fhir::FhirVersion::default_enabled())
+        && let Some(table) = helios_fhir::field_types(version)
     {
         consulted_field_types = true;
         for (parent, field, _ty, _is_collection) in table {
@@ -344,10 +360,11 @@ fn convert_fhir_field_to_fhirpath_type(value: &EvaluationResult, suffix: &str) -
 /// # Examples
 ///
 /// ```ignore
-/// // This function is used internally by the FHIRPath evaluator
-/// assert!(is_choice_element("value"));
-/// assert!(is_choice_element("effective"));
-/// assert!(!is_choice_element("name"));
+/// // This function is used internally by the FHIRPath evaluator.
+/// // The answer is version-specific: `class` is a choice base in R4 only,
+/// // `address` in R5 only (see issue #309).
+/// assert!(is_choice_element("value", FhirVersion::R4));
+/// assert!(is_choice_element("effective", FhirVersion::R4));
 /// ```
 /// Checks if a field name represents a FHIR choice element.
 ///
@@ -359,10 +376,16 @@ fn convert_fhir_field_to_fhirpath_type(value: &EvaluationResult, suffix: &str) -
 /// # Arguments
 /// * `field_name` - The field name to check
 /// * `context_metadata` - Optional slice of known choice element names for the context
+/// * `version` - The FHIR version of the data being evaluated, used only when
+///   `context_metadata` is `None` (see issue #309)
 ///
 /// # Returns
 /// `true` if the field is a choice element, `false` otherwise
-pub fn is_choice_element_with_context(field_name: &str, context_metadata: Option<&[&str]>) -> bool {
+pub fn is_choice_element_with_context(
+    field_name: &str,
+    context_metadata: Option<&[&str]>,
+    version: FhirVersion,
+) -> bool {
     // Pattern 1: Field name contains [x] - definitely a choice element
     if field_name.contains("[x]") {
         return true;
@@ -392,35 +415,39 @@ pub fn is_choice_element_with_context(field_name: &str, context_metadata: Option
     }
 
     // Without metadata, consult the generated `FIELD_TYPES` table for the
-    // default FHIR version: `field_name` is a choice base if at least one
-    // field in any parent type has the form `<field_name><UppercaseLetter>...`.
-    is_polymorphic_base_in_default_version(field_name)
+    // *evaluated data's* FHIR version: `field_name` is a choice base if at
+    // least one field in any parent type has the form
+    // `<field_name><UppercaseLetter>...`.
+    is_polymorphic_base_in_version(field_name, version)
 }
 
-/// Convenience function that calls is_choice_element_with_context without metadata.
-/// This is less accurate but maintains backward compatibility.
-pub fn is_choice_element(field_name: &str) -> bool {
-    is_choice_element_with_context(field_name, None)
+/// Convenience wrapper over [`is_choice_element_with_context`] for callers with
+/// no choice metadata to offer.
+fn is_choice_element(field_name: &str, version: FhirVersion) -> bool {
+    is_choice_element_with_context(field_name, None, version)
 }
 
-/// Returns true when `name` is the base of a polymorphic FHIR field in the
-/// default FHIR version's generated `FIELD_TYPES` table — i.e. some declared
-/// field is `<name><UppercaseLetter>...`. Lets the no-context choice-element
-/// check return a useful answer for common polymorphic bases (`value`,
-/// `effective`, `onset`, …) instead of the always-false fallback that
-/// preceded this.
-fn is_polymorphic_base_in_default_version(name: &str) -> bool {
-    let table: &[(&str, &str, &str, bool)] = match helios_fhir::FhirVersion::default_enabled() {
-        #[cfg(feature = "R4")]
-        helios_fhir::FhirVersion::R4 => helios_fhir::r4::FIELD_TYPES,
-        #[cfg(feature = "R4B")]
-        helios_fhir::FhirVersion::R4B => helios_fhir::r4b::FIELD_TYPES,
-        #[cfg(feature = "R5")]
-        helios_fhir::FhirVersion::R5 => helios_fhir::r5::FIELD_TYPES,
-        #[cfg(feature = "R6")]
-        helios_fhir::FhirVersion::R6 => helios_fhir::r6::FIELD_TYPES,
-        #[allow(unreachable_patterns)]
-        _ => return false,
+/// Returns true when `name` is the base of a polymorphic FHIR field in
+/// `version`'s generated `FIELD_TYPES` table — i.e. some declared field is
+/// `<name><UppercaseLetter>...`. Lets the no-context choice-element check
+/// return a useful answer for common polymorphic bases (`value`, `effective`,
+/// `onset`, …) instead of the always-false fallback that preceded this.
+///
+/// The answer is version-specific and genuinely differs: `class` is a
+/// polymorphic base in R4 (`Encounter.classHistory`) but not R5, and `address`
+/// is one in R5 (`VirtualServiceDetail.addressString`) but not R4 — hence
+/// issue #309.
+///
+/// Returns `false` when `version`'s feature isn't compiled in: the honest
+/// answer is "unknown", and `false` preserves the prior behaviour for that case.
+///
+/// NOTE: this scan is *parent-unscoped* — it asks whether any parent type
+/// anywhere has such a field — which makes it loose even within a single
+/// version. Tightening that is tracked separately; this function only fixes
+/// which version's table is consulted.
+fn is_polymorphic_base_in_version(name: &str, version: FhirVersion) -> bool {
+    let Some(table) = helios_fhir::field_types(version) else {
+        return false;
     };
     table.iter().any(|(_, f, _, _)| {
         f.strip_prefix(name)
@@ -442,6 +469,10 @@ fn is_polymorphic_base_in_default_version(name: &str) -> bool {
 /// * `op` - The operation to perform: "is" or "as"
 /// * `type_name` - The name of the type to check/convert to
 /// * `namespace` - Optional namespace for the type (e.g., "System", "FHIR")
+/// * `context` - The caller's evaluation context. Used for its `fhir_version`
+///   when delegating to [`crate::resource_type`] and to the choice-element
+///   check; previously a throwaway default-version context was fabricated here,
+///   which resolved types against the wrong FHIR version (issue #309).
 ///
 /// # Returns
 ///
@@ -453,15 +484,15 @@ fn is_polymorphic_base_in_default_version(name: &str) -> bool {
 /// ```ignore
 /// // This function is used internally by the FHIRPath evaluator
 /// // to handle polymorphic type operations on FHIR choice elements
-/// let result = apply_polymorphic_type_operation(value, op_type, target_type);
-/// let result1 = apply_polymorphic_type_operation(&value, "is", "Quantity", None);
-/// let result2 = apply_polymorphic_type_operation(&value, "as", "Quantity", None);
+/// let result1 = apply_polymorphic_type_operation(&value, "is", "Quantity", None, context);
+/// let result2 = apply_polymorphic_type_operation(&value, "as", "Quantity", None, context);
 /// ```
 pub fn apply_polymorphic_type_operation(
     value: &EvaluationResult,
     op: &str,
     type_name: &str,
-    _namespace: Option<&str>,
+    namespace: Option<&str>,
+    context: &crate::EvaluationContext,
 ) -> Result<EvaluationResult, EvaluationError> {
     // Handle empty values first
     if let EvaluationResult::Empty = value {
@@ -483,7 +514,7 @@ pub fn apply_polymorphic_type_operation(
         if items.len() != 1 {
             return Ok(EvaluationResult::Empty);
         }
-        return apply_polymorphic_type_operation(&items[0], op, type_name, _namespace);
+        return apply_polymorphic_type_operation(&items[0], op, type_name, namespace, context);
     }
 
     // Since we need to determine if the original path is a choice element
@@ -592,30 +623,26 @@ pub fn apply_polymorphic_type_operation(
         // For proper type checking, delegate to resource_type module which has type hierarchy support
         match op {
             "is" => {
-                // First try using the resource_type module for proper type checking with hierarchy support
-                if let Some(ns) = _namespace {
-                    let type_spec = crate::parser::TypeSpecifier::QualifiedIdentifier(
+                // First try using the resource_type module for proper type checking with hierarchy
+                // support. The caller's context is passed through so the type hierarchy is read
+                // for the evaluated data's FHIR version rather than a fabricated default one
+                // (issue #309); it also avoids allocating a throwaway context per `is`/`as`.
+                let type_spec = match namespace {
+                    Some(ns) => crate::parser::TypeSpecifier::QualifiedIdentifier(
                         ns.to_string(),
                         Some(type_name.to_string()),
-                    );
-                    // Create a minimal context for type checking
-                    let context = crate::EvaluationContext::new_empty_with_default_version();
-                    if let Ok(result) =
-                        crate::resource_type::is_of_type_with_context(value, &type_spec, &context)
-                    {
-                        return Ok(EvaluationResult::boolean(result));
-                    }
-                } else {
-                    let type_spec = crate::parser::TypeSpecifier::QualifiedIdentifier(
+                    ),
+                    None => crate::parser::TypeSpecifier::QualifiedIdentifier(
                         type_name.to_string(),
                         None,
-                    );
-                    let context = crate::EvaluationContext::new_empty_with_default_version();
-                    if let Ok(result) =
-                        crate::resource_type::is_of_type_with_context(value, &type_spec, &context)
-                    {
-                        return Ok(EvaluationResult::boolean(result));
-                    }
+                    ),
+                };
+                // A resolution failure deliberately falls through to the heuristics below
+                // rather than propagating — `test_as_type_operation` depends on it.
+                if let Ok(result) =
+                    crate::resource_type::is_of_type_with_context(value, &type_spec, context)
+                {
+                    return Ok(EvaluationResult::boolean(result));
                 }
 
                 // Fall back to original implementation if resource_type didn't handle it
@@ -733,7 +760,7 @@ pub fn apply_polymorphic_type_operation(
                         for key in obj.keys() {
                             if key.ends_with(type_name) && key.len() > type_name.len() {
                                 let base_name = &key[0..(key.len() - type_name.len())];
-                                if is_choice_element(base_name) {
+                                if is_choice_element(base_name, context.fhir_version) {
                                     return Ok(EvaluationResult::boolean(true));
                                 }
                             }
@@ -858,7 +885,7 @@ pub fn apply_polymorphic_type_operation(
                 // The 'as' operator returns the input value if it 'is' of the specified type,
                 // otherwise it returns Empty.
                 let is_type_result =
-                    apply_polymorphic_type_operation(value, "is", type_name, _namespace)?;
+                    apply_polymorphic_type_operation(value, "is", type_name, namespace, context)?;
                 match is_type_result {
                     EvaluationResult::Boolean(true, _, _) => Ok(value.clone()),
                     EvaluationResult::Boolean(false, _, _) => Ok(EvaluationResult::Empty),
@@ -886,6 +913,18 @@ pub fn apply_polymorphic_type_operation(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The version these version-agnostic tests run under. They use
+    /// `valueQuantity`, which is declared in every FHIR version, so the choice
+    /// of table does not affect them.
+    fn test_version() -> FhirVersion {
+        FhirVersion::default_enabled()
+    }
+
+    /// A minimal context for the `is`/`as` tests, at the default version.
+    fn ctx() -> crate::EvaluationContext {
+        crate::EvaluationContext::new_empty(test_version())
+    }
 
     // Helper function to create a FHIR Observation with a valueQuantity
     fn create_observation_with_quantity() -> HashMap<String, EvaluationResult> {
@@ -938,7 +977,7 @@ mod tests {
         let obs = create_observation_with_quantity();
 
         // Test accessing a polymorphic element
-        let value = access_polymorphic_element(&obs, "value").unwrap();
+        let value = access_polymorphic_element(&obs, "value", test_version()).unwrap();
 
         // Verify that it correctly finds valueQuantity
         if let EvaluationResult::Object {
@@ -964,12 +1003,14 @@ mod tests {
         // Since we enhanced our polymorphic_access.rs for choice elements,
         // we'll now recognize a valueQuantity object as a Quantity type
         let result =
-            apply_polymorphic_type_operation(&value_quantity, "is", "Quantity", None).unwrap();
+            apply_polymorphic_type_operation(&value_quantity, "is", "Quantity", None, &ctx())
+                .unwrap();
         assert_eq!(result, EvaluationResult::boolean(true)); // Now tests for true
 
         // Test is(String) on valueQuantity object directly
         let result =
-            apply_polymorphic_type_operation(&value_quantity, "is", "String", None).unwrap();
+            apply_polymorphic_type_operation(&value_quantity, "is", "String", None, &ctx())
+                .unwrap();
         assert_eq!(result, EvaluationResult::boolean(false));
 
         // Test is() on the Observation object itself
@@ -977,7 +1018,8 @@ mod tests {
             map: obs,
             type_info: None,
         };
-        let result = apply_polymorphic_type_operation(&obj, "is", "Observation", None).unwrap();
+        let result =
+            apply_polymorphic_type_operation(&obj, "is", "Observation", None, &ctx()).unwrap();
         assert_eq!(result, EvaluationResult::boolean(true));
     }
 
@@ -988,13 +1030,15 @@ mod tests {
         // First, let's test as(Quantity) on the valueQuantity object directly
         let value_quantity = obs.get("valueQuantity").unwrap().clone();
         let result =
-            apply_polymorphic_type_operation(&value_quantity, "is", "Quantity", None).unwrap();
+            apply_polymorphic_type_operation(&value_quantity, "is", "Quantity", None, &ctx())
+                .unwrap();
         // The valueQuantity looks like a Quantity type now, so is(Quantity) should be true
         assert_eq!(result, EvaluationResult::boolean(true)); // Updated to true
 
         // Now since is(Quantity) is true, as(Quantity) should return the original value
         let result =
-            apply_polymorphic_type_operation(&value_quantity, "as", "Quantity", None).unwrap();
+            apply_polymorphic_type_operation(&value_quantity, "as", "Quantity", None, &ctx())
+                .unwrap();
         assert_eq!(result, value_quantity);
 
         // Test with an Observation object
@@ -1005,11 +1049,144 @@ mod tests {
 
         // Testing valueQuantity field indirectly via Quantity
         // In our updated implementation, Observation.is(Quantity) should return true if it contains a valueQuantity
-        let result = apply_polymorphic_type_operation(&obj, "is", "Quantity", None).unwrap();
+        let result =
+            apply_polymorphic_type_operation(&obj, "is", "Quantity", None, &ctx()).unwrap();
         assert_eq!(result, EvaluationResult::boolean(true)); // Should return true because it contains valueQuantity
 
         // Test for a wrong type
-        let result = apply_polymorphic_type_operation(&obj, "is", "NonExistentType", None).unwrap();
+        let result =
+            apply_polymorphic_type_operation(&obj, "is", "NonExistentType", None, &ctx()).unwrap();
         assert_eq!(result, EvaluationResult::boolean(false));
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #309 — version-specific choice-element resolution.
+    //
+    // These need two version features compiled in to say anything: the bug is
+    // "consulted the default version's table instead of the data's", which is
+    // only observable when those differ. Each assertion is two-sided (R5 says
+    // yes, R4 says no) so it cannot be satisfied by hardcoding a different
+    // default.
+    // ------------------------------------------------------------------
+
+    /// An R5-only choice variant must be found when asking for R5, and must not
+    /// be invented when asking for R4.
+    ///
+    /// `Observation.valueAttachment` is declared in R5/R6 but not R4.
+    #[cfg(all(feature = "R4", feature = "R5"))]
+    #[test]
+    fn get_polymorphic_fields_honours_the_requested_version() {
+        let mut attachment = HashMap::new();
+        attachment.insert(
+            "title".to_string(),
+            EvaluationResult::string("scan.pdf".to_string()),
+        );
+
+        let mut obs = HashMap::new();
+        obs.insert(
+            "resourceType".to_string(),
+            EvaluationResult::string("Observation".to_string()),
+        );
+        obs.insert(
+            "valueAttachment".to_string(),
+            EvaluationResult::Object {
+                map: attachment,
+                type_info: None,
+            },
+        );
+
+        let r5 = get_polymorphic_fields(&obs, "value", FhirVersion::R5);
+        assert_eq!(
+            r5.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>(),
+            vec!["valueAttachment"],
+            "R5 declares Observation.valueAttachment, so it must resolve"
+        );
+
+        let r4 = get_polymorphic_fields(&obs, "value", FhirVersion::R4);
+        assert!(
+            r4.is_empty(),
+            "R4 does not declare Observation.valueAttachment; the R4 table must \
+             not report it. Getting a hit here would mean the version argument \
+             is ignored."
+        );
+    }
+
+    /// The same, through the entry point the evaluator actually calls.
+    #[cfg(all(feature = "R4", feature = "R5"))]
+    #[test]
+    fn access_polymorphic_element_honours_the_requested_version() {
+        let mut attachment = HashMap::new();
+        attachment.insert(
+            "title".to_string(),
+            EvaluationResult::string("scan.pdf".to_string()),
+        );
+
+        let mut obs = HashMap::new();
+        obs.insert(
+            "resourceType".to_string(),
+            EvaluationResult::string("Observation".to_string()),
+        );
+        obs.insert(
+            "valueAttachment".to_string(),
+            EvaluationResult::Object {
+                map: attachment,
+                type_info: None,
+            },
+        );
+
+        assert!(
+            access_polymorphic_element(&obs, "value", FhirVersion::R5).is_some(),
+            "R5 Observation.value must resolve to the Attachment (issue #309)"
+        );
+        assert!(
+            access_polymorphic_element(&obs, "value", FhirVersion::R4).is_none(),
+            "R4 has no Observation.valueAttachment to resolve to"
+        );
+    }
+
+    /// Isolates "this choice base is new in R5" from "this parent type is new
+    /// in R5": `Person` is declared in both tables (18 field rows in R4), but
+    /// only R5 gives it `deceased[x]`.
+    #[cfg(all(feature = "R4", feature = "R5"))]
+    #[test]
+    fn choice_base_added_in_a_later_version_on_a_shared_parent() {
+        let mut person = HashMap::new();
+        person.insert(
+            "resourceType".to_string(),
+            EvaluationResult::string("Person".to_string()),
+        );
+        person.insert(
+            "deceasedBoolean".to_string(),
+            EvaluationResult::boolean(true),
+        );
+
+        assert_eq!(
+            access_polymorphic_element(&person, "deceased", FhirVersion::R5),
+            Some(EvaluationResult::boolean(true)),
+            "Person.deceased[x] is R5+; it must resolve under R5 (issue #309)"
+        );
+        assert!(
+            access_polymorphic_element(&person, "deceased", FhirVersion::R4).is_none(),
+            "R4 Person has no deceased[x]"
+        );
+    }
+
+    /// The choice-base *classification* is version-specific too. Verified
+    /// against the generated tables: `class` is a base in R4 only
+    /// (`Encounter.classHistory`), `address` in R5 only
+    /// (`VirtualServiceDetail.addressString`), and `value` in both.
+    #[cfg(all(feature = "R4", feature = "R5"))]
+    #[test]
+    fn is_polymorphic_base_is_version_specific() {
+        assert!(is_polymorphic_base_in_version("class", FhirVersion::R4));
+        assert!(!is_polymorphic_base_in_version("class", FhirVersion::R5));
+
+        assert!(!is_polymorphic_base_in_version("address", FhirVersion::R4));
+        assert!(is_polymorphic_base_in_version("address", FhirVersion::R5));
+
+        // Control: a base present in every version must stay stable, so the
+        // check does not become spuriously version-sensitive.
+        assert!(is_polymorphic_base_in_version("value", FhirVersion::R4));
+        assert!(is_polymorphic_base_in_version("value", FhirVersion::R5));
     }
 }

--- a/crates/fhirpath/src/polymorphic_access.rs
+++ b/crates/fhirpath/src/polymorphic_access.rs
@@ -215,10 +215,22 @@ fn get_polymorphic_fields(
         }
     }
 
-    // Fallback for nested objects (no `resourceType`) and for the
-    // version-feature-disabled case — preserves prior behavior so callers
-    // working below the resource root still resolve typed variants.
-    if !consulted_field_types {
+    // Fallback for nested objects (no `resourceType`), for the
+    // version-feature-disabled case, and — crucially — whenever the table was
+    // consulted but matched nothing.
+    //
+    // That last condition is a defence-in-depth measure for #309. Suppressing
+    // the scan on a *miss* is what turned "consulted the wrong version's
+    // table" into "the element vanishes": the table lookup is an optimisation
+    // over this scan, so a miss should degrade to the scan rather than to an
+    // empty result. It keeps callers that still cannot supply an accurate
+    // version — notably the search-index extractor in `helios-persistence`,
+    // which hardcodes the default version and is fixed separately — resolving
+    // choice elements correctly.
+    //
+    // When the table matched, `matches` is non-empty and behaviour is
+    // unchanged, so this cannot loosen the well-formed, correct-version case.
+    if !consulted_field_types || matches.is_empty() {
         for (field_name, value) in obj {
             if matches.iter().any(|(name, _)| name == field_name) {
                 continue;
@@ -1069,17 +1081,27 @@ mod tests {
     // default.
     // ------------------------------------------------------------------
 
-    /// An R5-only choice variant must be found when asking for R5, and must not
-    /// be invented when asking for R4.
+    /// The table consulted must be the one for the requested version.
     ///
-    /// `Observation.valueAttachment` is declared in R5/R6 but not R4.
+    /// The fixture carries **two** typed variants: `valueQuantity` (declared in
+    /// every version) and `valueAttachment` (R5/R6 only). That combination is
+    /// what makes the assertion discriminating even with the `matches.is_empty()`
+    /// fallback in place — under R4 the table still matches `valueQuantity`, so
+    /// `matches` is non-empty, the prefix-scan fallback never runs, and
+    /// `valueAttachment` is correctly absent. A single-variant fixture would be
+    /// rescued by the fallback under both versions and would prove nothing.
     #[cfg(all(feature = "R4", feature = "R5"))]
     #[test]
-    fn get_polymorphic_fields_honours_the_requested_version() {
+    fn get_polymorphic_fields_consults_the_requested_versions_table() {
         let mut attachment = HashMap::new();
         attachment.insert(
             "title".to_string(),
             EvaluationResult::string("scan.pdf".to_string()),
+        );
+        let mut quantity = HashMap::new();
+        quantity.insert(
+            "unit".to_string(),
+            EvaluationResult::string("kg".to_string()),
         );
 
         let mut obs = HashMap::new();
@@ -1094,62 +1116,50 @@ mod tests {
                 type_info: None,
             },
         );
-
-        let r5 = get_polymorphic_fields(&obs, "value", FhirVersion::R5);
-        assert_eq!(
-            r5.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>(),
-            vec!["valueAttachment"],
-            "R5 declares Observation.valueAttachment, so it must resolve"
-        );
-
-        let r4 = get_polymorphic_fields(&obs, "value", FhirVersion::R4);
-        assert!(
-            r4.is_empty(),
-            "R4 does not declare Observation.valueAttachment; the R4 table must \
-             not report it. Getting a hit here would mean the version argument \
-             is ignored."
-        );
-    }
-
-    /// The same, through the entry point the evaluator actually calls.
-    #[cfg(all(feature = "R4", feature = "R5"))]
-    #[test]
-    fn access_polymorphic_element_honours_the_requested_version() {
-        let mut attachment = HashMap::new();
-        attachment.insert(
-            "title".to_string(),
-            EvaluationResult::string("scan.pdf".to_string()),
-        );
-
-        let mut obs = HashMap::new();
         obs.insert(
-            "resourceType".to_string(),
-            EvaluationResult::string("Observation".to_string()),
-        );
-        obs.insert(
-            "valueAttachment".to_string(),
+            "valueQuantity".to_string(),
             EvaluationResult::Object {
-                map: attachment,
+                map: quantity,
                 type_info: None,
             },
         );
 
+        let names = |v: FhirVersion| -> Vec<String> {
+            get_polymorphic_fields(&obs, "value", v)
+                .into_iter()
+                .map(|(n, _)| n)
+                .collect()
+        };
+
+        let r5 = names(FhirVersion::R5);
         assert!(
-            access_polymorphic_element(&obs, "value", FhirVersion::R5).is_some(),
-            "R5 Observation.value must resolve to the Attachment (issue #309)"
+            r5.iter().any(|n| n == "valueAttachment"),
+            "R5 declares Observation.valueAttachment, so it must be resolved; got {r5:?}"
+        );
+
+        let r4 = names(FhirVersion::R4);
+        assert!(
+            !r4.iter().any(|n| n == "valueAttachment"),
+            "R4 does not declare Observation.valueAttachment, so the R4 table must \
+             not report it; got {r4:?}. A hit here means the version argument was \
+             ignored (issue #309)."
         );
         assert!(
-            access_polymorphic_element(&obs, "value", FhirVersion::R4).is_none(),
-            "R4 has no Observation.valueAttachment to resolve to"
+            r4.iter().any(|n| n == "valueQuantity"),
+            "valueQuantity is declared in R4 and must still resolve; got {r4:?}"
         );
     }
 
-    /// Isolates "this choice base is new in R5" from "this parent type is new
-    /// in R5": `Person` is declared in both tables (18 field rows in R4), but
-    /// only R5 gives it `deceased[x]`.
+    /// A table *miss* must degrade to the prefix scan, not to an empty result.
+    ///
+    /// This is the defence-in-depth half of the #309 fix, and the reason
+    /// callers that cannot yet supply an accurate version (the persistence
+    /// search-index extractor) still resolve choice elements. `Person` is
+    /// declared in both tables but gained `deceased[x]` only in R5, so the R4
+    /// lookup finds the parent, matches nothing, and must fall through.
     #[cfg(all(feature = "R4", feature = "R5"))]
     #[test]
-    fn choice_base_added_in_a_later_version_on_a_shared_parent() {
+    fn table_miss_falls_back_to_the_prefix_scan() {
         let mut person = HashMap::new();
         person.insert(
             "resourceType".to_string(),
@@ -1160,15 +1170,14 @@ mod tests {
             EvaluationResult::boolean(true),
         );
 
-        assert_eq!(
-            access_polymorphic_element(&person, "deceased", FhirVersion::R5),
-            Some(EvaluationResult::boolean(true)),
-            "Person.deceased[x] is R5+; it must resolve under R5 (issue #309)"
-        );
-        assert!(
-            access_polymorphic_element(&person, "deceased", FhirVersion::R4).is_none(),
-            "R4 Person has no deceased[x]"
-        );
+        for version in [FhirVersion::R5, FhirVersion::R4] {
+            assert_eq!(
+                access_polymorphic_element(&person, "deceased", version),
+                Some(EvaluationResult::boolean(true)),
+                "Person.deceased must resolve under {version:?} — via the R5 table \
+                 directly, and via the fallback scan when the R4 table misses"
+            );
+        }
     }
 
     /// The choice-base *classification* is version-specific too. Verified

--- a/crates/fhirpath/tests/polymorphic_version_tests.rs
+++ b/crates/fhirpath/tests/polymorphic_version_tests.rs
@@ -1,0 +1,155 @@
+//! Regression tests for issue #309 — choice-element (`value[x]`) resolution must
+//! consult the FHIR version of the resource being evaluated, not the build's
+//! default version.
+//!
+//! # Why these tests are gated on `all(R4, R5)`
+//!
+//! The defect only exists in a build where more than one FHIR version feature is
+//! compiled in: `polymorphic_access::get_polymorphic_fields` looked up the
+//! generated `FIELD_TYPES` table for `FhirVersion::default_enabled()` (R4
+//! whenever R4 is enabled) rather than for the resource's own version. In a
+//! single-version build the default *is* the resource's version, so there is
+//! nothing to catch.
+//!
+//! That configuration is not exotic: release artifacts are built with
+//! `cargo build --workspace --all-features --release` (`.github/workflows/ci.yml`),
+//! so every shipped binary has R4/R4B/R5/R6 compiled in with `default_enabled()`
+//! == R4.
+//!
+//! # Why `Observation.value` with `valueAttachment`
+//!
+//! `Observation.valueAttachment` exists in R5 and R6 but **not** in R4 (verified
+//! against the generated tables in `crates/fhir/src/r4.rs` / `r5.rs`). Before the
+//! fix, evaluating `Observation.value` on an R5 Observation carrying
+//! `valueAttachment` consulted the R4 table, found no `Observation.value*` field
+//! matching the data — and, because `consulted_field_types` was set on table
+//! *existence* rather than on a match, the prefix-scan fallback was skipped too.
+//! The element resolved to **Empty**: silent, total loss of the value rather than
+//! a merely mis-typed one.
+//!
+//! A test using `valueQuantity` would prove nothing — it is present in both
+//! tables and resolves either way. That is the trap in the issue's own suggested
+//! test ("assert both resolve"), which passes on unfixed code.
+
+#![cfg(all(feature = "R4", feature = "R5"))]
+
+use helios_fhir::{FhirResource, FhirVersion};
+use helios_fhirpath::{EvaluationContext, evaluate_expression};
+use helios_fhirpath_support::EvaluationResult;
+
+/// Builds an evaluation context whose version is *inferred from the resource*
+/// (`EvaluationContext::new` reads `FhirResource::version()`), which is the whole
+/// point: the context version must differ from `default_enabled()`.
+///
+/// Parsing real JSON into the typed `r5::Resource` — rather than hand-building a
+/// `HashMap` — is load-bearing. A hand-built object without a `resourceType` key
+/// never reaches the `FIELD_TYPES` lookup at all (it falls through to the
+/// version-independent prefix scan), so such a test would pass on unfixed code
+/// for entirely the wrong reason.
+fn r5_context(json: &str) -> EvaluationContext {
+    let resource: helios_fhir::r5::Resource =
+        serde_json::from_str(json).expect("R5 fixture parses into the typed model");
+    EvaluationContext::new(vec![FhirResource::R5(Box::new(resource))])
+}
+
+fn r4_context(json: &str) -> EvaluationContext {
+    let resource: helios_fhir::r4::Resource =
+        serde_json::from_str(json).expect("R4 fixture parses into the typed model");
+    EvaluationContext::new(vec![FhirResource::R4(Box::new(resource))])
+}
+
+/// Guards against the tests silently becoming vacuous if `default_enabled()` is
+/// ever reordered to R5 — at which point the R5 fixtures would stop exercising
+/// the cross-version path and would pass for the wrong reason.
+fn assert_not_vacuous() {
+    assert_ne!(
+        FhirVersion::default_enabled(),
+        FhirVersion::R5,
+        "issue #309 is only exercised when the build default differs from the \
+         fixture's version; a default_enabled() reorder makes these tests vacuous"
+    );
+}
+
+const R5_OBSERVATION_ATTACHMENT: &str = r#"{
+    "resourceType": "Observation",
+    "id": "obs-attachment",
+    "status": "final",
+    "code": { "text": "Scanned report" },
+    "valueAttachment": { "title": "scanned-report.pdf", "contentType": "application/pdf" }
+}"#;
+
+const R4_OBSERVATION_QUANTITY: &str = r#"{
+    "resourceType": "Observation",
+    "id": "obs-quantity",
+    "status": "final",
+    "code": { "text": "Body weight" },
+    "valueQuantity": { "value": 185, "unit": "lbs", "system": "http://unitsofmeasure.org", "code": "lb_av" }
+}"#;
+
+/// The core #309 regression: an R5-only choice variant must resolve through the
+/// choice base name when the evaluation context says R5, even though the build
+/// default is R4.
+#[test]
+fn r5_only_choice_variant_resolves_via_choice_base() {
+    assert_not_vacuous();
+    let context = r5_context(R5_OBSERVATION_ATTACHMENT);
+
+    let exists =
+        evaluate_expression("Observation.value.exists()", &context).expect("expression evaluates");
+    assert_eq!(
+        exists,
+        EvaluationResult::boolean(true),
+        "Observation.value must resolve to valueAttachment for an R5 resource. \
+         Empty here means the R4 FIELD_TYPES table was consulted for an R5 \
+         resource (issue #309)."
+    );
+
+    let title =
+        evaluate_expression("Observation.value.title", &context).expect("expression evaluates");
+    assert_eq!(
+        title,
+        EvaluationResult::string("scanned-report.pdf".to_string()),
+        "the resolved choice element must be the Attachment itself"
+    );
+}
+
+/// Control: the R4 path must be bit-identical after the fix. R4 *is*
+/// `default_enabled()`, so any change here means the wrong value was threaded
+/// rather than that the bug was fixed.
+#[test]
+fn r4_choice_variant_still_resolves() {
+    let context = r4_context(R4_OBSERVATION_QUANTITY);
+
+    let unit =
+        evaluate_expression("Observation.value.unit", &context).expect("expression evaluates");
+    assert_eq!(
+        unit,
+        EvaluationResult::string("lbs".to_string()),
+        "R4 choice resolution must be unaffected by threading the context version"
+    );
+}
+
+/// The same defect on a resource type that exists in *both* tables, isolating
+/// "this base is new in R5" from "this parent is new in R5".
+///
+/// `Person` is present in the R4 table (18 field rows) but gained
+/// `deceased[x]` only in R5, so an R4 lookup finds the parent, finds no
+/// `deceased*` match, and — before the fix — suppressed the fallback as well.
+#[test]
+fn r5_only_choice_base_on_a_parent_present_in_both_versions() {
+    assert_not_vacuous();
+    let context = r5_context(
+        r#"{
+            "resourceType": "Person",
+            "id": "person-deceased",
+            "deceasedBoolean": true
+        }"#,
+    );
+
+    let deceased = evaluate_expression("Person.deceased", &context).expect("expression evaluates");
+    assert_eq!(
+        deceased,
+        EvaluationResult::boolean(true),
+        "Person.deceased is R5-only; resolving it must use the R5 table (issue #309)"
+    );
+}

--- a/crates/fhirpath/tests/polymorphic_version_tests.rs
+++ b/crates/fhirpath/tests/polymorphic_version_tests.rs
@@ -135,6 +135,13 @@ fn r4_choice_variant_still_resolves() {
 /// `Person` is present in the R4 table (18 field rows) but gained
 /// `deceased[x]` only in R5, so an R4 lookup finds the parent, finds no
 /// `deceased*` match, and — before the fix — suppressed the fallback as well.
+///
+/// Note on attribution: once the table-miss fallback is restored (the
+/// defence-in-depth half of the fix), this case is resolved by *either* half
+/// independently. The test that uniquely pins the version-threading half is
+/// `get_polymorphic_fields_consults_the_requested_versions_table` in
+/// `polymorphic_access.rs`, which uses a two-variant fixture the fallback
+/// cannot rescue.
 #[test]
 fn r5_only_choice_base_on_a_parent_present_in_both_versions() {
     assert_not_vacuous();


### PR DESCRIPTION
Fixes #309.

## What the bug actually is — and where the issue is wrong

#309 is real, but it names the wrong line, and it understates both the severity and the reach. Reporting that plainly here because implementing the issue's own "Suggested fix" literally would have shipped a PR that changes almost nothing.

**The site the issue names is nearly dead.** `is_polymorphic_base_in_default_version` (`polymorphic_access.rs:412`) is reached only through `is_choice_element`, whose callers are `:66` — guarded by `if field_name.contains('.')`, and an `Invocation::Member` is built from a single identifier, so it never contains a dot — and `:736`, inside the `is`/`as` heuristic fallback.

**The damaging site is `get_polymorphic_fields` (`:175`)**, which the issue does not mention. That is the *value-resolution* path — which concrete typed variant gets returned — and it had a second defect layered on top: `consulted_field_types` was set when the `FIELD_TYPES` table merely **existed**, not when it **matched**, so a miss in the wrong version's table also suppressed the prefix-scan fallback.

The result is not the misclassification the issue describes. It is silent, total non-resolution:

```
// R5 Observation, multi-version build, default_enabled() == R4
{ "resourceType": "Observation", "valueAttachment": { "title": "scan.pdf" } }

Observation.value   =>  Empty     (before)
Observation.value   =>  Attachment (after)
```

**The issue's suggested test passes on unfixed code.** "Evaluate the same choice-element expression against R4 and R5 resources and assert both resolve" uses `valueQuantity`, which is declared in every version and resolves either way. The fixtures here use variants that genuinely differ across versions.

**Severity: this is live in released binaries, not a CI curiosity.** The issue frames it as reachable only under `--all-features` in CI. Release artifacts are built with `cargo build --workspace --all-features --release` (`.github/workflows/ci.yml:1260`, `:1267`, `:1271`), so **every shipped `hfs`/`hts` binary is a multi-version build with `default_enabled() == R4`**. Any tenant served R5/R6 hits this.

**Not a public API change.** `mod polymorphic_access;` (`lib.rs:286`) is private and nothing re-exports it, so there is no semver surface and no compatibility shim was added. A `*_with_default_version` wrapper would only have preserved the bug under a new name.

## Verified divergences

Measured against the generated `FIELD_TYPES` tables in this repo:

| element | R4 | R5 | R6 |
|---|---|---|---|
| `Observation.valueAttachment` | absent | present | present |
| `Observation.valueReference` | absent | present | absent |
| `Person.deceased[x]` | absent (parent present, 18 rows) | present | present |
| `class` as a choice base | yes (`Encounter.classHistory`) | no | — |
| `address` as a choice base | no | yes (`VirtualServiceDetail.addressString`) | — |

169 identifiers change polymorphic-base classification between R4 and R5, including `class`, `outcome`, `address`, `description`, `end`, `high`, `low`, `parent`, `purpose`.

## What changed

**1. Thread the evaluation context's version (`b83001c`).** `access_polymorphic_element`, `get_polymorphic_fields` and `is_choice_element` take an explicit `FhirVersion`, supplied by callers from `EvaluationContext::fhir_version`. `is_polymorphic_base_in_default_version` is replaced by `is_polymorphic_base_in_version`, delegating to the existing `helios_fhir::field_types(version)` instead of repeating its cfg ladder.

`apply_polymorphic_type_operation` now takes the caller's `&EvaluationContext` rather than fabricating one with `new_empty_with_default_version()`. **Labelled as hygiene, not a fix:** the sole caller (`evaluator.rs:7938-7972`) always yields `Some(namespace)`, so the unqualified branch was unreachable and the qualified `TypeSpecifier` never reached a `fhir_version` read. It changes no observable behaviour; it drops two allocations per `is`/`as` and removes a footgun. Also deletes a dead strict-mode probe in `evaluate_invocation` (`_found_polymorphically`, computed and never read).

**2. A table miss falls back to the prefix scan (`ca2a4c1`).** The table lookup can only ever return a subset of the scan, so a miss should degrade to the scan, not to an empty result. When the table matches, behaviour is unchanged.

## Scope: the persistence path is deliberately NOT fixed here

`crates/persistence/src/search/extractor.rs:385` builds its FHIRPath context with `new_empty_with_default_version()`, and its output is written to the search index of every backend (SQLite, PostgreSQL, Elasticsearch, MongoDB). That is not fixed in this PR, for three reasons:

- **Measured exposure is near zero for built-in parameters.** Replaying `rewrite_choice_types()` over every shipped SearchParameter expression leaves 1 reachable parameter in R5 and 2 in R6 — the cast forms (`ofType`/`as`) are rewritten to concrete field names before evaluation. The real exposure is custom/tenant-POSTed SearchParameters naming a choice element by its bare base.
- **The remediation path is currently circular.** `sqlite/transaction.rs:218` and `postgres/transaction.rs:194` do `let fhir_version = FhirVersion::default_enabled();` and persist *that* into the `resources.fhir_version` column. Threading a per-resource version through the extractor would faithfully re-index using a fabricated one. That has to be fixed first, and it is its own PR.
- ~25 mechanical edits across 12 files on database write paths, riding on a FHIRPath fix, in an environment with no local compiler, would destroy the reviewability-by-reading this PR depends on.

**Commit 2 is the compensating control that makes that deferral safe rather than a mask.** With the table-miss fallback restored, the extractor resolves choice elements correctly even though it still cannot supply an accurate version. The index is derived data, so remediation is `$reindex`, not a migration — but `$reindex` is only trustworthy once the persisted `fhir_version` is.

Follow-ups to file: persistence write-path default-version leaks (incl. MongoDB and `search/reindex.rs`); `resource_type::check_type_match` unioning across all enabled versions; SOF's `EvaluationContext::new(vec![])` version loss; and `is_choice_element` being parent-unscoped (its own doc asserts `!is_choice_element("name")`, which is false in R4 — `ImplementationGuideDefinitionPage.nameUrl`).

## Tests

Committed **before** the fix (`02a35c0`) so CI records the red run — see the checks on that commit.

- `crates/fhirpath/tests/polymorphic_version_tests.rs` — end-to-end through `evaluate_expression`, gated `all(feature="R4", feature="R5")`. Contexts are built via `EvaluationContext::new(vec![FhirResource::R5(..)])` from parsed JSON, not hand-built maps: a map without `resourceType` never reaches the `FIELD_TYPES` lookup and would go green for the wrong reason. Includes an R4 control that must stay bit-identical, and a `default_enabled() != R5` guard so the suite cannot silently become vacuous.
- Unit tests in `polymorphic_access.rs` (the module is private, so integration tests cannot reach these functions).

**Honest note on attribution.** With commit 2's fallback in place, the end-to-end fixtures are satisfied by either half of the fix independently. The test that uniquely pins the version threading is `get_polymorphic_fields_consults_the_requested_versions_table`: its fixture carries `valueQuantity` (declared in every version) alongside `valueAttachment` (R5-only), so the R4 table still matches, the fallback never runs, and `valueAttachment` must be absent under R4 and present under R5.

## What I could not verify

- **Nothing was compiled or executed locally** — this environment has `cargo` but no C linker, so `check`/`test`/`clippy` cannot link. Every claim above is from reading the source and the generated tables. CI is the only execution evidence; `cargo fmt` was run.
- **No discriminating behavioural test exists for the `apply_polymorphic_type_operation` context change**, because it is provably inert (see above). The only honest coverage is reading the diff.
- **Nothing here proves the persistence path is fixed** — it is not fixed, only mitigated.
- **No test can tell whether existing R5/R6 rows in a deployed search index were extracted with R4 metadata.** That needs a data audit.
- Codecov runs R4-only by design (`ci.yml:554`), so the `all(R4, R5)`-gated tests will read as uncovered. That is expected and was not worked around.

## Regression watchlist

The fix is asymmetric — it can *remove* results as well as add them. An R5-context evaluation of an R4-shaped fixture can now correctly go Empty. Watch `crates/fhirpath/tests/r5_tests.rs` (1037 cases), `r4_tests.rs` as the control (**any R4 delta is a bug in this patch, never a test to update**), the `helios-sof` R5/R6 suites (SOF builds version-inferring contexts, so it has been evaluating non-R4 resources with R4 metadata all along and its output may legitimately change), and the Windows R5 FHIRPath conformance job — whose audit step at `ci.yml:978` is a hard gate despite the validator step being `continue-on-error`.

If a conformance case moves, it gets root-caused. No assertion, gate, pin, or `known-test-failures.json` entry will be added or weakened to obtain green.
