### PR TITLE
fix(tenant): make the `__system__` reservation non-bypassable (#317)

### DIFF
--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -1101,13 +1101,15 @@ jobs:
           EXAMPLE_FILE="audit-db-results/example-event.json"
           CHECK_COUNT=0
 
+          # Every arm reads the audit store directly. `shared` mode used to read
+          # over HTTP with `X-Tenant-ID: __system__`, but addressing the internal
+          # system tenant from the network is exactly the isolation hole closed
+          # in #317, so that door no longer opens. Reading the store is what the
+          # `dedicated` arms and the S3 arm always did, and it asserts the same
+          # thing — that the database sink persisted an AuditEvent — without
+          # depending on a request path that must now be refused.
           for _ in {1..20}; do
-            if [ "${{ matrix.mode }}" = "shared" ] && [ "${{ matrix.backend }}" != "s3" ]; then
-              curl -sS -H "X-Tenant-ID: __system__" \
-                "http://localhost:$HFS_PORT_SMOKE/AuditEvent?_count=20" > audit-db-results/auditevent-search.json
-              CHECK_COUNT=$(jq -r '.entry | length // 0' audit-db-results/auditevent-search.json)
-              jq '.entry[0].resource // {}' audit-db-results/auditevent-search.json > "$EXAMPLE_FILE"
-            elif [ "${{ matrix.backend }}" = "sqlite" ]; then
+            if [ "${{ matrix.backend }}" = "sqlite" ]; then
               DB_PATH="$PRIMARY_SQLITE_DB"
               if [ "${{ matrix.mode }}" = "dedicated" ]; then
                 DB_PATH="$AUDIT_SQLITE_DB"

--- a/crates/persistence/src/backends/elasticsearch/storage.rs
+++ b/crates/persistence/src/backends/elasticsearch/storage.rs
@@ -961,6 +961,7 @@ impl ResourceStorage for ElasticsearchBackend {
     // composite storage can clear a purged tenant's offloaded search documents
     // (in `*-elasticsearch` modes the primary's own search index is empty).
     async fn purge_tenant_data(&self, id: &str) -> StorageResult<u64> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         // Documents are matched by an exact `tenant_id` term, not by the index
         // pattern alone: index names lowercase the tenant id, so the pattern
         // for tenant `acme` would also sweep `acme_corp`'s indices.

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -1507,6 +1507,7 @@ impl ResourceStorage for MongoBackend {
         id: &str,
         display_name: Option<&str>,
     ) -> StorageResult<crate::core::TenantRecord> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let db = self.get_database().await?;
         let tenants = db.collection::<Document>(MongoBackend::TENANTS_COLLECTION);
         // RFC 3339 string, matching the SQLite registry's `created_at` format so
@@ -1531,6 +1532,7 @@ impl ResourceStorage for MongoBackend {
     }
 
     async fn deregister_tenant(&self, id: &str) -> StorageResult<bool> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let db = self.get_database().await?;
         let tenants = db.collection::<Document>(MongoBackend::TENANTS_COLLECTION);
         let result = tenants
@@ -1541,6 +1543,7 @@ impl ResourceStorage for MongoBackend {
     }
 
     async fn purge_tenant_data(&self, id: &str) -> StorageResult<u64> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let db = self.get_database().await?;
         // Count current-version docs first (soft-deleted included, mirroring the
         // SQLite purge) so we can report what was removed.

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -777,6 +777,7 @@ impl ResourceStorage for PostgresBackend {
         id: &str,
         display_name: Option<&str>,
     ) -> StorageResult<crate::core::TenantRecord> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let client = self.get_client().await?;
         // Plain INSERT so a duplicate id surfaces as a constraint error; the
         // admin handler pre-checks existence and returns 409, so reaching here
@@ -797,6 +798,7 @@ impl ResourceStorage for PostgresBackend {
     }
 
     async fn deregister_tenant(&self, id: &str) -> StorageResult<bool> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let client = self.get_client().await?;
         let changed = client
             .execute("DELETE FROM tenants WHERE id = $1", &[&id])
@@ -806,6 +808,7 @@ impl ResourceStorage for PostgresBackend {
     }
 
     async fn purge_tenant_data(&self, id: &str) -> StorageResult<u64> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let mut client = self.get_client().await?;
         let tx = client
             .transaction()

--- a/crates/persistence/src/backends/s3/storage.rs
+++ b/crates/persistence/src/backends/s3/storage.rs
@@ -1057,6 +1057,7 @@ impl ResourceStorage for S3Backend {
         id: &str,
         display_name: Option<&str>,
     ) -> StorageResult<crate::core::TenantRecord> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let location = self
             .registry_location()
             .ok_or_else(|| self.tenant_registry_unsupported())?;
@@ -1078,6 +1079,7 @@ impl ResourceStorage for S3Backend {
     }
 
     async fn deregister_tenant(&self, id: &str) -> StorageResult<bool> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let location = self
             .registry_location()
             .ok_or_else(|| self.tenant_registry_unsupported())?;
@@ -1117,6 +1119,7 @@ impl ResourceStorage for S3Backend {
     }
 
     async fn purge_tenant_data(&self, id: &str) -> StorageResult<u64> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         // Resolve the tenant's data location exactly as request handling does.
         let tenant = TenantContext::new(TenantId::new(id), TenantPermissions::full_access());
         let location = self.tenant_location(&tenant)?;

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -834,6 +834,7 @@ impl ResourceStorage for SqliteBackend {
         id: &str,
         display_name: Option<&str>,
     ) -> StorageResult<crate::core::TenantRecord> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let conn = self.get_connection()?;
         // Plain INSERT so a duplicate id surfaces as a constraint error; the
         // admin handler pre-checks existence and returns 409, so reaching here
@@ -858,6 +859,7 @@ impl ResourceStorage for SqliteBackend {
     }
 
     async fn deregister_tenant(&self, id: &str) -> StorageResult<bool> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let conn = self.get_connection()?;
         let changed = conn
             .execute("DELETE FROM tenants WHERE id = ?1", params![id])
@@ -866,6 +868,7 @@ impl ResourceStorage for SqliteBackend {
     }
 
     async fn purge_tenant_data(&self, id: &str) -> StorageResult<u64> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let mut conn = self.get_connection()?;
         let tx = conn
             .transaction()

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -1037,14 +1037,17 @@ impl ResourceStorage for CompositeStorage {
         id: &str,
         display_name: Option<&str>,
     ) -> StorageResult<crate::core::TenantRecord> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         self.primary.register_tenant(id, display_name).await
     }
 
     async fn deregister_tenant(&self, id: &str) -> StorageResult<bool> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         self.primary.deregister_tenant(id).await
     }
 
     async fn purge_tenant_data(&self, id: &str) -> StorageResult<u64> {
+        crate::tenant::ensure_mutable_tenant(id)?;
         let removed = self.primary.purge_tenant_data(id).await?;
         for (backend_id, secondary) in &self.secondaries {
             match secondary.purge_tenant_data(id).await {

--- a/crates/persistence/src/core/storage.rs
+++ b/crates/persistence/src/core/storage.rs
@@ -781,6 +781,18 @@ pub trait ResourceStorage: Send + Sync {
     /// Registers (provisions) a new tenant, stamping `created_at` with the
     /// current time. Returns [`StorageError`] if the tenant is already
     /// registered. Default: unsupported-capability error.
+    ///
+    /// # Implementor contract
+    ///
+    /// This method, [`deregister_tenant`](Self::deregister_tenant) and
+    /// [`purge_tenant_data`](Self::purge_tenant_data) take a bare `&str` and
+    /// mutate or destroy tenant state, so an override **must** begin with
+    /// [`ensure_mutable_tenant`](crate::tenant::ensure_mutable_tenant) to refuse
+    /// reserved ids. `__system__` holds the AuditEvent trail and shared
+    /// terminology; a purge of it is an anti-forensic primitive (issue #317).
+    /// The REST ingress rejects reserved ids first, but this family is reachable
+    /// from more than one handler, so the guard is the backstop rather than the
+    /// only control.
     async fn register_tenant(
         &self,
         _id: &str,

--- a/crates/persistence/src/tenant/id.rs
+++ b/crates/persistence/src/tenant/id.rs
@@ -8,12 +8,115 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
+use crate::error::{StorageResult, TenantError};
+
 /// The system tenant identifier, used for shared/global resources.
 ///
 /// Resources stored under the system tenant are accessible to all tenants
 /// (subject to permission checks). This is used for shared resources like
 /// CodeSystems, ValueSets, and other terminology resources.
+///
+/// This id names an *internal* tenant: it is only ever legitimate when the
+/// process itself authors it (via [`TenantId::system`] /
+/// [`TenantContext::system`](crate::tenant::TenantContext::system)). It must
+/// never be accepted from a request — see [`TenantId::parse`] and
+/// [`ensure_mutable_tenant`], and issue #317.
 pub const SYSTEM_TENANT: &str = "__system__";
+
+/// Maximum accepted length of a caller-supplied tenant id.
+///
+/// Bounds the value that flows into storage keys, index terms and (for S3)
+/// object key prefixes.
+pub const MAX_TENANT_ID_LEN: usize = 128;
+
+/// Tenant ids that are reserved for internal use and may never be supplied by
+/// a caller.
+///
+/// [`SYSTEM_TENANT`] is the shared-tenant sentinel. The remainder name
+/// control-plane namespaces in the S3 backend's keyspace (the sibling prefixes
+/// of `tenants/`; see `S3Keyspace` and issue #271).
+///
+/// This is the single authority: the REST tenant extractor, the `/admin/tenants`
+/// API, the web UI's tenant page, and the storage-layer tenant-lifecycle guard
+/// all consult it, so a new reserved id cannot be added to one door and
+/// forgotten on another.
+pub const RESERVED_TENANT_IDS: &[&str] =
+    &[SYSTEM_TENANT, "tenants", "resources", "history", "bulk"];
+
+/// Why a caller-supplied tenant id was rejected by [`TenantId::parse`].
+///
+/// Deliberately carries no HTTP status: mapping a rejection onto a response
+/// code depends on *which door* the id arrived at (a reserved id in a JWT claim
+/// is a different statement from one in a URL), and that is the REST layer's
+/// business. See `helios_rest::extractors::TenantExtractor`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TenantIdError {
+    /// The id was empty.
+    Empty,
+    /// The id exceeded [`MAX_TENANT_ID_LEN`].
+    TooLong {
+        /// Actual length, in bytes.
+        len: usize,
+        /// The maximum permitted length.
+        max: usize,
+    },
+    /// The id contained a character outside the permitted set.
+    InvalidChar {
+        /// The offending character.
+        ch: char,
+    },
+    /// The id is reserved for internal use (see [`RESERVED_TENANT_IDS`]).
+    Reserved {
+        /// The rejected id.
+        id: String,
+    },
+}
+
+impl fmt::Display for TenantIdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "tenant id must not be empty"),
+            Self::TooLong { len, max } => {
+                write!(f, "tenant id is {len} characters, maximum is {max}")
+            }
+            Self::InvalidChar { ch } => write!(
+                f,
+                "tenant id contains unsupported character {ch:?}; \
+                 only letters, digits, '-', '_', '.', and '/' are allowed"
+            ),
+            Self::Reserved { id } => {
+                write!(f, "tenant id {id:?} is reserved for internal use")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TenantIdError {}
+
+/// Refuses a tenant-lifecycle mutation that targets a reserved tenant.
+///
+/// This is the storage-layer backstop for issue #317. The primary control is at
+/// the REST ingress (`helios_rest::extractors::TenantExtractor`), but
+/// `register_tenant` / `deregister_tenant` / `purge_tenant_data` take a bare
+/// `&str` and are reachable from more than one handler — including, today, an
+/// unauthenticated web-UI route. Every backend calls this at the top of those
+/// three methods so no future call site can reach a destructive registry
+/// operation on the shared tenant.
+///
+/// Read operations are deliberately *not* guarded: `get_tenant(SYSTEM_TENANT)`
+/// truthfully returns `None` (the sentinel is never registered), and turning
+/// that into an error would convert a benign lookup into a 500 while adding a
+/// cleaner existence oracle rather than removing one.
+pub fn ensure_mutable_tenant(id: &str) -> StorageResult<()> {
+    if TenantId::is_reserved(id) {
+        return Err(TenantError::InvalidTenant {
+            tenant_id: TenantId::new(id),
+        }
+        .into());
+    }
+    Ok(())
+}
 
 /// An opaque tenant identifier with hierarchical namespace support.
 ///
@@ -60,6 +163,76 @@ impl TenantId {
     /// ```
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
+    }
+
+    /// Parses a **caller-supplied** tenant id, rejecting ids that are empty,
+    /// over-long, outside the permitted character set, or reserved for internal
+    /// use.
+    ///
+    /// Use this — never [`TenantId::new`] — for any id that originates outside
+    /// the process: an `X-Tenant-ID` header, a `/{tenant}/…` URL prefix, a JWT
+    /// tenant claim, or an admin-API request body. [`TenantId::new`] stays
+    /// infallible for ids the process itself authored (constants, validated
+    /// configuration, values read back from storage), which is why
+    /// `TenantContext::system()` and the ~120 terminology-server call sites are
+    /// unaffected.
+    ///
+    /// The permitted character set is `[A-Za-z0-9._/-]`, matching what the
+    /// `/admin/tenants` provisioning API has always accepted. Note that `/` is
+    /// meaningful — it is the hierarchy separator (see
+    /// [`TenantId::is_descendant_of`]) — and that URL-path tenant *routing*
+    /// accepts a narrower set still (no `.` or `/`), so a hierarchical tenant is
+    /// addressable by header or JWT claim but not as a URL prefix. That
+    /// long-standing divergence is documented, not introduced, here.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use helios_persistence::tenant::TenantId;
+    ///
+    /// assert!(TenantId::parse("acme").is_ok());
+    /// assert!(TenantId::parse("acme/research").is_ok());
+    /// assert!(TenantId::parse("__system__").is_err());
+    /// assert!(TenantId::parse("bad tenant").is_err());
+    /// ```
+    pub fn parse(id: &str) -> Result<Self, TenantIdError> {
+        if id.is_empty() {
+            return Err(TenantIdError::Empty);
+        }
+        if id.len() > MAX_TENANT_ID_LEN {
+            return Err(TenantIdError::TooLong {
+                len: id.len(),
+                max: MAX_TENANT_ID_LEN,
+            });
+        }
+        if let Some(ch) = id
+            .chars()
+            .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/')))
+        {
+            return Err(TenantIdError::InvalidChar { ch });
+        }
+        if Self::is_reserved(id) {
+            return Err(TenantIdError::Reserved { id: id.to_string() });
+        }
+        Ok(Self(id.to_string()))
+    }
+
+    /// Returns `true` if `id` is reserved for internal use and must never be
+    /// accepted from a caller.
+    ///
+    /// Matching is exact and case-sensitive, mirroring how the ids are compared
+    /// everywhere else (tenant ids are opaque and case-sensitive throughout the
+    /// storage layer, so a case-insensitive check here would reject ids that are
+    /// in fact distinct tenants).
+    ///
+    /// Only the exact reserved strings are refused, not a `__`-prefixed
+    /// namespace. A tenant id is a partition key in every backend and there is
+    /// no rename operation, so banning a prefix would strand any deployment that
+    /// already holds such a tenant — its data would keep serving while becoming
+    /// permanently impossible to deregister or purge. Reserving the wider space
+    /// is a follow-up that has to start on the provisioning path, not here.
+    pub fn is_reserved(id: &str) -> bool {
+        RESERVED_TENANT_IDS.contains(&id)
     }
 
     /// Returns the system tenant ID.
@@ -364,5 +537,108 @@ mod tests {
 
         let tenant2: TenantId = String::from("my-tenant").into();
         assert_eq!(tenant2.as_str(), "my-tenant");
+    }
+
+    // ── `parse` — the validating constructor for caller-supplied ids (#317) ──
+
+    #[test]
+    fn test_parse_accepts_ordinary_ids() {
+        for id in [
+            "acme",
+            "tenant-123",
+            "my_tenant",
+            "ABC123",
+            "a.b",
+            "acme/research",
+        ] {
+            assert!(TenantId::parse(id).is_ok(), "{id} should parse");
+        }
+    }
+
+    /// The whole point of #317: the shared-tenant sentinel must never survive
+    /// parsing of a caller-supplied id.
+    #[test]
+    fn test_parse_rejects_system_tenant() {
+        assert_eq!(
+            TenantId::parse(SYSTEM_TENANT),
+            Err(TenantIdError::Reserved {
+                id: SYSTEM_TENANT.to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_rejects_every_reserved_id() {
+        for id in RESERVED_TENANT_IDS {
+            assert!(
+                TenantId::parse(id).is_err(),
+                "reserved id {id} must not parse"
+            );
+            assert!(TenantId::is_reserved(id));
+        }
+    }
+
+    /// Reservation is exact, not a `__` namespace ban — a deployment that
+    /// already holds a `__`-prefixed tenant must keep working, because tenant id
+    /// is a partition key with no rename. Guards against someone "hardening"
+    /// this into a prefix check without a migration story.
+    #[test]
+    fn test_parse_reserves_exact_ids_not_the_underscore_namespace() {
+        assert!(TenantId::parse("__system").is_ok());
+        assert!(TenantId::parse("__system__x").is_ok());
+        assert!(TenantId::parse("__legacy").is_ok());
+        // Single-underscore tenants are a supported, separately-tested feature
+        // of URL-path routing (`/_x/Patient/123`).
+        assert!(TenantId::parse("_x").is_ok());
+    }
+
+    /// Tenant ids are opaque and case-sensitive in the storage layer, so a
+    /// differently-cased id is a genuinely different tenant, not an evasion.
+    #[test]
+    fn test_parse_reservation_is_case_sensitive() {
+        assert!(TenantId::parse("__SYSTEM__").is_ok());
+        assert!(!TenantId::is_reserved("__SYSTEM__"));
+    }
+
+    #[test]
+    fn test_parse_rejects_empty_overlong_and_bad_charset() {
+        assert_eq!(TenantId::parse(""), Err(TenantIdError::Empty));
+
+        let long = "a".repeat(MAX_TENANT_ID_LEN + 1);
+        assert_eq!(
+            TenantId::parse(&long),
+            Err(TenantIdError::TooLong {
+                len: MAX_TENANT_ID_LEN + 1,
+                max: MAX_TENANT_ID_LEN,
+            })
+        );
+        assert!(TenantId::parse(&"a".repeat(MAX_TENANT_ID_LEN)).is_ok());
+
+        for (id, ch) in [("bad tenant", ' '), ("a:b", ':'), ("a\0b", '\0')] {
+            assert_eq!(TenantId::parse(id), Err(TenantIdError::InvalidChar { ch }));
+        }
+    }
+
+    /// `new` must stay infallible: `TenantContext::system()` and the ~120
+    /// terminology-server call sites depend on constructing the sentinel
+    /// in-process.
+    #[test]
+    fn test_new_still_builds_the_system_tenant() {
+        assert_eq!(TenantId::new(SYSTEM_TENANT).as_str(), SYSTEM_TENANT);
+        assert!(TenantId::system().is_system());
+    }
+
+    // ── `ensure_mutable_tenant` — the storage-layer backstop ──
+
+    #[test]
+    fn test_ensure_mutable_tenant_refuses_reserved_ids() {
+        assert!(ensure_mutable_tenant("acme").is_ok());
+        assert!(ensure_mutable_tenant("acme/research").is_ok());
+        for id in RESERVED_TENANT_IDS {
+            assert!(
+                ensure_mutable_tenant(id).is_err(),
+                "lifecycle mutation on reserved id {id} must be refused"
+            );
+        }
     }
 }

--- a/crates/persistence/src/tenant/mod.rs
+++ b/crates/persistence/src/tenant/mod.rs
@@ -90,7 +90,10 @@ mod permissions;
 mod tenancy;
 
 pub use context::{TenantContext, TenantContextBuilder};
-pub use id::{SYSTEM_TENANT, TenantId};
+pub use id::{
+    MAX_TENANT_ID_LEN, RESERVED_TENANT_IDS, SYSTEM_TENANT, TenantId, TenantIdError,
+    ensure_mutable_tenant,
+};
 pub use permissions::{
     CompartmentRestriction, Operation, TenantPermissions, TenantPermissionsBuilder,
 };

--- a/crates/persistence/tests/multitenancy/isolation_tests.rs
+++ b/crates/persistence/tests/multitenancy/isolation_tests.rs
@@ -486,3 +486,108 @@ async fn test_hierarchical_tenant_access() {
 
     // This test documents expected hierarchical access behavior
 }
+
+// ============================================================================
+// Reserved-tenant lifecycle guard (issue #317)
+// ============================================================================
+
+/// The storage-layer backstop: the tenant-lifecycle mutators must refuse the
+/// shared system tenant regardless of which handler reached them.
+///
+/// The primary control for #317 is at the REST ingress, but these three methods
+/// take a bare `&str` and are reachable from more than one caller — including,
+/// at the time of writing, an unauthenticated web-UI route. `__system__` holds
+/// the AuditEvent trail and shared terminology, so a purge of it is an
+/// anti-forensic primitive: it destroys the record of the attack that issued it.
+///
+/// Every backend calls `ensure_mutable_tenant` at the top of these methods. This
+/// asserts it on SQLite, which is the one backend that runs without a container;
+/// the guard is a plain string check with no backend-specific behaviour, so the
+/// per-backend container tests would assert nothing further.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_system_tenant_lifecycle_mutations_are_refused() {
+    let backend = create_sqlite_backend();
+    let system = TenantContext::system();
+
+    // Seed the shared tenant the way the database audit sink does.
+    let created = backend
+        .create(
+            &system,
+            "AuditEvent",
+            json!({ "resourceType": "AuditEvent" }),
+            FhirVersion::default(),
+        )
+        .await
+        .expect("seed system-tenant AuditEvent");
+
+    let system_id = helios_persistence::tenant::SYSTEM_TENANT;
+
+    assert!(
+        backend.register_tenant(system_id, None).await.is_err(),
+        "registering the system tenant must be refused"
+    );
+    assert!(
+        backend.deregister_tenant(system_id).await.is_err(),
+        "deregistering the system tenant must be refused"
+    );
+    assert!(
+        backend.purge_tenant_data(system_id).await.is_err(),
+        "purging the system tenant must be refused"
+    );
+
+    // The data consequence: the refused purge destroyed nothing.
+    let survivor = backend
+        .read(&system, "AuditEvent", created.id())
+        .await
+        .expect("read must not error");
+    assert!(
+        survivor.is_some(),
+        "a refused purge must leave the audit trail intact"
+    );
+}
+
+/// The other reserved ids (S3 control-plane namespaces, issue #271) share the
+/// same authority and are refused identically.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_control_plane_namespace_lifecycle_mutations_are_refused() {
+    let backend = create_sqlite_backend();
+
+    for reserved in helios_persistence::tenant::RESERVED_TENANT_IDS {
+        assert!(
+            backend.register_tenant(reserved, None).await.is_err(),
+            "registering reserved id {reserved} must be refused"
+        );
+        assert!(
+            backend.purge_tenant_data(reserved).await.is_err(),
+            "purging reserved id {reserved} must be refused"
+        );
+    }
+}
+
+/// The reservation is exact, not a `__` namespace ban. A tenant id is a
+/// partition key in every backend and there is no rename, so banning the prefix
+/// would strand any deployment already holding such a tenant: its data would
+/// keep serving while becoming permanently impossible to deregister or purge.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_underscore_prefixed_tenants_remain_mutable() {
+    let backend = create_sqlite_backend();
+
+    backend
+        .register_tenant("__legacy", None)
+        .await
+        .expect("__legacy is not reserved and must remain registrable");
+    assert!(
+        backend
+            .deregister_tenant("__legacy")
+            .await
+            .expect("deregister must not error"),
+        "__legacy must remain deregisterable"
+    );
+    backend
+        .purge_tenant_data("__legacy")
+        .await
+        .expect("__legacy must remain purgeable");
+}

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -1257,6 +1257,21 @@ impl ServerConfig {
             errors.push("Default page size cannot exceed max page size".to_string());
         }
 
+        // A reserved default tenant is the isolation hole of issue #317 in
+        // configuration shape: `main.rs` auto-provisions the configured default
+        // at boot, which would materialise the sentinel in the registry, and
+        // every request that names no tenant would land in the shared tenant.
+        // Fail at startup rather than per request — a per-request rejection
+        // would be an outage with a confusing cause, and there is no sane
+        // fallback when the fallback itself is the invalid value.
+        if helios_persistence::tenant::TenantId::is_reserved(&self.default_tenant) {
+            errors.push(format!(
+                "HFS_DEFAULT_TENANT '{}' is reserved for internal use and cannot be \
+                 the default tenant",
+                self.default_tenant
+            ));
+        }
+
         if let Err(mut bulk_errors) = self.bulk_export.validate() {
             errors.append(&mut bulk_errors);
         }
@@ -1378,6 +1393,37 @@ mod tests {
     #[test]
     fn test_validate_valid() {
         let config = ServerConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    /// `HFS_DEFAULT_TENANT=__system__` is the #317 isolation hole in
+    /// configuration shape: the boot path auto-provisions the configured default,
+    /// which would put the sentinel in the registry, and every request naming no
+    /// tenant would land in the shared tenant. Fail at startup.
+    #[test]
+    fn test_validate_rejects_reserved_default_tenant() {
+        for id in helios_persistence::tenant::RESERVED_TENANT_IDS {
+            let config = ServerConfig {
+                default_tenant: id.to_string(),
+                ..Default::default()
+            };
+            let errors = config
+                .validate()
+                .expect_err("a reserved default tenant must fail startup validation");
+            assert!(
+                errors.iter().any(|e| e.contains("HFS_DEFAULT_TENANT")),
+                "expected a HFS_DEFAULT_TENANT error for {id}, got {errors:?}"
+            );
+        }
+    }
+
+    /// The reservation is exact — a merely internal-*looking* default still boots.
+    #[test]
+    fn test_validate_allows_underscore_prefixed_default_tenant() {
+        let config = ServerConfig {
+            default_tenant: "__legacy".to_string(),
+            ..Default::default()
+        };
         assert!(config.validate().is_ok());
     }
 

--- a/crates/rest/src/extractors/tenant.rs
+++ b/crates/rest/src/extractors/tenant.rs
@@ -142,6 +142,39 @@ where
     }
 }
 
+/// Refuses a tenant id that is reserved for internal use (issue #317).
+///
+/// This is the **single** place the whole REST surface enforces the reservation.
+/// `TenantExtractor::new` / `from_resolved` are constructed nowhere outside this
+/// module and `TenantResolver` is consulted nowhere else, so every request-time
+/// tenant — header, URL prefix, JWT claim, or configured default — passes
+/// through [`TenantExtractor::resolve`] and therefore through here. Enforcing it
+/// per-extractor instead would mean four denylists that must agree, which is the
+/// shape of the bug being fixed.
+///
+/// `403` rather than `400`: `__system__` is a well-formed id, and the statement
+/// being made is "you may not address this tenant", not "your request is
+/// malformed". The same status is returned regardless of which door the id
+/// arrived at, so an operator debugging a rejected client sees one behaviour.
+///
+/// The reason is logged at `WARN` with the offending id and its source, because
+/// the most likely non-attack cause is a deployment that was reading the audit
+/// trail through `X-Tenant-ID: __system__` and now needs to be repointed.
+fn reject_reserved_tenant(id: &str, source: TenantSource) -> Result<(), (StatusCode, String)> {
+    if !helios_persistence::tenant::TenantId::is_reserved(id) {
+        return Ok(());
+    }
+    tracing::warn!(
+        tenant = %id,
+        source = ?source,
+        "Rejected request naming a reserved internal tenant"
+    );
+    Err((
+        StatusCode::FORBIDDEN,
+        format!("tenant '{id}' is reserved for internal use and cannot be addressed by a request"),
+    ))
+}
+
 impl TenantExtractor {
     /// Resolves the tenant for a request from JWT claim / header / URL / default,
     /// applying strict-validation consistency checks. Provisioned-tenant
@@ -178,6 +211,11 @@ impl TenantExtractor {
                         ));
                     }
                 }
+                // A reserved id is refused even though it came from a validated
+                // token: the claim is authoritative for *which* tenant, not for
+                // whether that tenant may be addressed at all. An issuer able to
+                // set the tenant claim would otherwise reach the shared tenant.
+                reject_reserved_tenant(jwt_tenant, TenantSource::JwtClaim)?;
                 return Ok(TenantExtractor::new(
                     jwt_tenant,
                     crate::tenant::TenantSource::JwtClaim,
@@ -217,6 +255,12 @@ impl TenantExtractor {
             if config.default_tenant.is_empty() {
                 return Err((StatusCode::BAD_REQUEST, "Invalid tenant ID".to_string()));
             }
+            // `HFS_DEFAULT_TENANT` is rejected at startup by `ServerConfig::validate`,
+            // so this is unreachable in the server binary. It is kept because
+            // `AppState` can be built directly by an embedder or a test that
+            // never calls `validate()`, and collapsing to a reserved default
+            // would put every unauthenticated request in the shared tenant.
+            reject_reserved_tenant(&config.default_tenant, TenantSource::Default)?;
             return Ok(TenantExtractor::new(
                 &config.default_tenant,
                 TenantSource::Default,
@@ -244,15 +288,27 @@ impl TenantExtractor {
             return Err((StatusCode::BAD_REQUEST, "Invalid tenant ID".to_string()));
         }
 
+        // Covers the header, URL-path and (auth-disabled) JWT-claim doors in one
+        // place, plus the configured default when nothing was requested.
+        reject_reserved_tenant(resolved.tenant_id_str(), resolved.source)?;
+
         Ok(TenantExtractor::from_resolved(resolved))
     }
 }
 
 /// Rejects a resolved tenant that is not provisioned, when
 /// `HFS_TENANT_REQUIRE_PROVISIONED` is set and the backend maintains a tenant
-/// registry. The internal system tenant is always allowed; backends without a
-/// registry (mock stores, minimal deployments) are never enforced, so the
-/// common single-tenant and test configurations are unaffected.
+/// registry. Backends without a registry (mock stores, minimal deployments) are
+/// never enforced, so the common single-tenant and test configurations are
+/// unaffected.
+///
+/// This used to early-return `Ok` for the internal system tenant, which made the
+/// one control an operator can switch on useless against precisely the id it
+/// should have refused (issue #317). The exemption is gone:
+/// [`reject_reserved_tenant`] now refuses reserved ids before this runs, and the
+/// system tenant is never in the registry anyway, so a reserved id that somehow
+/// reached here would correctly fail the provisioned check rather than be waved
+/// through.
 async fn enforce_provisioned<S>(
     state: &AppState<S>,
     extractor: &TenantExtractor,
@@ -268,9 +324,6 @@ where
         return Ok(());
     }
     let id = extractor.tenant_id();
-    if id == helios_persistence::tenant::SYSTEM_TENANT {
-        return Ok(());
-    }
     match storage.get_tenant(id).await {
         Ok(Some(_)) => Ok(()),
         Ok(None) => Err((
@@ -518,6 +571,97 @@ mod tests {
                 .expect("JWT claim should win over a conflicting header in non-strict mode");
             assert_eq!(extractor.tenant_id(), "acme");
             assert_eq!(extractor.source(), TenantSource::JwtClaim);
+        }
+
+        // ── #317: the internal system tenant is not addressable from a request ──
+
+        /// Header door, auth disabled (no `Principal`) — the default deployment
+        /// shape, where this needs no credentials at all.
+        #[tokio::test]
+        async fn test_system_tenant_via_header_is_forbidden() {
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(Some(helios_persistence::tenant::SYSTEM_TENANT), None);
+
+            let err = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect_err("__system__ must not be addressable via X-Tenant-ID");
+            assert_eq!(err.0, StatusCode::FORBIDDEN);
+        }
+
+        /// JWT door. The claim is authoritative for *which* tenant, never for
+        /// whether the shared tenant may be addressed — and `JwtTenantExtractor`
+        /// validated nothing at all before this fix.
+        #[tokio::test]
+        async fn test_system_tenant_via_jwt_claim_is_forbidden() {
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(
+                None,
+                Some(make_principal(Some(
+                    helios_persistence::tenant::SYSTEM_TENANT,
+                ))),
+            );
+
+            let err = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect_err("__system__ must not be addressable via a JWT tenant claim");
+            assert_eq!(err.0, StatusCode::FORBIDDEN);
+        }
+
+        /// URL-path door. The router stores the extracted prefix in extensions,
+        /// which is what `UrlPathTenantExtractor` reads first.
+        #[tokio::test]
+        async fn test_system_tenant_via_url_path_is_forbidden() {
+            use crate::middleware::tenant_prefix::ExtractedTenantFromUrl;
+
+            let backend = Arc::new(SqliteBackend::in_memory().expect("in-memory sqlite backend"));
+            let config = ServerConfig {
+                multitenancy: MultitenancyConfig {
+                    routing_mode: TenantRoutingMode::UrlPath,
+                    ..Default::default()
+                },
+                default_tenant: "test-tenant".to_string(),
+                ..ServerConfig::for_testing()
+            };
+            let state = AppState::new(backend, config);
+
+            let mut parts = make_parts(None, None);
+            parts.extensions.insert(ExtractedTenantFromUrl(
+                helios_persistence::tenant::SYSTEM_TENANT.to_string(),
+            ));
+
+            let err = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect_err("__system__ must not be addressable via a URL prefix");
+            assert_eq!(err.0, StatusCode::FORBIDDEN);
+        }
+
+        /// The other reserved ids (the S3 control-plane namespaces) go through
+        /// the same single authority, so they are refused identically.
+        #[tokio::test]
+        async fn test_other_reserved_ids_are_forbidden_too() {
+            for &id in helios_persistence::tenant::RESERVED_TENANT_IDS {
+                let state = make_state(false, "test-tenant");
+                let mut parts = make_parts(Some(id), None);
+                let err = TenantExtractor::from_request_parts(&mut parts, &state)
+                    .await
+                    .expect_err("reserved id must be refused");
+                assert_eq!(err.0, StatusCode::FORBIDDEN, "reserved id {id}");
+            }
+        }
+
+        /// An ordinary id that merely *looks* internal is still a valid tenant:
+        /// the reservation is exact, not a `__` namespace ban, because tenant id
+        /// is a partition key with no rename.
+        #[tokio::test]
+        async fn test_underscore_prefixed_tenants_still_resolve() {
+            for id in ["__legacy", "__system", "_x"] {
+                let state = make_state(false, "test-tenant");
+                let mut parts = make_parts(Some(id), None);
+                let extractor = TenantExtractor::from_request_parts(&mut parts, &state)
+                    .await
+                    .unwrap_or_else(|e| panic!("{id} should still resolve: {e:?}"));
+                assert_eq!(extractor.tenant_id(), id);
+            }
         }
 
         #[tokio::test]

--- a/crates/rest/src/handlers/admin_tenants.rs
+++ b/crates/rest/src/handlers/admin_tenants.rs
@@ -28,7 +28,6 @@ use axum::{
 };
 use helios_audit::{AuditAction, AuditEventBuilder};
 use helios_persistence::core::ResourceStorage;
-use helios_persistence::tenant::SYSTEM_TENANT;
 use serde::Deserialize;
 use serde_json::json;
 use tracing::debug;
@@ -36,15 +35,7 @@ use tracing::debug;
 use crate::error::{RestError, RestResult};
 use crate::state::AppState;
 
-/// Maximum accepted tenant-id length. Generous, but bounds the value that flows
-/// into schema names / storage keys.
-const MAX_TENANT_ID_LEN: usize = 128;
-
-/// Tenant ids that name a control-plane namespace in a storage backend's
-/// keyspace. Currently the S3 sibling prefixes of `tenants/` (see
-/// `S3Keyspace`); `__system__` is checked separately as the shared-tenant
-/// sentinel.
-const RESERVED_TENANT_IDS: &[&str] = &["tenants", "resources", "history", "bulk"];
+use helios_persistence::tenant::{MAX_TENANT_ID_LEN, SYSTEM_TENANT, TenantId, TenantIdError};
 
 /// Request body for `POST /admin/tenants`.
 #[derive(Debug, Deserialize)]
@@ -93,51 +84,37 @@ async fn seed_new_tenant<S: ResourceStorage>(
     .await;
 }
 
-/// Validates a tenant id: non-empty, within length, no whitespace, a
-/// conservative identifier charset, and never the internal system sentinel.
+/// Validates a tenant id: non-empty, within length, a conservative identifier
+/// charset, and never a reserved internal id.
+///
+/// Delegates to [`TenantId::parse`], the single reservation authority shared
+/// with the request-time tenant extractor, the web UI's tenant page, and the
+/// storage-layer lifecycle guard. Previously this function kept its own copy of
+/// the rules, which is how the reservation came to be enforced here but not on
+/// the doors an untrusted caller actually knocks on (issue #317).
+///
+/// The wording of each rejection is preserved so the API's error messages do not
+/// change.
 fn validate_tenant_id(id: &str) -> RestResult<()> {
-    if id.is_empty() {
-        return Err(RestError::BadRequest {
-            message: "tenant id must not be empty".to_string(),
-        });
-    }
-    if id.len() > MAX_TENANT_ID_LEN {
-        return Err(RestError::BadRequest {
-            message: format!("tenant id exceeds {MAX_TENANT_ID_LEN} characters"),
-        });
-    }
-    if id == SYSTEM_TENANT {
-        return Err(RestError::BadRequest {
-            message: "'__system__' is reserved for internal shared resources".to_string(),
-        });
-    }
-    // Names that collide with a control-plane namespace in the S3 keyspace.
-    //
-    // Defense in depth and a UX guardrail only — it is *not* what makes the
-    // keyspace safe. The S3 backend is safe structurally (registry records are
-    // direct `{id}.json` children of `tenants/`, tenant data is always nested
-    // deeper), because this check is reachable from the admin API alone: the JWT
-    // tenant extractor validates nothing. See `S3Keyspace::tenant_registry_prefix`
-    // and issue #271 — do not conclude from this list that the reader-side filter
-    // is redundant.
-    if RESERVED_TENANT_IDS.contains(&id) {
-        return Err(RestError::BadRequest {
-            message: format!("'{id}' is reserved for internal use"),
-        });
-    }
-    // Allow the characters that are safe across routing (header / URL prefix /
-    // JWT claim) and storage keys: alphanumerics plus `-`, `_`, `.`, and `/`
-    // (the hierarchy separator). Reject everything else, including whitespace.
-    if !id
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/'))
-    {
-        return Err(RestError::BadRequest {
-            message: "tenant id may contain only letters, digits, '-', '_', '.', and '/'"
-                .to_string(),
-        });
-    }
-    Ok(())
+    TenantId::parse(id).map(|_| ()).map_err(|e| {
+        let message = match e {
+            TenantIdError::Empty => "tenant id must not be empty".to_string(),
+            TenantIdError::TooLong { .. } => {
+                format!("tenant id exceeds {MAX_TENANT_ID_LEN} characters")
+            }
+            TenantIdError::Reserved { id } if id == SYSTEM_TENANT => {
+                "'__system__' is reserved for internal shared resources".to_string()
+            }
+            TenantIdError::Reserved { id } => format!("'{id}' is reserved for internal use"),
+            TenantIdError::InvalidChar { .. } => {
+                "tenant id may contain only letters, digits, '-', '_', '.', and '/'".to_string()
+            }
+            // `TenantIdError` is `#[non_exhaustive]`; a variant added later falls
+            // back to its own `Display` rather than failing to compile here.
+            other => other.to_string(),
+        };
+        RestError::BadRequest { message }
+    })
 }
 
 /// `GET /admin/tenants`
@@ -280,6 +257,12 @@ where
     S: ResourceStorage + Send + Sync,
 {
     require_registry(state.storage())?;
+    // Validate BEFORE the existence probe below. `__system__` has data (the
+    // AuditEvent trail), so probing first would let a reserved id past the 404
+    // check and straight into `deregister_tenant` + `purge_tenant_data` — the
+    // create path validated but this one never did (issue #317). Validating
+    // first also means a reserved id reports 400 rather than a misleading 404.
+    validate_tenant_id(&id)?;
 
     // Establish what exists before mutating so we can 404 on a no-op and report
     // accurately. A tenant may be registered, have data, both, or neither.

--- a/crates/rest/src/handlers/console_metrics.rs
+++ b/crates/rest/src/handlers/console_metrics.rs
@@ -475,6 +475,14 @@ where
         .clamp(60, 86_400);
 
     let mut resource_counts = state.storage().count_by_tenant().await?;
+    // `count_by_tenant` is a raw cross-tenant aggregate and includes the internal
+    // system tenant, which holds the AuditEvent trail under
+    // `HFS_AUDIT_BACKEND=database`. Publishing its live row count here made the
+    // roster an audit-volume side channel and confirmed the sentinel exists.
+    // `admin_tenants::list_tenants_handler` has always filtered it; this is the
+    // same filter, applied at the other presentation site (issue #317).
+    resource_counts
+        .retain(|(tenant, _)| !helios_persistence::tenant::TenantId::is_reserved(tenant.as_str()));
     resource_counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
     let traffic = helios_observability::reqlog::per_tenant(window);

--- a/crates/rest/src/middleware/auth.rs
+++ b/crates/rest/src/middleware/auth.rs
@@ -615,6 +615,44 @@ mod tests {
         assert_eq!(op, FhirOperation::Read);
     }
 
+    /// Regression guard for the trap in the #317 fix.
+    ///
+    /// The reserved-tenant rejection MUST NOT be implemented by making
+    /// `extract_tenant_from_path` return `None` for `__system__`. If it did,
+    /// this classifier would fall through to `extract_operation` on the raw
+    /// path, which declines any first segment starting with `_` (see the
+    /// system-paths branch above) and returns `None` — meaning **the SMART scope
+    /// check is skipped entirely**. The un-stripped three-segment path then
+    /// still matches the compartment-search route, so the request reaches a
+    /// handler unauthorized. That would trade a tenant-isolation bug for an
+    /// authorization bypass.
+    ///
+    /// The rejection therefore lives in `TenantExtractor` (after stripping),
+    /// and path classification here is deliberately left unchanged.
+    #[test]
+    fn test_url_routing_reserved_tenant_still_classifies_for_scope_check() {
+        let (rt, op) =
+            extract_operation_for_routing("/__system__/Patient/123", "GET", true).unwrap();
+        assert_eq!(
+            rt, "Patient",
+            "reserved-tenant paths must still classify so the scope check runs"
+        );
+        assert_eq!(op, FhirOperation::Read);
+        // Specifically NOT the compartment reading of the un-stripped path,
+        // which would authorize against a resource type of "123".
+        assert_ne!(rt, "123");
+
+        // Same for the type-level and write paths.
+        let (rt, op) = extract_operation_for_routing("/__system__/Patient", "POST", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Create);
+
+        let (rt, op) =
+            extract_operation_for_routing("/__system__/Patient/123", "DELETE", true).unwrap();
+        assert_eq!(rt, "Patient");
+        assert_eq!(op, FhirOperation::Delete);
+    }
+
     #[test]
     fn test_url_routing_search_strips_tenant() {
         // GET /{tenant}/Patient must authorize Search on Patient, NOT the tenant.

--- a/crates/rest/src/tenant/resolver.rs
+++ b/crates/rest/src/tenant/resolver.rs
@@ -459,6 +459,39 @@ mod tests {
         assert!(!is_reserved_path("my_tenant", &version));
     }
 
+    /// The resolver deliberately still *extracts* a reserved id (#317).
+    ///
+    /// Refusal happens one layer up, in `TenantExtractor`, which is the single
+    /// door every request-time tenant passes through. Teaching the resolver (or
+    /// `is_valid_tenant_id`) to drop reserved ids instead would silently change
+    /// what the authorization classifier sees for `/__system__/Patient/123`:
+    /// with no tenant extracted it falls back to the raw path, declines the
+    /// leading `_` segment, and skips the SMART scope check altogether. See
+    /// `middleware::auth::test_url_routing_reserved_tenant_still_classifies_for_scope_check`.
+    ///
+    /// If you are here because you want to reject earlier: reject in
+    /// `TenantExtractor`, not here.
+    #[test]
+    fn test_resolver_still_extracts_reserved_ids_for_consistent_classification() {
+        use helios_persistence::tenant::SYSTEM_TENANT;
+
+        let config = MultitenancyConfig {
+            routing_mode: TenantRoutingMode::Both,
+            ..Default::default()
+        };
+        let resolver = TenantResolver::new(&config);
+
+        let parts = make_parts("/Patient/123", Some(SYSTEM_TENANT));
+        let resolved = resolver.resolve(&parts, &config, "default");
+        assert_eq!(resolved.tenant_id_str(), SYSTEM_TENANT);
+        assert_eq!(resolved.source, TenantSource::Header);
+
+        let parts = make_parts("/__system__/Patient/123", None);
+        let resolved = resolver.resolve(&parts, &config, "default");
+        assert_eq!(resolved.tenant_id_str(), SYSTEM_TENANT);
+        assert_eq!(resolved.source, TenantSource::UrlPath);
+    }
+
     #[test]
     fn test_is_valid_tenant_id() {
         assert!(is_valid_tenant_id("acme"));

--- a/crates/rest/tests/admin_tenants.rs
+++ b/crates/rest/tests/admin_tenants.rs
@@ -260,3 +260,164 @@ async fn delete_unknown_tenant_is_404() {
         .await
         .assert_status(StatusCode::NOT_FOUND);
 }
+
+// ── #317: the internal system tenant is not addressable from a request ───────
+
+/// Builds the same server as [`create_test_server`] but also hands back the
+/// backend, so a test can seed and re-read system-tenant data directly — the
+/// REST create path can no longer be used for that, which is the point.
+async fn create_test_server_with_backend() -> (TestServer, Arc<SqliteBackend>) {
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("data"))
+        .unwrap_or_else(|| PathBuf::from("data"));
+
+    let backend_config = SqliteBackendConfig {
+        data_dir: Some(data_dir),
+        ..Default::default()
+    };
+    let backend = SqliteBackend::with_config(":memory:", backend_config)
+        .expect("Failed to create SQLite backend");
+    backend.init_schema().expect("Failed to init schema");
+    let backend = Arc::new(backend);
+
+    let config = ServerConfig {
+        multitenancy: MultitenancyConfig {
+            routing_mode: TenantRoutingMode::HeaderOnly,
+            ..Default::default()
+        },
+        base_url: "http://localhost:8080".to_string(),
+        default_tenant: "default-tenant".to_string(),
+        seed_conformance: false,
+        ..ServerConfig::for_testing()
+    };
+
+    let state = helios_rest::AppState::new(Arc::clone(&backend), config);
+    let router = helios_rest::routing::fhir_routes::create_routes(state.clone())
+        .merge(helios_rest::routing::admin_tenants::routes(state));
+    (
+        TestServer::new(router).expect("Failed to create test server"),
+        backend,
+    )
+}
+
+/// Writes a resource into the system tenant the way the audit sink does — in
+/// process, with a `TenantContext::system()` — and returns its id.
+async fn seed_system_tenant_resource(backend: &Arc<SqliteBackend>) -> String {
+    use helios_persistence::core::ResourceStorage;
+    use helios_persistence::tenant::TenantContext;
+
+    let stored = backend
+        .create(
+            &TenantContext::system(),
+            "AuditEvent",
+            json!({ "resourceType": "AuditEvent" }),
+            helios_fhir::FhirVersion::R4,
+        )
+        .await
+        .expect("seed system-tenant AuditEvent");
+    stored.id().to_string()
+}
+
+async fn system_tenant_resource_count(backend: &Arc<SqliteBackend>) -> u64 {
+    use helios_persistence::core::ResourceStorage;
+    backend
+        .count_by_tenant()
+        .await
+        .expect("count_by_tenant")
+        .into_iter()
+        .find(|(t, _)| t == helios_persistence::tenant::SYSTEM_TENANT)
+        .map(|(_, n)| n)
+        .unwrap_or(0)
+}
+
+/// The header door. With auth disabled — the default deployment shape — this
+/// needed no credentials at all, and returned the cross-tenant AuditEvent trail.
+#[tokio::test]
+async fn system_tenant_is_not_readable_via_header() {
+    let (server, backend) = create_test_server_with_backend().await;
+    seed_system_tenant_resource(&backend).await;
+
+    let res = server
+        .get("/AuditEvent")
+        .add_header(TENANT_HEADER, HeaderValue::from_static("__system__"))
+        .await;
+
+    res.assert_status(StatusCode::FORBIDDEN);
+    // The data consequence, not just the status: nothing from the shared tenant
+    // came back.
+    assert!(
+        !res.text().contains("AuditEvent"),
+        "system-tenant resources must not appear in the response body"
+    );
+}
+
+/// The destructive half. `delete_tenant_handler` never validated its path id, so
+/// this deregistered *and* purged the shared tenant — destroying the audit trail
+/// that records the attack.
+#[tokio::test]
+async fn deleting_the_system_tenant_is_refused_and_purges_nothing() {
+    let (server, backend) = create_test_server_with_backend().await;
+    let seeded_id = seed_system_tenant_resource(&backend).await;
+    let before = system_tenant_resource_count(&backend).await;
+    assert!(before > 0, "precondition: system tenant has data");
+
+    // 400, not 404 — validation must run before the existence probe, or a
+    // reserved id with data would sail past it into the purge.
+    server
+        .delete("/admin/tenants/__system__?purge=true")
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+
+    // Nothing was destroyed.
+    assert_eq!(
+        system_tenant_resource_count(&backend).await,
+        before,
+        "a refused delete must not purge any system-tenant data"
+    );
+    use helios_persistence::core::ResourceStorage;
+    // `read` returns `Ok(None)` for a purged resource, so assert on the payload,
+    // not merely on `is_ok()`.
+    let survivor = backend
+        .read(
+            &helios_persistence::tenant::TenantContext::system(),
+            "AuditEvent",
+            &seeded_id,
+        )
+        .await
+        .expect("read must not error");
+    assert!(
+        survivor.is_some(),
+        "the seeded system-tenant resource must still be readable"
+    );
+}
+
+/// The other reserved ids take the same door.
+#[tokio::test]
+async fn deleting_a_control_plane_namespace_tenant_is_refused() {
+    let server = create_test_server().await;
+    for reserved in ["tenants", "resources", "history", "bulk"] {
+        server
+            .delete(&format!("/admin/tenants/{reserved}?purge=true"))
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
+    }
+}
+
+/// The reservation is exact, not a `__` namespace ban: tenant id is a partition
+/// key with no rename, so a deployment already holding `__legacy` must keep
+/// being able to route to it and, crucially, to delete it.
+#[tokio::test]
+async fn underscore_prefixed_tenants_remain_usable() {
+    let server = create_test_server().await;
+    server
+        .post("/admin/tenants")
+        .json(&json!({ "id": "__legacy" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .delete("/admin/tenants/__legacy")
+        .await
+        .assert_status(StatusCode::OK);
+}

--- a/crates/ui/src/tenants.rs
+++ b/crates/ui/src/tenants.rs
@@ -127,28 +127,30 @@ pub struct DeleteQuery {
     purge: bool,
 }
 
-const MAX_TENANT_ID_LEN: usize = 128;
-
 /// Mirrors the API's id validation so the page rejects the same inputs.
+///
+/// Delegates to [`TenantId::parse`](helios_persistence::tenant::TenantId::parse),
+/// the single reservation authority shared with the `/admin/tenants` API, the
+/// request-time tenant extractor, and the storage-layer lifecycle guard, so this
+/// page cannot drift from them (issue #317).
 fn validate_id(id: &str) -> Result<(), String> {
-    if id.is_empty() {
-        return Err("Tenant id must not be empty.".to_string());
-    }
-    if id.len() > MAX_TENANT_ID_LEN {
-        return Err(format!("Tenant id exceeds {MAX_TENANT_ID_LEN} characters."));
-    }
-    if id == helios_persistence::tenant::SYSTEM_TENANT {
-        return Err("That id is reserved for internal shared resources.".to_string());
-    }
-    if !id
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/'))
-    {
-        return Err(
-            "Tenant id may contain only letters, digits, '-', '_', '.', and '/'.".to_string(),
-        );
-    }
-    Ok(())
+    use helios_persistence::tenant::{MAX_TENANT_ID_LEN, TenantId, TenantIdError};
+
+    TenantId::parse(id).map(|_| ()).map_err(|e| match e {
+        TenantIdError::Empty => "Tenant id must not be empty.".to_string(),
+        TenantIdError::TooLong { .. } => {
+            format!("Tenant id exceeds {MAX_TENANT_ID_LEN} characters.")
+        }
+        TenantIdError::Reserved { .. } => {
+            "That id is reserved for internal shared resources.".to_string()
+        }
+        TenantIdError::InvalidChar { .. } => {
+            "Tenant id may contain only letters, digits, '-', '_', '.', and '/'.".to_string()
+        }
+        // `TenantIdError` is `#[non_exhaustive]`; a variant added later falls
+        // back to its own `Display` rather than failing to compile here.
+        other => other.to_string(),
+    })
 }
 
 /// Builds the tenant rows from the registry joined with live per-tenant counts,
@@ -355,6 +357,21 @@ pub async fn delete(
         )
             .into_response();
     };
+
+    // Refuse reserved ids before touching the registry. This route is destructive
+    // (`?purge=true` permanently deletes the tenant's data) and, unlike the
+    // `/admin/tenants` API, it validated nothing — so `DELETE
+    // /ui/tenants/__system__?purge=true` would have wiped the AuditEvent trail
+    // and shared terminology (issue #317).
+    //
+    // This closes the reserved-id hole only. The separate, known question of
+    // `/ui/*` being mounted outside the auth layer is deliberately untouched
+    // here; the storage-layer guard in `helios-persistence` backs this up
+    // regardless of how the route is reached.
+    if let Err(message) = validate_id(&id) {
+        let rows = load_rows(storage, "").await.unwrap_or_default();
+        return rows_response(i18n, rows, Some(message));
+    }
 
     let _ = storage.deregister_tenant(&id).await;
     if query.purge {

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -384,3 +384,71 @@ async fn tenant_choice_persists_and_the_selector_follows_it() {
         .unwrap();
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
+
+/// This route is destructive and — unlike `/admin/tenants` — is mounted outside
+/// the auth layer, so before #317 an unauthenticated
+/// `DELETE /ui/tenants/__system__?purge=true` wiped the AuditEvent trail and the
+/// shared terminology. It now refuses reserved ids.
+///
+/// This closes the reserved-id hole only; whether `/ui/*` should be
+/// authenticated at all is a separate, deliberately untouched question.
+#[tokio::test]
+async fn delete_refuses_the_reserved_system_tenant() {
+    let store = store();
+
+    // Seed the shared tenant the way the database audit sink does.
+    let system = TenantContext::system();
+    let created = store
+        .create(
+            &system,
+            "AuditEvent",
+            serde_json::json!({ "resourceType": "AuditEvent" }),
+            FhirVersion::R4,
+        )
+        .await
+        .expect("seed system-tenant AuditEvent");
+
+    let res = app(&store)
+        .oneshot(
+            Request::delete("/ui/tenants/__system__?purge=true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // The page reports the refusal in its error banner rather than 500-ing.
+    let body = body_text(res).await;
+    assert!(
+        body.contains("form-error"),
+        "the refusal must surface as an error banner, got: {body}"
+    );
+
+    // The data consequence: nothing was purged.
+    let survivor = store
+        .read(&system, "AuditEvent", created.id())
+        .await
+        .expect("read must not error");
+    assert!(
+        survivor.is_some(),
+        "a refused purge must leave the audit trail intact"
+    );
+}
+
+/// The reservation is exact, so an ordinary `__`-prefixed tenant is still fully
+/// manageable from this page.
+#[tokio::test]
+async fn delete_still_accepts_underscore_prefixed_tenants() {
+    let store = store();
+    post_form(&store, "id=__legacy").await;
+
+    let res = app(&store)
+        .oneshot(
+            Request::delete("/ui/tenants/__legacy?purge=true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}


### PR DESCRIPTION
Closes #317.

## The problem

`__system__` was reachable from the network via all three request-time ingress points — the `X-Tenant-ID` header, a `/{tenant}/…` URL prefix, and the JWT tenant claim — while `admin_tenants::validate_tenant_id` carefully rejected the same id. The reservation was on the write door, not the doors an untrusted caller knocks on.

**This is live, not theoretical.** No backend filters the system tenant on the read path, and with `HFS_AUDIT_BACKEND=database` the audit sink writes every `AuditEvent` under `TenantContext::system()` (`crates/hfs/src/main.rs:203`). So `X-Tenant-ID: __system__` + `GET /AuditEvent` returned the cross-tenant audit trail on SQLite, Postgres and MongoDB. Auth is off by default, so the header and URL vectors needed no credentials.

## Approach

**One authority.** `TenantId::parse` (helios-persistence) now owns the rules — charset, length, and `RESERVED_TENANT_IDS` (the sentinel plus the S3 control-plane names from #271). `TenantId::new` stays infallible, so `TenantContext::system()` and the ~120 terminology-server call sites are untouched. `/admin/tenants` and the UI tenant page delegate to it instead of keeping their own copies — that duplication is how the rules came to disagree.

**One choke point.** `TenantExtractor::new`/`from_resolved` are constructed nowhere outside `extractors/tenant.rs`, and `TenantResolver` is consulted nowhere else, so every request-time tenant flows through `TenantExtractor::resolve`. The refusal lives there — covering header, URL, JWT and the configured default — and returns **403**: the id is well-formed; the statement is "you may not address this tenant".

**Purely additive.** No `FromStr`/`Deserialize` change. `release.toml` sets `shared-version = true`, so turning `Err = Infallible` into a real error would drag all 18 crates to 0.3.0 — and there are zero `.parse::<TenantId>()` call sites to benefit.

## The trap this deliberately avoids

The obvious fix — making `extract_tenant_from_path` return `None` for a reserved id — converts a tenant-isolation bug into an **authorization bypass**. `extract_operation_for_routing` would fall through to the raw path, `extract_operation` declines any `_`-prefixed first segment (`middleware/auth.rs:367`), and the SMART scope check is skipped entirely; the un-stripped three-segment path then still matches the compartment-search route. Path parsing is therefore left exactly as-is, and `test_url_routing_reserved_tenant_still_classifies_for_scope_check` pins it.

## Also closed (found tracing the same reservation)

| | |
|---|---|
| `delete_tenant_handler` never validated its path id | `DELETE /admin/tenants/__system__?purge=true` deregistered **and purged** the shared tenant — destroying the audit trail recording the attack. Validation now runs *before* the existence probe, so it's `400`, not a misleading `404`. |
| UI `DELETE /ui/tenants/{id}` validated nothing | Now refuses reserved ids. **Reserved-id hole only** — whether `/ui/*` should sit behind auth is a separate, known question and is deliberately untouched here. |
| `enforce_provisioned` waved `__system__` through | Made the one control an operator can enable useless against the id it should refuse. Exemption removed. |
| `HFS_DEFAULT_TENANT=__system__` | Same hole in config shape — boot auto-provisions the default. Now a startup error. |
| `/console/metrics/tenants` | Published the sentinel with a live row count (an audit-volume side channel). `admin_tenants` already filtered it; now both do. |

## All DBs

`register_tenant` / `deregister_tenant` / `purge_tenant_data` take a bare `&str` and are reachable from more than one handler, so **sqlite, postgres, mongodb, s3, elasticsearch and composite** each call `ensure_mutable_tenant` first (16 sites).

**No schema change, no migration, no backfill** — the guard is a string check ahead of the statement, and the `__system__` rows that exist are legitimate data that stays readable and writable.

## Exact string, not a `__` prefix ban

The issue suggested reserving the whole sentinel space. A tenant id is a **partition key with no rename** in every backend, so a prefix ban would strand a deployment already holding e.g. `__legacy`: its data would keep serving while becoming permanently impossible to deregister or purge — hardening turned into data loss. Reserving the wider space must start on the *provisioning* path after a release of startup warnings. Tests pin that `__legacy` / `__system` / `_x` still work.

## Operator-facing change

> **Breaking (security): `__system__` is no longer addressable from the network.** Requests naming it via `X-Tenant-ID`, a `/__system__/…` URL prefix, or a JWT tenant claim are rejected `403`; tenant-lifecycle calls against it are rejected too. It remains the internal storage tenant for AuditEvents, shared terminology and health probes — nothing about how those are stored changes, only who may address them over HTTP. **If you read audit events over the API using `X-Tenant-ID: __system__`, that stops working** — read the audit store directly or configure a dedicated audit backend (`HFS_AUDIT_*`). `HFS_DEFAULT_TENANT=__system__` is now a startup error.

## CI

`audit-events.yml` read audit events through the very vector being closed (`shared` mode, `X-Tenant-ID: __system__`). That arm now reads the audit store directly, exactly as the `dedicated` and S3 arms always have — same assertion, no dependence on a path that must now be refused. Not skipped, not weakened.

## Tests

- **Trap regression** — reserved-tenant paths still classify for the scope check.
- **Three ingress doors** + all reserved ids + `__`-prefixed still-works, at the extractor.
- **Resolver** — documents that it still *extracts* reserved ids on purpose (rejection is one layer up), so nobody "fixes" it and reintroduces the trap.
- **Destructive paths** — admin and UI delete refused, asserting the *data* consequence (seeded system-tenant AuditEvent survives), not just the status.
- **Persistence** — lifecycle mutators refused on SQLite; the guard is backend-agnostic, so container tests for pg/mongo/es/s3 would assert nothing further.
- **Config** — reserved default tenant fails startup.

## Not verified locally

No C linker in this environment, so nothing was compiled or run — CI is the only signal. Draft until it's green.

## Follow-ups (not in scope)

- Reserving the `__` namespace forward-only at provisioning, with startup warnings first.
- The routing-vs-provisioning charset/length divergence (64 + no `./` vs 128 + `./`), which makes a tenant provisioned as `a/b` unroutable by URL. Changing accepted-charset semantics doesn't belong in a security fix.
- `/ui/*` being mounted outside the auth layer.
