### PR TITLE
ci(subscriptions): point channels workflow testcontainers at remote Docker host

### DIFF
--- a/.github/workflows/subscriptions-channels.yml
+++ b/.github/workflows/subscriptions-channels.yml
@@ -14,6 +14,10 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_BUILD_JOBS: 2
   CARGO_PROFILE_DEV_DEBUG: 0
+  # Self-hosted Linux runners have no local /var/run/docker.sock; testcontainers
+  # reach Docker on a remote host, same as subscriptions-smoke.yml (issue #389).
+  DOCKER_HOST: ${{ secrets.DOCKER_HOST }}
+  DOCKER_HOST_IP: ${{ secrets.DOCKER_HOST_IP }}
 
 jobs:
   matrix-setup:
@@ -89,7 +93,7 @@ jobs:
         # so dropping defaults breaks builds; this matrix exercises adding
         # additional versions to the R4 baseline.
         run: |
-          cargo test \
+          cargo test --no-fail-fast \
             --features "${{ matrix.features }}" \
             -p helios-subscriptions -p helios-rest -p helios-persistence -p helios-fhirpath
 


### PR DESCRIPTION
## Summary

Fixes #389. The `subscriptions-channels.yml` workflow fails on the current `[self-hosted, Linux]` runner pool: the runners no longer expose a local `/var/run/docker.sock`, so every testcontainer-based test in the unit-tests matrix panics with `SocketNotFoundError` — and the email integration tests *silently skip* via their `docker_available()` guard, reporting green without testing anything. `subscriptions-smoke.yml` already adapted by pointing testcontainers at a remote Docker host via `DOCKER_HOST`; the channels workflow never got that env block.

## Changes

- **`.github/workflows/subscriptions-channels.yml`**:
  - add the `DOCKER_HOST: ${{ secrets.DOCKER_HOST }}` / `DOCKER_HOST_IP` env block used by `subscriptions-smoke.yml`, with a comment referencing #389;
  - run the unit-test step with `--no-fail-fast`, so a failing test binary no longer aborts `cargo test` before the remaining suites (previously the persistence failure masked that the subscriptions test binaries never ran at all).

## Testing

- Validated by dispatching the workflow with this exact change from `feat/cluster-capable-state` ([run 30099280985](https://github.com/HeliosSoftware/hfs/actions/runs/30099280985)): **all 112 jobs green**.
- The Email matrix jobs' mailpit tests genuinely ran — `5 passed` in **1.94s**, versus the prior 0.01s silent skip — because `docker_available()` also honors `DOCKER_HOST`, so this change simultaneously un-breaks the unit tests and reactivates real email delivery coverage.

## Notes

- The validation commit is being reverted out of `feat/cluster-capable-state` (#269) so this lands independently; #269 will pick it up on its next merge from main.
- Follow-up hardening (fail-loudly-in-CI guards instead of silent skips) is tracked in #389/#390 ("PR B").
