### PR TITLE
fix(bulk-submit): spec-conformance quick wins + Bulk Data Submit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,8 @@ JWT/bearer auth (`HFS_AUTH_*`, e.g. `HFS_AUTH_ENABLED`, `HFS_AUTH_JWKS_URL`, `HF
 | `HFS_SUBSCRIPTION_REHYDRATE_HANDSHAKE` | `true` | Re-run the activation handshake for stored `requested` subscriptions during rehydration |
 | `HFS_BULK_EXPORT_ENABLED` | `true` | Enable the [Bulk Data Export](crates/rest/README.md#bulk-data-export) `$export` operation; when `false`, all `$export` endpoints return `501` |
 | `HFS_BULK_EXPORT_OUTPUT_BACKEND` | `local-fs` | Bulk export output store: `local-fs` or `s3`. See the [rest crate README](crates/rest/README.md#bulk-data-export) for the full `HFS_BULK_EXPORT_*` table |
-| `HFS_BULK_SUBMIT_ENABLED` | `true` | Enable the Bulk Data Submit `$bulk-submit` operation (HFS as Data Consumer — fetches a provider manifest and ingests it); when `false`, all `$bulk-submit` endpoints return `501`. Available on `sqlite`/`postgres` (+ `-elasticsearch` composites). See the "Bulk Data Submit" section of `CLAUDE.md` for the full `HFS_BULK_SUBMIT_*` table |
-| `HFS_BULK_SUBMIT_OUTPUT_BACKEND` | `local-fs` | Bulk submit status-artifact store: `local-fs` or `s3` |
+| `HFS_BULK_SUBMIT_ENABLED` | `true` | Enable the [Bulk Data Submit](crates/rest/README.md#bulk-data-submit) `$bulk-submit` operation (HFS as Data Consumer — fetches a provider manifest and ingests it); when `false`, all `$bulk-submit` endpoints return `501`. Available on `sqlite`/`postgres` (+ `-elasticsearch` composites) |
+| `HFS_BULK_SUBMIT_OUTPUT_BACKEND` | `local-fs` | Bulk submit status-artifact store: `local-fs` or `s3`. See the [rest crate README](crates/rest/README.md#bulk-data-submit) for the full `HFS_BULK_SUBMIT_*` table |
 
 The SMTP delivery channel (`HFS_SUBSCRIPTION_SMTP_*`), delivery-retry tuning (`HFS_SUBSCRIPTION_HANDSHAKE_*`), and the remaining startup-rehydration knobs (`HFS_SUBSCRIPTION_REHYDRATE_*`) are documented in the [helios-subscriptions README](crates/subscriptions/README.md).
 

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -376,8 +376,8 @@ For a capability-by-capability narrative of FHIR Search against the [spec](https
 | Multiple fields                                                             | ✓      | ✓          | ◐       | ✗         | ○     | ✓             | ✗   |
 | **[Bulk Operations](https://hl7.org/fhir/uv/bulkdata/)**                    |
 | [Bulk Export](https://hl7.org/fhir/uv/bulkdata/export.html)                 | ✓      | ✓          | ○       | ○         | ○     | ○             | ◐   |
-| [Bulk Submit ingest](https://hackmd.io/@argonaut/rJoqHZrPle)                | ✓      | ✓          | ○       | ○         | ○     | ○             | ✓   |
-| [Bulk Submit REST worker](https://hackmd.io/@argonaut/rJoqHZrPle)           | ✓      | ✓          | ✗       | ✗         | ✗     | ✗             | ✗   |
+| [Bulk Submit ingest](https://build.fhir.org/ig/HL7/bulk-data/en/submit.html)                | ✓      | ✓          | ○       | ○         | ○     | ○             | ✓   |
+| [Bulk Submit REST worker](https://build.fhir.org/ig/HL7/bulk-data/en/submit.html)           | ✓      | ✓          | ✗       | ✗         | ✗     | ✗             | ✗   |
 
 **Notes on partial cells:**
 

--- a/crates/persistence/src/core/bulk_submit.rs
+++ b/crates/persistence/src/core/bulk_submit.rs
@@ -1,7 +1,8 @@
 //! Bulk submit types and traits.
 //!
 //! This module provides types and traits for implementing Bulk Data Submit
-//! as specified in the [Bulk Submit](https://hackmd.io/@argonaut/rJoqHZrPle) specification.
+//! as specified in the HL7 FHIR Bulk Data Access
+//! [Submit operation](https://build.fhir.org/ig/HL7/bulk-data/en/submit.html).
 //!
 //! # Overview
 //!

--- a/crates/rest/README.md
+++ b/crates/rest/README.md
@@ -14,6 +14,7 @@ This crate provides a complete implementation of the [FHIR RESTful API](https://
 - **Content Negotiation**: JSON format support with proper MIME types
 - **Multi-Tenant**: Built-in tenant isolation for multi-tenant deployments
 - **Bulk Data Export**: Asynchronous [FHIR Bulk Data Access](https://hl7.org/fhir/uv/bulkdata/export.html) `$export` (system / Patient / Group) with poll, manifest, download, and cancel
+- **Bulk Data Submit**: Asynchronous [FHIR Bulk Data Access **Submit**](https://build.fhir.org/ig/HL7/bulk-data/en/submit.html) `$bulk-submit` — HFS as Data Consumer fetches and ingests a provider's manifest/NDJSON, with poll, status manifest, and cancel
 
 ## Quick Start
 
@@ -76,6 +77,11 @@ cargo run --bin rest-server -- --port 3000 --log-level debug
 | export status / manifest | GET | `/export-status/[job_id]` |
 | export cancel + delete | DELETE | `/export-status/[job_id]` |
 | export file download | GET | `/export-file/[job_id]/[type]-[part]` |
+| bulk submit kick-off | POST | `/$bulk-submit` |
+| bulk submit status kick-off | POST | `/$bulk-submit-status` |
+| bulk submit poll / manifest | GET | `/bulk-submit-status/[poll_token]` |
+| bulk submit cancel | DELETE | `/bulk-submit-status/[poll_token]` |
+| bulk submit file download | GET | `/bulk-submit-file/[poll_token]/[part]` |
 | purge (instance) | DELETE | `/[type]/[id]/$purge` |
 | purge (type) | POST | `/[type]/$purge` |
 | reindex (system) | POST | `/$reindex` |
@@ -190,6 +196,57 @@ Bulk export is available on the `sqlite`, `postgres`, `sqlite-elasticsearch`, an
 
 A runnable multi-instance stack (HFS + PostgreSQL + MinIO + Keycloak) is provided
 as a compose example in [`docker/bulk-export/`](../../docker/bulk-export/README.md).
+
+### Bulk Data Submit
+
+HFS implements the HL7 FHIR Bulk Data Access **Submit** operation
+([`submit.html`](https://build.fhir.org/ig/HL7/bulk-data/en/submit.html)) in the
+**Data Consumer** role: a Data Provider `POST`s `$bulk-submit` referencing a Bulk
+Export Manifest, HFS asynchronously fetches the manifest and NDJSON files, ingests
+them, and exposes results through a status manifest.
+
+- **Endpoints**: `POST /$bulk-submit` (kick-off, `200`), `POST /$bulk-submit-status`
+  (`202` + `Content-Location`), `GET`/`DELETE /bulk-submit-status/{poll_token}`
+  (poll / cancel), and `GET /bulk-submit-file/{poll_token}/{part}` (HFS-hosted
+  status artifacts). See the [API Endpoints](#api-endpoints) table.
+- **Scope**: every surface requires the `system/bulk-submit` SMART scope when auth is
+  enabled; status, cancel, and file surfaces also enforce submission ownership.
+- **Backends**: available on `sqlite`, `postgres`, and their `-elasticsearch`
+  composites; other backends return `501`. Job state reuses the FHIR-resource
+  backend — no separate job store to configure.
+- **Status manifest**: emits `output[]`, `outcome[]`, and `deleted[]` arrays (each
+  entry carries `url`, `count`, and `fileSize`), plus `requiresAccessToken`,
+  `transactionTime`, and an always-present `link[]` (single, non-paginated).
+
+Configured via `HFS_BULK_SUBMIT_*` environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HFS_BULK_SUBMIT_ENABLED` | `true` | Master switch — when `false`, all `$bulk-submit` endpoints return `501`. |
+| `HFS_BULK_SUBMIT_OUTPUT_BACKEND` | `local-fs` | Status-artifact store: `local-fs` or `s3`. |
+| `HFS_BULK_SUBMIT_OUTPUT_DIR` | `${HFS_DATA_DIR}/submit` | Local-FS artifact root. |
+| `HFS_BULK_SUBMIT_S3_BUCKET` | *(none)* | S3 bucket — required when `OUTPUT_BACKEND=s3`. |
+| `HFS_BULK_SUBMIT_REQUIRES_ACCESS_TOKEN` | `auto` | Manifest posture: `auto` / `true` / `false`. **`false` is invalid with `local-fs`.** |
+| `HFS_BULK_SUBMIT_FILE_URL_TTL` | `3600` | Pre-signed artifact-URL lifetime, seconds. |
+| `HFS_BULK_SUBMIT_OUTPUT_TTL` | `86400` | Artifact retention after completion, seconds. |
+| `HFS_BULK_SUBMIT_RETRY_AFTER` | `120` | `Retry-After` (seconds) advertised on an in-progress status poll. |
+| `HFS_BULK_SUBMIT_WORKER_CONCURRENCY` | `2` | In-process submit-worker pool size. |
+| `HFS_BULK_SUBMIT_DISABLE_LOCAL_WORKER` | `false` | Disable in-pod workers. |
+| `HFS_BULK_SUBMIT_MAX_CONCURRENT_PER_TENANT` | `4` | Per-tenant active-submission cap (kick-off returns `429` if exceeded). |
+| `HFS_BULK_SUBMIT_BATCH_SIZE` | `1000` | Resources per ingestion batch. |
+| `HFS_BULK_SUBMIT_LEASE_DURATION` | `60` | Initial manifest lease length, seconds. Must exceed the heartbeat interval. |
+| `HFS_BULK_SUBMIT_HEARTBEAT_INTERVAL` | `20` | Worker heartbeat cadence, seconds. |
+| `HFS_BULK_SUBMIT_CLEANUP_INTERVAL` | `300` | Cleanup-task scan interval, seconds. |
+| `HFS_BULK_SUBMIT_CLIENT_ID` | *(none)* | OAuth `client_id` for fetching protected provider files. |
+| `HFS_BULK_SUBMIT_PRIVATE_KEY` | *(none)* | PEM key for the `private_key_jwt` client assertion. |
+| `HFS_BULK_SUBMIT_SIGNING_ALG` | `ES384` | Client-assertion signing algorithm: `ES384` or `RS384`. |
+| `HFS_BULK_SUBMIT_OUTBOUND_SCOPE` | `system/*.rs` | Read scope requested for file-retrieval tokens (never `system/bulk-submit`). |
+
+For protected provider files (`requiresAccessToken`), HFS acquires a read-scoped
+token via SMART Backend Services (`client_credentials` + `private_key_jwt`) when
+`HFS_BULK_SUBMIT_CLIENT_ID` and `HFS_BULK_SUBMIT_PRIVATE_KEY` are set. JWE-encrypted
+files (`fileEncryptionKey`) are supported for `dir` + `A128GCM`/`A256GCM` when built
+with the `bulk-submit-jwe` feature.
 
 ### SQL-on-FHIR Async Export
 

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -595,7 +595,7 @@ impl ValidationConfig {
 ///
 /// HFS acts as the Data Consumer: it accepts submissions, fetches the referenced
 /// manifests/files, ingests them, and serves a status manifest whose
-/// `output`/`error`/`deleted` artifacts are written to the output store below.
+/// `output`/`outcome`/`deleted` artifacts are written to the output store below.
 #[derive(Debug, Clone)]
 pub struct BulkSubmitConfig {
     /// Master switch — when `false`, the `$bulk-submit` endpoints return `501`.
@@ -636,6 +636,8 @@ pub struct BulkSubmitConfig {
     pub signing_alg: String,
     /// Read scope requested for the outbound file-retrieval token.
     pub outbound_scope: String,
+    /// `Retry-After` (seconds) advertised on an in-progress status poll.
+    pub retry_after_secs: u64,
 }
 
 impl Default for BulkSubmitConfig {
@@ -660,6 +662,7 @@ impl Default for BulkSubmitConfig {
             private_key: None,
             signing_alg: "ES384".to_string(),
             outbound_scope: "system/*.rs".to_string(),
+            retry_after_secs: 120,
         }
     }
 }
@@ -726,6 +729,7 @@ impl BulkSubmitConfig {
             signing_alg: std::env::var("HFS_BULK_SUBMIT_SIGNING_ALG").unwrap_or(d.signing_alg),
             outbound_scope: std::env::var("HFS_BULK_SUBMIT_OUTBOUND_SCOPE")
                 .unwrap_or(d.outbound_scope),
+            retry_after_secs: env_u64("HFS_BULK_SUBMIT_RETRY_AFTER", d.retry_after_secs),
         }
     }
 

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -6,7 +6,8 @@
 //! poll / cancel; and `GET /bulk-submit-file/{token}/{part}` serves HFS-hosted
 //! status-manifest artifacts.
 //!
-//! See `submit.html` (Argo25 branch of the Bulk Data IG).
+//! Implements the FHIR Bulk Data Access **Submit** operation:
+//! <https://build.fhir.org/ig/HL7/bulk-data/en/submit.html>.
 
 use std::time::Duration;
 
@@ -604,7 +605,7 @@ where
         return Response::builder()
             .status(StatusCode::ACCEPTED)
             .header("X-Progress", format!("processing {pct}% complete"))
-            .header("Retry-After", "120")
+            .header("Retry-After", cfg.retry_after_secs.to_string())
             .body(Body::empty())
             .map_err(|e| RestError::InternalError {
                 message: e.to_string(),
@@ -625,9 +626,12 @@ where
     let base = state.base_url().trim_end_matches('/');
 
     let mut output_arr = Vec::new();
-    let mut error_arr = Vec::new();
+    let mut outcome_arr = Vec::new();
     let mut deleted_arr = Vec::new();
-    let mut requires_token = cfg.requires_access_token != "false";
+    // `requiresAccessToken` describes whether retrieving *any* file requires a
+    // token. Seed from the configured posture, then OR in each file — never let a
+    // single open file clear a token requirement set by another file or the config.
+    let mut requires_token = cfg.requires_access_token == "true";
 
     for f in &files {
         let resource_type = f
@@ -650,20 +654,23 @@ where
         // `/bulk-submit-file/{poll_token}/{part}` surface so downloads are gated by
         // submit ownership + `system/bulk-submit` — never the export-file surface.
         // Pre-signed URLs (S3) are capability URLs and are used as-is.
+        requires_token |= dl.requires_access_token;
         let url = if dl.requires_access_token {
-            requires_token = true;
             format!(
                 "{base}/bulk-submit-file/{token}/{resource_type}-{}",
                 f.part_index
             )
         } else {
-            requires_token = false;
             dl.url
         };
         let url = serde_json::Value::String(url);
         match f.file_type.as_str() {
             "output" => {
-                let mut entry = json!({ "url": url, "count": f.line_count });
+                let mut entry = json!({
+                    "url": url,
+                    "count": f.line_count,
+                    "fileSize": f.byte_count,
+                });
                 if let Some(rt) = &f.resource_type {
                     entry["type"] = json!(rt);
                 }
@@ -676,15 +683,20 @@ where
                 let mut entry = json!({
                     "url": url,
                     "count": f.line_count,
+                    "fileSize": f.byte_count,
                     "manifestUrl": f.manifest_url.clone().unwrap_or_default(),
                 });
                 if let Some(cs) = &f.count_severity {
                     entry["countSeverity"] = severity_array(cs);
                 }
-                error_arr.push(entry);
+                outcome_arr.push(entry);
             }
             "deleted" => {
-                deleted_arr.push(json!({ "url": url, "count": f.line_count }));
+                deleted_arr.push(json!({
+                    "url": url,
+                    "count": f.line_count,
+                    "fileSize": f.byte_count,
+                }));
             }
             _ => {}
         }
@@ -696,7 +708,7 @@ where
         "requiresAccessToken": requires_token,
         "outputFormat": "application/fhir+ndjson",
         "output": output_arr,
-        "error": error_arr,
+        "outcome": outcome_arr,
         "deleted": deleted_arr,
         // `link` is part of the status-manifest schema; HFS returns a single,
         // non-paginated manifest, so it is always empty.

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -275,7 +275,17 @@ async fn test_full_lifecycle_ingests_and_polls() {
     let manifest: Value = done.json();
     assert_eq!(manifest["submissionId"], "it-1");
     assert!(manifest["output"].is_array());
+    // Spec (build.fhir.org submit.html): the OperationOutcome array is `outcome`,
+    // output entries carry `fileSize`, and `link` is always present.
+    assert!(manifest["outcome"].is_array());
     assert!(manifest["link"].is_array());
+    assert!(
+        manifest["output"][0]["fileSize"].is_number(),
+        "output entry must carry fileSize, got {}",
+        manifest["output"][0]
+    );
+    // Every local-fs artifact is token-gated, so requiresAccessToken aggregates true.
+    assert_eq!(manifest["requiresAccessToken"], true);
     // HFS-served (local-fs) artifacts MUST be advertised on the submit-file
     // surface, not the export-file surface.
     let out_url = manifest["output"][0]["url"].as_str().unwrap();


### PR DESCRIPTION
## Summary

Aligns the `$bulk-submit` status manifest with the HL7 FHIR Bulk Data Access **Submit** operation (https://build.fhir.org/ig/HL7/bulk-data/en/submit.html — now the spec of record) and documents the operation, which previously had no README coverage.

This lands the small, safe conformance fixes; the larger gaps are tracked as separate issues for their own PRs.

## Changes

**Quick-win manifest fixes**
- `requiresAccessToken` now OR-aggregates across all output/outcome/deleted files instead of reflecting only the last file processed — closes #397
- Emit `fileSize` (from the already-captured `byte_count`) on `output[]`/`outcome[]`/`deleted[]` entries — closes #398
- Rename the manifest OperationOutcome array `error[]` → `outcome[]` to match the build spec's Outcome Array; `manifestUrl` and `countSeverity` were already spec-compliant — closes #400
- Make the in-progress poll `Retry-After` configurable via new `HFS_BULK_SUBMIT_RETRY_AFTER` (default 120) — partially addresses #399 (the `429` rate-limiting piece stays open there)

**Documentation**
- New `### Bulk Data Submit` section in `crates/rest/README.md` (endpoints, `system/bulk-submit` scope, full `HFS_BULK_SUBMIT_*` env table, spec link) + endpoint-table rows + feature bullet
- Fix the dangling `HFS_BULK_SUBMIT_*` pointer in the top-level `README.md` (it referenced a non-existent CLAUDE.md section) → now points to the new rest README section
- Repoint code doc-comments from the Argonaut HackMD draft to build.fhir.org (`handlers/bulk_submit.rs`, `core/bulk_submit.rs`, persistence capability matrix)

## Not in this PR (tracked separately)

#399 (429 rate-limiting), #401 (import/metadata ingestion semantics), #402 (streaming vs in-memory buffering), #403 (JWE algorithm coverage), #404 (status-manifest pagination) — each a larger change with its own design/test surface.

## Verification

- `cargo build -p helios-rest -p helios-hfs` and `cargo build -p helios-hfs --features bulk-submit-jwe` — both clean
- `cargo test -p helios-rest --test bulk_submit` (4 passed) and `--test bulk_submit_oauth` (3 passed), with strengthened assertions for `outcome[]`, per-file `fileSize`, and aggregated `requiresAccessToken`
- No new clippy warnings in the touched files

https://claude.ai/code/session_01LTDQFXxvs6SRcECptiznNH