### PR TITLE
feat(ui): make the sidebar brand link to Home

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -163,6 +163,18 @@ svg {
   align-items: center;
   gap: 12px;
   padding: 4px 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand:hover .brand__name,
+.brand:focus-visible .brand__name {
+  color: var(--accent-text);
+}
+
+.brand:focus-visible {
+  outline: 2px solid var(--accent-text);
+  outline-offset: 2px;
 }
 
 .brand__logo {

--- a/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
+++ b/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
@@ -12,6 +12,23 @@ test("the landing page renders server-side with no JavaScript", async ({ page, c
   await expect(chrome.sidebar).toBeVisible();
 });
 
+test("the sidebar brand is an accessible native Home link", async ({ page }) => {
+  await page.goto("/ui/resources");
+  const brand = page.locator("a.brand");
+  const name = /^Helios FHIR Server hfs v.+ — Home$/;
+
+  await expect(brand).toHaveAttribute("href", "/ui");
+  await expect(brand).not.toHaveAttribute("aria-current", "page");
+  await expect(brand).toHaveAccessibleName(name);
+  await expect(brand.locator("img")).toHaveAttribute("alt", "");
+
+  await brand.focus();
+  await expect(brand).toHaveAccessibleName(name);
+  await brand.press("Enter");
+  await expect(page).toHaveURL(/\/ui$/);
+  await expect(page.locator("h1.page-title")).toHaveText("Home");
+});
+
 test("the language switcher works as plain links (en → es → de)", async ({ page, chrome }) => {
   await page.goto("/ui");
   await expect(chrome.langLink("es")).toHaveAttribute("href", /lang=es/);

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -15,13 +15,13 @@
 </head>
 <body class="{% block body_class %}{% endblock %}">
   <aside class="sidebar" id="sidebar">
-    <div class="brand">
+    <a class="brand" href="/ui" aria-label="{{ i18n.t("app-title") }} hfs v{{ status.version }} — {{ i18n.t("nav-home") }}">
       <img class="brand__logo" src="/ui/assets/logo.png" alt="">
       <div class="brand__text">
         <span class="brand__name">{{ i18n.t("app-title") }}</span>
         <span class="brand__version">hfs v{{ status.version }}</span>
       </div>
-    </div>
+    </a>
 
     <!--
       Tenant selector (#344). A <details> disclosure — works without


### PR DESCRIPTION
Closes #552.

## Summary

Makes the sidebar brand a native link to `/ui`, covering the logo, app name, and version. Because this is a regular `<a href>`, it preserves full-page browser navigation, keyboard activation, Ctrl/Cmd-click, and operation without JavaScript.

The logo remains decorative, while the link has a localized accessible name that remains available when the sidebar rail is collapsed. The existing Home navigation item remains the only element with `aria-current="page"`.

Adds restrained hover and focus-visible affordances plus a no-JavaScript Playwright regression covering the native href, accessible name, decorative image, keyboard activation, and navigation to Home.

## Testing

- HFS build with the UI enabled — passed
- `git diff --check` — passed
- `cargo test -p helios-ui` — 144 passed
- No-JavaScript Playwright suite — 9 passed
- WCAG 2.2 AA suite in light and dark themes — 20 passed
- Latest GitHub Actions: Test Rust, Linting, Security Audit, UI browser suite, Test Python, Test FHIRPath, Code Coverage, Codecov patch, and Cleanup Test Containers — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
