### PR TITLE
feat(bulk-submit): apply import/metadata kick-off directives to ingestion

### DIFF
--- a/.agents/skills/bulk-data-submit/SKILL.md
+++ b/.agents/skills/bulk-data-submit/SKILL.md
@@ -33,9 +33,24 @@ The kick-off `Parameters` resource supports:
 - `fileRequestHeader`: part.
 - `oauthMetadataUrl`.
 - `fileEncryptionKey`: part.
-- `metadata` / `import`: parts.
+- `metadata` / `import`: parts (`parameterUrl` + `parameterValue`, both required; `parameterUrl` SHALL be absolute).
 
 At least one of `submissionStatus` or `manifestUrl` must be populated.
+
+## Pre-coordinated `import` / `metadata` Directives
+
+Both are persisted with the manifest they accompany and applied at ingestion. On a
+status-only kick-off (no `manifestUrl`) they have nothing to attach to and are ignored with a warning.
+
+| Directive | `parameterUrl` | Values | Effect |
+|---|---|---|---|
+| import mode | `https://helios.software/import-mode` | `replace` (default), `merge` | How a submitted resource is applied when one with the same id already exists |
+
+- `replace`: upsert-by-id, last-write-wins — the submitted resource replaces the stored one wholesale.
+- `merge`: RFC 7396 JSON Merge Patch of the submission onto the stored resource — elements absent from the submission are retained, present elements overwrite, arrays are replaced wholesale, and a `null` member removes the stored element. The stored `id` is always preserved.
+- A recognized directive with an unusable value (e.g. `import-mode=upsert`) is always `400`.
+- Unrecognized `import` `parameterUrl`s are `400` under `Prefer: handling=strict` and ignored with a warning otherwise.
+- `metadata` parts carry no processing semantics: HFS retains all of them verbatim on the manifest and logs them at ingestion, so none are rejected under strict handling. They are not echoed into the status manifest, whose schema defines no slot for them.
 
 ## Environment
 
@@ -70,7 +85,7 @@ Job state reuses the same backend as the FHIR resources. SQLite shares `./data/h
 - `deleted` files, either transaction Bundles or resource refs, are applied as deletes.
 - Partial success remains `200` with a populated `error[]` array of OperationOutcome NDJSON.
 - Per-resource issues carry the `artifact-relatedArtifact` extension.
-- `import` directives use upsert-by-id with last-write-wins, matching `replace`. `merge` semantics are a documented follow-up.
+- Resources are ingested per the submission's import mode (`replace` by default); see the directives section above.
 - JWE decryption for `fileEncryptionKey` supports `dir` plus `A128GCM` or `A256GCM` compact JWE files when built with `bulk-submit-jwe`.
 - Build JWE support with `cargo build -p helios-hfs --features bulk-submit-jwe`.
 - Without the feature, or for other JWE algorithms, encrypted files record a `not-supported` manifest-level error while unencrypted manifests proceed.

--- a/.claude/skills/bulk-data-submit/SKILL.md
+++ b/.claude/skills/bulk-data-submit/SKILL.md
@@ -33,9 +33,24 @@ The kick-off `Parameters` resource supports:
 - `fileRequestHeader`: part.
 - `oauthMetadataUrl`.
 - `fileEncryptionKey`: part.
-- `metadata` / `import`: parts.
+- `metadata` / `import`: parts (`parameterUrl` + `parameterValue`, both required; `parameterUrl` SHALL be absolute).
 
 At least one of `submissionStatus` or `manifestUrl` must be populated.
+
+## Pre-coordinated `import` / `metadata` Directives
+
+Both are persisted with the manifest they accompany and applied at ingestion. On a
+status-only kick-off (no `manifestUrl`) they have nothing to attach to and are ignored with a warning.
+
+| Directive | `parameterUrl` | Values | Effect |
+|---|---|---|---|
+| import mode | `https://helios.software/import-mode` | `replace` (default), `merge` | How a submitted resource is applied when one with the same id already exists |
+
+- `replace`: upsert-by-id, last-write-wins — the submitted resource replaces the stored one wholesale.
+- `merge`: RFC 7396 JSON Merge Patch of the submission onto the stored resource — elements absent from the submission are retained, present elements overwrite, arrays are replaced wholesale, and a `null` member removes the stored element. The stored `id` is always preserved.
+- A recognized directive with an unusable value (e.g. `import-mode=upsert`) is always `400`.
+- Unrecognized `import` `parameterUrl`s are `400` under `Prefer: handling=strict` and ignored with a warning otherwise.
+- `metadata` parts carry no processing semantics: HFS retains all of them verbatim on the manifest and logs them at ingestion, so none are rejected under strict handling. They are not echoed into the status manifest, whose schema defines no slot for them.
 
 ## Environment
 
@@ -70,7 +85,7 @@ Job state reuses the same backend as the FHIR resources. SQLite shares `./data/h
 - `deleted` files, either transaction Bundles or resource refs, are applied as deletes.
 - Partial success remains `200` with a populated `error[]` array of OperationOutcome NDJSON.
 - Per-resource issues carry the `artifact-relatedArtifact` extension.
-- `import` directives use upsert-by-id with last-write-wins, matching `replace`. `merge` semantics are a documented follow-up.
+- Resources are ingested per the submission's import mode (`replace` by default); see the directives section above.
 - JWE decryption for `fileEncryptionKey` supports `dir` plus `A128GCM` or `A256GCM` compact JWE files when built with `bulk-submit-jwe`.
 - Build JWE support with `cargo build -p helios-hfs --features bulk-submit-jwe`.
 - Without the feature, or for other JWE algorithms, encrypted files record a `not-supported` manifest-level error while unencrypted manifests proceed.

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -18,8 +18,8 @@ use crate::core::bulk_submit::{
     SubmissionManifest, SubmissionStatus, SubmissionSummary,
 };
 use crate::core::bulk_submit_worker::{
-    ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy, SubmitFileRecord,
-    SubmitFileRow, SubmitWorkerStorage,
+    ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
+    SubmitFileRecord, SubmitFileRow, SubmitWorkerStorage,
 };
 use crate::error::{BackendError, BulkSubmitError, StorageError, StorageResult};
 use crate::tenant::{TenantContext, TenantId, TenantPermissions};
@@ -884,9 +884,9 @@ impl PostgresBackend {
                     );
                     self.record_change(tenant, submission_id, &change).await?;
 
-                    let updated = self
-                        .update(tenant, &current, entry.resource.clone())
-                        .await?;
+                    // Update the resource, honoring the submission's import mode.
+                    let content = options.content_for_update(current.content(), &entry.resource);
+                    let updated = self.update(tenant, &current, content).await?;
 
                     Ok(BulkEntryResult::success(
                         entry.line_number,
@@ -1386,7 +1386,8 @@ impl SubmitWorkerStorage for PostgresBackend {
         let rows = client
             .query(
                 "SELECT manifest_url, fhir_base_url, output_format, file_request_headers,
-                        oauth_metadata_urls, file_encryption_key, last_processed_line
+                        oauth_metadata_urls, file_encryption_key, last_processed_line,
+                        import_directives, submission_metadata
                  FROM bulk_manifests
                  WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
                    AND manifest_id = $4 AND worker_id = $5 AND fencing_token = $6",
@@ -1410,6 +1411,8 @@ impl SubmitWorkerStorage for PostgresBackend {
         let oauth_json: Option<String> = row.get(4);
         let encryption_json: Option<String> = row.get(5);
         let last_processed_line: i64 = row.get(6);
+        let import_json: Option<String> = row.get(7);
+        let metadata_json: Option<String> = row.get(8);
 
         let file_request_headers: Vec<(String, String)> = headers_json
             .as_deref()
@@ -1422,6 +1425,14 @@ impl SubmitWorkerStorage for PostgresBackend {
         let file_encryption_key: Option<Value> = encryption_json
             .as_deref()
             .and_then(|s| serde_json::from_str(s).ok());
+        let import_directives: Vec<(String, String)> = import_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default();
+        let metadata: Vec<(String, String)> = metadata_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default();
         let fhir_version = fhir_version_from_output_format(output_format.as_deref());
 
         Ok(ManifestWorkerView {
@@ -1432,6 +1443,8 @@ impl SubmitWorkerStorage for PostgresBackend {
             file_request_headers,
             oauth_metadata_urls,
             file_encryption_key,
+            import_directives,
+            metadata,
             last_processed_line: last_processed_line.max(0) as u64,
             fhir_version,
         })
@@ -1615,30 +1628,34 @@ impl SubmitWorkerStorage for PostgresBackend {
         tenant: &TenantContext,
         id: &SubmissionId,
         manifest_id: &str,
-        fhir_base_url: Option<&str>,
-        output_format: Option<&str>,
-        file_request_headers: &[(String, String)],
-        oauth_metadata_urls: &[String],
-        file_encryption_key: Option<&Value>,
+        fetch: ManifestFetchParams<'_>,
     ) -> StorageResult<()> {
         let client = self.get_client().await?;
-        let fhir_base_url = fhir_base_url.map(|s| s.to_string());
-        let output_format = output_format.map(|s| s.to_string());
-        let headers_json = serde_json::to_string(file_request_headers).ok();
-        let oauth_json = serde_json::to_string(oauth_metadata_urls).ok();
-        let encryption_json = file_encryption_key.and_then(|v| serde_json::to_string(v).ok());
+        let fhir_base_url = fetch.fhir_base_url.map(|s| s.to_string());
+        let output_format = fetch.output_format.map(|s| s.to_string());
+        let headers_json = serde_json::to_string(fetch.file_request_headers).ok();
+        let oauth_json = serde_json::to_string(fetch.oauth_metadata_urls).ok();
+        let encryption_json = fetch
+            .file_encryption_key
+            .and_then(|v| serde_json::to_string(v).ok());
+        let import_json = serde_json::to_string(fetch.import_directives).ok();
+        let metadata_json = serde_json::to_string(fetch.metadata).ok();
         client
             .execute(
                 "UPDATE bulk_manifests
                  SET fhir_base_url = $1, output_format = $2, file_request_headers = $3,
-                     oauth_metadata_urls = $4, file_encryption_key = $5
-                 WHERE tenant_id = $6 AND submitter = $7 AND submission_id = $8 AND manifest_id = $9",
+                     oauth_metadata_urls = $4, file_encryption_key = $5,
+                     import_directives = $6, submission_metadata = $7
+                 WHERE tenant_id = $8 AND submitter = $9 AND submission_id = $10
+                   AND manifest_id = $11",
                 &[
                     &fhir_base_url,
                     &output_format,
                     &headers_json,
                     &oauth_json,
                     &encryption_json,
+                    &import_json,
+                    &metadata_json,
                     &tenant.tenant_id().as_str(),
                     &id.submitter,
                     &id.submission_id,

--- a/crates/persistence/src/backends/postgres/schema.rs
+++ b/crates/persistence/src/backends/postgres/schema.rs
@@ -703,6 +703,8 @@ async fn add_bulk_submit_worker_schema(
         "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS oauth_metadata_urls TEXT",
         "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS file_encryption_key TEXT",
         "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS last_processed_line BIGINT NOT NULL DEFAULT 0",
+        "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS import_directives TEXT",
+        "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS submission_metadata TEXT",
     ];
     for sql in &migrations {
         client

--- a/crates/persistence/src/backends/s3/bulk_submit.rs
+++ b/crates/persistence/src/backends/s3/bulk_submit.rs
@@ -670,9 +670,9 @@ impl S3Backend {
                         ));
                     }
 
-                    let updated = self
-                        .update(tenant, &current, entry.resource.clone())
-                        .await?;
+                    // Update the resource, honoring the submission's import mode.
+                    let content = options.content_for_update(current.content(), &entry.resource);
+                    let updated = self.update(tenant, &current, content).await?;
 
                     let change = SubmissionChange::update(
                         manifest_id,

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -20,8 +20,8 @@ use crate::core::bulk_submit::{
     SubmissionManifest, SubmissionStatus, SubmissionSummary,
 };
 use crate::core::bulk_submit_worker::{
-    ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy, SubmitFileRecord,
-    SubmitFileRow, SubmitWorkerStorage,
+    ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
+    SubmitFileRecord, SubmitFileRow, SubmitWorkerStorage,
 };
 use crate::error::{BackendError, BulkSubmitError, StorageError, StorageResult};
 use crate::tenant::{TenantContext, TenantId, TenantPermissions};
@@ -859,10 +859,9 @@ impl SqliteBackend {
                     );
                     self.record_change(tenant, submission_id, &change).await?;
 
-                    // Update the resource
-                    let updated = self
-                        .update(tenant, &current, entry.resource.clone())
-                        .await?;
+                    // Update the resource, honoring the submission's import mode.
+                    let content = options.content_for_update(current.content(), &entry.resource);
+                    let updated = self.update(tenant, &current, content).await?;
 
                     Ok(BulkEntryResult::success(
                         entry.line_number,
@@ -1381,11 +1380,14 @@ impl SubmitWorkerStorage for SqliteBackend {
             Option<String>,
             Option<String>,
             i64,
+            Option<String>,
+            Option<String>,
         );
         let row: Row = conn
             .query_row(
                 "SELECT manifest_url, fhir_base_url, output_format, file_request_headers,
-                        oauth_metadata_urls, file_encryption_key, last_processed_line
+                        oauth_metadata_urls, file_encryption_key, last_processed_line,
+                        import_directives, submission_metadata
                  FROM bulk_manifests
                  WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
                    AND manifest_id = ?4 AND worker_id = ?5 AND fencing_token = ?6",
@@ -1406,6 +1408,8 @@ impl SubmitWorkerStorage for SqliteBackend {
                         r.get(4)?,
                         r.get(5)?,
                         r.get(6)?,
+                        r.get(7)?,
+                        r.get(8)?,
                     ))
                 },
             )
@@ -1419,6 +1423,8 @@ impl SubmitWorkerStorage for SqliteBackend {
             oauth_json,
             encryption_json,
             last_processed_line,
+            import_json,
+            metadata_json,
         ) = row;
 
         let file_request_headers: Vec<(String, String)> = headers_json
@@ -1432,6 +1438,14 @@ impl SubmitWorkerStorage for SqliteBackend {
         let file_encryption_key: Option<Value> = encryption_json
             .as_deref()
             .and_then(|s| serde_json::from_str(s).ok());
+        let import_directives: Vec<(String, String)> = import_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default();
+        let metadata: Vec<(String, String)> = metadata_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default();
         let fhir_version = fhir_version_from_output_format(output_format.as_deref());
 
         Ok(ManifestWorkerView {
@@ -1442,6 +1456,8 @@ impl SubmitWorkerStorage for SqliteBackend {
             file_request_headers,
             oauth_metadata_urls,
             file_encryption_key,
+            import_directives,
+            metadata,
             last_processed_line: last_processed_line.max(0) as u64,
             fhir_version,
         })
@@ -1619,27 +1635,31 @@ impl SubmitWorkerStorage for SqliteBackend {
         tenant: &TenantContext,
         id: &SubmissionId,
         manifest_id: &str,
-        fhir_base_url: Option<&str>,
-        output_format: Option<&str>,
-        file_request_headers: &[(String, String)],
-        oauth_metadata_urls: &[String],
-        file_encryption_key: Option<&Value>,
+        fetch: ManifestFetchParams<'_>,
     ) -> StorageResult<()> {
         let conn = self.get_connection()?;
-        let headers_json = serde_json::to_string(file_request_headers).ok();
-        let oauth_json = serde_json::to_string(oauth_metadata_urls).ok();
-        let encryption_json = file_encryption_key.and_then(|v| serde_json::to_string(v).ok());
+        let headers_json = serde_json::to_string(fetch.file_request_headers).ok();
+        let oauth_json = serde_json::to_string(fetch.oauth_metadata_urls).ok();
+        let encryption_json = fetch
+            .file_encryption_key
+            .and_then(|v| serde_json::to_string(v).ok());
+        let import_json = serde_json::to_string(fetch.import_directives).ok();
+        let metadata_json = serde_json::to_string(fetch.metadata).ok();
         conn.execute(
             "UPDATE bulk_manifests
              SET fhir_base_url = ?1, output_format = ?2, file_request_headers = ?3,
-                 oauth_metadata_urls = ?4, file_encryption_key = ?5
-             WHERE tenant_id = ?6 AND submitter = ?7 AND submission_id = ?8 AND manifest_id = ?9",
+                 oauth_metadata_urls = ?4, file_encryption_key = ?5,
+                 import_directives = ?6, submission_metadata = ?7
+             WHERE tenant_id = ?8 AND submitter = ?9 AND submission_id = ?10
+               AND manifest_id = ?11",
             params![
-                fhir_base_url,
-                output_format,
+                fetch.fhir_base_url,
+                fetch.output_format,
                 headers_json,
                 oauth_json,
                 encryption_json,
+                import_json,
+                metadata_json,
                 tenant.tenant_id().as_str(),
                 id.submitter,
                 id.submission_id,

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -1080,6 +1080,14 @@ fn add_bulk_submit_worker_schema(conn: &Connection) -> StorageResult<()> {
             "last_processed_line",
             "ALTER TABLE bulk_manifests ADD COLUMN last_processed_line INTEGER NOT NULL DEFAULT 0",
         ),
+        (
+            "import_directives",
+            "ALTER TABLE bulk_manifests ADD COLUMN import_directives TEXT",
+        ),
+        (
+            "submission_metadata",
+            "ALTER TABLE bulk_manifests ADD COLUMN submission_metadata TEXT",
+        ),
     ];
     for (col, sql) in &manifest_adds {
         if !manifest_columns.iter().any(|c| c == col) {
@@ -1537,6 +1545,8 @@ mod tests {
             "oauth_metadata_urls",
             "file_encryption_key",
             "last_processed_line",
+            "import_directives",
+            "submission_metadata",
         ] {
             assert!(has_column("bulk_manifests", col), "missing {col}");
         }

--- a/crates/persistence/src/core/bulk_submit.rs
+++ b/crates/persistence/src/core/bulk_submit.rs
@@ -554,6 +554,108 @@ impl NdjsonEntry {
     }
 }
 
+/// The `import` directive `parameterUrl` HFS recognizes, selecting how a submitted
+/// resource is applied when a resource with the same id already exists.
+///
+/// The Bulk Data Submit IG defines the `import` parameter as a container for
+/// *pre-coordinated* processing options and leaves the vocabulary to implementers
+/// ("a Data Consumer might allow the Data Provider to specify whether or not
+/// existing data should be replaced with the data in the submission"). This is the
+/// URL HFS publishes for that choice; its `parameterValue` is an [`ImportMode`].
+pub const IMPORT_MODE_PARAMETER_URL: &str = "https://helios.software/import-mode";
+
+/// How a submitted resource is applied when one with the same id already exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ImportMode {
+    /// Last-write-wins: the submitted resource replaces the stored one wholesale.
+    ///
+    /// This is the default, and matches how `$bulk-submit` behaved before the
+    /// `import` directive was honored.
+    #[default]
+    Replace,
+    /// The submitted resource is merged onto the stored one with
+    /// [RFC 7396 JSON Merge Patch](https://www.rfc-editor.org/rfc/rfc7396)
+    /// semantics: elements absent from the submission are retained, elements
+    /// present overwrite, arrays are replaced wholesale, and a `null` member
+    /// removes the stored element. See [`merge_resource`].
+    Merge,
+}
+
+impl ImportMode {
+    /// The `parameterValue` string for this mode.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Replace => "replace",
+            Self::Merge => "merge",
+        }
+    }
+
+    /// Parses a `parameterValue`, returning `None` for unrecognized values.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "replace" => Some(Self::Replace),
+            "merge" => Some(Self::Merge),
+            _ => None,
+        }
+    }
+
+    /// Resolves the mode from persisted `(parameterUrl, parameterValue)` pairs.
+    ///
+    /// Directives HFS does not recognize are ignored here — the kickoff handler is
+    /// what rejects them (under `Prefer: handling=strict`) or logs them. The last
+    /// recognized directive wins.
+    pub fn from_directives(directives: &[(String, String)]) -> Self {
+        directives
+            .iter()
+            .filter(|(url, _)| url == IMPORT_MODE_PARAMETER_URL)
+            .filter_map(|(_, value)| Self::parse(value))
+            .next_back()
+            .unwrap_or_default()
+    }
+}
+
+impl std::fmt::Display for ImportMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Merges a submitted resource onto a stored one per [`ImportMode::Merge`].
+///
+/// This is RFC 7396 JSON Merge Patch with one FHIR-specific guard: the stored
+/// resource's `id` is always preserved, so a submission cannot re-key a resource it
+/// is merging into. Note that arrays are replaced wholesale — merge patch has no
+/// element-wise array semantics, and FHIR repeating elements have no reliable
+/// identity to match on.
+pub fn merge_resource(stored: &Value, submitted: &Value) -> Value {
+    let mut merged = merge_patch(stored, submitted);
+    if let (Some(obj), Some(id)) = (merged.as_object_mut(), stored.get("id")) {
+        obj.insert("id".to_string(), id.clone());
+    }
+    merged
+}
+
+/// RFC 7396 `MergePatch(target, patch)`.
+fn merge_patch(target: &Value, patch: &Value) -> Value {
+    let Some(patch_obj) = patch.as_object() else {
+        return patch.clone();
+    };
+    let mut out = match target.as_object() {
+        Some(obj) => obj.clone(),
+        None => serde_json::Map::new(),
+    };
+    for (key, value) in patch_obj {
+        if value.is_null() {
+            out.remove(key);
+        } else {
+            let target_value = out.get(key).cloned().unwrap_or(Value::Null);
+            out.insert(key.clone(), merge_patch(&target_value, value));
+        }
+    }
+    Value::Object(out)
+}
+
 /// Options for bulk processing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BulkProcessingOptions {
@@ -569,6 +671,9 @@ pub struct BulkProcessingOptions {
     /// Whether to allow updates to existing resources.
     #[serde(default = "default_allow_updates")]
     pub allow_updates: bool,
+    /// How a submitted resource is applied over an existing one with the same id.
+    #[serde(default)]
+    pub import_mode: ImportMode,
 }
 
 fn default_submit_batch_size() -> u32 {
@@ -597,6 +702,7 @@ impl BulkProcessingOptions {
             continue_on_error: default_continue_on_error(),
             max_errors: 0,
             allow_updates: default_allow_updates(),
+            import_mode: ImportMode::default(),
         }
     }
 
@@ -624,23 +730,36 @@ impl BulkProcessingOptions {
         self
     }
 
+    /// Sets how submitted resources are applied over existing ones.
+    pub fn with_import_mode(mut self, import_mode: ImportMode) -> Self {
+        self.import_mode = import_mode;
+        self
+    }
+
+    /// Resolves the content to write when a submitted resource lands on an existing
+    /// one, applying [`Self::import_mode`].
+    pub fn content_for_update(&self, stored: &Value, submitted: &Value) -> Value {
+        match self.import_mode {
+            ImportMode::Replace => submitted.clone(),
+            ImportMode::Merge => merge_resource(stored, submitted),
+        }
+    }
+
     /// Creates options for strict processing (no errors allowed).
     pub fn strict() -> Self {
         Self {
-            batch_size: default_submit_batch_size(),
             continue_on_error: false,
             max_errors: 1,
             allow_updates: true,
+            ..Self::new()
         }
     }
 
     /// Creates options for create-only processing.
     pub fn create_only() -> Self {
         Self {
-            batch_size: default_submit_batch_size(),
-            continue_on_error: true,
-            max_errors: 0,
             allow_updates: false,
+            ..Self::new()
         }
     }
 }
@@ -1292,5 +1411,117 @@ mod tests {
         let result = StreamProcessingResult::new().aborted("max errors exceeded");
         assert!(result.aborted);
         assert_eq!(result.abort_reason, Some("max errors exceeded".to_string()));
+    }
+
+    #[test]
+    fn test_import_mode_parse_and_default() {
+        assert_eq!(ImportMode::parse("replace"), Some(ImportMode::Replace));
+        assert_eq!(ImportMode::parse("merge"), Some(ImportMode::Merge));
+        assert_eq!(ImportMode::parse("Merge"), None);
+        assert_eq!(ImportMode::parse("upsert"), None);
+        // Absent directive → replace (the pre-existing behavior).
+        assert_eq!(ImportMode::default(), ImportMode::Replace);
+        assert_eq!(ImportMode::Merge.as_str(), "merge");
+    }
+
+    #[test]
+    fn test_import_mode_from_directives() {
+        let none: Vec<(String, String)> = vec![];
+        assert_eq!(ImportMode::from_directives(&none), ImportMode::Replace);
+
+        let merge = vec![(IMPORT_MODE_PARAMETER_URL.to_string(), "merge".to_string())];
+        assert_eq!(ImportMode::from_directives(&merge), ImportMode::Merge);
+
+        // Directives under other URLs never select a mode.
+        let other = vec![("https://example.org/other".to_string(), "merge".to_string())];
+        assert_eq!(ImportMode::from_directives(&other), ImportMode::Replace);
+
+        // Last recognized directive wins.
+        let both = vec![
+            (IMPORT_MODE_PARAMETER_URL.to_string(), "merge".to_string()),
+            (IMPORT_MODE_PARAMETER_URL.to_string(), "replace".to_string()),
+        ];
+        assert_eq!(ImportMode::from_directives(&both), ImportMode::Replace);
+    }
+
+    #[test]
+    fn test_merge_resource_retains_absent_elements() {
+        let stored = serde_json::json!({
+            "resourceType": "Patient",
+            "id": "p1",
+            "name": [{"family": "Original"}],
+            "gender": "female",
+            "active": true
+        });
+        let submitted = serde_json::json!({
+            "resourceType": "Patient",
+            "id": "p1",
+            "gender": "male"
+        });
+        let merged = merge_resource(&stored, &submitted);
+        // Submitted element overwrites...
+        assert_eq!(merged["gender"], serde_json::json!("male"));
+        // ...absent elements survive (this is the whole point of merge).
+        assert_eq!(merged["name"], serde_json::json!([{"family": "Original"}]));
+        assert_eq!(merged["active"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_merge_resource_replaces_arrays_and_deletes_nulls() {
+        let stored = serde_json::json!({
+            "resourceType": "Patient",
+            "id": "p1",
+            "name": [{"family": "A"}, {"family": "B"}],
+            "telecom": [{"system": "phone", "value": "555"}]
+        });
+        let submitted = serde_json::json!({
+            "resourceType": "Patient",
+            "name": [{"family": "C"}],
+            "telecom": null
+        });
+        let merged = merge_resource(&stored, &submitted);
+        // RFC 7396: arrays are replaced wholesale, never merged element-wise.
+        assert_eq!(merged["name"], serde_json::json!([{"family": "C"}]));
+        // RFC 7396: a null member removes the stored element.
+        assert!(merged.get("telecom").is_none());
+    }
+
+    #[test]
+    fn test_merge_resource_merges_nested_objects_and_keeps_stored_id() {
+        let stored = serde_json::json!({
+            "resourceType": "Observation",
+            "id": "o1",
+            "code": {"text": "BP", "coding": [{"code": "1234"}]},
+            "status": "final"
+        });
+        let submitted = serde_json::json!({
+            "resourceType": "Observation",
+            "id": "other",
+            "code": {"text": "Blood pressure"}
+        });
+        let merged = merge_resource(&stored, &submitted);
+        assert_eq!(merged["code"]["text"], serde_json::json!("Blood pressure"));
+        assert_eq!(
+            merged["code"]["coding"],
+            serde_json::json!([{"code": "1234"}])
+        );
+        assert_eq!(merged["status"], serde_json::json!("final"));
+        // A submission cannot re-key the resource it merges into.
+        assert_eq!(merged["id"], serde_json::json!("o1"));
+    }
+
+    #[test]
+    fn test_content_for_update_follows_import_mode() {
+        let stored = serde_json::json!({
+            "resourceType": "Patient", "id": "p1", "gender": "female", "active": true
+        });
+        let submitted = serde_json::json!({"resourceType": "Patient", "id": "p1"});
+
+        let replace = BulkProcessingOptions::new();
+        assert_eq!(replace.content_for_update(&stored, &submitted), submitted);
+
+        let merge = BulkProcessingOptions::new().with_import_mode(ImportMode::Merge);
+        let merged = merge.content_for_update(&stored, &submitted);
+        assert_eq!(merged["gender"], serde_json::json!("female"));
     }
 }

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -21,7 +21,7 @@ use crate::core::bulk_export_output::{ExportOutputStore, ExportPartKey};
 use crate::core::bulk_export_worker::{LeaseError, WorkerId};
 use crate::core::bulk_submit::{
     BulkEntryOutcome, BulkProcessingOptions, BulkSubmitProvider, BulkSubmitRollbackProvider,
-    StreamingBulkSubmitProvider, SubmissionId,
+    ImportMode, StreamingBulkSubmitProvider, SubmissionId,
 };
 use crate::core::bulk_submit_input::{SubmitInputFetcher, submission_output_job_id};
 use crate::error::StorageResult;
@@ -65,10 +65,43 @@ pub struct ManifestWorkerView {
     pub oauth_metadata_urls: Vec<String>,
     /// JWE file-encryption key descriptor, if the provider encrypts files.
     pub file_encryption_key: Option<Value>,
+    /// Pre-coordinated `import` processing directives as
+    /// `(parameterUrl, parameterValue)` pairs. Resolve with
+    /// [`ImportMode::from_directives`].
+    pub import_directives: Vec<(String, String)>,
+    /// Pre-coordinated `metadata` parts as `(parameterUrl, parameterValue)` pairs.
+    ///
+    /// The IG defines these as data the Data Provider passes to the Data Consumer
+    /// without prescribing any processing; HFS retains them verbatim alongside the
+    /// manifest and surfaces them to the worker (which logs them) so deployment- or
+    /// IG-specific handling can be layered on without another migration.
+    pub metadata: Vec<(String, String)>,
     /// Resume cursor: lines already processed for this manifest.
     pub last_processed_line: u64,
     /// FHIR version this submission ingests against.
     pub fhir_version: FhirVersion,
+}
+
+/// The kickoff-supplied parameters a worker needs to fetch and ingest a manifest.
+///
+/// Bundled into a struct because they are written together by the kickoff handler
+/// and read back together by [`SubmitWorkerStorage::get_manifest_for_worker`].
+#[derive(Debug, Clone, Default)]
+pub struct ManifestFetchParams<'a> {
+    /// Base URL for resolving relative references in ingested resources.
+    pub fhir_base_url: Option<&'a str>,
+    /// The kickoff `outputFormat` (MIME), used to derive the FHIR version.
+    pub output_format: Option<&'a str>,
+    /// HTTP headers the Data Provider asked us to include when fetching files.
+    pub file_request_headers: &'a [(String, String)],
+    /// OAuth 2.0 metadata endpoints for acquiring file-retrieval tokens.
+    pub oauth_metadata_urls: &'a [String],
+    /// JWE file-encryption key descriptor, if the provider encrypts files.
+    pub file_encryption_key: Option<&'a Value>,
+    /// `import` directives as `(parameterUrl, parameterValue)` pairs.
+    pub import_directives: &'a [(String, String)],
+    /// `metadata` parts as `(parameterUrl, parameterValue)` pairs.
+    pub metadata: &'a [(String, String)],
 }
 
 /// A finalized status-manifest artifact (output / error / deleted NDJSON part) to record.
@@ -197,19 +230,14 @@ pub trait SubmitWorkerStorage: Send + Sync {
     /// Persists the remote-fetch parameters for a manifest that the kickoff handler
     /// added via [`crate::core::bulk_submit::BulkSubmitProvider::add_manifest`].
     ///
-    /// `file_request_headers` / `oauth_metadata_urls` are stored as JSON arrays;
-    /// `file_encryption_key` as a JSON object.
-    #[allow(clippy::too_many_arguments)]
+    /// `file_request_headers` / `oauth_metadata_urls` / `import_directives` /
+    /// `metadata` are stored as JSON arrays; `file_encryption_key` as a JSON object.
     async fn set_manifest_fetch_params(
         &self,
         tenant: &TenantContext,
         id: &SubmissionId,
         manifest_id: &str,
-        fhir_base_url: Option<&str>,
-        output_format: Option<&str>,
-        file_request_headers: &[(String, String)],
-        oauth_metadata_urls: &[String],
-        file_encryption_key: Option<&Value>,
+        params: ManifestFetchParams<'_>,
     ) -> StorageResult<()>;
 
     /// Marks a previously-submitted manifest (identified by its submitted
@@ -390,7 +418,19 @@ where
             }
         };
 
-        let opts = BulkProcessingOptions::new();
+        // Apply the pre-coordinated `import` directives the Data Provider sent at
+        // kickoff. `metadata` carries no processing semantics of its own — it is
+        // retained with the manifest and surfaced here for operators.
+        let import_mode = ImportMode::from_directives(&view.import_directives);
+        if !view.metadata.is_empty() {
+            tracing::info!(
+                submission = %lease.submission_id,
+                manifest = %lease.manifest_id,
+                metadata = ?view.metadata,
+                "ingesting manifest with submission metadata"
+            );
+        }
+        let opts = BulkProcessingOptions::new().with_import_mode(import_mode);
         let mut processed: u64 = 0;
         let mut failed: u64 = 0;
 
@@ -864,6 +904,7 @@ mod tests {
     use crate::backends::sqlite::SqliteBackend;
     use crate::core::bulk_submit::BulkSubmitProvider;
     use crate::core::bulk_submit_input::{RemoteFile, RemoteManifest};
+    use crate::core::storage::ResourceStorage;
     use crate::tenant::{TenantContext, TenantId, TenantPermissions};
     use std::time::Duration as StdDuration;
 
@@ -1069,6 +1110,144 @@ mod tests {
         // A manifest-level error artifact was recorded.
         let files = backend.list_submit_files(&tenant, &sub_id).await.unwrap();
         assert!(files.iter().any(|f| f.file_type == "error"));
+    }
+
+    /// Seeds a submission whose single manifest carries the given `import` directives.
+    async fn seed_with_import(
+        backend: &Arc<SqliteBackend>,
+        tenant: &TenantContext,
+        directives: &[(String, String)],
+    ) -> SubmissionId {
+        let sub_id = SubmissionId::generate("mock-system");
+        backend
+            .create_submission(tenant, &sub_id, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(tenant, &sub_id, Some("http://provider/manifest.json"), None)
+            .await
+            .unwrap();
+        backend
+            .set_manifest_fetch_params(
+                tenant,
+                &sub_id,
+                &manifest.manifest_id,
+                ManifestFetchParams {
+                    import_directives: directives,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        sub_id
+    }
+
+    /// A fetcher serving one NDJSON file of `Patient` resources.
+    fn patient_fetcher(ndjson: &str) -> Arc<MockFetcher> {
+        let mut files = std::collections::HashMap::new();
+        files.insert(
+            "http://provider/p.ndjson".to_string(),
+            ndjson.as_bytes().to_vec(),
+        );
+        Arc::new(MockFetcher {
+            files,
+            manifest: RemoteManifest {
+                requires_access_token: false,
+                output: vec![RemoteFile {
+                    resource_type: Some("Patient".to_string()),
+                    url: "http://provider/p.ndjson".to_string(),
+                    count: Some(1),
+                }],
+                deleted: vec![],
+            },
+        })
+    }
+
+    /// Ingests a partial Patient over an existing one and returns the stored content.
+    async fn ingest_over_existing(directives: &[(String, String)]) -> Value {
+        let backend = Arc::new(SqliteBackend::in_memory().unwrap());
+        backend.init_schema().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let output = Arc::new(LocalFsOutputStore::new(
+            tmp.path().to_path_buf(),
+            "http://x",
+        ));
+        let tenant = tenant();
+
+        // An existing Patient carrying a name the submission never mentions.
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "p1",
+                    "name": [{"family": "Original"}],
+                    "gender": "female"
+                }),
+                helios_fhir::FhirVersion::default_enabled(),
+            )
+            .await
+            .unwrap();
+
+        let sub_id = seed_with_import(&backend, &tenant, directives).await;
+        let fetcher =
+            patient_fetcher("{\"resourceType\":\"Patient\",\"id\":\"p1\",\"gender\":\"male\"}\n");
+        let worker = DefaultSubmitWorker::new(backend.clone(), fetcher, output, WorkerId::new("w"));
+        let lease = backend
+            .claim_next_manifest(&WorkerId::new("w"), StdDuration::from_secs(60))
+            .await
+            .unwrap()
+            .unwrap();
+        worker.run_job(lease).await.unwrap();
+
+        let manifests = backend.list_manifests(&tenant, &sub_id).await.unwrap();
+        assert_eq!(
+            backend
+                .get_entry_counts(&tenant, &sub_id, &manifests[0].manifest_id)
+                .await
+                .unwrap()
+                .success,
+            1
+        );
+        backend
+            .read(&tenant, "Patient", "p1")
+            .await
+            .unwrap()
+            .expect("patient still stored")
+            .content()
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn test_import_mode_merge_retains_unsubmitted_elements() {
+        let stored = ingest_over_existing(&[(
+            crate::core::bulk_submit::IMPORT_MODE_PARAMETER_URL.to_string(),
+            "merge".to_string(),
+        )])
+        .await;
+        assert_eq!(stored["gender"], json!("male"));
+        assert_eq!(stored["name"], json!([{"family": "Original"}]));
+    }
+
+    #[tokio::test]
+    async fn test_import_mode_replace_is_the_default() {
+        // Explicit `replace` and no directive at all must behave identically:
+        // the submitted resource wins wholesale.
+        for directives in [
+            vec![(
+                crate::core::bulk_submit::IMPORT_MODE_PARAMETER_URL.to_string(),
+                "replace".to_string(),
+            )],
+            vec![],
+        ] {
+            let stored = ingest_over_existing(&directives).await;
+            assert_eq!(stored["gender"], json!("male"));
+            assert!(
+                stored.get("name").is_none(),
+                "replace must not retain unsubmitted elements, got {stored}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/persistence/src/core/mod.rs
+++ b/crates/persistence/src/core/mod.rs
@@ -122,16 +122,18 @@ pub use bulk_export_worker::{
 };
 pub use bulk_submit::{
     BulkEntryOutcome, BulkEntryResult, BulkProcessingOptions, BulkSubmitProvider,
-    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, ManifestStatus, NdjsonEntry,
-    StreamProcessingResult, StreamingBulkSubmitProvider, SubmissionChange, SubmissionId,
-    SubmissionManifest, SubmissionStatus, SubmissionSummary,
+    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, IMPORT_MODE_PARAMETER_URL,
+    ImportMode, ManifestStatus, NdjsonEntry, StreamProcessingResult, StreamingBulkSubmitProvider,
+    SubmissionChange, SubmissionId, SubmissionManifest, SubmissionStatus, SubmissionSummary,
+    merge_resource,
 };
 pub use bulk_submit_input::{
     FileTokenProvider, RemoteFile, RemoteManifest, SubmitInputFetcher, submission_output_job_id,
 };
 pub use bulk_submit_worker::{
-    BulkSubmitJobStore, DefaultSubmitWorker, ManifestLease, ManifestWorkerView, PollTokenTarget,
-    SubmitClaimStrategy, SubmitFileRecord, SubmitFileRow, SubmitWorkerStorage,
+    BulkSubmitJobStore, DefaultSubmitWorker, ManifestFetchParams, ManifestLease,
+    ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy, SubmitFileRecord, SubmitFileRow,
+    SubmitWorkerStorage,
 };
 pub use capabilities::{
     CapabilityProvider, GlobalSearchCapabilities, Interaction, ResourceCapabilities,

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -4918,4 +4918,109 @@ mod postgres_integration {
             "expected a backend error from an unmigrated database, got {create:?}"
         );
     }
+    /// The `import` / `metadata` kickoff directives must survive the PostgreSQL
+    /// round-trip and reach the worker, and `merge` must actually merge.
+    ///
+    /// This is the Postgres half of the coverage in
+    /// `core::bulk_submit_worker::tests` (which runs on SQLite): the plumbing is
+    /// shared but the SQL is not, so a typo in the new columns would otherwise
+    /// only surface in production.
+    #[tokio::test]
+    async fn postgres_bulk_submit_import_directives_round_trip() {
+        use helios_persistence::core::{
+            BulkProcessingOptions, BulkSubmitProvider, IMPORT_MODE_PARAMETER_URL, ImportMode,
+            ManifestFetchParams, NdjsonEntry, SubmissionId, SubmitClaimStrategy,
+            SubmitWorkerStorage,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("bulk_submit_import");
+        let sub_id = SubmissionId::generate("pg-import-test");
+        backend
+            .create_submission(&tenant, &sub_id, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(&tenant, &sub_id, Some("https://provider/m.json"), None)
+            .await
+            .unwrap();
+
+        let directives = vec![(IMPORT_MODE_PARAMETER_URL.to_string(), "merge".to_string())];
+        let metadata = vec![("https://ex/context".to_string(), "batch-7".to_string())];
+        backend
+            .set_manifest_fetch_params(
+                &tenant,
+                &sub_id,
+                &manifest.manifest_id,
+                ManifestFetchParams {
+                    fhir_base_url: Some("https://provider/fhir"),
+                    import_directives: &directives,
+                    metadata: &metadata,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // Claim the manifest the way the worker does, then read its view back.
+        let lease = backend
+            .claim_next_manifest(
+                &helios_persistence::core::WorkerId::new("pg-import-worker"),
+                std::time::Duration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .expect("claimable manifest");
+        let view = backend.get_manifest_for_worker(&lease).await.unwrap();
+        assert_eq!(view.import_directives, directives);
+        assert_eq!(view.metadata, metadata);
+        assert_eq!(
+            ImportMode::from_directives(&view.import_directives),
+            ImportMode::Merge
+        );
+
+        // And the resolved mode changes what ingestion writes.
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "pg-merge-1",
+                    "gender": "female",
+                    "name": [{"family": "Stale"}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        let entry = NdjsonEntry::new(
+            1,
+            "Patient",
+            json!({"resourceType": "Patient", "id": "pg-merge-1", "name": [{"family": "New"}]}),
+        );
+        let results = backend
+            .process_entries(
+                &tenant,
+                &sub_id,
+                &manifest.manifest_id,
+                vec![entry],
+                &BulkProcessingOptions::new().with_import_mode(ImportMode::Merge),
+            )
+            .await
+            .unwrap();
+        assert!(results[0].is_success());
+
+        let stored = backend
+            .read(&tenant, "Patient", "pg-merge-1")
+            .await
+            .unwrap()
+            .expect("patient still stored");
+        assert_eq!(stored.content()["name"], json!([{"family": "New"}]));
+        assert_eq!(
+            stored.content()["gender"],
+            json!("female"),
+            "merge must retain elements the submission omitted"
+        );
+    }
 }

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -19,8 +19,8 @@ use axum::{
 };
 use helios_auth::Principal;
 use helios_persistence::core::{
-    ExportPartKey, ManifestStatus, ResourceStorage, SubmissionId, SubmissionStatus,
-    submission_output_job_id,
+    ExportPartKey, IMPORT_MODE_PARAMETER_URL, ImportMode, ManifestFetchParams, ManifestStatus,
+    ResourceStorage, SubmissionId, SubmissionStatus, submission_output_job_id,
 };
 use serde_json::{Value, json};
 
@@ -112,6 +112,52 @@ fn part_scalar(param: &Value, child: &str) -> Option<String> {
         .and_then(scalar)
 }
 
+/// Reads an `import` / `metadata` parameter's `(parameterUrl, parameterValue)` pair.
+///
+/// Both child parts are 1..1 in the IG and `parameterUrl` SHALL be an absolute URL,
+/// so a malformed directive is a client error rather than something to drop silently.
+fn pre_coordinated_part(param: &Value, kind: &str) -> RestResult<(String, String)> {
+    let url = part_scalar(param, "parameterUrl")
+        .ok_or_else(|| bad_request(format!("`{kind}.parameterUrl` is required")))?;
+    if !url.contains("://") {
+        return Err(bad_request(format!(
+            "`{kind}.parameterUrl` must be an absolute URL, got '{url}'"
+        )));
+    }
+    let value = part_scalar(param, "parameterValue")
+        .ok_or_else(|| bad_request(format!("`{kind}.parameterValue` is required")))?;
+    Ok((url, value))
+}
+
+/// Validates the `import` directives HFS recognizes and reports the rest.
+///
+/// A recognized directive with an unusable value is always a `400`. Directives HFS
+/// does not recognize are rejected under `Prefer: handling=strict` and ignored
+/// (with a warning) otherwise. `metadata` parts carry no processing semantics — HFS
+/// retains every one of them verbatim, so none are rejected.
+fn validate_import_directives(directives: &[(String, String)], strict: bool) -> RestResult<()> {
+    for (url, value) in directives {
+        if url == IMPORT_MODE_PARAMETER_URL {
+            if ImportMode::parse(value).is_none() {
+                return Err(bad_request(format!(
+                    "unsupported import mode '{value}' for '{IMPORT_MODE_PARAMETER_URL}' \
+                     (expected replace|merge)"
+                )));
+            }
+        } else if strict {
+            return Err(bad_request(format!(
+                "unrecognized `import` directive '{url}' rejected under Prefer: handling=strict"
+            )));
+        } else {
+            tracing::warn!(
+                directive = %url,
+                "ignoring unrecognized `import` directive on $bulk-submit kickoff"
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Parses a `$bulk-submit` `Parameters` body, enforcing the spec's validation SHALLs.
 fn parse_submit_request(body: &Value) -> RestResult<SubmitRequest> {
     let params = body
@@ -189,22 +235,10 @@ fn parse_submit_request(body: &Value) -> RestResult<SubmitRequest> {
             "fileEncryptionKey" => {
                 req.file_encryption_key = Some(p.clone());
             }
-            "import" => {
-                if let (Some(u), Some(v)) = (
-                    part_scalar(p, "parameterUrl"),
-                    part_scalar(p, "parameterValue"),
-                ) {
-                    req.import_directives.push((u, v));
-                }
-            }
-            "metadata" => {
-                if let (Some(u), Some(v)) = (
-                    part_scalar(p, "parameterUrl"),
-                    part_scalar(p, "parameterValue"),
-                ) {
-                    req.metadata.push((u, v));
-                }
-            }
+            "import" => req
+                .import_directives
+                .push(pre_coordinated_part(p, "import")?),
+            "metadata" => req.metadata.push(pre_coordinated_part(p, "metadata")?),
             _ => {}
         }
     }
@@ -306,13 +340,7 @@ where
         .map_err(|e| bad_request(format!("invalid Parameters JSON: {e}")))?;
     let req = parse_submit_request(&body)?;
 
-    // Under `Prefer: handling=strict`, reject pre-coordinated directives we do not
-    // recognize (we recognize none specifically); lenient/absent → ignore them.
-    if strict && (!req.import_directives.is_empty() || !req.metadata.is_empty()) {
-        return Err(bad_request(
-            "unrecognized `import`/`metadata` directives rejected under Prefer: handling=strict",
-        ));
-    }
+    validate_import_directives(&req.import_directives, strict)?;
 
     let sub_id = SubmissionId::new(req.submitter_key(), req.submission_id.clone());
     let ctx = tenant.context();
@@ -405,14 +433,25 @@ where
             ctx,
             &sub_id,
             &manifest.manifest_id,
-            req.fhir_base_url.as_deref(),
-            req.output_format.as_deref(),
-            &req.file_request_headers,
-            &req.oauth_metadata_urls,
-            req.file_encryption_key.as_ref(),
+            ManifestFetchParams {
+                fhir_base_url: req.fhir_base_url.as_deref(),
+                output_format: req.output_format.as_deref(),
+                file_request_headers: &req.file_request_headers,
+                oauth_metadata_urls: &req.oauth_metadata_urls,
+                file_encryption_key: req.file_encryption_key.as_ref(),
+                import_directives: &req.import_directives,
+                metadata: &req.metadata,
+            },
         )
         .await
         .map_err(RestError::from)?;
+    } else if !req.import_directives.is_empty() || !req.metadata.is_empty() {
+        // `import`/`metadata` are pre-coordinated with the data they describe; a
+        // status-only kickoff carries no manifest for them to attach to.
+        tracing::warn!(
+            submission = %sub_id,
+            "ignoring `import`/`metadata` directives on a kickoff without a manifestUrl"
+        );
     }
 
     // submissionStatus=stopped → abort (rolls back recorded changes).
@@ -984,7 +1023,7 @@ mod tests {
                 {"name": "headerValue", "valueString": "abc"}
             ]}),
             json!({"name": "import", "part": [
-                {"name": "parameterUrl", "valueUri": "https://helios.software/import-mode"},
+                {"name": "parameterUrl", "valueUri": IMPORT_MODE_PARAMETER_URL},
                 {"name": "parameterValue", "valueString": "replace"}
             ]}),
             json!({"name": "metadata", "part": [
@@ -1004,6 +1043,115 @@ mod tests {
         assert_eq!(req.import_directives.len(), 1);
         assert_eq!(req.import_directives[0].1, "replace");
         assert_eq!(req.metadata.len(), 1);
+    }
+
+    /// Builds a kickoff body carrying a single `import` or `metadata` directive.
+    fn body_with_directive(kind: &str, parts: Value) -> Value {
+        json!({"resourceType": "Parameters", "parameter": [
+            param("submitter", "valueIdentifier", json!({"value": "e"})),
+            param("submissionId", "valueString", json!("s")),
+            param("manifestUrl", "valueUrl", json!("https://p/m.json")),
+            param("fhirBaseUrl", "valueUrl", json!("https://p/fhir")),
+            json!({"name": kind, "part": parts}),
+        ]})
+    }
+
+    #[test]
+    fn test_directive_parts_are_required_and_absolute() {
+        for kind in ["import", "metadata"] {
+            // parameterValue missing (1..1 in the IG).
+            let body = body_with_directive(
+                kind,
+                json!([{"name": "parameterUrl", "valueUri": "https://ex/a"}]),
+            );
+            assert!(parse_submit_request(&body).is_err(), "{kind} without value");
+
+            // parameterUrl missing.
+            let body = body_with_directive(
+                kind,
+                json!([{"name": "parameterValue", "valueString": "v"}]),
+            );
+            assert!(parse_submit_request(&body).is_err(), "{kind} without url");
+
+            // parameterUrl SHALL be an absolute URL.
+            let body = body_with_directive(
+                kind,
+                json!([
+                    {"name": "parameterUrl", "valueUri": "not-absolute"},
+                    {"name": "parameterValue", "valueString": "v"}
+                ]),
+            );
+            assert!(parse_submit_request(&body).is_err(), "{kind} relative url");
+        }
+    }
+
+    #[test]
+    fn test_import_mode_directive_values() {
+        for mode in ["replace", "merge"] {
+            let body = body_with_directive(
+                "import",
+                json!([
+                    {"name": "parameterUrl", "valueUri": IMPORT_MODE_PARAMETER_URL},
+                    {"name": "parameterValue", "valueString": mode}
+                ]),
+            );
+            let req = parse_submit_request(&body).expect("recognized mode");
+            // A recognized directive is accepted under both handling postures.
+            assert!(validate_import_directives(&req.import_directives, true).is_ok());
+            assert!(validate_import_directives(&req.import_directives, false).is_ok());
+            assert_eq!(
+                ImportMode::from_directives(&req.import_directives),
+                ImportMode::parse(mode).unwrap()
+            );
+        }
+
+        // An unusable value for a directive we DO recognize is always a 400.
+        let body = body_with_directive(
+            "import",
+            json!([
+                {"name": "parameterUrl", "valueUri": IMPORT_MODE_PARAMETER_URL},
+                {"name": "parameterValue", "valueString": "upsert"}
+            ]),
+        );
+        let req = parse_submit_request(&body).expect("parses");
+        assert!(validate_import_directives(&req.import_directives, false).is_err());
+        assert!(validate_import_directives(&req.import_directives, true).is_err());
+    }
+
+    #[test]
+    fn test_unrecognized_import_directive_handling() {
+        let body = body_with_directive(
+            "import",
+            json!([
+                {"name": "parameterUrl", "valueUri": "https://ex/unknown-option"},
+                {"name": "parameterValue", "valueString": "on"}
+            ]),
+        );
+        let req = parse_submit_request(&body).expect("parses");
+        // Lenient (default): ignored, and the mode falls back to replace.
+        assert!(validate_import_directives(&req.import_directives, false).is_ok());
+        assert_eq!(
+            ImportMode::from_directives(&req.import_directives),
+            ImportMode::Replace
+        );
+        // Strict: rejected.
+        assert!(validate_import_directives(&req.import_directives, true).is_err());
+    }
+
+    #[test]
+    fn test_metadata_is_never_rejected_under_strict() {
+        // HFS retains every `metadata` part verbatim, so unknown URLs are not a
+        // reason to fail the kickoff even under `Prefer: handling=strict`.
+        let body = body_with_directive(
+            "metadata",
+            json!([
+                {"name": "parameterUrl", "valueUri": "https://ex/whatever"},
+                {"name": "parameterValue", "valueString": "v"}
+            ]),
+        );
+        let req = parse_submit_request(&body).expect("parses");
+        assert_eq!(req.metadata.len(), 1);
+        assert!(validate_import_directives(&req.import_directives, true).is_ok());
     }
 
     #[test]

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -233,6 +233,114 @@ async fn test_strict_handling_rejects_unknown_directives() {
 }
 
 #[tokio::test]
+async fn test_strict_handling_accepts_recognized_import_mode() {
+    // Only *unrecognized* directives are rejected under strict handling — the
+    // import mode HFS publishes is honored regardless of posture.
+    let (server, ..) = create_submit_server().await;
+    let mut body = kickoff_body();
+    body["parameter"].as_array_mut().unwrap().push(json!({
+        "name": "import",
+        "part": [
+            {"name": "parameterUrl", "valueUri": "https://helios.software/import-mode"},
+            {"name": "parameterValue", "valueString": "merge"}
+        ]
+    }));
+    let resp = server
+        .post("/$bulk-submit")
+        .add_header("Prefer", "handling=strict")
+        .json(&body)
+        .await;
+    assert_eq!(resp.status_code(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_unsupported_import_mode_value_rejected() {
+    // A directive we recognize with a value we cannot honor is a 400 even under
+    // lenient handling — silently ingesting under the wrong mode would corrupt data.
+    let (server, ..) = create_submit_server().await;
+    let mut body = kickoff_body();
+    body["parameter"].as_array_mut().unwrap().push(json!({
+        "name": "import",
+        "part": [
+            {"name": "parameterUrl", "valueUri": "https://helios.software/import-mode"},
+            {"name": "parameterValue", "valueString": "upsert"}
+        ]
+    }));
+    let resp = server.post("/$bulk-submit").json(&body).await;
+    assert_eq!(resp.status_code(), StatusCode::BAD_REQUEST);
+}
+
+/// Kicks off a submission over a pre-existing `sub-p1` and returns its stored
+/// content after ingestion, so `replace` and `merge` can be compared end-to-end.
+async fn ingest_with_import_mode(mode: Option<&str>) -> Value {
+    let (server, backend, fetcher, output, _tmp) = create_submit_server().await;
+    let tenant = helios_persistence::tenant::TenantContext::new(
+        helios_persistence::tenant::TenantId::new("test-tenant"),
+        helios_persistence::tenant::TenantPermissions::full_access(),
+    );
+    // Already stored: a Patient with a `gender` the submission never mentions.
+    backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "id": "sub-p1",
+                "gender": "female",
+                "name": [{"family": "Stale"}]
+            }),
+            helios_fhir::FhirVersion::default_enabled(),
+        )
+        .await
+        .expect("seed patient");
+
+    let mut body = kickoff_body();
+    if let Some(mode) = mode {
+        body["parameter"].as_array_mut().unwrap().push(json!({
+            "name": "import",
+            "part": [
+                {"name": "parameterUrl", "valueUri": "https://helios.software/import-mode"},
+                {"name": "parameterValue", "valueString": mode}
+            ]
+        }));
+    }
+    assert_eq!(
+        server.post("/$bulk-submit").json(&body).await.status_code(),
+        StatusCode::OK
+    );
+    drain_submit(&backend, &fetcher, &output).await;
+
+    backend
+        .read(&tenant, "Patient", "sub-p1")
+        .await
+        .unwrap()
+        .expect("patient still stored")
+        .content()
+        .clone()
+}
+
+#[tokio::test]
+async fn test_import_mode_merge_applied_to_ingestion() {
+    let stored = ingest_with_import_mode(Some("merge")).await;
+    // Submitted element wins...
+    assert_eq!(stored["name"], json!([{"family": "A"}]));
+    // ...and the element the submission omitted survives.
+    assert_eq!(stored["gender"], json!("female"));
+}
+
+#[tokio::test]
+async fn test_import_mode_replace_applied_to_ingestion() {
+    for mode in [Some("replace"), None] {
+        let stored = ingest_with_import_mode(mode).await;
+        assert_eq!(stored["name"], json!([{"family": "A"}]));
+        assert!(
+            stored.get("gender").is_none(),
+            "replace must not retain unsubmitted elements, got {stored}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_full_lifecycle_ingests_and_polls() {
     let (server, backend, fetcher, output, _tmp) = create_submit_server().await;
 


### PR DESCRIPTION
Fixes #401.

## Problem

The `$bulk-submit` kick-off handler parsed the `import` and `metadata` parts into `SubmitRequest` but never forwarded them to the ingestion worker. Their only effect was to reject *everything* under `Prefer: handling=strict`, so the import-mode semantics the skill documented (`replace` / `merge`) were never actually wired into ingestion.

## Vocabulary

The [Submit IG](https://build.fhir.org/ig/HL7/bulk-data/en/submit.html) defines `import` as a container for pre-coordinated processing options and leaves the `parameterUrl` vocabulary to implementers ("a Data Consumer might allow the Data Provider to specify whether or not existing data should be replaced"). This PR publishes one:

| `parameterUrl` | Values | Effect |
|---|---|---|
| `https://helios.software/import-mode` | `replace` (default), `merge` | How a submitted resource is applied when one with the same id already exists |

- **`replace`** — upsert-by-id, last-write-wins. Unchanged from today's behavior, and still the default when no directive is sent, so existing submissions are unaffected.
- **`merge`** — RFC 7396 JSON Merge Patch of the submission onto the stored resource: elements absent from the submission are retained, present elements overwrite, arrays are replaced wholesale, and a `null` member removes the stored element. One FHIR-specific guard: the stored `id` is always preserved, so a submission cannot re-key what it merges into.

## Plumbing

- `set_manifest_fetch_params` now takes a `ManifestFetchParams` struct instead of 8 positional arguments — this is what retired its `#[allow(clippy::too_many_arguments)]` — and carries the directives.
- New `import_directives` / `submission_metadata` columns on `bulk_manifests` for SQLite and Postgres, read back through `ManifestWorkerView`.
- The worker resolves `ImportMode::from_directives(...)` and passes it via `BulkProcessingOptions`; SQLite, Postgres, and S3 ingestion honor it through one shared `BulkProcessingOptions::content_for_update`.

## Kick-off validation

Stricter where the IG is explicit, looser where it is not:

- `parameterUrl` and `parameterValue` are enforced as 1..1 with an absolute URL. A malformed directive used to be dropped silently.
- A directive we *do* recognize carrying a value we cannot honor (e.g. `import-mode=upsert`) is always `400`, regardless of handling posture — silently ingesting under the wrong mode would corrupt data.
- Only *unrecognized* `import` URLs are rejected under `Prefer: handling=strict`; lenient handling ignores them with a warning. Previously strict rejected all directives, recognized or not.
- Directives on a status-only kick-off (no `manifestUrl`) have no manifest to attach to and are ignored with a warning.

## Design decision worth a look

`metadata` has no defined Data Consumer behavior in the spec, and the status-manifest schema defines no slot for it. Rather than emit a non-conformant response field, HFS retains every `metadata` part verbatim on the manifest and logs it at ingestion — so `metadata` is never rejected under strict handling. If it should instead round-trip to the provider, that's a follow-up and would need a spec-blessed slot.

## Verification

All run locally, all passing:

- 25 core/worker unit tests — merge semantics (retention, array replacement, null deletion, nested objects, id preservation), mode resolution, and merge-vs-replace driven through the real worker on SQLite.
- 14 handler unit tests covering each validation branch.
- 8 `$bulk-submit` REST integration tests, including merge and replace end to end through the Axum router.
- A new Postgres testcontainer test that round-trips the directives through real SQL (`set_manifest_fetch_params` → claim → `get_manifest_for_worker`) and proves merge ingestion — the plumbing is shared across backends but the SQL is not.
- `cargo clippy --all-targets` with the CI flag set, `cargo fmt --check`, and workspace `cargo check --all-targets` with postgres+elasticsearch: clean.

https://claude.ai/code/session_01Cn5gbvkAZriiKDxUEYEvAL
