### PR TITLE
fix(search): honor :Type qualifiers and multi-target references in chained search

### DIFF
--- a/crates/persistence/src/search/chain_resolver.rs
+++ b/crates/persistence/src/search/chain_resolver.rs
@@ -64,13 +64,12 @@ where
                 },
             ));
         }
-        let chain = reconstruct_chain_string(param);
         let value = param
             .values
             .first()
             .map(|v| v.value.clone())
             .unwrap_or_default();
-        let ids = resolve_forward_chain(storage, tenant, &base_type, &chain, &value).await?;
+        let ids = resolve_forward_chain(storage, tenant, &base_type, param, &value).await?;
         id_sets.push(ids.into_iter().collect());
     }
 
@@ -117,16 +116,6 @@ where
     Ok(rewritten)
 }
 
-/// Reconstructs the dotted chain string (`subject.organization.name`) from a
-/// parameter's structured chain links.
-fn reconstruct_chain_string(param: &SearchParameter) -> String {
-    let mut parts = vec![param.name.clone()];
-    for link in &param.chain {
-        parts.push(link.target_param.clone());
-    }
-    parts.join(".")
-}
-
 /// Intersects a list of id sets (`AND` across chains). An empty input means no
 /// chains contributed, which should not happen here, but yields an empty set.
 fn intersect(mut sets: Vec<HashSet<String>>) -> HashSet<String> {
@@ -143,109 +132,127 @@ fn intersect(mut sets: Vec<HashSet<String>>) -> HashSet<String> {
 
 /// Resolves a forward chain (e.g. `subject.organization.name=Hospital`) to a
 /// set of `base_type` resource ids, walking from the deepest target back out.
+///
+/// Target types per hop come from an explicit `:Type` qualifier when the
+/// request carried one, else from the registry's declared targets — all of
+/// them: FHIR's untyped chain searches every target type, so a multi-target
+/// reference like `Patient.general-practitioner` fans out to Practitioner,
+/// Organization, and PractitionerRole rather than guessing one. The name
+/// heuristic remains only for parameters the registry does not know.
 async fn resolve_forward_chain<S>(
     storage: &S,
     tenant: &TenantContext,
     base_type: &str,
-    chain: &str,
+    param: &SearchParameter,
     value: &str,
 ) -> StorageResult<Vec<String>>
 where
     S: SearchProvider + ?Sized,
 {
-    let parts: Vec<&str> = chain.split('.').collect();
-    if parts.len() < 2 {
+    let hops = &param.chain;
+    if hops.is_empty() {
         return Ok(Vec::new());
     }
+    let terminal_param = &hops[hops.len() - 1].target_param;
 
-    // Per-link target types, resolved from the registry (single-target params)
-    // with a heuristic fallback for ambiguous references.
-    let target_types: Vec<String> = {
+    // Candidate parent/target types per hop, and the terminal param's type.
+    let (parent_types_per_hop, terminal_types, terminal_type) = {
         let reg = storage.search_param_registry(tenant);
         let registry = reg.read();
-        let mut types = Vec::with_capacity(parts.len() - 1);
-        let mut current = base_type.to_string();
-        for ref_param in parts.iter().take(parts.len() - 1) {
-            let next = registry
-                .get_param(&current, ref_param)
-                .and_then(|def| {
-                    def.target.as_ref().and_then(|t| {
-                        if t.len() == 1 {
-                            Some(t[0].clone())
-                        } else {
-                            None
+
+        let mut parents: Vec<Vec<String>> = Vec::with_capacity(hops.len());
+        let mut current: Vec<String> = vec![base_type.to_string()];
+        for hop in hops {
+            parents.push(current.clone());
+            current = match &hop.target_type {
+                Some(t) => vec![t.clone()],
+                None => {
+                    let mut targets: Vec<String> = Vec::new();
+                    for parent in &current {
+                        if let Some(def) = registry.get_param(parent, &hop.reference_param) {
+                            for t in def.target.as_deref().unwrap_or_default() {
+                                if !targets.contains(t) {
+                                    targets.push(t.clone());
+                                }
+                            }
                         }
-                    })
-                })
-                .unwrap_or_else(|| infer_target_type(ref_param));
-            types.push(next.clone());
-            current = next;
+                    }
+                    if targets.is_empty() {
+                        vec![infer_target_type(&hop.reference_param)]
+                    } else {
+                        targets
+                    }
+                }
+            };
         }
-        types
-    };
 
-    // Deepest hop: search the terminal target type for the terminal param.
-    let terminal_param = parts[parts.len() - 1];
-    let deepest_type = target_types.last().map(String::as_str).unwrap_or(base_type);
-    let terminal_type = {
-        let reg = storage.search_param_registry(tenant);
-        let registry = reg.read();
-        resolve_param_type(
+        // Only search terminal types that define the terminal param — the
+        // others cannot match. Keep the unfiltered set if that empties the
+        // list (an unregistered custom param still gets a permissive try).
+        let defined: Vec<String> = current
+            .iter()
+            .filter(|t| registry.get_param(t, terminal_param).is_some())
+            .cloned()
+            .collect();
+        let terminal_types = if defined.is_empty() { current } else { defined };
+        let terminal_type = resolve_param_type(
             &registry,
-            deepest_type,
+            &terminal_types[0],
             terminal_param,
             &[SearchValue::eq(value)],
-        )
+        );
+        (parents, terminal_types, terminal_type)
     };
-    let terminal_query = SearchQuery::new(deepest_type).with_parameter(SearchParameter {
-        name: terminal_param.to_string(),
-        param_type: terminal_type,
-        modifier: None,
-        values: vec![SearchValue::eq(value)],
-        chain: vec![],
-        components: vec![],
-    });
-    let result = storage.search(tenant, &terminal_query).await?;
-    let mut current_refs: Vec<String> = result
-        .resources
-        .items
-        .into_iter()
-        .map(|r| format!("{}/{}", r.resource_type(), r.id()))
-        .collect();
+
+    // Deepest hop: search each candidate terminal type, union the refs.
+    let mut current_refs: Vec<String> = Vec::new();
+    for terminal_target in &terminal_types {
+        let terminal_query = SearchQuery::new(terminal_target).with_parameter(SearchParameter {
+            name: terminal_param.clone(),
+            param_type: terminal_type,
+            modifier: None,
+            values: vec![SearchValue::eq(value)],
+            chain: vec![],
+            components: vec![],
+        });
+        let result = storage.search(tenant, &terminal_query).await?;
+        current_refs.extend(
+            result
+                .resources
+                .items
+                .into_iter()
+                .map(|r| format!("{}/{}", r.resource_type(), r.id())),
+        );
+    }
     if current_refs.is_empty() {
         return Ok(Vec::new());
     }
 
-    // Walk back out: for each reference hop, find parents pointing at the refs.
-    for i in (0..parts.len() - 1).rev() {
-        let ref_param = parts[i];
-        let parent_type = if i == 0 {
-            base_type
-        } else {
-            &target_types[i - 1]
-        };
+    // Walk back out: for each reference hop, find parents pointing at the
+    // refs, across every candidate parent type.
+    for i in (0..hops.len()).rev() {
+        let ref_param = &hops[i].reference_param;
         let values: Vec<SearchValue> = current_refs.iter().map(SearchValue::eq).collect();
-        let query = SearchQuery::new(parent_type).with_parameter(SearchParameter {
-            name: ref_param.to_string(),
-            param_type: SearchParamType::Reference,
-            modifier: None,
-            values,
-            chain: vec![],
-            components: vec![],
-        });
-        let r = storage.search(tenant, &query).await?;
-        current_refs = r
-            .resources
-            .items
-            .into_iter()
-            .map(|res| {
+        let mut next_refs: Vec<String> = Vec::new();
+        for parent_type in &parent_types_per_hop[i] {
+            let query = SearchQuery::new(parent_type).with_parameter(SearchParameter {
+                name: ref_param.clone(),
+                param_type: SearchParamType::Reference,
+                modifier: None,
+                values: values.clone(),
+                chain: vec![],
+                components: vec![],
+            });
+            let r = storage.search(tenant, &query).await?;
+            next_refs.extend(r.resources.items.into_iter().map(|res| {
                 if i == 0 {
                     res.id().to_string()
                 } else {
                     format!("{}/{}", res.resource_type(), res.id())
                 }
-            })
-            .collect();
+            }));
+        }
+        current_refs = next_refs;
         if current_refs.is_empty() {
             return Ok(Vec::new());
         }

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -276,7 +276,15 @@ fn parse_search_parameter(
     value: &str,
     registry: &SearchParameterRegistry,
 ) -> Result<SearchParameter, RestError> {
-    let (param_name, modifier) = parse_parameter_name(name);
+    // A dotted name is a chained parameter, and a colon inside it
+    // (`subject:Patient.name`) is the chain's type qualifier — modifier
+    // parsing must not eat it (it used to keep `subject` and drop the whole
+    // `.name` tail, turning the chain into a plain reference search).
+    let (param_name, modifier) = if name.contains('.') {
+        (name, None)
+    } else {
+        parse_parameter_name(name)
+    };
 
     // Check for chained parameters (e.g., "patient.name" or "subject:Patient.name")
     let (base_name, chain) = parse_chain(param_name);

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -1662,8 +1662,72 @@ mod chaining {
         response.assert_status_ok();
         let body: Value = response.json();
 
-        // Should work the same as without type qualifier
-        assert_eq!(body["resourceType"], "Bundle");
+        // Works the same as without the qualifier — and actually matches:
+        // the qualifier used to be parsed as a modifier that swallowed the
+        // chain, silently degrading this into `subject=Smith` (zero results).
+        let entries = get_bundle_entries(&body);
+        assert!(
+            !entries.is_empty(),
+            "typed chain must match the same observations as the untyped one"
+        );
+        for entry in &entries {
+            let subject_ref = entry["resource"]["subject"]["reference"].as_str().unwrap();
+            assert!(
+                subject_ref.contains("patient-1") || subject_ref.contains("patient-2"),
+                "Should only include observations for patients named Smith"
+            );
+        }
+    }
+
+    /// `general-practitioner` declares multiple targets (Practitioner,
+    /// Organization, PractitionerRole). The resolver used to fall back to a
+    /// name heuristic that fabricated a resource type called
+    /// `General-practitioner`, so this chain silently matched nothing.
+    #[tokio::test]
+    async fn test_chained_multi_target_reference() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        for url in [
+            "/Patient?general-practitioner.name=Brown",
+            "/Patient?general-practitioner:Practitioner.name=Brown",
+        ] {
+            let response = server
+                .get(url)
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .await;
+            response.assert_status_ok();
+            let body: Value = response.json();
+            let entries = get_bundle_entries(&body);
+            let ids: Vec<&str> = entries
+                .iter()
+                .map(|e| e["resource"]["id"].as_str().unwrap())
+                .collect();
+            assert_eq!(ids, ["patient-1"], "{url}");
+        }
+    }
+
+    /// A forward chain and a reverse chain in one query intersect.
+    #[tokio::test]
+    async fn test_forward_and_reverse_chain_combined() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_has:Observation:subject:status=final&general-practitioner.name=Brown")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+        let ids: Vec<&str> = entries
+            .iter()
+            .map(|e| e["resource"]["id"].as_str().unwrap())
+            .collect();
+        assert!(
+            ids.contains(&"patient-1"),
+            "patient-1 has both a final Observation and GP Brown, got {ids:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/ui/e2e/tests/queries.spec.ts
+++ b/crates/ui/e2e/tests/queries.spec.ts
@@ -46,6 +46,37 @@ test.describe("query builder", () => {
       .not.toBe(firstPage.join());
   });
 
+  /// Chained search end to end (#406): the two chain directions meet on the
+  /// patient in the middle — Practitioner <- Patient (generalPractitioner)
+  /// <- Observation (subject) — and the combined query returns exactly it.
+  test("a combined chain and _has query runs and returns the linked patient", async ({
+    queries,
+    request,
+  }) => {
+    // Unique per run: the suite may reuse a persistent dev server.
+    const tag = Date.now().toString(36);
+    const gp = await createResource(request, "Practitioner", {
+      name: [{ family: `ChainSmith${tag}` }],
+    });
+    const patient = await createResource(request, "Patient", {
+      name: [{ family: "ChainLinked" }],
+      generalPractitioner: [{ reference: `Practitioner/${gp}` }],
+    });
+    await createResource(request, "Observation", {
+      status: "final",
+      code: { coding: [{ code: `chain-94-${tag}` }] },
+      subject: { reference: `Patient/${patient}` },
+    });
+
+    await queries.goto();
+    await queries.builder.run(
+      `Patient?_has:Observation:patient:code=chain-94-${tag}&general-practitioner.name=ChainSmith${tag}`,
+    );
+    await queries.results.waitShown();
+    await expect(queries.results.rows).toHaveCount(1);
+    await expect(queries.results.rows.first()).toContainText(patient);
+  });
+
   test("adding a condition row hydrates the builder", async ({ queries }) => {
     // The builder sections are hidden until there's a base query to parse.
     await queries.builder.setUrl("Patient");


### PR DESCRIPTION
## Summary

Closes #406 — found by manually testing the #394 builder. Two defects made chained search silently return zero results on every backend (the shared resolver is the effective path):

1. **The `:Type` qualifier swallowed the chain.** The REST extractor split the raw key on the first colon before chain detection, so `subject:Patient.family=X` kept `subject`, read `Patient.family` as a modifier, and dropped the chain entirely — the documented disambiguator silently degraded the query into a plain reference search. Dotted names now go to the chain parser whole.
2. **Multi-target references resolved to a fabricated type.** The resolver flattened the structured chain back to a dotted string (losing qualifiers) and guessed ambiguous targets from the parameter name — producing types like `General-practitioner`, which match nothing. It now consumes the structured hops: an explicit qualifier wins; otherwise every declared registry target is searched and the refs unioned, per the spec's untyped-chain semantics (terminal candidates prune to types defining the leaf param). The name heuristic remains only for params the registry does not know.

## Tests

- The existing typed-chain integration test asserted only 'is a Bundle' — which is exactly how a zero-result degradation stayed green; it now asserts the matches.
- New integration coverage: the multi-target chain (`Patient?general-practitioner.name=`, untyped and typed) and a combined forward + `_has` query.
- New browser e2e: seeds Practitioner ← Patient ← Observation via the API and runs the combined chain from the query builder, asserting the linked patient row renders.
- helios-rest search_integration 99 green, persistence 727, rest 400, fmt clean.