### PR TITLE
feat(ui): wire Export/Import job cards to tenant-scoped counts (#554)

### DIFF
--- a/crates/observability/src/dashboard.rs
+++ b/crates/observability/src/dashboard.rs
@@ -130,6 +130,18 @@ pub struct DashboardSeries {
     pub points: Vec<DashboardPoint>,
 }
 
+/// Bulk-export jobs for one tenant, split by lifecycle stage.
+///
+/// Carried by [`DashboardSnapshot::export_jobs`]; both figures come from the
+/// same storage read so they are always consistent with each other.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ExportJobCounts {
+    /// Jobs a worker has claimed and is executing (`in-progress`).
+    pub running: u64,
+    /// Jobs accepted and waiting for a worker slot (`accepted`).
+    pub queued: u64,
+}
+
 /// A snapshot of the figures the dashboard renders. Plain data — no storage or
 /// FHIR types — so this crate stays dependency-light.
 #[derive(Clone, Debug, Default)]
@@ -144,6 +156,15 @@ pub struct DashboardSnapshot {
     pub window: DashboardWindow,
     /// Per-type series for the charted resource types, in display order.
     pub series: Vec<DashboardSeries>,
+    /// Bulk-export jobs for the tenant.
+    ///
+    /// `None` when the running storage backend has no bulk-export job store,
+    /// the subsystem is disabled, or the count could not be read — the UI
+    /// renders an explicit "unavailable" state instead of a fabricated zero.
+    pub export_jobs: Option<ExportJobCounts>,
+    /// Non-terminal bulk-submit (import) jobs for the tenant. `None` under the
+    /// same conditions as [`Self::export_jobs`].
+    pub import_jobs_active: Option<u64>,
 }
 
 /// Supplies [`DashboardSnapshot`]s on demand. Implemented in `helios-rest` over
@@ -470,6 +491,8 @@ mod tests {
                         cumulative: 7,
                     }],
                 }],
+                export_jobs: None,
+                import_jobs_active: None,
             }
         }
     }

--- a/crates/persistence/src/backends/postgres/bulk_export.rs
+++ b/crates/persistence/src/backends/postgres/bulk_export.rs
@@ -461,6 +461,25 @@ impl BulkExportStorage for PostgresBackend {
         Ok(count as u64)
     }
 
+    async fn count_exports_by_status(
+        &self,
+        tenant: &TenantContext,
+        status: ExportStatus,
+    ) -> StorageResult<u64> {
+        let client = self.get_client().await?;
+        let tenant_id = tenant.tenant_id().as_str();
+        let status = status.to_string();
+        let row = client
+            .query_one(
+                "SELECT COUNT(*) FROM bulk_export_jobs WHERE tenant_id = $1 AND status = $2",
+                &[&tenant_id, &status],
+            )
+            .await
+            .map_err(|e| internal_error(format!("Failed to count exports by status: {e}")))?;
+        let count: i64 = row.get(0);
+        Ok(count as u64)
+    }
+
     async fn list_expired_exports(
         &self,
         now: DateTime<Utc>,

--- a/crates/persistence/src/backends/sqlite/bulk_export.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_export.rs
@@ -563,6 +563,23 @@ impl BulkExportStorage for SqliteBackend {
         Ok(count as u64)
     }
 
+    async fn count_exports_by_status(
+        &self,
+        tenant: &TenantContext,
+        status: ExportStatus,
+    ) -> StorageResult<u64> {
+        let conn = self.get_connection()?;
+        let tenant_id = tenant.tenant_id().as_str();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM bulk_export_jobs WHERE tenant_id = ?1 AND status = ?2",
+                params![tenant_id, status.to_string()],
+                |row| row.get(0),
+            )
+            .map_err(|e| internal_error(format!("Failed to count exports by status: {e}")))?;
+        Ok(count as u64)
+    }
+
     async fn list_expired_exports(
         &self,
         now: DateTime<Utc>,
@@ -1641,6 +1658,69 @@ mod tests {
                 .unwrap();
         }
         assert_eq!(backend.count_active_exports(&tenant).await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn count_exports_by_status_splits_accepted_and_in_progress_per_tenant() {
+        let backend = create_test_backend();
+        let tenant_a = create_test_tenant();
+        let tenant_b = TenantContext::new(
+            TenantId::new("other-tenant"),
+            TenantPermissions::full_access(),
+        );
+
+        backend
+            .start_export(&tenant_a, test_input(ExportRequest::system()))
+            .await
+            .unwrap();
+        backend
+            .start_export(&tenant_a, test_input(ExportRequest::system()))
+            .await
+            .unwrap();
+
+        // Move one of tenant A's jobs to in-progress via the real worker path.
+        let worker = WorkerId::new("worker-1");
+        let lease = backend
+            .claim_next(&worker, StdDuration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("a job should be claimable");
+        backend
+            .mark_export_in_progress(&tenant_a, &lease.job_id, &worker, lease.fencing_token)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            backend
+                .count_exports_by_status(&tenant_a, ExportStatus::Accepted)
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            backend
+                .count_exports_by_status(&tenant_a, ExportStatus::InProgress)
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            backend
+                .count_exports_by_status(&tenant_a, ExportStatus::Complete)
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            backend
+                .count_exports_by_status(&tenant_b, ExportStatus::Accepted)
+                .await
+                .unwrap(),
+            0
+        );
+
+        // The concurrency-cap aggregate is unaffected by the new method.
+        assert_eq!(backend.count_active_exports(&tenant_a).await.unwrap(), 2);
     }
 
     #[tokio::test]

--- a/crates/persistence/src/core/bulk_export.rs
+++ b/crates/persistence/src/core/bulk_export.rs
@@ -994,6 +994,17 @@ pub trait BulkExportStorage: Send + Sync {
     /// enforce the per-tenant concurrency cap at kickoff.
     async fn count_active_exports(&self, tenant: &TenantContext) -> StorageResult<u64>;
 
+    /// Counts the tenant's export jobs currently in `status`.
+    ///
+    /// Used by the dashboard to show the running (`in-progress`) / queued
+    /// (`accepted`) split. The per-tenant concurrency cap keeps using
+    /// [`count_active_exports`](Self::count_active_exports).
+    async fn count_exports_by_status(
+        &self,
+        tenant: &TenantContext,
+        status: ExportStatus,
+    ) -> StorageResult<u64>;
+
     /// Lists expired completed jobs across *all* tenants, for the cleanup task.
     ///
     /// This is intentionally cross-tenant — the cleanup task is a server-wide

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -4887,6 +4887,13 @@ mod postgres_integration {
                 .unwrap();
         }
         assert_eq!(backend.count_active_exports(&tenant).await.unwrap(), 2);
+        assert_eq!(
+            backend
+                .count_exports_by_status(&tenant, ExportStatus::Accepted)
+                .await
+                .unwrap(),
+            2
+        );
 
         // Nothing is expired yet.
         let expired_now = backend

--- a/crates/rest/src/dashboard.rs
+++ b/crates/rest/src/dashboard.rs
@@ -21,8 +21,11 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use helios_observability::dashboard::{
     DashboardPoint, DashboardProvider, DashboardSeries, DashboardSnapshot, DashboardWindow,
+    ExportJobCounts,
 };
-use helios_persistence::core::{ResourceStorage, bucket_floor};
+use helios_persistence::core::{
+    BulkExportJobStore, BulkSubmitJobStore, ExportStatus, ResourceStorage, bucket_floor,
+};
 use helios_persistence::error::StorageResult;
 use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
 use tracing::warn;
@@ -182,12 +185,17 @@ pub(crate) struct StorageDashboardProvider<S> {
     fhir_version: String,
     types: Vec<String>,
     storage: Arc<S>,
+    /// Bulk-export job store, when the active backend provides one.
+    export_jobs: Option<Arc<dyn BulkExportJobStore>>,
+    /// Bulk-submit job store, when the active backend provides one.
+    submit_jobs: Option<Arc<dyn BulkSubmitJobStore>>,
 }
 
 impl<S> StorageDashboardProvider<S> {
     /// Builds a provider for the server's default tenant and default FHIR
     /// version, charting [`DEFAULT_DASHBOARD_TYPES`]. The window is chosen per
-    /// request by the UI, so it is not fixed here.
+    /// request by the UI, so it is not fixed here. Job-store counts start
+    /// unwired; call [`Self::with_job_stores`] to attach them.
     pub(crate) fn new(storage: Arc<S>, config: &ServerConfig) -> Self {
         Self {
             default_tenant: config.default_tenant.clone(),
@@ -197,7 +205,23 @@ impl<S> StorageDashboardProvider<S> {
                 .map(|t| t.to_string())
                 .collect(),
             storage,
+            export_jobs: None,
+            submit_jobs: None,
         }
+    }
+
+    /// Attaches the bulk-export and bulk-submit job stores, when the running
+    /// deployment has them. Passing `None` for either leaves the
+    /// corresponding snapshot field at `None` (unavailable) rather than a
+    /// fabricated zero.
+    pub(crate) fn with_job_stores(
+        mut self,
+        export_jobs: Option<Arc<dyn BulkExportJobStore>>,
+        submit_jobs: Option<Arc<dyn BulkSubmitJobStore>>,
+    ) -> Self {
+        self.export_jobs = export_jobs;
+        self.submit_jobs = submit_jobs;
+        self
     }
 }
 
@@ -256,12 +280,48 @@ where
                 0
             });
 
+        // Job counts degrade to `None` (unavailable) rather than zero on a read
+        // error: a zero here would tell an operator "no jobs" when the truth is
+        // "could not ask". `None` also covers the normal case of a deployment
+        // with no bulk-export/bulk-submit job store wired at all.
+        let export_jobs = match &self.export_jobs {
+            None => None,
+            Some(store) => {
+                let running = store
+                    .count_exports_by_status(&tenant, ExportStatus::InProgress)
+                    .await;
+                let queued = store
+                    .count_exports_by_status(&tenant, ExportStatus::Accepted)
+                    .await;
+                match (running, queued) {
+                    (Ok(running), Ok(queued)) => Some(ExportJobCounts { running, queued }),
+                    (Err(error), _) | (_, Err(error)) => {
+                        warn!(%error, "dashboard snapshot: export job count query failed");
+                        None
+                    }
+                }
+            }
+        };
+
+        let import_jobs_active = match &self.submit_jobs {
+            None => None,
+            Some(store) => match store.count_active_submissions(&tenant).await {
+                Ok(n) => Some(n),
+                Err(error) => {
+                    warn!(%error, "dashboard snapshot: import job count query failed");
+                    None
+                }
+            },
+        };
+
         DashboardSnapshot {
             fhir_version: self.fhir_version.clone(),
             total_resources,
             distinct_types,
             window,
             series,
+            export_jobs,
+            import_jobs_active,
         }
     }
 }
@@ -480,5 +540,128 @@ mod tests {
 
     fn test_tenant() -> TenantContext {
         TenantContext::new(TenantId::new("default"), TenantPermissions::full_access())
+    }
+
+    /// Wraps an `ExportRequest` in a `StartExportInput` with default kickoff
+    /// metadata, mirroring the sqlite backend's own test helper.
+    fn test_export_input(
+        request: helios_persistence::core::ExportRequest,
+    ) -> helios_persistence::core::StartExportInput {
+        helios_persistence::core::StartExportInput {
+            request,
+            transaction_time: Utc::now(),
+            request_url: "http://localhost/$export".to_string(),
+            owner_subject: Some("test-subject".to_string()),
+            fhir_version: helios_fhir::FhirVersion::default(),
+        }
+    }
+
+    /// With no job stores wired (the default from `new`), both job-count
+    /// fields stay `None` — this is a normal, unconfigured state, not an error.
+    #[tokio::test]
+    async fn job_counts_are_unavailable_when_no_job_stores_are_wired() {
+        let backend = SqliteBackend::in_memory().expect("in-memory sqlite backend");
+        backend.init_schema().expect("init schema");
+        let config = ServerConfig {
+            default_tenant: "default".to_string(),
+            ..ServerConfig::for_testing()
+        };
+
+        let provider = StorageDashboardProvider::new(Arc::new(backend), &config);
+        let snapshot = provider.snapshot(DashboardWindow::default(), "").await;
+
+        assert_eq!(snapshot.export_jobs, None);
+        assert_eq!(snapshot.import_jobs_active, None);
+    }
+
+    /// With both job stores wired but nothing submitted yet, the counts are
+    /// real zeros — distinct from the "not wired" `None` case above.
+    #[tokio::test]
+    async fn job_counts_are_zero_over_empty_job_stores() {
+        let backend = Arc::new(SqliteBackend::in_memory().expect("in-memory sqlite backend"));
+        backend.init_schema().expect("init schema");
+        let config = ServerConfig {
+            default_tenant: "default".to_string(),
+            ..ServerConfig::for_testing()
+        };
+
+        // SqliteBackend implements both BulkExportJobStore and BulkSubmitJobStore,
+        // so the same Arc can stand in for storage and both job stores.
+        let export_jobs = Arc::clone(&backend) as Arc<dyn BulkExportJobStore>;
+        let submit_jobs = Arc::clone(&backend) as Arc<dyn BulkSubmitJobStore>;
+        let provider = StorageDashboardProvider::new(Arc::clone(&backend), &config)
+            .with_job_stores(Some(export_jobs), Some(submit_jobs));
+        let snapshot = provider.snapshot(DashboardWindow::default(), "").await;
+
+        assert_eq!(
+            snapshot.export_jobs,
+            Some(ExportJobCounts {
+                running: 0,
+                queued: 0
+            })
+        );
+        assert_eq!(snapshot.import_jobs_active, Some(0));
+    }
+
+    /// Real export jobs in `accepted` and `in-progress` state, plus a real
+    /// active submission, are reflected exactly in the snapshot.
+    #[tokio::test]
+    async fn job_counts_reflect_accepted_and_in_progress_exports() {
+        use helios_persistence::core::{
+            BulkExportStorage, BulkSubmitProvider, ExportClaimStrategy, ExportRequest,
+            ExportWorkerStorage, SubmissionId, WorkerId,
+        };
+
+        let backend = Arc::new(SqliteBackend::in_memory().expect("in-memory sqlite backend"));
+        backend.init_schema().expect("init schema");
+        let config = ServerConfig {
+            default_tenant: "default".to_string(),
+            ..ServerConfig::for_testing()
+        };
+        let tenant = test_tenant();
+
+        // Two export jobs: one stays `accepted`, the other is claimed and
+        // driven to `in-progress` through the real worker path.
+        backend
+            .start_export(&tenant, test_export_input(ExportRequest::system()))
+            .await
+            .expect("start export 1");
+        backend
+            .start_export(&tenant, test_export_input(ExportRequest::system()))
+            .await
+            .expect("start export 2");
+
+        let worker = WorkerId::new("worker-1");
+        let lease = backend
+            .claim_next(&worker, std::time::Duration::from_secs(60))
+            .await
+            .expect("claim_next succeeds")
+            .expect("a job should be claimable");
+        backend
+            .mark_export_in_progress(&tenant, &lease.job_id, &worker, lease.fencing_token)
+            .await
+            .expect("mark in progress");
+
+        // One active submission (freshly created submissions start `in-progress`).
+        let submission_id = SubmissionId::generate("test-system");
+        backend
+            .create_submission(&tenant, &submission_id, None)
+            .await
+            .expect("create submission");
+
+        let export_jobs = Arc::clone(&backend) as Arc<dyn BulkExportJobStore>;
+        let submit_jobs = Arc::clone(&backend) as Arc<dyn BulkSubmitJobStore>;
+        let provider = StorageDashboardProvider::new(Arc::clone(&backend), &config)
+            .with_job_stores(Some(export_jobs), Some(submit_jobs));
+        let snapshot = provider.snapshot(DashboardWindow::default(), "").await;
+
+        assert_eq!(
+            snapshot.export_jobs,
+            Some(ExportJobCounts {
+                running: 1,
+                queued: 1
+            })
+        );
+        assert_eq!(snapshot.import_jobs_active, Some(1));
     }
 }

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -589,11 +589,16 @@ where
     let storage_arc = storage;
 
     // Register the process-global dashboard data provider so the web UI can
-    // render real per-type resource counts (default tenant) without depending on
-    // the persistence layer. Storage-agnostic consumers read it via
-    // `helios_observability::dashboard::snapshot()`.
+    // render real per-type resource counts (default tenant), plus bulk-export
+    // and bulk-submit job counts when those subsystems are wired, without
+    // depending on the persistence layer. Storage-agnostic consumers read it
+    // via `helios_observability::dashboard::snapshot()`.
     helios_observability::dashboard::set_provider(Arc::new(
-        dashboard::StorageDashboardProvider::new(Arc::clone(&storage_arc), &config),
+        dashboard::StorageDashboardProvider::new(Arc::clone(&storage_arc), &config)
+            .with_job_stores(
+                bulk_export.as_ref().map(|b| Arc::clone(&b.jobs)),
+                bulk_submit.as_ref().map(|b| Arc::clone(&b.jobs)),
+            ),
     ));
 
     let (app_audit_sink, app_audit_source_observer) = audit_state

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -634,6 +634,25 @@ button.menu__option {
   color: var(--muted);
 }
 
+.stat--link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.stat--link:hover {
+  border-color: var(--accent);
+}
+
+.stat--link:focus-visible {
+  outline: 2px solid var(--outline);
+  outline-offset: 2px;
+}
+
+.stat__value--unavailable {
+  color: var(--muted);
+}
+
 /* ---------- Chart card ---------- */
 
 .chart-card {
@@ -789,6 +808,16 @@ button.pill {
 .stat-grid--2 {
   grid-template-columns: repeat(2, 1fr);
   max-width: 620px;
+}
+
+.stat-grid--5 {
+  grid-template-columns: repeat(5, 1fr);
+}
+
+@media (max-width: 1100px) {
+  .stat-grid--5 {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .notice {

--- a/crates/ui/e2e/pages/dashboard.ts
+++ b/crates/ui/e2e/pages/dashboard.ts
@@ -12,6 +12,12 @@ export class DashboardPage {
   get statCards(): Locator {
     return this.page.locator(".card.stat");
   }
+  get exportJobsCard(): Locator {
+    return this.page.locator("a.card.stat", { hasText: "Export jobs" });
+  }
+  get importJobsCard(): Locator {
+    return this.page.locator("a.card.stat", { hasText: "Import jobs" });
+  }
   get chart(): Locator {
     return this.page.locator("svg.chart");
   }

--- a/crates/ui/e2e/tests/dashboard.spec.ts
+++ b/crates/ui/e2e/tests/dashboard.spec.ts
@@ -6,8 +6,24 @@ import { test, expect } from "../pages/fixtures";
 
 test("the dashboard renders its stat cards and chart", async ({ dashboard }) => {
   await dashboard.goto();
-  await expect(dashboard.statCards).toHaveCount(4);
+  await expect(dashboard.statCards).toHaveCount(5);
   await expect(dashboard.chart).toBeVisible();
+});
+
+test("export and import job cards show real counts and link to their pages", async ({ dashboard }) => {
+  await dashboard.goto();
+
+  const exportCard = dashboard.exportJobsCard;
+  await expect(exportCard).toBeVisible();
+  await expect(exportCard).toHaveAttribute("href", "/ui/bulk-export");
+  await expect(exportCard.locator(".stat__value")).toHaveText(/^\d+$/);
+  await expect(exportCard.locator(".stat__sub")).toHaveText(/running \(\d+ queued\)/);
+
+  const importCard = dashboard.importJobsCard;
+  await expect(importCard).toBeVisible();
+  await expect(importCard).toHaveAttribute("href", "/ui/bulk-import");
+  await expect(importCard.locator(".stat__value")).toHaveText(/^\d+$/);
+  await expect(importCard.locator(".stat__sub")).toHaveText("active");
 });
 
 test("the time-window selector re-renders over the chosen window", async ({ page, dashboard }) => {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -62,7 +62,7 @@ use axum_embed::ServeEmbed;
 use axum_htmx::{AutoVaryLayer, HxRequest};
 use chrono::{DateTime, Datelike, Duration, Utc};
 use helios_observability::dashboard::{
-    DashboardPoint, DashboardSeries, DashboardSnapshot, DashboardWindow,
+    DashboardPoint, DashboardSeries, DashboardSnapshot, DashboardWindow, ExportJobCounts,
 };
 use helios_persistence::core::{ResourceStorage, SettingsStore};
 use i18n::{I18n, RequestLocale};
@@ -322,18 +322,20 @@ impl Status {
 /// Dashboard headline metrics rendered by `pages/index.html` (design: Figma
 /// "Dashboard V1.1").
 ///
-/// `resource_types`, `stored_resources`, `fhir_version`, and `chart_total` are
-/// derived from the live [`DashboardSnapshot`] (default tenant). `export_jobs`,
-/// `export_jobs_queued`, and `uptime_percent` describe other subsystems (bulk
-/// export job state; availability history) that are not part of the
-/// resource-count read path and remain placeholder values until those read paths
-/// land.
+/// `resource_types`, `stored_resources`, `fhir_version`, `export_jobs`,
+/// `import_jobs`, and `chart_total` are derived from the live
+/// [`DashboardSnapshot`] (default tenant). `uptime_percent` describes
+/// availability history, which is not part of that read path and remains a
+/// placeholder value until #540 wires it to a real source.
 struct DashboardMetrics {
     fhir_version: String,
     resource_types: String,
     stored_resources: String,
-    export_jobs: String,
-    export_jobs_queued: u32,
+    /// Bulk-export jobs for the tenant; `None` renders the unavailable state.
+    export_jobs: Option<ExportJobCounts>,
+    /// Active bulk-submit (import) jobs for the tenant; `None` renders the
+    /// unavailable state.
+    import_jobs: Option<u64>,
     uptime_percent: String,
     chart_total: String,
 }
@@ -1368,10 +1370,9 @@ fn build_dashboard(
         fhir_version: snapshot.fhir_version.clone(),
         resource_types: snapshot.distinct_types.to_string(),
         stored_resources: compact_count(snapshot.total_resources),
-        // Not part of the resource-count read path — placeholder until the bulk
-        // export job-state and availability read paths are wired.
-        export_jobs: "13".to_string(),
-        export_jobs_queued: 1,
+        export_jobs: snapshot.export_jobs,
+        import_jobs: snapshot.import_jobs_active,
+        // Uptime is still a placeholder until #540 wires it to a real source.
         uptime_percent: "99.98".to_string(),
         chart_total: selected_series
             .map(|s| grouped(s.total))

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1594,6 +1594,8 @@ fn sample_snapshot(window: DashboardWindow) -> DashboardSnapshot {
         distinct_types: 142,
         window,
         series,
+        export_jobs: None,
+        import_jobs_active: None,
     }
 }
 
@@ -2003,6 +2005,8 @@ mod tests {
             distinct_types: 0,
             window: DashboardWindow::default(),
             series: Vec::new(),
+            export_jobs: None,
+            import_jobs_active: None,
         };
         let (metrics, chart, legend, windows) = build_dashboard(&empty, None);
         assert!(!chart.has_data);

--- a/crates/ui/templates/pages/index.html
+++ b/crates/ui/templates/pages/index.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="page-title">{{ i18n.t("nav-home") }}</h1>
 
-<section class="stat-grid">
+<section class="stat-grid stat-grid--5">
   <article class="card stat">
     <span class="stat__label">{{ i18n.t("card-resource-types") }}</span>
     <span class="stat__value">{{ metrics.resource_types }}</span>
@@ -14,11 +14,26 @@
     <span class="stat__value">{{ metrics.stored_resources }}</span>
     <span class="stat__sub">{{ i18n.t("card-stored-resources-sub") }}</span>
   </article>
-  <article class="card stat">
+  <a class="card stat stat--link" href="/ui/bulk-export">
     <span class="stat__label">{{ i18n.t("card-export-jobs") }}</span>
-    <span class="stat__value">{{ metrics.export_jobs }}</span>
-    <span class="stat__sub">{{ i18n.t_arg("card-export-jobs-sub", "queued", metrics.export_jobs_queued) }}</span>
-  </article>
+    {% if let Some(jobs) = metrics.export_jobs %}
+    <span class="stat__value">{{ jobs.running }}</span>
+    <span class="stat__sub">{{ i18n.t_arg("card-export-jobs-sub", "queued", jobs.queued) }}</span>
+    {% else %}
+    <span class="stat__value stat__value--unavailable" aria-label="{{ i18n.t("card-jobs-unavailable") }}">&mdash;</span>
+    <span class="stat__sub">{{ i18n.t("card-jobs-unavailable") }}</span>
+    {% endif %}
+  </a>
+  <a class="card stat stat--link" href="/ui/bulk-import">
+    <span class="stat__label">{{ i18n.t("card-import-jobs") }}</span>
+    {% if let Some(active) = metrics.import_jobs %}
+    <span class="stat__value">{{ active }}</span>
+    <span class="stat__sub">{{ i18n.t("card-import-jobs-sub") }}</span>
+    {% else %}
+    <span class="stat__value stat__value--unavailable" aria-label="{{ i18n.t("card-jobs-unavailable") }}">&mdash;</span>
+    <span class="stat__sub">{{ i18n.t("card-jobs-unavailable") }}</span>
+    {% endif %}
+  </a>
   <article class="card stat">
     <span class="stat__label">{{ i18n.t("card-uptime") }}</span>
     <span class="stat__value">{{ metrics.uptime_percent }}<span class="stat__unit">%</span></span>

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -63,6 +63,28 @@ async fn index_serves_the_full_landing_page() {
 }
 
 #[tokio::test]
+async fn dashboard_renders_job_cards_with_unavailable_state_when_no_provider() {
+    // No DashboardProvider is registered in this test router, so build_index_page
+    // falls back to sample_snapshot, whose export_jobs/import_jobs_active are
+    // both None — the dashboard must render the explicit "unavailable" state
+    // rather than any fabricated numbers.
+    let response = app()
+        .oneshot(Request::get("/ui").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    assert!(html.contains("Export jobs"));
+    assert!(html.contains("Import jobs"));
+    assert!(html.contains(r#"href="/ui/bulk-export""#));
+    assert!(html.contains(r#"href="/ui/bulk-import""#));
+    assert!(html.contains("unavailable"));
+    assert!(!html.contains(">13<"));
+    assert!(!html.contains("queued)"));
+}
+
+#[tokio::test]
 async fn page_wires_the_hover_rail_nav() {
     let response = app()
         .oneshot(Request::get("/ui").body(Body::empty()).unwrap())

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -135,6 +135,9 @@ card-stored-resources = Gespeicherte Ressourcen
 card-stored-resources-sub = im aktiven Tenant
 card-export-jobs = Export-Jobs
 card-export-jobs-sub = laufend ({ $queued } in der Warteschlange)
+card-import-jobs = Import-Jobs
+card-import-jobs-sub = aktiv
+card-jobs-unavailable = nicht verfügbar
 card-uptime = Verfügbarkeit
 card-uptime-sub = letzte 30 Tage
 

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -139,6 +139,9 @@ card-stored-resources = Stored resources
 card-stored-resources-sub = across active tenant
 card-export-jobs = Export jobs
 card-export-jobs-sub = running ({ $queued } queued)
+card-import-jobs = Import jobs
+card-import-jobs-sub = active
+card-jobs-unavailable = unavailable
 card-uptime = Uptime
 card-uptime-sub = last 30 days
 

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -135,6 +135,9 @@ card-stored-resources = Recursos almacenados
 card-stored-resources-sub = en el tenant activo
 card-export-jobs = Trabajos de exportación
 card-export-jobs-sub = en ejecución ({ $queued } en cola)
+card-import-jobs = Trabajos de importación
+card-import-jobs-sub = activos
+card-jobs-unavailable = no disponible
 card-uptime = Disponibilidad
 card-uptime-sub = últimos 30 días
 


### PR DESCRIPTION
Closes #554.

## What
- The Export jobs card now shows the tenant's real running / queued bulk-export counts (it was a hardcoded "13 / 1 queued").
- New Import jobs card with the tenant's active bulk-submit count, linking to /ui/bulk-import.
- Both cards render an explicit "unavailable" state (em dash + aria-label) when the running backend has no job store or the count cannot be read — never a fabricated zero.
- Both cards are links (`<a class="card stat stat--link">`): Export → /ui/bulk-export, Import → /ui/bulk-import.
- Stat grid gets a `stat-grid--5` modifier (5 cols on desktop, 3 ≤1100px, existing 2-col rule ≤900px).

## How
- persistence: `BulkExportStorage::count_exports_by_status(tenant, status)` (SQLite + Postgres, additive). `count_active_exports` is untouched — it still backs the concurrency cap.
- observability: `DashboardSnapshot` gains `export_jobs: Option<ExportJobCounts { running, queued }>` and `import_jobs_active: Option<u64>`; `None` means unavailable.
- rest: `StorageDashboardProvider::with_job_stores(..)` receives the optional bulk-export / bulk-submit job stores already built in `build_app` and fills the two fields. running = `in-progress`, queued = `accepted`. A read error logs a warning and yields `None`; no store wired yields `None` silently.
- ui: `DashboardMetrics` carries `Option`s, template + CSS + i18n (en/es/de) + HTTP test; e2e page object and spec cover both cards (stat-card count 4 → 5).

## Decisions (as requested by the issue)
- Per-tenant job counts come from the authenticated dashboard snapshot, not `/metrics`; nothing per-tenant is added to `/metrics`.
- Process-wide export/import Prometheus metrics: **not added here** — recorded decision; happy to file a follow-up issue if wanted (would instrument the workers, no tenant label).
- The running/queued split is backed by real data (`in-progress` / `accepted`); the card copy is unchanged.
- Uptime is untouched (#540, @angela-helios); only the placeholder comment next to it was reworded to cover uptime alone.
- 5-column grid kept after a visual check at 1440/1200/1000/800px (dark + light); the es labels wrap to two lines around 1200px but stay within the card.

## Coordination
- Depends on #538 for `/ui/bulk-export` (Export card link) — merge this after #538. If #538 changes the route name, the href in `crates/ui/templates/pages/index.html` and the e2e assertion are the only two places to touch.
- The issue mentions a `max-width: 1081px` breakpoint; `app.css` has no such rule — the existing 900px rule plus a new 1100px rule for the 5-col grid are used instead.

## Testing
- `cargo fmt --all -- --check`, workspace `cargo clippy --all-targets --all-features -D warnings` (CI allow-list), `cargo test -p helios-persistence bulk_export` (SQLite unit + Postgres via testcontainers), `cargo test -p helios-observability -p helios-rest -p helios-ui`, `cargo build -p helios-hfs --features ui`.
- Manual: `hfs` on SQLite → `/ui` shows Export "0 / running (0 queued)" and Import "0 / active".
- Playwright: spec compiles and is discovered (`--list`); the full browser run relies on CI (`ui-tests.yml`) — Chromium could not be downloaded on the dev box.
