### PR TITLE
fix(bulk-submit): rate-limit status polls with 429 + Retry-After

### DIFF
--- a/.claude/skills/bulk-data-submit/SKILL.md
+++ b/.claude/skills/bulk-data-submit/SKILL.md
@@ -13,7 +13,7 @@ HFS implements the FHIR Bulk Data Submit operation from the Argo25 branch as the
 |---|---|---|---|
 | kick-off | POST | `/$bulk-submit` | `200` sync accept; queues ingestion; `429` if blocking; `4XX` plus OperationOutcome on validation error |
 | status kick-off | POST | `/$bulk-submit-status` | `202` plus `Content-Location` poll URL |
-| poll or manifest | GET | `/bulk-submit-status/{poll_token}` | `202` in-progress with `X-Progress` and `Retry-After`; `200` plus status manifest when done; `404` after delete |
+| poll or manifest | GET | `/bulk-submit-status/{poll_token}` | `202` in-progress with `X-Progress` and `Retry-After`; `200` plus status manifest when done; `429` plus `Retry-After` when rate-limited; `404` after delete |
 | cancel | DELETE | `/bulk-submit-status/{poll_token}` | `202`; subsequent poll returns `404` |
 | HFS-served artifact | GET | `/bulk-submit-file/{poll_token}/{part}` | `200` `application/fhir+ndjson` |
 
@@ -59,6 +59,10 @@ At least one of `submissionStatus` or `manifestUrl` must be populated.
 | `HFS_BULK_SUBMIT_PRIVATE_KEY` | none | PEM key for `private_key_jwt` client assertion |
 | `HFS_BULK_SUBMIT_SIGNING_ALG` | `ES384` | `ES384` or `RS384` |
 | `HFS_BULK_SUBMIT_OUTBOUND_SCOPE` | `system/*.rs` | Read scope requested for file-retrieval tokens; never `system/bulk-submit` |
+| `HFS_BULK_SUBMIT_RETRY_AFTER` | `120` | `Retry-After` seconds advertised on an in-progress status poll |
+| `HFS_BULK_SUBMIT_POLL_RATE_LIMIT` | `10` | Status polls per client, per submission, per window; `0` disables |
+| `HFS_BULK_SUBMIT_POLL_RATE_WINDOW` | `60` | Sliding window for the poll rate limit, in seconds |
+| `HFS_BULK_SUBMIT_BLOCK_CONCURRENT_SUBMISSION` | `false` | Reject a new submission while one is in-progress; returns `429` |
 
 Job state reuses the same backend as the FHIR resources. SQLite shares `./data/hfs.db`; PostgreSQL shares `HFS_DATABASE_URL`. Bulk submit is available on `sqlite`, `postgres`, and their `-elasticsearch` composites. Other backends return `501`. The backend capability splits into `BulkSubmitIngest` (the synchronous `BulkSubmitProvider` ingestion engine) and `BulkSubmitRestWorker` (full `$bulk-submit` REST worker/job-store): SQLite and Postgres advertise both, while S3 advertises only `BulkSubmitIngest` and never owns REST-worker job state.
 
@@ -75,4 +79,5 @@ Job state reuses the same backend as the FHIR resources. SQLite shares `./data/h
 - Build JWE support with `cargo build -p helios-hfs --features bulk-submit-jwe`.
 - Without the feature, or for other JWE algorithms, encrypted files record a `not-supported` manifest-level error while unencrypted manifests proceed.
 - Status `link` and pagination: HFS returns a single, non-paginated status manifest; the `link` array is always present and empty.
+- Status-poll pacing: the `202` advertises `HFS_BULK_SUBMIT_RETRY_AFTER`, and a client that polls past `HFS_BULK_SUBMIT_POLL_RATE_LIMIT` within the window gets `429` plus a `Retry-After` pointing at the end of that window. Buckets are keyed by poll token plus principal, falling back to peer address; the check runs before any job-store work, so throttled polls stay cheap.
 - Cleanup periodically removes status artifacts for submissions whose `updated_at` exceeds `HFS_BULK_SUBMIT_OUTPUT_TTL`.

--- a/crates/rest/README.md
+++ b/crates/rest/README.md
@@ -211,6 +211,11 @@ them, and exposes results through a status manifest.
   status artifacts). See the [API Endpoints](#api-endpoints) table.
 - **Scope**: every surface requires the `system/bulk-submit` SMART scope when auth is
   enabled; status, cancel, and file surfaces also enforce submission ownership.
+- **Poll pacing**: an in-progress poll advertises `Retry-After`
+  (`HFS_BULK_SUBMIT_RETRY_AFTER`); a client that ignores it and hammers the poll URL
+  is throttled with `429` plus a `Retry-After` pointing at the end of the rate window
+  (`HFS_BULK_SUBMIT_POLL_RATE_LIMIT` / `_POLL_RATE_WINDOW`). Buckets are per client
+  (principal, else peer address) per poll token.
 - **Backends**: available on `sqlite`, `postgres`, and their `-elasticsearch`
   composites; other backends return `501`. Job state reuses the FHIR-resource
   backend — no separate job store to configure.
@@ -230,6 +235,8 @@ Configured via `HFS_BULK_SUBMIT_*` environment variables:
 | `HFS_BULK_SUBMIT_FILE_URL_TTL` | `3600` | Pre-signed artifact-URL lifetime, seconds. |
 | `HFS_BULK_SUBMIT_OUTPUT_TTL` | `86400` | Artifact retention after completion, seconds. |
 | `HFS_BULK_SUBMIT_RETRY_AFTER` | `120` | `Retry-After` (seconds) advertised on an in-progress status poll. |
+| `HFS_BULK_SUBMIT_POLL_RATE_LIMIT` | `10` | Status polls allowed per client, per submission, per rate window. `0` disables poll rate limiting. |
+| `HFS_BULK_SUBMIT_POLL_RATE_WINDOW` | `60` | Sliding window for the poll rate limit, seconds. |
 | `HFS_BULK_SUBMIT_WORKER_CONCURRENCY` | `2` | In-process submit-worker pool size. |
 | `HFS_BULK_SUBMIT_DISABLE_LOCAL_WORKER` | `false` | Disable in-pod workers. |
 | `HFS_BULK_SUBMIT_MAX_CONCURRENT_PER_TENANT` | `4` | Per-tenant active-submission cap (kick-off returns `429` if exceeded). |

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -638,6 +638,11 @@ pub struct BulkSubmitConfig {
     pub outbound_scope: String,
     /// `Retry-After` (seconds) advertised on an in-progress status poll.
     pub retry_after_secs: u64,
+    /// Status polls allowed per client, per submission, per rate window.
+    /// `0` disables poll rate limiting.
+    pub poll_rate_limit: u32,
+    /// Sliding window for [`Self::poll_rate_limit`], in seconds.
+    pub poll_rate_window_secs: u64,
 }
 
 impl Default for BulkSubmitConfig {
@@ -663,6 +668,11 @@ impl Default for BulkSubmitConfig {
             signing_alg: "ES384".to_string(),
             outbound_scope: "system/*.rs".to_string(),
             retry_after_secs: 120,
+            // A client honouring the advertised Retry-After polls twice an
+            // hour, so 10 polls a minute is far above any well-behaved cadence
+            // and only bites on a hammering loop.
+            poll_rate_limit: 10,
+            poll_rate_window_secs: 60,
         }
     }
 }
@@ -730,6 +740,11 @@ impl BulkSubmitConfig {
             outbound_scope: std::env::var("HFS_BULK_SUBMIT_OUTBOUND_SCOPE")
                 .unwrap_or(d.outbound_scope),
             retry_after_secs: env_u64("HFS_BULK_SUBMIT_RETRY_AFTER", d.retry_after_secs),
+            poll_rate_limit: env_u32("HFS_BULK_SUBMIT_POLL_RATE_LIMIT", d.poll_rate_limit),
+            poll_rate_window_secs: env_u64(
+                "HFS_BULK_SUBMIT_POLL_RATE_WINDOW",
+                d.poll_rate_window_secs,
+            ),
         }
     }
 
@@ -786,6 +801,12 @@ impl BulkSubmitConfig {
         }
         if self.cleanup_interval_secs == 0 {
             errors.push("HFS_BULK_SUBMIT_CLEANUP_INTERVAL must be > 0".to_string());
+        }
+        if self.poll_rate_limit > 0 && self.poll_rate_window_secs == 0 {
+            errors.push(
+                "HFS_BULK_SUBMIT_POLL_RATE_WINDOW must be > 0 when POLL_RATE_LIMIT is set"
+                    .to_string(),
+            );
         }
         if errors.is_empty() {
             Ok(())

--- a/crates/rest/src/error.rs
+++ b/crates/rest/src/error.rs
@@ -158,10 +158,15 @@ pub enum RestError {
         message: String,
     },
 
-    /// Too many requests — e.g. a concurrent submission is in progress (HTTP 429).
+    /// Too many requests — e.g. a concurrent submission is in progress, or a
+    /// rate limiter rejected the call (HTTP 429).
     TooManyRequests {
         /// Error message.
         message: String,
+        /// Delta-seconds to advertise in `Retry-After`. `None` when the server
+        /// has no honest estimate — better silent than a made-up number the
+        /// client would sleep on.
+        retry_after_secs: Option<u64>,
     },
 
     /// Backend temporarily over capacity — e.g. the database connection pool is
@@ -272,7 +277,7 @@ impl fmt::Display for RestError {
             RestError::Conflict { message } => {
                 write!(f, "Conflict: {}", message)
             }
-            RestError::TooManyRequests { message } => {
+            RestError::TooManyRequests { message, .. } => {
                 write!(f, "Too many requests: {}", message)
             }
             RestError::ServiceUnavailable { message } => {
@@ -384,7 +389,7 @@ impl RestError {
                 format!("Method {} not allowed on {}", method, resource_type),
             ),
             RestError::Conflict { message } => (StatusCode::CONFLICT, "conflict", message.clone()),
-            RestError::TooManyRequests { message } => {
+            RestError::TooManyRequests { message, .. } => {
                 (StatusCode::TOO_MANY_REQUESTS, "throttled", message.clone())
             }
             RestError::ServiceUnavailable { message } => (
@@ -461,6 +466,23 @@ impl IntoResponse for RestError {
                 Json(operation_outcome),
             )
                 .into_response();
+        }
+
+        // A throttled response carries the back-off the limiter computed, so the
+        // client knows when it may poll again instead of guessing (issue #399).
+        if let RestError::TooManyRequests {
+            retry_after_secs: Some(secs),
+            ..
+        } = &self
+        {
+            if let Ok(value) = axum::http::HeaderValue::from_str(&secs.to_string()) {
+                return (
+                    status,
+                    [(axum::http::header::RETRY_AFTER, value)],
+                    Json(operation_outcome),
+                )
+                    .into_response();
+            }
         }
 
         (status, Json(operation_outcome)).into_response()
@@ -949,6 +971,7 @@ mod tests {
     fn test_too_many_requests_display() {
         let err = RestError::TooManyRequests {
             message: "submission in progress".to_string(),
+            retry_after_secs: None,
         };
         assert_eq!(err.to_string(), "Too many requests: submission in progress");
     }
@@ -968,9 +991,34 @@ mod tests {
     fn test_too_many_requests_into_response_status() {
         let resp = RestError::TooManyRequests {
             message: "x".to_string(),
+            retry_after_secs: None,
         }
         .into_response();
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(
+            resp.headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .is_none(),
+            "no Retry-After when the server has no estimate to give"
+        );
+    }
+
+    #[test]
+    fn test_too_many_requests_carries_retry_after_when_known() {
+        // Spec (build.fhir.org submit.html): a rate-limited status poll SHOULD
+        // tell the client when to come back (issue #399).
+        let resp = RestError::TooManyRequests {
+            message: "slow down".to_string(),
+            retry_after_secs: Some(42),
+        }
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .expect("throttled response must carry Retry-After"),
+            "42"
+        );
     }
 
     // ── StorageError::BulkSubmit → RestError mapping ──────────────

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -9,6 +9,7 @@
 //! Implements the FHIR Bulk Data Access **Submit** operation:
 //! <https://build.fhir.org/ig/HL7/bulk-data/en/submit.html>.
 
+use std::net::IpAddr;
 use std::time::Duration;
 
 use axum::{
@@ -24,8 +25,10 @@ use helios_persistence::core::{
 };
 use serde_json::{Value, json};
 
+use crate::config::BulkSubmitConfig;
 use crate::error::{RestError, RestResult};
-use crate::extractors::TenantExtractor;
+use crate::extractors::{PeerIp, TenantExtractor};
+use crate::rate_limit::RateLimiter;
 use crate::state::AppState;
 
 /// The SMART operation scope authorizing every `$bulk-submit` surface.
@@ -65,6 +68,59 @@ fn owns_submission(principal: Option<&Principal>, owner_subject: Option<&str>) -
         None => true,
         Some(p) => owner_subject == Some(p.subject.as_str()) || p.scopes.has_system_wildcard(),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Status-poll rate limiting
+// ---------------------------------------------------------------------------
+
+/// Buckets for the status-poll surface. Private to this module, so a hammering
+/// poller cannot spend another surface's budget.
+static POLL_LIMITER: RateLimiter = RateLimiter::new();
+
+/// Who a poll is billed to: the poll token scopes the bucket to one submission,
+/// and the principal (else the peer address) separates clients sharing it. A
+/// deployment with neither auth nor a recorded peer shares one bucket per
+/// token — the restrictive reading, since polling is what we are limiting.
+fn poll_rate_limit_key(token: &str, principal: Option<&Principal>, peer: Option<IpAddr>) -> String {
+    match principal {
+        Some(p) => format!("{token}|sub:{}", p.subject),
+        None => match peer {
+            Some(ip) => format!("{token}|ip:{ip}"),
+            None => format!("{token}|anon"),
+        },
+    }
+}
+
+/// Enforces the per-client status-poll rate limit.
+///
+/// The Submit spec has Data Consumers rate-limit the status endpoint and tell a
+/// throttled client when to come back, so the `429` carries the delta-seconds
+/// until the window rolls forward (issue #399). `poll_rate_limit = 0` disables
+/// the limiter outright.
+fn check_poll_rate_limit(
+    cfg: &BulkSubmitConfig,
+    token: &str,
+    principal: Option<&Principal>,
+    peer: Option<IpAddr>,
+) -> RestResult<()> {
+    if cfg.poll_rate_limit == 0 {
+        return Ok(());
+    }
+    let key = poll_rate_limit_key(token, principal, peer);
+    POLL_LIMITER
+        .check_window(
+            &key,
+            cfg.poll_rate_limit,
+            Duration::from_secs(cfg.poll_rate_window_secs),
+        )
+        .map_err(|limited| RestError::TooManyRequests {
+            message: format!(
+                "too many status polls (max {} per {}s); honour the Retry-After header",
+                cfg.poll_rate_limit, cfg.poll_rate_window_secs
+            ),
+            retry_after_secs: Some(limited.retry_after_secs),
+        })
 }
 
 // ---------------------------------------------------------------------------
@@ -343,6 +399,10 @@ where
                     "too many concurrent submissions for this tenant (max {})",
                     cfg.max_concurrent_per_tenant
                 ),
+                // A slot frees when an in-flight submission finishes, which no
+                // one can time; the advertised poll cadence is the best hint
+                // available and keeps retries off a tight loop.
+                retry_after_secs: Some(cfg.retry_after_secs),
             });
         }
         let requires_token = cfg.requires_access_token != "false";
@@ -543,6 +603,7 @@ pub async fn bulk_submit_poll_handler<S>(
     State(state): State<AppState<S>>,
     Path(token): Path<String>,
     _tenant: TenantExtractor,
+    PeerIp(peer): PeerIp,
     request: Request,
 ) -> RestResult<Response>
 where
@@ -562,6 +623,10 @@ where
         .clone();
     let principal = request.extensions().get::<Principal>().cloned();
     check_submit_scope(principal.as_ref())?;
+
+    // Throttle before any job-store work: a client ignoring the advertised
+    // Retry-After should cost a cheap 429, not a round trip per poll.
+    check_poll_rate_limit(cfg, &token, principal.as_ref(), peer)?;
 
     let target = jobs
         .resolve_poll_token(&token)

--- a/crates/rest/src/handlers/nl_search.rs
+++ b/crates/rest/src/handlers/nl_search.rs
@@ -29,16 +29,14 @@ use axum::{
 use helios_persistence::core::{ResourceStorage, SearchProvider};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::HashMap;
-use std::collections::VecDeque;
 use std::net::IpAddr;
-use std::sync::{Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tracing::{debug, warn};
 
 use crate::error::{RestError, RestResult};
 use crate::extractors::{PeerIp, SearchParams, TenantExtractor, UserKey, unknown_search_params};
 use crate::fhir_types::get_resource_type_names_for_version;
+use crate::rate_limit::{LimitKind, RateLimiter};
 use crate::state::AppState;
 
 /// The reviewable system prompt. The live prompt appends the server's real
@@ -331,6 +329,13 @@ async fn call_llm(
         })?;
 
     let status = response.status();
+    // Pass the provider's own back-off through when it gave one; inventing a
+    // number here would just be a guess about someone else's limiter.
+    let upstream_retry_after = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u64>().ok());
     let payload: Value = response
         .json()
         .await
@@ -341,6 +346,7 @@ async fn call_llm(
     if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
         return Err(RestError::TooManyRequests {
             message: "The translation service is rate-limited; try again shortly".to_string(),
+            retry_after_secs: upstream_retry_after,
         });
     }
     if !status.is_success() {
@@ -482,76 +488,22 @@ fn rate_limit_key(tenant: &str, user: &UserKey, peer: Option<IpAddr>) -> String 
     }
 }
 
-/// Keys are unbounded in principle (one per IP), so the map is pruned of
-/// inactive buckets once it grows past this.
-const RATE_MAP_PRUNE_AT: usize = 10_000;
-
-struct RateState {
-    window: VecDeque<Instant>,
-    day: u64,
-    day_count: u32,
-}
-
-fn rate_map() -> &'static Mutex<HashMap<String, RateState>> {
-    static MAP: OnceLock<Mutex<HashMap<String, RateState>>> = OnceLock::new();
-    MAP.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-fn current_day() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() / 86_400)
-        .unwrap_or_default()
-}
+/// Buckets for this surface only — the operator's LLM budget is not shared
+/// with any other rate-limited endpoint.
+static NL_SEARCH_LIMITER: RateLimiter = RateLimiter::new();
 
 fn check_rate_limit(key: &str, limit: u32, window: Duration, daily_limit: u32) -> RestResult<()> {
-    let mut map = rate_map().lock().expect("rate limiter lock");
-    let now = Instant::now();
-    let today = current_day();
-
-    if map.len() > RATE_MAP_PRUNE_AT {
-        map.retain(|_, state| {
-            state.day == today
-                && (state.day_count > 0
-                    || state
-                        .window
-                        .back()
-                        .is_some_and(|t| now.duration_since(*t) <= window))
-        });
-    }
-
-    let state = map.entry(key.to_string()).or_insert_with(|| RateState {
-        window: VecDeque::new(),
-        day: today,
-        day_count: 0,
-    });
-
-    if state.day != today {
-        state.day = today;
-        state.day_count = 0;
-    }
-    while state
-        .window
-        .front()
-        .is_some_and(|t| now.duration_since(*t) > window)
-    {
-        state.window.pop_front();
-    }
-
-    if state.day_count >= daily_limit {
-        return Err(RestError::TooManyRequests {
-            message: "Daily natural-language search limit reached".to_string(),
-        });
-    }
-    if state.window.len() >= limit as usize {
-        return Err(RestError::TooManyRequests {
-            message: "Too many natural-language searches; slow down and retry".to_string(),
-        });
-    }
-
-    state.window.push_back(now);
-    state.day_count += 1;
-    Ok(())
+    NL_SEARCH_LIMITER
+        .check(key, limit, window, daily_limit)
+        .map_err(|limited| RestError::TooManyRequests {
+            message: match limited.kind {
+                LimitKind::Daily => "Daily natural-language search limit reached".to_string(),
+                LimitKind::Window => {
+                    "Too many natural-language searches; slow down and retry".to_string()
+                }
+            },
+            retry_after_secs: Some(limited.retry_after_secs),
+        })
 }
 
 #[cfg(test)]

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -157,6 +157,7 @@ pub mod extractors;
 pub mod fhir_types;
 pub mod handlers;
 pub mod middleware;
+pub(crate) mod rate_limit;
 pub mod responses;
 pub mod routing;
 pub mod state;

--- a/crates/rest/src/rate_limit.rs
+++ b/crates/rest/src/rate_limit.rs
@@ -1,0 +1,281 @@
+//! Shared per-key sliding-window rate limiting.
+//!
+//! One [`RateLimiter`] owns one bucket map, so each protected surface declares
+//! its own `static` limiter and surfaces never share (or steal) each other's
+//! budget. A rejection carries the delta-seconds until the caller has budget
+//! again, which the caller turns into a `Retry-After` header on its `429` —
+//! a bare `429` tells a client to back off but not for how long, so clients
+//! guess, and guessing is what the limiter is there to prevent.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Keys are unbounded in principle (one bucket per peer address), so a
+/// limiter's map is pruned of inactive buckets once it grows past this.
+const PRUNE_AT: usize = 10_000;
+
+/// Which ceiling a rejected request hit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LimitKind {
+    /// The sliding-window limit — retry once the window rolls forward.
+    Window,
+    /// The per-day ceiling — retry after the UTC day boundary.
+    Daily,
+}
+
+/// A rejected request, with the back-off the caller should advertise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RateLimited {
+    /// Which ceiling was hit.
+    pub(crate) kind: LimitKind,
+    /// Delta-seconds until the caller regains budget. Always `>= 1`, since a
+    /// `Retry-After: 0` reads as "retry immediately" and re-triggers the limit.
+    pub(crate) retry_after_secs: u64,
+}
+
+/// Per-key state: the request instants inside the current window, plus the
+/// running count for the current UTC day.
+struct RateState {
+    window: VecDeque<Instant>,
+    day: u64,
+    day_count: u32,
+}
+
+/// A sliding-window rate limiter with an optional per-day ceiling.
+///
+/// Declare one per protected surface:
+/// ```ignore
+/// static POLL_LIMITER: RateLimiter = RateLimiter::new();
+/// ```
+pub(crate) struct RateLimiter {
+    map: OnceLock<Mutex<HashMap<String, RateState>>>,
+}
+
+impl RateLimiter {
+    /// Creates an empty limiter. `const` so it can back a `static`.
+    pub(crate) const fn new() -> Self {
+        Self {
+            map: OnceLock::new(),
+        }
+    }
+
+    /// Records a request against `key`, rejecting it when either ceiling is hit.
+    ///
+    /// A rejected request is *not* counted, so a client that keeps hammering
+    /// never pushes its own recovery further out.
+    pub(crate) fn check(
+        &self,
+        key: &str,
+        limit: u32,
+        window: Duration,
+        daily_limit: u32,
+    ) -> Result<(), RateLimited> {
+        let mut map = self
+            .map
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .expect("rate limiter lock");
+        let now = Instant::now();
+        let today = current_day();
+
+        if map.len() > PRUNE_AT {
+            map.retain(|_, state| {
+                state.day == today
+                    && (state.day_count > 0
+                        || state
+                            .window
+                            .back()
+                            .is_some_and(|t| now.duration_since(*t) <= window))
+            });
+        }
+
+        let state = map.entry(key.to_string()).or_insert_with(|| RateState {
+            window: VecDeque::new(),
+            day: today,
+            day_count: 0,
+        });
+
+        if state.day != today {
+            state.day = today;
+            state.day_count = 0;
+        }
+        while state
+            .window
+            .front()
+            .is_some_and(|t| now.duration_since(*t) > window)
+        {
+            state.window.pop_front();
+        }
+
+        if state.day_count >= daily_limit {
+            return Err(RateLimited {
+                kind: LimitKind::Daily,
+                retry_after_secs: secs_until_utc_midnight(),
+            });
+        }
+        if state.window.len() >= limit as usize {
+            // The oldest request in the window is the first to age out, so that
+            // is when a slot frees up.
+            let oldest = state.window.front().copied().unwrap_or(now);
+            let elapsed = now.duration_since(oldest);
+            let remaining = window.saturating_sub(elapsed);
+            return Err(RateLimited {
+                kind: LimitKind::Window,
+                retry_after_secs: ceil_secs(remaining),
+            });
+        }
+
+        state.window.push_back(now);
+        state.day_count += 1;
+        Ok(())
+    }
+
+    /// [`RateLimiter::check`] without a per-day ceiling.
+    pub(crate) fn check_window(
+        &self,
+        key: &str,
+        limit: u32,
+        window: Duration,
+    ) -> Result<(), RateLimited> {
+        self.check(key, limit, window, u32::MAX)
+    }
+}
+
+/// Days since the Unix epoch, i.e. the current UTC day.
+fn current_day() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() / 86_400)
+        .unwrap_or_default()
+}
+
+/// Delta-seconds until the next UTC day boundary, when a daily ceiling resets.
+fn secs_until_utc_midnight() -> u64 {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default();
+    (86_400 - (now % 86_400)).max(1)
+}
+
+/// Rounds a back-off up to whole seconds, never below 1.
+fn ceil_secs(d: Duration) -> u64 {
+    let secs = d.as_secs() + u64::from(d.subsec_nanos() > 0);
+    secs.max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_requests_up_to_the_window_limit() {
+        let limiter = RateLimiter::new();
+        for _ in 0..3 {
+            assert!(
+                limiter
+                    .check_window("k", 3, Duration::from_secs(60))
+                    .is_ok()
+            );
+        }
+        let err = limiter
+            .check_window("k", 3, Duration::from_secs(60))
+            .expect_err("fourth request is over the limit");
+        assert_eq!(err.kind, LimitKind::Window);
+    }
+
+    #[test]
+    fn window_rejection_advertises_a_usable_retry_after() {
+        let limiter = RateLimiter::new();
+        limiter
+            .check_window("k", 1, Duration::from_secs(60))
+            .expect("first request");
+        let err = limiter
+            .check_window("k", 1, Duration::from_secs(60))
+            .expect_err("second request is over the limit");
+        // The single recorded request has barely aged, so the advertised
+        // back-off is the near-full window — and never 0.
+        assert!(
+            (1..=60).contains(&err.retry_after_secs),
+            "retry_after_secs out of range: {}",
+            err.retry_after_secs
+        );
+    }
+
+    #[test]
+    fn buckets_are_independent_per_key() {
+        let limiter = RateLimiter::new();
+        limiter
+            .check_window("a", 1, Duration::from_secs(60))
+            .expect("first request for a");
+        assert!(
+            limiter
+                .check_window("a", 1, Duration::from_secs(60))
+                .is_err()
+        );
+        assert!(
+            limiter
+                .check_window("b", 1, Duration::from_secs(60))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn limiters_are_independent_of_each_other() {
+        let one = RateLimiter::new();
+        let two = RateLimiter::new();
+        one.check_window("k", 1, Duration::from_secs(60))
+            .expect("first request");
+        assert!(one.check_window("k", 1, Duration::from_secs(60)).is_err());
+        assert!(two.check_window("k", 1, Duration::from_secs(60)).is_ok());
+    }
+
+    #[test]
+    fn a_lapsed_window_frees_the_budget() {
+        let limiter = RateLimiter::new();
+        // A zero-length window ages every recorded request out immediately.
+        for _ in 0..5 {
+            assert!(limiter.check_window("k", 1, Duration::ZERO).is_ok());
+        }
+    }
+
+    #[test]
+    fn daily_ceiling_rejects_after_the_window_has_room() {
+        let limiter = RateLimiter::new();
+        for _ in 0..2 {
+            limiter
+                .check("k", 100, Duration::from_secs(60), 2)
+                .expect("within both ceilings");
+        }
+        let err = limiter
+            .check("k", 100, Duration::from_secs(60), 2)
+            .expect_err("third request is over the daily ceiling");
+        assert_eq!(err.kind, LimitKind::Daily);
+        assert!(err.retry_after_secs >= 1 && err.retry_after_secs <= 86_400);
+    }
+
+    #[test]
+    fn rejected_requests_do_not_extend_the_back_off() {
+        let limiter = RateLimiter::new();
+        limiter
+            .check_window("k", 1, Duration::from_secs(60))
+            .expect("first request");
+        let first = limiter.check_window("k", 1, Duration::from_secs(60));
+        let second = limiter.check_window("k", 1, Duration::from_secs(60));
+        // Both rejections point at the same recorded request, so the advertised
+        // back-off shrinks (or holds) rather than resetting to a full window.
+        assert!(
+            second.unwrap_err().retry_after_secs <= first.unwrap_err().retry_after_secs,
+            "a rejected request must not be counted"
+        );
+    }
+
+    #[test]
+    fn ceil_secs_never_returns_zero() {
+        assert_eq!(ceil_secs(Duration::ZERO), 1);
+        assert_eq!(ceil_secs(Duration::from_millis(1)), 1);
+        assert_eq!(ceil_secs(Duration::from_millis(1_001)), 2);
+        assert_eq!(ceil_secs(Duration::from_secs(30)), 30);
+    }
+}

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -20,7 +20,7 @@ use helios_persistence::core::{
 use helios_persistence::error::StorageResult;
 use helios_rest::ServerConfig;
 use helios_rest::bulk_export_auth::BearerScopeAuth;
-use helios_rest::config::{MultitenancyConfig, TenantRoutingMode};
+use helios_rest::config::{BulkSubmitConfig, MultitenancyConfig, TenantRoutingMode};
 use serde_json::{Value, json};
 
 /// A fetcher that serves a fixed manifest + NDJSON from memory.
@@ -90,6 +90,18 @@ async fn create_submit_server() -> (
     Arc<LocalFsOutputStore>,
     tempfile::TempDir,
 ) {
+    create_submit_server_with(BulkSubmitConfig::default()).await
+}
+
+async fn create_submit_server_with(
+    bulk_submit: BulkSubmitConfig,
+) -> (
+    TestServer,
+    Arc<SqliteBackend>,
+    Arc<MockFetcher>,
+    Arc<LocalFsOutputStore>,
+    tempfile::TempDir,
+) {
     let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(|p| p.parent())
@@ -118,6 +130,7 @@ async fn create_submit_server() -> (
         },
         base_url: "http://localhost:8080".to_string(),
         default_tenant: "test-tenant".to_string(),
+        bulk_submit,
         ..ServerConfig::for_testing()
     };
 
@@ -173,6 +186,31 @@ fn status_body() -> Value {
             {"name": "submissionId", "valueString": "it-1"}
         ]
     })
+}
+
+/// Kicks off a submission plus its status request and returns the poll path.
+async fn start_and_get_poll_path(server: &TestServer) -> String {
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body())
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+    let status = server
+        .post("/$bulk-submit-status")
+        .json(&status_body())
+        .await;
+    assert_eq!(status.status_code(), StatusCode::ACCEPTED);
+    status
+        .headers()
+        .get("content-location")
+        .expect("Content-Location")
+        .to_str()
+        .unwrap()
+        .trim_start_matches("http://localhost:8080")
+        .to_string()
 }
 
 #[tokio::test]
@@ -320,4 +358,83 @@ async fn test_full_lifecycle_ingests_and_polls() {
         server.get(poll_path).await.status_code(),
         StatusCode::NOT_FOUND
     );
+}
+
+// ── Status-poll pacing: Retry-After + rate limiting (issue #399) ──────────────
+
+#[tokio::test]
+async fn test_in_progress_poll_advertises_the_configured_retry_after() {
+    let (server, ..) = create_submit_server_with(BulkSubmitConfig {
+        retry_after_secs: 7,
+        ..BulkSubmitConfig::default()
+    })
+    .await;
+    let poll_path = start_and_get_poll_path(&server).await;
+
+    // The worker has not run, so the submission is still in progress.
+    let resp = server.get(&poll_path).await;
+    assert_eq!(resp.status_code(), StatusCode::ACCEPTED);
+    assert_eq!(
+        resp.headers().get("retry-after").expect("Retry-After"),
+        "7",
+        "the in-progress poll must advertise HFS_BULK_SUBMIT_RETRY_AFTER"
+    );
+}
+
+#[tokio::test]
+async fn test_poll_beyond_the_rate_limit_returns_429_with_retry_after() {
+    // Spec (build.fhir.org submit.html): Data Consumers SHOULD rate-limit the
+    // status endpoint and return Retry-After so clients back off.
+    let (server, ..) = create_submit_server_with(BulkSubmitConfig {
+        poll_rate_limit: 2,
+        poll_rate_window_secs: 60,
+        ..BulkSubmitConfig::default()
+    })
+    .await;
+    let poll_path = start_and_get_poll_path(&server).await;
+
+    for _ in 0..2 {
+        assert_eq!(
+            server.get(&poll_path).await.status_code(),
+            StatusCode::ACCEPTED,
+            "polls within the limit must be served"
+        );
+    }
+
+    let throttled = server.get(&poll_path).await;
+    assert_eq!(throttled.status_code(), StatusCode::TOO_MANY_REQUESTS);
+    let secs: u64 = throttled
+        .headers()
+        .get("retry-after")
+        .expect("429 must carry Retry-After")
+        .to_str()
+        .unwrap()
+        .parse()
+        .expect("Retry-After must be delta-seconds");
+    assert!(
+        (1..=60).contains(&secs),
+        "Retry-After must point inside the rate window, got {secs}"
+    );
+    // The rejection is a FHIR OperationOutcome, not an empty body.
+    let outcome: Value = throttled.json();
+    assert_eq!(outcome["resourceType"], "OperationOutcome");
+    assert_eq!(outcome["issue"][0]["code"], "throttled");
+}
+
+#[tokio::test]
+async fn test_poll_rate_limit_of_zero_disables_throttling() {
+    let (server, ..) = create_submit_server_with(BulkSubmitConfig {
+        poll_rate_limit: 0,
+        ..BulkSubmitConfig::default()
+    })
+    .await;
+    let poll_path = start_and_get_poll_path(&server).await;
+
+    for _ in 0..12 {
+        assert_eq!(
+            server.get(&poll_path).await.status_code(),
+            StatusCode::ACCEPTED,
+            "poll rate limiting must be off when the limit is 0"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #399.

The configurable `Retry-After` half of the issue already landed on `main`; this adds the `429` rate-limiting follow-up the issue tracks.

## Problem

The Submit spec ([build.fhir.org](https://build.fhir.org/ig/HL7/bulk-data/en/submit.html)) has Data Consumers rate-limit the status endpoint and tell a throttled client when to come back. HFS advertised a `Retry-After` on the in-progress `202` but had no way to enforce it — a client ignoring the header could poll as fast as it liked, and every poll cost a job-store round trip.

## Changes

- **`crates/rest/src/rate_limit.rs`** (new) — shared per-key sliding-window limiter with an optional daily ceiling. Each protected surface declares its own `static RateLimiter`, so surfaces can never spend each other's budget. A rejection reports the delta-seconds until the caller regains budget (never `0`), and rejected requests are *not* counted, so hammering doesn't push out your own recovery.
- **`RestError::TooManyRequests`** carries `retry_after_secs: Option<u64>`, emitted as a `Retry-After` header — mirroring the existing 503 behaviour. It stays `None` where the server has no honest estimate rather than inventing a number the client would sleep on.
- **Poll surface** (`GET /bulk-submit-status/{token}`) throttles *before* any job-store work, so an ignored `Retry-After` costs a cheap `429` (a normal OperationOutcome, `code: throttled`) rather than a DB round trip. Buckets are keyed by poll token plus principal, falling back to peer address.
- Two adjacent 429s get honest values on the way past: the per-tenant concurrency cap advertises the configured poll cadence, and nl-search passes the LLM provider's own `Retry-After` through instead of dropping it. nl-search also moves onto the shared limiter rather than keeping a private copy of the same code.

## Config

| Variable | Default | Description |
|---|---|---|
| `HFS_BULK_SUBMIT_POLL_RATE_LIMIT` | `10` | Status polls per client, per submission, per window; `0` disables |
| `HFS_BULK_SUBMIT_POLL_RATE_WINDOW` | `60` | Sliding window, seconds |

Validated together (a window of `0` with a non-zero limit is a config error). A client honouring the default 120 s `Retry-After` polls twice an hour, so 10/minute is far above any well-behaved cadence and only bites on a hammering loop.

## Testing

`cargo test -p helios-rest --lib --test bulk_submit --test nl_search --test rest_conformance` — 480 passed, 0 failed. Workspace clippy with the CI flag set is clean; `cargo fmt --check` clean.

New coverage:
- 8 limiter unit tests (per-key and per-limiter isolation, back-off range, lapsed window, daily ceiling, rejections not extending the back-off)
- `Retry-After` present/absent on the error type
- 3 integration tests: configured `Retry-After` on the `202`, `429` with an in-window `Retry-After` and OperationOutcome shape, and `limit = 0` disabling the limiter

Docs updated in `crates/rest/README.md` and the `bulk-data-submit` skill (which was also missing `HFS_BULK_SUBMIT_RETRY_AFTER` and `_BLOCK_CONCURRENT_SUBMISSION`).

https://claude.ai/code/session_01KJbyezVW7i4ZEAPU5uk8Mg