### PR TITLE
test(validator): drop the R4 baseline entry that #432 already fixed

### DIFF
--- a/crates/fhir-validator/tests/fixtures/spec-examples/known-failures-r4.json
+++ b/crates/fhir-validator/tests/fixtures/spec-examples/known-failures-r4.json
@@ -1329,14 +1329,6 @@
       "reason": "Genuine defect in the published example, not an engine bug: the nested `Questionnaire.item` really omits the required `linkId` (verified in the corpus)."
     },
     {
-      "file": "questionnaire-cqf-example.json",
-      "issues": 1,
-      "kinds": [
-        "unknown-schema"
-      ],
-      "reason": "Documented gap: core extension StructureDefinitions (`extension-definitions.json`) are not in the vendored spec bundles, so these extension canonicals cannot be resolved."
-    },
-    {
       "file": "questionnaire-questionnaire.json",
       "issues": 72,
       "kinds": [


### PR DESCRIPTION
## The failure

`r4_spec_examples_match_baseline` fails with a single divergence — an improvement the ratchet refuses to accept silently:

```
FIXED  questionnaire-cqf-example.json: validates clean now.
       Good -- remove it from the baseline so the ratchet holds.
```

This is **not** specific to any one PR. It reproduces on `main`, it fails the scheduled `validator-conformance.yml` runs (2026-08-05, 2026-08-06), and it fails the `Pack smoke + spec example corpus` job on every validator PR since — #461, #465, #472 among them.

## Root cause

The baseline recorded exactly one entry whose only issue kind was `unknown-schema`:

> `questionnaire-cqf-example.json` — "Documented gap: core extension StructureDefinitions (`extension-definitions.json`) are not in the vendored spec bundles, so these extension canonicals cannot be resolved."

#432 (`feat/363-extension-catalogue`, 55e3f6dcd, merged 2026-08-04) vendored `resources/R4/extension-definitions.json` and regenerated `fhir_schemas_r4.json.gz` (180KB → 208KB). The file's three canonicals — `cqf-expression`, `cqf-library`, `cqf-questionnaire` — resolve now, so it validates clean. The R4 sweep no longer emits the `unknown-schema` kind at all. That PR did not update the baseline, so the ratchet has been firing on its own success ever since.

## The change

Delete the entry. 220 → 219 known failures. `resourcesValidated` stays at 2912 and no other manifest field moves, so this is the whole fix.

R5 still reports 1934 `unknown-schema` issues — its pack was never given extension definitions — and that baseline is untouched here.

## Verification

```
$ cargo test -p helios-fhir-validator --test spec_examples -- --ignored
R4: validated 2912 resources, 219 with issues
test result: ok. 1 passed; 0 failed
```

https://claude.ai/code/session_015Xv3QofZPCr89AgHjnATGR