### PR TITLE
style(fhir-validator): satisfy rustfmt in the editor tests (unbreak main)

### DIFF
--- a/crates/fhir-validator/src/editor.rs
+++ b/crates/fhir-validator/src/editor.rs
@@ -1117,11 +1117,23 @@ mod tests {
         let mut patient = donald();
         add_element(resolver, "Patient", &mut patient, &[], "active").unwrap();
 
-        set_value(resolver, "Patient", &mut patient, &path_from_string("active"), "true");
+        set_value(
+            resolver,
+            "Patient",
+            &mut patient,
+            &path_from_string("active"),
+            "true",
+        );
         assert_eq!(patient["active"], json!(true));
 
         // Clearing a field removes it rather than storing "".
-        set_value(resolver, "Patient", &mut patient, &path_from_string("active"), "");
+        set_value(
+            resolver,
+            "Patient",
+            &mut patient,
+            &path_from_string("active"),
+            "",
+        );
         assert!(patient.get("active").is_none());
     }
 
@@ -1134,7 +1146,13 @@ mod tests {
         // A year-precision date is legal FHIR and must stay a string, even
         // though it parses as an integer.
         add_element(resolver, "Patient", &mut patient, &[], "birthDate").unwrap();
-        set_value(resolver, "Patient", &mut patient, &path_from_string("birthDate"), "1974");
+        set_value(
+            resolver,
+            "Patient",
+            &mut patient,
+            &path_from_string("birthDate"),
+            "1974",
+        );
         assert_eq!(patient["birthDate"], json!("1974"));
 
         // Same for string-typed elements whose content merely looks numeric.


### PR DESCRIPTION
`main` is currently red. The **Linting** job fails at its first step, `cargo fmt --all -- --check`, and has since 96368886f (the #573 merge) — see [run 32282460213](https://github.com/HeliosSoftware/hfs/actions/runs/32282460213).

Because formatting is the first step, **clippy never runs on main right now**, and every branch cut from main inherits the failure. #585 hit exactly this.

## The cause

Three `set_value` calls in `editor.rs`'s `#[cfg(test)]` module sit just over rustfmt's default `fn_call_width` of 60, so rustfmt wants them exploded one-argument-per-line and `--check` fails on the difference:

```rust
set_value(resolver, "Patient", &mut patient, &path_from_string("active"), "true");
```

## The change

`rustfmt` applied to that file, nothing else. Whitespace only, entirely inside the test module — no behavior change.

## Verification

- `cargo fmt --all -- --check` — clean across the workspace
- `cargo test -p helios-fhir-validator --all-features` — all pass, 0 failures

Note the same three hunks are also in #585, which had to carry the fix to get its own Linting job past this step. Whichever lands first, the other side resolves as an identical no-op.