### PR TITLE
fix(elasticsearch): negate token :not once, around all values

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/token.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/parameter_handlers/token.rs
@@ -10,15 +10,10 @@ pub fn build_clause(param: &SearchParameter, value: &str) -> Option<Value> {
 
     // Handle modifiers first
     match param.modifier {
-        Some(SearchModifier::Not) => {
-            // Negate the inner clause
-            let inner = build_token_condition(name, value, None)?;
-            return Some(json!({
-                "bool": {
-                    "must_not": [inner]
-                }
-            }));
-        }
+        // `:not` builds the POSITIVE clause here; the query builder negates once,
+        // around the OR of all values (#473). Negating per value made
+        // `:not=a,b` mean "NOT a OR NOT b", so any resource carrying both values
+        // satisfied one half of the OR and leaked back into the result set.
         Some(SearchModifier::Text) => {
             return build_text_clause(name, value);
         }
@@ -217,11 +212,15 @@ mod tests {
     }
 
     #[test]
-    fn test_not_modifier() {
+    fn test_not_modifier_builds_positive_clause() {
+        // The query builder applies the negation once, around all values (#473);
+        // the per-value clause must stay positive.
         let param = make_param("gender", Some(SearchModifier::Not));
         let clause = build_clause(&param, "male").unwrap();
         let s = serde_json::to_string(&clause).unwrap();
-        assert!(s.contains("must_not"));
+        assert!(!s.contains("must_not"));
+        assert!(s.contains("search_params.token.code"));
+        assert!(s.contains("male"));
     }
 
     #[test]

--- a/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
@@ -211,16 +211,29 @@ impl<'a> EsQueryBuilder<'a> {
         }
 
         // Multiple values for the same parameter are ORed
-        if clauses.len() == 1 {
-            Some(clauses.into_iter().next().unwrap())
+        let combined = if clauses.len() == 1 {
+            clauses.into_iter().next().unwrap()
         } else {
-            Some(json!({
+            json!({
                 "bool": {
                     "should": clauses,
                     "minimum_should_match": 1
                 }
-            }))
+            })
+        };
+
+        // `:not` negates HERE, around the OR of every value, not per value
+        // (#473). FHIR's `:not` means "no value of the parameter matches", so
+        // `:not=a,b` is `NOT (a OR b)`; negating each value first would give
+        // `NOT a OR NOT b` and return every resource holding both values.
+        // `must_not` over the nested query is already resource-level: a nested
+        // clause matches when *some* indexed value matches, so its negation
+        // covers resources with no value for the parameter at all.
+        if matches!(param.modifier, Some(SearchModifier::Not)) {
+            return Some(json!({ "bool": { "must_not": [combined] } }));
         }
+
+        Some(combined)
     }
 
     /// Builds a clause for a single value of a parameter.
@@ -411,6 +424,57 @@ mod tests {
         let es_query = builder.build(&query);
         let body_str = serde_json::to_string(&es_query.body).unwrap();
         assert!(body_str.contains("resource_id"));
+    }
+
+    fn not_param(values: Vec<SearchValue>) -> SearchQuery {
+        SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "language".to_string(),
+            param_type: SearchParamType::Token,
+            modifier: Some(SearchModifier::Not),
+            values,
+            chain: vec![],
+            components: vec![],
+        })
+    }
+
+    /// `:not` wraps the token clause in a single resource-level `must_not`.
+    #[test]
+    fn test_not_modifier_negates_once() {
+        let query = not_param(vec![SearchValue::eq("en-US")]);
+        let builder = EsQueryBuilder::new("acme", "Patient", "hfs_acme_patient".to_string());
+        let es_query = builder.build(&query);
+
+        let clause = &es_query.body["query"]["bool"]["must"][0];
+        let negated = &clause["bool"]["must_not"][0];
+        assert!(
+            negated["nested"].is_object(),
+            "must_not wraps the nested query"
+        );
+        // The negated clause itself is positive — no double negation.
+        let inner = serde_json::to_string(negated).unwrap();
+        assert!(!inner.contains("must_not"));
+    }
+
+    /// `:not=a,b` is `NOT (a OR b)`, not `NOT a OR NOT b` (#473): the OR of the
+    /// positive value clauses sits inside one `must_not`, so a resource holding
+    /// both values is excluded rather than matching through the other value.
+    #[test]
+    fn test_not_modifier_multi_value_negates_the_or() {
+        let query = not_param(vec![SearchValue::eq("en-US"), SearchValue::eq("es")]);
+        let builder = EsQueryBuilder::new("acme", "Patient", "hfs_acme_patient".to_string());
+        let es_query = builder.build(&query);
+
+        let clause = &es_query.body["query"]["bool"]["must"][0];
+        let negated = &clause["bool"]["must_not"][0];
+        let should = negated["bool"]["should"].as_array().expect("OR of values");
+        assert_eq!(should.len(), 2);
+
+        let inner = serde_json::to_string(negated).unwrap();
+        assert!(
+            !inner.contains("must_not"),
+            "values must not be negated individually"
+        );
+        assert!(inner.contains("en-US") && inner.contains("es"));
     }
 
     #[test]

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -421,11 +421,15 @@ mod parameter_handler_tests {
         }
 
         #[test]
-        fn test_not_modifier() {
+        fn test_not_modifier_builds_positive_clause() {
+            // The negation is applied once by the query builder, around the OR
+            // of every value (#473) — the per-value clause stays positive.
             let param = make_param("gender", SearchParamType::Token, Some(SearchModifier::Not));
             let clause = token::build_clause(&param, "male").unwrap();
             let s = serde_json::to_string(&clause).unwrap();
-            assert!(s.contains("must_not"));
+            assert!(!s.contains("must_not"));
+            assert!(s.contains("search_params.token.code"));
+            assert!(s.contains("male"));
         }
 
         #[test]
@@ -2092,6 +2096,119 @@ mod es_integration {
             result.resources.items.len(),
             2,
             "Should find 2 patients with code 12345"
+        );
+    }
+
+    /// `:not` means "no value of the parameter matches" (#473). Three cases
+    /// that a per-value or per-row negation gets wrong:
+    /// resources whose element is absent must be returned; a multi-valued
+    /// element must not leak back in through its other values; and `:not=a,b`
+    /// is `NOT (a OR b)`, not `NOT a OR NOT b`.
+    #[tokio::test]
+    async fn es_integration_search_token_not_modifier() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("test-tenant");
+
+        let communication = |codes: &[&str]| {
+            codes
+                .iter()
+                .map(|code| {
+                    json!({ "language": { "coding": [{
+                        "system": "urn:ietf:bcp:47",
+                        "code": code
+                    }]}})
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for (id, langs) in [
+            ("lang-en", vec!["en-US"]),
+            // Multi-valued: holds the excluded code AND another one.
+            ("lang-en-es", vec!["en-US", "es"]),
+            ("lang-fr", vec!["fr"]),
+        ] {
+            backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({
+                        "resourceType": "Patient",
+                        "id": id,
+                        "communication": communication(&langs)
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+
+        // No communication element at all — has no value, so it matches :not.
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({ "resourceType": "Patient", "id": "lang-none" }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        let query = |values: Vec<SearchValue>| {
+            SearchQuery::new("Patient")
+                .with_parameter(SearchParameter {
+                    name: "language".to_string(),
+                    param_type: SearchParamType::Token,
+                    modifier: Some(SearchModifier::Not),
+                    values,
+                    chain: vec![],
+                    components: vec![],
+                })
+                .with_count(100)
+        };
+
+        let ids = |result: &helios_persistence::core::SearchResult| {
+            let mut ids: Vec<String> = result
+                .resources
+                .items
+                .iter()
+                .map(|r| r.id().to_string())
+                .collect();
+            ids.sort();
+            ids
+        };
+
+        let result = backend
+            .search(&tenant, &query(vec![SearchValue::token(None, "en-US")]))
+            .await
+            .unwrap();
+        assert_eq!(
+            ids(&result),
+            vec!["lang-fr", "lang-none"],
+            "language:not=en-US excludes both en-US patients (incl. the one that also has 'es') \
+             and returns the patient with no communication element"
+        );
+
+        let result = backend
+            .search(
+                &tenant,
+                &query(vec![
+                    SearchValue::token(None, "en-US"),
+                    SearchValue::token(None, "fr"),
+                ]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            ids(&result),
+            vec!["lang-none"],
+            "language:not=en-US,fr is NOT (en-US OR fr) — only the patient with no language remains"
         );
     }
 


### PR DESCRIPTION
Companion to #480 (sqlite) — same `:not` semantics, different backend. Relates to #473.

## The bug

Elasticsearch negated **each value separately**: the token handler wrapped its own clause in `must_not`, and the query builder then OR'd the per-value clauses with `should`/`minimum_should_match: 1`:

```
should: [ must_not(a), must_not(b) ]   →   NOT a OR NOT b
```

FHIR's `:not` means *no value of the parameter matches*, so `:not=a,b` is `NOT (a OR b)`. Any resource holding **both** values satisfied one half of the `should` and leaked back into the result set — `Patient?language:not=urn:ietf:bcp:47|en-US,urn:ietf:bcp:47|fr` returned every patient with two languages.

## What was already correct

The two failure modes from #480 do **not** apply to ES, for structural reasons worth recording:

- `must_not` around a `nested` query is already **resource-level** — it means *no nested doc matches*, so a second `communication`/`coding`/`identifier` entry can't rescue the resource, and a resource with no value for the parameter doesn't match the nested query and is therefore kept.
- The phantom contained-resource row can't happen either: ES indexes contained resources as separate documents (`is_contained: true`, filtered out by default), not as rows in the parent's index.

So this is the narrower variant of the sqlite bug: multi-**value queries** rather than multi-**valued elements**.

## The fix

The token handler always builds the positive nested clause; the query builder ORs the values and applies **one** `must_not` around the result when the modifier is `:not`:

```
must_not: [ { should: [ a, b ], minimum_should_match: 1 } ]   →   NOT (a OR b)
```

Mirrors #480 (which negates generically at the parameter level, not gated to token) and matches what Postgres already did.

## Other backends

Checked while I was here: **Postgres** is correct (`NOT (id IN (… OR …))`, resource-level, missing-element case asserted by `postgres_integration_search_not_modifier`). **MongoDB** returns `SearchError::UnsupportedModifier` for `:not` — no wrong results, just unsupported; left as-is since implementing it is a feature, not a fix. **S3/local_fs** have no modifier path.

## Tests

- Unit: the per-value token clause stays positive (negation is the builder's job).
- Unit: single-value `:not` negates exactly once; multi-value `:not=a,b` puts the two-branch `should` *inside* one `must_not`, with no per-value negation.
- Integration (container-backed, `es_integration_search_token_not_modifier`): four patients — `en-US`, `en-US`+`es`, `fr`, and one with no `communication` element.
  - `language:not=en-US` → `[lang-fr, lang-none]` (multi-valued patient excluded; missing-element patient returned)
  - `language:not=en-US,fr` → `[lang-none]`

The `:not` cases in the shared `search_suite` are all `#[cfg(feature = "sqlite")]` + `create_sqlite_backend()`, and ES's only prior `:not` coverage asserted that the string `"must_not"` appears somewhere in the JSON — which passes under both the correct and the broken shape. Hence the ES-specific integration test.

**Verified against pre-fix code:** reverting the two source files makes the integration test fail exactly as diagnosed — the multi-value query returns all four patients (`["lang-en", "lang-en-es", "lang-fr", "lang-none"]` vs expected `["lang-none"]`) while the single-value assertion passes.

Full runs: `elasticsearch_tests` 90 passed, persistence lib 850 passed, `cargo fmt` clean, no new clippy warnings on the changed lines.

https://claude.ai/code/session_01CwxXeFy9VUEQw35eUR9GQX