### PR TITLE
fix(search): _summary=count implies an accurate total

### DIFF
--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -112,6 +112,11 @@ pub fn build_search_query(
     // Process _summary
     if let Some(summary) = params.get("_summary") {
         query.summary = parse_summary_mode(summary);
+        // `_summary=count` exists to return Bundle.total and nothing else, so
+        // it implies an accurate total; an explicit `_total` still wins (#254).
+        if query.summary == Some(SummaryMode::Count) && query.total.is_none() {
+            query.total = Some(TotalMode::Accurate);
+        }
     }
 
     // Process _elements

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -2534,3 +2534,46 @@ mod contained_search {
         );
     }
 }
+
+mod summary_count {
+    use super::*;
+
+    /// #254: `_summary=count` exists to return `Bundle.total`, so it implies
+    /// an accurate total without the client also sending `_total=accurate`.
+    #[tokio::test]
+    async fn test_summary_count_implies_accurate_total() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_summary=count")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status_ok();
+        let body: Value = response.json();
+        assert!(
+            body["total"].is_u64(),
+            "count mode must carry the count: {body}"
+        );
+        assert!(body["total"].as_u64().unwrap() > 0);
+        assert!(
+            body.get("entry").is_none(),
+            "count mode returns no entries: {body}"
+        );
+    }
+
+    /// An explicit `_total` still wins over the implication.
+    #[tokio::test]
+    async fn test_summary_count_respects_explicit_total_none() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_summary=count&_total=none")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        response.assert_status_ok();
+        let body: Value = response.json();
+        assert!(body["total"].is_null(), "explicit _total=none wins: {body}");
+    }
+}


### PR DESCRIPTION
Closes #254

The count-only short-circuit in the search handler already returned a total-only Bundle, but the backends only compute `Bundle.total` when the query carries `TotalMode::Accurate` — so `GET /Patient?_summary=count` returned `total: null`, the one field the mode exists for.

One-line semantic fix in the query builder: `_summary=count` implies an accurate total; an explicit `_total` (e.g. `none`) still wins.

Two regression tests: the implication (numeric total, no entries) and the explicit-override precedence. search_integration 101 green; fmt clean.