### PR TITLE
feat(ui): wire the dashboard Uptime card to real process uptime

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -648,12 +648,6 @@ button.menu__option {
   color: var(--text);
 }
 
-.stat__unit {
-  font-size: 17px;
-  letter-spacing: -0.3px;
-  vertical-align: 12px;
-}
-
 .stat__sub {
   display: block;
   margin-top: 6px;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -351,9 +351,9 @@ impl Status {
 ///
 /// `resource_types`, `stored_resources`, `fhir_version`, `export_jobs`,
 /// `import_jobs`, and `chart_total` are derived from the live
-/// [`DashboardSnapshot`] (default tenant). `uptime_percent` describes
-/// availability history, which is not part of that read path and remains a
-/// placeholder value until #540 wires it to a real source.
+/// [`DashboardSnapshot`] (default tenant). `uptime` is the process uptime from
+/// `helios_observability::uptime` (#540); in a cluster it describes only the
+/// node that served this request.
 struct DashboardMetrics {
     fhir_version: String,
     resource_types: String,
@@ -363,8 +363,30 @@ struct DashboardMetrics {
     /// Active bulk-submit (import) jobs for the tenant; `None` renders the
     /// unavailable state.
     import_jobs: Option<u64>,
-    uptime_percent: String,
+    /// Formatted process uptime; `None` renders the unavailable state (the
+    /// uptime tracker was never initialized).
+    uptime: Option<String>,
     chart_total: String,
+}
+
+/// Process uptime as a short human duration ("3d 4h", "5h 12m", "42m", "18s"),
+/// or `None` when the tracker was never initialized and no honest figure
+/// exists.
+fn format_uptime(seconds: f64) -> Option<String> {
+    if seconds <= 0.0 {
+        return None;
+    }
+    let s = seconds as u64;
+    let (d, h, m) = (s / 86_400, (s % 86_400) / 3_600, (s % 3_600) / 60);
+    Some(if d > 0 {
+        format!("{d}d {h}h")
+    } else if h > 0 {
+        format!("{h}h {m}m")
+    } else if m > 0 {
+        format!("{m}m")
+    } else {
+        format!("{s}s")
+    })
 }
 
 /// A single axis gridline or tick, in the chart's `0 0 1060 300` viewBox. `pos`
@@ -1512,8 +1534,7 @@ fn build_dashboard(snapshot: &DashboardSnapshot, expand: bool) -> DashboardView 
         stored_resources: compact_count(snapshot.total_resources),
         export_jobs: snapshot.export_jobs,
         import_jobs: snapshot.import_jobs_active,
-        // Uptime is still a placeholder until #540 wires it to a real source.
-        uptime_percent: "99.98".to_string(),
+        uptime: format_uptime(helios_observability::uptime::uptime_seconds()),
         chart_total: {
             let sum: u64 = snapshot.series.iter().map(|s| s.total).sum();
             grouped(sum)
@@ -1913,6 +1934,22 @@ mod tests {
             i18n,
             active_page: "home",
         }
+    }
+
+    #[test]
+    fn format_uptime_picks_the_two_leading_units() {
+        assert_eq!(format_uptime(0.0), None);
+        assert_eq!(format_uptime(-5.0), None);
+        assert_eq!(format_uptime(18.4), Some("18s".to_string()));
+        assert_eq!(format_uptime(42.0 * 60.0 + 30.0), Some("42m".to_string()));
+        assert_eq!(
+            format_uptime(5.0 * 3_600.0 + 12.0 * 60.0),
+            Some("5h 12m".to_string())
+        );
+        assert_eq!(
+            format_uptime(3.0 * 86_400.0 + 4.0 * 3_600.0 + 59.0 * 60.0),
+            Some("3d 4h".to_string())
+        );
     }
 
     /// A point at a fixed instant, for geometry tests that don't care when.

--- a/crates/ui/templates/pages/index.html
+++ b/crates/ui/templates/pages/index.html
@@ -38,8 +38,13 @@
   </a>
   <article class="card stat">
     <span class="stat__label">{{ i18n.t("card-uptime") }}</span>
-    <span class="stat__value">{{ metrics.uptime_percent }}<span class="stat__unit">%</span></span>
+    {% if let Some(uptime) = metrics.uptime %}
+    <span class="stat__value">{{ uptime }}</span>
     <span class="stat__sub">{{ i18n.t("card-uptime-sub") }}</span>
+    {% else %}
+    <span class="stat__value stat__value--unavailable" aria-label="{{ i18n.t("card-jobs-unavailable") }}">&mdash;</span>
+    <span class="stat__sub">{{ i18n.t("card-jobs-unavailable") }}</span>
+    {% endif %}
   </article>
 </section>
 

--- a/crates/ui/tests/dashboard_uptime_http.rs
+++ b/crates/ui/tests/dashboard_uptime_http.rs
@@ -1,0 +1,47 @@
+//! The initialized half of the dashboard Uptime card (#540). The uptime
+//! tracker is process-global (`OnceCell` in `helios_observability::uptime`),
+//! so this lives in its own test binary: `router_http.rs` asserts the
+//! never-initialized fallback, this file asserts the real read path.
+
+use axum::{Router, body::Body, http::Request};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+fn app() -> Router {
+    helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        Some(std::path::PathBuf::from("../../data")),
+        helios_ui::NlSearch {
+            enabled: false,
+            configured: false,
+            model: String::new(),
+        },
+        None,
+        None,
+        "default".to_string(),
+        std::sync::Arc::new(helios_ui::StaticConformanceSource::from_data_dir(
+            std::path::Path::new("../../data"),
+        )),
+        helios_fhir::FhirVersion::R4,
+        None,
+    )
+}
+
+#[tokio::test]
+async fn uptime_card_shows_the_process_uptime_once_initialized() {
+    helios_observability::uptime::init();
+
+    let response = app()
+        .oneshot(Request::get("/ui").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let html = String::from_utf8(bytes.to_vec()).unwrap();
+
+    // The sub-label only renders on the initialized branch, and the value is
+    // a duration, never the old hardcoded percentage.
+    assert!(html.contains("since process start"));
+    assert!(!html.contains("99.98"));
+}

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -82,6 +82,14 @@ async fn dashboard_renders_job_cards_with_unavailable_state_when_no_provider() {
     assert!(html.contains("unavailable"));
     assert!(!html.contains(">13<"));
     assert!(!html.contains("queued)"));
+
+    // The Uptime card follows the same honesty rule (#540): this test binary
+    // never calls helios_observability::uptime::init(), so the card renders
+    // the unavailable state, not the old hardcoded percentage. The
+    // initialized path lives in tests/dashboard_uptime_http.rs — a separate
+    // binary, because the tracker is process-global.
+    assert!(!html.contains("99.98"));
+    assert!(!html.contains("since process start"));
 }
 
 #[tokio::test]

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -138,8 +138,8 @@ card-export-jobs-sub = laufend ({ $queued } in der Warteschlange)
 card-import-jobs = Import-Jobs
 card-import-jobs-sub = aktiv
 card-jobs-unavailable = nicht verfügbar
-card-uptime = Verfügbarkeit
-card-uptime-sub = letzte 30 Tage
+card-uptime = Betriebszeit
+card-uptime-sub = seit Prozessstart
 
 chart-title = FHIR-Ressourcen im Zeitverlauf
 chart-expand = Diagramm vergrößern

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -143,7 +143,7 @@ card-import-jobs = Import jobs
 card-import-jobs-sub = active
 card-jobs-unavailable = unavailable
 card-uptime = Uptime
-card-uptime-sub = last 30 days
+card-uptime-sub = since process start
 
 chart-title = FHIR resources over time
 chart-expand = Expand chart

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -138,8 +138,8 @@ card-export-jobs-sub = en ejecución ({ $queued } en cola)
 card-import-jobs = Trabajos de importación
 card-import-jobs-sub = activos
 card-jobs-unavailable = no disponible
-card-uptime = Disponibilidad
-card-uptime-sub = últimos 30 días
+card-uptime = Tiempo activo
+card-uptime-sub = desde el arranque del proceso
 
 chart-title = Recursos FHIR en el tiempo
 chart-expand = Ampliar el gráfico


### PR DESCRIPTION
Closes #540.

The Uptime stat card on /ui was a hardcoded `99.98%` / "last 30 days" regardless of how long the server had been running. This wires it to real data — option A from the issue: the self-contained process-uptime read, no external Prometheus server required.

## What changed

- The card now shows the process uptime from `helios_observability::uptime::uptime_seconds()` formatted as a short duration (`3d 4h`, `5h 12m`, `42m`, `18s` — the two leading units).
- Sub-label changed from "last 30 days" to "since process start" (en/es/de). The es/de card labels also move from "Disponibilidad"/"Verfügbarkeit" (availability) to "Tiempo activo"/"Betriebszeit", since the value is an uptime duration, not an availability percentage.
- When the uptime tracker was never initialized, the card renders the same explicit unavailable state (em dash + "unavailable") as the export/import job cards — never a fabricated number.
- `.stat__unit` (the `%` superscript) had no other consumer and is removed from app.css, per the #543 no-dead-classes rule.

## Notes

- In a clustered deployment the figure describes only the node that served the request — same caveat as the `uptime_seconds` gauge on `/metrics`; noted on the struct doc.
- No per-tenant data involved, so the `/metrics` tenant-label constraint is untouched.

## Tests

- `format_uptime` unit tests (unit selection, zero/negative → `None`).
- `router_http.rs`: the uninitialized binary asserts the unavailable state and that `99.98` is gone.
- New `tests/dashboard_uptime_http.rs`: separate test binary (the tracker is process-global) initializes it and asserts the duration path renders.
- Full `cargo test -p helios-ui` green locally.