### PR TITLE
feat(ui): OR value stacks on builder condition rows

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -3699,3 +3699,45 @@ html[data-nav="collapsed"] body.has-nav-panel {
   grid-template-columns: 76px 232px 1fr;
 }
 html[data-nav="collapsed"] .menu__panel { left: 0; }
+
+/* OR value stacks (#414): one input per comma alternative. */
+.builder-row__values {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+
+.builder-row__orvalue {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.builder-row__orvalue .builder-row__value {
+  flex: 1;
+}
+
+.builder-row__orvalue:only-child .builder-row__remove--or {
+  visibility: hidden;
+}
+
+.builder-row__or {
+  flex-shrink: 0;
+  align-self: flex-start;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--surface-border);
+  border-radius: 9px;
+  background: none;
+  color: var(--accent);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.builder-row__or:hover {
+  background: var(--accent-soft);
+}
+

--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -340,6 +340,46 @@
   }
 
   /* Modifier select + value input + remove button, shared by every row kind. */
+  /* One value input inside a row's OR stack (#414). The per-value remove
+   * only renders when the stack has siblings. */
+  function orValueInput(host, value) {
+    var wrap = document.createElement("span");
+    wrap.className = "builder-row__orvalue";
+    var input = document.createElement("input");
+    input.className = "builder-row__value";
+    input.value = value;
+    input.placeholder = sections.dataset.msgValue;
+    input.spellcheck = false;
+    wrap.appendChild(input);
+    var rm = document.createElement("button");
+    rm.type = "button";
+    rm.className = "builder-row__remove builder-row__remove--or";
+    rm.dataset.removeOr = "true";
+    rm.setAttribute("aria-label", sections.dataset.msgRemove);
+    rm.textContent = "×";
+    wrap.appendChild(rm);
+    host.appendChild(wrap);
+    return input;
+  }
+
+  /* FHIR's OR is a comma list on one parameter (`name=Smith,Jones`): the
+   * value column stacks one input per alternative, plus the `+ or` button. */
+  function appendValues(row, rawValue) {
+    var host = document.createElement("span");
+    host.className = "builder-row__values";
+    rawValue.split(",").forEach(function (v) {
+      orValueInput(host, v);
+    });
+    row.appendChild(host);
+
+    var addOr = document.createElement("button");
+    addOr.type = "button";
+    addOr.className = "builder-row__or";
+    addOr.dataset.addOr = "true";
+    addOr.textContent = sections.dataset.msgOr;
+    row.appendChild(addOr);
+  }
+
   function appendTail(row, part) {
     var value = part.value;
     var selectedMod = part.modifier;
@@ -359,12 +399,7 @@
     });
     row.appendChild(modifier);
 
-    var valueInput = document.createElement("input");
-    valueInput.className = "builder-row__value";
-    valueInput.value = value;
-    valueInput.placeholder = sections.dataset.msgValue;
-    valueInput.spellcheck = false;
-    row.appendChild(valueInput);
+    appendValues(row, value);
 
     var remove = document.createElement("button");
     remove.type = "button";
@@ -688,12 +723,16 @@
       row.appendChild(modifier);
     }
 
-    var valueInput = document.createElement("input");
-    valueInput.className = "builder-row__value";
-    valueInput.value = value;
-    valueInput.placeholder = sections.dataset.msgValue;
-    valueInput.spellcheck = false;
-    row.appendChild(valueInput);
+    if (kind === "condition") {
+      appendValues(row, value);
+    } else {
+      var valueInput = document.createElement("input");
+      valueInput.className = "builder-row__value";
+      valueInput.value = value;
+      valueInput.placeholder = sections.dataset.msgValue;
+      valueInput.spellcheck = false;
+      row.appendChild(valueInput);
+    }
 
     var remove = document.createElement("button");
     remove.type = "button";
@@ -788,9 +827,16 @@
       if (!key) return;
       var modifierEl = row.querySelector(".builder-row__modifier");
       var mod = modifierEl ? modifierEl.value : "";
-      var value = row.querySelector(".builder-row__value").value.trim();
-      if (PREFIXES.indexOf(mod) >= 0) value = mod + value;
-      else if (mod) key += ":" + mod;
+      var isPrefix = PREFIXES.indexOf(mod) >= 0;
+      var values = [];
+      row.querySelectorAll(".builder-row__value").forEach(function (vi) {
+        var v = vi.value.trim();
+        if (!v) return;
+        if (isPrefix && !PREFIX_RE.test(v)) v = mod + v;
+        values.push(v);
+      });
+      var value = values.join(",");
+      if (!isPrefix && mod) key += ":" + mod;
       parts.push(key + "=" + value);
     });
     urlInput.value =
@@ -811,7 +857,22 @@
     sections.addEventListener("click", function (event) {
       var remove = event.target.closest("[data-remove-row]");
       var drillFrom = event.target.closest("[data-chain-from]");
+      var addOr = event.target.closest("[data-add-or]");
+      var removeOr = event.target.closest("[data-remove-or]");
       var add = event.target.closest("[data-add]");
+      if (addOr) {
+        var orHost = addOr.closest(".builder-row").querySelector(".builder-row__values");
+        orValueInput(orHost, "").focus();
+        return;
+      }
+      if (removeOr) {
+        var orWrap = removeOr.closest(".builder-row__orvalue");
+        if (orWrap.parentElement.children.length > 1) {
+          orWrap.remove();
+          updateUrl();
+        }
+        return;
+      }
       if (remove) {
         remove.closest(".builder-row").remove();
         updateUrl();

--- a/crates/ui/e2e/tests/queries.spec.ts
+++ b/crates/ui/e2e/tests/queries.spec.ts
@@ -183,6 +183,45 @@ test.describe("query builder", () => {
     );
   });
 
+  /* ---- OR values (#414) ------------------------------------------------ */
+
+  test("comma OR values hydrate as stacked inputs and round-trip", async ({ queries }) => {
+    await queries.builder.setUrl("Patient?name=Smith,Jones");
+    const row = queries.builder.conditionRows.first();
+    const values = row.locator(".builder-row__value");
+    await expect(values).toHaveCount(2);
+    await expect(values.nth(0)).toHaveValue("Smith");
+    await expect(values.nth(1)).toHaveValue("Jones");
+
+    await values.nth(1).fill("Garcia");
+    await expect(queries.builder.url).toHaveValue("GET /Patient?name=Smith,Garcia");
+  });
+
+  test("the + or button stacks a value; the per-value × removes it", async ({
+    queries,
+  }) => {
+    await queries.builder.setUrl("Patient?name=Smith");
+    const row = queries.builder.conditionRows.first();
+    await row.locator("[data-add-or]").click();
+    await row.locator(".builder-row__value").nth(1).fill("Jones");
+    await expect(queries.builder.url).toHaveValue("GET /Patient?name=Smith,Jones");
+
+    await row.locator("[data-remove-or]").first().click();
+    await expect(row.locator(".builder-row__value")).toHaveCount(1);
+    await expect(queries.builder.url).toHaveValue("GET /Patient?name=Jones");
+  });
+
+  test("comparator OR values keep a prefix per alternative", async ({ queries }) => {
+    await queries.builder.setUrl("Patient?birthdate=ge1980-01-01,le1990-12-31");
+    const row = queries.builder.conditionRows.first();
+    await expect(row.locator(".builder-row__value")).toHaveCount(2);
+    // The second alternative keeps its own comparator on round-trip.
+    await row.locator(".builder-row__value").nth(0).fill("ge1985-01-01");
+    await expect(queries.builder.url).toHaveValue(
+      "GET /Patient?birthdate=ge1985-01-01,le1990-12-31",
+    );
+  });
+
   test("picking a type swaps in that type's parameter datalist", async ({ queries }) => {
     await queries.railItem("Patient").click();
     // /ui/queries/params fills #param-options for the picked type.

--- a/crates/ui/templates/partials/search-builder.html
+++ b/crates/ui/templates/partials/search-builder.html
@@ -56,7 +56,8 @@
        data-msg-has-type="{{ i18n.t("queries-has-type-placeholder") }}"
        data-msg-has-via="{{ i18n.t("queries-has-via") }}"
        data-msg-has-where="{{ i18n.t("queries-has-where") }}"
-       data-msg-match-is="{{ i18n.t("queries-match-is") }}">
+       data-msg-match-is="{{ i18n.t("queries-match-is") }}"
+       data-msg-or="{{ i18n.t("queries-or") }}">
     <div class="builder-section">
       <h3 class="builder-section__title">{{ i18n.t("queries-conditions") }}</h3>
       <div class="builder-rows" id="builder-conditions"></div>

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -307,6 +307,7 @@ queries-includes = Includes
 queries-result-controls = Ergebnis-Steuerung
 queries-remove = Entfernen
 queries-match-is = ist
+queries-or = + oder
 queries-chain-into = Nach einer Eigenschaft der referenzierten Ressource filtern
 queries-chain-any-target = beliebig
 queries-has-pill = hat eine verknüpfte

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -311,6 +311,7 @@ queries-includes = Includes
 queries-result-controls = Result controls
 queries-remove = Remove
 queries-match-is = is
+queries-or = + or
 queries-chain-into = Filter by a property of the referenced resource
 queries-chain-any-target = any
 queries-has-pill = has a related

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -307,6 +307,7 @@ queries-includes = Includes
 queries-result-controls = Controles de resultado
 queries-remove = Quitar
 queries-match-is = es
+queries-or = + o
 queries-chain-into = Filtrar por una propiedad del recurso referenciado
 queries-chain-any-target = cualquiera
 queries-has-pill = tiene un recurso relacionado


### PR DESCRIPTION
## Summary

Closes #414. Per the design's OR frame: the value column stacks one input per FHIR comma alternative with a per-value remove, and a **+ or** button appends another. Serializes to `name=Smith,Jones` and hydrates back from pasted URLs; comparator alternatives keep a prefix per value (`birthdate=ge1980-01-01,le1990-12-31`). Applies to plain, chain, and `_has` rows; includes and result controls stay single-valued.

**Stacked on #407** — merge that first; this diff then shrinks to the OR work.

![OR values](https://raw.githubusercontent.com/HeliosSoftware/hfs/assets/255-nl-search-screenshots/builder-screens/414-or-values.png)

## Tests

Three new builder e2e cases: comma hydration + round-trip, add/remove alternatives, and per-alternative comparator prefixes. Full queries suite green (15 at this layer).