### PR TITLE
feat(ui,rest): manifest replace, per-manifest abort, and legacy status leniency

### DIFF
--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -40,6 +40,11 @@ const PAGE_PARAM: &str = "page";
 
 /// The code system for the `submissionStatus` Coding (per the IG).
 const SUBMISSION_STATUS_SYSTEM: &str = "http://hl7.org/fhir/event-status";
+/// The pre-STU4 draft's status system, still sent by providers tracking the
+/// older spec (the SMART reference provider among them). Accepted leniently;
+/// its `complete`/`aborted` codes map onto `completed`/`stopped`.
+const LEGACY_SUBMISSION_STATUS_SYSTEM: &str =
+    "http://hl7.org/fhir/uv/bulkdata/ValueSet/submission-status";
 
 fn not_implemented() -> RestError {
     RestError::NotImplemented {
@@ -259,7 +264,9 @@ fn parse_submit_request(body: &Value) -> RestResult<SubmitRequest> {
                 // Bulk Data submission-status system.
                 if let Some(coding) = p.get("valueCoding") {
                     if let Some(system) = coding.get("system").and_then(|v| v.as_str()) {
-                        if system != SUBMISSION_STATUS_SYSTEM {
+                        if system != SUBMISSION_STATUS_SYSTEM
+                            && system != LEGACY_SUBMISSION_STATUS_SYSTEM
+                        {
                             return Err(bad_request(format!(
                                 "submissionStatus.system must be '{SUBMISSION_STATUS_SYSTEM}', got '{system}'"
                             )));
@@ -273,7 +280,13 @@ fn parse_submit_request(body: &Value) -> RestResult<SubmitRequest> {
                     .map(String::from)
                     .or_else(|| scalar(p));
                 if let Some(code) = code {
-                    req.submission_status = code;
+                    // Providers tracking the pre-STU4 draft (the SMART
+                    // reference among them) code these two differently.
+                    req.submission_status = match code.as_str() {
+                        "complete" => "completed".to_string(),
+                        "aborted" => "stopped".to_string(),
+                        _ => code,
+                    };
                 }
             }
             "manifestUrl" => req.manifest_url = scalar(p),
@@ -1083,6 +1096,40 @@ mod tests {
         assert_eq!(req.submission_id, "sub-1");
         assert_eq!(req.submitter_key(), "http://ehr|ehr-1");
         assert_eq!(req.submission_status, "in-progress");
+    }
+
+    /// Providers on the pre-STU4 draft (the SMART reference among them) code
+    /// the status against the old ValueSet URL with `complete`/`aborted`.
+    /// Both are accepted and normalized onto the spec vocabulary.
+    #[test]
+    fn test_parse_legacy_status_vocabulary() {
+        for (legacy, normalized) in [("complete", "completed"), ("aborted", "stopped")] {
+            let body = json!({
+                "resourceType": "Parameters",
+                "parameter": [
+                    param("submitter", "valueIdentifier", json!({"system": "http://ehr", "value": "ehr-1"})),
+                    param("submissionId", "valueString", json!("sub-1")),
+                    param("submissionStatus", "valueCoding", json!({
+                        "system": LEGACY_SUBMISSION_STATUS_SYSTEM,
+                        "code": legacy
+                    })),
+                ]
+            });
+            let req = parse_submit_request(&body).expect("legacy accepted");
+            assert_eq!(req.submission_status, normalized);
+        }
+        // An unknown system is still rejected.
+        let body = json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                param("submitter", "valueIdentifier", json!({"system": "http://ehr", "value": "ehr-1"})),
+                param("submissionId", "valueString", json!("sub-1")),
+                param("submissionStatus", "valueCoding", json!({
+                    "system": "http://example.org/other", "code": "completed"
+                })),
+            ]
+        });
+        assert!(parse_submit_request(&body).is_err());
     }
 
     #[test]

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -512,6 +512,7 @@ fn kickoff_parameters(
     id: &str,
     status: &str,
     manifest: Option<&Manifest>,
+    replaces: Option<&str>,
 ) -> Value {
     let system = if submission.submitter_system.is_empty() {
         "urn:helios:hfs:bulk-submit"
@@ -545,6 +546,9 @@ fn kickoff_parameters(
         parameter.push(json!({ "name": "fhirBaseUrl", "valueUrl": base }));
         if !m.output_format.is_empty() {
             parameter.push(json!({ "name": "outputFormat", "valueString": m.output_format }));
+        }
+        if let Some(old) = replaces {
+            parameter.push(json!({ "name": "replacesManifestUrl", "valueUrl": old }));
         }
         for line in m.file_request_headers.lines() {
             if let Some((name, value)) = line.split_once(':') {
@@ -671,7 +675,7 @@ async fn status_kickoff(submission: &Submission, id: &str) -> Result<String, Str
         submission.recipient_base_url.trim_end_matches('/')
     );
     // Only the identifying parameters ride the status kick-off.
-    let parameters = kickoff_parameters(submission, id, "", None);
+    let parameters = kickoff_parameters(submission, id, "", None, None);
     let identifying: Vec<Value> = parameters["parameter"]
         .as_array()
         .into_iter()
@@ -818,7 +822,7 @@ async fn submit_one_with_id(submission: &mut Submission, id: &str, mid: &str) {
         submission,
         format!("Submitting manifest \"{}\"...", m.manifest_url),
     );
-    let parameters = kickoff_parameters(submission, id, "in-progress", Some(&m));
+    let parameters = kickoff_parameters(submission, id, "in-progress", Some(&m), None);
     match post_kickoff(submission, &parameters).await {
         Ok((status, _)) if (200..300).contains(&status) => {
             push_log(
@@ -895,7 +899,7 @@ async fn set_status(
     let user_key = settings_user_key(principal.as_deref());
     if let Some(mut s) = load_one(&state, &user_key, &rt.id, &id).await {
         push_log(&mut s, format!("Marking submission {status}..."));
-        let parameters = kickoff_parameters(&s, &id, status, None);
+        let parameters = kickoff_parameters(&s, &id, status, None, None);
         match post_kickoff(&s, &parameters).await {
             Ok((code, _)) if (200..300).contains(&code) => {
                 push_log(&mut s, format!("Recipient acknowledged ({code})."));
@@ -971,6 +975,134 @@ pub async fn keys() -> Response {
         Some(jwk) => axum::Json(json!({ "keys": [jwk] })).into_response(),
         None => StatusCode::NOT_FOUND.into_response(),
     }
+}
+
+/// `GET /ui/bulk-import/empty-manifest.json` — an empty Bulk Export Manifest.
+/// Aborting a single manifest is spec'd as replacing it with an empty one;
+/// this is the empty one, hosted where the recipient can fetch it.
+pub async fn empty_manifest() -> Response {
+    axum::Json(json!({
+        "transactionTime": now_stamp(),
+        "request": "",
+        "requiresAccessToken": false,
+        "output": [],
+        "error": []
+    }))
+    .into_response()
+}
+
+/// `POST /ui/bulk-import/{id}/manifests/{mid}/replace` — submit a new
+/// manifest carrying `replacesManifestUrl` = the old one, then store the
+/// replacement under the same id.
+pub async fn replace_manifest(
+    State(state): State<WebState>,
+    rt: RequestTenant,
+    principal: Option<Extension<helios_auth::Principal>>,
+    Path((id, mid)): Path<(String, String)>,
+    axum::Form(form): axum::Form<ManifestForm>,
+) -> Response {
+    let user_key = settings_user_key(principal.as_deref());
+    if let Some(mut s) = load_one(&state, &user_key, &rt.id, &id).await {
+        let old_url = s
+            .manifests
+            .get(&mid)
+            .and_then(|m| m["manifestUrl"].as_str())
+            .unwrap_or_default()
+            .to_string();
+        if !old_url.is_empty() {
+            let replacement = Manifest {
+                manifest_url: form.manifest_url.trim().to_string(),
+                fhir_base_url: form.fhir_base_url.trim().to_string(),
+                output_format: form.output_format.trim().to_string(),
+                file_request_headers: form.file_request_headers.trim().to_string(),
+                last_submitted_at: String::new(),
+            };
+            push_log(
+                &mut s,
+                format!(
+                    "Replacing manifest \"{old_url}\" with \"{}\"...",
+                    replacement.manifest_url
+                ),
+            );
+            let parameters =
+                kickoff_parameters(&s, &id, "in-progress", Some(&replacement), Some(&old_url));
+            match post_kickoff(&s, &parameters).await {
+                Ok((code, _)) if (200..300).contains(&code) => {
+                    push_log(&mut s, format!("Replacement accepted ({code})."));
+                    let mut entry = serde_json::to_value(&replacement).unwrap_or(Value::Null);
+                    entry["lastSubmittedAt"] = json!(now_stamp());
+                    s.manifests.insert(mid, entry);
+                }
+                Ok((code, body)) => {
+                    push_log(
+                        &mut s,
+                        format!("Replacement rejected: {code} {}", body.replace('\n', " ")),
+                    );
+                }
+                Err(e) => {
+                    push_log(&mut s, format!("Replacement failed: {e}"));
+                }
+            }
+            let _ = store_submission(&state, &user_key, &rt.id, &id, &s).await;
+        }
+    }
+    Redirect::to(&format!("/ui/bulk-import/{id}")).into_response()
+}
+
+/// `POST /ui/bulk-import/{id}/manifests/{mid}/abort` — abort one manifest by
+/// replacing it with the empty manifest this server hosts. The empty
+/// manifest's URL is derived from the request's Host header, since that is
+/// the address the recipient reached us... the address the *browser* reached
+/// us on, which is the best externally-visible base the UI can know.
+pub async fn abort_manifest(
+    State(state): State<WebState>,
+    rt: RequestTenant,
+    principal: Option<Extension<helios_auth::Principal>>,
+    headers: axum::http::HeaderMap,
+    Path((id, mid)): Path<(String, String)>,
+) -> Response {
+    let user_key = settings_user_key(principal.as_deref());
+    if let Some(mut s) = load_one(&state, &user_key, &rt.id, &id).await {
+        let old_url = s
+            .manifests
+            .get(&mid)
+            .and_then(|m| m["manifestUrl"].as_str())
+            .unwrap_or_default()
+            .to_string();
+        if !old_url.is_empty() {
+            let host = headers
+                .get("host")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("localhost:8080");
+            let empty = Manifest {
+                manifest_url: format!("http://{host}/ui/bulk-import/empty-manifest.json"),
+                fhir_base_url: format!("http://{host}"),
+                ..Default::default()
+            };
+            push_log(&mut s, format!("Aborting manifest \"{old_url}\"..."));
+            let parameters =
+                kickoff_parameters(&s, &id, "in-progress", Some(&empty), Some(&old_url));
+            match post_kickoff(&s, &parameters).await {
+                Ok((code, _)) if (200..300).contains(&code) => {
+                    push_log(&mut s, format!("Abort accepted ({code})."));
+                    if let Some(entry) = s.manifests.get_mut(&mid) {
+                        entry["abortedAt"] = json!(now_stamp());
+                    }
+                }
+                Ok((code, body)) => {
+                    push_log(
+                        &mut s,
+                        format!("Abort rejected: {code} {}", body.replace('\n', " ")),
+                    );
+                }
+                Err(e) => {
+                    push_log(&mut s, format!("Abort failed: {e}"));
+                }
+            }
+            let _ = store_submission(&state, &user_key, &rt.id, &id, &s).await;
+        }
+    }
+    Redirect::to(&format!("/ui/bulk-import/{id}")).into_response()
 }
 
 #[derive(Deserialize)]

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -655,7 +655,19 @@ pub fn mount_with_conformance_source(
             "/ui/bulk-import/test-auth",
             axum::routing::post(bulk_import::test_auth),
         )
+        .route(
+            "/ui/bulk-import/empty-manifest.json",
+            get(bulk_import::empty_manifest),
+        )
         .route("/ui/bulk-import/keys", get(bulk_import::keys))
+        .route(
+            "/ui/bulk-import/{id}/manifests/{mid}/replace",
+            axum::routing::post(bulk_import::replace_manifest),
+        )
+        .route(
+            "/ui/bulk-import/{id}/manifests/{mid}/abort",
+            axum::routing::post(bulk_import::abort_manifest),
+        )
         .route("/ui/bulk-import/{id}", get(bulk_import::detail))
         .route(
             "/ui/bulk-import/{id}/status",

--- a/crates/ui/templates/pages/bulk-import-detail.html
+++ b/crates/ui/templates/pages/bulk-import-detail.html
@@ -109,6 +109,9 @@
           </form>
         </td>
         <td>
+          <form method="post" action="/ui/bulk-import/{{ id }}/manifests/{{ m.id }}/abort">
+            <button type="submit" class="button">{{ i18n.t("bulk-import-abort-manifest") }}</button>
+          </form>
           <form method="post" action="/ui/bulk-import/{{ id }}/manifests/{{ m.id }}/delete">
             <button type="submit" class="button">{{ i18n.t("bulk-import-remove") }}</button>
           </form>

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -919,3 +919,132 @@ async fn the_keys_endpoint_serves_the_configured_jwks() {
     assert_eq!(jwks["keys"][0]["kid"], "hfs-1");
     unsafe { std::env::remove_var("HFS_BULK_SUBMIT_PUBLIC_JWK") };
 }
+
+#[tokio::test]
+async fn the_empty_manifest_is_served() {
+    let settings = settings_store();
+    let (status, body) = get(&settings, "/ui/bulk-import/empty-manifest.json").await;
+    assert_eq!(status, StatusCode::OK);
+    let m: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(m["output"].as_array().unwrap().len(), 0);
+    assert_eq!(m["requiresAccessToken"], false);
+}
+
+#[tokio::test]
+async fn replacing_a_manifest_sends_replaces_manifest_url() {
+    let settings = settings_store();
+    let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        &format!(
+            "name=R&recipient_base_url={}&auth=none",
+            urlencode(&recipient_url)
+        ),
+    )
+    .await;
+    post_form(
+        &settings,
+        &format!("{detail_path}/manifests"),
+        "manifest_url=http%3A%2F%2Fold.example%2Fm.json",
+    )
+    .await;
+    let (_, html) = get(&settings, &detail_path).await;
+    let marker = format!("{detail_path}/manifests/");
+    let mid = html
+        .split(&marker)
+        .nth(1)
+        .and_then(|r| r.split('/').next())
+        .unwrap()
+        .to_string();
+
+    post_form(
+        &settings,
+        &format!("{detail_path}/manifests/{mid}/replace"),
+        "manifest_url=http%3A%2F%2Fnew.example%2Fm.json",
+    )
+    .await;
+
+    let bodies = received.lock().unwrap().clone();
+    assert_eq!(bodies.len(), 1);
+    let params = bodies[0]["parameter"].as_array().unwrap();
+    let get_p = |n: &str| {
+        params
+            .iter()
+            .find(|p| p["name"] == n)
+            .cloned()
+            .unwrap_or_default()
+    };
+    assert_eq!(
+        get_p("manifestUrl")["valueUrl"],
+        "http://new.example/m.json"
+    );
+    assert_eq!(
+        get_p("replacesManifestUrl")["valueUrl"],
+        "http://old.example/m.json"
+    );
+
+    let (_, html) = get(&settings, &detail_path).await;
+    assert!(html.contains("http://new.example/m.json"));
+    assert!(html.contains("Replacement accepted (200)"));
+}
+
+#[tokio::test]
+async fn aborting_one_manifest_replaces_it_with_the_empty_manifest() {
+    let settings = settings_store();
+    let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+    let (_, detail_path, _) = post_form(
+        &settings,
+        "/ui/bulk-import",
+        &format!(
+            "name=A&recipient_base_url={}&auth=none",
+            urlencode(&recipient_url)
+        ),
+    )
+    .await;
+    post_form(
+        &settings,
+        &format!("{detail_path}/manifests"),
+        "manifest_url=http%3A%2F%2Fold.example%2Fm.json",
+    )
+    .await;
+    let (_, html) = get(&settings, &detail_path).await;
+    let marker = format!("{detail_path}/manifests/");
+    let mid = html
+        .split(&marker)
+        .nth(1)
+        .and_then(|r| r.split('/').next())
+        .unwrap()
+        .to_string();
+
+    post_form(
+        &settings,
+        &format!("{detail_path}/manifests/{mid}/abort"),
+        "",
+    )
+    .await;
+
+    let bodies = received.lock().unwrap().clone();
+    assert_eq!(bodies.len(), 1);
+    let params = bodies[0]["parameter"].as_array().unwrap();
+    let get_p = |n: &str| {
+        params
+            .iter()
+            .find(|p| p["name"] == n)
+            .cloned()
+            .unwrap_or_default()
+    };
+    assert!(
+        get_p("manifestUrl")["valueUrl"]
+            .as_str()
+            .unwrap()
+            .ends_with("/ui/bulk-import/empty-manifest.json")
+    );
+    assert_eq!(
+        get_p("replacesManifestUrl")["valueUrl"],
+        "http://old.example/m.json"
+    );
+
+    let (_, html) = get(&settings, &detail_path).await;
+    assert!(html.contains("Abort accepted (200)"));
+}

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -587,3 +587,4 @@ bulk-import-result = Ergebnis
 bulk-import-result-finished = Verarbeitung abgeschlossen um
 bulk-import-result-outputs = Ausgabedateien
 bulk-import-result-errors = Fehlerdateien
+bulk-import-abort-manifest = Abbrechen

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -590,3 +590,4 @@ bulk-import-result = Result
 bulk-import-result-finished = Processing finished at
 bulk-import-result-outputs = Output files
 bulk-import-result-errors = Error files
+bulk-import-abort-manifest = Abort

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -587,3 +587,4 @@ bulk-import-result = Resultado
 bulk-import-result-finished = Procesamiento terminado a las
 bulk-import-result-outputs = Archivos de salida
 bulk-import-result-errors = Archivos de error
+bulk-import-abort-manifest = Abortar


### PR DESCRIPTION
Closes #531 — the last two functional items, on top of the merged round 2.

## Manifest replace + per-manifest abort (`replacesManifestUrl`)

- **Replace**: `POST /ui/bulk-import/{id}/manifests/{mid}/replace` submits the new manifest with `replacesManifestUrl` = the old URL (the consumer already parsed this parameter) and stores the replacement under the same id on accept. Endpoint + tests; the per-row popup control lands with the visual-refresh pass.
- **Abort one manifest**: spec'd as replacing it with an empty manifest. The UI now hosts one at `/ui/bulk-import/empty-manifest.json` and derives its externally visible URL from the request's `Host` header — the best base the UI can know without deployment config (same approach the reference app takes with its `BASE_URL`). Each manifest row gains an **Abort** button; rejections and transport failures land in the Submission Log.

## Consumer leniency for the pre-STU4 vocabulary

`parse_submit_request` now accepts the old draft's status system (`.../uv/bulkdata/ValueSet/submission-status`) and normalizes `complete`/`aborted` onto the spec's `completed`/`stopped` — so providers tracking the older draft (the SMART reference provider among them, per the comparison on #531) can complete and abort submissions against HFS instead of failing on the system check. Unknown systems are still rejected, and the spec vocabulary stays canonical.

## Tests

21 bulk-import router tests (empty manifest served; replace asserts `manifestUrl` + `replacesManifestUrl` at the recipient and the stored swap; abort asserts the empty-manifest URL + `replacesManifestUrl`), plus consumer-side unit tests for both legacy codes and the still-rejected unknown system. Full helios-ui suite green (6 binaries), fmt/clippy clean.