### PR TITLE
fix(search): match bare-id reference searches on Postgres

### DIFF
--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -1499,6 +1499,34 @@ impl PostgresQueryBuilder {
         Some(combined)
     }
 
+    /// Builds the condition for a reference parameter.
+    ///
+    /// # Bare ids
+    ///
+    /// Per [FHIR R4 search on references](https://hl7.org/fhir/R4/search.html#reference),
+    /// `[parameter]=[id]` — a bare logical id — is the *primary* form, with
+    /// `[type]/[id]` an additional one. References are indexed as written
+    /// (`search/writer.rs` stores `Reference.reference` verbatim), so the
+    /// overwhelmingly common `Patient/<id>` literal is what sits in
+    /// `value_reference`; matching a bare id therefore needs a suffix match, not
+    /// just equality. Comparing only the raw value made `Observation?patient=<id>`
+    /// — the single most common search shape in FHIR — return an empty Bundle
+    /// (#490), while `patient=Patient/<id>` worked.
+    ///
+    /// A `:Type` modifier resolves the ambiguity up front: `subject:Patient=<id>`
+    /// is normalized to `Patient/<id>` and matched as a type-prefixed reference,
+    /// mirroring the SQLite handler.
+    ///
+    /// Matching stays version-agnostic throughout: the search value is stripped of
+    /// any `/_history/<vid>`, and a stored versioned reference still matches.
+    ///
+    /// # LIKE escaping
+    ///
+    /// The plain path binds fully-formed patterns built with [`like_escape`] and
+    /// `ESCAPE '\'` rather than concatenating the raw value into a pattern in SQL.
+    /// The suffix match makes this load-bearing: an unescaped `%` would turn
+    /// `patient=%` into `LIKE '%/%'` and match every reference. (The `:contains`,
+    /// `:below` and `:above` paths keep their existing unescaped behavior.)
     fn build_reference_condition(param: &SearchParameter, offset: usize) -> Option<SqlFragment> {
         if matches!(param.modifier.as_ref(), Some(SearchModifier::Identifier)) {
             return Self::build_reference_identifier_condition(param, offset);
@@ -1515,44 +1543,86 @@ impl PostgresQueryBuilder {
         let is_code_text = matches!(modifier, Some(SearchModifier::CodeText));
         let is_below = matches!(modifier, Some(SearchModifier::Below));
         let is_above = matches!(modifier, Some(SearchModifier::Above));
+        let type_modifier = match modifier {
+            Some(SearchModifier::Type(type_name)) => Some(type_name.as_str()),
+            _ => None,
+        };
 
-        for (i, value) in param.values.iter().enumerate() {
-            let param_num = offset + i + 1;
+        // The plain path binds a variable number of parameters per value (two for
+        // a type-prefixed reference, three for a bare id), so `param_num` runs as
+        // a counter rather than `offset + i`. `build_search_query` advances the
+        // next parameter's offset by `params.len()`, so this stays consistent.
+        let mut param_num = offset;
+        for value in &param.values {
             let predicate = if is_text {
+                param_num += 1;
+                params.push(SqlParam::text(&value.value));
                 format!("value_reference_display ILIKE '%' || ${} || '%'", param_num)
             } else if is_code_text {
+                param_num += 1;
+                params.push(SqlParam::text(&value.value));
                 format!("value_reference_display ILIKE ${} || '%'", param_num)
             } else if is_contains {
+                param_num += 1;
+                params.push(SqlParam::text(&value.value));
                 format!("value_reference ILIKE '%' || ${} || '%'", param_num)
             } else if is_below {
                 // URL/path-prefix hierarchy (canonical |version not handled).
+                param_num += 1;
+                params.push(SqlParam::text(&value.value));
                 format!(
                     "(value_reference = ${0} OR value_reference LIKE ${0} || '/%')",
                     param_num
                 )
             } else if is_above {
+                param_num += 1;
+                params.push(SqlParam::text(&value.value));
                 format!(
                     "(${0} = value_reference OR ${0} LIKE value_reference || '/%')",
                     param_num
                 )
             } else {
-                // Plain reference match, version-agnostic: the bound value is
-                // the version-stripped base; match it exactly or carrying any
-                // `_history` version.
-                format!(
-                    "(value_reference = ${0} OR value_reference LIKE ${0} || '/_history/%')",
-                    param_num
-                )
-            };
-            // For the plain match the bound value is version-stripped; modifiers
-            // keep the literal value.
-            let bound = if is_text || is_code_text || is_contains || is_below || is_above {
-                value.value.clone()
-            } else {
-                strip_reference_version(&value.value).to_string()
+                // Plain reference match. Normalize `:Type` + bare id to `Type/id`,
+                // then match version-agnostically off the version-stripped base.
+                let stripped = strip_reference_version(&value.value);
+                let base = match type_modifier {
+                    Some(type_name) if !stripped.contains('/') => {
+                        format!("{}/{}", type_name, stripped)
+                    }
+                    _ => stripped.to_string(),
+                };
+                let escaped = like_escape(&base);
+
+                // `\_history` — the escape keeps the underscore literal.
+                if base.contains('/') {
+                    // `Type/id` or an absolute URL: match the base reference, or
+                    // the same reference carrying any `_history` version.
+                    let exact = param_num + 1;
+                    let versioned = param_num + 2;
+                    param_num += 2;
+                    params.push(SqlParam::text(&base));
+                    params.push(SqlParam::text(&format!("{}/\\_history/%", escaped)));
+                    format!(
+                        "(value_reference = ${exact} OR value_reference LIKE ${versioned} ESCAPE '\\')"
+                    )
+                } else {
+                    // Bare logical id: also match any reference ending in `/id`,
+                    // with or without a trailing `_history` version.
+                    let exact = param_num + 1;
+                    let suffix = param_num + 2;
+                    let versioned = param_num + 3;
+                    param_num += 3;
+                    params.push(SqlParam::text(&base));
+                    params.push(SqlParam::text(&format!("%/{}", escaped)));
+                    params.push(SqlParam::text(&format!("%/{}/\\_history/%", escaped)));
+                    format!(
+                        "(value_reference = ${exact} \
+                          OR value_reference LIKE ${suffix} ESCAPE '\\' \
+                          OR value_reference LIKE ${versioned} ESCAPE '\\')"
+                    )
+                }
             };
             conditions.push(predicate);
-            params.push(SqlParam::text(&bound));
         }
 
         if conditions.is_empty() {
@@ -2051,7 +2121,132 @@ mod tests {
             "reference OR-list must be one sublink: {}",
             frag.sql
         );
-        assert_eq!(frag.params.len(), 2);
+        // Two params per type-prefixed value: the exact base and the
+        // `/_history/%` pattern (the pattern is built in Rust so the value can be
+        // LIKE-escaped, rather than concatenated onto the raw bind in SQL).
+        assert_eq!(frag.params.len(), 4);
+    }
+
+    /// A bare logical id is the primary form of a reference search
+    /// (`Observation?patient=<id>`), and must match a stored `Patient/<id>`.
+    /// Postgres previously compared the raw value only, so a bare id matched
+    /// nothing while `patient=Patient/<id>` worked — #490.
+    #[test]
+    fn reference_bare_id_matches_type_prefixed_reference() {
+        let param = SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::new(SearchPrefix::Eq, "patient-1")],
+            chain: vec![],
+            components: vec![],
+        };
+        let query = SearchQuery::new("Observation").with_parameter(param);
+        let frag = PostgresQueryBuilder::build_search_query(&query, 2).expect("bare-id reference");
+
+        let params: Vec<&str> = frag
+            .params
+            .iter()
+            .map(|p| match p {
+                SqlParam::Text(t) => t.as_str(),
+                other => panic!("expected text params, got {:?}", other),
+            })
+            .collect();
+        assert_eq!(
+            params,
+            vec!["patient-1", "%/patient-1", "%/patient-1/\\_history/%"],
+            "a bare id must match exactly, as a `/id` suffix, and versioned: {}",
+            frag.sql
+        );
+        assert_eq!(
+            frag.sql.matches("id IN (SELECT").count(),
+            1,
+            "still a single sublink: {}",
+            frag.sql
+        );
+    }
+
+    /// `subject:Patient=<id>` resolves the bare id to `Patient/<id>` and matches
+    /// it as a type-prefixed reference, mirroring the SQLite handler.
+    #[test]
+    fn reference_type_modifier_normalizes_bare_id() {
+        let param = SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: Some(SearchModifier::Type("Patient".to_string())),
+            values: vec![SearchValue::new(SearchPrefix::Eq, "patient-1")],
+            chain: vec![],
+            components: vec![],
+        };
+        let query = SearchQuery::new("Observation").with_parameter(param);
+        let frag = PostgresQueryBuilder::build_search_query(&query, 2).expect(":Type reference");
+
+        let params: Vec<&str> = frag
+            .params
+            .iter()
+            .map(|p| match p {
+                SqlParam::Text(t) => t.as_str(),
+                other => panic!("expected text params, got {:?}", other),
+            })
+            .collect();
+        assert_eq!(
+            params,
+            vec!["Patient/patient-1", "Patient/patient-1/\\_history/%"],
+            "the type modifier pins the reference, so no `/id` suffix match: {}",
+            frag.sql
+        );
+    }
+
+    /// A versioned search value is stripped before the bare-id suffix match, so
+    /// `subject=patient-1/_history/2` still matches a stored `Patient/patient-1`.
+    #[test]
+    fn reference_bare_id_is_version_stripped() {
+        let param = SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::new(SearchPrefix::Eq, "patient-1/_history/2")],
+            chain: vec![],
+            components: vec![],
+        };
+        let query = SearchQuery::new("Observation").with_parameter(param);
+        let frag = PostgresQueryBuilder::build_search_query(&query, 2)
+            .expect("versioned bare-id reference");
+
+        match &frag.params[0] {
+            SqlParam::Text(t) => assert_eq!(t, "patient-1"),
+            other => panic!("expected a text param, got {:?}", other),
+        }
+        assert_eq!(frag.params.len(), 3, "version-stripped back to a bare id");
+    }
+
+    /// The suffix match makes LIKE escaping load-bearing: unescaped, `patient=%`
+    /// would become `LIKE '%/%'` and match every stored reference.
+    #[test]
+    fn reference_bare_id_escapes_like_metacharacters() {
+        let param = SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::new(SearchPrefix::Eq, "%")],
+            chain: vec![],
+            components: vec![],
+        };
+        let query = SearchQuery::new("Observation").with_parameter(param);
+        let frag = PostgresQueryBuilder::build_search_query(&query, 2).expect("wildcard reference");
+
+        match &frag.params[1] {
+            SqlParam::Text(t) => assert_eq!(
+                t, "%/\\%",
+                "only the leading wildcard is live; the value's own '%' is escaped"
+            ),
+            other => panic!("expected a text param, got {:?}", other),
+        }
+        assert!(
+            frag.sql.contains("ESCAPE '\\'"),
+            "the pattern must carry its escape clause: {}",
+            frag.sql
+        );
     }
 
     #[test]

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -3725,6 +3725,96 @@ mod postgres_integration {
         assert!(ids.contains(&"obs-2"));
     }
 
+    /// A bare logical id must match a stored `Patient/<id>` reference.
+    ///
+    /// `Observation?patient=<id>` is the primary form in the spec and the shape
+    /// Inferno uses throughout, but Postgres compared the raw search value
+    /// against the stored `Patient/<id>` and so matched nothing — every clinical
+    /// search returned an empty Bundle (#490). The sibling test above covers the
+    /// `Type/id` form, which always worked; only that form was ever asserted,
+    /// which is how the gap survived.
+    #[tokio::test]
+    async fn postgres_integration_search_reference_bare_id() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        for (id, subject) in [
+            ("obs-1", "Patient/patient-1"),
+            ("obs-2", "Patient/patient-1"),
+            ("obs-3", "Patient/patient-2"),
+        ] {
+            backend
+                .create(
+                    &tenant,
+                    "Observation",
+                    json!({
+                        "resourceType": "Observation",
+                        "id": id,
+                        "subject": {"reference": subject},
+                        "code": {"coding": [{"code": "8867-4"}]},
+                        "status": "final"
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let bare_id = |modifier: Option<SearchModifier>| {
+            SearchQuery::new("Observation").with_parameter(SearchParameter {
+                name: "subject".to_string(),
+                param_type: SearchParamType::Reference,
+                modifier,
+                values: vec![SearchValue::eq("patient-1")],
+                chain: vec![],
+                components: vec![],
+            })
+        };
+
+        for (label, query) in [
+            ("bare id", bare_id(None)),
+            (
+                ":Type + bare id",
+                bare_id(Some(SearchModifier::Type("Patient".to_string()))),
+            ),
+        ] {
+            let result = backend.search(&tenant, &query).await.unwrap();
+            let mut ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+            ids.sort_unstable();
+            assert_eq!(
+                ids,
+                vec!["obs-1", "obs-2"],
+                "{label} must match Patient/patient-1 and not the decoy patient-2"
+            );
+        }
+
+        // The suffix match must not become a wildcard: `subject=%` matches the
+        // literal id `%`, i.e. nothing, rather than every reference.
+        let wildcard = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::eq("%")],
+            chain: vec![],
+            components: vec![],
+        });
+        assert!(
+            backend
+                .search(&tenant, &wildcard)
+                .await
+                .unwrap()
+                .resources
+                .items
+                .is_empty(),
+            "a LIKE metacharacter must be matched literally, not as a wildcard"
+        );
+    }
+
     #[tokio::test]
     async fn postgres_integration_search_reference_identifier() {
         use helios_persistence::core::SearchProvider;


### PR DESCRIPTION
## Summary

On the Postgres backend, reference search parameters matched only when the query value carried a `Type/` prefix — a bare logical id matched nothing and returned an empty Bundle. `Observation?patient=<id>` is the primary form in the spec and the shape Inferno uses throughout, so essentially every clinical search on Postgres returned zero.

References are indexed as written (`search/writer.rs` stores `Reference.reference` verbatim), so the stored value is the literal `Patient/<id>`. The query compared the raw search value against it with equality only. SQLite, MongoDB and Elasticsearch all branch on whether the value carries a `/` and fall back to a suffix match; only Postgres did not.

Fixes #490.

## Changes

### `postgres/search/query_builder.rs`

- `build_reference_condition` now branches on whether the version-stripped value contains `/`, mirroring the SQLite handler. A bare id matches exactly, as a `/<id>` suffix, or with a trailing `/_history/<vid>`; a `Type/id` or absolute URL keeps its previous exact-plus-versioned semantics.
- Added the `:Type` modifier, which was not handled on Postgres at all — `subject:Patient=<id>` also returned zero. A bare id is now resolved to `Type/id` and matched as a type-prefixed reference.
- The plain path binds fully-formed patterns built with the file's existing `like_escape` plus `ESCAPE '\'`, rather than concatenating the raw value onto a pattern in SQL. This is load-bearing for the new suffix match: unescaped, `patient=%` would become `LIKE '%/%'` and match every stored reference. The `:contains`, `:below` and `:above` paths keep their existing behavior.
- That varies the parameter count per value (two for a type-prefixed reference, three for a bare id), so the loop runs a counter instead of `offset + i`. `build_search_query` already advances the next parameter's offset by `params.len()`, and both production callers append `fragment.params` wholesale, so placeholder numbering for following parameters is unaffected.
- Matching stays version-agnostic and the OR-list still compiles to a single sublink (the semi-join shape that `reference_or_list_is_a_single_sublink` guards).

## Testing

- `cargo test -p helios-persistence --features postgres,sqlite,R4 --lib backends::postgres::search::query_builder` — 14 passed, including 4 new: bare-id parameter binding, `:Type` normalization, version stripping, and LIKE-metacharacter escaping.
- `cargo test -p helios-persistence --features postgres,sqlite,R4` — full suite, **0 failures**.
- New `postgres_integration_search_reference_bare_id` against a real Postgres via testcontainers, covering bare id, `:Type` + bare id, a decoy patient, and the wildcard case. The existing `postgres_integration_search_reference` only ever asserted the `Type/id` form, which is how the gap survived.
- Regression guard confirmed: with the fix reverted, the new integration test fails with `left: [] right: ["obs-1", "obs-2"]`.

### End to end

Postgres 16 in Docker, `hfs` built as CI builds it (`--features R4,sqlite,elasticsearch,postgres,mongodb,s3`), Inferno fixtures loaded via `crates/hfs/tests/inferno/install.sh` — the reproduction from #490:

| query | before | after |
|---|---:|---:|
| `Observation?_summary=count` (control) | 246 | 246 |
| `Observation?patient=us-core-client-tests-patient` | **0** | **27** |
| `Observation?patient=Patient/us-core-client-tests-patient` | 27 | 27 |
| `Observation?subject=us-core-client-tests-patient` | **0** | **27** |
| `Observation?subject:Patient=us-core-client-tests-patient` | — | 27 |
| `Condition?patient=us-core-client-tests-patient` | **0** | **2** |
| `Encounter?patient=us-core-client-tests-patient` | **0** | **1** |
| `Observation?patient=%` | — | 0 |
| `Observation?patient=nonexistent-id` | — | 0 |

Every value now matches the SQLite column.

### Inferno

Ran `us_core_v800` locally against both backends on the same fixtures:

| backend | pass rate |
|---|---:|
| postgres (before, 2026-08-02 nightly) | 4.6% (25/544) |
| **postgres (after)** | **60.2% (328/544)** |
| sqlite (same local run) | 59.9% (326/544) |

Postgres is now at parity with SQLite. Diffing the two failure sets: 10 shared (all already in the workflow's `OMITTED_TESTS` for v8.0.0), 0 SQLite-only, 3 Postgres-only.

## Notes

- **Expect the Postgres Inferno job to go red after this merges.** It reported success at 4.6% only because the gate counts fail/error and every clinical group degraded to `skip`. With those groups now proceeding, the 3 Postgres-only failures become real. That is the gate working, but it will look like a regression in the run history.
- Those 3 failures are all `patient_category_date_search_test` on vital-signs profiles, and are a separate pre-existing defect — filed as #494. Dates carrying a negative UTC offset fail to parse in the Postgres writer and are silently indexed as `Utc::now()`. Confirmed independent of this change: it reproduces with no reference parameter at all (`Observation?_id=<obs>&date=gt2023-08-02` returns 1 on Postgres, 0 on SQLite), and bare-id and type-prefixed reference forms return identical results.
- No schema or migration change; this is query-side only. Existing indexed data is unaffected.
- Not addressed here: `build_contained` (`_contained=true`) still compares references with equality only — same gap on a narrow path. Chained search is identical on both backends (`LIKE '%value%'`) and unaffected.
- Also unchanged: the silent-failure posture from #490 — an unsatisfiable reference shape still returns a `Bundle` with `total: 0` rather than an `OperationOutcome`, and `Prefer: handling=strict` still returns a Bundle. That is the #474-class concern and is out of scope here.
- Clippy was not run locally; the workspace has pre-existing failures under clippy 1.96 in files untouched by this change (`doc_lazy_continuation` in `helios-serde-support`, `collapsible_if` in the `helios-fhir` build script, `large_enum_variant` in generated `crates/fhir/src/r6.rs`). Leaving that to CI.
