### PR TITLE
fix(rest,ui): unbreak main — drop rsa from JWKS derivation, fix the stale keys test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,7 +3587,6 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest",
- "rsa",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3726,7 +3725,6 @@ dependencies = [
  "jsonwebtoken",
  "p384",
  "reqwest",
- "rsa",
  "rust-embed",
  "serde",
  "serde_json",
@@ -4566,9 +4564,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -5128,22 +5123,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -5791,17 +5770,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
 
 [[package]]
 name = "pkcs8"
@@ -6696,26 +6664,6 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "signature 2.2.0",
- "spki 0.7.3",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "rusqlite"

--- a/crates/rest/Cargo.toml
+++ b/crates/rest/Cargo.toml
@@ -120,7 +120,6 @@ hmac = "0.12"                                            # A*CBC-HS* authenticat
 sha2 = "0.10"                                            # Concat KDF, A*CBC-HS*
 p256 = { version = "0.13", features = ["ecdh", "jwk", "pem", "pkcs8"] }  # ECDH-ES (P-256)
 p384 = { version = "0.13", features = ["ecdh", "jwk", "pem", "pkcs8"] }  # ECDH-ES (P-384)
-rsa = { version = "0.9", features = ["pem"] }                # RS384 public JWK derivation (#529)
 flate2 = "1"                                             # JWE `zip: "DEF"` payloads
 
 [dev-dependencies]

--- a/crates/rest/src/bulk_submit_oauth.rs
+++ b/crates/rest/src/bulk_submit_oauth.rs
@@ -183,26 +183,12 @@ pub(crate) fn derive_public_jwk(pem: &str, alg: &str) -> Option<Value> {
                 "alg": "ES384",
             }))
         }
-        "RS384" => {
-            use rsa::pkcs8::DecodePrivateKey;
-            use rsa::traits::PublicKeyParts;
-
-            let private_key = rsa::RsaPrivateKey::from_pkcs8_pem(pem).ok()?;
-            let pub_key = private_key.to_public_key();
-            let n = URL_SAFE_NO_PAD.encode(pub_key.n().to_bytes_be());
-            let e = URL_SAFE_NO_PAD.encode(pub_key.e().to_bytes_be());
-            // RFC 7638 §3.3: required RSA members in lexicographic order.
-            let canonical = format!(r#"{{"e":"{e}","kty":"RSA","n":"{n}"}}"#);
-            let kid = URL_SAFE_NO_PAD.encode(Sha256::digest(canonical.as_bytes()));
-            Some(serde_json::json!({
-                "kty": "RSA",
-                "n": n,
-                "e": e,
-                "kid": kid,
-                "use": "sig",
-                "alg": "RS384",
-            }))
-        }
+        // RS384 derivation is deliberately not offered: the only pure-Rust
+        // RSA implementation carries RUSTSEC-2023-0071 (Marvin Attack timing
+        // sidechannel) with no fixed release — the same reason jwe.rs rejects
+        // RSA-OAEP. An RS384 deployment registers its public key with the
+        // recipient out-of-band; the JWKS endpoint serves an empty set, as
+        // its handler documents.
         _ => None,
     }
 }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -64,7 +64,6 @@ uuid = { version = "1", features = ["v4"] }
 jsonwebtoken = "9"
 # RFC 7638 thumbprint derivation for the bulk-submit signing key kid (#529).
 p384 = { version = "0.13", features = ["pem", "pkcs8"] }
-rsa = { version = "0.9", features = ["pem"] }
 sha2 = "0.10"
 base64 = "0.22"
 

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -582,17 +582,12 @@ fn signing_kid(pem: &str, alg: &str) -> Option<String> {
     use sha2::{Digest, Sha256};
 
     match alg {
-        "RS384" => {
-            use rsa::pkcs8::DecodePrivateKey;
-            use rsa::traits::PublicKeyParts;
-
-            let private_key = rsa::RsaPrivateKey::from_pkcs8_pem(pem).ok()?;
-            let pub_key = private_key.to_public_key();
-            let n = URL_SAFE_NO_PAD.encode(pub_key.n().to_bytes_be());
-            let e = URL_SAFE_NO_PAD.encode(pub_key.e().to_bytes_be());
-            let canonical = format!(r#"{{"e":"{e}","kty":"RSA","n":"{n}"}}"#);
-            Some(URL_SAFE_NO_PAD.encode(Sha256::digest(canonical.as_bytes())))
-        }
+        // RS384 thumbprints are deliberately not derived: the only pure-Rust
+        // RSA implementation carries RUSTSEC-2023-0071 (Marvin Attack) with
+        // no fixed release — the same reason jwe.rs rejects RSA-OAEP. An
+        // RS384 assertion goes out without a kid; the key is registered with
+        // the recipient out-of-band.
+        "RS384" => None,
         _ => {
             use p384::elliptic_curve::sec1::ToEncodedPoint;
             use p384::pkcs8::DecodePrivateKey;

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -899,25 +899,27 @@ async fn status_polling_tracks_progress_and_lands_the_result() {
     assert!(detail.contains("got 200 OK"));
 }
 
+/// The UI route became a permanent redirect to the server-level JWKS when
+/// `/.well-known/bulk-submit-jwks.json` landed; existing registrations keep
+/// working through it.
 #[tokio::test]
-async fn the_keys_endpoint_serves_the_configured_jwks() {
+async fn the_keys_endpoint_redirects_to_the_well_known_jwks() {
     let settings = settings_store();
-
-    unsafe { std::env::remove_var("HFS_BULK_SUBMIT_PUBLIC_JWK") };
-    let (status, _) = get(&settings, "/ui/bulk-import/keys").await;
-    assert_eq!(status, StatusCode::NOT_FOUND);
-
-    unsafe {
-        std::env::set_var(
-            "HFS_BULK_SUBMIT_PUBLIC_JWK",
-            r#"{"kty":"EC","crv":"P-384","x":"abc","y":"def","alg":"ES384","kid":"hfs-1"}"#,
+    let res = app(&settings)
+        .oneshot(
+            Request::get("/ui/bulk-import/keys")
+                .body(Body::empty())
+                .unwrap(),
         )
-    };
-    let (status, body) = get(&settings, "/ui/bulk-import/keys").await;
-    assert_eq!(status, StatusCode::OK);
-    let jwks: serde_json::Value = serde_json::from_str(&body).unwrap();
-    assert_eq!(jwks["keys"][0]["kid"], "hfs-1");
-    unsafe { std::env::remove_var("HFS_BULK_SUBMIT_PUBLIC_JWK") };
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(
+        res.headers()
+            .get(header::LOCATION)
+            .and_then(|v| v.to_str().ok()),
+        Some("/.well-known/bulk-submit-jwks.json")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Main is red for every open PR since #539 merged — two independent breakages, both fixed here:

**1. Security Audit fails on `rsa` (RUSTSEC-2023-0071).** #539 added the pure-Rust `rsa` crate in two places (rest's `derive_public_jwk`, ui's `signing_kid`) for RS384 public-JWK derivation. The Marvin Attack advisory has **no fixed release**, and this repo already refuses the crate on principle — `jwe.rs` rejects RSA-OAEP citing exactly this advisory, and the JWKS handler's own doc comment promises *"an empty keys array when … the configured algorithm is not ES384"*. The code now honors that contract: RS384 → `None` with the rationale inline, ES384 derivation (via the existing `p384`) untouched, `rsa` gone from both manifests and the lockfile. An RS384 deployment registers its key out-of-band and its assertions go out without a `kid` — consistent with the endpoint serving no RSA key either.

**2. Test Rust fails on the stale keys test.** #539 turned `/ui/bulk-import/keys` into a `Redirect::permanent` to `/.well-known/bulk-submit-jwks.json` but left the old test asserting the 404/200 env-var contract — so `the_keys_endpoint_serves_the_configured_jwks` fails (308 ≠ 404) on every merge ref. Replaced with a test of the actual contract: 308 + the Location header.

Verified: `cargo tree -i rsa` empty, both crates' suites green, fmt clean. Once this merges, re-running the checks on the open PRs (#538, #558) should clear them.