### PR TITLE
fix(search): stop waving every `_`-prefixed search parameter through

### DIFF
--- a/crates/persistence/docs/search-spec-assessment.md
+++ b/crates/persistence/docs/search-spec-assessment.md
@@ -246,7 +246,11 @@ Ordered roughly by impact:
 
 **Recently landed (REST layer).** Repeated query parameters are now preserved as FHIR AND semantics
 (previously collapsed to last-wins by `HashMap` extraction); `Prefer: handling=strict` rejects
-unknown search parameters with `400` on type-level search (lenient default still ignores them);
+unknown search parameters with `400` on type-level search — including `_`-prefixed names outside
+the set of global parameters the server honours (`_typo`, `_language`, …), which used to bypass the
+check wholesale — while the lenient default ignores them for real: dropped from the executed query,
+omitted from the searchset `self` link, and reported in an `entry.search.mode = outcome`
+`OperationOutcome`;
 `_include`/`_revinclude` (with `:iterate` and `Type:*` wildcard) resolve on SQLite/Postgres;
 nested `_has` resolves; `Bundle.total` populates on SQLite/Postgres; and `_summary`/`_elements`
 responses carry the `SUBSETTED` tag.

--- a/crates/rest/src/extractors/mod.rs
+++ b/crates/rest/src/extractors/mod.rs
@@ -25,8 +25,8 @@ pub use pagination::Pagination;
 pub use peer::PeerIp;
 pub use search_params::SearchParams;
 pub use search_query_builder::{
-    build_search_query, build_search_query_from_map, build_search_query_from_pairs,
-    unknown_search_params,
+    GLOBAL_SEARCH_PARAMS, build_search_query, build_search_query_from_map,
+    build_search_query_from_pairs, unknown_search_params,
 };
 pub use tenant::TenantExtractor;
 pub use user::UserKey;

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -221,14 +221,64 @@ pub fn build_search_query_from_map(
     build_search_query(resource_type, &search_params, registry)
 }
 
+/// The `_`-prefixed global/result parameters this server actually honours.
+///
+/// Every other underscore name is unknown, exactly like a misspelled ordinary
+/// parameter: a blanket `starts_with('_')` bypass would wave through `_typo`
+/// and any future spec parameter this server has not implemented, so
+/// `Prefer: handling=strict` could never reject one and the self link would
+/// claim it had been applied (see issue #524).
+///
+/// Result/control parameters (`_count`, `_sort`, `_format`, …) are already
+/// filtered out of [`SearchParams::search_params`], but are listed here too so
+/// the set stays a complete statement of what the server honours and the check
+/// is correct for any caller.
+///
+/// `_query` is deliberately absent — named queries are not implemented, and
+/// [`crate::handlers`] rejects them outright.
+pub const GLOBAL_SEARCH_PARAMS: &[&str] = &[
+    // Filters over resource metadata / content.
+    "_id",
+    "_lastUpdated",
+    "_tag",
+    "_profile",
+    "_security",
+    "_source",
+    "_text",
+    "_content",
+    "_filter",
+    "_list",
+    "_has",
+    "_type",
+    // Result-shaping parameters.
+    "_contained",
+    "_containedType",
+    "_include",
+    "_revinclude",
+    "_sort",
+    "_count",
+    "_offset",
+    "_cursor",
+    "_total",
+    "_summary",
+    "_elements",
+    "_score",
+    "_format",
+    "_pretty",
+];
+
 /// Returns the names of search parameters that are not recognized for the given
-/// resource type (used to enforce `Prefer: handling=strict`).
+/// resource type.
 ///
 /// A parameter is "unknown" when its base name (after stripping any modifier and
-/// chain) is not registered for `resource_type` or for `Resource`, and is not a
-/// global parameter (those start with `_`, e.g. `_id`, `_text`, `_has`). Under
-/// lenient handling the server ignores such parameters; under strict handling
-/// the caller turns this list into a `400`.
+/// chain) is neither one of the [`GLOBAL_SEARCH_PARAMS`] this server honours nor
+/// registered for `resource_type` or for `Resource`.
+///
+/// Per FHIR search, an unsupported parameter may be ignored only under lenient
+/// handling and only if that is reported; under `Prefer: handling=strict` it is
+/// an error. Callers turn this list into a `400` under strict handling, and
+/// under lenient handling drop these parameters from both the executed query and
+/// the searchset self link.
 pub fn unknown_search_params(
     resource_type: &str,
     params: &SearchParams,
@@ -248,11 +298,8 @@ pub fn unknown_search_params(
             .split('.')
             .next()
             .unwrap_or(name);
-        // Global/result parameters (`_id`, `_text`, `_type`, …) are always allowed.
-        if base.starts_with('_') {
-            continue;
-        }
-        let known = registry.get_param(resource_type, base).is_some()
+        let known = GLOBAL_SEARCH_PARAMS.contains(&base)
+            || registry.get_param(resource_type, base).is_some()
             || registry.get_param("Resource", base).is_some();
         if !known {
             unknown.push(name.clone());
@@ -1063,6 +1110,47 @@ mod tests {
         let patient =
             parse_search_parameter("Observation", "patient", "Patient/1", &registry).unwrap();
         assert_eq!(patient.param_type, SearchParamType::Reference);
+    }
+
+    #[test]
+    fn test_unknown_search_params_flags_unhonoured_underscore_names() {
+        // Regression for #524: a blanket `starts_with('_')` bypass let every
+        // underscore name through, so strict handling could never reject one.
+        let registry = test_registry();
+        let unknown = |q: Vec<(&str, &str)>| {
+            let sp = SearchParams::from_pairs(
+                q.into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            );
+            unknown_search_params("Patient", &sp, &registry)
+        };
+
+        // Underscore names the server does not implement are unknown.
+        assert_eq!(unknown(vec![("_typo", "x")]), vec!["_typo".to_string()]);
+        assert_eq!(
+            unknown(vec![("_whatever", "x")]),
+            vec!["_whatever".to_string()]
+        );
+        // …including with a modifier, which is stripped before the check.
+        assert_eq!(
+            unknown(vec![("_typo:exact", "x")]),
+            vec!["_typo:exact".to_string()]
+        );
+
+        // Every global parameter the server honours stays allowed, even though
+        // the test registry holds no `Resource`-level definitions.
+        for name in GLOBAL_SEARCH_PARAMS {
+            assert!(
+                unknown(vec![(name, "x")]).is_empty(),
+                "{name} must be treated as a known global parameter"
+            );
+        }
+
+        // Reverse chaining and ordinary registered parameters are unaffected.
+        assert!(unknown(vec![("_has:Observation:patient:code", "1")]).is_empty());
+        assert!(unknown(vec![("name", "Smith")]).is_empty());
+        assert_eq!(unknown(vec![("nope", "x")]), vec!["nope".to_string()]);
     }
 
     #[test]

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -227,7 +227,47 @@ where
         pairs
     };
 
-    let search_params = SearchParams::from_pairs(pairs);
+    let mut search_params = SearchParams::from_pairs(pairs);
+
+    // Unknown search parameters. Per FHIR search error handling these may be
+    // ignored only under lenient handling and only if that is reported; under
+    // `Prefer: handling=strict` they are an error.
+    //
+    // Scope the registry read guard tightly so it doesn't span any await —
+    // parking_lot guards aren't Send by default, which would make this async fn
+    // !Send.
+    let ignored_params = {
+        let reg = state.storage().search_param_registry(tenant.context());
+        let registry = reg.read();
+        unknown_search_params(resource_type, &search_params, &registry)
+    };
+    if !ignored_params.is_empty() {
+        if strict {
+            return Err(RestError::InvalidParameter {
+                param: ignored_params.join(", "),
+                message: format!(
+                    "unknown search parameter(s) rejected under Prefer: handling=strict: {}",
+                    ignored_params.join(", ")
+                ),
+            });
+        }
+        // Lenient: ignore them for real. Dropping them here keeps the filter out
+        // of the executed query (an unrecognized name would otherwise be matched
+        // against the search index and quietly return nothing), keeps them out of
+        // the self link built below, and they are reported as an OperationOutcome
+        // entry on the bundle.
+        debug!(
+            resource_type = %resource_type,
+            params = %ignored_params.join(", "),
+            "Ignoring unknown search parameter(s) under lenient handling"
+        );
+        let retained: Vec<(String, String)> = search_params
+            .iter()
+            .filter(|(k, _)| !ignored_params.contains(k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        search_params = SearchParams::from_pairs(retained);
+    }
 
     // Convert REST params to persistence SearchQuery. Scope the registry read
     // guard tightly so it doesn't span any await — parking_lot guards aren't
@@ -235,20 +275,6 @@ where
     let mut query = {
         let reg = state.storage().search_param_registry(tenant.context());
         let registry = reg.read();
-        // Under `Prefer: handling=strict`, reject unknown search parameters
-        // (the lenient default ignores them).
-        if strict {
-            let unknown = unknown_search_params(resource_type, &search_params, &registry);
-            if !unknown.is_empty() {
-                return Err(RestError::InvalidParameter {
-                    param: unknown.join(", "),
-                    message: format!(
-                        "unknown search parameter(s) rejected under Prefer: handling=strict: {}",
-                        unknown.join(", ")
-                    ),
-                });
-            }
-        }
         let built = build_search_query(resource_type, &search_params, &registry)?;
         // Under strict handling, reject a `_sort` on a field the server cannot
         // actually sort by (it would otherwise silently fall back to `id`). Only
@@ -390,14 +416,47 @@ where
     // Get FHIR version from config for subsetting
     let fhir_version = state.config().default_fhir_version;
 
-    let bundle_json =
+    let mut bundle_json =
         bundle_to_json_with_subsetting(bundle, summary_mode, elements.as_deref(), fhir_version);
+
+    // Report the parameters that were ignored under lenient handling. Added
+    // after subsetting so `_elements`/`_summary` don't strip the outcome.
+    // `_summary=count` returns only `Bundle.total`, so there is no entry list to
+    // attach it to.
+    if !ignored_params.is_empty() && summary_mode != Some(SummaryMode::Count) {
+        append_ignored_params_outcome(&mut bundle_json, &ignored_params);
+    }
 
     format_resource_response(StatusCode::OK, HeaderMap::new(), &bundle_json, format).map_err(|_| {
         RestError::InternalError {
             message: "Failed to serialize response".to_string(),
         }
     })
+}
+
+/// Appends a `search.mode = outcome` entry to a searchset bundle reporting the
+/// search parameters the server ignored under lenient handling.
+///
+/// FHIR allows an unsupported parameter to be ignored only if the server says
+/// so; the self link already omits it, and this outcome names it explicitly.
+fn append_ignored_params_outcome(bundle_json: &mut serde_json::Value, ignored: &[String]) {
+    let outcome = crate::responses::OperationOutcomeBuilder::new()
+        .warning(
+            crate::responses::operation_outcome::IssueType::NotSupported,
+            format!(
+                "search parameter(s) not supported by this server and ignored: {}",
+                ignored.join(", ")
+            ),
+        )
+        .build();
+    let entry = serde_json::json!({
+        "search": { "mode": "outcome" },
+        "resource": outcome,
+    });
+    match bundle_json.get_mut("entry").and_then(|e| e.as_array_mut()) {
+        Some(entries) => entries.push(entry),
+        None => bundle_json["entry"] = serde_json::json!([entry]),
+    }
 }
 
 /// Executes a system-level search across all resource types.

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -406,6 +406,139 @@ mod basic_search {
         ok.assert_status_ok();
     }
 
+    /// Returns the bundle's `self` link URL.
+    fn self_link(body: &Value) -> String {
+        body["link"]
+            .as_array()
+            .and_then(|links| links.iter().find(|l| l["relation"] == "self"))
+            .and_then(|l| l["url"].as_str())
+            .expect("searchset must carry a self link")
+            .to_string()
+    }
+
+    /// Returns the `search.mode = outcome` entries of a searchset bundle.
+    fn outcome_entries(body: &Value) -> Vec<&Value> {
+        get_bundle_entries(body)
+            .into_iter()
+            .filter(|e| e["search"]["mode"] == "outcome")
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_unknown_underscore_param_rejected_under_strict() {
+        // Regression for #524: `_`-prefixed names used to bypass the unknown
+        // parameter check entirely, so strict handling could never reject one.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        for param in ["_typo=foo", "_whatever=foo", "_language=en"] {
+            let strict = server
+                .get(&format!("/Patient?{param}"))
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .add_header(
+                    HeaderName::from_static("prefer"),
+                    HeaderValue::from_static("handling=strict"),
+                )
+                .await;
+            assert_eq!(
+                strict.status_code(),
+                StatusCode::BAD_REQUEST,
+                "{param} must be rejected under Prefer: handling=strict"
+            );
+        }
+
+        // Global parameters the server does honour are still accepted.
+        for param in ["_id=patient-1", "_lastUpdated=gt2000-01-01", "_tag=foo"] {
+            let ok = server
+                .get(&format!("/Patient?{param}"))
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .add_header(
+                    HeaderName::from_static("prefer"),
+                    HeaderValue::from_static("handling=strict"),
+                )
+                .await;
+            ok.assert_status_ok();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ignored_param_dropped_from_self_link_and_reported() {
+        // Under lenient handling an unsupported parameter may be ignored only if
+        // the server says so: it must not appear in the self link (which states
+        // what was applied) and is reported as an OperationOutcome entry.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let all: Value = server
+            .get("/Patient")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await
+            .json();
+        let total = get_bundle_entries(&all).len();
+        assert!(total > 0, "fixture should seed patients");
+
+        for query in ["_typo=foo", "nonsense-param=foo"] {
+            let response = server
+                .get(&format!("/Patient?{query}"))
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .await;
+            response.assert_status_ok();
+            let body: Value = response.json();
+
+            let link = self_link(&body);
+            assert!(
+                !link.contains("typo") && !link.contains("nonsense-param"),
+                "self link must not echo the ignored parameter ({query}): {link}"
+            );
+
+            let outcomes = outcome_entries(&body);
+            assert_eq!(
+                outcomes.len(),
+                1,
+                "ignored parameter must be reported ({query})"
+            );
+            let issue = &outcomes[0]["resource"]["issue"][0];
+            assert_eq!(issue["severity"], "warning");
+            assert_eq!(issue["code"], "not-supported");
+            let text = issue["details"]["text"].as_str().unwrap_or_default();
+            assert!(
+                text.contains(query.split('=').next().unwrap()),
+                "outcome must name the ignored parameter: {text}"
+            );
+
+            // "Ignored" is literal: the filter is not applied, so the result set
+            // is the same as the unfiltered search (previously the parameter
+            // reached the backend and silently matched nothing).
+            let matches = get_bundle_entries(&body)
+                .into_iter()
+                .filter(|e| e["search"]["mode"] == "match")
+                .count();
+            assert_eq!(
+                matches, total,
+                "ignored parameter must not filter ({query})"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_known_params_survive_lenient_handling() {
+        // The self link still carries every parameter that was applied, and no
+        // outcome entry is added when nothing was ignored.
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let body: Value = server
+            .get("/Patient?name=Smith&_count=5")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await
+            .json();
+
+        let link = self_link(&body);
+        assert!(link.contains("name=Smith"), "self link: {link}");
+        assert!(link.contains("_count=5"), "self link: {link}");
+        assert!(outcome_entries(&body).is_empty());
+    }
+
     #[tokio::test]
     async fn test_date_prefix_uses_precision_boundaries() {
         let (server, backend) = create_test_server().await;


### PR DESCRIPTION
Fixes #524.

## The bug

`unknown_search_params` skipped any name starting with `_` before the registry check:

```rust
// Global/result parameters (`_id`, `_text`, `_type`, …) are always allowed.
if base.starts_with('_') {
    continue;
}
```

The premise — that every underscore name is a global parameter the server honours — doesn't hold. `_typo`, `_whatever`, `_language`, and any future spec parameter this server hasn't implemented all sailed through. So `Prefer: handling=strict` could never reject one, and the self link echoed it back: the server's own statement that it had been applied.

Backend-independent — it lives in the REST layer.

## The fix

`GLOBAL_SEARCH_PARAMS` replaces the bypass with an explicit list of the global/result parameters this server actually honours (`_id`, `_lastUpdated`, `_tag`, `_profile`, `_security`, `_source`, `_text`, `_content`, `_filter`, `_list`, `_has`, `_type`, plus the result-shaping controls). Anything else is unknown, exactly like a misspelled ordinary parameter.

`_query` is deliberately absent: named queries are unimplemented and the handler rejects them outright with a 400 under either handling mode.

## Behaviour

| | before | after |
|---|---|---|
| `?_typo=x` + `handling=strict` | 200, unfiltered | **400** |
| `?_typo=x` lenient, self link | `…?_typo=x` | `…/Patient` |
| `?_typo=x` lenient, reporting | none | `entry.search.mode = outcome` OperationOutcome (`warning` / `not-supported`) |
| `?nonsense=x` lenient, result set | 0 rows (filter hit the index) | full result set |

Under lenient handling the parameter is now ignored in the literal sense FHIR requires: dropped from the executed query, kept out of the self link, and named in an OperationOutcome entry.

Dropping it from the query also settles a backend disagreement worth calling out — an unknown `_`-name previously produced an **unfiltered** result on SQLite (its query builder returns `None` for any underscore name it doesn't special-case) and **zero results** on PostgreSQL / MongoDB / Elasticsearch (which emit a `param_name = '_typo'` filter against the search index). Neither was reported. Now all four ignore it identically and say so.

`nl_search`, which reuses `unknown_search_params` to validate model-generated queries, inherits the tightening.

## Out of scope

The allow-list includes `_tag`/`_profile`/`_security`/`_source` because the server does mean to honour them; that SQLite silently drops them is #474/#482, and that `_source` is never indexed is #523. Both stay open.

## Tests

- `test_unknown_search_params_flags_unhonoured_underscore_names` (unit) — `_typo`, `_typo:exact`, `_whatever` flagged; every `GLOBAL_SEARCH_PARAMS` entry and `_has:…` still allowed.
- `test_unknown_underscore_param_rejected_under_strict` — `_typo` / `_whatever` / `_language` → 400 under strict; `_id` / `_lastUpdated` / `_tag` still 200.
- `test_ignored_param_dropped_from_self_link_and_reported` — self link omits the parameter, the outcome entry names it, and the match count equals the unfiltered search.
- `test_known_params_survive_lenient_handling` — applied parameters stay in the self link, no outcome entry when nothing was ignored.

`cargo test -p helios-rest` (all suites), `-p helios-hfs`, `-p helios-ui` green; `cargo fmt --check` clean; no new clippy warnings.

https://claude.ai/code/session_01LU3dbkR8UHcoKCzYFUFKxg