### PR TITLE
ci: sweep the Windows runner's target dir too

### DIFF
--- a/.github/actions/cargo-target-gc/action.yml
+++ b/.github/actions/cargo-target-gc/action.yml
@@ -32,7 +32,25 @@ description: >
 # Scope: this caps `target/` only. `~/.cargo/registry` also grows without bound
 # (every `.crate` tarball and unpacked source ever resolved), but far more
 # slowly — it is measured in single-digit GB, not hundreds. If it ever becomes
-# the problem it needs a different tool; cargo-sweep does not touch it.
+# the problem it needs a different tool; cargo-sweep does not touch it. The
+# `free-floor-gb` warning exists so that "something *else* on this box is
+# filling up" surfaces in a job log rather than as a mystery.
+#
+# Why two near-identical steps below
+# ----------------------------------
+# This originally skipped Windows on the grounds that "the Windows runner is not
+# the one running out of space". That stopped being true immediately: agent4 is
+# the sole Windows agent, `test-fhirpath` is pinned to it and checks out with
+# `clean: false`, and the unpinned `runs-on: [self-hosted]` jobs land there too
+# — so it accumulated a full all-features workspace target dir with nothing ever
+# evicting it, and filled the disk. Skipping it was the bug.
+#
+# The plain `shell: bash` alias resolves to WSL bash on that agent, which has no
+# distro installed and aborts before running a line, so the Windows step points
+# at Git Bash through its space-free 8.3 short path — the same workaround
+# ci.yml already uses for its bash-only steps. Both steps run the identical
+# `sweep.sh` with the identical arguments; the script lives in a file rather
+# than inline precisely so the two paths cannot drift.
 
 inputs:
   maxsize:
@@ -41,8 +59,27 @@ inputs:
       directory is under this. ALWAYS pass an explicit unit: a bare number is
       interpreted as MEGABYTES, so `100` means 100MB and would evict essentially
       the entire warm cache on every run.
+
+      100GB suits every agent we have: the smallest disk in the fleet is the
+      1.5TB C: on the Windows agent, so the ceiling leaves an order of magnitude
+      of headroom while still bounding the thing that compounds. Check this
+      assumption before adding a runner with a smaller disk — a ceiling above
+      the volume size is a no-op, not a cap.
     required: false
     default: 100GB
+  free-floor-gb:
+    description: >
+      Emit a `::warning::` when the checkout's filesystem has less than this
+      many GB free *after* sweeping. Not a failure — it is the early signal that
+      something this action does not manage is filling the runner. `0` disables.
+
+      100 rather than something tighter because a single job here can consume
+      tens of GB in one go: an all-features workspace build, or `cargo llvm-cov`
+      laying down a whole second instrumented profile. A floor that only trips
+      at 20GB free would routinely fire for the first time on the run that
+      already failed.
+    required: false
+    default: "100"
   cargo-sweep-version:
     description: >
       Pinned cargo-sweep version. >=0.7.0 is required for unit suffixes on
@@ -53,68 +90,23 @@ inputs:
 runs:
   using: composite
   steps:
-    # `runs-on: [self-hosted]` is unpinned on several ci.yml jobs, so this
-    # action can land on the Windows runner, where the plain `shell: bash` alias
-    # is unreliable (see the Git Bash 8.3-path workaround in ci.yml). The
-    # Windows runner is not the one running out of space; skip rather than
-    # invent a second code path for it.
-    - name: Cap target dir size
+    - name: Cap target dir size (Unix)
       if: runner.os != 'Windows'
       shell: bash
-      run: |
-        # `set +e` is load-bearing, and NOT redundant with omitting `set -e`.
-        # Actions invokes `shell: bash` as
-        #   /usr/bin/bash --noprofile --norc -e -o pipefail {0}
-        # so errexit is already on at the process level before the first line
-        # runs; simply not turning it on does not turn it off. Without this the
-        # very first probe -- `cargo sweep --version` on a runner that has not
-        # got cargo-sweep yet -- exits the script with cargo's 101 and fails the
-        # job, which is exactly the opposite of what this step is for. That is
-        # not hypothetical: it happened on the first CI run of this action.
-        #
-        # This is janitorial work running under `if: always()`. Failing to
-        # reclaim space must never turn a green build red, so every command
-        # below is non-fatal and reports loudly instead, and the script ends in
-        # an explicit `exit 0`.
-        set +e
-        set -uo pipefail
+      env:
+        MAXSIZE: ${{ inputs.maxsize }}
+        WANT: ${{ inputs.cargo-sweep-version }}
+        FREE_FLOOR_GB: ${{ inputs.free-floor-gb }}
+      # `${GITHUB_ACTION_PATH//\\//}` — the runner hands this out in native form,
+      # so on Windows it arrives with backslashes, which bash reads as escapes.
+      # Normalising in both steps keeps the two `run:` bodies byte-identical.
+      run: bash "${GITHUB_ACTION_PATH//\\//}/sweep.sh"
 
-        MAXSIZE='${{ inputs.maxsize }}'
-        WANT='${{ inputs.cargo-sweep-version }}'
-
-        if [ ! -d target ]; then
-          echo "No target/ directory in $(pwd) — nothing to sweep."
-          exit 0
-        fi
-
-        # Guard against the footgun the flag invites. cargo-sweep's own help
-        # says "Unit defaults to MB", so `--maxsize 100` means 100 megabytes,
-        # not 100 gigabytes. Refuse a unitless value rather than silently
-        # nuking the cache the `clean: false` checkouts exist to preserve.
-        if ! printf '%s' "$MAXSIZE" | grep -qiE '^[0-9]+(\.[0-9]+)?[[:space:]]*(k|m|g|t)i?b$'; then
-          echo "::error::maxsize='${MAXSIZE}' has no unit suffix. cargo-sweep reads a bare number as MEGABYTES, which would wipe the warm build cache on every run. Use e.g. 100GB."
-          exit 0
-        fi
-
-        HAVE="$(cargo sweep --version 2>/dev/null | awk '{print $NF}')"
-        if [ "$HAVE" != "$WANT" ]; then
-          echo "cargo-sweep: have '${HAVE:-none}', want '${WANT}' — installing."
-          cargo install cargo-sweep --locked --version "$WANT" || true
-        fi
-        if ! cargo sweep --version >/dev/null 2>&1; then
-          echo "::warning::cargo-sweep unavailable (install failed?); skipping target dir GC. This runner's target/ is unbounded until a later run succeeds."
-          exit 0
-        fi
-
-        # `du` on a multi-million-file target dir is not instant, but it is the
-        # only number that makes the trend legible in the job log. Both calls
-        # are non-fatal so a transient stat error cannot break the step.
-        before="$(du -sh target 2>/dev/null | cut -f1)"
-        cargo sweep --maxsize "$MAXSIZE" || true
-        after="$(du -sh target 2>/dev/null | cut -f1)"
-        echo "target/: ${before:-?} before, ${after:-?} after (ceiling ${MAXSIZE})."
-        df -h . 2>/dev/null | tail -2 || true
-
-        # Belt and braces: the step's exit status is the last command's, and no
-        # future edit to the reporting above should be able to fail the job.
-        exit 0
+    - name: Cap target dir size (Windows)
+      if: runner.os == 'Windows'
+      shell: 'C:\Progra~1\Git\bin\bash.exe --noprofile --norc -eo pipefail {0}'
+      env:
+        MAXSIZE: ${{ inputs.maxsize }}
+        WANT: ${{ inputs.cargo-sweep-version }}
+        FREE_FLOOR_GB: ${{ inputs.free-floor-gb }}
+      run: bash "${GITHUB_ACTION_PATH//\\//}/sweep.sh"

--- a/.github/actions/cargo-target-gc/sweep.sh
+++ b/.github/actions/cargo-target-gc/sweep.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Cap the workspace target/ dir with cargo-sweep. Shared verbatim by the Unix
+# and Windows steps in action.yml — see the header there for why this exists.
+#
+# Inputs arrive as environment variables (MAXSIZE, WANT, FREE_FLOOR_GB) rather
+# than `${{ inputs.* }}` interpolation, so the two call sites run byte-identical
+# code and cannot drift.
+
+# `set +e` is load-bearing, and NOT redundant with omitting `set -e`. Both call
+# sites invoke bash with `-e -o pipefail` at the process level, so errexit is
+# already on before the first line runs; simply not turning it on does not turn
+# it off. Without this the very first probe -- `cargo sweep --version` on a
+# runner that has not got cargo-sweep yet -- exits with cargo's 101 and fails
+# the job, which is exactly the opposite of what this script is for. That is not
+# hypothetical: it happened on the first CI run of this action.
+#
+# This is janitorial work running under `if: always()`. Failing to reclaim space
+# must never turn a green build red, so every command below is non-fatal and
+# reports loudly instead, and the script ends in an explicit `exit 0`.
+set +e
+set -uo pipefail
+
+MAXSIZE="${MAXSIZE:-}"
+WANT="${WANT:-}"
+FREE_FLOOR_GB="${FREE_FLOOR_GB:-0}"
+
+# `du` over a multi-million-file target dir is slow everywhere and *very* slow
+# on NTFS through Git Bash, where every stat crosses the Win32 layer. It is only
+# reporting, so bound it and accept "?" when it does not finish.
+#
+# `timeout` is GNU coreutils: present on Linux and in Git Bash, absent from a
+# stock macOS (which has neither `timeout` nor `gtimeout` unless coreutils is
+# brewed). Degrade to a plain `du` there rather than silently reporting "?" on a
+# runner where this used to print real numbers.
+if command -v timeout >/dev/null 2>&1; then
+  dir_size() { timeout 180 du -sh "$1" 2>/dev/null | cut -f1; }
+elif command -v gtimeout >/dev/null 2>&1; then
+  dir_size() { gtimeout 180 du -sh "$1" 2>/dev/null | cut -f1; }
+else
+  dir_size() { du -sh "$1" 2>/dev/null | cut -f1; }
+fi
+
+# Free space on the filesystem holding the checkout, in whole GB. `df -k` is the
+# portable spelling: GNU coreutils (Linux, Git Bash) and BSD df (macOS) all
+# agree on 1K blocks in field 4, whereas `-h` output is not machine-readable and
+# `--output=` is GNU-only.
+free_gb() {
+  df -k . 2>/dev/null | awk 'NR==2 {printf "%d", $4/1024/1024}'
+}
+
+if [ ! -d target ]; then
+  echo "No target/ directory in $(pwd) — nothing to sweep."
+  exit 0
+fi
+
+# Guard against the footgun the flag invites. cargo-sweep's own help says "Unit
+# defaults to MB", so `--maxsize 100` means 100 megabytes, not 100 gigabytes.
+# Refuse a unitless value rather than silently nuking the cache the
+# `clean: false` checkouts exist to preserve.
+if ! printf '%s' "$MAXSIZE" | grep -qiE '^[0-9]+(\.[0-9]+)?[[:space:]]*(k|m|g|t)i?b$'; then
+  echo "::error::maxsize='${MAXSIZE}' has no unit suffix. cargo-sweep reads a bare number as MEGABYTES, which would wipe the warm build cache on every run. Use e.g. 100GB."
+  exit 0
+fi
+
+HAVE="$(cargo sweep --version 2>/dev/null | awk '{print $NF}')"
+if [ "$HAVE" != "$WANT" ]; then
+  echo "cargo-sweep: have '${HAVE:-none}', want '${WANT}' — installing."
+  cargo install cargo-sweep --locked --version "$WANT" || true
+fi
+if ! cargo sweep --version >/dev/null 2>&1; then
+  echo "::warning::cargo-sweep unavailable (install failed?); skipping target dir GC. This runner's target/ is unbounded until a later run succeeds."
+  exit 0
+fi
+
+before="$(dir_size target)"
+cargo sweep --maxsize "$MAXSIZE" || true
+after="$(dir_size target)"
+echo "target/: ${before:-?} before, ${after:-?} after (ceiling ${MAXSIZE})."
+df -h . 2>/dev/null | tail -2 || true
+
+# The failure this guard exists for was invisible until it was terminal: the
+# runner filled up and the NEXT job died in "Set up job", before any step could
+# run and therefore before any workflow change could help it. A ceiling on
+# target/ does not bound anything else on the box (~/.cargo/registry, the
+# runner's _diag logs, stale _work/_actions, Docker/WSL images), so once we have
+# swept, say so out loud while a human can still act on it.
+free="$(free_gb)"
+if [ -n "$free" ] && [ "$FREE_FLOOR_GB" -gt 0 ] && [ "$free" -lt "$FREE_FLOOR_GB" ]; then
+  echo "::warning title=Runner low on disk::${RUNNER_NAME:-this runner} has ${free}GB free after sweeping target/ to ${MAXSIZE}, below the ${FREE_FLOOR_GB}GB floor. target/ is not the only thing growing here — check ~/.cargo/registry, the runner's _diag/ logs and _work/_actions/. A runner that reaches 0 fails the NEXT job in 'Set up job', where no workflow step can rescue it."
+fi
+
+# Belt and braces: the script's exit status is the last command's, and no future
+# edit to the reporting above should be able to fail the job.
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,8 @@ jobs:
       # target dir warm across runs, which is what makes this job fit in 120
       # minutes — but cargo never evicts the artifacts a bump or a toolchain
       # update orphans, so that cache only ever grows. The macOS runner hit its
-      # disk ceiling this way. See .github/actions/cargo-target-gc.
+      # disk ceiling this way, then the Windows one did.
+      # See .github/actions/cargo-target-gc.
       - name: Cap target dir size
         if: always()
         uses: ./.github/actions/cargo-target-gc
@@ -1331,6 +1332,16 @@ jobs:
             Stop-Process -Id $serverPid -Force -ErrorAction SilentlyContinue
             Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
           }
+
+      # This job is the reason the action had to learn Windows. agent4 is the
+      # only Windows agent, this job is pinned to it and checks out with
+      # `clean: false`, and the unpinned `runs-on: [self-hosted]` jobs land there
+      # too — so its target dir grew unbounded until the disk filled and the
+      # NEXT run died in "Set up job", before any step could run. Must come
+      # after the cleanup above so a sweep can never race the running server.
+      - name: Cap target dir size
+        if: always()
+        uses: ./.github/actions/cargo-target-gc
 
   # Release-only conformance gate: run the HTS and extended-CI suites as
   # reusable sub-workflows against the exact tagged commit, so a release is


### PR DESCRIPTION
## The failure

[Run 32182495263](https://github.com/HeliosSoftware/hfs/actions/runs/32182495263/job/95904450543) — `Test FHIRPath` failed in **"Set up job"**:

```
There is not enough space on the disk. :
'C:\actions-runner\_work\_actions\_temp_.../checkout-.../dist/index.js'
```

`github-agent4` was out of disk. Failing in "Set up job" means it failed *before any step ran*, so no workflow change can rescue that run — only the run after a manual reclaim benefits.

## Why the existing GC missed it

`cargo-target-gc` (#564) skipped Windows, reasoning that "the Windows runner is not the one running out of space." That turned out to be the bug:

- **agent4 is the only Windows agent** (`gh api repos/HeliosSoftware/hfs/actions/runners`). `test-fhirpath` is pinned to `[self-hosted, Windows]` and checks out with `clean: false`, so it lands there *every run* — and had no GC step at all.
- `test-rust`, `lint` and `security` use unpinned `runs-on: [self-hosted]` and land there unpredictably with full all-features builds; the action no-oped whenever they did.

So agent4 accumulated a workspace `target/` with nothing ever evicting from it — precisely the failure mode #564 exists to prevent, on the one runner it exempted.

## Changes

**Windows support in the action.** The sweep moves out of an inline `run:` into `sweep.sh`, and a second step invokes it through Git Bash's space-free 8.3 short path (`C:\Progra~1\Git\bin\bash.exe`) — the workaround `ci.yml` already uses twice, since the plain `shell: bash` alias resolves to WSL bash on that agent, which has no distro installed and aborts before running a line. Both platforms run the same script with the same env; that's *why* it's a file now, so the two paths can't drift.

**`test-fhirpath` gets the GC step**, placed after the `fhirpath-server` cleanup so a sweep can never race the running process. The Windows leg of `build` already had the step and simply becomes live.

**A `free-floor-gb` warning** (default 100GB), emitted *after* the sweep. Capping `target/` bounds the thing that compounds but nothing else on the box — `~/.cargo/registry`, the runner's `_diag` logs, stale `_work/_actions`, Docker/WSL images. This outage was invisible until it was terminal; the floor makes "something else is filling this runner" show up in a job log while a human can still act on it. 100GB rather than something tighter because one job here can consume tens of GB in a single run (an all-features build; `cargo llvm-cov` laying down a second instrumented profile), so a 20GB floor would first fire on the run that already failed.

It warns, it never fails. The whole step runs under `if: always()` and must not turn a green build red.

**`du` degrades gracefully** where GNU `timeout` is absent (stock macOS has neither `timeout` nor `gtimeout`), rather than silently reporting `?` on a runner where it used to print real numbers. Where `timeout` exists it's bounded at 180s — `du` over a multi-million-file target dir is slow everywhere and very slow on NTFS through Git Bash, where every stat crosses the Win32 layer.

## On the 100GB ceiling

Left at the default and now documented against the actual fleet: the smallest disk we have is agent4's **1.5TB** C:, so 100GB leaves an order of magnitude of headroom. A ceiling above the volume size is a no-op rather than a cap, so that assumption is written down where the next person adding a runner will read it.

## What this does not do

**It does not reclaim the space already lost.** agent4 needs a manual sweep before it can run a job at all:

```powershell
cd C:\actions-runner\_work\hfs\hfs
cargo clean          # or: cargo sweep --maxsize 100GB
Remove-Item -Recurse -Force $env:USERPROFILE\.cargo\registry\src, $env:USERPROFILE\.cargo\registry\cache
Remove-Item -Recurse -Force C:\actions-runner\_work\_actions\* -EA SilentlyContinue
Remove-Item -Force C:\actions-runner\_diag\*.log -EA SilentlyContinue
```

**And it assumes `target/` is the bulk of the 1.5TB.** Worth confirming rather than taking on faith — if `target/` is only ~200GB, a terabyte is unaccounted for and this recurs:

```powershell
Get-ChildItem C:\ -Directory -Force -EA SilentlyContinue | ForEach-Object {
  [PSCustomObject]@{
    Path = $_.FullName
    GB   = [math]::Round((Get-ChildItem $_.FullName -Recurse -Force -EA SilentlyContinue |
                          Measure-Object Length -Sum).Sum / 1GB, 1)
  }
} | Sort-Object GB -Descending | Select-Object -First 15
```

If a different directory turns out to be the whale, that wants its own follow-up — none of the candidates above are things cargo-sweep touches.

## Verification

The Windows path cannot be exercised locally; it needs a real run on agent4 after the reclaim. `sweep.sh` passes `bash -n`, and both YAML files parse. Watch the `Cap target dir size (Windows)` step on the first `Test FHIRPath` run that lands after merge — it should report before/after sizes and a `df` line.

https://claude.ai/code/session_01TbhNtRsDJvZUrBsjaZUajt
