### PR TITLE
fix(persistence,rest): scope PHI-bearing user settings per tenant so a purge can reach them (#313)

### DIFF
--- a/.claude/skills/run-hfs-server/SKILL.md
+++ b/.claude/skills/run-hfs-server/SKILL.md
@@ -140,9 +140,36 @@ rules to the FHIR prefixes.
 ## Per-user UI settings
 
 `GET`/`PUT`/`PATCH /_user/settings` stores an opaque, per-user JSON document (UI
-theme, default tenant, recent queries). It is keyed by user only, never by tenant.
-Responses carry a weak `ETag` (`W/"{version}"`); clients may send `If-Match` on a
-write for optimistic concurrency.
+theme, default tenant, saved and recent queries). It is keyed by user only, never
+by tenant. Responses carry a weak `ETag` (`W/"{version}"`); clients may send
+`If-Match` on a write for optimistic concurrency.
+
+### Tenant scoping inside the document (#313)
+
+The row is keyed by user, but most of what a client stores is derived from one
+*tenant's* data — a saved query like `Patient?name=smith&birthdate=1970-01-01` is
+a PHI-bearing string. Those keys are therefore stored under a reserved `byTenant`
+map so `purge_tenant_data` can reach them; only `theme`, `nav`, `fhirVersion` and
+`tenantId` stay user-global.
+
+**The wire format is unchanged** — the server projects on read and scopes on
+write, so clients still see a flat document and need no changes. Two operational
+consequences:
+
+- **Saved queries and recent searches now change when a user switches tenants.**
+  That is the intended semantics (a query saved against `acme` is meaningless in
+  `beta`), but it will be reported as "my queries disappeared" if unannounced.
+- **Deleting a tenant with `?purge=true` now also erases that tenant's saved and
+  recent queries from every user's settings document**, on all four backends and
+  through both the `/admin/tenants` API and the `/ui/tenants` page. The document
+  itself survives — it holds other tenants' content and the user's global
+  preferences — and its `version` is bumped, so a client holding a stale `ETag`
+  gets a `412` and re-reads rather than writing the purged content back.
+
+A document written before this existed keeps working: it is still readable, the
+first write files its keys under the tenant it recorded in `tenantId` (or the
+writing tenant if it never recorded one), and a purge sweeps any that remain
+unattributed. Sending `byTenant` in a request body is rejected with `422`.
 
 Supported on the **SQLite, PostgreSQL, MongoDB, and S3** backends. Elasticsearch is
 search-only and never a standalone primary, so an Elasticsearch-only deployment

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -16,8 +16,8 @@ use serde_json::Value;
 use crate::core::{
     BundleEntry, BundleEntryResult, BundleMethod, BundleProvider, BundleResult, BundleType,
     HistoryEntry, HistoryMethod, HistoryPage, HistoryParams, InstanceHistoryProvider,
-    PurgableStorage, ResourceStorage, SystemHistoryProvider, TypeHistoryProvider, VersionedStorage,
-    bundle_if_match_gate, if_match_field_satisfied, normalize_etag,
+    PurgableStorage, ResourceStorage, SettingsStore, SystemHistoryProvider, TypeHistoryProvider,
+    VersionedStorage, bundle_if_match_gate, if_match_field_satisfied, normalize_etag,
 };
 use crate::error::{
     BackendError, ConcurrencyError, ResourceError, StorageError, StorageResult, TransactionError,
@@ -1558,6 +1558,17 @@ impl ResourceStorage for MongoBackend {
                 .delete_many(doc! { "tenant_id": id })
                 .await
                 .map_err(|e| internal_error(format!("purge delete ({}): {}", collection, e)))?;
+        }
+        // Per-user settings are keyed by user, not tenant, so the deletes above
+        // do not reach them — but a client stores PHI-derived query strings in
+        // them, which belong to this tenant (issue #313).
+        let settings = SettingsStore::purge_tenant_settings(self, id).await?;
+        if settings > 0 {
+            tracing::info!(
+                tenant = %id,
+                documents = settings,
+                "purged tenant-scoped content from user settings documents"
+            );
         }
         Ok(removed)
     }

--- a/crates/persistence/src/backends/mongodb/user_settings.rs
+++ b/crates/persistence/src/backends/mongodb/user_settings.rs
@@ -25,7 +25,9 @@ use mongodb::bson::{Document, doc};
 use mongodb::error::Error as MongoError;
 use serde_json::Value;
 
-use crate::core::user_settings::{SettingsStore, StoredUserSettings, apply_merge_patch};
+use crate::core::user_settings::{
+    SettingsStore, StoredUserSettings, apply_merge_patch, purge_tenant_subtree,
+};
 use crate::error::{BackendError, ConcurrencyError, StorageError, StorageResult};
 
 use super::MongoBackend;
@@ -239,6 +241,109 @@ impl SettingsStore for MongoBackend {
         .await
         .map_err(|e| backend_err(format!("delete user_settings: {e}")))?;
         Ok(result.deleted_count > 0)
+    }
+
+    /// Sweeps `tenant_id` out of every settings document.
+    ///
+    /// MongoDB standalone has no multi-document transactions, so — exactly as
+    /// [`write_settings`](MongoBackend::write_settings) does — each document is
+    /// rewritten with a **version-conditioned update**, and a document whose
+    /// version moved under us is re-read and re-swept. A concurrent
+    /// `/_user/settings` write therefore cannot be clobbered, and cannot slip a
+    /// purged subtree back in either: it either lands before the sweep (and is
+    /// then swept) or after it (and finds the subtree already gone).
+    ///
+    /// Deliberately **not** a `$unset` of the dotted path `byTenant.<id>`:
+    /// MongoDB has no escape for `.` in a field path, and
+    /// `admin_tenants::validate_tenant_id` permits tenant ids containing `.`, so
+    /// a tenant named `a.b` would have `$unset` target `byTenant.a` → `b` — the
+    /// wrong node, silently. Editing the parsed document with the shared
+    /// [`purge_tenant_subtree`] is both correct here and identical to the other
+    /// three backends.
+    async fn purge_tenant_settings(&self, tenant_id: &str) -> StorageResult<u64> {
+        let db = self.get_database().await?;
+        let collection = db.collection::<Document>(USER_SETTINGS_COLLECTION);
+
+        // Collect the keys first rather than editing while the cursor is open:
+        // each edit is its own version-conditioned update, and a long-lived
+        // cursor over a collection being written to can miss or repeat documents.
+        let mut cursor = collection
+            .find(doc! {})
+            .await
+            .map_err(|e| backend_err(format!("scan user_settings: {e}")))?;
+        let mut user_keys: Vec<String> = Vec::new();
+        while cursor
+            .advance()
+            .await
+            .map_err(|e| backend_err(format!("scan user_settings: {e}")))?
+        {
+            let stored = cursor
+                .deserialize_current()
+                .map_err(|e| backend_err(format!("decode user_settings: {e}")))?;
+            if let Ok(user_key) = stored.get_str("user_key") {
+                user_keys.push(user_key.to_string());
+            }
+        }
+
+        let mut changed = 0u64;
+        for user_key in user_keys {
+            let user_key = user_key.as_str();
+            for _ in 0..=MAX_WRITE_RETRIES {
+                // Re-read on every attempt after the first so a lost race is
+                // resolved against current state rather than the stale snapshot.
+                let current = retry_transient(|| async {
+                    collection.find_one(doc! { "user_key": user_key }).await
+                })
+                .await
+                .map_err(|e| backend_err(format!("read user_settings: {e}")))?;
+                let Some(current) = current else {
+                    // Deleted underneath us — nothing left to purge.
+                    break;
+                };
+
+                let version = current.get_i64("version").unwrap_or(0);
+                // A document this backend cannot decode is skipped rather than
+                // aborting the tenant purge; one corrupt row must not block an
+                // offboarding.
+                let Ok(mut document) = decode_document(&current) else {
+                    tracing::warn!(
+                        "skipping undecodable user_settings document during tenant purge; \
+                         it cannot hold tenant-scoped content this purge could reach"
+                    );
+                    break;
+                };
+                if !purge_tenant_subtree(&mut document, tenant_id) {
+                    break;
+                }
+
+                let data = serde_json::to_string(&document)
+                    .map_err(|e| backend_err(format!("encode user_settings: {e}")))?;
+                let now = Utc::now();
+                let now_bson = mongodb::bson::DateTime::from_millis(now.timestamp_millis());
+                let next_version = version + 1;
+                let result = retry_transient(|| async {
+                    collection
+                        .update_one(
+                            doc! { "user_key": user_key, "version": version },
+                            doc! { "$set": {
+                                "data": &data,
+                                "version": next_version,
+                                "updated_at": now_bson,
+                            }},
+                        )
+                        .await
+                })
+                .await
+                .map_err(|e| backend_err(format!("purge user_settings: {e}")))?;
+
+                if result.matched_count == 1 {
+                    changed += 1;
+                    break;
+                }
+                // Version moved under us: loop and re-sweep the new content.
+            }
+        }
+        Ok(changed)
     }
 }
 

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -833,9 +833,21 @@ impl ResourceStorage for PostgresBackend {
                 .await
                 .map_err(|e| internal_error(format!("purge delete: {e}")))?;
         }
+        // Per-user settings are keyed by user, not tenant, so they are not swept
+        // by the deletes above — but a client stores PHI-derived query strings in
+        // them, which belong to this tenant (issue #313). Same transaction, so an
+        // offboarding cannot half-apply.
+        let settings = PostgresBackend::purge_tenant_settings_in_txn(&tx, id).await?;
         tx.commit()
             .await
             .map_err(|e| internal_error(format!("purge commit: {e}")))?;
+        if settings > 0 {
+            tracing::info!(
+                tenant = %id,
+                documents = settings,
+                "purged tenant-scoped content from user settings documents"
+            );
+        }
         Ok(removed.max(0) as u64)
     }
 }

--- a/crates/persistence/src/backends/postgres/user_settings.rs
+++ b/crates/persistence/src/backends/postgres/user_settings.rs
@@ -10,7 +10,9 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 
-use crate::core::user_settings::{SettingsStore, StoredUserSettings, apply_merge_patch};
+use crate::core::user_settings::{
+    SettingsStore, StoredUserSettings, apply_merge_patch, purge_tenant_subtree,
+};
 use crate::error::{BackendError, ConcurrencyError, StorageError, StorageResult};
 
 use super::PostgresBackend;
@@ -83,6 +85,53 @@ impl PostgresBackend {
             updated_at: now,
         })
     }
+
+    /// Sweeps `tenant_id` out of every settings document **using the caller's
+    /// transaction**, returning how many documents changed.
+    ///
+    /// Takes the transaction so the sweep commits atomically with the resource
+    /// deletes in
+    /// [`purge_tenant_data`](crate::core::ResourceStorage::purge_tenant_data):
+    /// an offboarding must not be able to half-apply, leaving a tenant's saved
+    /// queries behind after its records are gone. `FOR UPDATE` serialises against
+    /// a concurrent `/_user/settings` write, which locks the same rows.
+    ///
+    /// The edit is done on a parsed `Value` via the shared
+    /// [`purge_tenant_subtree`] rather than with `jsonb #-`, for two reasons: all
+    /// four backends then erase byte-identically, and a JSONB text path would
+    /// need care for tenant ids containing `.` or `/`, both of which
+    /// `admin_tenants::validate_tenant_id` permits.
+    pub(crate) async fn purge_tenant_settings_in_txn(
+        txn: &deadpool_postgres::Transaction<'_>,
+        tenant_id: &str,
+    ) -> StorageResult<u64> {
+        let rows = txn
+            .query(
+                "SELECT user_key, data, version FROM user_settings FOR UPDATE",
+                &[],
+            )
+            .await
+            .map_err(|e| backend_err(format!("scan user_settings: {e}")))?;
+
+        let mut changed = 0u64;
+        for row in rows {
+            let user_key: String = row.get(0);
+            let mut document: Value = row.get(1);
+            let version: i64 = row.get(2);
+            if !purge_tenant_subtree(&mut document, tenant_id) {
+                continue;
+            }
+            txn.execute(
+                "UPDATE user_settings SET data = $2, version = $3, updated_at = $4 \
+                 WHERE user_key = $1",
+                &[&user_key, &document, &(version + 1), &Utc::now()],
+            )
+            .await
+            .map_err(|e| backend_err(format!("purge user_settings: {e}")))?;
+            changed += 1;
+        }
+        Ok(changed)
+    }
 }
 
 #[async_trait]
@@ -145,6 +194,19 @@ impl SettingsStore for PostgresBackend {
             .await
             .map_err(|e| backend_err(format!("delete user_settings: {e}")))?;
         Ok(removed > 0)
+    }
+
+    async fn purge_tenant_settings(&self, tenant_id: &str) -> StorageResult<u64> {
+        let mut client = self.get_client().await?;
+        let txn = client
+            .transaction()
+            .await
+            .map_err(|e| backend_err(format!("begin user_settings purge: {e}")))?;
+        let changed = Self::purge_tenant_settings_in_txn(&txn, tenant_id).await?;
+        txn.commit()
+            .await
+            .map_err(|e| backend_err(format!("commit user_settings purge: {e}")))?;
+        Ok(changed)
     }
 }
 

--- a/crates/persistence/src/backends/s3/keyspace.rs
+++ b/crates/persistence/src/backends/s3/keyspace.rs
@@ -312,8 +312,34 @@ impl S3Keyspace {
     /// In particular, a future change that widened a tenant purge to sweep the
     /// whole tenant prefix would break the structural argument above and must
     /// exclude this namespace explicitly.
+    ///
+    /// # What a tenant purge *does* reach
+    ///
+    /// The paragraph above says a tenant purge cannot **delete** these objects,
+    /// and that remains true and deliberate: they are user-global, and one
+    /// tenant's offboarding must not destroy a user's theme or their other
+    /// tenants' saved queries. Since issue #313 a purge instead **edits** each
+    /// object, removing the `byTenant.{tenant}` subtree from the document inside
+    /// (see [`user_settings_prefix`](Self::user_settings_prefix) and
+    /// `crate::core::user_settings::purge_tenant_subtree`). The object survives;
+    /// the purged tenant's content in it does not.
     pub fn user_settings_key(&self, object_id: &str) -> String {
         self.join(&["_system.user-settings", &format!("{object_id}.json")])
+    }
+
+    /// Prefix covering every per-user settings object.
+    ///
+    /// Used only by the tenant-settings purge (issue #313), which must visit
+    /// every user's document to remove the offboarded tenant's subtree — the
+    /// settings store is keyed by an opaque digest of the user key, so there is
+    /// no way to select the affected documents other than listing them.
+    ///
+    /// Structurally disjoint from every tenant's keyspace, by the same argument
+    /// as [`user_settings_key`](Self::user_settings_key): a tenant's objects live
+    /// under `resources/`, `history/` or `bulk/` sub-prefixes of its own segment,
+    /// so listing this prefix can never return one.
+    pub fn user_settings_prefix(&self) -> String {
+        self.join(&["_system.user-settings/"])
     }
 
     /// Joins `parts` with `/`, prepending the base prefix when set.

--- a/crates/persistence/src/backends/s3/storage.rs
+++ b/crates/persistence/src/backends/s3/storage.rs
@@ -1136,6 +1136,20 @@ impl ResourceStorage for S3Backend {
                     .map_err(|e| self.map_client_error(e))?;
             }
         }
+        // Per-user settings live outside every tenant prefix (they are
+        // user-global), so the sweep above structurally cannot reach them — see
+        // `S3Keyspace::user_settings_key`. They nonetheless hold PHI-derived
+        // query strings belonging to this tenant, so each object is *edited* to
+        // drop this tenant's subtree (issue #313). Never deleted: the same object
+        // holds other tenants' content and the user's global preferences.
+        let settings = crate::core::SettingsStore::purge_tenant_settings(self, id).await?;
+        if settings > 0 {
+            tracing::info!(
+                tenant = %id,
+                objects = settings,
+                "purged tenant-scoped content from user settings objects"
+            );
+        }
         Ok(removed)
     }
 }

--- a/crates/persistence/src/backends/s3/user_settings.rs
+++ b/crates/persistence/src/backends/s3/user_settings.rs
@@ -47,7 +47,9 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::core::user_settings::{SettingsStore, StoredUserSettings, apply_merge_patch};
+use crate::core::user_settings::{
+    SettingsStore, StoredUserSettings, apply_merge_patch, purge_tenant_subtree,
+};
 use crate::error::{BackendError, ConcurrencyError, StorageError, StorageResult};
 
 use super::backend::{S3Backend, TenantLocation};
@@ -401,6 +403,124 @@ impl SettingsStore for S3Backend {
             .map_err(|e| context("delete user_settings", self.map_client_error(e)))?;
 
         Ok(existed)
+    }
+
+    /// Sweeps `tenant_id` out of every settings object, returning how many
+    /// changed.
+    ///
+    /// The objects are named by an opaque digest of the user key, so the only way
+    /// to reach the affected ones is to list the whole namespace — a tenant purge
+    /// therefore costs one `LIST` plus a `GET`/`PUT` per settings object. That is
+    /// acceptable for an administrative offboarding, and is the price of keeping
+    /// user identifiers out of S3 key names.
+    ///
+    /// Each object is rewritten with the same **compare-and-swap** the ordinary
+    /// write path uses — pinned to the S3 ETag it was read at — so a concurrent
+    /// `/_user/settings` write is never clobbered, and cannot reinstate a purged
+    /// subtree either: it either lands before the sweep (and is swept) or after it
+    /// (and finds the subtree already gone). A lost race is retried against fresh
+    /// state; exhausting the bound is an error rather than a silent skip, because
+    /// a settings object quietly left un-purged is exactly the gap this closes.
+    ///
+    /// Objects are **edited, never deleted**: they are user-global, and one
+    /// tenant's offboarding must not destroy another tenant's saved queries or a
+    /// user's theme.
+    async fn purge_tenant_settings(&self, tenant_id: &str) -> StorageResult<u64> {
+        // Bucket-per-tenant with no system bucket cannot host settings at all
+        // (`supports_user_settings`), so there is nothing to sweep.
+        if !self.supports_user_settings() {
+            return Ok(0);
+        }
+        let location = self.settings_location()?;
+        let bucket = location.bucket.as_str();
+        let prefix = location.keyspace.user_settings_prefix();
+
+        let objects = self.list_objects_all(bucket, &prefix).await?;
+        let mut changed = 0u64;
+
+        for item in objects {
+            let mut attempt = 0usize;
+            loop {
+                if attempt >= MAX_WRITE_ATTEMPTS {
+                    // Surfaced, not skipped: a settings object quietly left
+                    // un-purged is exactly the erasure gap this closes, so the
+                    // operator must be told the offboarding was incomplete.
+                    return Err(StorageError::Concurrency(
+                        ConcurrencyError::OptimisticLockFailure {
+                            resource_type: "UserSettings".to_string(),
+                            id: item.key.clone(),
+                            expected_etag: "W/\"*\"".to_string(),
+                            actual_etag: None,
+                        },
+                    ));
+                }
+                if attempt > 0 {
+                    tokio::time::sleep(retry_backoff(attempt - 1)).await;
+                }
+                attempt += 1;
+
+                let loaded = self
+                    .get_json_object::<SettingsObject>(bucket, &item.key)
+                    .await
+                    .map_err(|e| context("read user_settings", e))?;
+                let Some((stored, metadata)) = loaded else {
+                    // Deleted underneath us — nothing left to purge.
+                    break;
+                };
+                let Some(etag) = metadata.etag else {
+                    return Err(StorageError::Backend(BackendError::Internal {
+                        backend_name: "s3".to_string(),
+                        message: format!(
+                            "S3 returned no ETag for user_settings object {}; refusing an \
+                             unconditional write during a tenant purge",
+                            item.key
+                        ),
+                        source: None,
+                    }));
+                };
+
+                let mut document = stored.document;
+                if !purge_tenant_subtree(&mut document, tenant_id) {
+                    break;
+                }
+
+                let updated = SettingsObject {
+                    user_key: stored.user_key,
+                    document,
+                    version: stored.version + 1,
+                    updated_at: Utc::now(),
+                };
+                let payload = self.serialize_json(&updated)?;
+                match self
+                    .client
+                    .put_object(
+                        bucket,
+                        &item.key,
+                        payload,
+                        Some("application/json"),
+                        Some(&etag),
+                        None,
+                    )
+                    .await
+                {
+                    Ok(_) => {
+                        changed += 1;
+                        break;
+                    }
+                    // Lost the compare-and-swap (or the object vanished under an
+                    // `If-Match`, which some S3-compatible stores answer 404):
+                    // re-read and re-sweep.
+                    Err(S3ClientError::PreconditionFailed) | Err(S3ClientError::NotFound) => {
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(context("purge user_settings", self.map_client_error(e)));
+                    }
+                }
+            }
+        }
+
+        Ok(changed)
     }
 }
 

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -888,8 +888,21 @@ impl ResourceStorage for SqliteBackend {
             tx.execute(sql, params![id])
                 .map_err(|e| internal_error(format!("purge delete: {e}")))?;
         }
+        // Per-user settings are keyed by user, not tenant, so they are not swept
+        // by the deletes above — but a client stores PHI-derived query strings in
+        // them, which belong to this tenant (issue #313). Same transaction: this
+        // connection already holds the write lock, and a second one would
+        // deadlock against it.
+        let settings = SqliteBackend::purge_tenant_settings_in_txn(&tx, id)?;
         tx.commit()
             .map_err(|e| internal_error(format!("purge commit: {e}")))?;
+        if settings > 0 {
+            tracing::info!(
+                tenant = %id,
+                documents = settings,
+                "purged tenant-scoped content from user settings documents"
+            );
+        }
         Ok(removed.max(0) as u64)
     }
 }

--- a/crates/persistence/src/backends/sqlite/user_settings.rs
+++ b/crates/persistence/src/backends/sqlite/user_settings.rs
@@ -7,10 +7,12 @@
 
 use async_trait::async_trait;
 use chrono::Utc;
-use rusqlite::{OptionalExtension, params};
+use rusqlite::{OptionalExtension, Transaction, params};
 use serde_json::Value;
 
-use crate::core::user_settings::{SettingsStore, StoredUserSettings, apply_merge_patch};
+use crate::core::user_settings::{
+    SettingsStore, StoredUserSettings, apply_merge_patch, purge_tenant_subtree,
+};
 use crate::error::{BackendError, ConcurrencyError, StorageError, StorageResult};
 
 use super::SqliteBackend;
@@ -82,6 +84,67 @@ impl SqliteBackend {
             updated_at: now,
         })
     }
+
+    /// Sweeps `tenant_id` out of every settings document **using the caller's
+    /// transaction**, returning how many documents changed.
+    ///
+    /// Taking the transaction rather than opening one is not a style choice:
+    /// [`purge_tenant_data`](crate::core::ResourceStorage::purge_tenant_data)
+    /// calls this while already holding a write transaction on a pooled
+    /// connection. Acquiring a *second* connection here and beginning a second
+    /// write transaction would have the purge deadlock against itself with
+    /// `SQLITE_BUSY`, since SQLite permits only one writer.
+    ///
+    /// The document edit itself is [`purge_tenant_subtree`], shared with the
+    /// other three backends so all four erase identically.
+    pub(crate) fn purge_tenant_settings_in_txn(
+        txn: &Transaction<'_>,
+        tenant_id: &str,
+    ) -> StorageResult<u64> {
+        let mut select = txn
+            .prepare("SELECT user_key, data, version FROM user_settings")
+            .map_err(|e| backend_err(format!("scan user_settings: {e}")))?;
+        let rows = select
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            })
+            .map_err(|e| backend_err(format!("scan user_settings: {e}")))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| backend_err(format!("scan user_settings: {e}")))?;
+        drop(select);
+
+        let mut changed = 0u64;
+        for (user_key, data, version) in rows {
+            // A row this backend cannot decode is skipped rather than aborting
+            // the whole tenant purge: one corrupt settings document must not
+            // block an offboarding. `get_settings` still surfaces it as an error
+            // to the user who owns it.
+            let Ok(mut document) = serde_json::from_slice::<Value>(&data) else {
+                tracing::warn!(
+                    "skipping undecodable user_settings row during tenant purge; \
+                     it cannot hold tenant-scoped content this purge could reach"
+                );
+                continue;
+            };
+            if !purge_tenant_subtree(&mut document, tenant_id) {
+                continue;
+            }
+            let encoded = serde_json::to_vec(&document)
+                .map_err(|e| backend_err(format!("encode user_settings: {e}")))?;
+            txn.execute(
+                "UPDATE user_settings SET data = ?2, version = ?3, updated_at = ?4 \
+                 WHERE user_key = ?1",
+                params![user_key, encoded, version + 1, Utc::now().to_rfc3339()],
+            )
+            .map_err(|e| backend_err(format!("purge user_settings: {e}")))?;
+            changed += 1;
+        }
+        Ok(changed)
+    }
 }
 
 #[async_trait]
@@ -144,6 +207,17 @@ impl SettingsStore for SqliteBackend {
             .execute("DELETE FROM user_settings WHERE user_key = ?1", [user_key])
             .map_err(|e| backend_err(format!("delete user_settings: {e}")))?;
         Ok(removed > 0)
+    }
+
+    async fn purge_tenant_settings(&self, tenant_id: &str) -> StorageResult<u64> {
+        let mut conn = self.get_connection()?;
+        let txn = conn
+            .transaction()
+            .map_err(|e| backend_err(format!("begin user_settings purge: {e}")))?;
+        let changed = Self::purge_tenant_settings_in_txn(&txn, tenant_id)?;
+        txn.commit()
+            .map_err(|e| backend_err(format!("commit user_settings purge: {e}")))?;
+        Ok(changed)
     }
 }
 
@@ -333,6 +407,227 @@ mod tests {
         }
         let err = backend.get_settings("corrupt").await.unwrap_err();
         assert!(matches!(err, StorageError::Backend(_)));
+    }
+
+    // ── Tenant purge of settings documents (issue #313) ─────────────────────
+
+    /// The core guarantee: after purging a tenant, its subtree is gone from every
+    /// user's document while the other tenants' and the globals survive.
+    #[tokio::test]
+    async fn purge_tenant_settings_removes_only_that_tenants_subtree() {
+        let backend = backend();
+        backend
+            .put_settings(
+                "alice",
+                json!({
+                    "theme": "dark",
+                    "byTenant": {
+                        "acme": {"savedQueries": {"Patient": {"q": {"query": "name=smith"}}}},
+                        "beta": {"savedQueries": {"Patient": {"q": {"query": "name=jones"}}}}
+                    }
+                }),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(backend.purge_tenant_settings("acme").await.unwrap(), 1);
+
+        let stored = backend.get_settings("alice").await.unwrap().unwrap();
+        assert_eq!(stored.document["theme"], "dark");
+        assert!(stored.document["byTenant"].get("acme").is_none());
+        assert_eq!(
+            stored.document["byTenant"]["beta"]["savedQueries"]["Patient"]["q"]["query"],
+            "name=jones"
+        );
+        assert!(
+            !serde_json::to_string(&stored.document)
+                .unwrap()
+                .contains("smith")
+        );
+    }
+
+    /// Every user's document is swept, not just the caller's — offboarding is
+    /// server-wide.
+    #[tokio::test]
+    async fn purge_tenant_settings_sweeps_every_user() {
+        let backend = backend();
+        for user in ["alice", "bob", "carol"] {
+            backend
+                .put_settings(
+                    user,
+                    json!({"byTenant": {"acme": {"savedQueries": {"Patient": {"q": {}}}}}}),
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(backend.purge_tenant_settings("acme").await.unwrap(), 3);
+        for user in ["alice", "bob", "carol"] {
+            let stored = backend.get_settings(user).await.unwrap().unwrap();
+            assert_eq!(stored.document, json!({}));
+        }
+    }
+
+    /// The version must bump, or a client holding a stale ETag could `PUT` the
+    /// purged content straight back with an `If-Match` that still validates.
+    #[tokio::test]
+    async fn purge_tenant_settings_bumps_the_version() {
+        let backend = backend();
+        let before = backend
+            .put_settings(
+                "alice",
+                json!({"byTenant": {"acme": {"savedQueries": {}}}}),
+                None,
+            )
+            .await
+            .unwrap();
+
+        backend.purge_tenant_settings("acme").await.unwrap();
+
+        let after = backend.get_settings("alice").await.unwrap().unwrap();
+        assert_eq!(after.version, before.version + 1);
+        // The pre-purge version is now stale, so a conditional write is rejected.
+        assert!(
+            backend
+                .put_settings("alice", json!({"x": 1}), Some(before.version))
+                .await
+                .is_err()
+        );
+    }
+
+    /// A document with nothing for the purged tenant is left completely alone —
+    /// no wasted write, no needlessly invalidated ETag.
+    #[tokio::test]
+    async fn purge_tenant_settings_leaves_untouched_documents_at_their_version() {
+        let backend = backend();
+        let before = backend
+            .put_settings("alice", json!({"theme": "dark"}), None)
+            .await
+            .unwrap();
+        assert_eq!(backend.purge_tenant_settings("beta").await.unwrap(), 0);
+        let after = backend.get_settings("alice").await.unwrap().unwrap();
+        assert_eq!(after.version, before.version);
+    }
+
+    /// Documents written before scoping existed are still reachable: an
+    /// unattributed one is swept by any tenant purge, an attributed one only by
+    /// its own. This is the erasure gap #313 exists to close.
+    #[tokio::test]
+    async fn purge_tenant_settings_reaches_pre_scoping_documents() {
+        let backend = backend();
+        backend
+            .put_settings(
+                "unattributed",
+                json!({"theme": "dark", "savedQueries": {"Patient": {"q": {"query": "name=smith"}}}}),
+                None,
+            )
+            .await
+            .unwrap();
+        backend
+            .put_settings(
+                "attributed",
+                json!({"tenantId": "beta", "savedQueries": {"Patient": {"q": {"query": "name=jones"}}}}),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(backend.purge_tenant_settings("acme").await.unwrap(), 1);
+
+        let swept = backend.get_settings("unattributed").await.unwrap().unwrap();
+        assert_eq!(swept.document, json!({"theme": "dark"}));
+        // Attributed to beta, so an acme purge must not touch it.
+        let kept = backend.get_settings("attributed").await.unwrap().unwrap();
+        assert_eq!(
+            kept.document["savedQueries"]["Patient"]["q"]["query"],
+            "name=jones"
+        );
+
+        // …but beta's own purge does.
+        assert_eq!(backend.purge_tenant_settings("beta").await.unwrap(), 1);
+        let kept = backend.get_settings("attributed").await.unwrap().unwrap();
+        assert!(kept.document.get("savedQueries").is_none());
+    }
+
+    /// One undecodable row must not abort an offboarding.
+    #[tokio::test]
+    async fn purge_tenant_settings_skips_a_corrupt_row() {
+        let backend = backend();
+        {
+            let conn = backend.get_connection().unwrap();
+            conn.execute(
+                "INSERT INTO user_settings (user_key, data, version, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![
+                    "corrupt",
+                    b"not json".as_slice(),
+                    1_i64,
+                    "2020-01-01T00:00:00Z"
+                ],
+            )
+            .unwrap();
+        }
+        backend
+            .put_settings(
+                "alice",
+                json!({"byTenant": {"acme": {"savedQueries": {}}}}),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(backend.purge_tenant_settings("acme").await.unwrap(), 1);
+        assert_eq!(
+            backend
+                .get_settings("alice")
+                .await
+                .unwrap()
+                .unwrap()
+                .document,
+            json!({})
+        );
+    }
+
+    /// The purge is wired into `purge_tenant_data`, so an offboarding through the
+    /// admin API or the UI reaches settings without either call site having to
+    /// remember. That single choke point is the point of the hook.
+    #[tokio::test]
+    async fn purge_tenant_data_also_purges_settings() {
+        use crate::core::ResourceStorage;
+
+        let backend = backend();
+        backend
+            .put_settings(
+                "alice",
+                json!({
+                    "theme": "dark",
+                    "byTenant": {"acme": {"savedQueries": {"Patient": {"q": {"query": "name=smith"}}}}}
+                }),
+                None,
+            )
+            .await
+            .unwrap();
+
+        backend.purge_tenant_data("acme").await.unwrap();
+
+        let stored = backend.get_settings("alice").await.unwrap().unwrap();
+        assert_eq!(stored.document, json!({"theme": "dark"}));
+        assert!(
+            !serde_json::to_string(&stored.document)
+                .unwrap()
+                .contains("smith")
+        );
+    }
+
+    /// Purging a tenant with no data at all still completes and leaves settings
+    /// alone — the empty-store path a fresh deployment hits.
+    #[tokio::test]
+    async fn purge_tenant_data_on_an_empty_store_is_a_no_op() {
+        use crate::core::ResourceStorage;
+
+        let backend = backend();
+        assert_eq!(backend.purge_tenant_data("nobody").await.unwrap(), 0);
     }
 
     #[tokio::test]

--- a/crates/persistence/src/core/mod.rs
+++ b/crates/persistence/src/core/mod.rs
@@ -164,5 +164,8 @@ pub use transaction::{
     BundleEntry, BundleEntryResult, BundleMethod, BundleProvider, BundleResult, BundleType,
     IsolationLevel, LockingStrategy, Transaction, TransactionOptions, TransactionProvider,
 };
-pub use user_settings::{SettingsStore, StoredUserSettings, apply_merge_patch};
+pub use user_settings::{
+    BY_TENANT_KEY, GLOBAL_SETTINGS_KEYS, SettingsStore, StoredUserSettings, apply_merge_patch,
+    normalize_legacy, project_for_tenant, purge_tenant_subtree, scope_merge_patch, stored_for_put,
+};
 pub use versioned::{VersionConflictInfo, VersionedStorage, check_version_match, normalize_etag};

--- a/crates/persistence/src/core/user_settings.rs
+++ b/crates/persistence/src/core/user_settings.rs
@@ -17,14 +17,66 @@
 //! - **Opaque and extensible.** The document is stored as an arbitrary
 //!   [`serde_json::Value`] object, so new settings keys require no schema or
 //!   code changes — the frontend owns the document shape.
-//! - **User-global.** Settings are keyed by user only, not by tenant: a
-//!   preference like "default tenant" is inherently cross-tenant. Settings that
-//!   genuinely need per-tenant scoping should nest inside the document (e.g.
-//!   `{"perTenant": {"<tenant>": {...}}}`) rather than changing the key.
+//! - **Keyed by user, scoped by tenant *inside* the document.** The document is
+//!   keyed by user only — a preference like "default tenant" is inherently
+//!   cross-tenant, and the key must stay tenant-free for it to roam. But most of
+//!   what a client stores is *derived from one tenant's data*: a saved FHIR query
+//!   such as `Patient?name=smith&birthdate=1970-01-01` is a PHI-bearing string
+//!   belonging to the tenant it was written against. Those keys therefore live
+//!   under a reserved [`BY_TENANT_KEY`] map so a tenant purge can reach them.
+//!   See [the scoping section](#tenant-scoping-within-the-document).
 //! - **Optimistically lockable.** Each document carries a monotonic `version`
 //!   that increments on every write and is surfaced to clients as a weak ETag
 //!   (`W/"{version}"`). Callers may pass `if_match_version` to make a write
 //!   conditional and avoid lost updates.
+//!
+//! # Tenant scoping within the document
+//!
+//! The **wire format is flat** and unchanged: a client `GET`s, `PUT`s and
+//! `PATCH`es a plain object with `theme`, `savedQueries`, … at the top level. The
+//! REST layer projects and scopes on the way through, so no client — including
+//! ones this project does not ship — has to know about the layout below.
+//!
+//! The **stored format** separates the two lifetimes:
+//!
+//! ```json
+//! {
+//!   "theme": "dark",              // user-global: roams across tenants
+//!   "fhirVersion": "R4",          // user-global
+//!   "byTenant": {
+//!     "acme": { "savedQueries": { "Patient": { … } }, "recentSearches": [ … ] },
+//!     "beta": { "savedQueries": { … } }
+//!   }
+//! }
+//! ```
+//!
+//! [`GLOBAL_SETTINGS_KEYS`] is the *complete* list of top-level keys that stay
+//! user-global — deliberately a denylist rather than an allowlist of scoped keys.
+//! A client key the server has never heard of is scoped by default, so a future
+//! key holding PHI-derived content is covered without anyone remembering to add
+//! it here. The cost of getting it wrong in this direction is that a preference
+//! resets once per tenant; the cost in the other direction is unreachable PHI,
+//! which is the whole point of this design (issue #313).
+//!
+//! ## Documents written before scoping existed
+//!
+//! A pre-#313 document has its scoped keys at the top level with no
+//! [`BY_TENANT_KEY`] map. Such a document is *attributed* to its `tenantId` key
+//! (the tenant the UI was pointed at, and therefore the tenant those queries were
+//! written against) when that names a tenant, and is otherwise **unattributed**.
+//!
+//! - [`project_for_tenant`] shows a legacy document's scoped keys to its
+//!   attributed tenant, or — when unattributed — to every tenant, exactly
+//!   reproducing the pre-#313 user-global behaviour until the document is
+//!   normalized. Reads never rewrite: `GET` stays side-effect-free.
+//! - [`normalize_legacy`] runs on the first **write**, moving those keys under
+//!   `byTenant.{attribution}`.
+//! - [`purge_tenant_subtree`] removes an *unattributed* legacy document's scoped
+//!   keys on **any** tenant purge. That is deliberate: unattributed PHI cannot be
+//!   proven to belong to another tenant, and leaving it behind is the exact gap
+//!   this design closes. A saved-query list is convenience state that a user can
+//!   recreate; unreachable PHI is not. After the first purge the store is fully
+//!   attributed and this branch stops firing.
 //!
 //! # Document conventions
 //!
@@ -76,9 +128,310 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::error::StorageResult;
+
+/// The reserved top-level key holding the per-tenant subtrees of a stored
+/// settings document.
+///
+/// This key is **never** accepted from a client: the REST layer rejects a
+/// request body carrying it. If it were writable, a caller scoped to one tenant
+/// could plant (or read back) content under another tenant's subtree, turning
+/// this scoping into the cross-user leak that issue #270 closed.
+pub const BY_TENANT_KEY: &str = "byTenant";
+
+/// The complete set of top-level keys that stay **user-global**. Every other
+/// top-level key is tenant-scoped.
+///
+/// These are exactly the keys the server itself reads or writes, and each is a
+/// preference that must roam across tenants for the UI to behave:
+///
+/// | Key | Written by | Why it is global |
+/// |-----|------------|------------------|
+/// | `theme` | `crates/ui/assets/theme.js` | a user's light/dark choice is not tenant state |
+/// | `nav` | `crates/ui/assets/nav.js` | sidebar collapsed/expanded, ditto |
+/// | `fhirVersion` | `helios_ui::set_version` | the version selector, read by `resolve_prefs` |
+/// | `tenantId` | `helios_ui::set_tenant` | **the tenant selector itself** — scoping this per tenant would make it unreadable before a tenant is known |
+///
+/// Adding a key here removes it from a tenant purge's reach, so it must be a
+/// preference that provably cannot carry data derived from a tenant's records.
+pub const GLOBAL_SETTINGS_KEYS: &[&str] = &["theme", "nav", "fhirVersion", "tenantId"];
+
+/// The `tenantId` key, read to attribute a pre-#313 document to a tenant.
+const TENANT_CHOICE_KEY: &str = "tenantId";
+
+/// Whether a top-level settings key is user-global (as opposed to tenant-scoped).
+///
+/// [`BY_TENANT_KEY`] itself is structural rather than global — it is neither
+/// projected to a client nor swept by a purge of some other tenant — so it is
+/// handled separately by every caller and answers `false` here.
+fn is_global_key(key: &str) -> bool {
+    GLOBAL_SETTINGS_KEYS.contains(&key)
+}
+
+/// Borrows a document as an object, or an empty one for any non-object value.
+///
+/// A stored document is always an object (the REST layer rejects anything else),
+/// but the store is schema-less and this module must not panic on a hand-edited
+/// or corrupt row.
+fn as_object(value: &Value) -> Map<String, Value> {
+    match value {
+        Value::Object(map) => map.clone(),
+        _ => Map::new(),
+    }
+}
+
+/// The tenant a pre-#313 (un-normalized) document's top-level scoped keys belong
+/// to, taken from its `tenantId` preference.
+///
+/// `None` means *unattributed*: the user never used the tenant selector, so the
+/// server has no evidence of which tenant those keys came from. See the module
+/// docs for how each operation treats that case.
+fn legacy_attribution(document: &Value) -> Option<&str> {
+    document
+        .get(TENANT_CHOICE_KEY)
+        .and_then(Value::as_str)
+        .filter(|choice| !choice.is_empty())
+}
+
+/// Whether `document` still carries tenant-scoped keys at the top level, i.e.
+/// was written before this scoping existed.
+fn has_legacy_scoped_keys(document: &Value) -> bool {
+    as_object(document)
+        .keys()
+        .any(|key| key != BY_TENANT_KEY && !is_global_key(key))
+}
+
+/// Projects a stored document into the flat, client-facing view for `tenant`.
+///
+/// The result is the shape every client has always seen: user-global keys and
+/// this tenant's scoped keys, side by side at the top level, with no
+/// [`BY_TENANT_KEY`] map. **Exactly one** tenant subtree is ever projected, so a
+/// caller scoped to one tenant can never observe another's.
+///
+/// A pre-#313 document's top-level scoped keys are projected when the document is
+/// attributed to `tenant`, or when it is unattributed (preserving the pre-#313
+/// user-global behaviour until a write normalizes it). This is a pure function:
+/// reads never rewrite the store.
+pub fn project_for_tenant(document: &Value, tenant: &str) -> Value {
+    let stored = as_object(document);
+    let mut out = Map::new();
+
+    let show_legacy = legacy_attribution(document).is_none_or(|owner| owner == tenant);
+    for (key, value) in &stored {
+        if key == BY_TENANT_KEY {
+            continue;
+        }
+        if is_global_key(key) || show_legacy {
+            out.insert(key.clone(), value.clone());
+        }
+    }
+
+    // This tenant's subtree wins over any legacy key of the same name: it is the
+    // normalized, authoritative copy.
+    if let Some(subtree) = stored
+        .get(BY_TENANT_KEY)
+        .and_then(Value::as_object)
+        .and_then(|by_tenant| by_tenant.get(tenant))
+        .and_then(Value::as_object)
+    {
+        for (key, value) in subtree {
+            out.insert(key.clone(), value.clone());
+        }
+    }
+
+    Value::Object(out)
+}
+
+/// Moves a pre-#313 document's top-level scoped keys under
+/// `byTenant.{attribution}`, where `attribution` is the document's own
+/// `tenantId` when it has one and `writing_tenant` otherwise.
+///
+/// Returns `true` when the document was changed. Idempotent: a document that has
+/// already been normalized has no top-level scoped keys left to move.
+///
+/// Called on the **write** path only. Attribution prefers the document's own
+/// `tenantId` so a user who has switched tenants does not have queries written
+/// against tenant A silently re-filed under tenant B.
+pub fn normalize_legacy(document: &mut Value, writing_tenant: &str) -> bool {
+    if !has_legacy_scoped_keys(document) {
+        return false;
+    }
+    let owner = legacy_attribution(document)
+        .unwrap_or(writing_tenant)
+        .to_string();
+
+    let stored = as_object(document);
+    let mut globals = Map::new();
+    let mut moved = Map::new();
+    let mut by_tenant = stored
+        .get(BY_TENANT_KEY)
+        .map(|value| as_object(value))
+        .unwrap_or_default();
+
+    for (key, value) in stored {
+        if key == BY_TENANT_KEY {
+            continue;
+        }
+        if is_global_key(&key) {
+            globals.insert(key, value);
+        } else {
+            moved.insert(key, value);
+        }
+    }
+
+    // An existing subtree wins: it is the normalized copy, and the legacy key is
+    // the stale one it superseded.
+    let subtree = by_tenant
+        .entry(owner)
+        .or_insert_with(|| Value::Object(Map::new()));
+    let mut merged = as_object(subtree);
+    for (key, value) in moved {
+        merged.entry(key).or_insert(value);
+    }
+    *subtree = Value::Object(merged);
+
+    globals.insert(BY_TENANT_KEY.to_string(), Value::Object(by_tenant));
+    *document = Value::Object(globals);
+    true
+}
+
+/// Builds the stored document for a `PUT` of the flat `incoming` view by `tenant`.
+///
+/// `PUT` replaces the document the client can *see*, which is exactly
+/// [`project_for_tenant`]'s output — so it replaces the user-global keys and this
+/// tenant's subtree, and **leaves every other tenant's subtree untouched**. A
+/// naive whole-document replace would destroy them.
+///
+/// `current` is normalized first, so a legacy document's scoped keys are filed
+/// under their attributed tenant rather than silently dropped by the replace.
+pub fn stored_for_put(current: &Value, incoming: Value, tenant: &str) -> Value {
+    let mut base = current.clone();
+    normalize_legacy(&mut base, tenant);
+
+    let mut by_tenant = as_object(&base)
+        .get(BY_TENANT_KEY)
+        .map(|value| as_object(value))
+        .unwrap_or_default();
+
+    let mut globals = Map::new();
+    let mut scoped = Map::new();
+    for (key, value) in as_object(&incoming) {
+        // A client body carrying `byTenant` is rejected upstream; drop it here
+        // too so this function is safe for any caller.
+        if key == BY_TENANT_KEY {
+            continue;
+        }
+        if is_global_key(&key) {
+            globals.insert(key, value);
+        } else {
+            scoped.insert(key, value);
+        }
+    }
+
+    if scoped.is_empty() {
+        by_tenant.remove(tenant);
+    } else {
+        by_tenant.insert(tenant.to_string(), Value::Object(scoped));
+    }
+    if !by_tenant.is_empty() {
+        globals.insert(BY_TENANT_KEY.to_string(), Value::Object(by_tenant));
+    }
+    Value::Object(globals)
+}
+
+/// Rewrites a flat [RFC 7386](https://www.rfc-editor.org/rfc/rfc7386) merge-patch
+/// so its tenant-scoped members apply to `tenant`'s subtree.
+///
+/// Wrapping — rather than rewriting member by member — preserves merge-patch
+/// semantics exactly, including `null` deletion: a patch of
+/// `{"savedQueries": {"Patient": {"id": null}}}` becomes
+/// `{"byTenant": {"acme": {"savedQueries": {"Patient": {"id": null}}}}}`, which
+/// deletes the same single entry and nothing else.
+pub fn scope_merge_patch(patch: Value, tenant: &str) -> Value {
+    let mut globals = Map::new();
+    let mut scoped = Map::new();
+    for (key, value) in as_object(&patch) {
+        if key == BY_TENANT_KEY {
+            continue;
+        }
+        if is_global_key(&key) {
+            globals.insert(key, value);
+        } else {
+            scoped.insert(key, value);
+        }
+    }
+    if !scoped.is_empty() {
+        let mut by_tenant = Map::new();
+        by_tenant.insert(tenant.to_string(), Value::Object(scoped));
+        globals.insert(BY_TENANT_KEY.to_string(), Value::Object(by_tenant));
+    }
+    Value::Object(globals)
+}
+
+/// Removes everything belonging to `tenant` from a stored settings document,
+/// in place. Returns `true` when the document was changed.
+///
+/// Removes two things:
+///
+/// 1. `byTenant.{tenant}` — the normalized subtree. Always, and only, that one
+///    key: other tenants' subtrees and every user-global key survive.
+/// 2. A pre-#313 document's top-level scoped keys, when the document is
+///    attributed to `tenant` **or is unattributed**.
+///
+/// The unattributed case is the deliberate choice recorded in the module docs:
+/// such content cannot be proven to belong to another tenant, and leaving it is
+/// the erasure gap this exists to close. It is bounded — only tenant-scoped keys,
+/// never a user-global preference, never another tenant's subtree — and
+/// self-limiting, since the first purge leaves the store fully attributed.
+pub fn purge_tenant_subtree(document: &mut Value, tenant: &str) -> bool {
+    let mut stored = as_object(document);
+    let mut changed = false;
+
+    // Attribution is read up front, as an owned value: it comes from `tenantId`,
+    // a user-global key that neither removal below touches, so the order is
+    // immaterial — but taking it first keeps the two edits independent.
+    let owner = legacy_attribution(document).map(str::to_string);
+
+    // 1. The normalized subtree. Exactly this one key: `Map::remove` is an exact
+    //    match, so a sibling whose id merely starts with `tenant` is untouched.
+    let mut drop_empty_map = false;
+    if let Some(Value::Object(by_tenant)) = stored.get_mut(BY_TENANT_KEY) {
+        if by_tenant.remove(tenant).is_some() {
+            changed = true;
+            // Only tidy away a map this call emptied. An already-empty one is
+            // left alone so a purge that found nothing stays a true no-op and
+            // does not burn a version (and a client's ETag) for cosmetics.
+            drop_empty_map = by_tenant.is_empty();
+        }
+    }
+    if drop_empty_map {
+        stored.remove(BY_TENANT_KEY);
+    }
+
+    // 2. A pre-#313 document's top-level scoped keys, when this tenant owns them
+    //    or nobody does.
+    if owner.as_deref().is_none_or(|owner| owner == tenant) {
+        let doomed: Vec<String> = stored
+            .keys()
+            .filter(|key| {
+                let key = key.as_str();
+                key != BY_TENANT_KEY && !is_global_key(key)
+            })
+            .cloned()
+            .collect();
+        for key in doomed {
+            stored.remove(&key);
+            changed = true;
+        }
+    }
+
+    if changed {
+        *document = Value::Object(stored);
+    }
+    changed
+}
 
 /// A stored per-user settings document together with its optimistic-lock
 /// version and last-modified timestamp.
@@ -148,6 +501,32 @@ pub trait SettingsStore: Send + Sync {
     /// that a user's stored preferences — which may include recent FHIR search
     /// strings — are erasable at all.
     async fn delete_settings(&self, user_key: &str) -> StorageResult<bool>;
+
+    /// Removes everything belonging to `tenant_id` from **every** stored settings
+    /// document, returning how many documents were changed.
+    ///
+    /// This is the tenant-offboarding half of the erasure story (issue #313).
+    /// Settings are keyed by user, not tenant, so
+    /// [`purge_tenant_data`](crate::core::ResourceStorage::purge_tenant_data)
+    /// could not otherwise reach the PHI-derived query strings a client stores —
+    /// a saved `Patient?name=…&birthdate=…` is derived from one tenant's records
+    /// even though the document holding it is user-global.
+    ///
+    /// Every implementation applies [`purge_tenant_subtree`] to each document, so
+    /// all four backends erase byte-identically; a backend's only freedom is how
+    /// it enumerates and writes back. Each changed document's `version` is bumped
+    /// so a client holding a stale `ETag` is forced to re-read rather than being
+    /// able to `PUT` the purged content straight back.
+    ///
+    /// This is deliberately a purpose-built sweep rather than a general
+    /// "enumerate every user" primitive: nothing else needs to list users, and
+    /// adding that surface would invite exactly the cross-user access this store
+    /// spent issue #270 closing.
+    ///
+    /// Callers do not invoke this directly — every backend's `purge_tenant_data`
+    /// runs it as part of the purge, so there is one choke point rather than one
+    /// per call site.
+    async fn purge_tenant_settings(&self, tenant_id: &str) -> StorageResult<u64>;
 }
 
 /// Applies an [RFC 7386](https://www.rfc-editor.org/rfc/rfc7386) JSON Merge
@@ -223,5 +602,421 @@ mod tests {
         let target = json!("not-an-object");
         let patch = json!({"theme": "dark"});
         assert_eq!(apply_merge_patch(target, &patch), json!({"theme": "dark"}));
+    }
+
+    // ── Tenant scoping within the document (issue #313) ─────────────────────
+
+    /// A normalized document projects globals plus exactly one tenant's subtree.
+    #[test]
+    fn projection_shows_one_tenant_and_hides_the_reserved_key() {
+        let stored = json!({
+            "theme": "dark",
+            "byTenant": {
+                "acme": {"savedQueries": {"Patient": {"q1": {"query": "name=smith"}}}},
+                "beta": {"savedQueries": {"Patient": {"q2": {"query": "name=jones"}}}}
+            }
+        });
+        assert_eq!(
+            project_for_tenant(&stored, "acme"),
+            json!({"theme": "dark", "savedQueries": {"Patient": {"q1": {"query": "name=smith"}}}})
+        );
+    }
+
+    /// The reserved key is never visible on the wire, and another tenant's
+    /// content is never projected — the leak the scoping exists to prevent.
+    #[test]
+    fn projection_never_leaks_another_tenants_subtree() {
+        let stored = json!({
+            "byTenant": {"acme": {"savedQueries": {"Patient": {"secret": {"query": "name=smith"}}}}}
+        });
+        let seen = project_for_tenant(&stored, "beta");
+        assert_eq!(seen, json!({}));
+        assert!(seen.get(BY_TENANT_KEY).is_none());
+        assert!(!serde_json::to_string(&seen).unwrap().contains("smith"));
+    }
+
+    /// A tenant with no subtree sees only the globals.
+    #[test]
+    fn projection_for_unknown_tenant_returns_globals_only() {
+        let stored = json!({"theme": "dark", "byTenant": {"acme": {"savedQueries": {}}}});
+        assert_eq!(
+            project_for_tenant(&stored, "beta"),
+            json!({"theme": "dark"})
+        );
+    }
+
+    /// A legacy document attributed by `tenantId` shows its scoped keys to that
+    /// tenant only.
+    #[test]
+    fn projection_of_attributed_legacy_document_is_scoped_to_its_owner() {
+        let legacy = json!({
+            "theme": "dark",
+            "tenantId": "acme",
+            "savedQueries": {"Patient": {"q1": {"query": "name=smith"}}}
+        });
+        let owner = project_for_tenant(&legacy, "acme");
+        assert_eq!(
+            owner["savedQueries"]["Patient"]["q1"]["query"],
+            "name=smith"
+        );
+
+        let other = project_for_tenant(&legacy, "beta");
+        assert!(other.get("savedQueries").is_none());
+        assert_eq!(other["tenantId"], "acme", "globals still roam");
+    }
+
+    /// An unattributed legacy document keeps its pre-#313 user-global behaviour
+    /// until a write normalizes it — nobody's settings vanish on upgrade.
+    #[test]
+    fn projection_of_unattributed_legacy_document_is_visible_everywhere() {
+        let legacy = json!({"savedQueries": {"Patient": {"q1": {"query": "name=smith"}}}});
+        for tenant in ["acme", "beta"] {
+            assert_eq!(
+                project_for_tenant(&legacy, tenant)["savedQueries"]["Patient"]["q1"]["query"],
+                "name=smith"
+            );
+        }
+    }
+
+    /// A normalized subtree supersedes a same-named legacy key.
+    #[test]
+    fn projection_prefers_the_normalized_subtree_over_a_legacy_key() {
+        let stored = json!({
+            "savedQueries": {"Patient": {"old": {}}},
+            "byTenant": {"acme": {"savedQueries": {"Patient": {"new": {}}}}}
+        });
+        assert_eq!(
+            project_for_tenant(&stored, "acme")["savedQueries"],
+            json!({"Patient": {"new": {}}})
+        );
+    }
+
+    /// Normalization files legacy keys under the document's own `tenantId`, not
+    /// under whichever tenant happens to be writing.
+    #[test]
+    fn normalize_prefers_the_documents_own_attribution() {
+        let mut doc = json!({
+            "theme": "dark",
+            "tenantId": "acme",
+            "savedQueries": {"Patient": {"q1": {}}}
+        });
+        assert!(normalize_legacy(&mut doc, "beta"));
+        assert_eq!(
+            doc,
+            json!({
+                "theme": "dark",
+                "tenantId": "acme",
+                "byTenant": {"acme": {"savedQueries": {"Patient": {"q1": {}}}}}
+            })
+        );
+    }
+
+    /// With no attribution, the writing tenant is the best available evidence.
+    #[test]
+    fn normalize_falls_back_to_the_writing_tenant() {
+        let mut doc = json!({"savedQueries": {"Patient": {"q1": {}}}});
+        assert!(normalize_legacy(&mut doc, "beta"));
+        assert_eq!(
+            doc,
+            json!({"byTenant": {"beta": {"savedQueries": {"Patient": {"q1": {}}}}}})
+        );
+    }
+
+    /// Normalization is idempotent and reports "no change" on an already-scoped
+    /// document, so it can run on every write without churning versions.
+    #[test]
+    fn normalize_is_idempotent() {
+        let mut doc = json!({"theme": "dark", "byTenant": {"acme": {"savedQueries": {}}}});
+        let before = doc.clone();
+        assert!(!normalize_legacy(&mut doc, "acme"));
+        assert_eq!(doc, before);
+    }
+
+    /// An unknown client key is scoped by default — the denylist property that
+    /// keeps a future PHI-bearing key from silently reintroducing issue #313.
+    #[test]
+    fn unknown_keys_are_tenant_scoped_by_default() {
+        let mut doc = json!({"theme": "dark", "somethingNew": {"mrn": "12345"}});
+        assert!(normalize_legacy(&mut doc, "acme"));
+        assert_eq!(doc["theme"], "dark");
+        assert_eq!(doc["byTenant"]["acme"]["somethingNew"]["mrn"], "12345");
+    }
+
+    /// Every documented global key stays at the top level.
+    #[test]
+    fn every_global_key_stays_global() {
+        let mut doc = json!({
+            "theme": "dark", "nav": "collapsed", "fhirVersion": "R4", "tenantId": "acme",
+            "savedQueries": {}
+        });
+        normalize_legacy(&mut doc, "acme");
+        for key in GLOBAL_SETTINGS_KEYS {
+            assert!(doc.get(*key).is_some(), "{key} must stay user-global");
+        }
+    }
+
+    /// A `PUT` replaces this tenant's subtree and the globals, and must leave
+    /// every other tenant's subtree intact.
+    #[test]
+    fn put_replaces_only_the_writing_tenants_subtree() {
+        let current = json!({
+            "theme": "dark",
+            "byTenant": {
+                "acme": {"savedQueries": {"Patient": {"a": {}}}},
+                "beta": {"savedQueries": {"Patient": {"b": {}}}}
+            }
+        });
+        let stored = stored_for_put(
+            &current,
+            json!({"theme": "light", "savedQueries": {"Patient": {"a2": {}}}}),
+            "acme",
+        );
+        assert_eq!(stored["theme"], "light");
+        assert_eq!(
+            stored["byTenant"]["acme"]["savedQueries"],
+            json!({"Patient": {"a2": {}}})
+        );
+        assert_eq!(
+            stored["byTenant"]["beta"]["savedQueries"],
+            json!({"Patient": {"b": {}}}),
+            "a PUT by acme must not touch beta"
+        );
+    }
+
+    /// A `PUT` that drops every scoped key removes this tenant's subtree without
+    /// disturbing the others.
+    #[test]
+    fn put_with_no_scoped_keys_clears_only_this_tenants_subtree() {
+        let current = json!({
+            "byTenant": {"acme": {"savedQueries": {}}, "beta": {"savedQueries": {"P": {}}}}
+        });
+        let stored = stored_for_put(&current, json!({"theme": "dark"}), "acme");
+        assert!(stored["byTenant"].get("acme").is_none());
+        assert!(stored["byTenant"].get("beta").is_some());
+    }
+
+    /// A `PUT` normalizes first, so a legacy document attributed elsewhere is
+    /// filed rather than dropped by the replace.
+    #[test]
+    fn put_preserves_legacy_content_attributed_to_another_tenant() {
+        let current = json!({
+            "tenantId": "acme",
+            "savedQueries": {"Patient": {"acme-query": {}}}
+        });
+        let stored = stored_for_put(
+            &current,
+            json!({"savedQueries": {"Patient": {"beta-q": {}}}}),
+            "beta",
+        );
+        assert_eq!(
+            stored["byTenant"]["acme"]["savedQueries"],
+            json!({"Patient": {"acme-query": {}}})
+        );
+        assert_eq!(
+            stored["byTenant"]["beta"]["savedQueries"],
+            json!({"Patient": {"beta-q": {}}})
+        );
+    }
+
+    /// A client cannot smuggle content into another tenant by naming the
+    /// reserved key.
+    #[test]
+    fn put_ignores_a_client_supplied_reserved_key() {
+        let stored = stored_for_put(
+            &json!({}),
+            json!({"byTenant": {"victim": {"savedQueries": {"P": {"x": {}}}}}}),
+            "attacker",
+        );
+        assert!(stored.get("byTenant").is_none());
+    }
+
+    /// Wrapping preserves merge-patch semantics, including `null` deletion of a
+    /// single sibling entry.
+    #[test]
+    fn scoped_merge_patch_deletes_one_entry_and_nothing_else() {
+        let stored = json!({
+            "theme": "dark",
+            "byTenant": {"acme": {"savedQueries": {"Patient": {"keep": {}, "drop": {}}}}}
+        });
+        let patch = scope_merge_patch(json!({"savedQueries": {"Patient": {"drop": null}}}), "acme");
+        let merged = apply_merge_patch(stored, &patch);
+        assert_eq!(
+            merged["byTenant"]["acme"]["savedQueries"]["Patient"],
+            json!({"keep": {}})
+        );
+        assert_eq!(merged["theme"], "dark");
+    }
+
+    /// Global members of a patch stay at the top level; scoped ones are wrapped.
+    #[test]
+    fn scoped_merge_patch_splits_globals_from_scoped_members() {
+        assert_eq!(
+            scope_merge_patch(json!({"theme": "light", "savedQueries": {"P": {}}}), "acme"),
+            json!({"theme": "light", "byTenant": {"acme": {"savedQueries": {"P": {}}}}})
+        );
+        // A purely-global patch produces no subtree at all.
+        assert_eq!(
+            scope_merge_patch(json!({"theme": null}), "acme"),
+            json!({"theme": null})
+        );
+    }
+
+    /// A purge removes exactly one subtree and leaves globals and siblings alone.
+    #[test]
+    fn purge_removes_only_the_named_tenants_subtree() {
+        let mut doc = json!({
+            "theme": "dark",
+            "byTenant": {"acme": {"savedQueries": {"P": {}}}, "beta": {"savedQueries": {"Q": {}}}}
+        });
+        assert!(purge_tenant_subtree(&mut doc, "acme"));
+        assert_eq!(
+            doc,
+            json!({"theme": "dark", "byTenant": {"beta": {"savedQueries": {"Q": {}}}}})
+        );
+    }
+
+    /// Emptying the last subtree drops the now-pointless reserved key.
+    #[test]
+    fn purge_drops_an_emptied_by_tenant_map() {
+        let mut doc = json!({"theme": "dark", "byTenant": {"acme": {"savedQueries": {}}}});
+        assert!(purge_tenant_subtree(&mut doc, "acme"));
+        assert_eq!(doc, json!({"theme": "dark"}));
+    }
+
+    /// Purging a tenant with nothing stored changes nothing, so no version is
+    /// burned and no client ETag is needlessly invalidated.
+    #[test]
+    fn purge_of_an_absent_tenant_is_a_no_op() {
+        let mut doc = json!({"theme": "dark", "byTenant": {"acme": {"savedQueries": {}}}});
+        let before = doc.clone();
+        assert!(!purge_tenant_subtree(&mut doc, "beta"));
+        assert_eq!(doc, before);
+    }
+
+    /// An attributed legacy document is swept only by *its own* tenant's purge.
+    #[test]
+    fn purge_sweeps_attributed_legacy_content_only_for_its_owner() {
+        let legacy = json!({
+            "theme": "dark",
+            "tenantId": "acme",
+            "savedQueries": {"Patient": {"q1": {"query": "name=smith"}}}
+        });
+
+        let mut other = legacy.clone();
+        assert!(!purge_tenant_subtree(&mut other, "beta"));
+        assert!(
+            other.get("savedQueries").is_some(),
+            "beta must not erase acme's content"
+        );
+
+        let mut owner = legacy;
+        assert!(purge_tenant_subtree(&mut owner, "acme"));
+        assert_eq!(owner, json!({"theme": "dark", "tenantId": "acme"}));
+    }
+
+    /// The decision recorded in the module docs: unattributed legacy PHI is swept
+    /// by any tenant purge. Leaving it is the erasure gap #313 exists to close.
+    #[test]
+    fn purge_sweeps_unattributed_legacy_content() {
+        let mut doc = json!({
+            "theme": "dark",
+            "savedQueries": {"Patient": {"q1": {"query": "name=smith&birthdate=1970-01-01"}}},
+            "recentSearches": [{"query": "/Patient?name=smith"}]
+        });
+        assert!(purge_tenant_subtree(&mut doc, "any-tenant"));
+        assert_eq!(doc, json!({"theme": "dark"}));
+        assert!(!serde_json::to_string(&doc).unwrap().contains("smith"));
+    }
+
+    /// A purge never removes a user-global preference, however aggressive the
+    /// legacy sweep is.
+    #[test]
+    fn purge_never_removes_a_global_preference() {
+        let mut doc = json!({
+            "theme": "dark", "nav": "collapsed", "fhirVersion": "R4", "tenantId": "acme",
+            "savedQueries": {"P": {}}
+        });
+        purge_tenant_subtree(&mut doc, "acme");
+        assert_eq!(
+            doc,
+            json!({"theme": "dark", "nav": "collapsed", "fhirVersion": "R4", "tenantId": "acme"})
+        );
+    }
+
+    /// Tenant ids may contain `.` and `/` (`admin_tenants::validate_tenant_id`
+    /// permits both), which is why every backend edits a parsed `Value` rather
+    /// than a dotted JSON path — a `$unset: {"byTenant.a.b": 1}` would target the
+    /// wrong node for a tenant literally named `a.b`.
+    #[test]
+    fn tenant_ids_containing_dots_and_slashes_round_trip() {
+        for tenant in ["a.b", "org/unit", "a.b/c"] {
+            let mut doc = stored_for_put(&json!({}), json!({"savedQueries": {"P": {}}}), tenant);
+            assert_eq!(
+                project_for_tenant(&doc, tenant)["savedQueries"],
+                json!({"P": {}})
+            );
+            assert!(
+                purge_tenant_subtree(&mut doc, tenant),
+                "{tenant} must be purgeable"
+            );
+            assert_eq!(doc, json!({}));
+        }
+    }
+
+    /// A sibling whose id is a prefix of the purged one is untouched — the case a
+    /// naive string-prefix implementation would get wrong.
+    #[test]
+    fn purge_does_not_match_a_prefix_sibling() {
+        let mut doc =
+            json!({"byTenant": {"acme": {"savedQueries": {}}, "acme-2": {"savedQueries": {}}}});
+        assert!(purge_tenant_subtree(&mut doc, "acme"));
+        assert!(doc["byTenant"].get("acme-2").is_some());
+    }
+
+    /// The transforms must not panic on a corrupt or hand-edited row.
+    #[test]
+    fn transforms_tolerate_a_non_object_document() {
+        assert_eq!(project_for_tenant(&json!("corrupt"), "acme"), json!({}));
+        let mut doc = json!(["corrupt"]);
+        assert!(!purge_tenant_subtree(&mut doc, "acme"));
+        assert!(!normalize_legacy(&mut json!(null), "acme"));
+    }
+
+    /// A `byTenant` value of the wrong shape is inert rather than fatal.
+    #[test]
+    fn transforms_tolerate_a_malformed_by_tenant_value() {
+        let stored = json!({"theme": "dark", "byTenant": "not-a-map"});
+        assert_eq!(
+            project_for_tenant(&stored, "acme"),
+            json!({"theme": "dark"})
+        );
+        let mut doc = stored;
+        assert!(!purge_tenant_subtree(&mut doc, "acme"));
+    }
+
+    /// End to end: write under two tenants, then offboard one.
+    #[test]
+    fn offboarding_one_tenant_leaves_the_other_intact() {
+        let mut stored = json!({"theme": "dark"});
+        stored = stored_for_put(
+            &stored,
+            json!({"theme": "dark", "savedQueries": {"P": {"a": {}}}}),
+            "acme",
+        );
+        stored = stored_for_put(
+            &stored,
+            json!({"theme": "dark", "savedQueries": {"P": {"b": {}}}}),
+            "beta",
+        );
+
+        assert!(purge_tenant_subtree(&mut stored, "acme"));
+        assert_eq!(
+            project_for_tenant(&stored, "acme"),
+            json!({"theme": "dark"})
+        );
+        assert_eq!(
+            project_for_tenant(&stored, "beta"),
+            json!({"theme": "dark", "savedQueries": {"P": {"b": {}}}})
+        );
     }
 }

--- a/crates/persistence/src/core/user_settings.rs
+++ b/crates/persistence/src/core/user_settings.rs
@@ -265,10 +265,7 @@ pub fn normalize_legacy(document: &mut Value, writing_tenant: &str) -> bool {
     let stored = as_object(document);
     let mut globals = Map::new();
     let mut moved = Map::new();
-    let mut by_tenant = stored
-        .get(BY_TENANT_KEY)
-        .map(|value| as_object(value))
-        .unwrap_or_default();
+    let mut by_tenant = stored.get(BY_TENANT_KEY).map(as_object).unwrap_or_default();
 
     for (key, value) in stored {
         if key == BY_TENANT_KEY {
@@ -312,7 +309,7 @@ pub fn stored_for_put(current: &Value, incoming: Value, tenant: &str) -> Value {
 
     let mut by_tenant = as_object(&base)
         .get(BY_TENANT_KEY)
-        .map(|value| as_object(value))
+        .map(as_object)
         .unwrap_or_default();
 
     let mut globals = Map::new();

--- a/crates/persistence/tests/minio_s3_tests.rs
+++ b/crates/persistence/tests/minio_s3_tests.rs
@@ -1177,7 +1177,7 @@ async fn test_minio_purge_tenant_settings_edits_objects_in_place() {
 
     let changed = harness.backend.purge_tenant_settings("acme").await.unwrap();
     assert!(
-        changed >= 1,
+        changed > 0,
         "the settings object should have been rewritten"
     );
 

--- a/crates/persistence/tests/minio_s3_tests.rs
+++ b/crates/persistence/tests/minio_s3_tests.rs
@@ -1142,6 +1142,101 @@ async fn test_minio_settings_delete_is_idempotent() {
     assert!(!harness.backend.delete_settings(&user).await.unwrap());
 }
 
+/// Issue #313: a tenant purge must reach the PHI-derived query strings a client
+/// stores in the settings document — objects that sit *outside* every tenant
+/// prefix and that `purge_tenant_data`'s prefix sweep therefore cannot touch.
+///
+/// This is the S3-specific risk the mock cannot prove: the sweep rewrites each
+/// object with a real conditional `PutObject`, so if the service ignored
+/// `If-Match` the purge could silently clobber a concurrent settings write.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_minio_purge_tenant_settings_edits_objects_in_place() {
+    if skip_if_disabled("test_minio_purge_tenant_settings_edits_objects_in_place") {
+        return;
+    }
+
+    let harness = make_prefix_backend("settings-tenant-purge").await;
+    let user = unique_user_key("tenant-purge");
+
+    harness
+        .backend
+        .put_settings(
+            &user,
+            json!({
+                "theme": "dark",
+                "byTenant": {
+                    "acme": {"savedQueries": {"Patient": {"q": {"query": "name=smith"}}}},
+                    "beta": {"savedQueries": {"Patient": {"q": {"query": "name=jones"}}}}
+                }
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    let before = harness.backend.get_settings(&user).await.unwrap().unwrap();
+
+    let changed = harness.backend.purge_tenant_settings("acme").await.unwrap();
+    assert!(
+        changed >= 1,
+        "the settings object should have been rewritten"
+    );
+
+    let after = harness.backend.get_settings(&user).await.unwrap().unwrap();
+    // The object survives — it holds another tenant's content and the user's
+    // global preferences — but acme's subtree is gone from it.
+    assert_eq!(after.document["theme"], "dark");
+    assert!(after.document["byTenant"].get("acme").is_none());
+    assert_eq!(
+        after.document["byTenant"]["beta"]["savedQueries"]["Patient"]["q"]["query"],
+        "name=jones"
+    );
+    assert!(
+        !serde_json::to_string(&after.document)
+            .unwrap()
+            .contains("smith"),
+        "purged content must not survive in the stored object"
+    );
+    // The version bumped, so a client holding the pre-purge ETag cannot write
+    // the purged content back.
+    assert_eq!(after.version, before.version + 1);
+    assert!(
+        harness
+            .backend
+            .put_settings(&user, json!({"x": 1}), Some(before.version))
+            .await
+            .is_err()
+    );
+}
+
+/// A tenant with nothing stored costs a listing and no writes, leaving every
+/// document at its original version (so no client ETag is needlessly broken).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_minio_purge_tenant_settings_is_a_no_op_when_nothing_matches() {
+    if skip_if_disabled("test_minio_purge_tenant_settings_is_a_no_op_when_nothing_matches") {
+        return;
+    }
+
+    let harness = make_prefix_backend("settings-tenant-purge-noop").await;
+    let user = unique_user_key("tenant-purge-noop");
+
+    harness
+        .backend
+        .put_settings(&user, json!({"theme": "dark"}), None)
+        .await
+        .unwrap();
+    let before = harness.backend.get_settings(&user).await.unwrap().unwrap();
+
+    harness
+        .backend
+        .purge_tenant_settings("absent")
+        .await
+        .unwrap();
+
+    let after = harness.backend.get_settings(&user).await.unwrap().unwrap();
+    assert_eq!(after.version, before.version);
+    assert_eq!(after.document, json!({"theme": "dark"}));
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // #284: a missing bucket must never read as an empty store on the real client.
 //

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -3538,3 +3538,83 @@ async fn mongodb_integration_settings_get_surfaces_decode_error() {
     let err = backend.get_settings(&user).await.unwrap_err();
     assert!(matches!(err, StorageError::Backend(_)));
 }
+
+/// Issue #313: a tenant purge must reach the PHI-derived query strings a client
+/// stores in its settings document, which are keyed by *user* and so are not
+/// touched by the tenant-scoped deletes in `purge_tenant_data`.
+///
+/// The MongoDB-specific risk this proves is the write shape: with no
+/// multi-document transaction available, the sweep rewrites each document with a
+/// version-conditioned update, and it must remove exactly the named tenant's
+/// subtree — which is why it edits the parsed document rather than `$unset`ing a
+/// dotted path (`admin_tenants::validate_tenant_id` permits tenant ids containing
+/// `.`, which a dotted path would misparse).
+#[tokio::test]
+async fn mongodb_integration_purge_tenant_settings() {
+    let Some(backend) = settings_mongo::backend("settings_tenant_purge").await else {
+        eprintln!(
+            "Skipping mongodb_integration_purge_tenant_settings (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let user = unique_user_key("tenant-purge");
+    let dotted = unique_user_key("tenant-purge-dotted");
+
+    backend
+        .put_settings(
+            &user,
+            json!({
+                "theme": "dark",
+                "byTenant": {
+                    "acme": {"savedQueries": {"Patient": {"q": {"query": "name=smith"}}}},
+                    "beta": {"savedQueries": {"Patient": {"q": {"query": "name=jones"}}}}
+                }
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    // A tenant id containing a dot: `$unset: {"byTenant.a.b": 1}` would target
+    // `byTenant.a` → `b`, the wrong node.
+    backend
+        .put_settings(
+            &dotted,
+            json!({"byTenant": {"a.b": {"savedQueries": {"Patient": {"q": {}}}}}}),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let before = backend.get_settings(&user).await.unwrap().unwrap();
+    backend.purge_tenant_settings("acme").await.unwrap();
+
+    let after = backend.get_settings(&user).await.unwrap().unwrap();
+    assert_eq!(after.document["theme"], "dark");
+    assert!(after.document["byTenant"].get("acme").is_none());
+    assert_eq!(
+        after.document["byTenant"]["beta"]["savedQueries"]["Patient"]["q"]["query"],
+        "name=jones"
+    );
+    assert!(
+        !serde_json::to_string(&after.document)
+            .unwrap()
+            .contains("smith"),
+        "purged content must not survive in the stored document"
+    );
+    assert_eq!(
+        after.version,
+        before.version + 1,
+        "the version must bump so a stale ETag cannot write the content back"
+    );
+
+    // The dotted tenant is purgeable, and only by its own id.
+    backend.purge_tenant_settings("a").await.unwrap();
+    let dotted_doc = backend.get_settings(&dotted).await.unwrap().unwrap();
+    assert!(
+        dotted_doc.document["byTenant"].get("a.b").is_some(),
+        "purging 'a' must not touch the tenant literally named 'a.b'"
+    );
+    backend.purge_tenant_settings("a.b").await.unwrap();
+    let dotted_doc = backend.get_settings(&dotted).await.unwrap().unwrap();
+    assert_eq!(dotted_doc.document, json!({}));
+}

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -4684,6 +4684,105 @@ mod postgres_integration {
         assert_eq!(ok.version, 2);
     }
 
+    /// Issue #313: a tenant purge must reach the PHI-derived query strings a
+    /// client stores in its settings document. Those rows are keyed by *user*,
+    /// so none of `purge_tenant_data`'s tenant-scoped deletes touch them.
+    ///
+    /// The PostgreSQL-specific risk this proves is that the sweep runs inside
+    /// the purge's own transaction (`SELECT … FOR UPDATE`), so the offboarding
+    /// commits atomically: it cannot leave a tenant's saved queries behind after
+    /// its records are gone.
+    #[tokio::test]
+    async fn postgres_integration_purge_tenant_settings() {
+        let backend = create_backend().await;
+        let user = unique_user_key("tenant-purge");
+        let dotted = unique_user_key("tenant-purge-dotted");
+
+        backend
+            .put_settings(
+                &user,
+                json!({
+                    "theme": "dark",
+                    "byTenant": {
+                        "acme-purge": {"savedQueries": {"Patient": {"q": {"query": "name=smith"}}}},
+                        "beta-keep": {"savedQueries": {"Patient": {"q": {"query": "name=jones"}}}}
+                    }
+                }),
+                None,
+            )
+            .await
+            .unwrap();
+        // A tenant id containing `.` and `/`, both permitted by
+        // `admin_tenants::validate_tenant_id` — the reason the sweep edits a
+        // parsed document rather than using a `jsonb` text path.
+        backend
+            .put_settings(
+                &dotted,
+                json!({"byTenant": {"org.a/b": {"savedQueries": {"Patient": {"q": {}}}}}}),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let before = backend.get_settings(&user).await.unwrap().unwrap();
+
+        // Driven through `purge_tenant_data`, which is the single choke point
+        // both the admin API and the web UI go through.
+        backend.purge_tenant_data("acme-purge").await.unwrap();
+
+        let after = backend.get_settings(&user).await.unwrap().unwrap();
+        assert_eq!(after.document["theme"], "dark");
+        assert!(after.document["byTenant"].get("acme-purge").is_none());
+        assert_eq!(
+            after.document["byTenant"]["beta-keep"]["savedQueries"]["Patient"]["q"]["query"],
+            "name=jones"
+        );
+        assert!(
+            !serde_json::to_string(&after.document)
+                .unwrap()
+                .contains("smith"),
+            "purged content must not survive in the stored row"
+        );
+        assert_eq!(
+            after.version,
+            before.version + 1,
+            "the version must bump so a stale ETag cannot write the content back"
+        );
+
+        // A tenant whose id is a prefix of another must not take it with it.
+        backend.purge_tenant_data("org.a").await.unwrap();
+        let dotted_doc = backend.get_settings(&dotted).await.unwrap().unwrap();
+        assert!(
+            dotted_doc.document["byTenant"].get("org.a/b").is_some(),
+            "purging 'org.a' must not touch the tenant named 'org.a/b'"
+        );
+        backend.purge_tenant_data("org.a/b").await.unwrap();
+        let dotted_doc = backend.get_settings(&dotted).await.unwrap().unwrap();
+        assert_eq!(dotted_doc.document, json!({}));
+    }
+
+    /// A tenant with nothing in the settings store leaves every document at its
+    /// original version, so no client ETag is needlessly invalidated.
+    #[tokio::test]
+    async fn postgres_integration_purge_tenant_settings_is_a_no_op_when_nothing_matches() {
+        let backend = create_backend().await;
+        let user = unique_user_key("tenant-purge-noop");
+        backend
+            .put_settings(&user, json!({"theme": "dark"}), None)
+            .await
+            .unwrap();
+        let before = backend.get_settings(&user).await.unwrap().unwrap();
+
+        backend
+            .purge_tenant_data("tenant-that-has-no-settings")
+            .await
+            .unwrap();
+
+        let after = backend.get_settings(&user).await.unwrap().unwrap();
+        assert_eq!(after.version, before.version);
+        assert_eq!(after.document, json!({"theme": "dark"}));
+    }
+
     // ========================================================================
     // _contained / _containedType search
     // ========================================================================

--- a/crates/rest/src/handlers/user_settings.rs
+++ b/crates/rest/src/handlers/user_settings.rs
@@ -19,6 +19,35 @@
 //! conditional fetches. The weak form is still *accepted* on `If-Match` for
 //! clients built against earlier releases.
 //!
+//! # Tenant scoping (issue #313)
+//!
+//! The document is keyed by *user*, but most of what a client puts in it is
+//! derived from one *tenant's* data — a saved query such as
+//! `Patient?name=smith&birthdate=1970-01-01` is a PHI-bearing string. Keyed by
+//! user alone, those strings were unreachable by `purge_tenant_data`, so tenant
+//! offboarding and right-to-erasure could not complete.
+//!
+//! These handlers therefore **project on read and scope on write**, against the
+//! request's [`TenantExtractor`]:
+//!
+//! - `GET` returns the user-global keys plus *this tenant's* scoped keys, flat.
+//! - `PUT` replaces the globals and this tenant's subtree, leaving every other
+//!   tenant's subtree untouched — it replaces what the caller could *see*.
+//! - `PATCH` has its scoped members rewritten to apply to this tenant's subtree,
+//!   which preserves merge-patch semantics exactly, `null` deletes included.
+//!
+//! **The wire format is unchanged.** Clients — including ones this project does
+//! not ship — see the same flat document they always did; only the stored layout
+//! gained a [`BY_TENANT_KEY`] map. That is deliberate: it makes the guarantee
+//! server-side rather than something every client has to be upgraded to honour,
+//! and it means an old client cannot write PHI to an unpurgeable location. The
+//! one visible consequence is that saved queries and recent searches now change
+//! when the user switches tenants, which is the intended semantics.
+//!
+//! Which keys are global is decided by
+//! [`GLOBAL_SETTINGS_KEYS`](helios_persistence::core::GLOBAL_SETTINGS_KEYS); see
+//! that constant for why it is a denylist.
+//!
 //! [RFC 7386]: https://www.rfc-editor.org/rfc/rfc7386
 
 use std::sync::Arc;
@@ -31,13 +60,14 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use helios_persistence::core::{
-    EntityTagPrecondition, ResourceStorage, SettingsStore, StoredUserSettings, apply_merge_patch,
+    BY_TENANT_KEY, EntityTagPrecondition, ResourceStorage, SettingsStore, StoredUserSettings,
+    apply_merge_patch, normalize_legacy, project_for_tenant, scope_merge_patch, stored_for_put,
 };
 use helios_persistence::error::{ConcurrencyError, StorageError};
 use serde_json::Value;
 
 use crate::error::{RestError, RestResult};
-use crate::extractors::UserKey;
+use crate::extractors::{TenantExtractor, UserKey};
 use crate::middleware::conditional::ConditionalHeaders;
 use crate::state::AppState;
 
@@ -62,9 +92,19 @@ const MAX_SAVED_QUERIES_PER_TYPE: usize = 100;
 ///
 /// Returns the caller's settings document, or an empty object (`{}`, version 0)
 /// when none has been stored yet, so the UI always receives a usable document.
+///
+/// The document is *projected* for the request's tenant: user-global keys plus
+/// this tenant's scoped keys, flat, with the stored [`BY_TENANT_KEY`] map never
+/// on the wire. Exactly one tenant subtree is ever projected, so a caller cannot
+/// observe another tenant's saved queries.
+///
+/// The projection is a pure read — a document written before scoping existed is
+/// shown as-is and normalized on the first *write*, so `GET` stays
+/// side-effect-free.
 pub async fn get_user_settings<S>(
     State(state): State<AppState<S>>,
     user: UserKey,
+    tenant: TenantExtractor,
     conditional: ConditionalHeaders,
 ) -> RestResult<Response>
 where
@@ -72,7 +112,10 @@ where
 {
     let store = settings_store(&state)?;
     let (document, version) = match load_settings(store, &user).await? {
-        Some(stored) => (stored.document, stored.version),
+        Some(stored) => (
+            project_for_tenant(&stored.document, tenant.tenant_id()),
+            stored.version,
+        ),
         None => (Value::Object(Default::default()), 0),
     };
     let current_etag = etag(version);
@@ -98,9 +141,15 @@ where
 /// Replaces the caller's entire settings document with the request body, which
 /// must be a JSON object. An optional `If-Match` header makes the write
 /// conditional on the current version.
+///
+/// "Entire" means what the caller can *see* — the projection for this tenant —
+/// so the user-global keys and this tenant's scoped subtree are replaced while
+/// every other tenant's subtree survives. A wholesale replace of the *stored*
+/// document would destroy content the caller was never shown.
 pub async fn put_user_settings<S>(
     State(state): State<AppState<S>>,
     user: UserKey,
+    tenant: TenantExtractor,
     conditional: ConditionalHeaders,
     body: Bytes,
 ) -> RestResult<Response>
@@ -108,17 +157,16 @@ where
     S: ResourceStorage + Send + Sync,
 {
     let store = settings_store(&state)?;
-    let document = parse_object_body(&body)?;
-    validate_settings_document(&document)?;
+    let incoming = parse_object_body(&body)?;
     // Parse before touching storage so a malformed precondition fails fast.
     let precondition = parse_if_match(&conditional)?;
 
     // Adopt any pre-#270 document first, so a wholesale replace does not leave
     // the legacy copy stranded and unreachable.
-    let current_version = load_settings(store, &user)
-        .await?
-        .map(|stored| stored.version)
-        .unwrap_or(0);
+    let (current, current_version) = match load_settings(store, &user).await? {
+        Some(stored) => (stored.document, stored.version),
+        None => (Value::Object(Default::default()), 0),
+    };
 
     // Evaluate the precondition against the version we just read, then pin the
     // write to that same version. The store cannot express `*` (or a multi-tag
@@ -128,10 +176,15 @@ where
     check_if_match(&precondition, current_version)?;
     let if_match = precondition.is_present().then_some(current_version);
 
+    // The bounds apply to what is *stored*: with several tenants the stored
+    // document is the thing that grows, and it is the row every read pays for.
+    let document = stored_for_put(&current, incoming, tenant.tenant_id());
+    validate_settings_document(&document)?;
+
     let stored = store
         .put_settings(user.as_str(), document, if_match)
         .await?;
-    Ok(settings_response(stored))
+    Ok(settings_response(&stored, tenant.tenant_id()))
 }
 
 /// Handler for `PATCH /_user/settings`.
@@ -140,10 +193,16 @@ where
 /// caller's settings document — ideal for toggling a single key such as the
 /// theme. An optional `If-Match` header makes the write conditional.
 ///
+/// The patch applies to the *projection*: its tenant-scoped members are rewritten
+/// to target this tenant's subtree, which preserves merge-patch semantics exactly
+/// — a `null` member still deletes precisely the entry it names, just at a nested
+/// path.
+///
 /// [RFC 7386]: https://www.rfc-editor.org/rfc/rfc7386
 pub async fn patch_user_settings<S>(
     State(state): State<AppState<S>>,
     user: UserKey,
+    tenant: TenantExtractor,
     conditional: ConditionalHeaders,
     body: Bytes,
 ) -> RestResult<Response>
@@ -153,27 +212,36 @@ where
     let store = settings_store(&state)?;
     let merge_patch = parse_object_body(&body)?;
     let precondition = parse_if_match(&conditional)?;
+    let scoped_patch = scope_merge_patch(merge_patch, tenant.tenant_id());
 
-    // The bounds below apply to the *post-merge* document, which only the
-    // backend sees. Compute the merge here against the version we read, pin the
-    // write to that version so what was validated is exactly what lands, and —
-    // only when the caller sent no precondition of their own — absorb a benign
-    // concurrent-writer race with a couple of retries.
+    // The bounds below apply to the *post-merge stored* document. Compute the
+    // merge here against the version we read and write that exact document back
+    // pinned to the same version, so what was validated is what lands — the
+    // merge can no longer be handed to `patch_settings`, because a legacy
+    // document also has to be normalized first and a merge patch cannot express
+    // "move these keys". Pinning makes this equivalent: the backend still
+    // rejects the write atomically if another writer landed in between. Only
+    // when the caller sent no precondition of their own is a benign
+    // concurrent-writer race absorbed with a couple of retries.
     let mut attempts = 0;
     loop {
-        let (current, version) = match load_settings(store, &user).await? {
+        let (mut current, version) = match load_settings(store, &user).await? {
             Some(stored) => (stored.document, stored.version),
             None => (Value::Object(Default::default()), 0),
         };
         check_if_match(&precondition, version)?;
-        let merged = apply_merge_patch(current, &merge_patch);
+
+        // File any pre-scoping keys under their attributed tenant before merging,
+        // so this write does not leave them stranded outside the purge's reach.
+        normalize_legacy(&mut current, tenant.tenant_id());
+        let merged = apply_merge_patch(current, &scoped_patch);
         validate_settings_document(&merged)?;
 
         match store
-            .patch_settings(user.as_str(), merge_patch.clone(), Some(version))
+            .put_settings(user.as_str(), merged, Some(version))
             .await
         {
-            Ok(stored) => return Ok(settings_response(stored)),
+            Ok(stored) => return Ok(settings_response(&stored, tenant.tenant_id())),
             // Only a caller who sent *no* precondition gets the conflict
             // absorbed. A caller who sent one — including `*` — asked to be
             // told about the race, so the failure must surface.
@@ -199,6 +267,12 @@ fn is_lock_failure(error: &StorageError) -> bool {
 /// [`savedQueries` convention](helios_persistence::core::user_settings) is
 /// present — that it is an object keyed by resource type, each holding an
 /// object of at most [`MAX_SAVED_QUERIES_PER_TYPE`] entries keyed by query id.
+///
+/// Runs against the **stored** document, not the projection. With several
+/// tenants the stored document is what actually grows, and it is the row every
+/// read pays for; validating only the caller's slice would let a user exceed the
+/// cap one tenant at a time. For the same reason the per-type entry limit is
+/// checked inside every tenant subtree, not just at the top level.
 fn validate_settings_document(document: &Value) -> RestResult<()> {
     let size = serde_json::to_vec(document).map(|v| v.len()).unwrap_or(0);
     if size > MAX_SETTINGS_DOCUMENT_BYTES {
@@ -209,26 +283,43 @@ fn validate_settings_document(document: &Value) -> RestResult<()> {
         });
     }
 
-    let Some(saved_queries) = document.get("savedQueries") else {
+    // Top-level: a document written before tenant scoping existed.
+    validate_saved_queries(document, None)?;
+    // Per tenant: the normalized location.
+    if let Some(by_tenant) = document.get(BY_TENANT_KEY).and_then(Value::as_object) {
+        for (tenant, subtree) in by_tenant {
+            validate_saved_queries(subtree, Some(tenant))?;
+        }
+    }
+    Ok(())
+}
+
+/// Checks the `savedQueries` convention within one scope (the document root, or
+/// one tenant's subtree). `tenant` only labels the error message.
+fn validate_saved_queries(scope: &Value, tenant: Option<&str>) -> RestResult<()> {
+    let Some(saved_queries) = scope.get("savedQueries") else {
         return Ok(());
     };
+    // The client never sees the tenant subtree, so an error naming one would be
+    // confusing; report the key as the caller wrote it.
+    let at = tenant.map(|t| format!(" (tenant {t})")).unwrap_or_default();
     let Some(by_type) = saved_queries.as_object() else {
         return Err(RestError::UnprocessableEntity {
-            message: "savedQueries must be an object keyed by FHIR resource type".to_string(),
+            message: format!("savedQueries must be an object keyed by FHIR resource type{at}"),
         });
     };
     for (resource_type, entries) in by_type {
         let Some(entries) = entries.as_object() else {
             return Err(RestError::UnprocessableEntity {
                 message: format!(
-                    "savedQueries.{resource_type} must be an object keyed by query id"
+                    "savedQueries.{resource_type} must be an object keyed by query id{at}"
                 ),
             });
         };
         if entries.len() > MAX_SAVED_QUERIES_PER_TYPE {
             return Err(RestError::UnprocessableEntity {
                 message: format!(
-                    "savedQueries.{resource_type} has {} entries; the limit is {}",
+                    "savedQueries.{resource_type} has {} entries; the limit is {}{at}",
                     entries.len(),
                     MAX_SAVED_QUERIES_PER_TYPE
                 ),
@@ -287,6 +378,19 @@ fn parse_object_body(body: &Bytes) -> RestResult<Value> {
     if !value.is_object() {
         return Err(RestError::BadRequest {
             message: "Settings document must be a JSON object".to_string(),
+        });
+    }
+    // `byTenant` is the server's own storage layout, never part of the wire
+    // format. Accepting it would let a caller scoped to one tenant plant content
+    // under another tenant's subtree — or read it back on the next GET — which is
+    // exactly the cross-scope access this scoping exists to prevent. Rejecting is
+    // also honest: silently dropping the key would make the write look applied.
+    if value.get(BY_TENANT_KEY).is_some() {
+        return Err(RestError::UnprocessableEntity {
+            message: format!(
+                "'{BY_TENANT_KEY}' is reserved: settings are scoped to the request's tenant \
+                 automatically and it cannot be set directly"
+            ),
         });
     }
     Ok(value)
@@ -404,11 +508,12 @@ async fn adopt_legacy_document(
     Ok(Some(adopted))
 }
 
-/// Builds the success response for a write: the stored document plus its ETag.
-fn settings_response(stored: StoredUserSettings) -> Response {
+/// Builds the success response for a write: the document as the caller sees it
+/// (projected for `tenant`), plus its ETag.
+fn settings_response(stored: &StoredUserSettings, tenant: &str) -> Response {
     (
         [(header::ETAG, etag(stored.version))],
-        Json(stored.document),
+        Json(project_for_tenant(&stored.document, tenant)),
     )
         .into_response()
 }
@@ -441,6 +546,7 @@ fn etag(version: i64) -> String {
 mod tests {
     use super::*;
     use axum::http::HeaderMap;
+    use helios_persistence::core::GLOBAL_SETTINGS_KEYS;
 
     #[test]
     fn parse_object_body_rejects_empty() {
@@ -489,6 +595,101 @@ mod tests {
     fn parse_object_body_accepts_object() {
         let value = parse_object_body(&Bytes::from_static(b"{\"theme\":\"dark\"}")).unwrap();
         assert!(value.is_object());
+    }
+
+    /// The storage layout is not part of the wire format. Accepting it would let
+    /// a caller in one tenant write into (and then read back) another tenant's
+    /// subtree — see `parse_object_body`.
+    #[test]
+    fn parse_object_body_rejects_the_reserved_by_tenant_key() {
+        let body = br#"{"byTenant":{"victim":{"savedQueries":{"Patient":{"x":{}}}}}}"#;
+        let err = parse_object_body(&Bytes::from_static(body)).unwrap_err();
+        match err {
+            RestError::UnprocessableEntity { message } => {
+                assert!(
+                    message.contains("reserved"),
+                    "unexpected message: {message}"
+                )
+            }
+            other => panic!("expected 422 for the reserved key, got {other:?}"),
+        }
+        // Including when it is the null of a merge patch.
+        assert!(parse_object_body(&Bytes::from_static(br#"{"byTenant":null}"#)).is_err());
+    }
+
+    // ── Tenant-scoped validation bounds (issue #313) ────────────────────────
+
+    /// The per-type entry cap must hold inside every tenant subtree, not just at
+    /// the top level — otherwise a user exceeds it one tenant at a time.
+    #[test]
+    fn validation_bounds_saved_queries_within_each_tenant_subtree() {
+        let mut entries = serde_json::Map::new();
+        for i in 0..=MAX_SAVED_QUERIES_PER_TYPE {
+            entries.insert(format!("q{i}"), serde_json::json!({}));
+        }
+        let document = serde_json::json!({
+            "byTenant": {"acme": {"savedQueries": {"Patient": entries}}}
+        });
+        let err = validate_settings_document(&document).unwrap_err();
+        match err {
+            RestError::UnprocessableEntity { message } => {
+                assert!(message.contains("the limit is"), "unexpected: {message}");
+                assert!(
+                    message.contains("acme"),
+                    "should name the tenant: {message}"
+                );
+            }
+            other => panic!("expected 422, got {other:?}"),
+        }
+    }
+
+    /// The legacy top-level location is still bounded, so a pre-#313 document
+    /// cannot be grown past the cap either.
+    #[test]
+    fn validation_still_bounds_legacy_top_level_saved_queries() {
+        let document = serde_json::json!({"savedQueries": "not-an-object"});
+        assert!(matches!(
+            validate_settings_document(&document).unwrap_err(),
+            RestError::UnprocessableEntity { .. }
+        ));
+    }
+
+    /// A well-formed multi-tenant document passes.
+    #[test]
+    fn validation_accepts_a_scoped_document() {
+        let document = serde_json::json!({
+            "theme": "dark",
+            "byTenant": {
+                "acme": {"savedQueries": {"Patient": {"q1": {"query": "name=smith"}}}},
+                "beta": {"savedQueries": {"Observation": {"q2": {"query": "code=1234"}}}}
+            }
+        });
+        assert!(validate_settings_document(&document).is_ok());
+    }
+
+    /// The size cap is measured on the stored document, so a large *other*
+    /// tenant's subtree still counts against a small write.
+    #[test]
+    fn validation_measures_the_stored_document_not_the_projection() {
+        let bloat = "x".repeat(MAX_SETTINGS_DOCUMENT_BYTES);
+        let document = serde_json::json!({
+            "byTenant": {"other": {"junk": bloat}, "acme": {"savedQueries": {}}}
+        });
+        assert!(matches!(
+            validate_settings_document(&document).unwrap_err(),
+            RestError::PayloadTooLarge { .. }
+        ));
+    }
+
+    /// Guards the constant the whole design turns on: these four keys, and only
+    /// these, escape a tenant purge. Anything added here must provably not carry
+    /// content derived from a tenant's records.
+    #[test]
+    fn the_global_key_set_is_the_reviewed_one() {
+        assert_eq!(
+            GLOBAL_SETTINGS_KEYS,
+            &["theme", "nav", "fhirVersion", "tenantId"]
+        );
     }
 
     fn with_if_match(raw: &str) -> ConditionalHeaders {

--- a/crates/rest/tests/user_settings.rs
+++ b/crates/rest/tests/user_settings.rs
@@ -754,6 +754,59 @@ async fn put_in_one_tenant_does_not_erase_another_tenants_queries() {
     );
 }
 
+/// The other half of `PUT`-replaces-the-projection: the user-global keys are
+/// part of that view, so a `PUT` that omits one deletes it — from *every*
+/// tenant, since those keys are shared.
+///
+/// This is ordinary `PUT` semantics and is unchanged by tenant scoping (a `PUT`
+/// without `theme` always dropped it). It is pinned here because the scoping
+/// makes it newly surprising — "I only wrote my tenant's queries" — and because
+/// the fix is not to make `PUT` a merge: clients that want to touch one key use
+/// `PATCH`, which is what every shipped client does.
+#[tokio::test]
+async fn put_replaces_the_user_global_keys_too() {
+    let (server, _backend) = server_with_backend();
+
+    server
+        .patch("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(&json!({"theme": "dark"}))
+        .await;
+
+    // A PUT from another tenant that does not echo `theme` back drops it.
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("beta"))
+        .json(&json!({"savedQueries": {"Patient": {"b": {}}}}))
+        .await;
+    let acme = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .await;
+    assert_eq!(acme.json::<Value>(), json!({}), "PUT replaces the globals");
+
+    // Echoing it back keeps it, and a PATCH never touches it.
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("beta"))
+        .json(&json!({"theme": "dark", "savedQueries": {"Patient": {"b": {}}}}))
+        .await;
+    server
+        .patch("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(&json!({"savedQueries": {"Patient": {"a": {}}}}))
+        .await;
+    let acme = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .await;
+    assert_eq!(acme.json::<Value>()["theme"], "dark");
+    assert_eq!(
+        acme.json::<Value>()["savedQueries"]["Patient"],
+        json!({"a": {}})
+    );
+}
+
 /// Merge-patch semantics survive the rewrite: a `null` still deletes exactly one
 /// sibling entry, in this tenant only.
 #[tokio::test]
@@ -805,8 +858,12 @@ async fn purging_a_tenant_erases_its_saved_queries_from_user_settings() {
 
     let (server, backend) = server_with_backend();
 
+    // Written the way the web UI actually writes: a merge patch per change
+    // (`saved-queries.js`, `theme.js` and `nav.js` all PATCH). A `PUT` here would
+    // additionally exercise the replace-the-globals semantics covered by
+    // `put_replaces_the_user_global_keys_too`, which is not what this is about.
     server
-        .put("/_user/settings")
+        .patch("/_user/settings")
         .add_header(TENANT, HeaderValue::from_static("acme"))
         .json(&json!({
             "theme": "dark",
@@ -814,7 +871,7 @@ async fn purging_a_tenant_erases_its_saved_queries_from_user_settings() {
         }))
         .await;
     server
-        .put("/_user/settings")
+        .patch("/_user/settings")
         .add_header(TENANT, HeaderValue::from_static("beta"))
         .json(&json!({"savedQueries": {"Patient": {"q": {"query": "name=jones"}}}}))
         .await;

--- a/crates/rest/tests/user_settings.rs
+++ b/crates/rest/tests/user_settings.rs
@@ -607,3 +607,384 @@ async fn migration_does_not_clobber_an_existing_current_document() {
     let get = server.get("/_user/settings").await;
     assert_eq!(get.json::<Value>(), json!({"theme": "current"}));
 }
+
+// ── Tenant scoping (issue #313) ─────────────────────────────────────────────
+//
+// The wire format is unchanged — a client still sends and receives a flat
+// document — but PHI-bearing keys are stored under `byTenant.{tenant}` so a
+// tenant purge can reach them. These exercise that through the full stack, with
+// the tenant selected by `X-Tenant-ID` (the default `header_only` routing mode).
+
+const TENANT: HeaderName = HeaderName::from_static("x-tenant-id");
+
+/// Builds a test server, returning the backend handle too so a test can inspect
+/// the *stored* document and drive `purge_tenant_data`.
+fn server_with_backend() -> (TestServer, Arc<SqliteBackend>) {
+    let backend = SqliteBackend::in_memory().expect("create in-memory SQLite backend");
+    backend.init_schema().expect("init schema");
+    let backend = Arc::new(backend);
+
+    let config = ServerConfig {
+        base_url: "http://localhost:8080".to_string(),
+        ..ServerConfig::for_testing()
+    };
+    let settings_store: Arc<dyn SettingsStore> = backend.clone();
+    let state =
+        helios_rest::AppState::new(backend.clone(), config).with_settings_store(settings_store);
+    let server = TestServer::new(helios_rest::routing::fhir_routes::create_routes(state))
+        .expect("create test server");
+    (server, backend)
+}
+
+/// A saved query written under one tenant is invisible under another, and each
+/// tenant's user-global preferences still roam.
+#[tokio::test]
+async fn saved_queries_are_scoped_per_tenant_but_theme_roams() {
+    let (server, _backend) = server_with_backend();
+
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(
+            &json!({"theme": "dark", "savedQueries": {"Patient": {"q1": {"query": "name=smith"}}}}),
+        )
+        .await;
+
+    // Same user, different tenant: the global preference roams, the query does not.
+    let beta = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("beta"))
+        .await;
+    assert_eq!(beta.status_code(), StatusCode::OK);
+    assert_eq!(beta.json::<Value>(), json!({"theme": "dark"}));
+
+    // Back in acme it is still there.
+    let acme = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .await;
+    assert_eq!(
+        acme.json::<Value>()["savedQueries"]["Patient"]["q1"]["query"],
+        "name=smith"
+    );
+}
+
+/// The storage layout must never appear on the wire.
+#[tokio::test]
+async fn the_by_tenant_key_is_never_returned_to_a_client() {
+    let (server, _backend) = server_with_backend();
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(&json!({"savedQueries": {"Patient": {"q1": {}}}}))
+        .await;
+
+    let get = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .await;
+    assert!(get.json::<Value>().get("byTenant").is_none());
+}
+
+/// …and a client cannot set it either, which would otherwise let a caller in one
+/// tenant plant content under another's subtree.
+#[tokio::test]
+async fn setting_the_reserved_key_is_rejected() {
+    let (server, _backend) = server_with_backend();
+
+    for method in ["put", "patch"] {
+        let body = json!({"byTenant": {"victim": {"savedQueries": {"Patient": {"x": {}}}}}});
+        let response = if method == "put" {
+            server
+                .put("/_user/settings")
+                .add_header(TENANT, HeaderValue::from_static("attacker"))
+                .json(&body)
+                .await
+        } else {
+            server
+                .patch("/_user/settings")
+                .add_header(TENANT, HeaderValue::from_static("attacker"))
+                .json(&body)
+                .await
+        };
+        assert_eq!(
+            response.status_code(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "{method} of the reserved key must be rejected"
+        );
+    }
+
+    // Nothing landed under the victim tenant.
+    let victim = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("victim"))
+        .await;
+    assert_eq!(victim.json::<Value>(), json!({}));
+}
+
+/// A `PUT` replaces what the caller can see. Another tenant's saved queries were
+/// never in that view, so they must survive it.
+#[tokio::test]
+async fn put_in_one_tenant_does_not_erase_another_tenants_queries() {
+    let (server, _backend) = server_with_backend();
+
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(&json!({"savedQueries": {"Patient": {"a": {"query": "name=smith"}}}}))
+        .await;
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("beta"))
+        .json(&json!({"savedQueries": {"Patient": {"b": {"query": "name=jones"}}}}))
+        .await;
+
+    let acme = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .await;
+    assert_eq!(
+        acme.json::<Value>()["savedQueries"]["Patient"]["a"]["query"],
+        "name=smith"
+    );
+    assert!(
+        acme.json::<Value>()["savedQueries"]["Patient"]
+            .get("b")
+            .is_none()
+    );
+}
+
+/// Merge-patch semantics survive the rewrite: a `null` still deletes exactly one
+/// sibling entry, in this tenant only.
+#[tokio::test]
+async fn patch_null_deletes_one_scoped_entry_only() {
+    let (server, _backend) = server_with_backend();
+
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(&json!({"savedQueries": {"Patient": {"keep": {}, "drop": {}}}}))
+        .await;
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("beta"))
+        .json(&json!({"savedQueries": {"Patient": {"drop": {}}}}))
+        .await;
+
+    server
+        .patch("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(&json!({"savedQueries": {"Patient": {"drop": null}}}))
+        .await;
+
+    let acme = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .await;
+    assert_eq!(
+        acme.json::<Value>()["savedQueries"]["Patient"],
+        json!({"keep": {}})
+    );
+    // beta's identically-named entry is untouched.
+    let beta = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("beta"))
+        .await;
+    assert_eq!(
+        beta.json::<Value>()["savedQueries"]["Patient"],
+        json!({"drop": {}})
+    );
+}
+
+/// The whole point: offboarding a tenant now reaches the PHI-derived query
+/// strings in every user's settings document, while leaving the other tenants'
+/// and the user's own preferences alone.
+#[tokio::test]
+async fn purging_a_tenant_erases_its_saved_queries_from_user_settings() {
+    use helios_persistence::core::ResourceStorage;
+
+    let (server, backend) = server_with_backend();
+
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(&json!({
+            "theme": "dark",
+            "savedQueries": {"Patient": {"q": {"query": "name=smith&birthdate=1970-01-01"}}}
+        }))
+        .await;
+    server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("beta"))
+        .json(&json!({"savedQueries": {"Patient": {"q": {"query": "name=jones"}}}}))
+        .await;
+
+    backend.purge_tenant_data("acme").await.expect("purge acme");
+
+    // acme's PHI is gone …
+    let acme = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .await;
+    assert_eq!(acme.json::<Value>(), json!({"theme": "dark"}));
+
+    // … from the stored document, not merely hidden by the projection …
+    let stored = SettingsStore::get_settings(backend.as_ref(), "l2:")
+        .await
+        .expect("read stored document")
+        .expect("document exists");
+    assert!(
+        !serde_json::to_string(&stored.document)
+            .unwrap()
+            .contains("smith"),
+        "purged content must not survive anywhere in the stored document"
+    );
+
+    // … while beta and the user's theme are untouched.
+    let beta = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("beta"))
+        .await;
+    assert_eq!(
+        beta.json::<Value>()["savedQueries"]["Patient"]["q"]["query"],
+        "name=jones"
+    );
+    assert_eq!(beta.json::<Value>()["theme"], "dark");
+}
+
+/// A document written before scoping existed keeps working: its queries are
+/// still readable, and the first write files them under a tenant so a later
+/// purge can reach them.
+#[tokio::test]
+async fn a_pre_scoping_document_is_readable_then_normalized_on_write() {
+    let (server, backend) = server_with_backend();
+
+    // Seed exactly what a previous release would have stored: flat, no `byTenant`.
+    SettingsStore::put_settings(
+        backend.as_ref(),
+        "l2:",
+        json!({"theme": "dark", "savedQueries": {"Patient": {"q": {"query": "name=smith"}}}}),
+        None,
+    )
+    .await
+    .expect("seed pre-scoping document");
+
+    // Unattributed, so it still reads as user-global — nobody's queries vanish
+    // on upgrade.
+    let get = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .await;
+    assert_eq!(
+        get.json::<Value>()["savedQueries"]["Patient"]["q"]["query"],
+        "name=smith"
+    );
+
+    // A read must not rewrite it: GET stays side-effect-free.
+    let stored = SettingsStore::get_settings(backend.as_ref(), "l2:")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(stored.document.get("byTenant").is_none());
+    assert_eq!(stored.version, 1, "GET must not bump the version");
+
+    // The first write files it under the writing tenant …
+    server
+        .patch("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(&json!({"theme": "light"}))
+        .await;
+    let stored = SettingsStore::get_settings(backend.as_ref(), "l2:")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        stored.document["byTenant"]["acme"]["savedQueries"]["Patient"]["q"]["query"],
+        "name=smith"
+    );
+    assert!(stored.document.get("savedQueries").is_none());
+}
+
+/// A pre-scoping document that recorded a tenant choice is attributed to *that*
+/// tenant, not to whichever tenant happens to write next.
+#[tokio::test]
+async fn a_pre_scoping_document_is_attributed_by_its_recorded_tenant() {
+    let (server, backend) = server_with_backend();
+
+    SettingsStore::put_settings(
+        backend.as_ref(),
+        "l2:",
+        json!({"tenantId": "acme", "savedQueries": {"Patient": {"q": {"query": "name=smith"}}}}),
+        None,
+    )
+    .await
+    .expect("seed pre-scoping document");
+
+    // Writing from beta must not re-file acme's queries under beta.
+    server
+        .patch("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("beta"))
+        .json(&json!({"theme": "dark"}))
+        .await;
+
+    let stored = SettingsStore::get_settings(backend.as_ref(), "l2:")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        stored.document["byTenant"]["acme"]["savedQueries"]["Patient"]["q"]["query"],
+        "name=smith"
+    );
+    assert!(stored.document["byTenant"].get("beta").is_none());
+}
+
+/// A pre-scoping document that no write ever normalized is still reachable by a
+/// purge — the dormant-user residual that would otherwise keep the erasure gap
+/// open. Unattributed content is swept by any tenant's purge, deliberately.
+#[tokio::test]
+async fn a_dormant_pre_scoping_document_is_still_purgeable() {
+    use helios_persistence::core::ResourceStorage;
+
+    let (server, backend) = server_with_backend();
+
+    SettingsStore::put_settings(
+        backend.as_ref(),
+        "l2:",
+        json!({"theme": "dark", "savedQueries": {"Patient": {"q": {"query": "name=smith"}}}}),
+        None,
+    )
+    .await
+    .expect("seed dormant document");
+
+    backend.purge_tenant_data("acme").await.expect("purge acme");
+
+    let stored = SettingsStore::get_settings(backend.as_ref(), "l2:")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.document, json!({"theme": "dark"}));
+
+    let get = server
+        .get("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .await;
+    assert_eq!(get.json::<Value>(), json!({"theme": "dark"}));
+}
+
+/// The per-type saved-query cap applies within each tenant, so it cannot be
+/// exceeded one tenant at a time.
+#[tokio::test]
+async fn the_saved_query_cap_applies_within_each_tenant() {
+    let (server, _backend) = server_with_backend();
+
+    let mut entries = serde_json::Map::new();
+    for i in 0..=100 {
+        entries.insert(format!("q{i}"), json!({}));
+    }
+    let response = server
+        .put("/_user/settings")
+        .add_header(TENANT, HeaderValue::from_static("acme"))
+        .json(&json!({"savedQueries": {"Patient": entries}}))
+        .await;
+    assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -132,6 +132,15 @@ struct WebState {
 /// authenticated principal, `l2:` when auth is disabled (`/ui` also sits
 /// outside the auth layer today; #320 tracks the authenticated modes). Keep in
 /// step with `crates/rest/src/extractors/user.rs`.
+///
+/// These two go through [`SettingsStore`] **directly**, not through
+/// `/_user/settings`, so they bypass the per-tenant scoping that handler applies
+/// (issue #313). That is correct precisely because both are in
+/// [`GLOBAL_SETTINGS_KEYS`](helios_persistence::core::GLOBAL_SETTINGS_KEYS) —
+/// they are user-global preferences, and `tenantId` in particular has to be
+/// readable *before* a tenant is known. Anything added here that is **not** in
+/// that list must go through the handler instead, or it will be written outside
+/// a tenant purge's reach.
 const SETTINGS_VERSION_KEY: &str = "fhirVersion";
 const SETTINGS_TENANT_KEY: &str = "tenantId";
 const LOCAL_USER_KEY: &str = "l2:";


### PR DESCRIPTION
Fixes #313.

## The problem, restated

The settings document is keyed by user, and that part is right — a "default
tenant" preference is inherently cross-tenant. But `savedQueries` and
`recentSearches` hold **FHIR search strings**, which in practice carry names,
MRNs and dates of birth, and which are derived from one *tenant's* records.
Stored with no tenant attribution, `purge_tenant_data` could not reach them, so
tenant offboarding and right-to-erasure were incomplete.

This is a compliance gap, not an access-control one. #270 already established
that no principal can read another's settings.

## Shape

The issue proposed `byTenant`, and that is what landed. What it did not settle
was **whether clients see it**. They do not:

- **Stored:** `{ theme, fhirVersion, byTenant: { acme: { savedQueries … } } }`
- **On the wire:** unchanged — flat, exactly as before.

`GET` projects the caller's tenant subtree over the globals; `PUT` replaces the
globals and *that* subtree; `PATCH` has its scoped members wrapped so they target
that subtree. Wrapping preserves RFC 7386 exactly, `null`-deletes included.

Keeping the wire format fixed matters for two reasons: the three JS clients need
no changes, and — more importantly — the guarantee becomes **server-side**. A
client this project does not ship, or one that simply has not been upgraded,
cannot write PHI to an unpurgeable location.

The one visible behaviour change: **saved queries and recent searches now change
when a user switches tenants.** That is the intended semantics (a query saved
against `acme` is meaningless in `beta`), but it will be read as "my queries
disappeared" if unannounced. Documented in the run-hfs-server skill.

## Which keys are scoped — a denylist, deliberately

`GLOBAL_SETTINGS_KEYS` is `theme`, `nav`, `fhirVersion`, `tenantId`; **everything
else is tenant-scoped**, including keys the server has never heard of.

An allowlist of known-PHI keys was the obvious alternative and is rejected: a
future client key holding query text would silently reintroduce this exact issue,
with nobody remembering to add it. The failure modes are asymmetric — a
wrongly-scoped preference resets once per tenant; wrongly-global PHI is
unreachable. There is a test pinning the list so widening it is a decision, not a
drive-by.

`tenantId` in particular has to stay global: scoping the tenant selector per
tenant makes it unreadable before a tenant is known.

## Purge — all four backends, one transform

`SettingsStore::purge_tenant_settings(tenant)`, called from **inside** each
backend's `purge_tenant_data`. That is the single choke point both `/admin/tenants`
and `/ui/tenants` already go through, and `CompositeStorage` delegates to its
primary — which is the concrete backend implementing `SettingsStore` in every
wiring in `main.rs` — so every deployment inherits it without a second call site
to forget.

All four apply the **same** `purge_tenant_subtree` from `core::user_settings`, so
they erase byte-identically. Only the enumeration and write-back differ, matching
each backend's existing model:

| Backend | Mechanism | Why |
|---|---|---|
| SQLite | scan + `UPDATE`, **in the purge's own transaction** | a second pooled connection would `SQLITE_BUSY` against the write lock the purge already holds |
| PostgreSQL | `SELECT … FOR UPDATE` + `UPDATE`, same transaction | offboarding commits atomically; cannot half-apply |
| MongoDB | version-conditioned `update_one`, retried | no multi-document transactions on standalone |
| S3 | compare-and-swap on the object ETag, retried | no transactions; same shape as the ordinary write path |

Deliberately **not** `jsonb #-` / `$unset "byTenant.<id>"`: `admin_tenants::validate_tenant_id`
permits `.` and `/` in tenant ids, and MongoDB has no escape for `.` in a field
path — a tenant named `a.b` would have `$unset` hit `byTenant.a` → `b`, silently
wrong. Editing a parsed `Value` is correct *and* keeps the four identical. There
are tests for dotted and slashed ids, and for a prefix sibling (`acme` vs `acme-2`).

Every changed document's `version` bumps, so a client holding a stale `ETag` gets
a `412` and re-reads rather than `PUT`ting the purged content straight back. A
tenant with nothing stored is a true no-op — no write, no burned version.

On S3 the objects are named by a digest of the user key, so the sweep costs one
`LIST` plus `GET`/`PUT` per object. Acceptable for an administrative operation,
and the price of keeping user identifiers out of S3 key names. Exhausting the
CAS retry bound is an **error**, not a silent skip: an object quietly left
un-purged is the gap this closes.

## Documents written before this

Lazy, on the write path, mirroring #270 — with one addition the issue did not
cover.

- **Attribution** comes from the document's own `tenantId` (the tenant the UI was
  pointed at, and therefore the one those queries were written against), falling
  back to the writing request's tenant. Not "the default tenant" as the issue
  suggested: a user who has switched tenants would have had acme's queries
  re-filed under beta.
- **Reads never rewrite.** A legacy document is *projected* as-is — to its
  attributed tenant, or everywhere when unattributed, exactly reproducing the
  pre-upgrade behaviour. Nobody's queries vanish on upgrade, and `GET` stays
  side-effect-free (#270 already made `GET` write once for the key migration;
  a second one is not worth it).
- **The dormant-user residual is closed.** Lazy normalization alone leaves users
  who never return holding unattributed PHI that no purge can reach — the same
  gap, just smaller, and not something you can write into an offboarding runbook.
  So a purge sweeps **unattributed** legacy content unconditionally. It is
  bounded (only tenant-scoped keys, never a global preference, never another
  tenant's subtree), evidence-respecting (content attributed to *another* tenant
  is left alone), and self-healing: after the first purge the store is fully
  attributed and the branch stops firing. A saved-query list is convenience state
  a user can recreate; unreachable PHI is not.

**No schema migration on any backend** — `data` was already an opaque
BLOB/JSONB/string/object on all four. Nothing to roll back.

## Also

- `byTenant` in a request body → `422`. Silently dropping it would make the write
  look applied, and accepting it would let a caller in one tenant plant content
  under another's subtree — reopening #270 from the other side.
- Validation now runs on the **stored** document: the size cap and the
  per-type saved-query cap are checked inside every tenant subtree, so a user
  cannot exceed them one tenant at a time.
- `PATCH` now computes the merged document and writes it with `put_settings`
  pinned to the version it read, instead of handing the patch to
  `patch_settings`. A merge patch cannot express "move these keys", which
  normalization needs. Pinning makes it equivalent — the backend still rejects
  atomically on a concurrent write — and the existing conflict-absorbing retry is
  unchanged. `patch_settings` stays on the trait; `helios-ui` uses it directly.
- A note in `crates/ui/src/lib.rs`: `set_version`/`set_tenant` write through the
  store directly and so bypass the scoping. That is correct *because* both keys
  are global, and the note says what to do if that ever stops being true.

## Testing

- **Transform unit tests** (`core::user_settings`, ~25): projection isolation and
  that the reserved key never reaches the wire; `PUT` not destroying a sibling
  tenant; merge-patch `null` deleting one entry in one tenant; attributed vs
  unattributed legacy handling; dotted/slashed tenant ids; prefix siblings;
  corrupt and malformed documents.
- **SQLite backend tests** (in-crate, run everywhere): sweep across multiple
  users, version bump, no-op when nothing matches, corrupt row skipped rather
  than aborting the offboarding, and `purge_tenant_data` reaching settings.
- **REST integration** (`crates/rest/tests/user_settings.rs`, 11 new): the whole
  thing end to end over `X-Tenant-ID`, including the reserved-key rejection on
  both `PUT` and `PATCH`, and a check that purged content is gone from the
  *stored* document rather than merely hidden by the projection.
- **PostgreSQL / MongoDB / MinIO** integration tests for the same guarantee,
  each exercising that backend's specific risk (transaction atomicity,
  dotted-tenant `$unset` avoidance, real conditional `PutObject`).
- Existing tests were not rewritten — they exercise a single default tenant, so
  the projection is transparent to them, which is itself the compatibility claim.

**Not compiled or run locally** — this environment has no C linker, so build
scripts cannot compile. Everything is `cargo fmt`-clean and reviewed by hand, and
the document transform was additionally validated by simulating every scenario in
the test suite. CI is the first real check; draft for that reason.

## Deliberately out of scope

- The residual after all of the above is a user who has **both** never returned
  **and** recorded a `tenantId` for a tenant that is never purged. Their legacy
  keys stay attributed to that tenant and are erased when it is offboarded. That
  is correct, not a gap.
- `delete_settings` already erases one user's document; a bulk right-to-erasure
  sweep across users is a separate feature.
