### PR TITLE
fix(search): index _source instead of evaluating Resource.meta.source

### DIFF
--- a/crates/fhir/src/search/loader.rs
+++ b/crates/fhir/src/search/loader.rs
@@ -655,6 +655,25 @@ impl SearchParameterLoader {
             .with_source(SearchParameterSource::Embedded),
         );
 
+        // `_source` completes the meta-level set. Its absence here is what made
+        // #523 a `_source`-only defect: the other four were shadowed by these
+        // embedded definitions, whose expressions carry no `Resource.` prefix,
+        // so only `_source` kept the spec file's unevaluable
+        // `Resource.meta.source` and went unindexed. Without it, a registry
+        // built from the fallbacks alone also types `_source` by value-shape
+        // heuristic (String), which would look for the value in the wrong
+        // index column.
+        params.push(
+            SearchParameterDefinition::new(
+                "http://hl7.org/fhir/SearchParameter/Resource-source",
+                "_source",
+                SearchParamType::Uri,
+                "meta.source",
+            )
+            .with_base(vec!["Resource"])
+            .with_source(SearchParameterSource::Embedded),
+        );
+
         // SQL-on-FHIR canonical resources: `url` and `version` are not in the
         // base FHIR R4/R4B search-parameters bundle for ViewDefinition (which
         // first appears in R5+). The SoF `$viewdefinition-run`,
@@ -706,13 +725,33 @@ mod tests {
         let params = loader.load_embedded().unwrap();
 
         assert!(!params.is_empty());
-        assert!(params.len() <= 9, "Minimal fallback should have ~9 params");
+        assert!(
+            params.len() <= 10,
+            "Minimal fallback should have ~10 params"
+        );
 
-        let has_id = params.iter().any(|p| p.code == "_id");
-        assert!(has_id, "Should have _id parameter");
-
-        let has_last_updated = params.iter().any(|p| p.code == "_lastUpdated");
-        assert!(has_last_updated, "Should have _lastUpdated parameter");
+        // The whole `Resource`-level meta set, asserted by name. `_source` was
+        // the one omission, and because these definitions shadow the spec
+        // file's `Resource.`-prefixed expressions, its absence is what left
+        // `_source` unindexed (#523). Losing any of them again is the same bug.
+        for code in [
+            "_id",
+            "_lastUpdated",
+            "_tag",
+            "_profile",
+            "_security",
+            "_source",
+        ] {
+            let def = params
+                .iter()
+                .find(|p| p.code == code)
+                .unwrap_or_else(|| panic!("Should have {code} parameter"));
+            assert!(
+                !def.expression.starts_with("Resource."),
+                "{code} fallback expression must be resource-relative, got {:?}",
+                def.expression
+            );
+        }
 
         let has_patient_specific = params
             .iter()

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -545,7 +545,13 @@ impl QueryBuilder {
                 self.build_filter_condition(&param.values, param_offset)
             }
             _ => {
-                // Other special parameters - fall through to regular handling
+                // Not "fall through to regular handling", as this comment used
+                // to claim: the caller returns whatever this yields, so `None`
+                // *drops* the parameter and the search answers with every
+                // resource of the type. That is how `_tag`/`_profile`/
+                // `_security`/`_source` came to be unfiltered (#474). Anything
+                // that must actually filter belongs in an arm above, or in the
+                // caller's exclusion list so it never reaches here.
                 None
             }
         }

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -1301,8 +1301,8 @@ mod tests {
 
     fn create_test_backend() -> SqliteBackend {
         // Point at the workspace's data directory so the search-parameter
-        // registry loads the full FHIR spec (otherwise only the 5 minimal
-        // embedded params are available and chained-search tests fail to
+        // registry loads the full FHIR spec (otherwise only the handful of
+        // minimal embedded params are available and chained-search tests fail to
         // resolve param types like Observation.code → Token).
         let data_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("..")

--- a/crates/persistence/src/search/extractor.rs
+++ b/crates/persistence/src/search/extractor.rs
@@ -328,18 +328,29 @@ impl SearchParameterExtractor {
     ///
     /// This method extracts only the parts that start with the given resource type and
     /// simplifies common patterns that use `resolve()`.
+    ///
+    /// Parts prefixed with an abstract base type (`Resource.`, `DomainResource.`)
+    /// apply to every resource, so the prefix is stripped instead of being matched
+    /// literally — see [`strip_abstract_base_prefix`].
     fn filter_expression_for_resource(&self, expression: &str, resource_type: &str) -> String {
         // Split by | and filter to parts starting with our resource type
         let parts: Vec<String> = expression
             .split('|')
             .map(|p| p.trim())
-            .filter(|p| {
+            .filter_map(|p| {
+                // Abstract-base parts first: when `resource_type` is itself
+                // "Resource", the literal prefix match below would keep the
+                // unevaluable form.
+                if let Some(rest) = strip_abstract_base_prefix(p) {
+                    return Some(rest);
+                }
                 // Check if this part starts with our resource type
-                p.starts_with(resource_type)
+                let matches_type = p.starts_with(resource_type)
                     && (p.len() == resource_type.len()
-                        || p.chars().nth(resource_type.len()) == Some('.'))
+                        || p.chars().nth(resource_type.len()) == Some('.'));
+                matches_type.then(|| p.to_string())
             })
-            .map(|p| self.simplify_resolve_pattern(p))
+            .map(|p| self.simplify_resolve_pattern(&p))
             .collect();
 
         if parts.is_empty() {
@@ -396,6 +407,40 @@ impl SearchParameterExtractor {
         // Convert EvaluationResult back to JSON values
         evaluation_result_to_json_values(&result)
     }
+}
+
+/// Abstract base types every FHIR resource conforms to. A SearchParameter
+/// expression may be written against one of them instead of a concrete type.
+const ABSTRACT_BASE_TYPES: [&str; 2] = ["Resource", "DomainResource"];
+
+/// Strips a leading abstract base type from one union member of a FHIRPath
+/// expression, returning the resource-relative remainder.
+///
+/// The `Resource`-level SearchParameters carry expressions like
+/// `Resource.meta.source` (`_source`) and `Resource.id` (`_id`). Evaluated
+/// against a concrete resource these resolve to nothing — FHIRPath matches the
+/// leading identifier against the resource's own type, so `Patient.meta.source`
+/// and `meta.source` both work but `Resource.meta.source` yields an empty
+/// collection, and the parameter is never indexed (#523). Since these
+/// expressions apply to every resource, the prefix is dropped and the rest is
+/// evaluated relative to the resource.
+///
+/// Returns `None` for parts that are not abstract-base-prefixed, so concrete
+/// prefixes (`Patient.name`) keep their normal filtering behaviour.
+fn strip_abstract_base_prefix(part: &str) -> Option<String> {
+    for base in ABSTRACT_BASE_TYPES {
+        if let Some(rest) = part.strip_prefix(base) {
+            if let Some(path) = rest.strip_prefix('.') {
+                return Some(path.to_string());
+            }
+            // The bare type name selects the resource itself (composite base
+            // expressions use this form, e.g. `Observation`).
+            if rest.is_empty() {
+                return Some("$this".to_string());
+            }
+        }
+    }
+    None
 }
 
 /// Rewrites FHIRPath choice-type casts to concrete element names.
@@ -905,6 +950,129 @@ mod tests {
         assert_eq!(careplan_filtered, "CarePlan.subject");
         let obs_filtered = extractor.filter_expression_for_resource(patient_expr, "Observation");
         assert_eq!(obs_filtered, "Observation.subject");
+    }
+
+    #[test]
+    fn test_filter_expression_strips_abstract_base_prefix() {
+        let extractor = create_test_extractor();
+
+        // `Resource.`-prefixed expressions apply to every resource; the prefix
+        // has to go, or FHIRPath resolves nothing against a concrete resource.
+        assert_eq!(
+            extractor.filter_expression_for_resource("Resource.meta.source", "Patient"),
+            "meta.source"
+        );
+        assert_eq!(
+            extractor.filter_expression_for_resource("Resource.id", "Observation"),
+            "id"
+        );
+        assert_eq!(
+            extractor.filter_expression_for_resource("DomainResource.meta.tag", "Patient"),
+            "meta.tag"
+        );
+
+        // Also when the resource type is itself the abstract base.
+        assert_eq!(
+            extractor.filter_expression_for_resource("Resource.meta.source", "Resource"),
+            "meta.source"
+        );
+
+        // A bare abstract base selects the resource itself. No shipped parameter
+        // uses that form, but a composite base expression could; assert the
+        // substitution and that the evaluator actually resolves it.
+        assert_eq!(
+            extractor.filter_expression_for_resource("Resource", "Patient"),
+            "$this"
+        );
+        let patient = json!({"resourceType": "Patient", "id": "p1"});
+        let this = extractor.evaluate_fhirpath(&patient, "$this").unwrap();
+        assert_eq!(this.len(), 1);
+        assert_eq!(this[0]["id"], "p1");
+
+        // A concrete type that merely starts with the same letters is untouched.
+        assert_eq!(
+            extractor.filter_expression_for_resource("ResourceThing.name", "ResourceThing"),
+            "ResourceThing.name"
+        );
+
+        // Union members are handled independently.
+        assert_eq!(
+            extractor.filter_expression_for_resource(
+                "Patient.name | Resource.meta.source | Observation.code",
+                "Patient"
+            ),
+            "Patient.name | meta.source"
+        );
+    }
+
+    /// Every `Resource`-level meta parameter must produce a positive index row —
+    /// the failure in #523 was silent, because an unindexed parameter simply
+    /// matches nothing (or, on backends that drop it, everything).
+    #[test]
+    fn test_extract_meta_level_parameters() {
+        let extractor = create_test_extractor();
+
+        let patient = json!({
+            "resourceType": "Patient",
+            "id": "p1",
+            "meta": {
+                "source": "http://example.org/src",
+                "profile": ["http://example.org/StructureDefinition/my-patient"],
+                "lastUpdated": "2024-01-01T00:00:00Z",
+                "tag": [{"system": "http://example.org/tags", "code": "t1"}],
+                "security": [{"system": "http://example.org/labels", "code": "R"}]
+            }
+        });
+
+        let values = extractor.extract(&patient, "Patient").unwrap();
+        let find = |name: &str| -> Vec<&ExtractedValue> {
+            values.iter().filter(|v| v.param_name == name).collect()
+        };
+
+        let source = find("_source");
+        assert_eq!(source.len(), 1, "_source should be indexed exactly once");
+        match &source[0].value {
+            IndexValue::Uri(value) => assert_eq!(value, "http://example.org/src"),
+            other => panic!("_source should index as a URI, got {:?}", other),
+        }
+
+        match &find("_profile")[..] {
+            [v] => match &v.value {
+                IndexValue::Uri(value) => {
+                    assert_eq!(value, "http://example.org/StructureDefinition/my-patient")
+                }
+                other => panic!("_profile should index as a URI, got {:?}", other),
+            },
+            other => panic!("_profile should be indexed exactly once, got {:?}", other),
+        }
+
+        match &find("_tag")[..] {
+            [v] => match &v.value {
+                IndexValue::Token { system, code, .. } => {
+                    assert_eq!(system.as_deref(), Some("http://example.org/tags"));
+                    assert_eq!(code, "t1");
+                }
+                other => panic!("_tag should index as a token, got {:?}", other),
+            },
+            other => panic!("_tag should be indexed exactly once, got {:?}", other),
+        }
+
+        match &find("_security")[..] {
+            [v] => match &v.value {
+                IndexValue::Token { system, code, .. } => {
+                    assert_eq!(system.as_deref(), Some("http://example.org/labels"));
+                    assert_eq!(code, "R");
+                }
+                other => panic!("_security should index as a token, got {:?}", other),
+            },
+            other => panic!("_security should be indexed exactly once, got {:?}", other),
+        }
+
+        assert!(
+            !find("_lastUpdated").is_empty(),
+            "_lastUpdated should be indexed"
+        );
+        assert!(!find("_id").is_empty(), "_id should be indexed");
     }
 
     #[test]

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -41,6 +41,21 @@ mod tenant_id_fidelity_suite;
 #[path = "search/fts_purge_suite.rs"]
 mod fts_purge_suite;
 
+/// The backend-agnostic `Resource`-level meta-parameter scenarios (#523),
+/// shared verbatim with the SQLite suite that owns the file.
+///
+/// `_source` matched nothing on every index-backed backend until the extractor
+/// stopped evaluating the spec's `Resource.meta.source` verbatim. Running one
+/// scenario on both engines is what keeps that honest — the SQLite-only
+/// `meta_params_tests.rs` from #474 cannot see an extraction bug, because a
+/// dropped filter and a correct filter over a missing index row look identical
+/// from there.
+///
+/// Declared at the top level for the same `#[path]` resolution reason as
+/// `if_match_suite` above.
+#[path = "search/meta_params_suite.rs"]
+mod meta_params_suite;
+
 // ============================================================================
 // Backend Configuration Tests (no PostgreSQL instance required)
 // ============================================================================
@@ -2055,6 +2070,15 @@ mod postgres_integration {
             "Search by name should find the patient"
         );
         assert_eq!(result.resources.items[0].id(), "p1");
+    }
+
+    /// The backend-agnostic meta-parameter scenario (#523), shared verbatim
+    /// with the SQLite suite that owns the file.
+    #[tokio::test]
+    async fn postgres_integration_search_by_meta_parameters() {
+        let backend = create_backend().await;
+        let tenant = create_tenant("meta-params");
+        crate::meta_params_suite::meta_parameters_match_only_their_carrier(&backend, &tenant).await;
     }
 
     #[tokio::test]

--- a/crates/persistence/tests/search/meta_params_suite.rs
+++ b/crates/persistence/tests/search/meta_params_suite.rs
@@ -1,0 +1,190 @@
+//! Backend-agnostic `Resource`-level meta-parameter search suite (#523).
+//!
+//! `_source`, `_tag`, `_profile` and `_security` are ordinary indexed
+//! parameters over `meta.*`, and every backend is supposed to filter on them.
+//! Two defects with opposite symptoms have hit this set:
+//!
+//!  * **Never indexed** (#523) — `_source` is the only `Resource`-level
+//!    parameter with no embedded definition, so it kept the spec file's
+//!    `Resource.meta.source`. Evaluated against a concrete resource, FHIRPath
+//!    matches the leading identifier against the resource's own type and
+//!    returns nothing, so no index row was ever written and `_source` matched
+//!    **nothing** on every index-backed backend.
+//!  * **Dropped at query time** (#474, fixed separately) — SQLite routed all
+//!    four to the special-parameter path, which returned `None` for them. A
+//!    `None` condition is dropped rather than rejected, so the filter silently
+//!    vanished and the search returned **everything**.
+//!
+//! Both directions therefore have to be asserted, and on more than one engine.
+//! A positive-only test passes against a backend that ignores the filter; a
+//! negative-only test passes against one that never indexed it; and a
+//! single-backend test cannot tell a dropped filter from a correct filter over
+//! a missing row. Each parameter is checked both ways, on SQLite and
+//! PostgreSQL.
+//!
+//! Like `fts_purge_suite.rs`, this file is `#[path]`-included by each backend's
+//! test binary rather than living in `tests/common/`, which no test target
+//! declares and cargo therefore never compiles (issue #306).
+//!
+//! ## Shared-database backends
+//!
+//! The PostgreSQL binary runs against one long-lived container database, so
+//! callers must pass a **distinct tenant per scenario**. The scenario seeds
+//! fixed logical ids within that tenant.
+
+#![allow(dead_code)]
+
+use serde_json::json;
+
+use helios_fhir::FhirVersion;
+use helios_persistence::core::{ResourceStorage, SearchProvider};
+use helios_persistence::tenant::TenantContext;
+use helios_persistence::types::{SearchParamType, SearchParameter, SearchQuery, SearchValue};
+
+/// The resource carrying every meta value.
+const CARRIER_ID: &str = "meta-carrier";
+/// The resource carrying none of them, which every query must exclude.
+const BYSTANDER_ID: &str = "meta-bystander";
+
+const SOURCE: &str = "http://example.org/meta-suite/src";
+const PROFILE: &str = "http://example.org/meta-suite/StructureDefinition/tagged";
+const TAG_SYSTEM: &str = "http://example.org/meta-suite/tags";
+const SECURITY_SYSTEM: &str = "http://example.org/meta-suite/labels";
+
+/// One parameter's matching and non-matching query values.
+struct Case {
+    name: &'static str,
+    param_type: SearchParamType,
+    hit: String,
+    miss: String,
+}
+
+fn cases() -> Vec<Case> {
+    vec![
+        Case {
+            name: "_source",
+            param_type: SearchParamType::Uri,
+            hit: SOURCE.to_string(),
+            miss: "http://example.org/meta-suite/other-src".to_string(),
+        },
+        Case {
+            name: "_profile",
+            param_type: SearchParamType::Uri,
+            hit: PROFILE.to_string(),
+            miss: "http://example.org/meta-suite/StructureDefinition/other".to_string(),
+        },
+        Case {
+            name: "_tag",
+            param_type: SearchParamType::Token,
+            hit: format!("{TAG_SYSTEM}|carried"),
+            miss: format!("{TAG_SYSTEM}|absent"),
+        },
+        Case {
+            name: "_security",
+            param_type: SearchParamType::Token,
+            hit: format!("{SECURITY_SYSTEM}|R"),
+            miss: format!("{SECURITY_SYSTEM}|V"),
+        },
+    ]
+}
+
+/// Seeds the carrier and the bystander.
+async fn seed<B>(backend: &B, tenant: &TenantContext)
+where
+    B: ResourceStorage,
+{
+    backend
+        .create(
+            tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "id": CARRIER_ID,
+                "meta": {
+                    "source": SOURCE,
+                    "profile": [PROFILE],
+                    "tag": [{"system": TAG_SYSTEM, "code": "carried"}],
+                    "security": [{"system": SECURITY_SYSTEM, "code": "R"}]
+                },
+                "name": [{"family": "Carrier"}]
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .expect("seed carrier");
+
+    backend
+        .create(
+            tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "id": BYSTANDER_ID,
+                "name": [{"family": "Bystander"}]
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .expect("seed bystander");
+}
+
+fn query(name: &str, param_type: SearchParamType, value: &str) -> SearchQuery {
+    SearchQuery::new("Patient").with_parameter(SearchParameter {
+        name: name.to_string(),
+        param_type,
+        modifier: None,
+        values: vec![SearchValue::eq(value)],
+        chain: vec![],
+        components: vec![],
+    })
+}
+
+/// Each meta parameter matches the resource that carries the value, and only
+/// that resource.
+pub async fn meta_parameters_match_only_their_carrier<B>(backend: &B, tenant: &TenantContext)
+where
+    B: ResourceStorage + SearchProvider,
+{
+    seed(backend, tenant).await;
+
+    // Positive control: the seeded pair is reachable at all, so a later "0
+    // matches" means the filter excluded them rather than the seeding failing.
+    let all = backend
+        .search(tenant, &SearchQuery::new("Patient"))
+        .await
+        .expect("unfiltered search");
+    assert_eq!(
+        all.resources.items.len(),
+        2,
+        "both seeded Patients should be present before filtering"
+    );
+
+    for case in cases() {
+        let matched = backend
+            .search(tenant, &query(case.name, case.param_type, &case.hit))
+            .await
+            .unwrap_or_else(|e| panic!("{}={} search failed: {e}", case.name, case.hit));
+        let ids: Vec<&str> = matched.resources.items.iter().map(|r| r.id()).collect();
+        assert_eq!(
+            ids,
+            vec![CARRIER_ID],
+            "{}={} should match exactly the resource carrying it",
+            case.name,
+            case.hit
+        );
+
+        let unmatched = backend
+            .search(tenant, &query(case.name, case.param_type, &case.miss))
+            .await
+            .unwrap_or_else(|e| panic!("{}={} search failed: {e}", case.name, case.miss));
+        let ids: Vec<&str> = unmatched.resources.items.iter().map(|r| r.id()).collect();
+        assert!(
+            ids.is_empty(),
+            "{}={} matches nothing, but the search returned {:?} — \
+             a dropped filter reads as 'everything matched'",
+            case.name,
+            case.miss,
+            ids
+        );
+    }
+}

--- a/crates/persistence/tests/search/meta_params_suite_tests.rs
+++ b/crates/persistence/tests/search/meta_params_suite_tests.rs
@@ -1,0 +1,26 @@
+//! SQLite bindings for the backend-agnostic meta-parameter suite (#523).
+//!
+//! The scenario lives in `meta_params_suite.rs` and is shared verbatim with the
+//! PostgreSQL test binary; this file only supplies the SQLite backend and the
+//! `#[tokio::test]` wrapper.
+//!
+//! The sibling `meta_params_tests.rs` covers the same four parameters on the
+//! query side only, on SQLite only (#474). It cannot catch an extraction bug:
+//! from there, a filter that never runs and a filter that runs against a
+//! missing index row are indistinguishable.
+
+#![cfg(feature = "sqlite")]
+
+use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
+
+use super::meta_params_suite as suite;
+
+fn tenant(id: &str) -> TenantContext {
+    TenantContext::new(TenantId::new(id), TenantPermissions::full_access())
+}
+
+#[tokio::test]
+async fn meta_parameters_match_only_their_carrier() {
+    let backend = super::make_sqlite_backend();
+    suite::meta_parameters_match_only_their_carrier(&backend, &tenant("meta-params")).await;
+}

--- a/crates/persistence/tests/search/mod.rs
+++ b/crates/persistence/tests/search/mod.rs
@@ -45,6 +45,12 @@ pub mod date_tests;
 pub mod fts_purge_suite;
 pub mod fts_purge_tests;
 pub mod include_tests;
+/// Backend-agnostic scenarios, shared with the PostgreSQL test binary via
+/// `#[path]` (issue #523). Complements the SQLite-only `meta_params_tests`
+/// from #474: those cover the query side on one engine, this covers indexing
+/// and querying on both.
+pub mod meta_params_suite;
+pub mod meta_params_suite_tests;
 pub mod meta_params_tests;
 pub mod modifier_tests;
 pub mod number_tests;

--- a/crates/persistence/tests/search_param_seeding.rs
+++ b/crates/persistence/tests/search_param_seeding.rs
@@ -181,9 +181,12 @@ async fn seeding_with_missing_spec_bundle_seeds_only_fallbacks() {
         seed_spec_search_parameters(&backend, FhirVersion::R4, empty_dir.path(), "default")
             .await
             .expect("seed fallbacks");
-    // Only the handful of embedded fallbacks are seeded — no spec set.
+    // Only the handful of embedded fallbacks are seeded — no spec set. The
+    // upper bound tracks `get_minimal_fallback_parameters`: five meta-level
+    // params plus `_source` (added with #523), plus ViewDefinition/Library
+    // url+version.
     assert!(
-        outcome.created > 0 && outcome.created <= 9,
+        outcome.created > 0 && outcome.created <= 10,
         "expected only embedded fallbacks, got {outcome:?}"
     );
     assert_eq!(outcome.failed, 0);


### PR DESCRIPTION
Fixes #523 — the extraction half of the meta-parameter story. #474 fixed the query half on SQLite; this is why that fix's test file covers `_tag`/`_profile`/`_security` but not the `_source` named in its title, and why its commit message's "the extraction side was already correct" holds for three of the four parameters but not for `_source`.

## The defect

`_source` was never indexed on any backend, so `Patient?_source=…` matched **nothing** wherever the filter is genuinely applied — PostgreSQL, MongoDB, Elasticsearch, and SQLite since #474.

It is the only `Resource`-level parameter with no embedded definition, so it kept the spec bundle's `Resource.meta.source`. `filter_expression_for_resource` kept only the `|`-alternatives whose prefix matched the concrete resource type, and fell back to the *original* expression when none matched. FHIRPath resolves a leading identifier against the resource's own type, so `Patient.meta.source` and `meta.source` both resolve, but `Resource.meta.source` yields an empty collection — no index row was ever written. The four siblings survived only because embedded definitions shadow them with resource-relative expressions:

```
("_lastUpdated", "meta.lastUpdated",     Embedded)
("_id",          "id",                   Embedded)
("_profile",     "meta.profile",         Embedded)
("_security",    "meta.security",        Embedded)
("_tag",         "meta.tag",             Embedded)
("_source",      "Resource.meta.source", Embedded)   <-- from the spec file, unshadowed
```

## The fix

1. **`crates/persistence/src/search/extractor.rs`** — abstract base prefixes (`Resource.`, `DomainResource.`) are stripped rather than matched literally, so the remainder evaluates against the resource. This covers every present and future `Resource`-base parameter rather than special-casing `_source`; `_language` on R5/R6 is indexed by the same change. That's the reason for fixing it here rather than adding an embedded `_source` definition, which would paper over this one parameter.
2. **`crates/fhir/src/search/loader.rs`** — `_source` nonetheless joins the embedded fallback set, closing the asymmetry that made this a `_source`-only defect. It also stops a fallback-only registry (no spec bundle on disk) from typing `_source` as `String` by value-shape heuristic, which would then search the wrong index column.
3. **`crates/persistence/src/backends/sqlite/search/query_builder.rs`** — comment only. The `_ => None` arm that caused #474 claimed it "falls through to regular handling"; it does not, and the replacement says what `None` actually costs.

## Coverage

`tests/search/meta_params_suite.rs` is backend-agnostic and runs on **both** SQLite and PostgreSQL (the `#[path]` sharing pattern from `fts_purge_suite.rs`), asserting each of the four parameters **positively and negatively**, with a positive control that both fixtures are reachable before filtering.

Every one of those properties is load-bearing, and their absence is why this survived alongside #474:

- a positive-only test passes against a backend that ignores the filter;
- a negative-only test passes against one that never indexed it;
- and a single-backend test cannot distinguish a dropped filter from a correct filter over a missing index row — which is exactly the pair of bugs in play.

The existing SQLite-only `meta_params_tests.rs` from #474 is left untouched; the two are complementary and the new file's docs say so.

Confirmed to actually catch the defect: with the fix reverted, the suite fails on `_source` with 0 matches on PostgreSQL, while the other three still pass.

## Verification (rebased onto current `main`)

- `helios-persistence` lib tests (sqlite+postgres): 840 passed
- PostgreSQL binary against a real container: 155 passed
- SQLite `search_suite` (103) / `sqlite_tests` (85) / `crud_suite` (82) / `search_param_seeding` (6): all green
- `helios-fhir` search tests: 25 passed
- `cargo fmt --check` clean; clippy clean under the CI flag set with `-D warnings`

One pre-existing assertion needed updating: `search_param_seeding.rs` bounded the embedded fallback count at 9, which the new `_source` fallback exceeds. The loader's own fallback test now asserts the whole meta set by name and that none of them carries a `Resource.` prefix, so dropping one again fails loudly.

## Not included

`_source` still isn't advertised in the CapabilityStatement's common parameter list, and no backend declares `SpecialSearchParam::Source`. Nothing reads that flag outside tests today, so it's cosmetic — but now that the parameter genuinely works everywhere, advertising it would be truthful. Happy to add it here or as a follow-up.

https://claude.ai/code/session_01BT25XtZGQnsvdqVrfNZ8sk
