### PR TITLE
ci: ignore RUSTSEC-2026-0235 (rkyv 0.7.46, never built)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,6 +604,20 @@ jobs:
         # helios-serde's own quick-xml (client FHIR XML) is already on 0.41 and
         # sits behind the non-default `xml` feature. Remove these once
         # object_store and octofhir-ucum ship builds on quick-xml >= 0.41.
+        #
+        # rkyv 0.7.46 (RUSTSEC-2026-0235, out-of-bounds read when validating
+        # archives containing Rc/Arc). We never build it: it is an *optional*
+        # dependency of rust_decimal, and nothing in the workspace turns that
+        # feature on. Across `--all-features --target all` the activated
+        # rust_decimal features are default, macros, serde, serde_json,
+        # serde-with-arbitrary-precision and serde-with-float -- no `rkyv`, and
+        # `cargo tree -i rkyv --all-features --target all` reports "nothing to
+        # print". The crate is a Cargo.lock entry that is never compiled, let
+        # alone handed an untrusted archive. There is also no upgrade path:
+        # the advisory is patched in >= 0.8.17, the 0.7 line is unsupported
+        # upstream, and rust_decimal still declares optional `rkyv ^0.7.46`
+        # as of 1.42.1 (its 0.8 dependency is dev-only). Remove this once
+        # rust_decimal moves its optional rkyv to 0.8.
         run: >-
           cargo audit
           --ignore RUSTSEC-2026-0098
@@ -611,6 +625,7 @@ jobs:
           --ignore RUSTSEC-2026-0104
           --ignore RUSTSEC-2026-0194
           --ignore RUSTSEC-2026-0195
+          --ignore RUSTSEC-2026-0235
  
   coverage:
     name: Code Coverage


### PR DESCRIPTION
## Why

The **Security Audit** job is failing on every branch, including `main`, with `error: 1 vulnerability found!` — a new advisory against `rkyv 0.7.46`. `main`'s last audit ran on Jul 31 and passed; the advisory landed in the RustSec DB since, so nothing in any PR caused it.

## Why it is safe to ignore

**We never build the crate.** `rkyv` is an *optional* dependency of `rust_decimal` (which reaches us via `octofhir-ucum` and `helios-fhir`), and nothing in the workspace enables that feature:

- across `--all-features --target all`, the activated `rust_decimal` features are `default`, `macros`, `serde`, `serde_json`, `serde-with-arbitrary-precision`, `serde-with-float` — no `rkyv`;
- `cargo tree -i rkyv --all-features --target all` reports *"nothing to print"*.

It is a `Cargo.lock` entry that is never compiled. RUSTSEC-2026-0235 is an out-of-bounds read when *validating untrusted rkyv archives* containing `Rc`/`Arc` — we compile no rkyv code and parse no archives. This is a stronger justification than the five ignores already on that list, which cover code we do link.

**There is no upgrade path.** The advisory is patched in `>= 0.8.17`; the 0.7 series is affected and unsupported upstream. `rust_decimal` still declares optional `rkyv ^0.7.46` as of the latest 1.42.1 (its `rkyv ^0.8.13` is a dev-dependency only), so bumping `rust_decimal` changes nothing.

Vulnerability-class advisories cannot go in `audit.toml` (cargo-audit only honors it for warning-class entries), so it joins the CLI `--ignore` list, with a comment recording the reasoning and the condition for removing it: `rust_decimal` moving its optional `rkyv` to 0.8.

## Verification

```
$ cargo audit <existing five ignores>          # on main
error: 1 vulnerability found!                  # exit 1

$ cargo audit <existing five> --ignore RUSTSEC-2026-0235
warning: 7 allowed warnings found              # exit 0
```

Found while reviewing #423, which is unaffected by this — that branch changes no dependencies (`git diff main...HEAD -- Cargo.lock Cargo.toml` is empty).

https://claude.ai/code/session_018dtprXBni8PvvyGSn8aXjr