### PR TITLE
perf(fhir-codegen): share generated serde/FHIRPath bodies across FHIR types (1.53 GiB → 1.02 GiB)

### DIFF
--- a/crates/fhir-macro/src/lib.rs
+++ b/crates/fhir-macro/src/lib.rs
@@ -1677,7 +1677,14 @@ fn generate_deserialize_impl(data: &Data, name: &Ident) -> proc_macro2::TokenStr
                 let variant_key = rename.unwrap_or_else(|| variant_name_str.clone());
                 variant_names.push(variant_key.clone()); // Keep track of expected keys
 
-                // Generate the specific deserialization logic for this variant
+                // Generate the specific deserialization logic for this variant.
+                //
+                // Every arm below delegates the actual work to a shared helper in
+                // `helios-serde-support` rather than expanding it inline. Choice enums carry
+                // one variant per permitted FHIR datatype (dozens each) and there are hundreds
+                // of such enums per FHIR version, so inlining the extension-reunification and
+                // error-formatting logic multiplies out into hundreds of megabytes of
+                // near-identical code in any binary that deserializes typed resources.
                 let deserialization_logic = match &variant.fields {
                     Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
                         // Newtype variant (e.g., String(String))
@@ -1687,100 +1694,28 @@ fn generate_deserialize_impl(data: &Data, name: &Ident) -> proc_macro2::TokenStr
 
                         if is_element || is_decimal_element {
                             // --- Element/DecimalElement Variant Construction ---
-                            let underscore_variant_key_str = format!("_{}", variant_key); // For error messages
-
-                            // Determine the primitive type V or PreciseDecimal for the value field
-                            let primitive_type_for_element = if is_decimal_element {
-                                quote! { crate::PreciseDecimal }
-                            } else {
-                                // Extract V from Element<V, E> or the alias's underlying primitive
-                                // Need to re-determine the base type here
-                                let base_type = get_base_type(field_ty);
-                                if let Type::Path(type_path) = base_type {
-                                    if let Some(last_segment) = type_path.path.segments.last() {
-                                        if last_segment.ident == "Element" {
-                                            // Direct Element<V, E>
-                                            if let PathArguments::AngleBracketed(generics) =
-                                                &last_segment.arguments
-                                            {
-                                                if let Some(GenericArgument::Type(inner_v_type)) =
-                                                    generics.args.first()
-                                                {
-                                                    quote! { #inner_v_type }
-                                                } else {
-                                                    panic!("Element missing generic argument V");
-                                                }
-                                            } else {
-                                                panic!("Element missing angle bracketed arguments");
-                                            }
-                                        } else {
-                                            // Alias
-                                            let alias_name = last_segment.ident.to_string();
-                                            let primitive_type_str =
-                                                extract_inner_element_type(&alias_name);
-                                            let primitive_type_parsed: Type = syn::parse_str(
-                                                primitive_type_str,
-                                            )
-                                            .expect("Failed to parse primitive type string");
-                                            quote! { #primitive_type_parsed }
-                                        }
-                                    } else {
-                                        panic!("Could not get last segment of Element type path");
-                                    }
-                                } else {
-                                    panic!("Element type is not a Type::Path");
-                                }
-                            };
-
+                            // `V` and `E` are inferred from the assignments into `element`,
+                            // so the primitive type never has to be spelled out here.
                             quote! {
-                                // Check if parts exist *before* potentially moving them
-                                let has_value_part = value_part.is_some();
-                                let has_extension_part = extension_part.is_some();
-
-                                // Deserialize the extension part if present
-                                let mut ext_helper_opt: Option<IdAndExtensionHelper> = None;
-                                if let Some(ext_value) = extension_part { // Move happens here
-                                    ext_helper_opt = Some(serde::Deserialize::deserialize(ext_value)
-                                        .map_err(|e| serde::de::Error::custom(format!("Error deserializing extension {}: {}", #underscore_variant_key_str, e)))?);
-                                }
-
-                                // Deserialize the value part if present, consuming value_part
-                                let deserialized_value_opt = if let Some(prim_value) = value_part { // Move of value_part happens here
-                                    // Use #primitive_type_for_element determined outside
-                                    Some(<#primitive_type_for_element>::deserialize(prim_value)
-                                         .map_err(|e| serde::de::Error::custom(format!("Error deserializing primitive {}: {}", #variant_key, e)))?)
-                                } else {
-                                    None::<#primitive_type_for_element> // Explicit type needed for None
-                                };
-
-                                // Construct the element using deserialized parts
-                                let mut element: #field_ty = Default::default(); // Start with default
-
-                                // Assign deserialized value
-                                element.value = deserialized_value_opt; // Assign the Option<V> or Option<PreciseDecimal>
-
-                                // Merge the extension data if it exists
-                                if let Some(ext_helper) = ext_helper_opt {
-                                    if ext_helper.id.is_some() {
-                                        element.id = ext_helper.id;
-                                    }
-                                    if ext_helper.extension.is_some() {
-                                        element.extension = ext_helper.extension;
-                                    }
-                                }
-                                // Note: The check `if !has_value_part && has_extension_part { element.value = None; }`
-                                // is now redundant because element.value is already None if !has_value_part.
-
+                                let (__value, __id, __extension) =
+                                    ::helios_serde_support::deserialize_choice_element_parts::<_, _, A::Error>(
+                                        value_part, extension_part, #variant_key,
+                                    )?;
+                                let mut element: #field_ty = Default::default();
+                                element.value = __value;
+                                element.id = __id;
+                                element.extension = __extension;
                                 Ok(#name::#variant_name(element))
                             }
                             // --- End Element/DecimalElement Variant Construction ---
                         } else {
                             // --- Regular Newtype Variant Construction ---
                             quote! {
-                                let value = value_part.ok_or_else(|| serde::de::Error::missing_field(#variant_key))?;
-                                let inner_value = serde::Deserialize::deserialize(value)
-                                    .map_err(|e| serde::de::Error::custom(format!("Error deserializing non-element variant {}: {}", #variant_key, e)))?;
-                                Ok(#name::#variant_name(inner_value)) // Removed .into()
+                                Ok(#name::#variant_name(
+                                    ::helios_serde_support::deserialize_choice_value::<_, A::Error>(
+                                        value_part, #variant_key, "non-element variant",
+                                    )?
+                                ))
                             }
                             // --- End Regular Newtype Variant Construction ---
                         }
@@ -1788,19 +1723,21 @@ fn generate_deserialize_impl(data: &Data, name: &Ident) -> proc_macro2::TokenStr
                     Fields::Unnamed(_) => {
                         // Tuple variant
                         quote! {
-                            let value = value_part.ok_or_else(|| serde::de::Error::missing_field(#variant_key))?;
-                            let inner_value = serde::Deserialize::deserialize(value)
-                                .map_err(|e| serde::de::Error::custom(format!("Error deserializing tuple variant {}: {}", #variant_key, e)))?;
-                            Ok(#name::#variant_name(inner_value)) // Use variant_name directly
+                            Ok(#name::#variant_name(
+                                ::helios_serde_support::deserialize_choice_value::<_, A::Error>(
+                                    value_part, #variant_key, "tuple variant",
+                                )?
+                            ))
                         }
                     }
                     Fields::Named(_) => {
                         // Struct variant
                         quote! {
-                            let value = value_part.ok_or_else(|| serde::de::Error::missing_field(#variant_key))?;
-                            let inner_value = serde::Deserialize::deserialize(value)
-                                .map_err(|e| serde::de::Error::custom(format!("Error deserializing struct variant {}: {}", #variant_key, e)))?;
-                            Ok(#name::#variant_name(inner_value)) // Use variant_name directly
+                            Ok(#name::#variant_name(
+                                ::helios_serde_support::deserialize_choice_value::<_, A::Error>(
+                                    value_part, #variant_key, "struct variant",
+                                )?
+                            ))
                         }
                     }
                     Fields::Unit => {
@@ -1811,130 +1748,57 @@ fn generate_deserialize_impl(data: &Data, name: &Ident) -> proc_macro2::TokenStr
                     }
                 }; // End match variant.fields
 
-                // Push the complete match arm
+                // Push the complete match arm, keyed on the variant's index in
+                // `VARIANT_KEYS` so the dispatch compiles to a jump table rather than
+                // a chain of string comparisons.
+                let variant_index = variant_matches.len();
                 variant_matches.push(quote! {
-                    #variant_key => { // Use the string key as the match pattern
+                    #variant_index => {
                         #deserialization_logic // Embed the generated logic block
                     }
                 });
             } // End loop over variants
 
-            // Define the helper type alias needed for enum deserialization
-            let id_extension_helper_def = quote! {
-                // Type alias for deserializing the id/extension part from _fieldName
-                type IdAndExtensionHelper = helios_serde_support::IdAndExtensionOwned<Extension>;
-            };
-
-            // Generate the enum deserialization implementation
+            // Generate the enum deserialization implementation.
+            //
+            // The key scan lives in `helios_serde_support::deserialize_choice_parts`, which is
+            // generic only over the `MapAccess` implementation — so it is emitted once per
+            // deserializer rather than once per enum. All that remains here is a jump table
+            // over the matched variant index.
             return quote! {
-                // Import necessary crates/modules at the top level of the impl block
-                use serde::{Deserialize, de::{self, Visitor, MapAccess}};
-                use serde_json; // Needed for Value
-                use std::collections::HashSet; // Needed for processed_keys
-                // NOTE: Removed `use syn;` as it's not needed at runtime
+                struct EnumVisitor;
 
-                // Define the helper struct at the top level of the impl block
-                #id_extension_helper_def
-
-                // Define a visitor for the enum (no longer needs variants reference)
-                struct EnumVisitor; // Removed lifetime and variants field
-
-                impl<'de> serde::de::Visitor<'de> for EnumVisitor { // Removed lifetime 'a
+                impl<'de> serde::de::Visitor<'de> for EnumVisitor {
                     type Value = #name;
 
                     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                         formatter.write_str(concat!("a ", #enum_name, " enum"))
                     }
 
-                    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
                     where
                         A: serde::de::MapAccess<'de>,
                     {
-                        let mut found_variant_key: Option<std::string::String> = None;
-                        let mut value_part: Option<serde_json::Value> = None;
-                        let mut extension_part: Option<serde_json::Value> = None;
-                        let mut processed_keys = std::collections::HashSet::new(); // Track processed keys
+                        const VARIANT_KEYS: &[&str] = &[#(#variant_names),*];
 
-                        // Iterate through map entries directly, deserializing key as Value
-                        while let Some((key_value, current_value)) = map.next_entry::<serde_json::Value, serde_json::Value>()? {
-                            // Ensure the key is a string
-                            let key_str = match key_value {
-                                serde_json::Value::String(s) => s,
-                                _ => return Err(serde::de::Error::invalid_type(serde::de::Unexpected::Other("non-string key"), &"a string key")),
-                            };
+                        let ::helios_serde_support::ChoiceParts {
+                            index,
+                            value: value_part,
+                            extension: extension_part,
+                        } = ::helios_serde_support::deserialize_choice_parts(map, VARIANT_KEYS)?;
 
-                            let mut key_matched = false;
-                            #( // Loop over variant_names (&'static str)
-                                let base_name = #variant_names; // e.g., "authorString"
-                                let underscore_name = format!("_{}", base_name); // e.g., "_authorString"
-
-                                if key_str.as_str() == base_name { // Compare &str == &'static str
-                                    if value_part.is_some() {
-                                        return Err(serde::de::Error::duplicate_field(base_name));
-                                    }
-                                    value_part = Some(current_value.clone()); // Store the value
-                                    // If we already found a key based on the underscore version, ensure it matches
-                                    if let Some(ref existing_key) = found_variant_key {
-                                        if existing_key != base_name {
-                                             // Use key_str.as_str() for formatting
-                                             return Err(serde::de::Error::custom(format!("Mismatched keys found: {} and {}", existing_key, key_str.as_str())));
-                                        }
-                                    } else {
-                                        found_variant_key = Some(base_name.to_string());
-                                    }
-                                    processed_keys.insert(key_str.clone()); // Clone the String key
-                                    key_matched = true;
-                                } else if key_str.as_str() == underscore_name.as_str() { // Compare &str == &str
-                                    if extension_part.is_some() {
-                                        // Use custom error message as duplicate_field requires 'static str
-                                        return Err(serde::de::Error::custom(format!("duplicate field '{}'", key_str)));
-                                    }
-                                    extension_part = Some(current_value.clone()); // Store the extension value
-                                    // If we already found a key based on the base version, ensure it matches
-                                     if let Some(ref existing_key) = found_variant_key {
-                                        if existing_key != base_name {
-                                             // Use key_str.as_str() for formatting
-                                             return Err(serde::de::Error::custom(format!("Mismatched keys found: {} and {}", existing_key, key_str.as_str())));
-                                        }
-                                    } else {
-                                        found_variant_key = Some(base_name.to_string()); // Store the BASE name
-                                    }
-                                    processed_keys.insert(key_str.clone());
-                                    key_matched = true;
-                                }
-                            )*
-                            // If the key didn't match any expected variant key (base or underscore), ignore it?
-                            // Or error? Let's ignore for now, assuming other fields might be present.
-                            // if !key_matched {
-                            //     // Handle unexpected fields if necessary
-                            // }
-                        }
-
-                        // Ensure a variant key was found
-                        let variant_key = match found_variant_key {
-                            Some(key) => key, // key is the base name (String)
-                            None => {
-                                // No matching key found at all
-                                return Err(serde::de::Error::custom(format!(
-                                    "Expected one of the variant keys {:?} (or their underscore-prefixed versions) but found none",
-                                    [#(#variant_names),*]
-                                )));
-                            }
-                        };
-
-                        // --- Construct the variant based on found_variant_key, value_part, extension_part ---
-                        match variant_key.as_str() {
+                        match index {
                             // Use the pre-generated match arms
                             #(#variant_matches)*
 
-                            // Fallback for unknown variant key (should not be reached if logic above is correct)
-                            _ => Err(serde::de::Error::unknown_variant(&variant_key, &[#(#variant_names),*])),
+                            // Unreachable: `deserialize_choice_parts` only ever returns an
+                            // index into VARIANT_KEYS, which the arms above cover exhaustively.
+                            _ => Err(serde::de::Error::custom("unknown choice variant index")),
                         }
                     }
                 }
 
-                // Use the visitor to deserialize the enum (no longer needs variants)
-                deserializer.deserialize_map(EnumVisitor) // Removed variants passing
+                deserializer.deserialize_map(EnumVisitor)
             };
         }
         Data::Struct(ref data) => {
@@ -2590,6 +2454,19 @@ fn generate_deserialize_impl(data: &Data, name: &Ident) -> proc_macro2::TokenStr
         type IdAndExtensionHelper = helios_serde_support::IdAndExtensionOwned<Extension>;
     };
 
+    // The reunification step — merging each `field` with its `_field` metadata sibling
+    // back into an `Element` — is by far the largest part of the generated deserializer,
+    // and it depends only on the temporary struct, never on `D`. Emitting it as a nested
+    // *non-generic* `fn` (items in a function body do not inherit the enclosing generics)
+    // means it is codegen'd once per FHIR type instead of once per `(type, Deserializer)`
+    // pair in every crate that deserializes it. `Deserializer` implementations are
+    // plentiful — serde_json's reader and `Value`, serde's `MapAccessDeserializer` /
+    // `ContentDeserializer` wrappers, the XML deserializer — so the same body was
+    // previously landing in a binary a dozen or more times over.
+    //
+    // `serde_json::Error` is used as the intermediate error type (it implements
+    // `serde::de::Error`, so the error text is unchanged) and is re-wrapped into
+    // `D::Error` via `custom` at the call site.
     quote! {
         #id_extension_helper_def
 
@@ -2605,13 +2482,18 @@ fn generate_deserialize_impl(data: &Data, name: &Ident) -> proc_macro2::TokenStr
             #(#temp_struct_json_attrs)*
         }
 
-        let temp_struct = #struct_name::deserialize(deserializer)?;
-
         #[cfg(feature = "xml")]
-        return Ok(#name { #(#constructor_xml_attrs)* });
+        fn __from_temp(temp_struct: #struct_name) -> Result<#name, serde_json::Error> {
+            Ok(#name { #(#constructor_xml_attrs)* })
+        }
 
         #[cfg(not(feature = "xml"))]
-        return Ok(#name { #(#constructor_json_attrs)* });
+        fn __from_temp(temp_struct: #struct_name) -> Result<#name, serde_json::Error> {
+            Ok(#name { #(#constructor_json_attrs)* })
+        }
+
+        let temp_struct = #struct_name::deserialize(deserializer)?;
+        __from_temp(temp_struct).map_err(serde::de::Error::custom)
     }
 }
 
@@ -3183,86 +3065,27 @@ fn generate_fhirpath_enum_impl(
                     let is_choice_type_enum = fhir_field_name != variant_name_str &&
                         extract_type_suffix_from_field_name(&fhir_field_name).is_some();
 
+                    // Both shapes stamp the key-derived FHIR type onto the inner result so
+                    // `.ofType()` keeps working; a choice-type enum additionally wraps it in a
+                    // single-key object named after the type-suffixed field. Both steps live in
+                    // `helios-fhirpath-support` rather than being inlined per variant — see
+                    // `with_choice_type_info` for why.
                     if is_choice_type_enum {
                         quote! {
-                            Self::#variant_name(value) => {
-                                // Get the base evaluation result from the inner value
-                                let mut result = value.to_evaluation_result();
-                                // Add FHIR type information to preserve type for .ofType() operations
-                                // For choice type enums, always use the type determined from the field name
-                                result = match result {
-                                    helios_fhirpath_support::EvaluationResult::String(s, _existing_type_info, m) => {
-                                        // Always use the determined type from the field name for choice types
-                                        let type_info = helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type);
-                                        helios_fhirpath_support::EvaluationResult::String(s, Some(type_info), m)
-                                    },
-                                    helios_fhirpath_support::EvaluationResult::Integer(i, existing_type_info, m) => {
-                                        let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Integer(i, Some(type_info), m)
-                                    },
-                                    helios_fhirpath_support::EvaluationResult::Decimal(d, existing_type_info, m) => {
-                                        let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Decimal(d, Some(type_info), m)
-                                    },
-                                    helios_fhirpath_support::EvaluationResult::Boolean(b, existing_type_info, m) => {
-                                        let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Boolean(b, Some(type_info), m)
-                                    },
-                                    helios_fhirpath_support::EvaluationResult::Object { map, type_info: existing_type_info } => {
-                                        let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Object {
-                                            map,
-                                            type_info: Some(type_info),
-                                        }
-                                    },
-                                    _ => result, // For other types, return as-is
-                                };
-
-                                // Wrap the result in an object with the field name as the key
-                                let mut map = std::collections::HashMap::new();
-                                map.insert(#fhir_field_name.to_string(), result);
-                                helios_fhirpath_support::EvaluationResult::Object {
-                                    map,
-                                    type_info: None, // No type info for the wrapper object
-                                }
-                            }
+                            Self::#variant_name(value) => helios_fhirpath_support::wrap_choice_field(
+                                helios_fhirpath_support::with_choice_type_info(
+                                    value.to_evaluation_result(),
+                                    #fhir_type,
+                                ),
+                                #fhir_field_name,
+                            ),
                         }
                     } else {
                         quote! {
-                            Self::#variant_name(value) => {
-                                // Get the base evaluation result from the inner value
-                                let mut result = value.to_evaluation_result();
-                                // Add FHIR type information to preserve type for .ofType() operations
-                                // For choice type enums, always use the type determined from the field name
-                                result = match result {
-                                    helios_fhirpath_support::EvaluationResult::String(s, _existing_type_info, m) => {
-                                        // Always use the determined type from the field name for choice types
-                                        let type_info = helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type);
-                                        helios_fhirpath_support::EvaluationResult::String(s, Some(type_info), m)
-                                    },
-                                    helios_fhirpath_support::EvaluationResult::Integer(i, existing_type_info, m) => {
-                                        let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Integer(i, Some(type_info), m)
-                                    },
-                                    helios_fhirpath_support::EvaluationResult::Decimal(d, existing_type_info, m) => {
-                                        let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Decimal(d, Some(type_info), m)
-                                    },
-                                    helios_fhirpath_support::EvaluationResult::Boolean(b, existing_type_info, m) => {
-                                        let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Boolean(b, Some(type_info), m)
-                                    },
-                                    helios_fhirpath_support::EvaluationResult::Object { map, type_info: existing_type_info } => {
-                                        let type_info = existing_type_info.unwrap_or_else(|| helios_fhirpath_support::TypeInfoResult::new("FHIR", &#fhir_type));
-                                        helios_fhirpath_support::EvaluationResult::Object {
-                                            map,
-                                            type_info: Some(type_info),
-                                        }
-                                    },
-                                    _ => result, // For other types, return as-is
-                                };
-                                result
-                            }
+                            Self::#variant_name(value) => helios_fhirpath_support::with_choice_type_info(
+                                value.to_evaluation_result(),
+                                #fhir_type,
+                            ),
                         }
                     }
                 }

--- a/crates/fhirpath-support/src/lib.rs
+++ b/crates/fhirpath-support/src/lib.rs
@@ -159,6 +159,70 @@ pub trait IntoEvaluationResult {
     fn to_evaluation_result(&self) -> EvaluationResult;
 }
 
+/// Stamps the FHIR type a choice element's key implies onto its evaluation result.
+///
+/// A choice element (`value[x]`) encodes its datatype in the JSON key — `valueString`,
+/// `valueQuantity` — so the type is known from the variant alone and has to be attached
+/// to the result for `.ofType()` to work. `String` results always take the key-derived
+/// type; the other primitives keep a type the inner conversion already supplied.
+///
+/// This is shared out of the `FhirPath` derive rather than inlined per variant: choice
+/// enums have one variant per permitted datatype, and repeating this match in each of
+/// them across four FHIR versions is worth tens of megabytes of near-identical code in
+/// any binary that links the models.
+pub fn with_choice_type_info(result: EvaluationResult, fhir_type: &str) -> EvaluationResult {
+    match result {
+        EvaluationResult::String(s, _existing_type_info, m) => {
+            // Always use the determined type from the field name for choice types
+            EvaluationResult::String(s, Some(TypeInfoResult::new("FHIR", fhir_type)), m)
+        }
+        EvaluationResult::Integer(i, existing_type_info, m) => {
+            let type_info =
+                existing_type_info.unwrap_or_else(|| TypeInfoResult::new("FHIR", fhir_type));
+            EvaluationResult::Integer(i, Some(type_info), m)
+        }
+        EvaluationResult::Decimal(d, existing_type_info, m) => {
+            let type_info =
+                existing_type_info.unwrap_or_else(|| TypeInfoResult::new("FHIR", fhir_type));
+            EvaluationResult::Decimal(d, Some(type_info), m)
+        }
+        EvaluationResult::Boolean(b, existing_type_info, m) => {
+            let type_info =
+                existing_type_info.unwrap_or_else(|| TypeInfoResult::new("FHIR", fhir_type));
+            EvaluationResult::Boolean(b, Some(type_info), m)
+        }
+        EvaluationResult::Object {
+            map,
+            type_info: existing_type_info,
+        } => {
+            let type_info =
+                existing_type_info.unwrap_or_else(|| TypeInfoResult::new("FHIR", fhir_type));
+            EvaluationResult::Object {
+                map,
+                type_info: Some(type_info),
+            }
+        }
+        // For other types, return as-is
+        other => other,
+    }
+}
+
+/// Wraps a choice element's result in the single-key object FHIRPath expects.
+///
+/// The key is the type-suffixed field name (`valueString`), so navigation over the
+/// parent resource sees the polymorphic field under its concrete name. The wrapper
+/// object itself carries no type info.
+///
+/// Shared out of the `FhirPath` derive for the same reason as [`with_choice_type_info`].
+pub fn wrap_choice_field(result: EvaluationResult, field_name: &str) -> EvaluationResult {
+    let mut map = std::collections::HashMap::new();
+    map.insert(field_name.to_string(), result);
+    EvaluationResult::Object {
+        map,
+        type_info: None,
+    }
+}
+
 /// Universal result type for FHIRPath expression evaluation.
 ///
 /// This enum represents any value that can result from evaluating a FHIRPath expression

--- a/crates/serde-support/src/lib.rs
+++ b/crates/serde-support/src/lib.rs
@@ -682,3 +682,172 @@ pub struct IdAndExtensionOwned<E> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extension: Option<Vec<E>>,
 }
+
+/// The raw JSON pieces of a FHIR choice element (`value[x]`, `effective[x]`, …).
+///
+/// FHIR serialises a choice element as a *type-suffixed* key (`valueQuantity`),
+/// optionally paired with an underscore-prefixed sibling (`_valueString`) that
+/// carries `id`/`extension` metadata for primitive choices. [`deserialize_choice_parts`]
+/// locates that pair and reports which variant matched.
+pub struct ChoiceParts {
+    /// Index into the `variant_keys` slice that was matched.
+    pub index: usize,
+    /// The value under the type-suffixed key, when present.
+    pub value: Option<serde_json::Value>,
+    /// The value under the underscore-prefixed key, when present.
+    pub extension: Option<serde_json::Value>,
+}
+
+/// Scans a map for the single choice-element key it contains.
+///
+/// This exists so that the `FhirSerde` derive does not have to expand a
+/// per-variant key comparison into every generated `visit_map`. Choice enums
+/// carry one variant per permitted FHIR datatype — dozens each — and there are
+/// hundreds of such enums per FHIR version, so an inlined scan multiplies out
+/// into hundreds of megabytes of near-identical machine code in any binary that
+/// deserializes typed resources. Keying the scan on a `&'static [&'static str]`
+/// collapses all of it to one function per `MapAccess` implementation.
+///
+/// Keys that match neither a variant key nor its underscore-prefixed form are
+/// ignored, matching the previous generated behaviour.
+///
+/// # Errors
+///
+/// Returns an error when a key is not a string, when either the value or the
+/// extension key appears twice, when two *different* variant keys are present,
+/// or when no variant key is found at all.
+pub fn deserialize_choice_parts<'de, A>(
+    mut map: A,
+    variant_keys: &'static [&'static str],
+) -> Result<ChoiceParts, A::Error>
+where
+    A: serde::de::MapAccess<'de>,
+{
+    let mut index: Option<usize> = None;
+    let mut value: Option<serde_json::Value> = None;
+    let mut extension: Option<serde_json::Value> = None;
+
+    while let Some((key, current)) = map.next_entry::<serde_json::Value, serde_json::Value>()? {
+        let key = match key {
+            serde_json::Value::String(key) => key,
+            _ => {
+                return Err(serde::de::Error::invalid_type(
+                    serde::de::Unexpected::Other("non-string key"),
+                    &"a string key",
+                ));
+            }
+        };
+
+        // Exact match first, so a (hypothetical) variant key starting with `_`
+        // still wins over being read as another variant's metadata sibling.
+        let matched = if let Some(pos) = variant_keys.iter().position(|k| *k == key) {
+            if value.is_some() {
+                return Err(serde::de::Error::duplicate_field(variant_keys[pos]));
+            }
+            value = Some(current);
+            pos
+        } else if let Some(pos) = key
+            .strip_prefix('_')
+            .and_then(|base| variant_keys.iter().position(|k| *k == base))
+        {
+            if extension.is_some() {
+                // `duplicate_field` requires a `&'static str`, which we do not
+                // have for the underscore-prefixed form.
+                return Err(serde::de::Error::custom(format!(
+                    "duplicate field '{}'",
+                    key
+                )));
+            }
+            extension = Some(current);
+            pos
+        } else {
+            continue;
+        };
+
+        match index {
+            Some(existing) if existing != matched => {
+                return Err(serde::de::Error::custom(format!(
+                    "Mismatched keys found: {} and {}",
+                    variant_keys[existing], key
+                )));
+            }
+            _ => index = Some(matched),
+        }
+    }
+
+    match index {
+        Some(index) => Ok(ChoiceParts {
+            index,
+            value,
+            extension,
+        }),
+        None => Err(serde::de::Error::custom(format!(
+            "Expected one of the variant keys {:?} (or their underscore-prefixed versions) but found none",
+            variant_keys
+        ))),
+    }
+}
+
+/// Deserializes the `value`/`id`/`extension` pieces of a primitive choice variant.
+///
+/// The caller assembles them into its concrete `Element<V, E>` or
+/// `DecimalElement<E>`; `V` and `E` are inferred from that assignment. Shared
+/// out of the derive for the same code-size reason as [`deserialize_choice_parts`].
+///
+/// # Errors
+///
+/// Returns an error when either piece fails to deserialize.
+#[allow(clippy::type_complexity)]
+pub fn deserialize_choice_element_parts<V, E, Err>(
+    value: Option<serde_json::Value>,
+    extension: Option<serde_json::Value>,
+    key: &str,
+) -> Result<(Option<V>, Option<String>, Option<Vec<E>>), Err>
+where
+    V: serde::de::DeserializeOwned,
+    E: serde::de::DeserializeOwned,
+    Err: serde::de::Error,
+{
+    let (id, extension) = match extension {
+        Some(extension) => {
+            let helper: IdAndExtensionOwned<E> =
+                serde::Deserialize::deserialize(extension).map_err(|e| {
+                    Err::custom(format!("Error deserializing extension _{}: {}", key, e))
+                })?;
+            (helper.id, helper.extension)
+        }
+        None => (None, None),
+    };
+
+    let value = match value {
+        Some(value) => Some(V::deserialize(value).map_err(|e| {
+            Err::custom(format!("Error deserializing primitive {}: {}", key, e))
+        })?),
+        None => None,
+    };
+
+    Ok((value, id, extension))
+}
+
+/// Deserializes the payload of a non-primitive choice variant.
+///
+/// `kind` only shapes the error message (`"non-element variant"`,
+/// `"tuple variant"`, …). Shared out of the derive for the same code-size
+/// reason as [`deserialize_choice_parts`].
+///
+/// # Errors
+///
+/// Returns an error when the value is absent or fails to deserialize.
+pub fn deserialize_choice_value<T, Err>(
+    value: Option<serde_json::Value>,
+    key: &'static str,
+    kind: &'static str,
+) -> Result<T, Err>
+where
+    T: serde::de::DeserializeOwned,
+    Err: serde::de::Error,
+{
+    let value = value.ok_or_else(|| Err::missing_field(key))?;
+    T::deserialize(value)
+        .map_err(|e| Err::custom(format!("Error deserializing {} {}: {}", kind, key, e)))
+}

--- a/crates/serde-support/src/lib.rs
+++ b/crates/serde-support/src/lib.rs
@@ -810,8 +810,8 @@ where
 {
     let (id, extension) = match extension {
         Some(extension) => {
-            let helper: IdAndExtensionOwned<E> =
-                serde::Deserialize::deserialize(extension).map_err(|e| {
+            let helper: IdAndExtensionOwned<E> = serde::Deserialize::deserialize(extension)
+                .map_err(|e| {
                     Err::custom(format!("Error deserializing extension _{}: {}", key, e))
                 })?;
             (helper.id, helper.extension)
@@ -819,12 +819,13 @@ where
         None => (None, None),
     };
 
-    let value = match value {
-        Some(value) => Some(V::deserialize(value).map_err(|e| {
-            Err::custom(format!("Error deserializing primitive {}: {}", key, e))
-        })?),
-        None => None,
-    };
+    let value =
+        match value {
+            Some(value) => Some(V::deserialize(value).map_err(|e| {
+                Err::custom(format!("Error deserializing primitive {}: {}", key, e))
+            })?),
+            None => None,
+        };
 
     Ok((value, id, extension))
 }


### PR DESCRIPTION
Fixes #508.

## Result

`helios-rest --lib`, same recipe as the issue (`CARGO_PROFILE_DEV_DEBUG=0`, `rustc 1.95.0`, Linux):

| | size | vs baseline |
|---|---:|---:|
| baseline (reproduced exactly) | 1,642,581,296 B (1.53 GiB) | — |
| choice-enum deserializer shared | 1,582,117,064 B | −60 MB |
| + struct constructor hoisted | 1,125,974,616 B | −517 MB |
| + choice-enum FHIRPath shared | **1,095,621,400 B (1.02 GiB)** | **−547 MB (−33.3%)** |

FHIR-model symbol bytes: 802.3 MB → 433.5 MB.

## The issue's stated direction accounts for 60 MB of it

I implemented it first, exactly as written. The per-enum `visit_map` key scan now lives in `helios_serde_support::deserialize_choice_parts`, generic only over the `MapAccess` implementation and keyed on a `&'static [&'static str]`, so it is emitted once per deserializer instead of once per enum. Dispatch became a jump table over the matched variant index rather than a string match, and the per-variant arms delegate to shared helpers — which also means the primitive type no longer has to be spelled out, so a chunk of fragile type-extraction logic (and four `panic!`s) came out of the macro.

Choice-enum `EnumVisitor` symbols went from ~70 MB to 9.4 MB, and those `visit_map` bodies are no longer the largest symbols in the binary.

But that is not where the 599.6 MB was.

## What actually dominated

Measuring the remainder showed a different multiplication: **every `<T as Deserialize>::deserialize` was landing in the binary 13–23 times.**

```
distinct names: 3709   total occurrences: 31177   bytes: 353.1 MB
copies-per-name: 2-4 for ~1850 types, 13-23 for ~1850 types
one copy each would be ~45.9 MB
```

The multiplier is the `D` type parameter — serde_json's reader and `Value`, serde's `MapAccessDeserializer` / `ContentDeserializer` wrappers, the XML deserializer — crossed with each crate in the graph that instantiates them. `Coding` had 23 copies in 11 distinct sizes; `Measure`, only ever deserialized as a top-level resource, had 3.

The fat part of that body is the `field` / `_field` reunification into `Element`, and it never touches `D`. It just happened to live inside `fn deserialize<D>`. Emitting it as a nested non-generic `fn __from_temp` — items in a function body do not inherit the enclosing generics — collapses 353.6 MB to 64.5 MB. That is the 456 MB step.

I then applied the same treatment to the `FhirPath` derive, whose choice-enum `to_evaluation_result` had by then become the largest individual symbol (~0.21 MB each): the identical per-variant repetition #508 describes, in a different derive.

## Changes

- `crates/serde-support/src/lib.rs` — `deserialize_choice_parts`, `deserialize_choice_element_parts`, `deserialize_choice_value`
- `crates/fhirpath-support/src/lib.rs` — `with_choice_type_info`, `wrap_choice_field`
- `crates/fhir-macro/src/lib.rs` — call the above; index-keyed dispatch; hoist the struct constructor

`serde_json::Error` is the intermediate error type in the hoisted constructor. It implements `serde::de::Error`, so error text is unchanged; all message wording is preserved throughout (no test asserted on it, but the strings are identical anyway).

## Verification

All green:

- `helios-fhir` (all features)
- `helios-serde` — including `test_examples` round-trips over the FHIR spec examples, and the `xml` feature paths
- `helios-fhirpath` + `helios-sof` — 989 tests, 98 binaries
- `helios-rest --lib` — 483 tests
- `helios-fhir-macro`, `helios-serde-support`, `helios-fhirpath-support`, `helios-fhir-validator`
- `cargo fmt --all --check` clean
- `cargo clippy --all-targets --all-features` clean with the CI flag set

## Pushing further

Tracked in #510.

The remaining FHIR-model bytes are measured and the next levers are specific, but each is a bigger change than this one, so I stopped here rather than commit the project to them:

| remaining | size | symbols |
|---|---:|---:|
| serde's own `#[derive(Deserialize)]` on the generated `Temp*` structs | 165.5 MB | 72,822 |
| `Serialize` | 135.1 MB | 34,843 |
| hoisted `__from_temp` | 51.3 MB | 26,698 |
| outer generic `deserialize` wrappers | 13.2 MB | 37,797 |
| choice `EnumVisitor` | 9.4 MB | 1,930 |

Both leaders are still multiplied by `D` / `S` the same way the constructor was — but unlike the constructor, neither can simply be hoisted, because both genuinely consume the generic parameter. Erasing them would mean something like `erased-serde` at the type boundary: a real architectural change with runtime dispatch cost and error-type consequences. That is #510, which carries the full breakdown, the benchmarking that would need to happen first, and the decisions it depends on.

Two cheaper observations from the same data, both also captured in #510:

- The hoisted `__from_temp` is non-generic yet still appears ~7× per type. Worth understanding before assuming a single copy is achievable elsewhere — it suggests nested items in generic functions are not deduplicated across crates as cleanly as the rule implies.
- The 13–23× spread correlates with *nesting depth*, not resource size. Types deserialized only at the top level (`Measure`, `Patient`) have 3 copies; types deserialized as fields inside many containers (`Coding`, `Extension`) have 22–23. Reducing the number of distinct `Deserializer` types the workspace routes FHIR JSON through would shrink the multiplier without touching the derive at all.

## Notes

- Not addressed here: #508 observes that `ci.yml` attributes the macOS dyld signature to `-undefined dynamic_lookup` in rustflags, and that the failing run carried no rustflags. That comment is still inaccurate; left alone since it is a separate concern.
- The macOS link remains **unconfirmed**. The binary is now well under the ~2 GiB Apple Silicon ceiling, but I have no Apple Silicon evidence either way. The bloat stands on its own regardless, as the issue says.
- The build script refreshed 1,602 R6 spec fixtures under `crates/fhir/tests/data/json/R6/` during these builds (the 24-hour auto-download). Deliberately **not** included in this branch.

https://claude.ai/code/session_012scJWEd3vbUsJMWBqWAa8n
