### PR TITLE
fix(ui): unbreak main — editor page must pass the request tenant to current_status

### DIFF
--- a/crates/ui/src/editor.rs
+++ b/crates/ui/src/editor.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::i18n::{I18n, RequestLocale};
-use crate::{RequestVersion, WebState, render};
+use crate::{RequestTenant, RequestVersion, WebState, render};
 
 /// One line of the editor tree. The tree is flattened here rather than rendered
 /// recursively: Askama has no recursive includes, and a flat list with an
@@ -153,10 +153,11 @@ pub async fn page(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
+    rt: RequestTenant,
     Query(query): Query<EditorQuery>,
 ) -> Response {
     render(EditorPage {
-        status: crate::current_status(state.version, rv.0),
+        status: crate::current_status(state.version, rv.0, &rt),
         i18n: I18n::new(locale),
         active_page: "editor",
         nl_enabled: state.nl.enabled,


### PR DESCRIPTION
`main` does not compile as of `176bbc7ee`, so **every** open PR's CI is red: the `pull_request` event builds the merge ref, which inherits the breakage regardless of what the PR touches.

```
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
    --> crates/ui/src/editor.rs:159:17
     |
 159 |         status: crate::current_status(state.version, rv.0),
     |                 ^^^^^^^^^^^^^^^^^^^^^--------------------- argument #3 of type `&RequestTenant` is missing
```

## How it happened

A semantic conflict between two PRs that merged 23 minutes apart, each green on its own base:

| when (UTC) | PR | what |
|---|---|---|
| 12:25 | #277 resource editor | adds `editor::page`, calling `current_status(state.version, rv.0)` |
| 12:30 | #346 version selector | *(green)* |
| 12:53 | #348 tenant selector | adds `tenant: &RequestTenant` to `current_status`, updates the call sites on its branch — which did not include `editor.rs` |

Neither branch contained the other's code, so neither CI run could see it. Nothing textually conflicted, so the merges were clean.

## The fix

`editor::page` is the only stale call site — the other eight already take an `rt: RequestTenant` extractor and pass `&rt`. It now does the same, which also makes the editor header show the active tenant like every other page, as #344 intended.

Three lines, one file, no behavior change beyond that.