### PR TITLE
ci: reap testcontainer volumes, not just containers

### DIFF
--- a/.github/workflows/audit-events.yml
+++ b/.github/workflows/audit-events.yml
@@ -229,7 +229,7 @@ jobs:
         if: matrix.backend == 'sqlite-elasticsearch' || matrix.backend == 's3-elasticsearch'
         run: |
           ES_CONTAINER="es-audit-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$ES_CONTAINER" 2>/dev/null || true
           docker run -d --name "$ES_CONTAINER" -p 0:9200 \
             -e "discovery.type=single-node" \
             -e "xpack.security.enabled=false" \
@@ -260,7 +260,7 @@ jobs:
         if: matrix.backend == 'postgres'
         run: |
           PG_CONTAINER="pg-audit-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -291,7 +291,7 @@ jobs:
         if: matrix.backend == 'mongodb'
         run: |
           MONGO_CONTAINER="mongo-audit-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
@@ -383,7 +383,7 @@ jobs:
       - name: Start ephemeral Keycloak
         run: |
           KC_CONTAINER="kc-audit-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$KC_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$KC_CONTAINER" 2>/dev/null || true
 
           docker create --name "$KC_CONTAINER" -p 0:8080 \
             -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
@@ -760,16 +760,16 @@ jobs:
           fi
 
           echo "Stopping Keycloak..."
-          docker rm -f "${KC_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${KC_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Stopping Elasticsearch..."
-          docker rm -f "${ES_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${ES_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Stopping PostgreSQL..."
-          docker rm -f "${PG_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${PG_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Stopping MongoDB..."
-          docker rm -f "${MONGO_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${MONGO_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Cleanup complete"
 
@@ -826,7 +826,7 @@ jobs:
         if: matrix.backend == 'postgres'
         run: |
           PG_CONTAINER="pg-audit-db-${{ matrix.mode }}-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -862,7 +862,7 @@ jobs:
         if: matrix.backend == 'mongodb'
         run: |
           MONGO_CONTAINER="mongo-audit-db-${{ matrix.mode }}-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
@@ -1196,5 +1196,5 @@ jobs:
       - name: Cleanup smoke resources
         if: always()
         run: |
-          docker rm -f "${PG_CONTAINER:-none}" 2>/dev/null || true
-          docker rm -f "${MONGO_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${PG_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${MONGO_CONTAINER:-none}" 2>/dev/null || true

--- a/.github/workflows/bulk-export-smoke.yml
+++ b/.github/workflows/bulk-export-smoke.yml
@@ -136,7 +136,7 @@ jobs:
         if: contains(matrix.backend, 'elasticsearch')
         run: |
           ES_CONTAINER="es-bulk-export-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.output }}"
-          docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$ES_CONTAINER" 2>/dev/null || true
           docker run -d --name "$ES_CONTAINER" -p 0:9200 \
             -e "discovery.type=single-node" \
             -e "xpack.security.enabled=false" \
@@ -162,7 +162,7 @@ jobs:
         if: contains(matrix.backend, 'postgres')
         run: |
           PG_CONTAINER="pg-bulk-export-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.output }}"
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -191,7 +191,7 @@ jobs:
         if: contains(matrix.backend, 'mongodb')
         run: |
           MONGO_CONTAINER="mongo-bulk-export-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.output }}"
-          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
 
@@ -217,7 +217,7 @@ jobs:
         if: startsWith(matrix.backend, 's3')
         run: |
           MINIO_CONTAINER="minio-bulk-export-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.output }}"
-          docker rm -f "$MINIO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MINIO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MINIO_CONTAINER" -p 0:9000 -p 0:9001 \
             -e MINIO_ROOT_USER=hfs-minio \
             -e MINIO_ROOT_PASSWORD=hfs-minio-secret \
@@ -499,14 +499,14 @@ jobs:
         if: always()
         run: |
           if [ -n "${ES_CONTAINER:-}" ]; then
-            docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$ES_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${PG_CONTAINER:-}" ]; then
-            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${MONGO_CONTAINER:-}" ]; then
-            docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${MINIO_CONTAINER:-}" ]; then
-            docker rm -f "$MINIO_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$MINIO_CONTAINER" 2>/dev/null || true
           fi

--- a/.github/workflows/bulk-submit-smoke.yml
+++ b/.github/workflows/bulk-submit-smoke.yml
@@ -123,7 +123,7 @@ jobs:
         if: contains(matrix.backend, 'elasticsearch')
         run: |
           ES_CONTAINER="es-bulk-submit-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.output }}"
-          docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$ES_CONTAINER" 2>/dev/null || true
           docker run -d --name "$ES_CONTAINER" -p 0:9200 \
             -e "discovery.type=single-node" \
             -e "xpack.security.enabled=false" \
@@ -149,7 +149,7 @@ jobs:
         if: contains(matrix.backend, 'postgres')
         run: |
           PG_CONTAINER="pg-bulk-submit-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.output }}"
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -178,7 +178,7 @@ jobs:
         if: contains(matrix.backend, 'mongodb')
         run: |
           MONGO_CONTAINER="mongo-bulk-submit-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.output }}"
-          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
 
@@ -204,7 +204,7 @@ jobs:
         if: startsWith(matrix.backend, 's3')
         run: |
           MINIO_CONTAINER="minio-bulk-submit-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.fhir_version }}-${{ matrix.backend }}-${{ matrix.output }}"
-          docker rm -f "$MINIO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MINIO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MINIO_CONTAINER" -p 0:9000 -p 0:9001 \
             -e MINIO_ROOT_USER=hfs-minio \
             -e MINIO_ROOT_PASSWORD=hfs-minio-secret \
@@ -562,14 +562,14 @@ jobs:
         if: always()
         run: |
           if [ -n "${ES_CONTAINER:-}" ]; then
-            docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$ES_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${PG_CONTAINER:-}" ]; then
-            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${MONGO_CONTAINER:-}" ]; then
-            docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${MINIO_CONTAINER:-}" ]; then
-            docker rm -f "$MINIO_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$MINIO_CONTAINER" 2>/dev/null || true
           fi

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Remove testcontainers from this run
         run: |
-          docker ps -aq --filter "label=github.run_id=${{ github.run_id }}" | xargs -r docker rm -f || true
+          docker ps -aq --filter "label=github.run_id=${{ github.run_id }}" | xargs -r docker rm -fv || true
 
       - name: Sweep orphaned testcontainers from dead runs
         run: |
@@ -64,7 +64,7 @@ jobs:
             age_min=$(( (now - $(date -d "$started" +%s)) / 60 ))
             if [ "$age_min" -ge "$MAX_CONTAINER_AGE_MIN" ]; then
               echo "Reaping orphan $id (age ${age_min}m)"
-              docker rm -f "$id" || true
+              docker rm -fv "$id" || true
               reaped=$((reaped + 1))
             fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,8 +318,16 @@ jobs:
           # The test helpers stamp `github.run_id`, which is exactly what makes
           # them reapable. No age guard: these are *this* run's containers, and
           # by construction they are only minutes old.
+          #
+          # `-v` is load-bearing. The postgres/elasticsearch/mongo images all
+          # declare VOLUME in their Dockerfiles, so every testcontainer gets an
+          # anonymous volume — and plain `docker rm -f` leaves it behind
+          # forever. That is what filled the shared host's 200G ZFS quota until
+          # containerd could not even write meta.db and *every* container start
+          # failed with "disk quota exceeded". `-v` removes only anonymous
+          # volumes; named volumes are never touched.
           docker ps -aq --filter "label=github.run_id=${{ github.run_id }}" \
-            | xargs -r docker rm -f || true
+            | xargs -r docker rm -fv || true
 
       - name: Sweep orphaned testcontainers from dead runs
         run: |
@@ -335,7 +343,7 @@ jobs:
             age_min=$(( (now - $(date -d "$started" +%s)) / 60 ))
             if [ "$age_min" -ge "$MAX_CONTAINER_AGE_MIN" ]; then
               echo "Reaping orphan $id (age ${age_min}m)"
-              docker rm -f "$id" || true
+              docker rm -fv "$id" || true
               reaped=$((reaped + 1))
             fi
           done

--- a/.github/workflows/cluster-smoke.yml
+++ b/.github/workflows/cluster-smoke.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Start PostgreSQL
         run: |
           PG_CONTAINER="pg-cluster-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -129,7 +129,7 @@ jobs:
         run: |
           mkdir -p "$RESULTS_DIR"
           NGINX_CONTAINER="nginx-cluster-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$NGINX_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$NGINX_CONTAINER" 2>/dev/null || true
 
           # Upstreams are the two hfs processes on the runner. X-Hfs-Upstream
           # lets the smoke script prove round-robin. The Upgrade/Connection
@@ -301,8 +301,8 @@ jobs:
         if: always()
         run: |
           if [ -n "${PG_CONTAINER:-}" ]; then
-            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${NGINX_CONTAINER:-}" ]; then
-            docker rm -f "$NGINX_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$NGINX_CONTAINER" 2>/dev/null || true
           fi

--- a/.github/workflows/fhir-benchmark.yml
+++ b/.github/workflows/fhir-benchmark.yml
@@ -240,7 +240,7 @@ jobs:
           echo "TGZ_CONTAINER=$TGZ_CONTAINER" >> "$GITHUB_ENV"
 
           docker build -t "$TGZ_IMAGE" fhir-benchmark/infra/tgz
-          docker rm -f "$TGZ_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$TGZ_CONTAINER" 2>/dev/null || true
           docker run -d --name "$TGZ_CONTAINER" -p 0:8080 "$TGZ_IMAGE" \
             "https://storage.googleapis.com/aidbox-public/synthea/performance/bulk_1k.tar.gz" >/dev/null
 
@@ -281,7 +281,7 @@ jobs:
         if: matrix.backend == 'postgres'
         run: |
           set -euo pipefail
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           # Tuning approximates the benchmark's infra/postgres/postgres.conf.
           # shared_buffers/effective_cache_size are scaled DOWN from the
           # published values (10G/25G) to fit a typical self-hosted runner;
@@ -644,12 +644,12 @@ jobs:
         if: always()
         run: |
           if [ -n "${TGZ_CONTAINER:-}" ]; then
-            docker rm -f "$TGZ_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$TGZ_CONTAINER" 2>/dev/null || true
           fi
 
       - name: Stop ephemeral Postgres
         if: always() && matrix.backend == 'postgres'
         run: |
           if [ -n "${PG_CONTAINER:-}" ]; then
-            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           fi

--- a/.github/workflows/hts-benchmark.yml
+++ b/.github/workflows/hts-benchmark.yml
@@ -344,7 +344,7 @@ jobs:
         if: matrix.backend == 'postgres'
         run: |
           set -euo pipefail
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           # `-c shared_buffers=1GB -c work_mem=64MB` give the bench a fair
           # chance against SQLite's in-process locality; the defaults are
           # tuned for tiny VPS instances and would penalise PG unfairly when
@@ -677,7 +677,7 @@ jobs:
         if: always() && matrix.backend == 'postgres'
         run: |
           if [ -n "${PG_CONTAINER:-}" ]; then
-            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           fi
 
       # Turn the job red if any arm never started/verified — but only after the

--- a/.github/workflows/hts-ig-conformance.yml
+++ b/.github/workflows/hts-ig-conformance.yml
@@ -269,7 +269,7 @@ jobs:
         if: matrix.backend == 'postgres'
         run: |
           set -euo pipefail
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           # `-c shared_buffers=1GB -c work_mem=64MB` give PG enough cache to
           # hold the SNOMED `concept_closure` without evicting the hot
           # working set. `--shm-size=2g` ensures the larger shared-memory
@@ -809,7 +809,7 @@ jobs:
         if: always() && matrix.backend == 'postgres'
         run: |
           if [ -n "${PG_CONTAINER:-}" ]; then
-            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           fi
 
       - name: Clean up working files

--- a/.github/workflows/hts.yml
+++ b/.github/workflows/hts.yml
@@ -704,7 +704,7 @@ jobs:
             age_min=$(( (now - $(date -d "$started" +%s)) / 60 ))
             if [ "$age_min" -ge "$MAX_CONTAINER_AGE_MIN" ]; then
               echo "Reaping orphan $id (age ${age_min}m)"
-              docker rm -f "$id" || true
+              docker rm -fv "$id" || true
               reaped=$((reaped + 1))
             fi
           done

--- a/.github/workflows/inferno-bulk-data.yml
+++ b/.github/workflows/inferno-bulk-data.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Start PostgreSQL
         run: |
           PG_CONTAINER="pg-inferno-bulk-data-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -251,7 +251,7 @@ jobs:
       - name: Start MinIO
         run: |
           MINIO_CONTAINER="minio-inferno-bulk-data-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$MINIO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MINIO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MINIO_CONTAINER" -p 0:9000 -p 0:9001 \
             -e MINIO_ROOT_USER=hfs-minio \
             -e MINIO_ROOT_PASSWORD=hfs-minio-secret \
@@ -318,7 +318,7 @@ jobs:
       - name: Start Keycloak
         run: |
           KC_CONTAINER="kc-inferno-bulk-data-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$KC_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$KC_CONTAINER" 2>/dev/null || true
 
           docker create --name "$KC_CONTAINER" -p 0:8080 \
             -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
@@ -778,13 +778,13 @@ jobs:
           fi
 
           echo "Stopping PostgreSQL..."
-          docker rm -f "${PG_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${PG_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Stopping MinIO..."
-          docker rm -f "${MINIO_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${MINIO_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Stopping Keycloak..."
-          docker rm -f "${KC_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${KC_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Cleanup complete"
 
@@ -804,7 +804,7 @@ jobs:
 
           IDS=$(docker ps -aq --filter "label=com.docker.compose.project=$PROJECT")
           if [ -n "$IDS" ]; then
-            docker rm -f $IDS
+            docker rm -fv $IDS
           fi
 
           NETS=$(docker network ls --filter "label=com.docker.compose.project=$PROJECT" -q)

--- a/.github/workflows/inferno-subscription.yml
+++ b/.github/workflows/inferno-subscription.yml
@@ -206,7 +206,7 @@ jobs:
         if: matrix.backend == 'sqlite-elasticsearch' || matrix.backend == 's3-elasticsearch'
         run: |
           ES_CONTAINER="es-inferno-subscriptions-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$ES_CONTAINER" 2>/dev/null || true
           docker run -d --name "$ES_CONTAINER" -p 0:9200 \
             -e "discovery.type=single-node" \
             -e "xpack.security.enabled=false" \
@@ -237,7 +237,7 @@ jobs:
         if: matrix.backend == 'postgres'
         run: |
           PG_CONTAINER="pg-inferno-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -268,7 +268,7 @@ jobs:
         if: matrix.backend == 'mongodb'
         run: |
           MONGO_CONTAINER="mongo-inferno-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
@@ -771,9 +771,9 @@ jobs:
           fi
 
           echo "Stopping backend containers..."
-          docker rm -f "${ES_CONTAINER:-none}" 2>/dev/null || true
-          docker rm -f "${PG_CONTAINER:-none}" 2>/dev/null || true
-          docker rm -f "${MONGO_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${ES_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${PG_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${MONGO_CONTAINER:-none}" 2>/dev/null || true
 
   inferno-stack-down:
     name: Stop Shared Inferno Subscriptions Stack
@@ -791,7 +791,7 @@ jobs:
 
           IDS=$(docker ps -aq --filter "label=com.docker.compose.project=$PROJECT")
           if [ -n "$IDS" ]; then
-            docker rm -f $IDS
+            docker rm -fv $IDS
           fi
 
           NETS=$(docker network ls --filter "label=com.docker.compose.project=$PROJECT" -q)

--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -281,7 +281,7 @@ jobs:
         if: matrix.backend == 'mongodb'
         run: |
           MONGO_CONTAINER="mongo-${{ matrix.suite_id }}-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
@@ -325,7 +325,7 @@ jobs:
         if: matrix.backend == 'sqlite-elasticsearch' || matrix.backend == 's3-elasticsearch'
         run: |
           ES_CONTAINER="es-${{ matrix.suite_id }}-${{ matrix.backend }}"
-          docker rm -f $ES_CONTAINER 2>/dev/null || true
+          docker rm -fv $ES_CONTAINER 2>/dev/null || true
           docker run -d --name $ES_CONTAINER -p 0:9200 \
             -e "discovery.type=single-node" \
             -e "xpack.security.enabled=false" \
@@ -355,7 +355,7 @@ jobs:
         if: matrix.backend == 'postgres'
         run: |
           PG_CONTAINER="pg-${{ matrix.suite_id }}"
-          docker rm -f $PG_CONTAINER 2>/dev/null || true
+          docker rm -fv $PG_CONTAINER 2>/dev/null || true
           docker run -d --name $PG_CONTAINER -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -760,13 +760,13 @@ jobs:
           fi
 
           echo "Stopping Elasticsearch..."
-          docker rm -f "${ES_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${ES_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Stopping PostgreSQL..."
-          docker rm -f "${PG_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${PG_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Stopping MongoDB..."
-          docker rm -f "${MONGO_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${MONGO_CONTAINER:-none}" 2>/dev/null || true
 
           echo "Cleanup complete"
 
@@ -786,7 +786,7 @@ jobs:
 
           IDS=$(docker ps -aq --filter "label=com.docker.compose.project=$PROJECT")
           if [ -n "$IDS" ]; then
-            docker rm -f $IDS
+            docker rm -fv $IDS
           fi
 
           NETS=$(docker network ls --filter "label=com.docker.compose.project=$PROJECT" -q)

--- a/.github/workflows/subscriptions-smoke.yml
+++ b/.github/workflows/subscriptions-smoke.yml
@@ -158,7 +158,7 @@ jobs:
         if: matrix.backend == 'sqlite-elasticsearch' || matrix.backend == 's3-elasticsearch'
         run: |
           ES_CONTAINER="es-subscriptions-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.build_key }}-${{ matrix.fhir_version }}"
-          docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$ES_CONTAINER" 2>/dev/null || true
           docker run -d --name "$ES_CONTAINER" -p 0:9200 \
             -e "discovery.type=single-node" \
             -e "xpack.security.enabled=false" \
@@ -189,7 +189,7 @@ jobs:
         if: matrix.backend == 'postgres'
         run: |
           PG_CONTAINER="pg-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.build_key }}-${{ matrix.fhir_version }}"
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -220,7 +220,7 @@ jobs:
         if: matrix.backend == 'mongodb'
         run: |
           MONGO_CONTAINER="mongo-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.build_key }}-${{ matrix.fhir_version }}"
-          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> $GITHUB_ENV
@@ -284,7 +284,7 @@ jobs:
       - name: Start mailpit (email channel sink)
         run: |
           MP_CONTAINER="mailpit-subscriptions-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.build_key }}-${{ matrix.fhir_version }}-${{ matrix.backend }}"
-          docker rm -f "$MP_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MP_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MP_CONTAINER" -p 0:1025 -p 0:8025 axllent/mailpit:latest
           echo "MP_CONTAINER=$MP_CONTAINER" >> $GITHUB_ENV
 
@@ -493,14 +493,14 @@ jobs:
         if: always()
         run: |
           if [ -n "${ES_CONTAINER:-}" ]; then
-            docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$ES_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${PG_CONTAINER:-}" ]; then
-            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${MONGO_CONTAINER:-}" ]; then
-            docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           fi
           if [ -n "${MP_CONTAINER:-}" ]; then
-            docker rm -f "$MP_CONTAINER" 2>/dev/null || true
+            docker rm -fv "$MP_CONTAINER" 2>/dev/null || true
           fi

--- a/.github/workflows/ui-tests-matrix.yml
+++ b/.github/workflows/ui-tests-matrix.yml
@@ -127,7 +127,7 @@ jobs:
         if: matrix.backend == 'sqlite-elasticsearch' || matrix.backend == 's3-elasticsearch'
         run: |
           ES_CONTAINER="es-ui-matrix-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$ES_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$ES_CONTAINER" 2>/dev/null || true
           docker run -d --name "$ES_CONTAINER" -p 0:9200 \
             -e "discovery.type=single-node" \
             -e "xpack.security.enabled=false" \
@@ -158,7 +158,7 @@ jobs:
         if: matrix.backend == 'postgres'
         run: |
           PG_CONTAINER="pg-ui-matrix-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             -e POSTGRES_USER=helios \
             -e POSTGRES_PASSWORD=helios \
@@ -189,7 +189,7 @@ jobs:
         if: matrix.backend == 'mongodb'
         run: |
           MONGO_CONTAINER="mongo-ui-matrix-${{ github.run_id }}-${{ github.run_attempt }}"
-          docker rm -f "$MONGO_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MONGO_CONTAINER" -p 0:27017 mongo:7.0 --replSet rs0 --bind_ip_all
 
           echo "MONGO_CONTAINER=$MONGO_CONTAINER" >> "$GITHUB_ENV"
@@ -352,7 +352,7 @@ jobs:
           set -euo pipefail
           BASE="http://$RUNNER_IP:$HFS_PORT"
           echo "Driving browser against $BASE"
-          docker rm -f "$PW_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PW_CONTAINER" 2>/dev/null || true
           # 2g shm: Chromium needs more than docker's 64m default.
           docker run -d --name "$PW_CONTAINER" --shm-size=2g -w /work "$PLAYWRIGHT_IMAGE" sleep 3600
           docker cp crates/ui/e2e "$PW_CONTAINER":/work/e2e
@@ -377,7 +377,7 @@ jobs:
         if: always()
         run: |
           echo "Removing Playwright container..."
-          docker rm -f "$PW_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$PW_CONTAINER" 2>/dev/null || true
 
           echo "Stopping HFS..."
           if [ -f /tmp/hfs-ui-matrix-${{ matrix.backend }}.pid ]; then
@@ -395,6 +395,6 @@ jobs:
           fi
 
           echo "Stopping backend containers..."
-          docker rm -f "${ES_CONTAINER:-none}" 2>/dev/null || true
-          docker rm -f "${PG_CONTAINER:-none}" 2>/dev/null || true
-          docker rm -f "${MONGO_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${ES_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${PG_CONTAINER:-none}" 2>/dev/null || true
+          docker rm -fv "${MONGO_CONTAINER:-none}" 2>/dev/null || true

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run browser suite (Playwright)
         run: |
           set -euo pipefail
-          docker rm -f "$RUN_CONTAINER" 2>/dev/null || true
+          docker rm -fv "$RUN_CONTAINER" 2>/dev/null || true
           # 2g shm: Chromium and the tmpfs-backed SQLite DB share /dev/shm, and
           # per-tenant conformance seeding overflows docker's 64m default.
           docker run -d --name "$RUN_CONTAINER" --shm-size=2g -w /work "$PLAYWRIGHT_IMAGE" sleep 3600
@@ -97,4 +97,4 @@ jobs:
 
       - name: Remove Playwright container
         if: always()
-        run: docker rm -f "$RUN_CONTAINER" 2>/dev/null || true
+        run: docker rm -fv "$RUN_CONTAINER" 2>/dev/null || true


### PR DESCRIPTION
## The bug

Every CI cleanup path force-removes its containers with `docker rm -f`, which **does not remove anonymous volumes** — that requires `-v`.

The postgres, elasticsearch, mongo, minio and keycloak images all declare `VOLUME` in their Dockerfiles, so every testcontainer gets an anonymous volume, and every reap orphans it permanently. This has been leaking on every run, on every workflow, for as long as the reaps have existed.

## How it surfaced

The shared self-hosted Docker host is an LXC container on a ZFS dataset (`nvme1/subvol-106-disk-0`) with a 200G refquota. The orphaned volumes filled it until containerd could no longer write `io.containerd.metadata.v1.bolt/meta.db`, at which point *every* container start failed:

```
Failed to start Postgres container: Client(CreateContainer(DockerResponseServerError {
  status_code: 500,
  message: "write /var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db: disk quota exceeded"
}))
```

Note `EDQUOT` ("disk quota exceeded"), not `ENOSPC` — the ZFS dataset quota, not a full disk. The failures are protean, because *anything* needing a container dies: see #449 for the Elasticsearch variant.

Seen in [run 30559660973](https://github.com/HeliosSoftware/hfs/actions/runs/30559660973/job/90929100594) (`Test Rust`, `postgres_bootstrap_lock.rs`), and it is not PR-specific — any run landing in that window fails the same way.

The fingerprint on the host, *after* a manual prune had already recovered it:

```
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          11        4         6.316GB   3.715GB (58%)
Containers      5         5         13.41MB   0B (0%)
Local Volumes   144       4         38.5GB    20.02GB (51%)
Build Cache     158       0         2.975GB   2.583GB
```

144 volumes, 4 active. 140 orphans.

## The change

`docker rm -f` → `docker rm -fv` at 84 call sites across 16 workflows, plus a comment at the canonical reap site in `ci.yml` recording why `-v` is load-bearing.

## Safety

`docker rm -v` removes **only** anonymous volumes; named volumes are never touched. No workflow in this repo runs `docker volume create` or mounts a named volume — every volume in play is anonymous, so all of them were pure leak.

`actionlint` was diffed against `main`: identical findings, no new ones. The only delta is three pre-existing `SC2086` warnings shifting column 16→17, from the extra character on those lines.

## Follow-ups

This stops *new* orphans, but an already-orphaned volume has no container left, so no `docker rm -fv` will ever reclaim it. The backlog still needs sweeping — see the per-run GC in the follow-up PR, which supersedes #451's nightly janitor.

#451 also carries an unrelated real fix (`ci(ui-matrix): route the Elasticsearch self-traffic around the runner proxy`) that is worth keeping.
