### PR TITLE
fix(ui): surface tenant-list load failures instead of rendering an empty table

### DIFF
--- a/crates/ui/src/tenants.rs
+++ b/crates/ui/src/tenants.rs
@@ -267,12 +267,11 @@ pub async fn rows(
             error: None,
         });
     };
-    let rows = load_rows(storage, &query.q).await.unwrap_or_default();
-    render(TenantRowsPartial {
-        i18n,
-        rows,
-        error: None,
-    })
+    let (rows, error) = match load_rows(storage, &query.q).await {
+        Ok(rows) => (rows, None),
+        Err(e) => (Vec::new(), Some(e)),
+    };
+    render(TenantRowsPartial { i18n, rows, error })
 }
 
 /// Returns the refreshed (unfiltered) rows fragment, with an optional error
@@ -299,8 +298,10 @@ pub async fn create(
 
     let id = form.id.trim().to_string();
     let load = |err: Option<String>| async {
-        let rows = load_rows(storage, "").await.unwrap_or_default();
-        rows_response(i18n, rows, err)
+        match load_rows(storage, "").await {
+            Ok(rows) => rows_response(i18n, rows, err),
+            Err(e) => rows_response(i18n, Vec::new(), err.or(Some(e))),
+        }
     };
 
     if let Err(msg) = validate_id(&id) {
@@ -362,8 +363,10 @@ pub async fn delete(
         let _ = storage.purge_tenant_data(&id).await;
     }
 
-    let rows = load_rows(storage, "").await.unwrap_or_default();
-    rows_response(i18n, rows, None)
+    match load_rows(storage, "").await {
+        Ok(rows) => rows_response(i18n, rows, None),
+        Err(e) => rows_response(i18n, Vec::new(), Some(e)),
+    }
 }
 
 // (helpers below)

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -200,3 +200,33 @@ async fn embedded_assets_carry_no_cache_so_rebuilt_css_is_never_stale() {
         .unwrap();
     assert!(cc.contains("no-cache"), "got {cc}");
 }
+
+/// A storage failure must surface as the error banner, never as an empty
+/// 'no tenants' table that hides every row and purge affordance. A store
+/// whose schema was never initialised makes every query fail, standing in
+/// for a transient error (e.g. a pool wait under concurrent seeding).
+#[tokio::test]
+async fn storage_failure_renders_the_error_banner_not_a_silent_empty_table() {
+    let broken: Arc<dyn ResourceStorage> =
+        Arc::new(SqliteBackend::in_memory().expect("in-memory sqlite"));
+
+    let (status, body) = get(&broken, "/ui/tenants/rows?q=").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("form-error"), "rows fragment: {body}");
+
+    let (status, body) = post_form(&broken, "id=acme&display_name=").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("form-error"), "create fragment: {body}");
+
+    let res = app(&broken)
+        .oneshot(
+            Request::delete("/ui/tenants/acme")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = body_text(res).await;
+    assert!(body.contains("form-error"), "delete fragment: {body}");
+}


### PR DESCRIPTION
## Summary

Found while chasing a #290 e2e failure: after deregistering a tenant on the per-PR sqlite leg, the expected `unregistered` row was sometimes missing entirely — the fragment came back as an **empty table**.

Root cause is in the page, not the store: the create, delete, and search fragment handlers collapse a failed `load_rows` into `unwrap_or_default()`. Any transient storage error — in CI, a connection-pool wait while a parallel test seeds ~1.4k conformance resources into another tenant (pool wait cap is 30s; the suite shares one server) — renders as 'no tenants at all'. Every row and every purge affordance silently vanishes until the next successful refresh. For an operator page whose whole job is 'leftover data stays visible', failing invisible is the worst available behavior.

## Change

Surface the failure in the fragment's existing error banner (`rows_response` already takes the error; the partial already renders it; htmx swaps it in place). On create, a validation error still wins over a concurrent load error.

The #290 spec gets a matching hardening commit on its own branch (reload-polling instead of a single 15s wait on the swapped fragment).

## Verification

helios-ui suites green (85 tests), fmt clean. The e2e tenants spec passes locally against this handler change.