### PR TITLE
ci: stop the MinIO S3 step from rebuilding and re-downloading R6 data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,17 @@ jobs:
       # preconditions would turn every concurrent settings write into a lost
       # update, and nothing else in CI would notice.
       #
-      # Same package and feature set as the step above, so the build is already
-      # cached and this costs only the MinIO container. The harness stamps
-      # `github.run_id`, so `cleanup-test-containers` reaps it.
+      # This MUST use the same `--workspace --all-features` selection as the step
+      # above so the build is already cached and this costs only the MinIO
+      # container. It previously ran `-p helios-persistence --all-features`, and
+      # `--all-features` only activates features of the *selected* packages: with
+      # only `helios-persistence` selected, `helios-fhir` picked up `R6` (via
+      # `R6 = ["helios-fhir/R6", ...]`) but not `skip-r6-download`, which nothing
+      # forwards. That is a different feature set from the step above, so it
+      # recompiled `helios-fhir` and everything downstream *and* re-ran the
+      # helios-fhir build script's R6 example download from build.fhir.org.
+      # `--test minio_s3_tests` still narrows the run to the one target.
+      # The harness stamps `github.run_id`, so `cleanup-test-containers` reaps it.
       #
       # This step must not be able to pass vacuously. `cargo test` exits 0 when a
       # name filter matches nothing ("0 passed; N filtered out"), and the suite
@@ -130,7 +138,7 @@ jobs:
           EXPECTED_MINIO_SETTINGS_TESTS: "5"
         run: |
           set -o pipefail
-          cargo test -p helios-persistence --all-features \
+          cargo test --workspace --all-features \
             --test minio_s3_tests test_minio_settings -- --nocapture \
             | tee minio-settings.log
           if ! grep -qE "test result: ok\. ${EXPECTED_MINIO_SETTINGS_TESTS} passed" minio-settings.log; then
@@ -169,7 +177,7 @@ jobs:
         # plain `shell: bash` alias is unreliable on this self-hosted runner.
         run: |
           set -o pipefail
-          cargo test -p helios-persistence --all-features \
+          cargo test --workspace --all-features \
             --test minio_s3_tests test_minio_settings -- --nocapture \
             | tee minio-settings.log
           if ! grep -qE "test result: ok\. ${EXPECTED_MINIO_SETTINGS_TESTS} passed" minio-settings.log; then


### PR DESCRIPTION
## Problem

The **Verify S3 conditional writes against MinIO** step in `ci.yml` added a full recompile plus a network download from the HL7 build server on every run:

```
warning: helios-fhir@0.2.1: Downloading R6 test data from HL7 build server
warning: helios-fhir@0.2.1: Cleaning resources directory before extraction...
warning: helios-fhir@0.2.1: Resources directory cleaned
warning: helios-fhir@0.2.1: Cleaning resources directory before extraction...
warning: helios-fhir@0.2.1: Resources directory cleaned
```

## Root cause

The step ran `cargo test -p helios-persistence --all-features`, while the step immediately before it ran `cargo test --workspace --all-features`.

`--all-features` only activates features of the **selected** packages, so the two invocations resolved `helios-fhir` differently:

- `--workspace` selects `helios-fhir` itself, enabling its `skip-r6-download` feature, so `crates/fhir/build.rs` returns early.
- `-p helios-persistence` selects only that package. `helios-fhir` then gets `R6` (via `R6 = ["helios-fhir/R6", ...]` in `crates/persistence/Cargo.toml`) but **not** `skip-r6-download` — nothing forwards it. `helios-hfs` and `helios-fhir-gen` each declare their own empty `skip-r6-download = []` for their own build scripts only.

The differing feature set meant the S3 step recompiled `helios-fhir` and everything downstream from scratch, and re-ran its build script, which downloads `examples-json.zip` + `examples.zip` from build.fhir.org and wipes/re-extracts both R6 resource directories (hence the two "Cleaning resources directory" lines — one for JSON, one for XML).

## Fix

Use `--workspace --all-features` in both the Linux and Windows legs so feature resolution matches the preceding step and the artifacts are already cached.

- `--test minio_s3_tests` still narrows execution to the single target. Confirmed via `cargo metadata` that this target name is unique to `helios-persistence`.
- `RUN_MINIO_S3_TESTS` remains opt-in for this step only, so the slow full S3 CRUD suite still does not run in the main test step.
- The `EXPECTED_MINIO_SETTINGS_TESTS` vacuous-pass guard is unchanged.

The step's remaining cost is just the MinIO container.

I also replaced the now-inaccurate "Same package and feature set as the step above" comment with an explanation of why the selection must stay `--workspace`.

## Verification

- `cargo metadata` confirms `minio_s3_tests` resolves to exactly one target (`helios-persistence`).
- Confirmed cargo accepts `--workspace --all-features --test minio_s3_tests` (args parse, build starts).
- YAML parses.
- Checked the other workflows: nothing else enables R6 outside a workspace-wide `--all-features` (the coverage job deliberately avoids `--all-features`), so this was the only offender.

The cache-reuse benefit only materializes on the CI runner, where step 1 has already built that exact configuration. **The real check is this PR's own CI run:** the S3 step should show no `Compiling helios-fhir` and no `Downloading R6 test data` lines.

## Not addressed here

None of the three build scripts (`crates/fhir`, `crates/hfs`, `crates/fhir-gen`) emit `cargo:rerun-if-changed`, so cargo falls back to "re-run if anything in the package changed". Adding it would stop spurious re-runs but would also mean the 24h R6 refresh effectively never fires, which interacts with the known definitions/test-data skew problem. Left for a deliberate decision.

https://claude.ai/code/session_0168dPKRtSNzhixHhUwGwnxN