### PR TITLE
fix(ui): close menu dropdowns on outside click and Esc, add an X to Recent

### DIFF
--- a/crates/ui/assets/addbox.js
+++ b/crates/ui/assets/addbox.js
@@ -1,9 +1,12 @@
-/* Close behavior for <details class="addbox"> disclosures (#545): Esc closes
-   the open panel, a [data-addbox-close] control closes its own panel, and a
-   click outside any open panel closes it. The disclosures stay fully usable
-   without this script — it only adds ways out. */
+/* Close behavior for <details class="addbox"> disclosures (#545) and
+   <details class="menu"> dropdowns (tenant and version pickers, recent
+   searches): Esc closes the open panel, a [data-addbox-close] control closes
+   its own panel, and a click outside any open panel closes it. The disclosures
+   stay fully usable without this script — it only adds ways out. */
 (function () {
   "use strict";
+
+  var OPEN = "details.addbox[open], details.menu[open]";
 
   function close(box) {
     box.removeAttribute("open");
@@ -11,20 +14,20 @@
 
   document.addEventListener("keydown", function (event) {
     if (event.key !== "Escape") return;
-    document.querySelectorAll("details.addbox[open]").forEach(close);
+    document.querySelectorAll(OPEN).forEach(close);
   });
 
   document.addEventListener("click", function (event) {
     var closer = event.target.closest("[data-addbox-close]");
     if (closer) {
-      var own = closer.closest("details.addbox");
+      var own = closer.closest("details.addbox, details.menu");
       if (own) {
         event.preventDefault();
         close(own);
       }
       return;
     }
-    document.querySelectorAll("details.addbox[open]").forEach(function (box) {
+    document.querySelectorAll(OPEN).forEach(function (box) {
       if (!box.contains(event.target)) close(box);
     });
   });

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -4200,6 +4200,13 @@ body.has-nav-panel {
   gap: 10px;
 }
 
+.menu__heading--row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
 .addbox__x {
   border: 0;
   background: none;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1816,6 +1816,9 @@ mod tests {
         assert!(html.contains(r#"data-intent="run""#));
         assert!(html.contains(r#"data-intent="save""#));
         assert!(html.contains(r#"id="recent-searches""#));
+        // The Recent panel closes from an explicit X as well as outside
+        // click / Esc (addbox.js covers details.menu too).
+        assert!(html.contains("data-addbox-close"));
         // Resource picker rail: the version's full type list, with count
         // slots the script hydrates via _summary=count.
         assert!(html.contains(r#"data-rail-type="Patient""#));

--- a/crates/ui/templates/partials/search-builder.html
+++ b/crates/ui/templates/partials/search-builder.html
@@ -31,7 +31,11 @@
         {{ i18n.t("queries-recent") }}
       </summary>
       <div class="menu__panel menu__panel--right">
-        <div class="menu__heading">{{ i18n.t("queries-recent-heading") }}</div>
+        <div class="menu__heading menu__heading--row">
+          {{ i18n.t("queries-recent-heading") }}
+          <button type="button" class="addbox__x" data-addbox-close
+                  aria-label="{{ i18n.t("ui-close") }}" title="{{ i18n.t("ui-close") }}">×</button>
+        </div>
         <div id="recent-searches"
              data-msg-empty="{{ i18n.t("queries-recent-empty") }}"
              data-msg-delete="{{ i18n.t("queries-delete") }}"


### PR DESCRIPTION
The Recent-searches popup on Search / Saved Queries only closed by re-clicking its toggle (or by picking an entry). Manual testing flagged that it should also close on an outside click and from an explicit control.

## What changed

- `addbox.js` (#545) now covers `<details class="menu">` dropdowns as well as `details.addbox`: an outside click closes any open panel, Esc closes them, and `[data-addbox-close]` closes its own panel. That picks up the Recent popup **and** the sidebar's tenant and FHIR-version selectors, which had the same gap — all the chrome dropdowns now behave alike.
- The Recent panel's heading row gains an X (`data-addbox-close`, `aria-label`/`title` from the existing `ui-close` key, so no new i18n strings).
- The dropdowns remain fully usable without JavaScript — the script only adds ways out, same contract as #545.

## Tests

- Extended the existing queries-page render test to assert the close control ships (`data-addbox-close`).
- `cargo test -p helios-ui --lib`: 67 passed.
- Exercised manually: outside click, Esc, and the X on the Recent popup; outside click and Esc on the tenant and version menus.