### PR TITLE
feat(ui): link the editor's guided form and JSON view — live sync, cross-highlight, type-honest edits

### DIFF
--- a/crates/fhir-validator/src/editor.rs
+++ b/crates/fhir-validator/src/editor.rs
@@ -606,23 +606,58 @@ pub fn remove_at(document: &mut Value, path: &[Step]) -> bool {
 
 /// Sets a primitive value at `path`. An empty string removes the element rather
 /// than storing `""`, which is not a valid FHIR primitive.
-pub fn set_value(document: &mut Value, path: &[Step], raw: &str) -> bool {
+pub fn set_value(
+    resolver: &dyn SchemaResolver,
+    root_type: &str,
+    document: &mut Value,
+    path: &[Step],
+    raw: &str,
+) -> bool {
     if raw.is_empty() {
         return remove_at(document, path);
     }
+    let declared = schema_at(resolver, root_type, path).and_then(|schema| schema.type_.clone());
     let Some(node) = node_at_mut(document, path) else {
         return false;
     };
-    // Keep JSON types honest: booleans and numbers are not strings in FHIR.
-    *node = match raw {
-        "true" => Value::Bool(true),
-        "false" => Value::Bool(false),
-        _ => match raw.parse::<i64>() {
-            Ok(number) if !raw.starts_with('0') || raw == "0" => Value::from(number),
+    *node = coerce_primitive(declared.as_deref(), raw);
+    true
+}
+
+/// The JSON type the declared FHIR primitive demands. Only booleans and the
+/// numeric primitives leave string-land; a date of `1974`, an id of `123`, or
+/// an identifier value of `12345` merely *looks* numeric and must stay a
+/// string — guessing from the shape of the text turned all of them into JSON
+/// numbers the validator then rejected. (`integer64` stays a string too: FHIR
+/// serializes it that way.) An element the schema does not know keeps the old
+/// shape-based guess, so unknown keys still round-trip their JSON types.
+fn coerce_primitive(declared: Option<&str>, raw: &str) -> Value {
+    match declared {
+        Some("boolean") => match raw {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
             _ => Value::String(raw.to_string()),
         },
-    };
-    true
+        Some("integer") | Some("positiveInt") | Some("unsignedInt") => raw
+            .parse::<i64>()
+            .map(Value::from)
+            .unwrap_or_else(|_| Value::String(raw.to_string())),
+        Some("decimal") => match raw.parse::<f64>() {
+            Ok(number) if number.is_finite() => serde_json::Number::from_f64(number)
+                .map(Value::Number)
+                .unwrap_or_else(|| Value::String(raw.to_string())),
+            _ => Value::String(raw.to_string()),
+        },
+        Some(_) => Value::String(raw.to_string()),
+        None => match raw {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            _ => match raw.parse::<i64>() {
+                Ok(number) if !raw.starts_with('0') || raw == "0" => Value::from(number),
+                _ => Value::String(raw.to_string()),
+            },
+        },
+    }
 }
 
 /// Picks a concrete arm of a `value[x]`: creates `valueString` and drops any
@@ -1077,15 +1112,60 @@ mod tests {
 
     #[test]
     fn setting_a_value_keeps_json_types_honest() {
+        let registry = registry();
+        let resolver = registry.as_ref();
         let mut patient = donald();
-        add_element(registry().as_ref(), "Patient", &mut patient, &[], "active").unwrap();
+        add_element(resolver, "Patient", &mut patient, &[], "active").unwrap();
 
-        set_value(&mut patient, &path_from_string("active"), "true");
+        set_value(resolver, "Patient", &mut patient, &path_from_string("active"), "true");
         assert_eq!(patient["active"], json!(true));
 
         // Clearing a field removes it rather than storing "".
-        set_value(&mut patient, &path_from_string("active"), "");
+        set_value(resolver, "Patient", &mut patient, &path_from_string("active"), "");
         assert!(patient.get("active").is_none());
+    }
+
+    #[test]
+    fn coercion_follows_the_declared_type_not_the_shape_of_the_text() {
+        let registry = registry();
+        let resolver = registry.as_ref();
+        let mut patient = donald();
+
+        // A year-precision date is legal FHIR and must stay a string, even
+        // though it parses as an integer.
+        add_element(resolver, "Patient", &mut patient, &[], "birthDate").unwrap();
+        set_value(resolver, "Patient", &mut patient, &path_from_string("birthDate"), "1974");
+        assert_eq!(patient["birthDate"], json!("1974"));
+
+        // Same for string-typed elements whose content merely looks numeric.
+        add_element(resolver, "Patient", &mut patient, &[], "identifier").unwrap();
+        add_element(
+            resolver,
+            "Patient",
+            &mut patient,
+            &path_from_string("identifier.0"),
+            "value",
+        )
+        .unwrap();
+        set_value(
+            resolver,
+            "Patient",
+            &mut patient,
+            &path_from_string("identifier.0.value"),
+            "12345",
+        );
+        assert_eq!(patient["identifier"][0]["value"], json!("12345"));
+
+        // A key the schema does not know keeps the old shape-based guess.
+        patient["unknownField"] = json!(0);
+        set_value(
+            resolver,
+            "Patient",
+            &mut patient,
+            &path_from_string("unknownField"),
+            "7",
+        );
+        assert_eq!(patient["unknownField"], json!(7));
     }
 }
 

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2987,6 +2987,21 @@ button.filter-rail__item {
   line-height: 1.6;
 }
 
+/* Form ↔ JSON cross-highlight (editor-sync.js): hovering or focusing a form
+   row lights the JSON lines that hold that node, and vice versa. */
+.json-line--hit {
+  background: var(--accent-soft);
+}
+
+.json-line[data-jpath] .json-line__code {
+  cursor: pointer;
+}
+
+.editor-row--hit {
+  background: var(--accent-soft);
+  border-radius: 8px;
+}
+
 .json-line {
   display: flex;
   align-items: baseline;
@@ -3914,9 +3929,14 @@ body.has-nav-panel {
   font-weight: 600;
 }
 
-.editor-row__name {
+/* The element's short description rides second to its name, quiet, one line. */
+.editor-row__desc {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 11px;
 }
 

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -3115,6 +3115,7 @@ button.filter-rail__item {
 .editor-row__head {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   min-height: 28px;
 }
@@ -3133,7 +3134,9 @@ button.filter-rail__item {
 
 .editor-row__input {
   flex: 1;
-  min-width: 0;
+  /* Never squeezed below a usable width — the head wraps it to its own line
+     instead of eating the content. */
+  min-width: 180px;
   max-width: 420px;
   height: 28px;
   padding: 0 10px;
@@ -3973,15 +3976,13 @@ body.has-nav-panel {
   font-weight: 600;
 }
 
-/* The element's short description rides second to its name, quiet, one line. */
+/* The element's short description sits on its own line under the head, so it
+   can never squeeze the input out of the row. */
 .editor-row__desc {
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  margin: 2px 0 0;
   color: var(--muted);
   font-size: 11px;
+  line-height: 1.4;
 }
 
 .editor-row__ms,

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -3358,6 +3358,49 @@ button.filter-rail__item {
   resize: vertical;
 }
 
+/* Raw-mode highlight (editor-sync.js): a mirror <pre> sits behind the
+   textarea with identical metrics; its text is invisible and only the <mark>
+   around the hovered node's range shows through the textarea, whose own
+   background goes transparent while the mirror is present. */
+.editor-json__raw {
+  position: relative;
+}
+
+.editor-json__raw--mirrored .editor__source {
+  position: relative;
+  z-index: 1;
+  background: transparent;
+}
+
+.editor__source-mirror {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 12px;
+  box-sizing: border-box;
+  overflow: hidden;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: normal;
+  color: transparent;
+  background: var(--input-bg);
+  border: 1px solid transparent;
+  border-radius: 10px;
+}
+
+.editor__source-mirror mark {
+  color: transparent;
+  background: var(--accent-soft);
+  border-radius: 3px;
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
 .editor__source-hint {
   margin: 8px 2px 0;
   font-size: 12px;

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -3379,6 +3379,7 @@ button.filter-rail__item {
   width: 100%;
   height: 100%;
   margin: 0;
+  pointer-events: none;
   padding: 12px;
   box-sizing: border-box;
   overflow: hidden;

--- a/crates/ui/assets/editor-sync.js
+++ b/crates/ui/assets/editor-sync.js
@@ -179,6 +179,64 @@
     return parts.join(".");
   }
 
+  /* ---- live raw → form sync -------------------------------------------- */
+
+  /* As soon as the textarea parses as JSON, the guided form catches up: the
+     document is re-rendered server-side and only the form pane (plus the
+     hidden document field and the binding datalists) is swapped, so the
+     textarea — and the caret in it — is never touched. Invalid JSON simply
+     waits; the form always reflects the last parseable state. */
+  var syncTimer = null;
+  var syncSeq = 0;
+  var lastSynced = null;
+  document.addEventListener("input", function (event) {
+    var source = event.target;
+    if (!source.classList || !source.classList.contains("editor__source")) return;
+    clearTimeout(syncTimer);
+    syncTimer = setTimeout(function () {
+      var text = source.value;
+      var parsed;
+      try {
+        parsed = JSON.parse(text);
+      } catch (invalid) {
+        return;
+      }
+      var canonical = JSON.stringify(parsed);
+      if (canonical === lastSynced) return;
+      var g = grid(source);
+      if (!g || !g.parentElement) return;
+      var seq = ++syncSeq;
+      var form = new URLSearchParams();
+      form.set("doc", text);
+      form.set("op", "");
+      fetch("/ui/editor/render", { method: "POST", body: form })
+        .then(function (r) { return r.text(); })
+        .then(function (html) {
+          if (seq !== syncSeq || !document.contains(source)) return;
+          lastSynced = canonical;
+          var fresh = new DOMParser().parseFromString(html, "text/html");
+          var container = g.parentElement;
+          var freshDoc = fresh.querySelector("#editor-form");
+          var oldDoc = container.querySelector("#editor-form");
+          if (freshDoc && oldDoc) oldDoc.replaceWith(freshDoc);
+          var freshForm = fresh.querySelector("section.editor-form");
+          var oldForm = g.querySelector("section.editor-form");
+          if (freshForm && oldForm) oldForm.replaceWith(freshForm);
+          // Required-binding datalists ride at the fragment's top level.
+          container.querySelectorAll(":scope > datalist").forEach(function (d) { d.remove(); });
+          fresh.querySelectorAll("body > datalist").forEach(function (d) { container.appendChild(d); });
+          g.__hitKey = null;
+          var path = pathAtCaret(text, source.selectionStart || 0);
+          var row = path ? rowForJsonPath(g, path) : null;
+          if (row) {
+            row.classList.add("editor-row--hit");
+            reveal(g.querySelector(".editor-tree"), row);
+          }
+        })
+        .catch(function () {});
+    }, 600);
+  });
+
   var caretTimer = null;
   document.addEventListener("selectionchange", function () {
     var source = document.activeElement;

--- a/crates/ui/assets/editor-sync.js
+++ b/crates/ui/assets/editor-sync.js
@@ -18,6 +18,9 @@
     g.querySelectorAll(".editor-row--hit").forEach(function (n) {
       n.classList.remove("editor-row--hit");
     });
+    g.querySelectorAll(".editor__source-mirror").forEach(function (m) {
+      m.textContent = "";
+    });
     g.__hitKey = null;
   }
 
@@ -74,7 +77,7 @@
     clear(g);
     g.__hitKey = key;
     if (row) {
-      lightJson(g, row.dataset.path);
+      if (!lightRaw(g, row.dataset.path)) lightJson(g, row.dataset.path);
     } else {
       var match = rowForJsonPath(g, line.dataset.jpath);
       if (match) match.classList.add("editor-row--hit");
@@ -107,6 +110,137 @@
     var input = row.querySelector("[data-set]");
     if (input) input.focus();
   });
+
+  /* ---- raw-mode highlight ----------------------------------------------- */
+
+  /* The character range a dotted path occupies in the JSON text: from its key
+     (or its opening bracket, for array items) to the end of its value. Same
+     structure-only scan as pathAtCaret, watching for the moment the walk
+     enters and leaves the target's subtree. */
+  function rangeOfPath(text, target) {
+    var frames = [];
+    var lastStr = null;
+    var lastStrStart = -1;
+    var start = -1;
+    function cur() {
+      if (!frames.length) return "";
+      var parts = [];
+      for (var j = 1; j < frames.length; j++) {
+        if (frames[j].segment != null) parts.push(frames[j].segment);
+      }
+      var tip = frames[frames.length - 1];
+      var c = tip.kind === "o" ? tip.key : String(tip.index);
+      if (c != null) parts.push(c);
+      return parts.join(".");
+    }
+    function inside() {
+      var p = cur();
+      return !!p && within(p, target);
+    }
+    for (var i = 0; i < text.length; i++) {
+      var ch = text[i];
+      if (ch === '"') {
+        var sStart = i;
+        var end = i + 1;
+        var esc = false;
+        var buf = "";
+        while (end < text.length) {
+          var c2 = text[end];
+          if (esc) { buf += c2; esc = false; }
+          else if (c2 === "\\") esc = true;
+          else if (c2 === '"') break;
+          else buf += c2;
+          end++;
+        }
+        lastStr = buf;
+        lastStrStart = sStart;
+        i = end;
+        continue;
+      }
+      if ("{}[]:,".indexOf(ch) === -1) continue;
+      var top = frames[frames.length - 1];
+      var before = inside();
+      var closedOwn = false;
+      if (ch === ":") {
+        if (top && top.kind === "o") top.key = lastStr;
+      } else if (ch === ",") {
+        if (top && top.kind === "a") top.index++;
+        else if (top) top.key = null;
+      } else if (ch === "{" || ch === "[") {
+        var seg = top ? (top.kind === "o" ? top.key : String(top.index)) : null;
+        frames.push({ kind: ch === "{" ? "o" : "a", key: null, index: 0, segment: seg });
+      } else {
+        // The bracket belongs to the target only when it closes the target's
+        // own container — closing an ancestor while a scalar tail is inside
+        // the subtree must not drag the ancestor's bracket into the range.
+        var segments = [];
+        for (var s = 1; s < frames.length; s++) {
+          if (frames[s].segment != null) segments.push(frames[s].segment);
+        }
+        closedOwn = segments.join(".") === target;
+        frames.pop();
+      }
+      var after = inside();
+      if (!before && after && start === -1) {
+        if (ch === ":" && lastStrStart !== -1) start = lastStrStart;
+        else if (ch === ",") {
+          start = i + 1;
+          while (start < text.length && /\s/.test(text[start])) start++;
+        } else start = i;
+      }
+      if (before && !after && start !== -1) {
+        return { start: start, end: ch === "," || (ch !== ":" && !closedOwn && "}]".indexOf(ch) !== -1) ? i : i + 1 };
+      }
+    }
+    return start === -1 ? null : { start: start, end: text.length };
+  }
+
+  /* A mirror <pre> behind the textarea carries the same text, invisible except
+     the <mark> around the highlighted range. Created on first use, cleared on
+     every keystroke (stale offsets would mark the wrong characters). */
+  function mirrorFor(rawPane, source) {
+    var mirror = rawPane.querySelector(".editor__source-mirror");
+    if (!mirror) {
+      mirror = document.createElement("pre");
+      mirror.className = "editor__source-mirror";
+      mirror.setAttribute("aria-hidden", "true");
+      rawPane.insertBefore(mirror, source);
+      rawPane.classList.add("editor-json__raw--mirrored");
+      source.addEventListener("scroll", function () {
+        mirror.scrollTop = source.scrollTop;
+        mirror.scrollLeft = source.scrollLeft;
+      });
+      source.addEventListener("input", function () {
+        mirror.textContent = "";
+      });
+    }
+    mirror.style.height = source.offsetHeight + "px";
+    return mirror;
+  }
+
+  /* Highlights `path` inside the raw textarea. Returns false when raw mode is
+     closed, so the caller falls back to the fold-view lines. */
+  function lightRaw(g, path) {
+    var rawPane = g.querySelector("#editor-json-raw");
+    if (!rawPane || rawPane.hidden) return false;
+    var source = rawPane.querySelector(".editor__source");
+    if (!source) return false;
+    var mirror = mirrorFor(rawPane, source);
+    var range = rangeOfPath(source.value, path);
+    mirror.textContent = "";
+    if (!range) return true;
+    mirror.appendChild(document.createTextNode(source.value.slice(0, range.start)));
+    var mark = document.createElement("mark");
+    mark.textContent = source.value.slice(range.start, range.end);
+    mirror.appendChild(mark);
+    mirror.appendChild(document.createTextNode(source.value.slice(range.end)));
+    if (mark.offsetTop < source.scrollTop || mark.offsetTop > source.scrollTop + source.clientHeight - 40) {
+      source.scrollTop = Math.max(0, mark.offsetTop - source.clientHeight / 3);
+    }
+    mirror.scrollTop = source.scrollTop;
+    mirror.scrollLeft = source.scrollLeft;
+    return true;
+  }
 
   /* ---- raw-edit caret follow ------------------------------------------- */
 

--- a/crates/ui/assets/editor-sync.js
+++ b/crates/ui/assets/editor-sync.js
@@ -25,9 +25,19 @@
     return path === ancestor || path.indexOf(ancestor + ".") === 0;
   }
 
+  /* Container-only reveal: brings `el` into `pane`'s viewport by moving the
+     pane's own scroll — never the page's. */
+  function reveal(pane, el) {
+    if (!pane || !el || pane.scrollHeight <= pane.clientHeight) return;
+    var delta = el.getBoundingClientRect().top - pane.getBoundingClientRect().top;
+    var top = pane.scrollTop + delta;
+    if (top < pane.scrollTop || top > pane.scrollTop + pane.clientHeight - 32) {
+      pane.scrollTop = Math.max(0, top - pane.clientHeight / 3);
+    }
+  }
+
   /* Lights every JSON line inside the node at `path`, and keeps the first
-     visible one in the JSON pane's viewport (the pane's own scroll only —
-     never the page's). */
+     visible one in the JSON pane's viewport. */
   function lightJson(g, path) {
     var first = null;
     g.querySelectorAll(".json-line[data-jpath]").forEach(function (line) {
@@ -36,13 +46,7 @@
         if (!first && !line.hidden) first = line;
       }
     });
-    var view = g.querySelector(".json-view");
-    if (first && view && view.scrollHeight > view.clientHeight) {
-      var top = first.offsetTop - view.offsetTop;
-      if (top < view.scrollTop || top > view.scrollTop + view.clientHeight - 24) {
-        view.scrollTop = Math.max(0, top - view.clientHeight / 3);
-      }
-    }
+    reveal(g.querySelector(".json-view"), first);
   }
 
   /* The row for a JSON path: exact, else the nearest ancestor with a row
@@ -102,5 +106,98 @@
     row.classList.add("editor-row--hit");
     var input = row.querySelector("[data-set]");
     if (input) input.focus();
+  });
+
+  /* ---- raw-edit caret follow ------------------------------------------- */
+
+  /* While "Edit raw" is open the JSON pane is one textarea, so there are no
+     lines to light — instead the caret drives the form: a structure-only scan
+     of the text up to the caret yields the dotted path of the node it sits
+     in, and that row lights up. The scanner tracks strings and escapes, so a
+     half-typed (invalid) document still resolves to the enclosing node. */
+  function pathAtCaret(text, caret) {
+    var frames = [];
+    var inStr = false;
+    var esc = false;
+    var lastStr = null;
+    var limit = Math.min(caret, text.length);
+    for (var i = 0; i < limit; i++) {
+      var ch = text[i];
+      if (inStr) {
+        if (esc) esc = false;
+        else if (ch === "\\") esc = true;
+        else if (ch === '"') inStr = false;
+        continue;
+      }
+      if (ch === '"') {
+        // Read the whole string ahead so a key the caret sits inside still counts.
+        var end = i + 1;
+        var buf = "";
+        var esc2 = false;
+        while (end < text.length) {
+          var c2 = text[end];
+          if (esc2) { buf += c2; esc2 = false; }
+          else if (c2 === "\\") esc2 = true;
+          else if (c2 === '"') break;
+          else buf += c2;
+          end++;
+        }
+        lastStr = buf;
+        if (end >= limit) {
+          // Caret inside this string. If it is a key (a colon follows), bind
+          // it so the caret lands on that entry's row, not the container's.
+          var after = end + 1;
+          while (after < text.length && /\s/.test(text[after])) after++;
+          var owner = frames[frames.length - 1];
+          if (text[after] === ":" && owner && owner.kind === "o") owner.key = lastStr;
+          break;
+        }
+        i = end;
+        continue;
+      }
+      var top = frames[frames.length - 1];
+      if (ch === ":") {
+        if (top && top.kind === "o") top.key = lastStr;
+      } else if (ch === ",") {
+        if (top && top.kind === "a") top.index++;
+        else if (top) top.key = null;
+      } else if (ch === "{" || ch === "[") {
+        var segment = top ? (top.kind === "o" ? top.key : String(top.index)) : null;
+        frames.push({ kind: ch === "{" ? "o" : "a", key: null, index: 0, segment: segment });
+      } else if (ch === "}" || ch === "]") {
+        frames.pop();
+      }
+    }
+    if (!frames.length) return "";
+    var parts = [];
+    for (var j = 1; j < frames.length; j++) {
+      if (frames[j].segment != null) parts.push(frames[j].segment);
+    }
+    var tip = frames[frames.length - 1];
+    var current = tip.kind === "o" ? tip.key : String(tip.index);
+    if (current != null) parts.push(current);
+    return parts.join(".");
+  }
+
+  var caretTimer = null;
+  document.addEventListener("selectionchange", function () {
+    var source = document.activeElement;
+    if (!source || !source.classList || !source.classList.contains("editor__source")) return;
+    clearTimeout(caretTimer);
+    caretTimer = setTimeout(function () {
+      var g = grid(source);
+      if (!g) return;
+      var path = pathAtCaret(source.value, source.selectionStart || 0);
+      var key = "c:" + path;
+      if (g.__hitKey === key) return;
+      clear(g);
+      if (!path) return;
+      g.__hitKey = key;
+      var row = rowForJsonPath(g, path);
+      if (row) {
+        row.classList.add("editor-row--hit");
+        reveal(g.querySelector(".editor-tree"), row);
+      }
+    }, 120);
   });
 })();

--- a/crates/ui/assets/editor-sync.js
+++ b/crates/ui/assets/editor-sync.js
@@ -1,0 +1,106 @@
+/* Guided form ↔ JSON cross-highlight for the resource editor: hovering or
+   focusing a form row lights the JSON lines that hold that node, hovering a
+   JSON line lights the row that edits it, and clicking a JSON line jumps to
+   the row and focuses its input. Pure highlighting, delegated at the document
+   so it works in the standalone editor and the Resources modal alike; with
+   the script absent the editor is simply un-linked. */
+(function () {
+  "use strict";
+
+  function grid(el) {
+    return el && el.closest ? el.closest(".editor__grid") : null;
+  }
+
+  function clear(g) {
+    g.querySelectorAll(".json-line--hit").forEach(function (n) {
+      n.classList.remove("json-line--hit");
+    });
+    g.querySelectorAll(".editor-row--hit").forEach(function (n) {
+      n.classList.remove("editor-row--hit");
+    });
+    g.__hitKey = null;
+  }
+
+  function within(path, ancestor) {
+    return path === ancestor || path.indexOf(ancestor + ".") === 0;
+  }
+
+  /* Lights every JSON line inside the node at `path`, and keeps the first
+     visible one in the JSON pane's viewport (the pane's own scroll only —
+     never the page's). */
+  function lightJson(g, path) {
+    var first = null;
+    g.querySelectorAll(".json-line[data-jpath]").forEach(function (line) {
+      if (within(line.dataset.jpath, path)) {
+        line.classList.add("json-line--hit");
+        if (!first && !line.hidden) first = line;
+      }
+    });
+    var view = g.querySelector(".json-view");
+    if (first && view && view.scrollHeight > view.clientHeight) {
+      var top = first.offsetTop - view.offsetTop;
+      if (top < view.scrollTop || top > view.scrollTop + view.clientHeight - 24) {
+        view.scrollTop = Math.max(0, top - view.clientHeight / 3);
+      }
+    }
+  }
+
+  /* The row for a JSON path: exact, else the nearest ancestor with a row
+     (a scalar inside a CodeableConcept lands on the concept's row). */
+  function rowForJsonPath(g, path) {
+    while (path) {
+      var rows = g.querySelectorAll(".editor-row[data-path]");
+      for (var i = 0; i < rows.length; i++) {
+        if (rows[i].dataset.path === path) return rows[i];
+      }
+      var cut = path.lastIndexOf(".");
+      path = cut === -1 ? "" : path.slice(0, cut);
+    }
+    return null;
+  }
+
+  function handle(event) {
+    var target = event.target;
+    var row = target.closest ? target.closest(".editor-row[data-path]") : null;
+    var line = target.closest ? target.closest(".json-line[data-jpath]") : null;
+    var g = grid(row || line);
+    if (!g) return;
+    var key = row ? "r:" + row.dataset.path : "j:" + line.dataset.jpath;
+    if (g.__hitKey === key) return;
+    clear(g);
+    g.__hitKey = key;
+    if (row) {
+      lightJson(g, row.dataset.path);
+    } else {
+      var match = rowForJsonPath(g, line.dataset.jpath);
+      if (match) match.classList.add("editor-row--hit");
+    }
+  }
+
+  document.addEventListener("mouseover", handle);
+  document.addEventListener("focusin", handle);
+
+  document.addEventListener("mouseout", function (event) {
+    var from = event.target.closest
+      ? event.target.closest(".editor-row[data-path], .json-line[data-jpath]")
+      : null;
+    var g = grid(from);
+    if (!g) return;
+    var to = event.relatedTarget;
+    if (to && g.contains(to) && to.closest(".editor-row[data-path], .json-line[data-jpath]")) return;
+    clear(g);
+  });
+
+  document.addEventListener("click", function (event) {
+    if (event.target.closest && event.target.closest("[data-fold]")) return;
+    var line = event.target.closest ? event.target.closest(".json-line[data-jpath]") : null;
+    var g = grid(line);
+    if (!g) return;
+    var row = rowForJsonPath(g, line.dataset.jpath);
+    if (!row) return;
+    row.scrollIntoView({ block: "nearest" });
+    row.classList.add("editor-row--hit");
+    var input = row.querySelector("[data-set]");
+    if (input) input.focus();
+  });
+})();

--- a/crates/ui/assets/editor.js
+++ b/crates/ui/assets/editor.js
@@ -358,9 +358,15 @@
         event.target.classList.add("editor-json__act--on");
       } else {
         // Leaving raw: the text becomes the document, and the form re-renders.
+        // Close the pane before the round trip — the state capture during the
+        // swap keeps raw mode alive, and this is the one re-render that must
+        // read as "the user left raw mode".
         var source = document.getElementById("editor-source");
         var field = document.getElementById("editor-doc");
         if (source && field) field.value = source.value;
+        raw.hidden = true;
+        viewEl.hidden = false;
+        event.target.classList.remove("editor-json__act--on");
         send("");
       }
       return;

--- a/crates/ui/assets/editor.js
+++ b/crates/ui/assets/editor.js
@@ -78,7 +78,9 @@
    * its filter text, and the tree's scroll position. Captured at response
    * time — where the user is *now*, not where they were at request time. */
   function captureUiState() {
-    var state = { focus: null, pickers: [], scroll: 0 };
+    var state = { focus: null, pickers: [], scroll: 0, rawOpen: false };
+    var raw = body.querySelector("#editor-json-raw");
+    state.rawOpen = !!(raw && !raw.hidden);
     var tree = body.querySelector(".editor-tree");
     if (tree) state.scroll = tree.scrollTop;
     var active = document.activeElement;
@@ -119,6 +121,19 @@
   }
 
   function restoreUiState(state) {
+    // Raw mode survives the swap: the fresh textarea already carries the
+    // updated document, so a guided edit refreshes the JSON in place instead
+    // of kicking the user back to the fold view.
+    if (state.rawOpen) {
+      var raw = body.querySelector("#editor-json-raw");
+      var viewEl = body.querySelector("#json-view");
+      var toggle = body.querySelector("#editor-json-edit");
+      if (raw && viewEl) {
+        raw.hidden = false;
+        viewEl.hidden = true;
+        if (toggle) toggle.classList.add("editor-json__act--on");
+      }
+    }
     state.pickers.forEach(function (saved) {
       var row = rowByPath(saved.path);
       if (!row) return;

--- a/crates/ui/assets/resources.js
+++ b/crates/ui/assets/resources.js
@@ -385,6 +385,8 @@
           subject.textContent = current.type + "/" + current.id;
           say(messages.msgSaved, "ok");
           renderEditor(res.body);
+          // The results table behind the modal is now stale — let it catch up.
+          document.dispatchEvent(new CustomEvent("hfs:data-changed", { detail: { type: current.type } }));
         })
         .catch(function () { say(messages.msgLoadError, "error"); });
     });
@@ -395,8 +397,12 @@
     if (!window.confirm(messages.msgConfirmDelete)) return;
     fetch("/" + current.type + "/" + current.id, { method: "DELETE", headers: fhirHeaders() })
       .then(function (r) {
-        if (r.ok || r.status === 204) { closeModal(); location.reload(); }
-        else say(String(r.status), "error");
+        if (r.ok || r.status === 204) {
+          closeModal();
+          // No full reload: the table and counts refresh in place, keeping
+          // the rail selection and scroll where the user left them.
+          document.dispatchEvent(new CustomEvent("hfs:data-changed", { detail: { type: current.type } }));
+        } else say(String(r.status), "error");
       })
       .catch(function () { say(messages.msgLoadError, "error"); });
   });

--- a/crates/ui/assets/resources.js
+++ b/crates/ui/assets/resources.js
@@ -98,7 +98,9 @@
    * and the tree scroll. The server marks the node a mutation created via
    * data-focus on #editor-form; the caret goes there first. */
   function captureEditorState() {
-    var state = { focus: null, pickers: [], scroll: 0 };
+    var state = { focus: null, pickers: [], scroll: 0, rawOpen: false };
+    var rawPane = editorBody.querySelector("#editor-json-raw");
+    state.rawOpen = !!(rawPane && !rawPane.hidden);
     var tree = editorBody.querySelector(".editor-tree");
     if (tree) state.scroll = tree.scrollTop;
     var active = document.activeElement;
@@ -126,6 +128,19 @@
   }
 
   function restoreEditorState(state) {
+    // Raw mode survives the swap: the fresh textarea already carries the
+    // updated document, so a guided edit refreshes the JSON in place instead
+    // of kicking the user back to the fold view.
+    if (state.rawOpen) {
+      var rawPane = editorBody.querySelector("#editor-json-raw");
+      var viewEl = editorBody.querySelector("#json-view");
+      var toggle = editorBody.querySelector("#editor-json-edit");
+      if (rawPane && viewEl) {
+        rawPane.hidden = false;
+        viewEl.hidden = true;
+        if (toggle) toggle.classList.add("editor-json__act--on");
+      }
+    }
     state.pickers.forEach(function (saved) {
       var row = saved.path ? editorNodeBy("data-path", saved.path) : editorBody;
       if (!row) return;

--- a/crates/ui/assets/resources.js
+++ b/crates/ui/assets/resources.js
@@ -187,9 +187,14 @@
       if (!raw || !viewEl) return;
       if (raw.hidden) { raw.hidden = false; viewEl.hidden = true; event.target.classList.add("editor-json__act--on"); }
       else {
+        // Same as the standalone page: close the pane before the round trip
+        // so the raw-mode persistence reads this re-render as leaving raw.
         var src = editorBody.querySelector("#editor-source");
         var fld = editorBody.querySelector("#editor-doc");
         if (src && fld) fld.value = src.value;
+        raw.hidden = true;
+        viewEl.hidden = false;
+        event.target.classList.remove("editor-json__act--on");
         editorSend("");
       }
       return;

--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -1210,10 +1210,12 @@
   var railFilter = document.getElementById("type-rail-filter");
   var countFormat = new Intl.NumberFormat(lang);
 
-  function hydrateCounts() {
+  function hydrateCounts(onlyType) {
     if (!railList) return;
     var pending = Array.prototype.slice.call(
-      railList.querySelectorAll("[data-count-for]")
+      railList.querySelectorAll(
+        onlyType ? '[data-count-for="' + onlyType + '"]' : "[data-count-for]"
+      )
     );
     var CONCURRENCY = 4;
 
@@ -1391,6 +1393,9 @@
   }
 
   /* ---- Results: the FHIR search response, rendered in-page ------------- */
+
+  /* The last path handed to runSearch — what a data-changed re-run repeats. */
+  var lastSearchPath = null;
 
   var results = {
     card: document.getElementById("query-results"),
@@ -1581,6 +1586,7 @@
    * `record` adds it to the roaming recent list (explicit runs only, so
    * paging does not spam recents). */
   function runSearch(path, record) {
+    lastSearchPath = path;
     if (!results.card) {
       window.open(path, "_blank", "noopener");
     } else {
@@ -2031,6 +2037,15 @@
       });
     });
   }
+
+  /* Data changed behind the results (a save or delete in the Resources
+   * modal announces it): re-run the last search so the table shows what is
+   * actually stored, without recording a new recent, and refresh the rail
+   * count — only the affected type's when the event names one, not all 145. */
+  document.addEventListener("hfs:data-changed", function (event) {
+    if (lastSearchPath) runSearch(lastSearchPath, false);
+    hydrateCounts(event.detail && event.detail.type);
+  });
 
   reload();
   window.setTimeout(hydrateCounts, 50);

--- a/crates/ui/e2e/tests/editor-sync.spec.ts
+++ b/crates/ui/e2e/tests/editor-sync.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "../pages/fixtures";
+import { Editor } from "../pages/editor";
+
+// The linked editor: the guided form and the JSON view point at each other
+// (editor-sync.js). Hover/focus a form row and the node's JSON lines light
+// up; hover or click a JSON line and the row that edits it answers. With
+// "Edit raw" open the same link runs through the textarea: valid JSON
+// re-renders the form live, the caret drives the row highlight, and the
+// hovered row's character range is marked through the mirror.
+
+function standalone(page: import("@playwright/test").Page): Editor {
+  return new Editor(page, page.locator("#editor-body"));
+}
+
+test("hovering a form row lights the node's JSON lines, and back", async ({ page }) => {
+  await page.goto("/ui/editor?type=Patient", { waitUntil: "networkidle" });
+  const ed = standalone(page);
+  await ed.applyJson({ resourceType: "Patient", gender: "female", name: [{ family: "Sync" }] });
+
+  await page.locator('.editor-row[data-path="gender"]').hover();
+  await expect(page.locator('.json-line--hit[data-jpath="gender"]')).toHaveCount(1);
+
+  // Moving to another row moves the highlight; a parent row lights its whole subtree.
+  await page.locator('.editor-row[data-path="name.0"]').hover();
+  await expect(page.locator('.json-line--hit[data-jpath="gender"]')).toHaveCount(0);
+  await expect(page.locator('.json-line--hit[data-jpath="name.0.family"]')).toHaveCount(1);
+
+  // The reverse direction: hovering a JSON line lights the row that edits it.
+  await page.locator('.json-line[data-jpath="gender"]').hover();
+  await expect(page.locator('.editor-row--hit[data-path="gender"]')).toHaveCount(1);
+});
+
+test("clicking a JSON line focuses the row's input", async ({ page }) => {
+  await page.goto("/ui/editor?type=Patient", { waitUntil: "networkidle" });
+  const ed = standalone(page);
+  await ed.applyJson({ resourceType: "Patient", gender: "female" });
+
+  await page.locator('.json-line[data-jpath="gender"] .json-line__code').click();
+  await expect(page.locator('[data-set="gender"]')).toBeFocused();
+});
+
+test("valid raw JSON re-renders the guided form without leaving raw mode", async ({ page }) => {
+  await page.goto("/ui/editor?type=Patient", { waitUntil: "networkidle" });
+  const ed = standalone(page);
+  await ed.enterRaw();
+  await ed.source.fill(JSON.stringify({ resourceType: "Patient", gender: "male" }));
+
+  // The form catches up on its own (debounced live sync)…
+  await expect(page.locator('[data-set="gender"]')).toHaveCount(1, { timeout: 5000 });
+  // …and raw mode is still the active view.
+  await expect(page.locator("#editor-json-raw")).toBeVisible();
+
+  // The other direction: a guided edit refreshes the textarea in place
+  // instead of snapping back to the fold view.
+  await page.fill('[data-set="gender"]', "female");
+  await page.locator('[data-set="gender"]').evaluate((n) => (n as HTMLElement).blur());
+  await expect(page.locator("#editor-json-raw")).toBeVisible();
+  await expect
+    .poll(async () => (await ed.source.inputValue()).includes('"female"'))
+    .toBe(true);
+});
+
+test("the raw-mode caret lights the row of the node it sits in", async ({ page }) => {
+  await page.goto("/ui/editor?type=Patient", { waitUntil: "networkidle" });
+  const ed = standalone(page);
+  await ed.enterRaw();
+  const doc = JSON.stringify({ resourceType: "Patient", id: "x", gender: "male" }, null, 2);
+  await ed.source.fill(doc);
+  await expect(page.locator('[data-set="gender"]')).toHaveCount(1, { timeout: 5000 });
+
+  await ed.source.click();
+  const caret = doc.indexOf('"male"') + 2;
+  await ed.source.evaluate((n, at) => (n as HTMLTextAreaElement).setSelectionRange(at, at), caret);
+  await page.keyboard.press("ArrowRight");
+  await expect(page.locator('.editor-row--hit[data-path="gender"]')).toHaveCount(1, { timeout: 3000 });
+});
+
+test("with raw open, hovering a form row marks the node's text in the mirror", async ({ page }) => {
+  await page.goto("/ui/editor?type=Patient", { waitUntil: "networkidle" });
+  const ed = standalone(page);
+  await ed.enterRaw();
+  await ed.source.fill(JSON.stringify({ resourceType: "Patient", gender: "male" }, null, 2));
+  await expect(page.locator('[data-set="gender"]')).toHaveCount(1, { timeout: 5000 });
+
+  await page.locator('.editor-row[data-path="gender"]').hover();
+  const mark = page.locator(".editor__source-mirror mark");
+  await expect(mark).toHaveCount(1);
+  await expect(mark).toContainText('"gender"');
+
+  // The mirror is an overlay, never a click target: the textarea under it
+  // still takes the click.
+  await ed.source.click({ position: { x: 30, y: 10 } });
+  await expect(ed.source).toBeFocused();
+});
+
+test("the element name leads the row; the description sits under it", async ({ page }) => {
+  await page.goto("/ui/editor?type=Patient", { waitUntil: "networkidle" });
+  const ed = standalone(page);
+  await ed.applyJson({ resourceType: "Patient", gender: "female" });
+
+  const row = page.locator('.editor-row[data-path="gender"]');
+  await expect(row.locator(".editor-row__label")).toHaveText("gender");
+  await expect(row.locator(".editor-row__desc")).toContainText("male | female");
+  // The description renders outside the head line, as its own block.
+  await expect(row.locator(".editor-row__head .editor-row__desc")).toHaveCount(0);
+});
+
+test("a save in the Resources modal refreshes the results table behind it", async ({
+  resources,
+  page,
+}) => {
+  const family = "Zz" + Date.now().toString(36);
+  await resources.goto("Patient");
+  await page.fill(".query-builder__url", `GET /Patient?family=${family}`);
+  await page.click('[data-intent="run"]');
+  await expect(page.locator("#query-results")).toBeVisible();
+  await expect(page.locator("#query-results-body tr")).toHaveCount(0);
+
+  await resources.openCreate();
+  const ed = resources.modal.editor;
+  await ed.applyJson({ resourceType: "Patient", name: [{ family }] });
+  await page.click("#resource-save");
+
+  // No reload, no manual re-run: the table catches up on its own.
+  await expect(page.locator("#query-results-body tr")).toHaveCount(1, { timeout: 5000 });
+});

--- a/crates/ui/src/editor.rs
+++ b/crates/ui/src/editor.rs
@@ -300,7 +300,7 @@ fn apply(
             editor::remove_at(document, &path);
         }
         "set" => {
-            editor::set_value(document, &path, &form.value);
+            editor::set_value(resolver, resource_type, document, &path, &form.value);
         }
         // No op: a plain re-render (the first load, or a mode switch).
         _ => {}

--- a/crates/ui/src/json_view.rs
+++ b/crates/ui/src/json_view.rs
@@ -35,6 +35,10 @@ pub struct JsonLine {
     /// The shape shown on the opening line when it is folded (`{ … }`,
     /// `[ 3 ]`).
     pub summary: String,
+    /// Dotted document path of the node this line belongs to (`name.0.family`)
+    /// — the same spelling the guided form keys its rows on, so the two views
+    /// can point at each other. Empty on the root braces.
+    pub path: String,
     pub tokens: Vec<Token>,
 }
 
@@ -44,9 +48,18 @@ pub fn lines(value: &Value) -> Vec<JsonLine> {
         lines: Vec::new(),
         counter: 0,
     };
-    let mut root = Line::new(0, &[]);
+    let mut root = Line::new(0, &[], String::new());
     ctx.walk(value, &mut root, &[], true);
     ctx.lines
+}
+
+/// `name` + `0` → `name.0`; the root joins to just the segment.
+fn join(base: &str, segment: &str) -> String {
+    if base.is_empty() {
+        segment.to_string()
+    } else {
+        format!("{base}.{segment}")
+    }
 }
 
 struct Ctx {
@@ -62,10 +75,11 @@ struct Line {
     foldable: bool,
     fold_id: String,
     summary: String,
+    path: String,
 }
 
 impl Line {
-    fn new(depth: usize, parents: &[String]) -> Self {
+    fn new(depth: usize, parents: &[String], path: String) -> Self {
         Line {
             depth,
             parents: parents.to_vec(),
@@ -73,6 +87,7 @@ impl Line {
             foldable: false,
             fold_id: String::new(),
             summary: String::new(),
+            path,
         }
     }
     fn punct(&mut self, text: &str) {
@@ -93,6 +108,7 @@ impl Ctx {
             fold_id: line.fold_id,
             parents: line.parents.join(" "),
             summary: line.summary,
+            path: line.path,
             tokens: line.tokens,
         });
     }
@@ -108,18 +124,23 @@ impl Ctx {
         match value {
             Value::Object(map) if !map.is_empty() => {
                 let id = self.next_id();
+                let base = line.path.clone();
                 line.foldable = true;
                 line.fold_id = id.clone();
                 line.summary = format!("{{ … }}{}", trailing.join(""));
                 line.punct("{");
-                let opener = std::mem::replace(line, Line::new(0, &[]));
+                let opener = std::mem::replace(line, Line::new(0, &[], String::new()));
                 self.push(opener);
 
                 let mut child_parents = self.parents_of_last();
                 child_parents.push(id.clone());
                 let len = map.len();
                 for (i, (key, child_value)) in map.iter().enumerate() {
-                    let mut child = Line::new(depth_after(&child_parents), &child_parents);
+                    let mut child = Line::new(
+                        depth_after(&child_parents),
+                        &child_parents,
+                        join(&base, key),
+                    );
                     child.tokens.push(Token {
                         text: format!("\"{}\"", escape(key)),
                         kind: "key",
@@ -129,32 +150,43 @@ impl Ctx {
                     self.walk(child_value, &mut child, &[comma], false);
                 }
 
-                let mut closer =
-                    Line::new(depth_after(&child_parents) - 1, &prefix(&child_parents));
+                let mut closer = Line::new(
+                    depth_after(&child_parents) - 1,
+                    &prefix(&child_parents),
+                    base,
+                );
                 closer.parents.push(id);
                 closer.punct(&format!("}}{}", trailing.join("")));
                 self.push(closer);
             }
             Value::Array(items) if !items.is_empty() => {
                 let id = self.next_id();
+                let base = line.path.clone();
                 line.foldable = true;
                 line.fold_id = id.clone();
                 line.summary = format!("[ {} ]{}", items.len(), trailing.join(""));
                 line.punct("[");
-                let opener = std::mem::replace(line, Line::new(0, &[]));
+                let opener = std::mem::replace(line, Line::new(0, &[], String::new()));
                 self.push(opener);
 
                 let mut child_parents = self.parents_of_last();
                 child_parents.push(id.clone());
                 let len = items.len();
                 for (i, child_value) in items.iter().enumerate() {
-                    let mut child = Line::new(depth_after(&child_parents), &child_parents);
+                    let mut child = Line::new(
+                        depth_after(&child_parents),
+                        &child_parents,
+                        join(&base, &i.to_string()),
+                    );
                     let comma = if i + 1 < len { "," } else { "" };
                     self.walk(child_value, &mut child, &[comma], false);
                 }
 
-                let mut closer =
-                    Line::new(depth_after(&child_parents) - 1, &prefix(&child_parents));
+                let mut closer = Line::new(
+                    depth_after(&child_parents) - 1,
+                    &prefix(&child_parents),
+                    base,
+                );
                 closer.parents.push(id);
                 closer.punct(&format!("]{}", trailing.join("")));
                 self.push(closer);
@@ -165,7 +197,7 @@ impl Ctx {
                 for t in trailing {
                     line.punct(t);
                 }
-                let done = std::mem::replace(line, Line::new(0, &[]));
+                let done = std::mem::replace(line, Line::new(0, &[], String::new()));
                 self.push(done);
             }
         }

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -13,6 +13,7 @@
   <!-- Vendored, pinned htmx (no runtime CDN). Served from the embedded asset store. -->
   <script src="/ui/assets/htmx.min.js" defer></script>
   <script src="/ui/assets/addbox.js" defer></script>
+  <script src="/ui/assets/editor-sync.js" defer></script>
 </head>
 <body class="{% block body_class %}{% endblock %}">
   <aside class="sidebar" id="sidebar">

--- a/crates/ui/templates/partials/editor-body.html
+++ b/crates/ui/templates/partials/editor-body.html
@@ -91,9 +91,6 @@
 
         <div class="editor-row__head">
           <span class="editor-row__label">{{ row.label }}</span>
-          {% if !row.short.is_empty() %}
-          <span class="editor-row__desc" title="{{ row.short }}">{{ row.short }}</span>
-          {% endif %}
 
           {% if !row.type_label.is_empty() %}
           <span class="editor-row__type">{{ row.type_label }}</span>
@@ -159,6 +156,10 @@
                   aria-label="{{ i18n.t("editor-remove") }}" title="{{ i18n.t("editor-remove") }}">×</button>
           {% endif %}
         </div>
+
+        {% if !row.short.is_empty() %}
+        <p class="editor-row__desc">{{ row.short }}</p>
+        {% endif %}
 
         {% for message in row.errors %}
         <p class="editor-row__error">{{ message }}</p>

--- a/crates/ui/templates/partials/editor-body.html
+++ b/crates/ui/templates/partials/editor-body.html
@@ -47,7 +47,7 @@
     <div class="json-view" id="json-view">
       {% for line in json_lines %}
       <div class="json-line{% if line.foldable %} json-line--foldable{% endif %}"
-           data-fold-id="{{ line.fold_id }}" data-parents="{{ line.parents }}">
+           data-fold-id="{{ line.fold_id }}" data-parents="{{ line.parents }}"{% if !line.path.is_empty() %} data-jpath="{{ line.path }}"{% endif %}>
         <span class="json-line__num">{{ line.num }}</span>
         <span class="json-line__fold">{% if line.foldable %}<span class="json-line__arrow" data-fold="{{ line.fold_id }}">▾</span>{% endif %}</span>
         <span class="json-line__code" style="padding-left: {{ line.depth }}em">{% for t in line.tokens %}<span class="jt--{{ t.kind }}">{{ t.text }}</span>{% endfor %}<span class="json-line__summary">{{ line.summary }}</span></span>
@@ -90,11 +90,9 @@
            data-path="{{ row.path }}">
 
         <div class="editor-row__head">
-          {% if !row.short.is_empty() %}
-          <span class="editor-row__label" title="{{ row.label }}">{{ row.short }}</span>
-          <span class="editor-row__name">{{ row.label }}</span>
-          {% else %}
           <span class="editor-row__label">{{ row.label }}</span>
+          {% if !row.short.is_empty() %}
+          <span class="editor-row__desc" title="{{ row.short }}">{{ row.short }}</span>
           {% endif %}
 
           {% if !row.type_label.is_empty() %}

--- a/crates/ui/templates/partials/editor-body.html
+++ b/crates/ui/templates/partials/editor-body.html
@@ -57,7 +57,7 @@
 
     <!-- Raw editing, one toggle away. On apply it re-parses and the form
          re-renders from it. -->
-    <div id="editor-json-raw" hidden>
+    <div class="editor-json__raw" id="editor-json-raw" hidden>
       <textarea class="editor__source" id="editor-source" spellcheck="false">{{ pretty }}</textarea>
       <p class="editor__source-hint">{{ i18n.t("editor-source-hint") }}</p>
     </div>


### PR DESCRIPTION
Manual-review feedback on the resource editor, turned into a feature: the guided form and the JSON view now behave as two views of one document instead of two documents that meet on save.

**Stacked on #572** (base is `fix/543-stylesheet-unification` — it touches the same templates and stylesheet; GitHub will retarget to `main` when #572 merges).

## The link

- **Row → JSON**: hovering or focusing a guided-form row lights every JSON line of that node (its whole subtree), keeping the first in the pane's own viewport. Server-side, every JSON line now carries the node's dotted path (`data-jpath`) — the same spelling the rows key on, so the match is string equality.
- **JSON → row**: hovering a line lights the row that edits it (nearest ancestor with a row, for leaves inside a complex type); clicking a line jumps to the row and focuses its input.
- **Raw mode, both directions**: with "Edit raw" open, valid JSON re-renders the guided form live — only the form pane and the hidden document field are swapped, so the textarea and caret are never touched, and invalid JSON simply waits. The caret lights the row of the node it sits in (structure-only scan, string- and escape-aware, tolerant of half-typed documents). Hovering a row marks the node's character range inside the textarea through a metrics-identical mirror `<pre>` (`pointer-events: none`, invisible except the `<mark>`). And a guided edit no longer kicks the user back to the fold view: raw mode survives the re-render with the refreshed document in the textarea.
- The delegated script (`editor-sync.js`) drives the standalone page and the Resources modal alike; without JS the editor is simply un-linked.

## Fixes the same review shook out

- **Row hierarchy**: the element name leads the row (it used to render small and mono while the description got the label styling); the description sits on its own line below, muted, free to wrap — and the input keeps a 180px floor with the head wrapping instead of squeezing it invisible.
- **Type-honest value coercion** (`set_value`): the editor guessed JSON types from the shape of the text, so a year-precision `birthDate` of `1974` — legal FHIR — round-tripped as a JSON number and failed validation with "expected date, got number", and an `identifier.value` of `12345` was silently retyped. Coercion now follows the declared type: only booleans and the numeric primitives leave string-land (`integer64` stays a string, as FHIR serializes it); unknown keys keep the old shape-based guess. Decimal entry also works now — it previously fell through the integer-only parse.
- **The results table catches up**: saving or deleting in the Resources modal announces `hfs:data-changed`; the table re-runs the last search (without recording a new recent) and re-hydrates the affected type's rail count — not all 145. Delete loses its `location.reload()`.
- **Leaving raw mode** regressed once raw survived re-renders (the state capture ran while the pane was still open and faithfully restored it) — caught by the new spec's first run; both editor wirings now close the pane before that round trip.

## Tests

- `editor-sync.spec.ts`: seven browser-level specs — hover both directions, click-to-focus, live raw→form with raw surviving a guided edit, caret follow, the mirror marking without ever taking a click, the row hierarchy, and the modal save refreshing the table behind it.
- New validator unit tests for declared-type coercion (year-only date, numeric-looking identifier, unknown key).
- Full local suite, hermetic self-boot: **130 passed** (chromium + nojs + both auth legs, axe both themes).