### PR TITLE
feat(ui): Bulk Import follow-ups — popup dialogs, spec alignment, kick-off coverage

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -928,6 +928,41 @@ button.pill {
   margin-top: 4px;
 }
 
+/* Centered-popup variant of the addbox (the Bulk Import dialogs, #527): the
+   same no-JS <details> mechanics, presented as a modal. While open, the
+   summary itself stretches over the viewport as the backdrop, so clicking
+   outside the panel closes the dialog without any script. */
+.addbox--modal[open] > summary {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgb(10 14 20 / 45%);
+  border-radius: 0;
+  cursor: default;
+  /* The summary's label is a text node, which `> *` cannot hide. */
+  color: transparent;
+}
+
+.addbox--modal[open] > summary > * {
+  visibility: hidden;
+}
+
+.addbox--modal[open] > .addbox__panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  right: auto;
+  z-index: 50;
+  width: min(460px, calc(100vw - 40px));
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+  transform: translate(-50%, -50%);
+}
+
+.field__hint--error {
+  color: rgb(220 38 38);
+}
+
 .form-error {
   margin-bottom: 12px;
   padding: 10px 14px;

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -474,18 +474,18 @@ fn kickoff_parameters(id: &str, status: &str, manifest: Option<&Manifest>) -> Va
             "system": "http://hl7.org/fhir/event-status", "code": status } }),
     ];
     if let Some(m) = manifest {
-        parameter.push(json!({ "name": "manifestUrl", "valueUrl": m.manifest_url }));
+        // valueString, not valueUrl: HFS's consumer accepts either spelling,
+        // but the SMART reference recipient reads valueString only.
+        parameter.push(json!({ "name": "manifestUrl", "valueString": m.manifest_url }));
         // fhirBaseUrl is required alongside manifestUrl; an empty field falls
-        // back to the manifest's own base, per the design's hint text.
+        // back to the manifest URL's origin, matching the reference provider
+        // (`new URL(manifestUrl).origin`).
         let base = if m.fhir_base_url.is_empty() {
-            m.manifest_url
-                .rsplit_once('/')
-                .map(|(base, _)| base.to_string())
-                .unwrap_or_else(|| m.manifest_url.clone())
+            url_origin(&m.manifest_url)
         } else {
             m.fhir_base_url.clone()
         };
-        parameter.push(json!({ "name": "fhirBaseUrl", "valueUrl": base }));
+        parameter.push(json!({ "name": "fhirBaseUrl", "valueString": base }));
         if !m.output_format.is_empty() {
             parameter.push(json!({ "name": "outputFormat", "valueString": m.output_format }));
         }
@@ -499,6 +499,18 @@ fn kickoff_parameters(id: &str, status: &str, manifest: Option<&Manifest>) -> Va
         }
     }
     json!({ "resourceType": "Parameters", "parameter": parameter })
+}
+
+/// `scheme://authority` of a URL, dropping the path — the reference provider's
+/// fallback for an empty FHIR base.
+fn url_origin(url: &str) -> String {
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    match url[scheme_end + 3..].find('/') {
+        Some(path_start) => url[..scheme_end + 3 + path_start].to_string(),
+        None => url.to_string(),
+    }
 }
 
 /// Mints a SMART Backend Services access token (`client_credentials` +
@@ -531,7 +543,13 @@ async fn backend_services_token(client_id: &str, token_url: &str) -> Result<Stri
         "exp": Utc::now().timestamp() + 300,
         "jti": uuid::Uuid::new_v4().to_string(),
     });
-    let assertion = encode(&Header::new(algorithm), &claims, &key).map_err(|e| e.to_string())?;
+    let mut header = Header::new(algorithm);
+    // SMART Backend Services requires `kid` in the assertion header; it must
+    // match the key's id in the JWKS registered with the recipient.
+    if let Ok(kid) = std::env::var("HFS_BULK_SUBMIT_KID") {
+        header.kid = Some(kid);
+    }
+    let assertion = encode(&header, &claims, &key).map_err(|e| e.to_string())?;
 
     let response = reqwest::Client::new()
         .post(token_url)
@@ -542,7 +560,9 @@ async fn backend_services_token(client_id: &str, token_url: &str) -> Result<Stri
                 "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
             ),
             ("client_assertion", &assertion),
-            ("scope", "system/*.rs"),
+            // The scope the recipient's $bulk-submit endpoints require —
+            // HFS's own consumer and the SMART reference both gate on it.
+            ("scope", "system/bulk-submit"),
         ])
         .timeout(std::time::Duration::from_secs(10))
         .send()

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -474,9 +474,10 @@ fn kickoff_parameters(id: &str, status: &str, manifest: Option<&Manifest>) -> Va
             "system": "http://hl7.org/fhir/event-status", "code": status } }),
     ];
     if let Some(m) = manifest {
-        // valueString, not valueUrl: HFS's consumer accepts either spelling,
-        // but the SMART reference recipient reads valueString only.
-        parameter.push(json!({ "name": "manifestUrl", "valueString": m.manifest_url }));
+        // valueUrl per the Bulk Data IG (STU4 ballot: both parameters are
+        // type `url`). The SMART reference recipient reads valueString
+        // instead -- an off-spec leniency gap on its side, not ours.
+        parameter.push(json!({ "name": "manifestUrl", "valueUrl": m.manifest_url }));
         // fhirBaseUrl is required alongside manifestUrl; an empty field falls
         // back to the manifest URL's origin, matching the reference provider
         // (`new URL(manifestUrl).origin`).
@@ -485,7 +486,7 @@ fn kickoff_parameters(id: &str, status: &str, manifest: Option<&Manifest>) -> Va
         } else {
             m.fhir_base_url.clone()
         };
-        parameter.push(json!({ "name": "fhirBaseUrl", "valueString": base }));
+        parameter.push(json!({ "name": "fhirBaseUrl", "valueUrl": base }));
         if !m.output_format.is_empty() {
             parameter.push(json!({ "name": "outputFormat", "valueString": m.output_format }));
         }

--- a/crates/ui/templates/pages/bulk-import-detail.html
+++ b/crates/ui/templates/pages/bulk-import-detail.html
@@ -11,7 +11,7 @@
     <h1 class="page-title">{{ name }}</h1>
   </div>
 
-  <details class="addbox">
+  <details class="addbox addbox--modal">
     <summary class="button button--primary">
       {% include "icons/plus.svg" %}
       {{ i18n.t("bulk-import-add-manifest") }}

--- a/crates/ui/templates/pages/bulk-import-detail.html
+++ b/crates/ui/templates/pages/bulk-import-detail.html
@@ -56,32 +56,12 @@
 {% when None %}{% endmatch %}
 
 <section class="card detail">
-  <div class="detail__grid">
-    <div class="detail__field">
-      <span class="detail__label">{{ i18n.t("bulk-import-detail-recipient") }}</span>
-      <span class="detail__value">{{ recipient }}</span>
-    </div>
-    <div class="detail__field">
-      <span class="detail__label">{{ i18n.t("bulk-import-detail-id") }}</span>
-      <span class="detail__value">{{ id }}</span>
-    </div>
-    <div class="detail__field">
-      <span class="detail__label">{{ i18n.t("bulk-import-detail-submitter") }}</span>
-      <span class="detail__value">{{ submitter_display }}</span>
-    </div>
-    <div class="detail__field">
-      <span class="detail__label">{{ i18n.t("bulk-import-detail-created") }}</span>
-      <span class="detail__value">{{ created_at }}</span>
-    </div>
-    <div class="detail__field">
-      <span class="detail__label">{{ i18n.t("bulk-import-detail-status") }}</span>
-      <span class="detail__value">{{ status_label }}</span>
-    </div>
-    <div class="detail__field">
-      <span class="detail__label">{{ i18n.t("bulk-import-detail-auth") }}</span>
-      <span class="detail__value">{{ auth }}</span>
-    </div>
-  </div>
+  <div class="detail__field"><span>{{ i18n.t("bulk-import-detail-recipient") }}</span><code>{{ recipient }}</code></div>
+  <div class="detail__field"><span>{{ i18n.t("bulk-import-detail-id") }}</span><code>{{ id }}</code></div>
+  <div class="detail__field"><span>{{ i18n.t("bulk-import-detail-submitter") }}</span><code>{{ submitter_display }}</code></div>
+  <div class="detail__field"><span>{{ i18n.t("bulk-import-detail-created") }}</span><div>{{ created_at }}</div></div>
+  <div class="detail__field"><span>{{ i18n.t("bulk-import-detail-status") }}</span><div>{{ status_label }}</div></div>
+  <div class="detail__field"><span>{{ i18n.t("bulk-import-detail-auth") }}</span><div>{{ auth }}</div></div>
 
   <div class="detail__actions">
     <form method="post" action="/ui/bulk-import/{{ id }}/abort">
@@ -143,13 +123,10 @@
     <h2 class="toolbar__title">{{ i18n.t("bulk-import-log") }}</h2>
   </div>
   {% if log.is_empty() %}
-  <p class="detail__value">{{ i18n.t("bulk-import-log-empty") }}</p>
+  <p>{{ i18n.t("bulk-import-log-empty") }}</p>
   {% else %}
-  <ul class="log">
-    {% for line in log %}
-    <li class="log__line"><code>{{ line.at }}</code> {{ line.message }}</li>
-    {% endfor %}
-  </ul>
+  <pre class="detail__code">{% for line in log %}{{ line.at }}  {{ line.message }}
+{% endfor %}</pre>
   {% endif %}
 </section>
 {% endblock %}

--- a/crates/ui/templates/pages/bulk-import.html
+++ b/crates/ui/templates/pages/bulk-import.html
@@ -9,7 +9,7 @@
   <h1 class="page-title">{{ i18n.t("bulk-import-title") }}</h1>
 
   {% if available %}
-  <details class="addbox">
+  <details class="addbox addbox--modal">
     <summary class="button button--primary">
       {% include "icons/plus.svg" %}
       {{ i18n.t("bulk-import-new") }}

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -288,19 +288,482 @@ async fn a_rejected_kickoff_is_logged_as_a_failure() {
     assert!(html.contains("Not Started"), "status unchanged on failure");
 }
 
+fn urlencode(s: &str) -> String {
+    s.replace(':', "%3A").replace('/', "%2F")
+}
+
 #[tokio::test]
-async fn test_auth_without_a_server_key_reports_the_gap() {
+async fn a_single_manifest_can_be_submitted_from_its_row() {
     let settings = settings_store();
+    let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        &format!(
+            "name=Solo&recipient_base_url={}&auth=none",
+            urlencode(&recipient_url)
+        ),
+    )
+    .await;
+    for url in [
+        "http%3A%2F%2Fone.example%2Fm.json",
+        "http%3A%2F%2Ftwo.example%2Fm.json",
+    ] {
+        post_form(
+            &settings,
+            &format!("{detail_path}/manifests"),
+            &format!("manifest_url={url}"),
+        )
+        .await;
+    }
+    let (_, html) = get(&settings, &detail_path).await;
+    let marker = format!("{detail_path}/manifests/");
+    let mid = html
+        .split(&marker)
+        .nth(1)
+        .and_then(|rest| rest.split('/').next())
+        .expect("manifest id")
+        .to_string();
+
+    let (status, _, _) = post_form(
+        &settings,
+        &format!("{detail_path}/manifests/{mid}/submit"),
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+
+    // Only the one manifest went out.
+    assert_eq!(received.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn abort_and_complete_send_status_only_kickoffs() {
+    let settings = settings_store();
+    let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        &format!(
+            "name=Lifecycle&recipient_base_url={}&auth=none",
+            urlencode(&recipient_url)
+        ),
+    )
+    .await;
+
+    post_form(&settings, &format!("{detail_path}/abort"), "").await;
+    let (_, html) = get(&settings, &detail_path).await;
+    assert!(html.contains("Stopped"));
+    assert!(html.contains("Recipient acknowledged (200)"));
+
+    post_form(&settings, &format!("{detail_path}/complete"), "").await;
+    let (_, html) = get(&settings, &detail_path).await;
+    assert!(html.contains("Completed"));
+
+    // Status-only kick-offs carry no manifestUrl.
+    let bodies = received.lock().unwrap().clone();
+    assert_eq!(bodies.len(), 2);
+    let statuses: Vec<&str> = bodies
+        .iter()
+        .map(|b| {
+            b["parameter"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|p| p["name"] == "submissionStatus")
+                .and_then(|p| p["valueCoding"]["code"].as_str())
+                .unwrap()
+        })
+        .collect();
+    assert_eq!(statuses, vec!["stopped", "completed"]);
+    assert!(bodies.iter().all(|b| {
+        b["parameter"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|p| p["name"] != "manifestUrl")
+    }));
+}
+
+#[tokio::test]
+async fn a_rejected_status_change_keeps_the_status_and_logs_it() {
+    let settings = settings_store();
+    let (recipient_url, _) = mock_recipient(StatusCode::CONFLICT).await;
+
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        &format!(
+            "name=Reject&recipient_base_url={}&auth=none",
+            urlencode(&recipient_url)
+        ),
+    )
+    .await;
+    post_form(&settings, &format!("{detail_path}/abort"), "").await;
+
+    let (_, html) = get(&settings, &detail_path).await;
+    assert!(html.contains("Recipient rejected the status change: 409"));
+    assert!(html.contains("Not Started"));
+}
+
+#[tokio::test]
+async fn an_unreachable_recipient_fails_the_status_change() {
+    let settings = settings_store();
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        "name=Gone&recipient_base_url=http%3A%2F%2F127.0.0.1%3A9%2F&auth=none",
+    )
+    .await;
+    post_form(&settings, &format!("{detail_path}/abort"), "").await;
+
+    let (_, html) = get(&settings, &detail_path).await;
+    assert!(html.contains("Status change failed:"));
+    assert!(html.contains("Not Started"));
+}
+
+#[tokio::test]
+async fn manifest_options_ride_the_kickoff() {
+    let settings = settings_store();
+    let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        &format!(
+            "name=Options&recipient_base_url={}&auth=none",
+            urlencode(&recipient_url)
+        ),
+    )
+    .await;
+    post_form(
+        &settings,
+        &format!("{detail_path}/manifests"),
+        "manifest_url=http%3A%2F%2Fone.example%2Fm.json\
+         &fhir_base_url=http%3A%2F%2Fbase.example%2Ffhir\
+         &output_format=application%2Ffhir%2Bndjson\
+         &file_request_headers=Authorization%3A%20Bearer%20abc%0AX-Trace%3A%201",
+    )
+    .await;
+    post_form(&settings, &format!("{detail_path}/submit-all"), "").await;
+
+    let bodies = received.lock().unwrap().clone();
+    assert_eq!(bodies.len(), 1);
+    let params = bodies[0]["parameter"].as_array().unwrap().clone();
+    let value_of = |name: &str| {
+        params
+            .iter()
+            .find(|p| p["name"] == name)
+            .cloned()
+            .unwrap_or_default()
+    };
+    // The explicit FHIR base wins over the manifest-derived fallback.
+    assert_eq!(
+        value_of("fhirBaseUrl")["valueUrl"],
+        "http://base.example/fhir"
+    );
+    assert_eq!(
+        value_of("outputFormat")["valueString"],
+        "application/fhir+ndjson"
+    );
+    let headers: Vec<(String, String)> = params
+        .iter()
+        .filter(|p| p["name"] == "fileRequestHeader")
+        .map(|p| {
+            let part = p["part"].as_array().unwrap();
+            (
+                part[0]["valueString"].as_str().unwrap().to_string(),
+                part[1]["valueString"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        headers,
+        vec![
+            ("Authorization".to_string(), "Bearer abc".to_string()),
+            ("X-Trace".to_string(), "1".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn the_page_degrades_without_a_settings_store() {
+    let app = helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        None,
+        helios_ui::NlSearch::default(),
+        None,
+        None,
+        "default".to_string(),
+        Arc::new(helios_ui::StaticConformanceSource::empty()),
+        FhirVersion::R4,
+        None,
+    );
+    let res = app
+        .clone()
+        .oneshot(Request::get("/ui/bulk-import").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let html = body_text(res).await;
+    assert!(html.contains("settings store"));
+
+    // Creating fails loudly rather than dropping the submission.
+    let res = app
+        .oneshot(
+            Request::post("/ui/bulk-import")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("name=X&recipient_base_url=http%3A%2F%2Fx"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_GATEWAY);
+}
+
+/// A P-384 key generated for this test alone; it protects nothing.
+const TEST_EC_KEY: &str = "-----BEGIN PRIVATE KEY-----
+MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDBUhaaxv3+geGibr3l1
+4zsp7xiv25gKhynl2UEOwaEy/IubzysZPBLq/D/UFqR2Mn+hZANiAAR578fV49hI
+eGeRazDFYoj+Q7VBe0Eu60f9CorENX8+mpJzUDFB4p48cH1tgS1KvQgjqMbnR/RA
+P53KqB3RqJVeovdzKPFaCZjbwHj1fZMcKr08BqYQo6GgRAHpjMFY8o8=
+-----END PRIVATE KEY-----";
+
+/// A stub authorization server: `/token` answers with the given body.
+async fn mock_token_endpoint(status: StatusCode, body: &'static str) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new().route(
+        "/token",
+        axum::routing::post(move || async move {
+            (status, [("content-type", "application/json")], body)
+        }),
+    );
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    format!("http://{addr}/token")
+}
+
+/// One sequential test for everything that reads the process-wide signing-key
+/// environment variable — phases must not run concurrently with each other,
+/// and nothing else in this binary reads the variable.
+#[tokio::test]
+async fn backend_services_auth_mints_and_attaches_tokens() {
+    let settings = settings_store();
+    let token_url = mock_token_endpoint(StatusCode::OK, r#"{"access_token":"tok-123"}"#).await;
+
+    // Phase 1 — no key configured: the gap is reported, not swallowed.
+    unsafe { std::env::remove_var("HFS_BULK_SUBMIT_PRIVATE_KEY") };
     let (status, _, html) = post_form(
         &settings,
         "/ui/bulk-import/test-auth",
-        "client_id=alice&token_url=http%3A%2F%2Flocalhost%3A9%2Ftoken",
+        &format!("client_id=alice&token_url={}", urlencode(&token_url)),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
     assert!(html.contains("HFS_BULK_SUBMIT_PRIVATE_KEY"));
+
+    unsafe { std::env::set_var("HFS_BULK_SUBMIT_PRIVATE_KEY", TEST_EC_KEY) };
+
+    // Phase 2 — missing client id fails before any signing.
+    let (_, _, html) = post_form(
+        &settings,
+        "/ui/bulk-import/test-auth",
+        &format!("client_id=&token_url={}", urlencode(&token_url)),
+    )
+    .await;
+    assert!(html.contains("missing client_id"));
+
+    // Phase 3 — a working endpoint: the mint succeeds.
+    let (_, _, html) = post_form(
+        &settings,
+        "/ui/bulk-import/test-auth",
+        &format!("client_id=alice&token_url={}", urlencode(&token_url)),
+    )
+    .await;
+    assert!(html.contains("✓"), "success fragment: {html}");
+
+    // Phase 4 — the endpoint rejects: status is surfaced.
+    let denied =
+        mock_token_endpoint(StatusCode::BAD_REQUEST, r#"{"error":"invalid_client"}"#).await;
+    let (_, _, html) = post_form(
+        &settings,
+        "/ui/bulk-import/test-auth",
+        &format!("client_id=alice&token_url={}", urlencode(&denied)),
+    )
+    .await;
+    assert!(html.contains("token endpoint answered 400"));
+
+    // Phase 5 — a token response without access_token is an error.
+    let empty = mock_token_endpoint(StatusCode::OK, r#"{"scope":"none"}"#).await;
+    let (_, _, html) = post_form(
+        &settings,
+        "/ui/bulk-import/test-auth",
+        &format!("client_id=alice&token_url={}", urlencode(&empty)),
+    )
+    .await;
+    assert!(html.contains("no access_token"));
+
+    // Phase 6 — a backend-services submission attaches the Bearer token to
+    // the kick-off it POSTs at the recipient.
+    let (recipient_url, seen_auth) = mock_recipient_capturing_auth().await;
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        &format!(
+            "name=Authy&recipient_base_url={}&auth=backend-services&client_id=alice&token_url={}",
+            urlencode(&recipient_url),
+            urlencode(&token_url)
+        ),
+    )
+    .await;
+    post_form(
+        &settings,
+        &format!("{detail_path}/manifests"),
+        "manifest_url=http%3A%2F%2Fone.example%2Fm.json",
+    )
+    .await;
+    post_form(&settings, &format!("{detail_path}/submit-all"), "").await;
+
+    assert_eq!(
+        seen_auth.lock().unwrap().as_deref(),
+        Some("Bearer tok-123"),
+        "the kick-off carried the minted token"
+    );
+    let (_, html) = get(&settings, &detail_path).await;
+    assert!(html.contains("accepted by the recipient (200)"));
+
+    // Phase 7 — the RS384 signing path works with an RSA key.
+    unsafe { std::env::set_var("HFS_BULK_SUBMIT_PRIVATE_KEY", TEST_RSA_KEY) };
+    unsafe { std::env::set_var("HFS_BULK_SUBMIT_SIGNING_ALG", "RS384") };
+    let (_, _, html) = post_form(
+        &settings,
+        "/ui/bulk-import/test-auth",
+        &format!("client_id=alice&token_url={}", urlencode(&token_url)),
+    )
+    .await;
+    assert!(html.contains("✓"), "RS384 mint: {html}");
+    unsafe { std::env::remove_var("HFS_BULK_SUBMIT_SIGNING_ALG") };
+
+    unsafe { std::env::remove_var("HFS_BULK_SUBMIT_PRIVATE_KEY") };
 }
 
-fn urlencode(s: &str) -> String {
-    s.replace(':', "%3A").replace('/', "%2F")
+/// An RSA-2048 key generated for this test alone; it protects nothing.
+const TEST_RSA_KEY: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDH1Fo0WDU06NHP
+2JGiQSqMn40gjDALiqnTgxBFi/9i+Th4cTKXCYMmcpzQKCyWIhgtNF8no672XQsD
+O3zixg7YdGNJPdaO90lJmY8k7jm/jfGqzgnEYunmD1W1RY0OqkUo+Ni/4FVo/6uJ
+lZFrP7lTE5ZsY90CZc1/isVbYWgwZnhcOCNQfm5EkeMgNPShizoJJpEgGadnVlP1
+9sWEckO1lEY5Ed5fl6Rhb1EO+c7cCSug4WRATWSEP5pUhoulN6JUyxy7BAe9YZ5d
+Lx7Du6SBDmG8K8lOzqvAA1vVqcA85JYBZeMd+sTYCmTsW//bnBAymZRKMcbosyjk
+UdDZxR7VAgMBAAECggEAAPBerSqLwBHk5eSflh9zJ/1niYZTszqABi2/p6p/Xqpl
+yxg79garxc0wTYAHQsC9RNt7yKQTj0aSRNWFMtzGHOK78rdXfYBnPpXczZePnw1u
+j/Dv8LZpCtNwDksptJfWC6IcYD1IPl4ye5HZHe1CJuooCIJ3nYCOV3zhM31pszjo
+b4r+cm6SDxFnuAYtH6ngvvsN+pGht/DyN6u1KY5d06JNQ0aDCuGsRayZ55jHJubU
+1VRvqeBmcn4xkiWkvcfQuE72rbojoTCtupOaVmLjiOxd7F1IvNKKbbJIBbMlc7VX
+dnzMTLF2MCCYYtRzZUIlbZ7qSVSSOh89SUA8aNg0iQKBgQD7PFUU910UfQ77wIEr
+gOl062yskJMT97hfBl6HGTGfpmnHqS8L7ZZmTybNGznS4rZuiPC/uUEGMr01tnRD
+GlVBpugfe/8AO6J2nUY9e1IBplvhwB7uuy8MpwmkL1CzbDcat+s5f7GDvlLK6u18
+XKKtnK8GVaHzXXjSjyaFrE6iHwKBgQDLnnWw7SqW4+0BaenhWC51iHd2GeIQJQ0s
+cXFs5N6+i87UVaqSErAdFMRt08ocieO5t2v03YT2hiYSFxxgdpGDEG18e4/T/sQW
+T18fqo9iFaFmZ2Hzk3uRI2HG4FfYetwyv97nVEH0EibrKd/dSnZ8JbB87VR0LfhO
+c4srqPnoiwKBgF3Db5GKnE+IOO5WMx8UVozPTFi/AFVEb6fvTZooGfAWgIYGq0tN
+WYNHaRjFX3hIKoPoUcmMDyuMBjekp5Ffo5AEBb+yXEIu/3w7SDqr6rg46TPAqwq4
+C2AyexOuoPTFn282UvC7qnmbr3SR5x4xyHj48A1yKiYUrYIP8PWUkChLAoGAWHkV
+sjaa1s1aYc7fbKagKTmOjqZYb6NpwfHY0vPvROQCjohagPXVyA0J/J6VpyjS5hMo
+uVC3QVawnBOmpNNgDo7Iw9n8eKSuFvON5Xh6rKexZYluKiPfAQVaqss34DwiCXsN
+I36c2aw5dNzRBJoiOXc25FFK7OA8j/nscqANVlkCgYEAhgRQc/atd/GYETp2a8sn
+8nYahjwwC4lU753b9/akn3GQcE9T65yRoeqFi63v7AAwxwIUFZnxv4CuI/sgSYEL
+t+xX6yYqCQTVR3Y9XZgUWohxnpky0zdqat1BAJDzgRCWnZ75B++gDcLgbTYeqaVI
+CbOPbIKiVSNWN6XfYk/ZDEU=
+-----END PRIVATE KEY-----";
+
+/// A recipient that records the Authorization header of the kick-off.
+async fn mock_recipient_capturing_auth() -> (String, Arc<std::sync::Mutex<Option<String>>>) {
+    let seen: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let state = Arc::clone(&seen);
+    let recipient = Router::new()
+        .route(
+            "/$bulk-submit",
+            axum::routing::post(
+                move |axum::extract::State(seen): axum::extract::State<
+                    Arc<std::sync::Mutex<Option<String>>>,
+                >,
+                      headers: axum::http::HeaderMap| async move {
+                    *seen.lock().unwrap() = headers
+                        .get("authorization")
+                        .and_then(|v| v.to_str().ok())
+                        .map(String::from);
+                    axum::Json(serde_json::json!({"resourceType": "Parameters"}))
+                },
+            ),
+        )
+        .with_state(state);
+    tokio::spawn(async move { axum::serve(listener, recipient).await.unwrap() });
+    (format!("http://{addr}"), seen)
+}
+
+#[tokio::test]
+async fn unknown_ids_redirect_instead_of_crashing() {
+    let settings = settings_store();
+    let ghost = "/ui/bulk-import/00000000-0000-4000-8000-000000000000";
+
+    for uri in [
+        format!("{ghost}/manifests"),
+        format!("{ghost}/manifests/also-missing/delete"),
+        format!("{ghost}/manifests/also-missing/submit"),
+        format!("{ghost}/submit-all"),
+        format!("{ghost}/abort"),
+    ] {
+        let (status, _, _) = post_form(&settings, &uri, "manifest_url=http%3A%2F%2Fx").await;
+        assert_eq!(status, StatusCode::SEE_OTHER, "{uri}");
+    }
+}
+
+#[tokio::test]
+async fn a_missing_manifest_id_submits_nothing() {
+    let settings = settings_store();
+    let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        &format!(
+            "name=Ghost&recipient_base_url={}&auth=none",
+            urlencode(&recipient_url)
+        ),
+    )
+    .await;
+    post_form(
+        &settings,
+        &format!("{detail_path}/manifests/no-such-manifest/submit"),
+        "",
+    )
+    .await;
+    assert_eq!(received.lock().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn an_unreachable_recipient_fails_the_manifest_submit() {
+    let settings = settings_store();
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        "name=Down&recipient_base_url=http%3A%2F%2F127.0.0.1%3A9%2F&auth=none",
+    )
+    .await;
+    post_form(
+        &settings,
+        &format!("{detail_path}/manifests"),
+        "manifest_url=http%3A%2F%2Fone.example%2Fm.json",
+    )
+    .await;
+    post_form(&settings, &format!("{detail_path}/submit-all"), "").await;
+
+    let (_, html) = get(&settings, &detail_path).await;
+    assert!(html.contains("Bulk Submit request failed!"));
+    assert!(html.contains("Failed to submit manifest"));
 }

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -249,7 +249,7 @@ async fn submitting_a_manifest_posts_the_kickoff_and_logs_the_outcome() {
         .unwrap()
         .iter()
         .find(|p| p["name"] == "fhirBaseUrl")
-        .and_then(|p| p["valueString"].as_str())
+        .and_then(|p| p["valueUrl"].as_str())
         .unwrap();
     assert_eq!(
         fhir_base, "http://example.org",
@@ -464,7 +464,7 @@ async fn manifest_options_ride_the_kickoff() {
     };
     // The explicit FHIR base wins over the manifest-derived fallback.
     assert_eq!(
-        value_of("fhirBaseUrl")["valueString"],
+        value_of("fhirBaseUrl")["valueUrl"],
         "http://base.example/fhir"
     );
     assert_eq!(

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -249,9 +249,12 @@ async fn submitting_a_manifest_posts_the_kickoff_and_logs_the_outcome() {
         .unwrap()
         .iter()
         .find(|p| p["name"] == "fhirBaseUrl")
-        .and_then(|p| p["valueUrl"].as_str())
+        .and_then(|p| p["valueString"].as_str())
         .unwrap();
-    assert_eq!(fhir_base, "http://example.org/exports");
+    assert_eq!(
+        fhir_base, "http://example.org",
+        "origin, not parent directory"
+    );
 
     // The log recorded the attempt and the submission moved to In Progress.
     let (_, html) = get(&settings, &detail_path).await;
@@ -461,7 +464,7 @@ async fn manifest_options_ride_the_kickoff() {
     };
     // The explicit FHIR base wins over the manifest-derived fallback.
     assert_eq!(
-        value_of("fhirBaseUrl")["valueUrl"],
+        value_of("fhirBaseUrl")["valueString"],
         "http://base.example/fhir"
     );
     assert_eq!(


### PR DESCRIPTION
Follow-ups to #528, which merged with the first two commits while this work was still landing on the branch. Five commits, all reviewed-in-public on the #528 thread (screenshots, coverage numbers, and the spec discussion live there):

## What's in

- **Detail-card and log styling** (`01ee4664b`): the metadata card used invented class names no stylesheet defines; now it uses the search-parameters `detail__field` markup, and the Submission Log renders as a `detail__code` console block. Caught while taking the PR screenshots.
- **Centered popup dialogs** (`9d8af1b60`): Create Bulk Submission and Add Manifest present as centered popups with a backdrop, matching Brett's design — a CSS-only `addbox--modal` variant over the same no-JS `<details>` mechanics (the stretched summary is the backdrop; click-outside closes; nothing scripted). Also adds the missing red styling for the test-auth error state.
- **Kick-off client coverage** (`ae89bd90c`): codecov flagged 127 uncovered patch lines on #528. Now exercised against loopback stubs: single-manifest submit, abort/complete asserted at the recipient, rejected/unreachable paths, manifest options riding the kick-off, unknown-id guards, the degraded no-settings-store page, and the whole backend-services client (ES384 + RS384 mints, endpoint rejection, tokenless response, and a full submission asserting the minted Bearer reached the recipient). 4 defensive lines remain uncovered.
- **Spec/reference alignment** (`4490f9950` + `bd87b05ac`): validated against the SMART reference provider and the [current IG build](https://build.fhir.org/ig/HL7/bulk-data/en/submit.html). Real fix: the token grant now requests `system/bulk-submit` (was `system/*.rs`, the file-fetch scope). Also: empty `fhirBaseUrl` falls back to the manifest URL's origin, the assertion header carries `kid` from `HFS_BULK_SUBMIT_KID`, and `manifestUrl`/`fhirBaseUrl` ride as `valueUrl` per the spec (the STU4 ballot confirms our `event-status` vocabulary was already correct; the reference app tracks an older draft — deltas documented on #531).

## Tests

16 bulk-import router tests (was 7), full helios-ui suite green, clippy clean. Round 2 (status polling, /keys JWKS, manifest replace, editable submitter) tracked in #531.