### PR TITLE
fix(ui): bundle the row-walk's constant arguments into RowCtx

### DIFF
--- a/crates/ui/src/editor.rs
+++ b/crates/ui/src/editor.rs
@@ -331,13 +331,15 @@ fn build_body(
 
     let mut rows = Vec::new();
     build_rows(
-        registry.as_ref(),
-        registry.as_ref(),
-        &resource_type,
-        &document,
+        &RowCtx {
+            resolver: registry.as_ref(),
+            registry: registry.as_ref(),
+            resource_type: &resource_type,
+            document: &document,
+            errors: &by_path,
+        },
         &[],
         0,
-        &by_path,
         &mut rows,
     );
 
@@ -366,17 +368,28 @@ fn build_body(
     }
 }
 
+/// What a row walk carries unchanged all the way down.
+///
+/// Bundled so [`build_rows`] takes the walk position (`path`, `depth`) and its
+/// sink separately from its fixed inputs — the recursion threads five constant
+/// arguments through every level otherwise.
+struct RowCtx<'a> {
+    resolver: &'a dyn helios_fhir_validator::SchemaResolver,
+    registry: &'a helios_fhir_validator::SchemaRegistry,
+    resource_type: &'a str,
+    document: &'a Value,
+    errors: &'a HashMap<String, Vec<String>>,
+}
+
 /// Walks the document, emitting one row per node, depth-first, in spec order.
-fn build_rows(
-    resolver: &dyn helios_fhir_validator::SchemaResolver,
-    registry: &helios_fhir_validator::SchemaRegistry,
-    resource_type: &str,
-    document: &Value,
-    path: &[Step],
-    depth: usize,
-    errors: &HashMap<String, Vec<String>>,
-    out: &mut Vec<Row>,
-) {
+fn build_rows(ctx: &RowCtx<'_>, path: &[Step], depth: usize, out: &mut Vec<Row>) {
+    let RowCtx {
+        resolver,
+        registry,
+        resource_type,
+        document,
+        errors,
+    } = *ctx;
     let key = editor::path_to_string(path);
     let node = match editor::node_at(document, path) {
         Some(node) => node,
@@ -389,16 +402,7 @@ fn build_rows(
         for index in 0..items.len() {
             let mut item_path = path.to_vec();
             item_path.push(Step::Index(index));
-            build_rows(
-                resolver,
-                registry,
-                resource_type,
-                document,
-                &item_path,
-                depth,
-                errors,
-                out,
-            );
+            build_rows(ctx, &item_path, depth, out);
         }
         return;
     }
@@ -551,16 +555,7 @@ fn build_rows(
     for child in children {
         let mut child_path = path.to_vec();
         child_path.push(Step::Field(child.name.clone()));
-        build_rows(
-            resolver,
-            registry,
-            resource_type,
-            document,
-            &child_path,
-            depth + 1,
-            errors,
-            out,
-        );
+        build_rows(ctx, &child_path, depth + 1, out);
     }
 }
 


### PR DESCRIPTION
`build_rows` takes eight arguments, five of which are identical at every level of the recursion. `clippy::too_many_arguments` has failed the **Linting** job on `main` since #432 merged, so every open PR inherits a red CI as soon as it merges main in.

Bundling the fixed inputs (`resolver`, `registry`, `resource_type`, `document`, `errors`) into a `RowCtx` leaves the walk position (`path`, `depth`) and its sink as the arguments that actually vary — which is also the clearer signature for a recursive walk.

No behaviour change.

## Verification

- `cargo test -p helios-ui` — 113 tests pass
- `cargo clippy --all-targets --all-features` with the CI flag set — clean across the whole workspace (previously it stopped at `helios-ui` and never linted the downstream crates)
- `cargo fmt --all -- --check` — clean

Found while merging `main` into all 28 open PRs: no PR had a lint of its own, but every one of them inherits this.

https://claude.ai/code/session_01E35FipGEpRDxvdZGLT5HcG