### PR TITLE
perf(postgres): fix sparse search regressions

### DIFF
--- a/crates/persistence/src/backends/postgres/schema.rs
+++ b/crates/persistence/src/backends/postgres/schema.rs
@@ -3,7 +3,7 @@
 use crate::error::{BackendError, StorageResult};
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 15;
+pub const SCHEMA_VERSION: i32 = 16;
 
 /// Advisory-lock key serializing schema migration across HFS instances sharing
 /// one database. Arbitrary but must stay stable across releases.
@@ -313,6 +313,7 @@ async fn migrate_schema(
             12 => migrate_v12_to_v13(client).await?,
             13 => migrate_v13_to_v14(client).await?,
             14 => migrate_v14_to_v15(client).await?,
+            15 => migrate_v15_to_v16(client).await?,
             _ => {
                 return Err(pg_error(format!("Unknown schema version: {}", version)));
             }
@@ -829,36 +830,54 @@ async fn migrate_v12_to_v13(client: &deadpool_postgres::Client) -> StorageResult
     Ok(())
 }
 
-/// v14 -> v15: search performance indexes (issue #224).
+/// v15 -> v16: covering indexes on token and date + wider MCV + date multivariate
+/// stat (issue #281).
 ///
-/// Purely additive — nothing is dropped and no query semantics change. Every index
-/// here was validated against a 1.45M-row replica of the benchmark dataset: each
-/// one is measurably used by the plans the query builder now emits, and the set as
-/// a whole took a 30-client mixed search workload from 45 tps / 659 ms to
-/// 112 tps / 267 ms.
-///
-/// Deliberately NOT added: an index on
-/// `(tenant_id, resource_type, param_name, resource_id, composite_group)`. It looks
-/// like the obvious fix for the composite timeout, and it *is* required by the
-/// correlated-`EXISTS` formulation of that query (which runs in ~1 ms) — but with
-/// the SQL we actually emit, Postgres never scans it (0 scans over a clean 30 s
-/// run; it BitmapOrs the token and quantity indexes instead). It indexes every row
-/// of `search_index`, so it would be pure write amplification on the import path.
-/// See `build_composite_condition` for why the `EXISTS` form was rejected.
-///
-/// Also deliberately NOT dropped: `idx_search_resource`. It reads as redundant (a
-/// column prefix of `idx_search_composite`), but it is the per-resource probe in
-/// the new plans and takes ~12M scans in a 30 s run — the hottest index in the
-/// schema. It is also the write path's `DELETE FROM search_index WHERE
-/// tenant/type/resource_id` and the FK cascade.
-///
-/// Index builds take a `SHARE` lock, blocking writes for their duration — measured
-/// at ~6 s for this whole migration on 1.45M rows. Migrations run at startup before
-/// the instance serves traffic, and `initialize_schema` holds an advisory lock, so
-/// instances serialize rather than race. Operators upgrading a large database can
-/// pre-build these `CONCURRENTLY` by hand; the `IF NOT EXISTS` clauses then make
-/// this migration a no-op.
-///
+/// `idx_search_token_code` and `idx_search_date` are rebuilt with `INCLUDE (resource_id)`
+/// so the subquery probes are index-only. `value_token_code` statistics are widened to
+/// 4,000 and a matching multivariate stat is added for `value_date`, giving the planner
+/// the same cross-column correlation data for date that token received in v14->v15.
+async fn migrate_v15_to_v16(client: &deadpool_postgres::Client) -> StorageResult<()> {
+    let index_stmts = [
+        "DROP INDEX IF EXISTS idx_search_token_code",
+        "CREATE INDEX IF NOT EXISTS idx_search_token_code
+         ON search_index (tenant_id, resource_type, param_name, value_token_code, value_token_system)
+         INCLUDE (resource_id)
+         WHERE value_token_code IS NOT NULL",
+        "DROP INDEX IF EXISTS idx_search_date",
+        "CREATE INDEX IF NOT EXISTS idx_search_date
+         ON search_index (tenant_id, resource_type, param_name, value_date)
+         INCLUDE (resource_id)
+         WHERE value_date IS NOT NULL",
+    ];
+
+    for sql in index_stmts {
+        client
+            .execute(sql, &[])
+            .await
+            .map_err(|e| pg_error(format!("Migration v15->v16 failed: {}", e)))?;
+    }
+
+    let stats_stmts = [
+        "ALTER TABLE search_index ALTER COLUMN value_token_code SET STATISTICS 4000",
+        "CREATE STATISTICS IF NOT EXISTS stx_search_type_param_date (mcv, dependencies)
+         ON resource_type, param_name, value_date FROM search_index",
+        "ANALYZE search_index",
+    ];
+
+    for sql in stats_stmts {
+        if let Err(e) = client.execute(sql, &[]).await {
+            tracing::warn!(
+                "Migration v15->v16: optional statistics step failed (plans may be \
+                 suboptimal, search remains correct): {}",
+                e
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// `CREATE INDEX CONCURRENTLY` is deliberately NOT used here: if the process dies
 /// mid-build it leaves an `INVALID` index behind, and a later
 /// `CREATE INDEX CONCURRENTLY IF NOT EXISTS` would see the name and skip it forever

--- a/crates/persistence/src/backends/postgres/schema.rs
+++ b/crates/persistence/src/backends/postgres/schema.rs
@@ -878,6 +878,36 @@ async fn migrate_v15_to_v16(client: &deadpool_postgres::Client) -> StorageResult
     Ok(())
 }
 
+/// v14 -> v15: search performance indexes (issue #224).
+///
+/// Purely additive — nothing is dropped and no query semantics change. Every index
+/// here was validated against a 1.45M-row replica of the benchmark dataset: each
+/// one is measurably used by the plans the query builder now emits, and the set as
+/// a whole took a 30-client mixed search workload from 45 tps / 659 ms to
+/// 112 tps / 267 ms.
+///
+/// Deliberately NOT added: an index on
+/// `(tenant_id, resource_type, param_name, resource_id, composite_group)`. It looks
+/// like the obvious fix for the composite timeout, and it *is* required by the
+/// correlated-`EXISTS` formulation of that query (which runs in ~1 ms) — but with
+/// the SQL we actually emit, Postgres never scans it (0 scans over a clean 30 s
+/// run; it BitmapOrs the token and quantity indexes instead). It indexes every row
+/// of `search_index`, so it would be pure write amplification on the import path.
+/// See `build_composite_condition` for why the `EXISTS` form was rejected.
+///
+/// Also deliberately NOT dropped: `idx_search_resource`. It reads as redundant (a
+/// column prefix of `idx_search_composite`), but it is the per-resource probe in
+/// the new plans and takes ~12M scans in a 30 s run — the hottest index in the
+/// schema. It is also the write path's `DELETE FROM search_index WHERE
+/// tenant/type/resource_id` and the FK cascade.
+///
+/// Index builds take a `SHARE` lock, blocking writes for their duration — measured
+/// at ~6 s for this whole migration on 1.45M rows. Migrations run at startup before
+/// the instance serves traffic, and `initialize_schema` holds an advisory lock, so
+/// instances serialize rather than race. Operators upgrading a large database can
+/// pre-build these `CONCURRENTLY` by hand; the `IF NOT EXISTS` clauses then make
+/// this migration a no-op.
+///
 /// `CREATE INDEX CONCURRENTLY` is deliberately NOT used here: if the process dies
 /// mid-build it leaves an `INVALID` index behind, and a later
 /// `CREATE INDEX CONCURRENTLY IF NOT EXISTS` would see the name and skip it forever


### PR DESCRIPTION
Adds migrate_v15_to_v16 with covering indexes on idx_search_token_code and idx_search_date, a wider token MCV (4,000), and a date multivariate stat to fix the Observation?code and Encounter?date p95 regressions 