### PR TITLE
fix(search): index Postgres dates with negative UTC offsets correctly

### DIFF
--- a/crates/persistence/src/backends/postgres/search/writer.rs
+++ b/crates/persistence/src/backends/postgres/search/writer.rs
@@ -13,6 +13,26 @@ fn internal_error(message: String) -> crate::error::StorageError {
     })
 }
 
+/// Parses an extracted date value into the UTC timestamp stored in `value_date`.
+///
+/// Returns `None` when the value cannot be parsed, so the caller can skip the
+/// index row. This previously fell back to `Utc::now()`, which turned a parse
+/// failure into a plausible-looking timestamp: the row was silently indexed at
+/// ingestion time, so `date=gt<any past date>` matched it and `date=lt…` did
+/// not. Nothing was logged, and the resource itself read back correctly, so the
+/// corruption was visible only by querying `search_index` directly (#494).
+///
+/// A missing index row makes the parameter behave as absent for that resource —
+/// still a gap, but a silent under-match is recoverable and a silent *wrong*
+/// match is not.
+fn parse_index_date(value: &str) -> Option<DateTime<Utc>> {
+    let normalized = normalize_date_for_pg(value);
+    DateTime::parse_from_rfc3339(&normalized)
+        .map(|dt| dt.with_timezone(&Utc))
+        .or_else(|_| normalized.parse::<DateTime<Utc>>())
+        .ok()
+}
+
 /// PostgreSQL implementation of SearchIndexWriter.
 pub struct PostgresSearchIndexWriter;
 
@@ -88,11 +108,16 @@ impl PostgresSearchIndexWriter {
             }
             IndexValue::Date { value, precision } => {
                 let precision_str = precision.to_string();
-                let normalized = normalize_date_for_pg(value);
-                let timestamp: DateTime<Utc> = DateTime::parse_from_rfc3339(&normalized)
-                    .map(|dt| dt.with_timezone(&Utc))
-                    .or_else(|_| normalized.parse::<DateTime<Utc>>())
-                    .unwrap_or_else(|_| Utc::now());
+                let Some(timestamp) = parse_index_date(value) else {
+                    tracing::warn!(
+                        param_name = %extracted.param_name,
+                        resource_type = %resource_type,
+                        resource_id = %resource_id,
+                        value = %value,
+                        "skipping date search index entry: unparseable date value"
+                    );
+                    return Ok(());
+                };
                 client
                     .execute(
                         "INSERT INTO search_index (
@@ -293,13 +318,18 @@ impl PostgresSearchIndexWriter {
             }
             IndexValue::Date { value, precision } => {
                 date_precision = Some(precision.to_string());
-                let normalized = normalize_date_for_pg(value);
-                value_date = Some(
-                    DateTime::parse_from_rfc3339(&normalized)
-                        .map(|dt| dt.with_timezone(&Utc))
-                        .or_else(|_| normalized.parse::<DateTime<Utc>>())
-                        .unwrap_or_else(|_| Utc::now()),
-                );
+                let Some(timestamp) = parse_index_date(value) else {
+                    tracing::warn!(
+                        param_name = %extracted.param_name,
+                        container_type = %container_type,
+                        container_id = %container_id,
+                        contained_type = %contained_type,
+                        value = %value,
+                        "skipping contained date search index entry: unparseable date value"
+                    );
+                    return Ok(());
+                };
+                value_date = Some(timestamp);
             }
             IndexValue::Number(n) => value_number = Some(*n),
             IndexValue::Quantity {
@@ -397,10 +427,23 @@ impl PostgresSearchIndexWriter {
 /// - "2024-01" -> "2024-01-01T00:00:00+00:00"
 /// - "2024-01-15" -> "2024-01-15T00:00:00+00:00"
 /// - "2024-01-15T10:30:00" -> "2024-01-15T10:30:00+00:00"
+/// - "2024-01-15T10:30:00-07:00" -> unchanged (already zoned)
 fn normalize_date_for_pg(value: &str) -> String {
-    if value.contains('T') {
-        // Already has time component - ensure timezone
-        if value.contains('+') || value.contains('Z') || value.ends_with("-00:00") {
+    if let Some((_, time_part)) = value.split_once('T') {
+        // Already has a time component — append UTC only if it carries no zone.
+        //
+        // The zone test must look at the *time* component alone. Testing the
+        // whole value for `-` would match the date's own `YYYY-MM-DD`
+        // separators, and testing only for `+`/`Z`/`-00:00` (as this did) misses
+        // every other negative offset: `2019-05-04T12:12:29-07:00` was treated
+        // as zone-less and became `...-07:00+00:00`, which is not valid RFC3339.
+        // Per the FHIR `dateTime`/`instant` grammar the only `+` or `-` that can
+        // appear after `T` is the offset sign, so their presence is decisive.
+        let has_zone = time_part.ends_with('Z')
+            || time_part.ends_with('z')
+            || time_part.contains('+')
+            || time_part.contains('-');
+        if has_zone {
             value.to_string()
         } else {
             format!("{}+00:00", value)
@@ -417,5 +460,85 @@ fn normalize_date_for_pg(value: &str) -> String {
     } else {
         // Best effort
         value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The defect behind #494: a negative UTC offset was not recognised as a
+    /// zone, so `+00:00` was appended and the result stopped being valid
+    /// RFC3339. US/Americas data is overwhelmingly negative-offset, so this was
+    /// the common case rather than an edge case.
+    #[test]
+    fn negative_offsets_are_recognised_as_zoned() {
+        for value in [
+            "2019-05-04T12:12:29-07:00",
+            "1941-09-05T01:11:45-04:00",
+            "2021-11-10T16:48:57.246958-08:00",
+            "2024-01-15T10:30:00-00:00",
+        ] {
+            assert_eq!(
+                normalize_date_for_pg(value),
+                value,
+                "an already-zoned value must be left alone"
+            );
+            assert!(
+                parse_index_date(value).is_some(),
+                "{value} must parse rather than be dropped"
+            );
+        }
+    }
+
+    /// A negative offset must survive as an *instant*, not just parse. Appending
+    /// `+00:00` to `...-07:00` happened to be unparseable, but the failure mode
+    /// worth pinning is the resulting timestamp being wrong.
+    #[test]
+    fn negative_offset_converts_to_the_right_instant() {
+        let parsed = parse_index_date("2019-05-04T12:12:29-07:00").expect("parses");
+        assert_eq!(
+            parsed.to_rfc3339(),
+            "2019-05-04T19:12:29+00:00",
+            "-07:00 is seven hours behind UTC"
+        );
+    }
+
+    #[test]
+    fn positive_offsets_and_z_are_still_recognised() {
+        for value in [
+            "2024-01-15T10:30:00Z",
+            "2024-01-15T10:30:00+05:30",
+            "2024-01-15T10:30:00.123Z",
+        ] {
+            assert_eq!(normalize_date_for_pg(value), value);
+            assert!(parse_index_date(value).is_some());
+        }
+    }
+
+    #[test]
+    fn zone_less_and_partial_values_are_completed_as_utc() {
+        for (input, expected) in [
+            ("2024-01-15T10:30:00", "2024-01-15T10:30:00+00:00"),
+            ("2024-01-15", "2024-01-15T00:00:00+00:00"),
+            ("2024-01", "2024-01-01T00:00:00+00:00"),
+            ("2024", "2024-01-01T00:00:00+00:00"),
+        ] {
+            assert_eq!(normalize_date_for_pg(input), expected);
+            assert!(parse_index_date(input).is_some(), "{input} must parse");
+        }
+    }
+
+    /// An unparseable value yields `None` so the caller skips the row. It must
+    /// never resolve to a timestamp — the old `unwrap_or_else(|_| Utc::now())`
+    /// wrote ingestion time and made every date search over the row wrong.
+    #[test]
+    fn unparseable_values_are_dropped_not_substituted() {
+        for value in ["", "not-a-date", "2024-13-45T99:99:99", "T00:00:00"] {
+            assert!(
+                parse_index_date(value).is_none(),
+                "{value:?} must not resolve to a timestamp"
+            );
+        }
     }
 }

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -3650,6 +3650,118 @@ mod postgres_integration {
         assert_eq!(result.resources.items[0].id(), "date-1");
     }
 
+    /// Dates carrying a negative UTC offset must index as the instant they name.
+    ///
+    /// The writer treated `2019-05-04T12:12:29-07:00` as zone-less, appended
+    /// `+00:00`, and the resulting `...-07:00+00:00` failed to parse — at which
+    /// point it silently indexed `Utc::now()`. Every date search over such a row
+    /// was then answered against the ingestion time: `gt<any past date>` matched
+    /// and `lt` did not (#494). The sibling test above uses a date-only
+    /// `birthDate`, the one shape that always worked, which is how this survived.
+    #[tokio::test]
+    async fn postgres_integration_search_date_negative_utc_offset() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        for (id, effective) in [
+            ("obs-2019", "2019-05-04T12:12:29-07:00"),
+            ("obs-2025", "2025-05-04T12:12:29-07:00"),
+        ] {
+            backend
+                .create(
+                    &tenant,
+                    "Observation",
+                    json!({
+                        "resourceType": "Observation",
+                        "id": id,
+                        "status": "final",
+                        "code": {"coding": [{"code": "8867-4"}]},
+                        "effectiveDateTime": effective
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let date_query = |prefix: SearchPrefix, value: &str| {
+            SearchQuery::new("Observation").with_parameter(SearchParameter {
+                name: "date".to_string(),
+                param_type: SearchParamType::Date,
+                modifier: None,
+                values: vec![SearchValue::new(prefix, value)],
+                chain: vec![],
+                components: vec![],
+            })
+        };
+        fn ids(items: &[helios_persistence::types::StoredResource]) -> Vec<String> {
+            let mut v: Vec<String> = items.iter().map(|r| r.id().to_string()).collect();
+            v.sort();
+            v
+        }
+
+        // Before the fix both rows carried the ingestion timestamp, so `gt` on a
+        // past date matched both and `lt` matched neither.
+        let after = backend
+            .search(
+                &tenant,
+                &date_query(SearchPrefix::Gt, "2023-01-01T00:00:00+00:00"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            ids(&after.resources.items),
+            vec!["obs-2025"],
+            "gt must exclude the 2019 row"
+        );
+
+        let before = backend
+            .search(
+                &tenant,
+                &date_query(SearchPrefix::Lt, "2023-01-01T00:00:00+00:00"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            ids(&before.resources.items),
+            vec!["obs-2019"],
+            "lt must find the 2019 row"
+        );
+
+        // Pin the offset arithmetic, not just parseability: 12:12:29-07:00 is
+        // 19:12:29Z, so this one-hour window brackets it. A fix that merely
+        // stripped the offset would store 12:12:29Z and fall outside.
+        let bracketed = backend
+            .search(
+                &tenant,
+                &date_query(SearchPrefix::Gt, "2019-05-04T19:00:00+00:00").with_parameter(
+                    SearchParameter {
+                        name: "date".to_string(),
+                        param_type: SearchParamType::Date,
+                        modifier: None,
+                        values: vec![SearchValue::new(
+                            SearchPrefix::Lt,
+                            "2019-05-04T20:00:00+00:00",
+                        )],
+                        chain: vec![],
+                        components: vec![],
+                    },
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            ids(&bracketed.resources.items),
+            vec!["obs-2019"],
+            "-07:00 must convert to 19:12:29Z"
+        );
+    }
+
     #[tokio::test]
     async fn postgres_integration_search_reference() {
         use helios_persistence::core::SearchProvider;


### PR DESCRIPTION
> **Stacked on #495** (`fix/490-postgres-bare-id-reference-search`). Review that one first; this PR's diff is only the date fix. #495 must merge before this can.

## Summary

A date value carrying a **negative UTC offset** — `2019-05-04T12:12:29-07:00` — failed to parse in the Postgres search index writer and was silently stored as **`Utc::now()`**. The resource itself round-tripped correctly, so the corruption was visible only by querying `search_index` directly: every date search over such a row was answered against the ingestion timestamp, so `date=gt<any past date>` matched it and `date=lt…` did not.

FHIR `dateTime`/`instant` require an offset when a time is present, and US/Americas data is overwhelmingly negative-offset, so this was the common case rather than an edge case.

Fixes #494.

## Why it happened

Two defects compounded, both in `postgres/search/writer.rs`.

**1. The zone check missed negative offsets.** It tested the whole value for `+`, `Z`, or a trailing `-00:00`:

```rust
if value.contains('+') || value.contains('Z') || value.ends_with("-00:00")
```

`2019-05-04T12:12:29-07:00` matches none of those, so it was treated as zone-less and `+00:00` was appended, producing `...-07:00+00:00` — not valid RFC3339. Only `-00:00` was ever recognised among negative offsets.

**2. The parse failure silently substituted the current time:**

```rust
.unwrap_or_else(|_| Utc::now())
```

A malformed value became a plausible-looking timestamp, with nothing logged.

## Changes

- `normalize_date_for_pg` now tests the **time component alone** for a zone. After `T`, the FHIR grammar admits `+`/`-` only as the offset sign, so their presence is decisive — whereas testing the whole value would match the date's own `YYYY-MM-DD` separators. Zone-less and partial values (`2024`, `2024-01`, `2024-01-15`, `…T10:30:00`) still complete to UTC exactly as before.
- Both call sites (`write_entry` and `write_contained_entry`) share a new `parse_index_date` helper returning `Option<DateTime<Utc>>`, and **skip the index row with a `tracing::warn!`** when a value cannot be parsed. A missing row makes the parameter behave as absent for that resource — still a gap, but a silent under-match is recoverable where a silent wrong match is not.

## Scope

Not Observation-specific. Mis-indexed rows on the Inferno fixture set before the fix:

| resource / param | date rows | indexed as ingest time |
|---|---:|---:|
| `Encounter.date` | 384 | 380 |
| `Observation.date` | 251 | 203 |
| `DocumentReference.period` | 92 | 92 |
| `Procedure.date` | 82 | 80 |
| `CarePlan.date` | 48 | 48 |
| `CareTeam.date` | 48 | 48 |
| `DiagnosticReport.date` | 48 | 47 |
| `Condition.recorded-date` | 46 | 46 |
| `Condition.onset-date` | 46 | 43 |
| `Immunization.date` | 42 | 41 |
| `Condition.abatement-date` | 37 | 37 |
| `MedicationRequest.authoredon` | 36 | 34 |

The value shape correlates exactly — on `Observation.date`: 178/178 negative-offset values mis-indexed, 0/22 date-only, 0/20 positive-offset-or-`Z`.

## Testing

- 5 unit tests over `normalize_date_for_pg` / `parse_index_date`: negative offsets recognised as zoned, the resulting **instant** correct (`12:12:29-07:00` → `19:12:29Z`, so a fix that merely stripped the offset would fail), positive offsets and `Z` unaffected, partial dates unaffected, and unparseable values yielding `None` rather than a substituted timestamp.
- `postgres_integration_search_date_negative_utc_offset` against a real Postgres: `gt`/`lt` land on the correct side of a 2019 vs 2025 pair, plus a one-hour window bracketing `19:12:29Z` to pin the offset arithmetic. The existing `postgres_integration_search_date` uses a date-only `birthDate` — the one shape that always worked, which is how this survived.
- `cargo test -p helios-persistence --features postgres,sqlite,R4` — full suite, 24 test binaries, **0 failures**.
- Regression guard confirmed: with the fix reverted, the new integration test fails with `left: ["obs-2019", "obs-2025"] right: ["obs-2025"]`.

### End to end

Clean `postgres:16`, fixtures reloaded, index inspected directly:

| | before | after |
|---|---:|---:|
| `Observation.date` rows carrying an ingest timestamp | 203 / 251 | **0 / 251** |
| indexed value for the resource Inferno flagged | `2026-08-04 22:11:53+00` | **`2019-05-04 19:12:29+00`** |

No rows were dropped — all 251 still index, now with correct values.

### Inferno

`us_core_v800`, same fixtures, same local Inferno stack:

| | pass rate |
|---|---:|
| postgres before #490 (2026-08-02 nightly) | 4.6% (25/544) |
| postgres with #495 only | 60.2% (328/544) |
| **postgres with #495 + this** | **60.8% (331/544)** |
| sqlite (same local run) | 59.9% (326/544) |

This clears the last 3 Postgres-only failures. **Postgres and SQLite now have identical failure sets** — 10 each, all already in the workflow's `OMITTED_TESTS` for v8.0.0.

## Notes

- **Existing Postgres deployments need a reindex.** This fixes the write path; rows already written carry ingest timestamps and will keep answering date searches wrongly until reindexed.
- No schema or migration change.
- Once this lands, the concern I raised on #495 — that the Postgres Inferno job would go red — no longer applies: with the 3 remaining failures cleared, the job's failure set matches SQLite's, which is fully omitted.
- Observation for a follow-up, not addressed here: Postgres now passes 5 *more* tests than SQLite (331 vs 326) with an identical failure set, so the difference is in skips (202 vs 207). That suggests SQLite has its own unrelated precondition gap worth a look; SQLite's date handling on the negative-offset shape is correct (verified directly).
- Clippy not run locally — the workspace has pre-existing failures under clippy 1.96 in files untouched here. Leaving it to CI.
