### PR TITLE
ci: cap the self-hosted runners' cargo target dir size

### DIFF
--- a/.github/actions/cargo-target-gc/action.yml
+++ b/.github/actions/cargo-target-gc/action.yml
@@ -1,0 +1,104 @@
+name: Cargo target dir GC
+description: >
+  Cap the size of the workspace `target/` directory on a self-hosted runner by
+  evicting least-recently-used build artifacts. Runs at the end of every job
+  that compiles Rust on a persistent runner.
+
+# Why this exists
+# ---------------
+# Nothing in cargo ever deletes a stale artifact. Every dependency bump,
+# toolchain update and feature-flag combination adds a new set of `.rlib`s,
+# `.rmeta`s and incremental fragments alongside the old ones, and the old ones
+# stay forever. On a GitHub-hosted runner that does not matter — the machine is
+# thrown away. On our self-hosted runners it compounds indefinitely, because the
+# jobs that feed `target/` check out with `clean: false` on purpose (a warm
+# target dir is what keeps `test-rust` inside its 120-minute budget). Growth is
+# the price of that cache; a ceiling is the only thing that bounds it.
+#
+# Why per-run and not a nightly cron: same reasoning as `docker-host-gc`. The
+# runner fills during the working day, and a nightly sweep cannot help a job
+# that dies out of disk at 16:03 — by the time it fires the damage is twelve
+# hours old and several runs have already gone red.
+#
+# It is a soft cap, not a hard ceiling. cargo-sweep evicts the artifacts cargo
+# manages under `deps/`, `build/`, `.fingerprint/` and `incremental/` — which is
+# precisely the part that compounds — but it does not remove the linked outputs
+# at `target/<profile>/<bin>`. Those are hardlinked to their `deps/` copy
+# (verified: link count 2), so sweeping the dep entry frees nothing while the
+# top-level name survives. That residue is a small constant per profile and is
+# overwritten by the next build; it does not accumulate. Expect the swept
+# directory to settle slightly above `maxsize`, not exactly at it.
+#
+# Scope: this caps `target/` only. `~/.cargo/registry` also grows without bound
+# (every `.crate` tarball and unpacked source ever resolved), but far more
+# slowly — it is measured in single-digit GB, not hundreds. If it ever becomes
+# the problem it needs a different tool; cargo-sweep does not touch it.
+
+inputs:
+  maxsize:
+    description: >
+      Size ceiling for `target/`. cargo-sweep evicts oldest-first until the
+      directory is under this. ALWAYS pass an explicit unit: a bare number is
+      interpreted as MEGABYTES, so `100` means 100MB and would evict essentially
+      the entire warm cache on every run.
+    required: false
+    default: 100GB
+  cargo-sweep-version:
+    description: >
+      Pinned cargo-sweep version. >=0.7.0 is required for unit suffixes on
+      `--maxsize`; >=0.8.0 for Rust 1.85+ compatibility (our MSRV is 1.90).
+    required: false
+    default: 0.8.0
+
+runs:
+  using: composite
+  steps:
+    # `runs-on: [self-hosted]` is unpinned on several ci.yml jobs, so this
+    # action can land on the Windows runner, where the plain `shell: bash` alias
+    # is unreliable (see the Git Bash 8.3-path workaround in ci.yml). The
+    # Windows runner is not the one running out of space; skip rather than
+    # invent a second code path for it.
+    - name: Cap target dir size
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        # Deliberately NOT `set -e`. This is janitorial work running under
+        # `if: always()`; failing to reclaim space must never turn a green build
+        # red. Every command below is non-fatal and reports loudly instead.
+        set -uo pipefail
+
+        MAXSIZE='${{ inputs.maxsize }}'
+        WANT='${{ inputs.cargo-sweep-version }}'
+
+        if [ ! -d target ]; then
+          echo "No target/ directory in $(pwd) — nothing to sweep."
+          exit 0
+        fi
+
+        # Guard against the footgun the flag invites. cargo-sweep's own help
+        # says "Unit defaults to MB", so `--maxsize 100` means 100 megabytes,
+        # not 100 gigabytes. Refuse a unitless value rather than silently
+        # nuking the cache the `clean: false` checkouts exist to preserve.
+        if ! printf '%s' "$MAXSIZE" | grep -qiE '^[0-9]+(\.[0-9]+)?[[:space:]]*(k|m|g|t)i?b$'; then
+          echo "::error::maxsize='${MAXSIZE}' has no unit suffix. cargo-sweep reads a bare number as MEGABYTES, which would wipe the warm build cache on every run. Use e.g. 100GB."
+          exit 0
+        fi
+
+        HAVE="$(cargo sweep --version 2>/dev/null | awk '{print $NF}')"
+        if [ "$HAVE" != "$WANT" ]; then
+          echo "cargo-sweep: have '${HAVE:-none}', want '${WANT}' — installing."
+          cargo install cargo-sweep --locked --version "$WANT" || true
+        fi
+        if ! cargo sweep --version >/dev/null 2>&1; then
+          echo "::warning::cargo-sweep unavailable (install failed?); skipping target dir GC. This runner's target/ is unbounded until a later run succeeds."
+          exit 0
+        fi
+
+        # `du` on a multi-million-file target dir is not instant, but it is the
+        # only number that makes the trend legible in the job log. Both calls
+        # are non-fatal so a transient stat error cannot break the step.
+        before="$(du -sh target 2>/dev/null | cut -f1)"
+        cargo sweep --maxsize "$MAXSIZE" || true
+        after="$(du -sh target 2>/dev/null | cut -f1)"
+        echo "target/: ${before:-?} before, ${after:-?} after (ceiling ${MAXSIZE})."
+        df -h . 2>/dev/null | tail -2 || true

--- a/.github/actions/cargo-target-gc/action.yml
+++ b/.github/actions/cargo-target-gc/action.yml
@@ -62,9 +62,21 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        # Deliberately NOT `set -e`. This is janitorial work running under
-        # `if: always()`; failing to reclaim space must never turn a green build
-        # red. Every command below is non-fatal and reports loudly instead.
+        # `set +e` is load-bearing, and NOT redundant with omitting `set -e`.
+        # Actions invokes `shell: bash` as
+        #   /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+        # so errexit is already on at the process level before the first line
+        # runs; simply not turning it on does not turn it off. Without this the
+        # very first probe -- `cargo sweep --version` on a runner that has not
+        # got cargo-sweep yet -- exits the script with cargo's 101 and fails the
+        # job, which is exactly the opposite of what this step is for. That is
+        # not hypothetical: it happened on the first CI run of this action.
+        #
+        # This is janitorial work running under `if: always()`. Failing to
+        # reclaim space must never turn a green build red, so every command
+        # below is non-fatal and reports loudly instead, and the script ends in
+        # an explicit `exit 0`.
+        set +e
         set -uo pipefail
 
         MAXSIZE='${{ inputs.maxsize }}'
@@ -102,3 +114,7 @@ runs:
         after="$(du -sh target 2>/dev/null | cut -f1)"
         echo "target/: ${before:-?} before, ${after:-?} after (ceiling ${MAXSIZE})."
         df -h . 2>/dev/null | tail -2 || true
+
+        # Belt and braces: the step's exit status is the last command's, and no
+        # future edit to the reporting above should be able to fail the job.
+        exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,15 @@ jobs:
             exit 1
           fi
 
+      # Last step, and non-fatal by construction. `clean: false` above keeps the
+      # target dir warm across runs, which is what makes this job fit in 120
+      # minutes — but cargo never evicts the artifacts a bump or a toolchain
+      # update orphans, so that cache only ever grows. The macOS runner hit its
+      # disk ceiling this way. See .github/actions/cargo-target-gc.
+      - name: Cap target dir size
+        if: always()
+        uses: ./.github/actions/cargo-target-gc
+
   cleanup-test-containers:
     name: Cleanup Test Containers
     runs-on: [self-hosted, Linux]
@@ -430,6 +439,12 @@ jobs:
         working-directory: crates/pysof
         run: uv run python -m pytest python-tests/ -v --cov=src --cov-report=xml:coverage.xml --cov-report=term-missing
 
+      # maturin compiles pysof into the same shared workspace target dir, so
+      # this job accumulates like the Rust ones. See the note in `test-rust`.
+      - name: Cap target dir size
+        if: always()
+        uses: ./.github/actions/cargo-target-gc
+
   lint:
     name: Linting
     runs-on: [self-hosted]
@@ -510,6 +525,11 @@ jobs:
         working-directory: crates/pysof
         run: |
           uv run mypy src
+
+      # See the note in `test-rust`.
+      - name: Cap target dir size
+        if: always()
+        uses: ./.github/actions/cargo-target-gc
 
   security:
     name: Security Audit
@@ -626,7 +646,12 @@ jobs:
           --ignore RUSTSEC-2026-0194
           --ignore RUSTSEC-2026-0195
           --ignore RUSTSEC-2026-0235
- 
+
+      # See the note in `test-rust`.
+      - name: Cap target dir size
+        if: always()
+        uses: ./.github/actions/cargo-target-gc
+
   coverage:
     name: Code Coverage
     runs-on: [self-hosted, Unix] # llvm-tools-preview has problems on Windows, so restrict to Unix
@@ -728,6 +753,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
+
+      # The heaviest accumulator of the lot: `cargo llvm-cov` builds a whole
+      # separate instrumented profile, so every run this job's feature set
+      # changes leaves another full copy behind. See the note in `test-rust`.
+      - name: Cap target dir size
+        if: always()
+        uses: ./.github/actions/cargo-target-gc
 
   test-fhirpath:
     name: Test FHIRPath
@@ -1523,6 +1555,16 @@ jobs:
         with:
           name: pysof-${{ matrix.target }}
           path: crates/pysof/dist/*
+
+      # Runs after every upload above, so eviction can never race an artifact
+      # this job still has to publish. Unlike the jobs above this one checks out
+      # clean, so it does not accumulate across runs — but two of its four
+      # matrix legs (`Linux-ARM64` and `macOS`) land on the macOS runner and
+      # park a full release target dir there until the next tag. Bounding that
+      # is free: cargo-sweep does nothing when the dir is already under the cap.
+      - name: Cap target dir size
+        if: always()
+        uses: ./.github/actions/cargo-target-gc
 
   publish-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
## Problem

The macOS runner has been running out of disk.

Nothing in cargo ever deletes a stale artifact. Every dependency bump, toolchain update and feature-flag combination adds a new set of `.rlib`s, `.rmeta`s and incremental fragments alongside the old ones, and the old ones stay forever. On a GitHub-hosted runner that doesn't matter — the machine is thrown away. On our self-hosted runners it compounds indefinitely, because the jobs that feed `target/` check out with `clean: false` on purpose: a warm target dir is what keeps `test-rust` inside its 120-minute budget. Growth is the price of that cache, and a ceiling is the only thing that bounds it.

## Change

A `cargo-target-gc` composite action (following the existing `docker-host-gc` convention) that runs `cargo sweep --maxsize` at the end of every ci.yml job compiling Rust on a persistent runner — `test-rust`, `test-python`, `lint`, `security`, `coverage`, `build`.

**Per-run rather than a nightly cron**, for the reason `docker-host-gc` already documents: the runner fills during the working day, and a nightly sweep can't help a job that dies out of disk at 16:03. A cron would also have to be pinned to one runner, and four of these jobs use an unpinned `runs-on: [self-hosted]` and land on macOS unpredictably — so pinning would miss the jobs actually doing the accumulating.

## `--maxsize 100` is 100 MB, not 100 GB

Worth calling out explicitly, since it inverts the intent. Verified against the pinned binary rather than from docs:

```
  -m, --maxsize <MAXSIZE>
          Remove oldest artifacts from the target folder until it's smaller than MAXSIZE
          Unit defaults to MB, examples: --maxsize 500, --maxsize 10GB
```

A 100MB ceiling evicts essentially the whole warm cache on every run, so every build would start cold. Confirmed end-to-end on a scratch crate: a `1MB` cap cleaned 4.14 MiB out of a 4.4M target dir. The action passes `100GB` and **refuses a unitless value outright**, so a later edit can't reintroduce this silently.

## Other implementation notes

- **Non-fatal by construction.** Under `if: always()`, a failing sweep would turn a green build red — and `cargo install ... || true` alone doesn't fix that, because the next line still fails. Every command is guarded; the step reports via `::warning::` instead.
  - This needed a second commit to get right. Actions invokes `shell: bash` as `bash --noprofile --norc -e -o pipefail {0}`, so **errexit is already on before the script's first line** — omitting `set -e` does not disable it. The first CI run failed `Linting` on exactly that: `cargo sweep --version` on a runner without cargo-sweep exited 101 and took the script down with it. Now `set +e` explicitly, plus a trailing `exit 0`.
- **cargo-sweep pinned to 0.8.0**, installed only when absent. `>=0.7.0` is required for unit suffixes on `--maxsize`; `>=0.8.0` for Rust 1.85+ compatibility (our MSRV is 1.90).
- **Skipped on Windows** inside the action. The unpinned jobs can land there, and ci.yml already documents `shell: bash` being unreliable on that runner. Windows isn't the runner running out of space.
- Logs `du -sh target` before/after plus `df -h`, so the trend is visible per run.
- `test-fhirpath` is left alone (Windows-pinned).

## Limitations

**This is a soft cap.** cargo-sweep evicts `deps/`, `build/`, `.fingerprint/` and `incremental/` — precisely the part that compounds — but not the linked outputs at `target/<profile>/<bin>`. Those are hardlinked to their `deps/` copy (verified: link count 2), so removing the dep entry frees nothing while the top-level name survives. That residue is a small constant per profile, overwritten by the next build, and doesn't accumulate. Expect the directory to settle slightly above 100GB rather than exactly at it.

**Cap sizing:** the macOS runner has a 512GB disk (confirmed by @smunini), so a 100GB ceiling leaves ample headroom. It's an input (`with: maxsize:`) if it ever needs changing.

`~/.cargo/registry` also grows without bound, but it's single-digit GB and needs a different tool — cargo-sweep doesn't touch it. Not addressed here.

## Testing

- Both workflow files parse (`yaml.safe_load`); the action's script passes `bash -n`.
- Ran the extracted script under the **exact invocation CI uses** (`bash --noprofile --norc -e -o pipefail`) across all four paths: cargo-sweep absent and un-installable, cargo-sweep present against a real target dir, unitless maxsize, and a target dir cargo-sweep can't read. All exit 0. (The first round of local testing used plain `bash script`, which is why it missed the errexit bug above.)
- The pinned cargo-sweep 0.8.0 was installed and its `--version` output confirmed to parse as expected by the version check.

https://claude.ai/code/session_01Cqj66b1tDdvTPgL37ATMbR

