### PR TITLE
fix(bulk-submit): stream fetched NDJSON files instead of buffering them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,6 +3496,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/crates/rest/Cargo.toml
+++ b/crates/rest/Cargo.toml
@@ -55,6 +55,9 @@ helios-observability = { path = "../observability", version = "0.2.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
+# `io` provides StreamReader, bridging the reqwest byte stream for bulk-submit
+# NDJSON files into the AsyncBufRead the ingestion engine consumes.
+tokio-util = { version = "0.7", features = ["io"] }
 async-trait = "0.1"
 
 # Web framework

--- a/crates/rest/src/bulk_submit_fetcher.rs
+++ b/crates/rest/src/bulk_submit_fetcher.rs
@@ -5,14 +5,21 @@
 //! Fetches the remote Bulk Export Manifest and its NDJSON files, applying
 //! provider-supplied request headers, `gzip`, and — when files require an access
 //! token — a read-scoped bearer obtained via an optional [`FileTokenProvider`].
+//!
+//! NDJSON bodies are streamed to the ingestion engine rather than buffered, so a
+//! manifest referencing multi-gigabyte files costs a fixed amount of memory per
+//! concurrent fetch. The one exception is `fileEncryptionKey` (JWE) files, whose
+//! format forces whole-body buffering — see [`HttpSubmitInputFetcher::open_file_stream`].
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::TryStreamExt;
 use helios_persistence::core::{FileTokenProvider, RemoteManifest, SubmitInputFetcher};
 use helios_persistence::error::{BackendError, StorageError, StorageResult};
 use serde_json::Value;
 use tokio::io::AsyncBufRead;
+use tokio_util::io::StreamReader;
 
 /// Fetches submit input over HTTP(S) using `reqwest`.
 pub struct HttpSubmitInputFetcher {
@@ -219,6 +226,9 @@ impl SubmitInputFetcher for HttpSubmitInputFetcher {
             .map_err(|e| Self::err(format!("parsing manifest {url}: {e}")))
     }
 
+    /// Returns as soon as the response headers arrive; the body is read lazily
+    /// as the caller consumes lines. JWE-encrypted files are the exception and
+    /// are buffered whole (the authentication tag trails the ciphertext).
     async fn open_file_stream(
         &self,
         url: &str,
@@ -245,15 +255,29 @@ impl SubmitInputFetcher for HttpSubmitInputFetcher {
                 resp.status()
             )));
         }
-        // Buffer the (gzip-decoded) body; NDJSON files in practice fit comfortably,
-        // and this avoids pulling in a stream→AsyncRead bridge dependency.
-        let bytes = resp
-            .bytes()
-            .await
-            .map_err(|e| Self::err(format!("reading file {url}: {e}")))?;
-        let bytes = Self::maybe_decrypt(bytes.to_vec(), encryption_key)?;
-        Ok(Box::new(tokio::io::BufReader::new(std::io::Cursor::new(
-            bytes,
+        if encryption_key.is_some() {
+            // A compact JWE is a single AEAD ciphertext whose authentication tag
+            // is the final segment: no plaintext may be released before the whole
+            // body has been read and the tag verified. Encrypted files are
+            // therefore necessarily buffered; unencrypted ones stream.
+            let bytes = resp
+                .bytes()
+                .await
+                .map_err(|e| Self::err(format!("reading file {url}: {e}")))?;
+            let bytes = Self::maybe_decrypt(bytes.to_vec(), encryption_key)?;
+            return Ok(Box::new(tokio::io::BufReader::new(std::io::Cursor::new(
+                bytes,
+            ))));
+        }
+        // Stream the (gzip-decoded) body straight through to the ingestion
+        // engine, so peak memory stays bounded by the buffer size rather than
+        // by the file size.
+        let owned_url = url.to_string();
+        let stream = resp
+            .bytes_stream()
+            .map_err(move |e| std::io::Error::other(format!("reading file {owned_url}: {e}")));
+        Ok(Box::new(tokio::io::BufReader::new(StreamReader::new(
+            stream,
         ))))
     }
 }
@@ -308,6 +332,84 @@ mod tests {
             .build_get("http://example.com/m.json", &headers, false, &[])
             .await;
         assert!(rb.is_ok());
+    }
+
+    /// Serves one chunked NDJSON response: the first line, then (only after
+    /// `release` fires) the second line and the terminating chunk. A buffering
+    /// fetcher cannot hand back a reader until the body completes, so it would
+    /// deadlock here — which the surrounding timeout turns into a failure.
+    async fn serve_two_chunks(release: tokio::sync::oneshot::Receiver<()>) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            // Drain the request head so the client's write completes.
+            let mut req = Vec::new();
+            let mut buf = [0u8; 1024];
+            while !req.windows(4).any(|w| w == b"\r\n\r\n") {
+                match sock.read(&mut buf).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => req.extend_from_slice(&buf[..n]),
+                }
+            }
+            let head = b"HTTP/1.1 200 OK\r\nContent-Type: application/fhir+ndjson\r\n\
+                         Transfer-Encoding: chunked\r\n\r\n";
+            sock.write_all(head).await.unwrap();
+
+            let line1 = "{\"resourceType\":\"Patient\",\"id\":\"1\"}\n";
+            sock.write_all(format!("{:x}\r\n{line1}\r\n", line1.len()).as_bytes())
+                .await
+                .unwrap();
+            sock.flush().await.unwrap();
+
+            // Hold the body open until the test has consumed line 1.
+            let _ = release.await;
+
+            let line2 = "{\"resourceType\":\"Patient\",\"id\":\"2\"}\n";
+            sock.write_all(format!("{:x}\r\n{line2}\r\n", line2.len()).as_bytes())
+                .await
+                .unwrap();
+            sock.write_all(b"0\r\n\r\n").await.unwrap();
+            sock.flush().await.unwrap();
+        });
+        format!("http://{addr}/file.ndjson")
+    }
+
+    #[tokio::test]
+    async fn test_open_file_stream_yields_lines_before_body_completes() {
+        use tokio::io::AsyncBufReadExt;
+
+        let (release, wait) = tokio::sync::oneshot::channel();
+        let url = serve_two_chunks(wait).await;
+        let fetcher = HttpSubmitInputFetcher::new(None, "system/*.rs".to_string());
+
+        let reader = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            fetcher.open_file_stream(&url, &[], false, &[], None),
+        )
+        .await
+        .expect("open_file_stream must not wait for the whole body")
+        .expect("fetch succeeds");
+
+        let mut lines = reader.lines();
+        let first = tokio::time::timeout(std::time::Duration::from_secs(5), lines.next_line())
+            .await
+            .expect("first line must arrive before the body completes")
+            .unwrap()
+            .unwrap();
+        assert!(first.contains("\"id\":\"1\""));
+
+        // Let the server finish; the rest of the stream must follow.
+        release.send(()).unwrap();
+        let second = tokio::time::timeout(std::time::Duration::from_secs(5), lines.next_line())
+            .await
+            .expect("second line arrives")
+            .unwrap()
+            .unwrap();
+        assert!(second.contains("\"id\":\"2\""));
+        assert!(lines.next_line().await.unwrap().is_none());
     }
 
     #[cfg(not(feature = "bulk-submit-jwe"))]


### PR DESCRIPTION
Fixes #402.

## Problem

`HttpSubmitInputFetcher::open_file_stream` read each fetched NDJSON file fully into memory via `resp.bytes()` before handing a `Cursor` to the ingestion engine. That capped the practical file size a manifest could reference and inflated peak memory under concurrent fetches. The old code acknowledged this in a comment.

## Fix

Bridge reqwest's `bytes_stream()` into the `AsyncBufRead` the ingestion engine already expects, via `tokio_util::io::StreamReader`.

The `SubmitInputFetcher` trait was already streaming-shaped and both consumers — `process_ndjson_stream` (all backends) and `process_deleted_stream` — read line-by-line, so nothing downstream changed. Peak memory is now bounded by the buffer size rather than the file size.

gzip is unaffected: reqwest's decompression is a streaming `tower-http` layer, so `bytes_stream()` yields already-decoded chunks.

Adds `tokio-util = { version = "0.7", features = ["io"] }` to `helios-rest` (already present in the lock tree transitively).

## Deliberate exception: JWE files

Files carrying a `fileEncryptionKey` still buffer whole. A compact JWE is a single AEAD ciphertext whose authentication tag is the final segment, so no plaintext may be released before the entire body has been read and the tag verified — the format forbids streaming. That path is now explicitly branched and documented rather than being an unstated side effect of buffering everything.

## Behavioral note

Mid-stream network failures now surface from `process_ndjson_stream` rather than `open_file_stream`, so the worker records them as `failed to ingest file {url}` instead of `failed to fetch file {url}`. Both remain manifest-level errors with identical accounting, but the message text differs if anything matches on it.

## Testing

`test_open_file_stream_yields_lines_before_body_completes` runs a raw chunked-HTTP server that sends line 1, then holds the body open until the test has consumed that line before sending line 2 and the terminating chunk. Verified it fails against the old buffered implementation (times out at `open_file_stream must not wait for the whole body`) and passes with the fix.

- `cargo test -p helios-rest --lib` — 401 passed
- `cargo test -p helios-rest --test bulk_submit` — 4 passed
- `cargo clippy -p helios-rest --all-targets` — no new warnings
- `cargo check -p helios-rest --features bulk-submit-jwe` — clean

https://claude.ai/code/session_01AH8Gqj9ob5UcggiAH3jxAK