### PR TITLE
fix(rest,persistence): honor If-Match on DELETE (#312)

### DIFF
--- a/.agents/skills/run-hfs-server/SKILL.md
+++ b/.agents/skills/run-hfs-server/SKILL.md
@@ -126,7 +126,7 @@ curl http://localhost:8080/clinic-a/Patient
 | `HFS_ENABLE_REQUEST_ID` | `true` | Enable request ID tracking |
 | `HFS_RETURN_GONE` | `true` | Return 410 Gone for deleted resources instead of 404 |
 | `HFS_ENABLE_VERSIONING` | `true` | Enable ETag versioning |
-| `HFS_REQUIRE_IF_MATCH` | `false` | Require If-Match header for updates |
+| `HFS_REQUIRE_IF_MATCH` | `false` | Require If-Match header for updates and deletes |
 
 ## API Endpoints
 

--- a/.claude/skills/run-hfs-server/SKILL.md
+++ b/.claude/skills/run-hfs-server/SKILL.md
@@ -181,7 +181,7 @@ curl http://localhost:8080/clinic-a/Patient
 | `HFS_ENABLE_REQUEST_ID` | `true` | Enable request ID tracking |
 | `HFS_RETURN_GONE` | `true` | Return 410 Gone for deleted resources instead of 404 |
 | `HFS_ENABLE_VERSIONING` | `true` | Enable ETag versioning |
-| `HFS_REQUIRE_IF_MATCH` | `false` | Require If-Match header for updates |
+| `HFS_REQUIRE_IF_MATCH` | `false` | Require If-Match header for updates and deletes |
 
 ## Resource Validation
 

--- a/book/src/appendix-c-glossary.md
+++ b/book/src/appendix-c-glossary.md
@@ -15,7 +15,7 @@ An HL7 standard for invoking clinical decision support logic at specific points 
 An HFS pattern that combines two storage backends behind a single `ResourceStorage` interface: one for CRUD operations and one for search queries (e.g., SQLite + Elasticsearch). Configured via `HFS_STORAGE_BACKEND`.
 
 **ETag**
-An HTTP header used for optimistic concurrency control. HFS includes an ETag with each resource response. Clients submit the ETag in an `If-Match` header on updates to prevent lost updates.
+An HTTP header used for optimistic concurrency control. HFS includes an ETag with each resource response. Clients submit the ETag in an `If-Match` header on updates, patches and deletes to prevent lost updates and lost deletes.
 
 **FHIR**
 Fast Healthcare Interoperability Resources. An HL7 standard for exchanging electronic health records. Defines typed resources (Patient, Observation, etc.) with a REST API and JSON/XML serialization.

--- a/book/src/configuration/environment-variables.md
+++ b/book/src/configuration/environment-variables.md
@@ -67,7 +67,7 @@ are compressed when the client sends `Accept-Encoding`.
 | `HFS_ENABLE_REQUEST_ID` | `true` | Enable request ID tracking |
 | `HFS_RETURN_GONE` | `true` | Return 410 Gone for deleted resources (vs 404) |
 | `HFS_ENABLE_VERSIONING` | `true` | Enable ETag versioning |
-| `HFS_REQUIRE_IF_MATCH` | `false` | Require `If-Match` header for updates |
+| `HFS_REQUIRE_IF_MATCH` | `false` | Require `If-Match` header for updates and deletes |
 
 ## Natural-Language Search
 

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -435,15 +435,47 @@ impl ResourceStorage for PostgresBackend {
         let new_version_str = new_version.to_string();
         let is_deleted = true;
 
-        // Soft delete the resource
-        client
+        // Soft delete the resource, guarded by the version we just read.
+        //
+        // The `version_id`/`is_deleted` predicates make this a compare-and-swap
+        // rather than a blind overwrite. Without them a concurrent writer that
+        // lands between the SELECT above and this UPDATE is silently clobbered,
+        // and worse: `new_version` was computed from the stale read, so the
+        // history INSERT below then collides with the row that writer already
+        // wrote and trips `PRIMARY KEY (tenant_id, resource_type, id,
+        // version_id)` (schema.rs). Because neither statement runs inside a
+        // transaction, the UPDATE is already committed at that point — the
+        // caller gets a 500 and the current row now points at a version whose
+        // history entry holds someone else's content.
+        //
+        // MongoDB and S3 already guarded their equivalent writes (a
+        // `version_id` term in the update filter, and a conditional PUT
+        // respectively); this brings PostgreSQL to parity. Losing the race is
+        // reported as `NotFound`, which is what a caller racing a concurrent
+        // delete would have seen anyway.
+        let updated = client
             .execute(
                 "UPDATE resources SET is_deleted = TRUE, deleted_at = $1, version_id = $2, last_updated = $1
-                 WHERE tenant_id = $3 AND resource_type = $4 AND id = $5",
-                &[&now, &new_version_str, &tenant_id, &resource_type, &id],
+                 WHERE tenant_id = $3 AND resource_type = $4 AND id = $5
+                   AND version_id = $6 AND is_deleted = FALSE",
+                &[
+                    &now,
+                    &new_version_str,
+                    &tenant_id,
+                    &resource_type,
+                    &id,
+                    &current_version,
+                ],
             )
             .await
             .map_err(|e| internal_error(format!("Failed to delete resource: {}", e)))?;
+
+        if updated == 0 {
+            return Err(StorageError::Resource(ResourceError::NotFound {
+                resource_type: resource_type.to_string(),
+                id: id.to_string(),
+            }));
+        }
 
         // Insert deletion record into history (preserve fhir_version)
         client

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -443,13 +443,46 @@ impl ResourceStorage for SqliteBackend {
         let new_version: u64 = current_version.parse().unwrap_or(0) + 1;
         let new_version_str = new_version.to_string();
 
-        // Soft delete the resource
-        conn.execute(
-            "UPDATE resources SET is_deleted = 1, deleted_at = ?1, version_id = ?2, last_updated = ?1
-             WHERE tenant_id = ?3 AND resource_type = ?4 AND id = ?5",
-            params![deleted_at, new_version_str, tenant_id, resource_type, id],
-        )
-        .map_err(|e| internal_error(format!("Failed to delete resource: {}", e)))?;
+        // Soft delete the resource, guarded by the version we just read.
+        //
+        // The `version_id`/`is_deleted` predicates make this a compare-and-swap
+        // rather than a blind overwrite. Without them a concurrent writer that
+        // lands between the SELECT above and this UPDATE is silently clobbered,
+        // and worse: `new_version` was computed from the stale read, so the
+        // history INSERT below then collides with the row that writer already
+        // wrote and trips `PRIMARY KEY (tenant_id, resource_type, id,
+        // version_id)`. Because neither statement runs in a transaction, the
+        // UPDATE is already committed at that point — the caller gets a 500 and
+        // the current row now points at a version whose history entry holds
+        // someone else's content.
+        //
+        // MongoDB and S3 already guarded their equivalent writes (a
+        // `version_id` term in the update filter, and a conditional PUT
+        // respectively); this brings SQLite to parity. Losing the race is
+        // reported as `NotFound`, which is what a caller racing a concurrent
+        // delete would have seen anyway.
+        let updated = conn
+            .execute(
+                "UPDATE resources SET is_deleted = 1, deleted_at = ?1, version_id = ?2, last_updated = ?1
+                 WHERE tenant_id = ?3 AND resource_type = ?4 AND id = ?5
+                   AND version_id = ?6 AND is_deleted = 0",
+                params![
+                    deleted_at,
+                    new_version_str,
+                    tenant_id,
+                    resource_type,
+                    id,
+                    current_version
+                ],
+            )
+            .map_err(|e| internal_error(format!("Failed to delete resource: {}", e)))?;
+
+        if updated == 0 {
+            return Err(StorageError::Resource(ResourceError::NotFound {
+                resource_type: resource_type.to_string(),
+                id: id.to_string(),
+            }));
+        }
 
         // Insert deletion record into history (preserve fhir_version)
         conn.execute(

--- a/crates/rest/README.md
+++ b/crates/rest/README.md
@@ -467,7 +467,9 @@ curl -X POST http://localhost:8080/ \
 ### Conditional Operations in Bundles
 
 Bundle entries support conditional headers:
-- `ifMatch` - ETag for optimistic locking on updates
+- `ifMatch` - ETag for optimistic locking on `PUT` **and `DELETE`** entries, in
+  both `batch` and `transaction` bundles. Parsed as the comma-separated list
+  RFC 9110 §13.1.1 defines: satisfied when any supplied entity-tag matches.
 - `ifNoneMatch` - Prevent overwrites (`*` for conditional create)
 - `ifNoneExist` - Search query for conditional create
 
@@ -487,7 +489,7 @@ The server supports standard FHIR HTTP headers:
 |--------|---------|
 | `Accept` | Content negotiation |
 | `Content-Type` | Request body format |
-| `ETag` / `If-Match` | Optimistic locking |
+| `ETag` / `If-Match` | Optimistic locking on `PUT`, `PATCH` and `DELETE` |
 | `If-None-Match` | Conditional read |
 | `If-None-Exist` | Conditional create |
 | `If-Modified-Since` | Conditional read by date |

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -920,7 +920,11 @@ pub struct ServerConfig {
     #[arg(long, env = "HFS_ENABLE_VERSIONING", default_value = "true")]
     pub enable_versioning: bool,
 
-    /// Require If-Match header for updates.
+    /// Require If-Match header for updates and deletes.
+    ///
+    /// Honored by `PUT` and by `DELETE` (issue #312 — before that, deletes were
+    /// exempt, so a deployment that had opted into mandatory preconditions still
+    /// got unconditional deletes). `PATCH` does not yet consult it.
     #[arg(long, env = "HFS_REQUIRE_IF_MATCH", default_value = "false")]
     pub require_if_match: bool,
 

--- a/crates/rest/src/handlers/delete.rs
+++ b/crates/rest/src/handlers/delete.rs
@@ -9,10 +9,12 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use helios_persistence::core::{ConditionalStorage, ResourceStorage};
+use helios_persistence::error::{ResourceError, StorageError};
 use tracing::debug;
 
 use crate::error::{RestError, RestResult};
 use crate::extractors::{FhirVersionExtractor, TenantExtractor};
+use crate::middleware::ConditionalHeaders;
 use crate::state::AppState;
 
 /// Handler for the delete interaction.
@@ -23,17 +25,58 @@ use crate::state::AppState;
 ///
 /// `DELETE [base]/[type]/[id]`
 ///
+/// # Headers
+///
+/// - `If-Match` — optional version precondition (RFC 9110 §13.1.1). The delete
+///   is performed only if the supplied entity-tag matches the resource's current
+///   version. See [`delete_handler`]'s precondition section below.
+///
 /// # Response
 ///
 /// - `204 No Content` - Resource deleted successfully
 /// - `200 OK` - Resource deleted, returning OperationOutcome
-/// - `404 Not Found` - Resource does not exist
+/// - `404 Not Found` - Resource does not exist, or is already deleted
+/// - `412 Precondition Failed` - `If-Match` was supplied and is not satisfied
+/// - `405 Method Not Allowed` - `AuditEvent` resources are immutable
+///
+/// # The `If-Match` precondition
+///
+/// `If-Match` is a comma-separated list and is satisfied when ANY listed tag
+/// matches the current version (RFC 9110 §13.1.1). Before issue #312 this
+/// handler did not read the header at all: a client asking to "delete this only
+/// if it is still the version I saw" had its precondition silently discarded and
+/// whatever was current was destroyed. That is the same defect class as issue
+/// #270, on the one method where the consequence is not recoverable by simply
+/// re-sending the request.
+///
+/// A malformed value is a *failed* precondition, not an absent one — degrading
+/// it to "no precondition" is what turns a guarded delete into an unconditional
+/// one. Parsing therefore fails closed; see
+/// [`helios_persistence::core::preconditions`].
+///
+/// `*` asserts that a current representation exists. A soft-deleted resource has
+/// none, so `*` does not match a tombstone.
+///
+/// Note that a conditional delete is not idempotent under retry: if the delete
+/// succeeds but the response is lost, the retry sees a bumped version and
+/// answers `412`. That is correct RFC 9110 behavior, not a regression.
+///
+/// # Deliberately NOT covered
+///
+/// [`conditional_delete_handler`] (`DELETE [base]/[type]?[search]`) does not
+/// honor `If-Match`. That is a scope decision, not an oversight:
+/// [`ConditionalStorage::conditional_delete`] searches and deletes inside the
+/// backend and never surfaces a version to compare against, so honoring the
+/// header there means threading a precondition through all four backends. FHIR
+/// R6 does define it (`delete-conditional-single` lists `O: If-Match`); R4 and
+/// R5 are silent. Tracked as a follow-up, not silently forgotten.
 ///
 /// # Example
 ///
 /// ```http
 /// DELETE /Patient/123 HTTP/1.1
 /// Host: fhir.example.com
+/// If-Match: W/"3"
 /// ```
 pub async fn delete_handler<S>(
     State(state): State<AppState<S>>,
@@ -41,6 +84,7 @@ pub async fn delete_handler<S>(
     tenant: TenantExtractor,
     #[cfg_attr(not(feature = "subscriptions"), allow(unused_variables))]
     version: FhirVersionExtractor,
+    conditional: ConditionalHeaders,
 ) -> RestResult<Response>
 where
     S: ResourceStorage + Send + Sync,
@@ -57,14 +101,74 @@ where
         resource_type = %resource_type,
         id = %id,
         tenant = %tenant.tenant_id(),
+        if_match = ?conditional.if_match_tags(),
         "Processing delete request"
     );
 
-    #[cfg(feature = "subscriptions")]
-    let existing_resource = state
+    // Parse the precondition before touching storage. A malformed value is
+    // rejected without costing a round trip, and cannot be used as a probe.
+    let if_match = conditional
+        .if_match_tags()
+        .map_err(|e| RestError::PreconditionFailed {
+            message: format!("Malformed If-Match header: {e}"),
+        })?;
+
+    // `HFS_REQUIRE_IF_MATCH` is honored here as it is for updates. Before #312
+    // it was consulted only by the update handler, so a deployment that had
+    // explicitly opted into mandatory preconditions still got unconditional
+    // deletes — the control silently did not apply to the destructive verb.
+    //
+    // 412 (not 428) is deliberate: it is what `update_handler` returns today,
+    // and one status for one condition across PUT/PATCH/DELETE beats being
+    // individually more correct here. Moving all three to 428 is a follow-up.
+    if state.require_if_match() && !conditional.has_if_match() {
+        return Err(RestError::PreconditionFailed {
+            message: "If-Match header is required for deletes".to_string(),
+        });
+    }
+
+    // Read the current state so the precondition has something to evaluate
+    // against. This read used to be `#[cfg(feature = "subscriptions")]`-only.
+    //
+    // `Gone` maps to `None` — a soft-deleted resource has no current
+    // representation (RFC 9110 §13.1.1), so every supplied precondition,
+    // including `*`, must fail against a tombstone. Mapping it here rather than
+    // propagating with `?` is load-bearing twice over: it produces that 412, and
+    // it keeps a *precondition-less* delete of an already-deleted resource
+    // falling through to `delete()`'s own `NotFound` -> 404, which is what stock
+    // builds have always returned. Propagating `Gone` instead would have made
+    // 410 the answer in every build, silently, as a side effect of this fix.
+    let existing_resource = match state
         .storage()
         .read(tenant.context(), &resource_type, &id)
-        .await?;
+        .await
+    {
+        Ok(existing) => existing,
+        Err(StorageError::Resource(ResourceError::Gone { .. })) => None,
+        Err(e) => return Err(e.into()),
+    };
+
+    let current_version = existing_resource.as_ref().map(|stored| stored.version_id());
+
+    if !if_match.if_match_satisfied(current_version) {
+        // The current version is deliberately absent from the client-facing
+        // message. DELETE is authorized by `FhirOperation::Delete` alone, so a
+        // `system/Patient.d` principal holding no read scope reaches this path;
+        // echoing the versionId back would tell it how many times the record has
+        // been amended. Operators still get it from the debug log below.
+        debug!(
+            resource_type = %resource_type,
+            id = %id,
+            current_version = ?current_version,
+            "If-Match precondition failed; refusing delete"
+        );
+        return Err(RestError::PreconditionFailed {
+            message: format!(
+                "If-Match precondition failed: no supplied entity-tag matches \
+                 the current state of {resource_type}/{id}"
+            ),
+        });
+    }
 
     #[cfg(feature = "subscriptions")]
     let fhir_version = existing_resource
@@ -72,7 +176,8 @@ where
         .map(|stored| stored.fhir_version())
         .unwrap_or_else(|| version.storage_version_or(state.config().default_fhir_version));
 
-    // Perform the delete
+    // Perform the delete. Everything above this line is a refusal path; nothing
+    // below it may run for a request that failed its precondition.
     state
         .storage()
         .delete(tenant.context(), &resource_type, &id)
@@ -83,6 +188,15 @@ where
         id = %id,
         "Resource deleted"
     );
+
+    // Compartment reference for the audit record, taken from the pre-delete
+    // content while it is still in hand. `update_handler` and `patch_handler`
+    // both attach this; delete never did, so delete AuditEvents carried no
+    // patient reference and fell short of the IHE BALP profile. The read this
+    // fix makes unconditional is what puts the resource within reach here.
+    let patient_reference = existing_resource
+        .as_ref()
+        .and_then(|stored| super::extract_patient_from_resource(&resource_type, stored.content()));
 
     // Emit subscription event
     #[cfg(feature = "subscriptions")]
@@ -98,7 +212,15 @@ where
     }
 
     // Return 204 No Content (or 200 with OperationOutcome)
-    Ok(StatusCode::NO_CONTENT.into_response())
+    let mut response = StatusCode::NO_CONTENT.into_response();
+    response
+        .extensions_mut()
+        .insert(helios_audit::AuditResponseContext {
+            resource_type: Some(resource_type.clone()),
+            resource_id: Some(id.clone()),
+            patient_reference,
+        });
+    Ok(response)
 }
 
 /// Conditional delete handler.

--- a/crates/rest/tests/rest_conformance.rs
+++ b/crates/rest/tests/rest_conformance.rs
@@ -30,6 +30,18 @@ const IF_NONE_EXIST: HeaderName = HeaderName::from_static("if-none-exist");
 
 /// Creates a test server.
 async fn create_test_server() -> (TestServer, Arc<SqliteBackend>) {
+    create_test_server_with(|_| {}).await
+}
+
+/// Creates a test server, letting the caller adjust the [`ServerConfig`] first.
+///
+/// Used by the tests that need a non-default flag (e.g. `require_if_match`).
+/// The flag is set on the struct rather than through its environment variable:
+/// `HFS_REQUIRE_IF_MATCH` is read by clap at config-parse time, and
+/// `std::env::set_var` would race every other test in this binary.
+async fn create_test_server_with(
+    adjust: impl FnOnce(&mut ServerConfig),
+) -> (TestServer, Arc<SqliteBackend>) {
     // Configure with data directory to load spec SearchParameters
     // CARGO_MANIFEST_DIR for this test is crates/rest
     let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -47,7 +59,7 @@ async fn create_test_server() -> (TestServer, Arc<SqliteBackend>) {
     backend.init_schema().expect("Failed to init schema");
     let backend = Arc::new(backend);
 
-    let config = ServerConfig {
+    let mut config = ServerConfig {
         multitenancy: MultitenancyConfig {
             routing_mode: TenantRoutingMode::HeaderOnly,
             ..Default::default()
@@ -56,6 +68,7 @@ async fn create_test_server() -> (TestServer, Arc<SqliteBackend>) {
         default_tenant: "test-tenant".to_string(),
         ..ServerConfig::for_testing()
     };
+    adjust(&mut config);
 
     let state = helios_rest::AppState::new(Arc::clone(&backend), config);
     let app = helios_rest::routing::fhir_routes::create_routes(state);
@@ -848,6 +861,401 @@ mod conditional_update {
             .to_str()
             .unwrap()
             .to_string()
+    }
+}
+
+// =============================================================================
+// Conditional Delete Tests (If-Match on DELETE) — issue #312
+// =============================================================================
+
+/// `If-Match` on `DELETE [type]/[id]`.
+///
+/// Before #312 `delete_handler` took no `ConditionalHeaders` extractor at all,
+/// so a supplied precondition was unreachable and the resource was destroyed
+/// unconditionally.
+///
+/// Roughly half of these cells pass against the unfixed code. They are kept
+/// deliberately, as **controls**: without them, a "fix" that answered 412 to
+/// everything would look correct. Each is labelled. The regression evidence is
+/// the cells marked REGRESSION, which cannot pass while the header is unread.
+///
+/// Every REGRESSION cell asserts the resource **survives**, not merely that the
+/// status was 412 — a status-only assertion would also pass against a handler
+/// that refused *after* deleting.
+mod conditional_delete {
+    use super::*;
+
+    /// Asserts a resource is still readable, with the family name it was
+    /// seeded with. This is the assertion that makes a 412 meaningful.
+    async fn assert_still_present(server: &TestServer, id: &str, expect_family: &str) {
+        let read = server
+            .get(&format!("/Patient/{id}"))
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        read.assert_status(StatusCode::OK);
+        let body: serde_json::Value = read.json();
+        assert_eq!(
+            body["name"][0]["family"], expect_family,
+            "a refused delete must leave the resource intact"
+        );
+    }
+
+    /// Reads the current `ETag` for a resource.
+    async fn etag_of(server: &TestServer, id: &str) -> String {
+        let response = server
+            .get(&format!("/Patient/{id}"))
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response
+            .headers()
+            .get("etag")
+            .expect("ETag header")
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn delete_req(server: &TestServer, id: &str) -> axum_test::TestRequest {
+        server
+            .delete(&format!("/Patient/{id}"))
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+    }
+
+    /// CONTROL — no precondition still deletes. The majority population must
+    /// be untouched by #312.
+    #[tokio::test]
+    async fn absent_if_match_still_deletes() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        delete_req(&server, "patient-1")
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+    }
+
+    /// CONTROL — a matching tag must not be over-rejected.
+    #[tokio::test]
+    async fn matching_if_match_deletes() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+        let etag = etag_of(&server, "patient-1").await;
+
+        delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_str(&etag).unwrap())
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+    }
+
+    /// REGRESSION — the headline case from #312. Client saw v1, someone else
+    /// advanced the resource, the client's delete must be refused.
+    #[tokio::test]
+    async fn stale_if_match_is_412_and_the_resource_survives() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        let response = delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_static("W/\"99\""))
+            .await;
+
+        response.assert_status(StatusCode::PRECONDITION_FAILED);
+
+        // Not merely a 412 — the resource must still be there.
+        assert_still_present(&server, "patient-1", "Smith").await;
+
+        // And it must be *this* precondition failing, not an unrelated 412.
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["issue"][0]["code"], "conflict");
+        let diagnostics = body["issue"][0]["details"]["text"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            diagnostics.contains("If-Match"),
+            "diagnostics should name the failing precondition, got {diagnostics:?}"
+        );
+    }
+
+    /// CONTROL — the list semantics #311 established apply here too.
+    #[tokio::test]
+    async fn multi_valued_if_match_matching_any_member_deletes() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+        let etag = etag_of(&server, "patient-1").await;
+        let list = format!("W/\"99\", {etag}");
+
+        delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_str(&list).unwrap())
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+    }
+
+    /// REGRESSION — a list where nothing matches is still a failed precondition.
+    #[tokio::test]
+    async fn multi_valued_if_match_matching_nothing_is_412() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_static("W/\"98\", W/\"99\""))
+            .await
+            .assert_status(StatusCode::PRECONDITION_FAILED);
+
+        assert_still_present(&server, "patient-1", "Smith").await;
+    }
+
+    /// CONTROL — HFS compares the opaque tag value and ignores the `W/`
+    /// weakness flag, so the strong spelling of a weak ETag matches.
+    #[tokio::test]
+    async fn strong_form_matches_the_weak_etag() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+        let etag = etag_of(&server, "patient-1").await;
+        let strong = etag.trim_start_matches("W/").to_string();
+
+        delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_str(&strong).unwrap())
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+    }
+
+    /// REGRESSION — a malformed value must fail closed. Treating it as absent
+    /// is precisely what turns a guarded delete into an unconditional one.
+    #[tokio::test]
+    async fn malformed_if_match_is_412_not_an_unconditional_delete() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        let response = delete_req(&server, "patient-1")
+            // Unquoted: not a valid entity-tag.
+            .add_header(IF_MATCH, HeaderValue::from_static("garbage"))
+            .await;
+
+        response.assert_status(StatusCode::PRECONDITION_FAILED);
+        assert_still_present(&server, "patient-1", "Smith").await;
+
+        let body: serde_json::Value = response.json();
+        let diagnostics = body["issue"][0]["details"]["text"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            diagnostics.contains("If-Match"),
+            "diagnostics should name the failing precondition, got {diagnostics:?}"
+        );
+    }
+
+    /// REGRESSION — a non-UTF-8 field value is well-formed HTTP (`etagc` admits
+    /// `obs-text`) but cannot equal any tag this server issues. It must
+    /// evaluate to "no match", never to "absent".
+    #[tokio::test]
+    async fn non_utf8_if_match_is_412() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_bytes(&[0xFF, 0xFE]).unwrap())
+            .await
+            .assert_status(StatusCode::PRECONDITION_FAILED);
+
+        assert_still_present(&server, "patient-1", "Smith").await;
+    }
+
+    /// CONTROL — `*` is satisfied by any current representation.
+    #[tokio::test]
+    async fn star_deletes_an_existing_resource() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_static("*"))
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+    }
+
+    /// REGRESSION — `*` asserts a current representation EXISTS, so it must
+    /// fail against a resource that was never created. 412, not 404: the
+    /// precondition is evaluated before the not-found answer, matching the
+    /// bundle path (`if_match_suite::star_if_match_requires_an_existing_resource`).
+    #[tokio::test]
+    async fn star_on_an_absent_resource_is_412() {
+        let (server, _backend) = create_test_server().await;
+
+        delete_req(&server, "never-existed")
+            .add_header(IF_MATCH, HeaderValue::from_static("*"))
+            .await
+            .assert_status(StatusCode::PRECONDITION_FAILED);
+    }
+
+    /// REGRESSION — a soft-deleted resource has no current representation, so
+    /// `*` must not match the tombstone.
+    #[tokio::test]
+    async fn star_on_a_soft_deleted_resource_is_412() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        delete_req(&server, "patient-1")
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+
+        delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_static("*"))
+            .await
+            .assert_status(StatusCode::PRECONDITION_FAILED);
+    }
+
+    /// REGRESSION — a concrete tag against a resource that does not exist.
+    #[tokio::test]
+    async fn concrete_tag_on_an_absent_resource_is_412() {
+        let (server, _backend) = create_test_server().await;
+
+        delete_req(&server, "never-existed")
+            .add_header(IF_MATCH, HeaderValue::from_static("W/\"1\""))
+            .await
+            .assert_status(StatusCode::PRECONDITION_FAILED);
+    }
+
+    /// REGRESSION — the tombstone's own bumped version must not be matchable.
+    /// Comparing against it would let `DELETE If-Match: W/"2"` "succeed"
+    /// against an already-deleted resource whose delete bumped it to 2.
+    #[tokio::test]
+    async fn concrete_tag_on_a_soft_deleted_resource_is_412() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        delete_req(&server, "patient-1")
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+
+        for tag in ["W/\"1\"", "W/\"2\"", "W/\"3\""] {
+            delete_req(&server, "patient-1")
+                .add_header(IF_MATCH, HeaderValue::from_str(tag).unwrap())
+                .await
+                .assert_status(StatusCode::PRECONDITION_FAILED);
+        }
+    }
+
+    /// CONTROL — a precondition-less delete of an already-deleted resource
+    /// keeps answering 404, exactly as it did before #312.
+    ///
+    /// This is the cell that pins the trap: evaluating the precondition needs a
+    /// `read()`, and `read()` returns `Gone` for a tombstone. Propagating that
+    /// instead of mapping it to "no current version" would have silently made
+    /// 410 the answer here in every build.
+    #[tokio::test]
+    async fn absent_if_match_on_a_soft_deleted_resource_is_still_404() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        delete_req(&server, "patient-1")
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+
+        delete_req(&server, "patient-1")
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
+    }
+
+    /// REGRESSION — `HFS_REQUIRE_IF_MATCH` was honored only by the update
+    /// handler, so a deployment that had opted into mandatory preconditions
+    /// still got unconditional deletes.
+    #[tokio::test]
+    async fn require_if_match_rejects_a_delete_with_no_header() {
+        let (server, backend) = create_test_server_with(|c| c.require_if_match = true).await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        delete_req(&server, "patient-1")
+            .await
+            .assert_status(StatusCode::PRECONDITION_FAILED);
+
+        assert_still_present(&server, "patient-1", "Smith").await;
+    }
+
+    /// REGRESSION — under `require_if_match`, a malformed value counts as
+    /// SUPPLIED and then fails on its own merits. Reporting it as missing would
+    /// tell a client to retry with the header it already sent.
+    #[tokio::test]
+    async fn require_if_match_treats_a_malformed_value_as_supplied() {
+        let (server, backend) = create_test_server_with(|c| c.require_if_match = true).await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+
+        let response = delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_static("garbage"))
+            .await;
+
+        response.assert_status(StatusCode::PRECONDITION_FAILED);
+        let body: serde_json::Value = response.json();
+        let diagnostics = body["issue"][0]["details"]["text"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            diagnostics.contains("Malformed"),
+            "a malformed value must be rejected on its merits, not reported as \
+             missing; got {diagnostics:?}"
+        );
+    }
+
+    /// CONTROL — the precondition check must not be hoisted above the
+    /// `AuditEvent` immutability guard. Audit records are immutable regardless
+    /// of any tag, and reordering these would turn a 405 into a 412 (and make
+    /// delete scope an existence probe over the audit trail).
+    #[tokio::test]
+    async fn audit_event_immutability_outranks_the_precondition() {
+        let (server, _backend) = create_test_server().await;
+
+        let response = server
+            .delete("/AuditEvent/any-id")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .add_header(IF_MATCH, HeaderValue::from_static("W/\"99\""))
+            .await;
+
+        response.assert_status(StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    /// The client-facing 412 must not echo the current version.
+    ///
+    /// `DELETE` is authorized by `FhirOperation::Delete` alone, so a
+    /// `system/Patient.d` principal with no read scope reaches this path.
+    /// Telling it the versionId would disclose how many times the record has
+    /// been amended. Operators still get the value from the debug log.
+    #[tokio::test]
+    async fn the_412_body_does_not_disclose_the_current_version() {
+        let (server, backend) = create_test_server().await;
+        seed_patient(&backend, "patient-1", "Smith").await;
+        // Advance it so the current version is distinctive.
+        let etag = etag_of(&server, "patient-1").await;
+        server
+            .put("/Patient/patient-1")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .add_header(
+                CONTENT_TYPE,
+                HeaderValue::from_static("application/fhir+json"),
+            )
+            .add_header(IF_MATCH, HeaderValue::from_str(&etag).unwrap())
+            .json(&json!({
+                "resourceType": "Patient",
+                "id": "patient-1",
+                "name": [{"family": "Smith"}]
+            }))
+            .await
+            .assert_status(StatusCode::OK);
+
+        let current = etag_of(&server, "patient-1").await;
+        let version = current
+            .trim_start_matches("W/")
+            .trim_matches('"')
+            .to_string();
+
+        let response = delete_req(&server, "patient-1")
+            .add_header(IF_MATCH, HeaderValue::from_static("W/\"99\""))
+            .await;
+        response.assert_status(StatusCode::PRECONDITION_FAILED);
+
+        let body: serde_json::Value = response.json();
+        let diagnostics = body["issue"][0]["details"]["text"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            !diagnostics.contains(&format!("\"{version}\"")),
+            "the 412 must not disclose the current version, got {diagnostics:?}"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #312.

## What the spec requires

RFC 9110 §13.1.1: an origin server MUST NOT perform the method if `If-Match` evaluates to false, and MUST respond `412`. There is no method carve-out. FHIR R4 and R5 are silent on `If-Match` for delete; R6 defines it (`delete-conditional-single` lists `O: If-Match`). So this is HFS implementing the R6 interaction uniformly across all version modes, which is a stated decision rather than an accident.

## What HFS did

`delete_handler` took **no `ConditionalHeaders` extractor at all** — the header was unreachable, not merely unread. The resource was destroyed and the client was told `204`, the opposite of what it asked for.

## Why now

`b46b206b8` (#422) made every backend's Bundle executor honor `ifMatch` on DELETE. `git tag --contains b46b206b8` is empty, so that change is **unreleased**. Today `main` answers the same logical request two different ways depending on whether it is wrapped in a Bundle. Both halves ship in one release.

## Behavior change — operators read this

| Client sends | Before | After |
|---|---|---|
| No `If-Match` | 204 | **unchanged** |
| Matching tag | 204 | 204 |
| **Stale tag** | **204 — resource destroyed** | **412** |
| List, any member matches | 204 | 204 |
| List, none match | 204 | **412** |
| Malformed / non-UTF-8 | 204 | **412** |
| `*`, resource exists | 204 | 204 |
| `*` or a tag, resource absent | 404 | **412** |
| `*` or a tag, already deleted | 404 | **412** |
| No header, already deleted | 404 | **unchanged (404)** |
| `HFS_REQUIRE_IF_MATCH=true`, no header | 204 | **412** |

Nobody who is currently correct loses, with one exception: an idempotent retry loop that resends `DELETE` + `If-Match: *` after a timeout now gets 412 instead of 404. That is correct RFC behavior — a conditional delete is not idempotent under retry — but it is the one case worth calling out in the release note.

No config flag. A flag would only gate the HTTP path, re-creating the Bundle/HTTP divergence #422 just closed, and its off-position would be "ignore the client's precondition and delete anyway" — a switch for a data-loss bug, not a compatibility affordance.

## Design: why not `delete_with_match`

`VersionedStorage::delete_with_match` is already reachable from the handler (`InstanceHistoryProvider: VersionedStorage`, already in the router bounds). It was still the wrong tool:

- It returns `ConcurrencyError::VersionConflict` → **409**. RFC 9110 §13.2.2 permits only 412 or a 2xx for a false `If-Match`, and FHIR assigns 409 to delete refusals on referential-integrity grounds — so a client could not tell "re-read and retry" from "you may never delete this".
- It takes one `&str`, so it cannot express `Absent` or `*`, and re-collapses the RFC 9110 tag *list* that #311 just unpacked.
- It is read-then-compare-then-`delete()` in **all four** backends, so it buys zero atomicity.
- `CompositeStorage` routes `delete()` to `primary` but `delete_with_match()` to `versioned_storage` — separate fields that coincide only by construction convention.

The gate therefore lives in the handler, mirroring `update_handler` exactly.

## The `Gone` trap

Evaluating a precondition requires a read, and `read()` returns `Err(Gone)` for a soft-deleted resource on all four backends. That read was previously `#[cfg(feature = "subscriptions")]`-only, and `subscriptions` is **not** in `helios-hfs`'s default set — so stock builds never took it.

A naive `read().await?` would have made **410 the default answer for DELETE-of-already-deleted in every build**, silently. Mapping `Gone → None` instead is load-bearing twice: a supplied precondition (including `*`) correctly fails against a tombstone with 412, while a precondition-less delete still falls through to `delete()`'s own `NotFound` → 404. Pinned by `absent_if_match_on_a_soft_deleted_resource_is_still_404`.

## Backends: SQLite + PostgreSQL brought to parity

Not part of the issue, found by review, and included because it is the same defect family and cheap.

`SqliteBackend::delete` and `PostgresBackend::delete` issued an `UPDATE` with **no `version_id`/`is_deleted` predicate**. Under a concurrent PUT landing between the SELECT and the UPDATE, the delete clobbered the current row — and because `new_version` was computed from the stale read, the history `INSERT` then violated `PRIMARY KEY (tenant_id, resource_type, id, version_id)`. Neither statement runs in a transaction, so the UPDATE was already committed: **HTTP 500, current row pointing at a version whose history entry holds someone else's content.**

MongoDB (a `version_id` term in the update filter) and S3 (a conditional PUT with `If-Match`) already guarded this. Both laggards now do the same and report a lost race as `NotFound`.

**No schema migration, on any backend.** The guard is a predicate on `resources.version_id`, an existing primary-key column. PostgreSQL stays at `SCHEMA_VERSION = 16`; SQLite is unchanged.

## Security notes

- The 412 body deliberately **omits the current version**. DELETE is authorized by `FhirOperation::Delete` alone, so a `system/Patient.d` principal holding no read scope reaches this path; echoing the versionId would disclose how many times the record has been amended. Operators get it from the `debug!` log. Pinned by `the_412_body_does_not_disclose_the_current_version`.
- Ordering is fixed and tested: AuditEvent immutability → parse (malformed 412, before any I/O) → `require_if_match` gate → read → evaluate → delete → subscription emit. The precondition check must not be hoisted above the AuditEvent guard (that would turn a 405 into a 412 and make delete scope an existence probe over the audit trail) and the subscription event must not fire on a refused delete.
- Delete responses now carry an `AuditResponseContext` with the patient compartment reference. Update and patch already attached this; delete never did, so delete AuditEvents fell short of the IHE BALP profile. The now-unconditional read is what makes it free.

## Tests

16 new cells in `crates/rest/tests/rest_conformance.rs::conditional_delete`. **Roughly half pass against the unfixed code and are labelled `CONTROL`** — they exist so a "fix" that 412s everything cannot look correct. The regression evidence is the cells labelled `REGRESSION`, which cannot pass while the header is unread.

Every `REGRESSION` cell asserts the resource **survives**, not merely that the status was 412 — a status-only assertion would also pass against a handler that refused *after* deleting. The two most diagnostic cells additionally assert `issue[0].code == "conflict"` (distinguishing this from `MultipleMatches`, which is also 412) and that the message names the failing precondition.

`create_test_server_with` was added so `require_if_match` is set on the struct rather than through its env var — `HFS_REQUIRE_IF_MATCH` is read by clap at parse time and `set_var` would race every other test in the binary.

No existing assertion was weakened: `test_delete_returns_204` passes unchanged because it sends no precondition.

**Honest gap:** the SQLite/PG CAS guard is not directly regression-tested — a racy test would be flaky. It is covered indirectly by every existing delete test proving the guard does not reject the happy path.

## Verification status

I have no C linker in this environment, so `cargo check`/`test`/`clippy` cannot run locally (`cargo fmt --all --check` passes). **This PR is a draft until CI is green.** The `coverage` job is worth watching specifically: it builds `helios-rest` *without* `subscriptions`, exercising the second cfg-arm of the hoisted read.

## Deliberately not in this PR

- **`conditional_delete_handler`** (`DELETE [type]?[search]`). Not an oversight — documented in the handler's rustdoc. `ConditionalStorage::conditional_delete` searches *and* deletes inside the backend and never surfaces a version, so honoring the header means threading a precondition through four backends.
- **`delete_instance_history_handler` / `delete_version_handler`** ignore `If-Match`. R6 lists it as optional for both, but the normative prose defines no semantics for "the current representation of a `_history` collection", and both are Trial Use.
- **`$purge`** — considered and excluded. `If-Match` is semantically wrong for it: erasure targets the record, not a version.
- **412 vs 428.** `middleware/conditional.rs` documents the `require_if_match` gate as choosing between 428 ("you must send one") and 412 ("the one you sent does not hold"), but `update_handler` returns 412 and `RestError` has no 428 variant. I matched the existing behavior rather than fix it here; moving PUT, PATCH and DELETE to 428 together is the right follow-up.
- **`require_if_match` on PATCH** — only `update.rs` and now `delete.rs` consult it, so strict mode is still half-implemented on PATCH.
- **`capabilities.rs`** advertises `"versioning": "versioned"`. That needs no change for optional `If-Match` support, but is arguably under-claimed as `versioned-update` when strict mode is on.
- **HTS.** `crates/hts/src/operations/crud.rs` has the identical defect: `delete_resource` ignores `If-Match` while `update_resource` honors it, and its handlers do not even take a `HeaderMap`.
- **Backend parity nit.** A repeat DELETE returns 404 on SQLite/PG/Mongo and 410 on S3. Pre-existing; a supplied `If-Match` now masks it with a uniform 412.
- **Version.** Recommend cutting this as **0.3.0**, not 0.2.2: `^0.2` auto-resolves patch bumps, and this changes both an HTTP contract and a public fn signature (`delete_handler` gained a `ConditionalHeaders` argument — `Router` users need no change since it is a `FromRequestParts`, but direct callers do). Left to whoever runs the release; the `since = "0.2.2"` strings in `middleware/conditional.rs` will need updating if the version differs.
