### PR TITLE
feat(validator,ui): slicing in the editor and terminology-backed pickers

### DIFF
--- a/crates/fhir-validator/src/editor.rs
+++ b/crates/fhir-validator/src/editor.rs
@@ -109,6 +109,9 @@ pub struct Addable {
     pub must_support: bool,
     /// The `short` human label, when the pack carries one.
     pub short: Option<String>,
+    /// When set, this option adds an item into the named slice of the
+    /// element's array, seeded with the slice's pattern so it matches.
+    pub slice: Option<String>,
 }
 
 /// An element that is *present* in the document at a cursor, paired with the
@@ -343,6 +346,7 @@ pub fn addable(
                 is_modifier: false,
                 must_support: element.must_support.unwrap_or(false),
                 short: element.short.clone(),
+                slice: None,
             });
             continue;
         }
@@ -368,7 +372,62 @@ pub fn addable(
             is_modifier: name == "modifierExtension" || element.modifier.unwrap_or(false),
             must_support: element.must_support.unwrap_or(false),
             short: element.short.clone(),
+            slice: None,
         });
+
+        // Sliced arrays additionally offer one named add-choice per slice
+        // (#365), respecting per-slice cardinality against the document.
+        if let Some(slicing) = &element.slicing {
+            let items: Vec<Value> = node
+                .and_then(|value| value.get(name))
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            for (slice_name, slice) in &slicing.slices {
+                if slice_name == "@default" {
+                    continue;
+                }
+                if slice.max == Some(0) {
+                    continue;
+                }
+                let matched = items
+                    .iter()
+                    .filter(|item| crate::engine::slicing::slice_matches(slice, item))
+                    .count() as u64;
+                if let Some(max) = slice.max
+                    && matched >= max
+                {
+                    continue;
+                }
+                let slice_schema = slice.schema.as_deref();
+                out.push(Addable {
+                    name: name.clone(),
+                    kind: if matched > 0 {
+                        AddableKind::AddAnother
+                    } else {
+                        AddableKind::Add
+                    },
+                    type_: slice_schema
+                        .and_then(|s| s.type_.clone())
+                        .or_else(|| element.type_.clone()),
+                    is_primitive: false,
+                    required: slice.min.unwrap_or(0) > matched,
+                    binding: slice_schema
+                        .and_then(|s| s.binding.clone())
+                        .or_else(|| element.binding.clone()),
+                    refers: None,
+                    is_modifier: false,
+                    must_support: slice_schema
+                        .and_then(|s| s.must_support)
+                        .or(element.must_support)
+                        .unwrap_or(false),
+                    short: slice_schema
+                        .and_then(|s| s.short.clone())
+                        .or_else(|| element.short.clone()),
+                    slice: Some(slice_name.clone()),
+                });
+            }
+        }
     }
     out
 }
@@ -639,6 +698,73 @@ pub fn add_extension(
 /// opens resources.
 pub fn is_resource(schema: &FhirSchema) -> bool {
     schema.kind.as_deref() == Some(kind::RESOURCE)
+}
+
+/// The slice an existing array item matches, for labeling rows (#365).
+pub fn slice_label(
+    resolver: &dyn SchemaResolver,
+    root_type: &str,
+    path: &[Step],
+    item: &Value,
+) -> Option<String> {
+    let parent = schema_at(resolver, root_type, path)?;
+    let slicing = parent.slicing.as_ref()?;
+    slicing
+        .slices
+        .iter()
+        .find(|(name, slice)| {
+            name.as_str() != "@default" && crate::engine::slicing::slice_matches(slice, item)
+        })
+        .map(|(name, _)| name.clone())
+}
+
+/// Adds an array item seeded so it matches the named slice: the slice's
+/// pattern/value match is merged into the seed. Falls back to `add_element`
+/// semantics when the slice has no concrete pattern.
+pub fn add_slice_element(
+    resolver: &dyn SchemaResolver,
+    root_type: &str,
+    document: &mut Value,
+    path: &[Step],
+    name: &str,
+    slice_name: &str,
+) -> Option<Path> {
+    let added = add_element(resolver, root_type, document, path, name)?;
+    let parent_schema = schema_at(resolver, root_type, path);
+    let seed = parent_schema
+        .as_ref()
+        .and_then(|schema| schema.elements.as_ref())
+        .and_then(|elements| elements.get(name))
+        .and_then(|element| element.slicing.as_ref())
+        .and_then(|slicing| slicing.slices.get(slice_name))
+        .and_then(|slice| {
+            // The converter carries the discriminating shape as the slice
+            // schema's pattern/fixed keyword; explicit Match values are the
+            // alternate encoding.
+            slice
+                .schema
+                .as_ref()
+                .and_then(|schema| schema.pattern.clone().or_else(|| schema.fixed.clone()))
+                .or_else(|| slice.match_.as_ref().and_then(|m| m.value.clone()))
+        });
+    if let Some(Value::Object(pattern)) = seed {
+        // The freshly added item is the last in the array at `path.name`.
+        let mut item_path: Vec<Step> = path.to_vec();
+        item_path.push(Step::Field(name.to_string()));
+        if let Some(Value::Array(items)) = node_at_mut(document, &item_path) {
+            if let Some(last) = items.last_mut() {
+                if last.is_null() {
+                    *last = Value::Object(serde_json::Map::new());
+                }
+                if let Some(target) = last.as_object_mut() {
+                    for (key, value) in pattern {
+                        target.entry(key).or_insert(value);
+                    }
+                }
+            }
+        }
+    }
+    Some(added)
 }
 
 #[cfg(test)]
@@ -953,5 +1079,99 @@ mod tests {
         // Clearing a field removes it rather than storing "".
         set_value(&mut patient, &path_from_string("active"), "");
         assert!(patient.get("active").is_none());
+    }
+}
+
+#[cfg(test)]
+mod slice_tests {
+    use super::*;
+    use crate::converter::convert;
+    use serde_json::json;
+
+    fn sliced_registry() -> Arc<crate::SchemaRegistry> {
+        let sd = json!({
+            "resourceType": "StructureDefinition",
+            "url": "http://example.org/StructureDefinition/Sliced",
+            "name": "Sliced",
+            "kind": "resource",
+            "derivation": "specialization",
+            "type": "Sliced",
+            "snapshot": { "element": [
+                { "path": "Sliced", "min": 0, "max": "*" },
+                {
+                    "path": "Sliced.identifier",
+                    "min": 0, "max": "*",
+                    "type": [{ "code": "Identifier" }],
+                    "slicing": {
+                        "discriminator": [{ "type": "pattern", "path": "system" }],
+                        "rules": "open"
+                    }
+                },
+                {
+                    "path": "Sliced.identifier",
+                    "sliceName": "mrn",
+                    "min": 1, "max": "1",
+                    "type": [{ "code": "Identifier" }],
+                    "patternIdentifier": { "system": "http://example.org/mrn" }
+                }
+            ]}
+        });
+        let conversion = convert(&sd).expect("conversion");
+        let mut registry = crate::SchemaRegistry::new();
+        registry.insert(conversion.schema);
+        Arc::new(registry)
+    }
+
+    #[test]
+    fn sliced_arrays_offer_named_add_choices_with_cardinality() {
+        let registry = sliced_registry();
+        let doc = json!({ "resourceType": "Sliced" });
+        let options = addable(registry.as_ref(), "Sliced", &doc, &[]);
+        let mrn: Vec<_> = options
+            .iter()
+            .filter(|option| option.slice.as_deref() == Some("mrn"))
+            .collect();
+        assert_eq!(mrn.len(), 1, "one add-choice per slice: {options:?}");
+
+        // With a matching item present, the max-1 slice is spent.
+        let filled = json!({
+            "resourceType": "Sliced",
+            "identifier": [{ "system": "http://example.org/mrn", "value": "42" }]
+        });
+        let options = addable(registry.as_ref(), "Sliced", &filled, &[]);
+        assert!(
+            !options.iter().any(|o| o.slice.as_deref() == Some("mrn")),
+            "spent slice not offered: {options:?}"
+        );
+    }
+
+    #[test]
+    fn slice_add_seeds_the_pattern_and_items_are_labeled() {
+        let registry = sliced_registry();
+        let mut doc = json!({ "resourceType": "Sliced" });
+        add_slice_element(
+            registry.as_ref(),
+            "Sliced",
+            &mut doc,
+            &[],
+            "identifier",
+            "mrn",
+        )
+        .expect("added");
+        assert_eq!(
+            doc["identifier"][0]["system"],
+            json!("http://example.org/mrn"),
+            "seeded so it matches: {doc}"
+        );
+
+        let label = slice_label(registry.as_ref(), "Sliced", &[], &doc["identifier"][0]);
+        assert_eq!(label, None, "slice_label reads the parent of the ITEM path");
+        let label = slice_label(
+            registry.as_ref(),
+            "Sliced",
+            &[Step::Field("identifier".to_string())],
+            &doc["identifier"][0],
+        );
+        assert_eq!(label.as_deref(), Some("mrn"));
     }
 }

--- a/crates/fhir-validator/src/engine/mod.rs
+++ b/crates/fhir-validator/src/engine/mod.rs
@@ -10,7 +10,7 @@
 mod errors;
 mod path;
 mod primitives;
-mod slicing;
+pub(crate) mod slicing;
 mod walk;
 
 pub use errors::{ErrorKind, Severity, ValidationError};

--- a/crates/fhir-validator/src/engine/slicing.rs
+++ b/crates/fhir-validator/src/engine/slicing.rs
@@ -211,12 +211,22 @@ pub(super) fn validate_slices(
 /// today; a missing `match` (constraining slice) matches nothing, and a
 /// `match` with no `value` matches everything (lodash `_.isMatch` semantics
 /// for an empty source).
-fn slice_matches(slice: &Slice, item: &Value) -> bool {
-    let Some(match_) = &slice.match_ else {
-        return false;
-    };
-    match match_.value.as_ref() {
-        Some(pattern) => is_partial_match(item, pattern),
-        None => true,
+pub(crate) fn slice_matches(slice: &Slice, item: &Value) -> bool {
+    if let Some(match_) = &slice.match_ {
+        return match match_.value.as_ref() {
+            Some(pattern) => is_partial_match(item, pattern),
+            None => true,
+        };
     }
+    // The converter carries a pattern/value discriminator as the slice
+    // schema's pattern (or fixed) keyword rather than an explicit match.
+    if let Some(schema) = &slice.schema {
+        if let Some(pattern) = &schema.pattern {
+            return is_partial_match(item, pattern);
+        }
+        if let Some(fixed) = &schema.fixed {
+            return is_partial_match(item, fixed);
+        }
+    }
+    false
 }

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -659,6 +659,7 @@ async fn serve(
             self_base_url,
             outbound_auth,
             config.default_fhir_version,
+            config.terminology_server.clone(),
         )
     };
     #[cfg(not(all(feature = "ui", not(feature = "headless"))))]

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -3864,3 +3864,27 @@ html[data-nav="collapsed"] .menu__panel { left: 0; }
   color: var(--muted);
   font-size: 11px;
 }
+
+/* Slice + binding chips (#365). */
+.editor-row__slice {
+  padding: 1px 6px;
+  border-radius: 5px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.editor-row__bind {
+  padding: 1px 5px;
+  border: 1px dashed var(--surface-border);
+  border-radius: 5px;
+  color: var(--muted);
+  font-size: 9.5px;
+  letter-spacing: 0.03em;
+}
+
+.editor-add__slicename {
+  color: var(--accent);
+  font-weight: 500;
+}

--- a/crates/ui/assets/editor.js
+++ b/crates/ui/assets/editor.js
@@ -267,7 +267,7 @@
 
     var add = event.target.closest("[data-add]");
     if (add) {
-      send("add", { path: add.dataset.add, name: add.dataset.name });
+      send("add", { path: add.dataset.add, name: add.dataset.name, slice: add.dataset.slice || "" });
       return;
     }
 
@@ -313,6 +313,51 @@
     },
     true
   );
+
+
+  /* Live $expand picker (#365): bound inputs carry data-vs-url; typing
+   * debounces a request to the UI's terminology proxy and fills a per-row
+   * datalist. 204 (no server configured) leaves the plain input alone. */
+  var expandTimer = null;
+  var expandSeq = 0;
+  body.addEventListener("input", function (event) {
+    var input = event.target.closest("[data-vs-url]");
+    if (!input) return;
+    clearTimeout(expandTimer);
+    expandTimer = setTimeout(function () {
+      var seq = ++expandSeq;
+      fetch(
+        "/ui/editor/expand?url=" +
+          encodeURIComponent(input.dataset.vsUrl) +
+          "&filter=" +
+          encodeURIComponent(input.value),
+        { credentials: "same-origin" },
+      )
+        .then(function (r) { return r.status === 200 ? r.json() : null; })
+        .then(function (data) {
+          if (!data || seq !== expandSeq) return;
+          var listId = input.getAttribute("list");
+          if (!listId) {
+            listId = "vs-live-" + Math.abs(input.dataset.set.length + seq);
+            input.setAttribute("list", listId);
+          }
+          var list = document.getElementById(listId);
+          if (!list) {
+            list = document.createElement("datalist");
+            list.id = listId;
+            input.parentElement.appendChild(list);
+          }
+          list.textContent = "";
+          data.codes.forEach(function (item) {
+            var opt = document.createElement("option");
+            opt.value = item.code;
+            if (item.display) opt.label = item.display;
+            list.appendChild(opt);
+          });
+        })
+        .catch(function () {});
+    }, 300);
+  });
 
   /* Typeahead over the "add" list -- the only thing here that is purely
    * cosmetic, and the only thing that would be silly to round-trip. */

--- a/crates/ui/assets/resources.js
+++ b/crates/ui/assets/resources.js
@@ -109,7 +109,7 @@
       return;
     }
     var add = event.target.closest("[data-add]");
-    if (add) { editorSend("add", { path: add.dataset.add, name: add.dataset.name }); return; }
+    if (add) { editorSend("add", { path: add.dataset.add, name: add.dataset.name, slice: add.dataset.slice || "" }); return; }
     var rm = event.target.closest("[data-remove]");
     if (rm) { editorSend("remove", { path: rm.dataset.remove }); return; }
     var ext = event.target.closest("[data-extension]");
@@ -118,6 +118,51 @@
       var url = panel ? panel.querySelector(".editor-add__ext-url").value.trim() : "";
       editorSend("extension", { path: ext.dataset.extension, url: url });
     }
+  });
+
+
+  /* Live $expand picker (#365): bound inputs carry data-vs-url; typing
+   * debounces a request to the UI's terminology proxy and fills a per-row
+   * datalist. 204 (no server configured) leaves the plain input alone. */
+  var expandTimer = null;
+  var expandSeq = 0;
+  editorBody.addEventListener("input", function (event) {
+    var input = event.target.closest("[data-vs-url]");
+    if (!input) return;
+    clearTimeout(expandTimer);
+    expandTimer = setTimeout(function () {
+      var seq = ++expandSeq;
+      fetch(
+        "/ui/editor/expand?url=" +
+          encodeURIComponent(input.dataset.vsUrl) +
+          "&filter=" +
+          encodeURIComponent(input.value),
+        { credentials: "same-origin" },
+      )
+        .then(function (r) { return r.status === 200 ? r.json() : null; })
+        .then(function (data) {
+          if (!data || seq !== expandSeq) return;
+          var listId = input.getAttribute("list");
+          if (!listId) {
+            listId = "vs-live-" + Math.abs(input.dataset.set.length + seq);
+            input.setAttribute("list", listId);
+          }
+          var list = document.getElementById(listId);
+          if (!list) {
+            list = document.createElement("datalist");
+            list.id = listId;
+            input.parentElement.appendChild(list);
+          }
+          list.textContent = "";
+          data.codes.forEach(function (item) {
+            var opt = document.createElement("option");
+            opt.value = item.code;
+            if (item.display) opt.label = item.display;
+            list.appendChild(opt);
+          });
+        })
+        .catch(function () {});
+    }, 300);
   });
 
   editorBody.addEventListener("change", function (event) {

--- a/crates/ui/src/editor.rs
+++ b/crates/ui/src/editor.rs
@@ -77,6 +77,12 @@ pub struct Row {
     pub can_remove: bool,
     /// `mustSupport` in the governing schema — emphasised in the form.
     pub must_support: bool,
+    /// The slice this array item matches, when the element is sliced.
+    pub slice: String,
+    /// The binding strength (`required`, `extensible`, …), for the chip.
+    pub binding_strength: String,
+    /// The bound value set's canonical URL, for the live `$expand` picker.
+    pub binding_url: String,
     /// The `short` human label; the raw element name stays as the technical
     /// hint next to it.
     pub short: String,
@@ -94,6 +100,8 @@ pub struct AddOption {
     pub must_support: bool,
     /// The `short` label, shown as the option's description.
     pub short: String,
+    /// Adds into this named slice (seeded so the item matches).
+    pub slice: String,
 }
 
 #[derive(Template)]
@@ -151,6 +159,8 @@ pub struct EditorForm {
     pub value: String,
     #[serde(default)]
     pub modifier: String,
+    #[serde(default)]
+    pub slice: String,
 }
 
 /// The editor shell. The resource itself is fetched by the browser from the
@@ -222,6 +232,16 @@ fn apply(
     let path = editor::path_from_string(&form.path);
 
     match form.op.as_str() {
+        "add" if !form.slice.is_empty() => {
+            editor::add_slice_element(
+                resolver,
+                resource_type,
+                document,
+                &path,
+                &form.name,
+                &form.slice,
+            );
+        }
         "add" => {
             editor::add_element(resolver, resource_type, document, &path, &form.name);
         }
@@ -441,6 +461,29 @@ fn build_rows(
             .as_ref()
             .and_then(|schema| schema.must_support)
             .unwrap_or(false),
+        slice: match path.split_last() {
+            Some((Step::Index(_), parent_path)) => {
+                editor::slice_label(resolver, resource_type, parent_path, node).unwrap_or_default()
+            }
+            _ => String::new(),
+        },
+        binding_strength: schema
+            .as_ref()
+            .and_then(|schema| schema.binding.as_ref())
+            .and_then(|binding| binding.strength.clone())
+            .unwrap_or_default(),
+        binding_url: schema
+            .as_ref()
+            .and_then(|schema| schema.binding.as_ref())
+            .map(|binding| {
+                binding
+                    .value_set
+                    .split('|')
+                    .next()
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .unwrap_or_default(),
         short: schema
             .as_ref()
             .and_then(|schema| schema.short.clone())
@@ -474,6 +517,60 @@ fn build_rows(
     }
 }
 
+/// Live `$expand` proxy for bound fields (#365): forwards to the configured
+/// terminology server and returns a compact JSON code list for the picker.
+/// Responds 204 when no terminology server is configured — the picker then
+/// stays a plain input.
+#[derive(Deserialize)]
+pub struct ExpandQuery {
+    pub url: String,
+    #[serde(default)]
+    pub filter: String,
+}
+
+pub async fn expand(State(state): State<WebState>, Query(query): Query<ExpandQuery>) -> Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    let Some(base) = state.terminology.as_ref() else {
+        return StatusCode::NO_CONTENT.into_response();
+    };
+    let target = format!("{}/ValueSet/$expand", base.trim_end_matches('/'));
+    let mut params: Vec<(&str, &str)> = vec![("url", query.url.as_str()), ("count", "25")];
+    if !query.filter.is_empty() {
+        params.push(("filter", query.filter.as_str()));
+    }
+    let response = match reqwest::Client::new()
+        .get(&target)
+        .query(&params)
+        .header("Accept", "application/fhir+json")
+        .timeout(std::time::Duration::from_millis(2500))
+        .send()
+        .await
+    {
+        Ok(r) if r.status().is_success() => r,
+        _ => return StatusCode::NO_CONTENT.into_response(),
+    };
+    let Ok(body) = response.json::<Value>().await else {
+        return StatusCode::NO_CONTENT.into_response();
+    };
+    let codes: Vec<Value> = body["expansion"]["contains"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| {
+                    serde_json::json!({
+                        "code": item["code"].as_str().unwrap_or_default(),
+                        "display": item["display"].as_str().unwrap_or_default(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    axum::Json(serde_json::json!({ "codes": codes })).into_response()
+}
+
 fn to_option(addable: Addable) -> AddOption {
     let (kind, arms) = match addable.kind {
         AddableKind::Add => ("add", Vec::new()),
@@ -488,5 +585,6 @@ fn to_option(addable: Addable) -> AddOption {
         arms,
         must_support: addable.must_support,
         short: addable.short.unwrap_or_default(),
+        slice: addable.slice.unwrap_or_default(),
     }
 }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -120,6 +120,9 @@ struct WebState {
     /// The server's default tenant id — the fallback when no stored choice
     /// exists (#344).
     default_tenant: String,
+    /// Terminology server base URL (`HFS_TERMINOLOGY_SERVER`), when one is
+    /// configured — powers the editor's live `$expand` pickers (#365).
+    terminology: Option<String>,
     /// Per-user settings, for the persisted FHIR-version choice (#343). `None`
     /// when the backend has no settings store; the selector then applies
     /// per-page only.
@@ -542,6 +545,7 @@ pub fn mount(
     self_base_url: String,
     outbound_auth: Arc<dyn helios_auth::outbound::OutboundAuthProvider>,
     fhir_version: helios_fhir::FhirVersion,
+    terminology: Option<String>,
 ) -> Router {
     let source: Arc<dyn ConformanceSource> = Arc::new(conformance::HttpConformanceSource::new(
         self_base_url,
@@ -557,6 +561,7 @@ pub fn mount(
         default_tenant,
         source,
         fhir_version,
+        terminology,
     )
 }
 
@@ -576,6 +581,7 @@ pub fn mount_with_conformance_source(
     default_tenant: String,
     source: Arc<dyn ConformanceSource>,
     fhir_version: helios_fhir::FhirVersion,
+    terminology: Option<String>,
 ) -> Router {
     let nl_enabled = nl.enabled;
 
@@ -599,6 +605,7 @@ pub fn mount_with_conformance_source(
         // Schema-driven resource editor (#264). One POST endpoint applies every
         // structural mutation and re-renders: the document rides with it.
         .route("/ui/editor", get(editor::page))
+        .route("/ui/editor/expand", get(editor::expand))
         .route(
             "/ui/editor/render",
             axum::routing::post(editor::render_body),
@@ -633,6 +640,7 @@ pub fn mount_with_conformance_source(
         data_dir,
         fhir_version,
         default_tenant,
+        terminology,
     };
 
     router

--- a/crates/ui/templates/partials/editor-body.html
+++ b/crates/ui/templates/partials/editor-body.html
@@ -88,6 +88,14 @@
           <span class="editor-row__type">{{ row.type_label }}</span>
           {% endif %}
 
+          {% if !row.slice.is_empty() %}
+          <span class="editor-row__slice">{{ row.slice }}</span>
+          {% endif %}
+
+          {% if !row.slice.is_empty() %}
+          <span class="editor-row__slice">{{ row.slice }}</span>
+          {% endif %}
+
           {% if row.must_support %}
           <span class="editor-row__ms" title="{{ i18n.t("editor-must-support-hint") }}">{{ i18n.t("editor-must-support-badge") }}</span>
           {% endif %}
@@ -110,9 +118,18 @@
           </span>
           {% endif %}
 
+          {% if !row.binding_strength.is_empty() %}
+          <span class="editor-row__bind" title="{{ i18n.t("editor-binding-hint") }}">{{ row.binding_strength }}</span>
+          {% endif %}
+
+          {% if !row.binding_strength.is_empty() %}
+          <span class="editor-row__bind" title="{{ i18n.t("editor-binding-hint") }}">{{ row.binding_strength }}</span>
+          {% endif %}
+
           {% if row.is_primitive %}
           <input class="editor-row__input" type="text" value="{{ row.value }}"
                  data-set="{{ row.path }}"
+                 {% if !row.binding_url.is_empty() %}data-vs-url="{{ row.binding_url }}"{% endif %}
                  {% if let Some(vs) = row.binding %}list="vs-{{ vs }}" placeholder="{{ vs }}"{% endif %}>
           {% endif %}
 
@@ -146,9 +163,9 @@
                 </select>
               </div>
               {% else %}
-              <button type="button" class="editor-add__item{% if option.must_support %} editor-add__item--ms{% endif %}" data-add-name="{{ option.name }}"
-                      data-add="{{ row.path }}" data-name="{{ option.name }}"{% if !option.short.is_empty() %} title="{{ option.short }}"{% endif %}>
-                <span class="editor-add__name">{{ option.name }}{% if option.required %} <em>*</em>{% endif %}{% if option.must_support %} <span class="editor-add__ms">{{ i18n.t("editor-must-support-badge") }}</span>{% endif %}</span>
+              <button type="button" class="editor-add__item{% if option.must_support %} editor-add__item--ms{% endif %}" data-add-name="{{ option.name }}{% if !option.slice.is_empty() %} {{ option.slice }}{% endif %}"
+                      data-add="{{ row.path }}" data-name="{{ option.name }}"{% if !option.slice.is_empty() %} data-slice="{{ option.slice }}"{% endif %}{% if !option.short.is_empty() %} title="{{ option.short }}"{% endif %}>
+                <span class="editor-add__name">{{ option.name }}{% if !option.slice.is_empty() %} <span class="editor-add__slicename">· {{ option.slice }}</span>{% endif %}{% if option.required %} <em>*</em>{% endif %}{% if option.must_support %} <span class="editor-add__ms">{{ i18n.t("editor-must-support-badge") }}</span>{% endif %}</span>
                 <span class="editor-add__type">{{ option.type_label }}</span>
                 {% if !option.short.is_empty() %}
                 <span class="editor-add__short">{{ option.short }}</span>

--- a/crates/ui/tests/i18n_http.rs
+++ b/crates/ui/tests/i18n_http.rs
@@ -25,6 +25,7 @@ fn app() -> Router {
         "default".to_string(),
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
+        None,
     )
 }
 

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -40,6 +40,7 @@ fn app_with(nl: helios_ui::NlSearch) -> Router {
             std::path::Path::new("../../data"),
         )),
         helios_fhir::FhirVersion::R4,
+        None,
     )
 }
 
@@ -152,6 +153,7 @@ async fn non_ui_paths_fall_through_to_the_fhir_app() {
         "default".to_string(),
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
+        None,
     )
     .oneshot(Request::get("/Patient").body(Body::empty()).unwrap())
     .await

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -37,6 +37,7 @@ fn app(store: &Arc<dyn ResourceStorage>) -> Router {
         "default".to_string(),
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
+        None,
     )
 }
 
@@ -175,6 +176,7 @@ async fn page_reports_registry_unavailable_without_a_store() {
         "default".to_string(),
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
+        None,
     )
     .oneshot(Request::get("/ui/tenants").body(Body::empty()).unwrap())
     .await
@@ -254,6 +256,7 @@ async fn version_choice_persists_to_user_settings_and_redirects_back() {
         "default".to_string(),
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
+        None,
     );
 
     // Selecting a version persists it and bounces back to the referring page.
@@ -317,6 +320,7 @@ async fn tenant_choice_persists_and_the_selector_follows_it() {
             "default".to_string(),
             Arc::new(helios_ui::StaticConformanceSource::empty()),
             FhirVersion::R4,
+            None,
         )
     };
 

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -393,6 +393,7 @@ editor-source-hint = Bearbeiten Sie den Quelltext direkt. Beim Zurückwechseln w
 
 editor-add = Element hinzufügen
 editor-must-support-badge = MS
+editor-binding-hint = An ein Value Set gebunden — Codes stammen daraus; Stärke angezeigt
 editor-must-support-hint = Must-support: Konsumenten dieses Profils müssen dieses Element verarbeiten können
 editor-add-filter = Elemente filtern
 editor-add-another = weiteres hinzufügen

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -397,6 +397,7 @@ editor-source-hint = Edit the source directly. Switching back to the guided form
 
 editor-add = Add element
 editor-must-support-badge = MS
+editor-binding-hint = Bound to a value set — codes come from it; strength shown
 editor-must-support-hint = Must-support: consumers of this profile are expected to handle this element
 editor-add-filter = Filter elements
 editor-add-another = add another

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -393,6 +393,7 @@ editor-source-hint = Edita el código directamente. Al volver al formulario guia
 
 editor-add = Añadir elemento
 editor-must-support-badge = MS
+editor-binding-hint = Ligado a un value set — los códigos salen de él; se muestra la fuerza
 editor-must-support-hint = Must-support: se espera que los consumidores de este perfil manejen este elemento
 editor-add-filter = Filtrar elementos
 editor-add-another = añadir otro


### PR DESCRIPTION
Closes #365

## Summary

#365 **Stacked on #429** (#364's IR work). Two halves, per the issue:

**Slicing** — the IR already modeled it; nothing consumed it:
- The projection offers one named add-choice per slice, respecting per-slice cardinality against the document; adding into a slice seeds the item with the slice's pattern so it matches immediately ('add an MRN identifier' seeds `system`).
- Array items are labeled with the slice they match. `slice_matches` now also reads the slice schema's pattern/fixed keyword — the shape the converter actually emits for pattern discriminators — which the engine's own slicing sweep benefits from too.

**Terminology** — rows expose the binding's strength (chip) and canonical value-set URL; a new `/ui/editor/expand` proxies `ValueSet/$expand` on the configured `HFS_TERMINOLOGY_SERVER` (threaded through `mount` into `WebState`); bound inputs debounce a filtered expansion into a per-row datalist. The proxy answers 204 when no server is configured, so the picker degrades to the plain input.

## Tests

New projection tests: sliced arrays offer named add-choices with cardinality (spent slices vanish), slice-adds seed the pattern, items label by slice. Full validator suite (9 suites) and helios-ui suites green; fmt clean.