### PR TITLE
fix(ui): keep the editor cross-highlight in view on large documents

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -3204,13 +3204,23 @@ button.filter-rail__item {
 .editor-json__act:hover { color: var(--text); }
 .editor-json__act--on { color: var(--accent); border-color: var(--accent); }
 
-.editor-tree { padding: 12px 14px; }
+/* Both panes are viewport-bound scroll containers, so a large document
+   scrolls inside its own column and the cross-highlight's reveal always has
+   a scrollbar to move — with page-level scrolling, the highlighted
+   counterpart could sit far off-screen (#573 follow-up). */
+.editor-tree {
+  padding: 12px 14px;
+  max-height: 70vh;
+  overflow-y: auto;
+}
 
 /* ---- the foldable JSON view ---- */
 
 .json-view {
   padding: 10px 0;
   overflow-x: auto;
+  max-height: 70vh;
+  overflow-y: auto;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 12px;
   line-height: 1.6;

--- a/crates/ui/assets/editor-sync.js
+++ b/crates/ui/assets/editor-sync.js
@@ -80,7 +80,10 @@
       if (!lightRaw(g, row.dataset.path)) lightJson(g, row.dataset.path);
     } else {
       var match = rowForJsonPath(g, line.dataset.jpath);
-      if (match) match.classList.add("editor-row--hit");
+      if (match) {
+        match.classList.add("editor-row--hit");
+        reveal(g.querySelector(".editor-tree"), match);
+      }
     }
   }
 

--- a/crates/ui/e2e/tests/editor-sync.spec.ts
+++ b/crates/ui/e2e/tests/editor-sync.spec.ts
@@ -12,6 +12,48 @@ function standalone(page: import("@playwright/test").Page): Editor {
   return new Editor(page, page.locator("#editor-body"));
 }
 
+test("the highlight scrolls its counterpart into view on a large document", async ({ page }) => {
+  await page.goto("/ui/editor?type=Patient", { waitUntil: "networkidle" });
+  const ed = standalone(page);
+  // Enough repeating structure that both panes overflow their 70vh columns.
+  await ed.applyJson({
+    resourceType: "Patient",
+    identifier: Array.from({ length: 40 }, (_, i) => ({
+      system: "http://example.org/mrn",
+      value: String(10000 + i),
+    })),
+    gender: "female",
+  });
+
+  // Leaving raw shows the previous fold view immediately; the re-render with
+  // the big document lands a beat later — wait for its deepest row.
+  await page.locator('.editor-row[data-path="identifier.39.value"]').waitFor();
+
+  const jsonView = page.locator("#json-view");
+  const tree = page.locator(".editor-tree");
+  expect(await jsonView.evaluate((n) => n.scrollHeight > n.clientHeight)).toBe(true);
+  expect(await tree.evaluate((n) => n.scrollHeight > n.clientHeight)).toBe(true);
+
+  // Hovering a row deep in the form pulls the JSON pane down to its lines…
+  await tree.evaluate((n) => (n.scrollTop = n.scrollHeight));
+  await page.locator('.editor-row[data-path="identifier.39.value"]').hover();
+  await expect.poll(() => jsonView.evaluate((n) => n.scrollTop)).toBeGreaterThan(0);
+  const hit = page.locator('.json-line--hit[data-jpath="identifier.39.value"]');
+  expect(await hit.evaluate((n) => {
+    const view = document.getElementById("json-view")!;
+    const line = n.getBoundingClientRect();
+    const pane = view.getBoundingClientRect();
+    return line.top >= pane.top && line.bottom <= pane.bottom;
+  })).toBe(true);
+
+  // …and hovering a deep JSON line pulls the form pane to its row.
+  await jsonView.evaluate((n) => (n.scrollTop = n.scrollHeight));
+  await tree.evaluate((n) => (n.scrollTop = 0));
+  await page.locator('.json-line[data-jpath="identifier.35.value"]').hover();
+  await expect.poll(() => tree.evaluate((n) => n.scrollTop)).toBeGreaterThan(0);
+  await expect(page.locator('.editor-row--hit[data-path="identifier.35.value"]')).toHaveCount(1);
+});
+
 test("hovering a form row lights the node's JSON lines, and back", async ({ page }) => {
   await page.goto("/ui/editor?type=Patient", { waitUntil: "networkidle" });
   const ed = standalone(page);


### PR DESCRIPTION
Manual-review follow-up to #573: the cross-highlight works, but on a large document the highlighted counterpart could sit far off screen — both editor panes grew with their content, the *page* scrolled, and the reveal that keeps the counterpart visible had no scrollbar of its own to move.

## The fix

- Both panes become viewport-bound scroll columns (70vh, own overflow) — a big resource scrolls inside its column, side by side, and the reveal always has somewhere to act. This also matches how the design treats the two views: parallel panels over one document, not one endless page.
- The one missing reveal direction is wired: hovering a JSON line now brings the matched form row into its pane's viewport (row→JSON and the raw-mode caret already did this).

## Tests

A new spec overflows both panes with a 40-identifier Patient and asserts both directions: hovering the deepest form row scrolls the JSON pane until the lit line sits inside its visible box, and hovering a deep JSON line scrolls the tree to the matched row. Writing it caught a real timing subtlety — leaving raw mode shows the previous fold view before the re-render lands, so the spec waits for the new document's rows (worth knowing for future editor specs).

Full hermetic suite: **141 passed**.