### PR TITLE
docs(persistence): stop claiming Cassandra and Neo4j backends

### DIFF
--- a/crates/persistence/src/backends/mod.rs
+++ b/crates/persistence/src/backends/mod.rs
@@ -9,11 +9,21 @@
 //! |---------|---------|-------------|
 //! | SQLite | `sqlite` | Lightweight embedded database, great for development |
 //! | PostgreSQL | `postgres` | Full-featured RDBMS with JSONB support |
-//! | Cassandra | `cassandra` | Wide-column store for high write throughput |
 //! | MongoDB | `mongodb` | Document store with native JSON support |
-//! | Neo4j | `neo4j` | Graph database for relationship-heavy queries |
 //! | Elasticsearch | `elasticsearch` | Full-text search optimized |
 //! | S3 | `s3` | Object storage for bulk data |
+//!
+//! The local filesystem module ([`local_fs`]) is always compiled and provides an
+//! export output store rather than a full resource-storage backend.
+//!
+//! # Not Implemented
+//!
+//! The `cassandra` and `neo4j` cargo features exist and pull in driver
+//! dependencies, but no backend is implemented behind them — enabling them adds
+//! no storage capability. [`BackendKind::Cassandra`](crate::core::BackendKind)
+//! and [`BackendKind::Neo4j`](crate::core::BackendKind) are likewise accepted by
+//! the composite router configuration and the configuration advisor, but cannot
+//! be instantiated.
 //!
 //! # Example
 //!

--- a/crates/persistence/src/composite/mod.rs
+++ b/crates/persistence/src/composite/mod.rs
@@ -14,9 +14,13 @@
 //! |-----------|-----------------|-----|
 //! | CRUD + History | PostgreSQL/SQLite | ACID guarantees |
 //! | Full-text search | Elasticsearch | Optimized inverted indexes |
-//! | Relationship traversal | Neo4j | Efficient graph queries |
 //! | Terminology expansion | Terminology Service | Dedicated code hierarchies |
 //! | Bulk analytics | S3 + Parquet | Cost-effective columnar storage |
+//!
+//! Note that [`BackendKind`](crate::core::BackendKind) also names `Cassandra`
+//! and `Neo4j`, and the builder accepts them, but no backend is implemented for
+//! either — see [`backends`](crate::backends). A graph role configured with
+//! `BackendKind::Neo4j` cannot be instantiated at runtime.
 //!
 //! # Design Principles
 //!
@@ -39,7 +43,7 @@
 //! | SQLite-only | SQLite | None | Development, small deployments |
 //! | SQLite + ES | SQLite | Elasticsearch | Production with robust text search |
 //! | S3 + ES | S3 | Elasticsearch | Large-scale, cheap storage |
-//! | PostgreSQL + Neo4j | PostgreSQL | Neo4j | Graph-heavy queries |
+//! | PostgreSQL + ES | PostgreSQL | Elasticsearch | Production with robust text search |
 //!
 //! # Example
 //!
@@ -54,11 +58,10 @@
 //!     .primary("sqlite", BackendKind::Sqlite)
 //!     .build()?;
 //!
-//! // SQLite + Elasticsearch (production)
+//! // PostgreSQL + Elasticsearch (production)
 //! let production = CompositeConfig::builder()
 //!     .primary("pg", BackendKind::Postgres)
 //!     .search_backend("es", BackendKind::Elasticsearch)
-//!     .graph_backend("neo4j", BackendKind::Neo4j)
 //!     .sync_mode(SyncMode::Asynchronous)
 //!     .build()?;
 //! ```

--- a/crates/persistence/src/core/backend.rs
+++ b/crates/persistence/src/core/backend.rs
@@ -21,10 +21,16 @@ pub enum BackendKind {
     /// PostgreSQL database.
     Postgres,
     /// Apache Cassandra (wide-column store).
+    ///
+    /// Reserved: no backend is implemented for this kind. It is accepted by
+    /// composite configuration and the advisor but cannot be instantiated.
     Cassandra,
     /// MongoDB (document store).
     MongoDB,
     /// Neo4j (graph database).
+    ///
+    /// Reserved: no backend is implemented for this kind. It is accepted by
+    /// composite configuration and the advisor but cannot be instantiated.
     Neo4j,
     /// Elasticsearch (search engine).
     Elasticsearch,

--- a/crates/persistence/src/lib.rs
+++ b/crates/persistence/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! # Features
 //!
-//! - **Multiple Backends**: SQLite, PostgreSQL, Cassandra, MongoDB, Neo4j, Elasticsearch, S3
+//! - **Multiple Backends**: SQLite, PostgreSQL, MongoDB, Elasticsearch, S3
 //! - **Multitenancy**: Shared-schema isolation via a `tenant_id` discriminator on
 //!   every backend; the S3 backend additionally offers a bucket-per-tenant mode
 //! - **Full FHIR Search**: All parameter types, modifiers, chaining, _include/_revinclude
@@ -25,11 +25,13 @@
 //! Available backend features:
 //! - `sqlite` (default) - SQLite with in-memory and file modes
 //! - `postgres` - PostgreSQL with JSONB storage
-//! - `cassandra` - Apache Cassandra via cdrs-tokio
 //! - `mongodb` - MongoDB document storage
-//! - `neo4j` - Neo4j graph database
 //! - `elasticsearch` - Elasticsearch for full-text search
 //! - `s3` - AWS S3 object storage
+//!
+//! The `cassandra` and `neo4j` features are placeholders: they pull in driver
+//! dependencies but no backend is implemented behind them. See [`backends`] for
+//! details.
 //!
 //! FHIR version features:
 //! - `R4`, `R4B`, `R5`, `R6`


### PR DESCRIPTION
## Problem

The published rustdoc advertises Cassandra and Neo4j as available storage backends:

https://docs.rs/helios-persistence/0.2.1/helios_persistence/backends/index.html

Neither is implemented. `backends::cassandra` and `backends::neo4j` are commented out in `crates/persistence/src/backends/mod.rs`, and the `cassandra` / `neo4j` cargo features only pull in driver dependencies (`cdrs-tokio`, `neo4rs`) — enabling them adds no storage capability.

## Changes

Docs only, no behavior change. The claim appeared in four places, all of which render on docs.rs:

- **`backends/mod.rs`** — removed both rows from the "Available Backends" table; added a "Not Implemented" section explaining the placeholder features, and a note that `local_fs` is an export output store rather than a resource-storage backend.
- **`lib.rs`** — removed both from the "Multiple Backends" feature bullet and the backend feature list; added a pointer to `backends` for the placeholder explanation.
- **`composite/mod.rs`** — removed the "Relationship traversal → Neo4j" routing row and the `PostgreSQL + Neo4j` valid-configuration row (replaced with `PostgreSQL + ES`); dropped the `.graph_backend("neo4j", ...)` call from the example; added a caveat that the builder accepts these kinds but they cannot be instantiated.
- **`core/backend.rs`** — documented `BackendKind::Cassandra` and `BackendKind::Neo4j` as reserved variants with no implementation.

## Verification

`cargo doc -p helios-persistence --no-deps` builds clean, with no new intra-doc link warnings.

## Follow-ups not in this PR

1. The `cassandra` and `neo4j` cargo features still exist and pull unused optional deps (`cdrs-tokio` 8, `cdrs-tokio-helpers-derive` 5, `neo4rs` 0.8). They appear in the docs.rs feature list, so the page still hints at support. Removing them is the honest fix but is a nominal API break and touches `Cargo.lock`.
2. `advisor/suggestions.rs:95` actively emits "Consider Neo4j for relationship-heavy queries" with an action to add a `role=Graph, kind=Neo4j` backend that cannot be instantiated. That is a live user-facing recommendation, not just a doc comment.