### PR TITLE
feat(ui): make the conformance-backed resource-type lists FHIR-version aware

### DIFF
--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -54,6 +54,10 @@ helios-auth = { path = "../auth", version = "0.2.1" }
 # Web framework (matches the version used by helios-hfs / helios-rest)
 axum = "0.8"
 
+# Spec-bundle reads for non-default FHIR versions run off the async threads
+# (#562). Runtime only — the server (axum) always provides one.
+tokio = { version = "1", features = ["rt"] }
+
 # Chart bucket timestamps: formatting x-axis labels, and shaping the placeholder
 # series rendered when no dashboard provider is registered.
 chrono.workspace = true

--- a/crates/ui/src/bulk_export.rs
+++ b/crates/ui/src/bulk_export.rs
@@ -262,13 +262,7 @@ pub async fn page(
     let i18n = I18n::new(locale);
     let status = current_status(state.version, rv.0, &rt);
     let user_key = settings_user_key(principal.as_deref());
-    // Like the other three callers, the version here is a cache key only —
-    // the list reflects the server's seeded version regardless of the sidebar
-    // selector (see resource_type_names' caveat).
-    let resource_types = state
-        .compartments
-        .resource_type_names(&rt.id, helios_fhir::FhirVersion::default())
-        .await;
+    let resource_types = state.compartments.resource_type_names(&rt.id, rv.0).await;
     let active_count = load_jobs(&state, &user_key, &rt.id)
         .await
         .values()

--- a/crates/ui/src/compartments.rs
+++ b/crates/ui/src/compartments.rs
@@ -126,15 +126,11 @@ impl CompartmentCatalog {
     }
 
     /// Every resource type of the version, from the first CompartmentDefinition
-    /// (each enumerates the full set — 145 in R4). Used by the queries page's
-    /// resource picker rail.
-    ///
-    /// Caveat: `version` is a **cache key only**. The production
-    /// [`HttpConformanceSource`](crate::conformance) discards its version
-    /// argument, so the list always reflects whatever version the server
-    /// seeded (`HFS_FHIR_VERSION`) — the sidebar's version selector does not
-    /// change it. Correct on a single-version deployment, which is the common
-    /// case; making the version real end-to-end is tracked separately.
+    /// (each enumerates the full set — 145 in R4, 157 in R5). Used by the
+    /// resource pickers on the Search, Queries, Resources, and Bulk Export
+    /// pages, which pass the sidebar's selected version (#562). For versions
+    /// other than the server's seeded default the definitions come from the
+    /// shipped spec bundles, not storage — see [`crate::conformance`].
     pub async fn resource_type_names(&self, tenant: &str, version: FhirVersion) -> Vec<String> {
         self.definitions(tenant, version)
             .await

--- a/crates/ui/src/conformance.rs
+++ b/crates/ui/src/conformance.rs
@@ -6,11 +6,18 @@
 //! `/CompartmentDefinition`. This crate reads them from that FHIR API over
 //! HTTP rather than from disk, so the UI shows exactly what the server holds.
 //!
+//! Storage only ever holds the server's default FHIR version (seeding is
+//! keyed on `HFS_DEFAULT_FHIR_VERSION`), so a fetch for any *other* enabled
+//! version answers from the shipped `data/` spec bundles instead (#562) —
+//! the correct per-version spec set, minus tenant-stored custom resources,
+//! which only exist for the seeded default.
+//!
 //! [`ConformanceSource`] abstracts the fetch so tests can inject a
 //! [`StaticConformanceSource`] (offline, from the shipped `data/` bundles)
 //! instead of standing up a real server.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -40,18 +47,69 @@ pub(crate) struct HttpConformanceSource {
     client: reqwest::Client,
     base_url: String,
     outbound_auth: Arc<dyn helios_auth::outbound::OutboundAuthProvider>,
+    /// The version the server seeds into storage (`HFS_DEFAULT_FHIR_VERSION`).
+    /// Fetches for this version go over HTTP; any other enabled version
+    /// answers from the spec bundles in `data_dir` (#562).
+    default_version: FhirVersion,
+    data_dir: Option<PathBuf>,
 }
 
 impl HttpConformanceSource {
     pub fn new(
         base_url: String,
         outbound_auth: Arc<dyn helios_auth::outbound::OutboundAuthProvider>,
+        default_version: FhirVersion,
+        data_dir: Option<PathBuf>,
     ) -> Self {
         Self {
             client: reqwest::Client::new(),
             base_url: base_url.trim_end_matches('/').to_string(),
             outbound_auth,
+            default_version,
+            data_dir,
         }
+    }
+
+    /// Loads `resource_type` for a non-default `version` from the shipped
+    /// `data/` spec bundles. Storage cannot answer these: seeding only writes
+    /// the default version, and the FHIR search surface has no per-version
+    /// filter, so the bundle is the authoritative set for the version.
+    async fn fetch_spec_bundle(
+        &self,
+        resource_type: &str,
+        version: FhirVersion,
+    ) -> Result<Vec<Value>, String> {
+        let Some(dir) = self.data_dir.clone() else {
+            return Err(format!(
+                "no {resource_type} data for FHIR {}: storage holds the server default ({}) and no data directory is configured",
+                version.as_str(),
+                self.default_version.as_str(),
+            ));
+        };
+        let resource_type = resource_type.to_string();
+        tokio::task::spawn_blocking(move || match resource_type.as_str() {
+            "SearchParameter" => helios_fhir::search::SearchParameterLoader::new(version)
+                .load_spec_resources(&dir)
+                .map_err(|e| {
+                    format!(
+                        "loading the FHIR {} SearchParameter bundle failed: {e}",
+                        version.as_str()
+                    )
+                }),
+            "CompartmentDefinition" => {
+                helios_fhir::compartment::CompartmentDefinitionLoader::new(version)
+                    .load_spec_resources(&dir)
+                    .map_err(|e| {
+                        format!(
+                            "loading the FHIR {} CompartmentDefinition bundle failed: {e}",
+                            version.as_str()
+                        )
+                    })
+            }
+            other => Err(format!("unsupported conformance type {other}")),
+        })
+        .await
+        .map_err(|e| format!("spec bundle load failed: {e}"))?
     }
 }
 
@@ -60,9 +118,14 @@ impl ConformanceSource for HttpConformanceSource {
     async fn fetch(
         &self,
         resource_type: &str,
-        _version: FhirVersion,
+        version: FhirVersion,
         tenant: &str,
     ) -> Result<Vec<Value>, String> {
+        // Storage only holds the seeded default version; any other enabled
+        // version answers from the shipped spec bundles (#562).
+        if version != self.default_version {
+            return self.fetch_spec_bundle(resource_type, version).await;
+        }
         // Ask for everything at once, then follow `next` links for whatever
         // the server's `_count` policy withheld (#460): the request says
         // 10000, but a server capping at 1000 used to silently truncate the
@@ -72,10 +135,13 @@ impl ConformanceSource for HttpConformanceSource {
         let mut resources = Vec::new();
         // Generous page bound — only a runaway self-linking server hits it.
         for _ in 0..100 {
-            let mut request = self
-                .client
-                .get(&url)
-                .header("Accept", "application/fhir+json");
+            let mut request = self.client.get(&url).header(
+                "Accept",
+                format!(
+                    "application/fhir+json; fhirVersion={}",
+                    version.as_mime_param()
+                ),
+            );
             // Scope the self-call to the effective tenant (#344); an empty id
             // means the server default and needs no header.
             if !tenant.is_empty() {
@@ -244,14 +310,83 @@ mod tests {
         );
     }
 
+    /// #562: a fetch for a version other than the server default answers from
+    /// the shipped spec bundles without touching HTTP — nothing listens at the
+    /// base URL, so reaching for it would fail the fetch.
+    #[cfg(feature = "R4B")]
+    #[tokio::test]
+    async fn non_default_versions_answer_from_the_spec_bundles() {
+        let source = HttpConformanceSource::new(
+            "http://127.0.0.1:1".to_string(),
+            std::sync::Arc::new(helios_auth::outbound::NoOpOutboundAuthProvider),
+            FhirVersion::R4,
+            Some(std::path::PathBuf::from("../../data")),
+        );
+        let defs = source
+            .fetch("CompartmentDefinition", FhirVersion::R4B, "")
+            .await
+            .expect("spec bundle load");
+        let patient = defs
+            .iter()
+            .find(|d| d["code"] == "Patient")
+            .expect("patient compartment");
+        let codes: Vec<&str> = patient["resource"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|r| r["code"].as_str())
+            .collect();
+        // The set is genuinely the R4B one: Ingredient joined in R4B,
+        // EffectEvidenceSynthesis left after R4.
+        assert!(codes.contains(&"Ingredient"));
+        assert!(!codes.contains(&"EffectEvidenceSynthesis"));
+    }
+
+    /// #562: with no data directory a non-default version cannot be served —
+    /// the fetch fails loudly (degraded page) instead of silently answering
+    /// with the wrong version's set.
+    #[cfg(feature = "R4B")]
+    #[tokio::test]
+    async fn non_default_version_without_a_data_dir_fails_loudly() {
+        let source = HttpConformanceSource::new(
+            "http://127.0.0.1:1".to_string(),
+            std::sync::Arc::new(helios_auth::outbound::NoOpOutboundAuthProvider),
+            FhirVersion::R4,
+            None,
+        );
+        let err = source
+            .fetch("CompartmentDefinition", FhirVersion::R4B, "")
+            .await
+            .expect_err("no data dir to answer from");
+        assert!(err.contains(FhirVersion::R4B.as_str()), "{err}");
+    }
+
     /// #460: a server that caps `_count` answers in pages; the fetch must
     /// follow `next` links and return the union, not the first page.
+    /// The self-call also names the requested version on the Accept header
+    /// (#562) — the handler rejects a request without it.
     #[tokio::test]
     async fn http_fetch_follows_next_links() {
+        use axum::http::HeaderMap;
+        use axum::response::IntoResponse;
         use axum::{Router, extract::Query, routing::get};
         use std::collections::HashMap;
 
-        async fn page(Query(q): Query<HashMap<String, String>>) -> axum::Json<Value> {
+        async fn page(
+            headers: HeaderMap,
+            Query(q): Query<HashMap<String, String>>,
+        ) -> axum::response::Response {
+            let accept = headers
+                .get("accept")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default();
+            if !accept.contains("fhirVersion=4.0") {
+                return axum::http::StatusCode::NOT_ACCEPTABLE.into_response();
+            }
+            inner(q).into_response()
+        }
+
+        fn inner(q: HashMap<String, String>) -> axum::Json<Value> {
             let offset: usize = q.get("_offset").map(|o| o.parse().unwrap()).unwrap_or(0);
             let mut bundle = serde_json::json!({
                 "resourceType": "Bundle",
@@ -277,6 +412,8 @@ mod tests {
         let source = HttpConformanceSource::new(
             format!("http://{addr}"),
             std::sync::Arc::new(helios_auth::outbound::NoOpOutboundAuthProvider),
+            FhirVersion::R4,
+            None,
         );
         let resources = source
             .fetch("SearchParameter", FhirVersion::R4, "")

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -649,6 +649,8 @@ pub fn mount(
     let source: Arc<dyn ConformanceSource> = Arc::new(conformance::HttpConformanceSource::new(
         self_base_url,
         outbound_auth,
+        fhir_version,
+        data_dir.clone(),
     ));
     mount_with_conformance_source(
         fhir_app,
@@ -1048,10 +1050,7 @@ async fn search(
     rv: RequestVersion,
     rt: RequestTenant,
 ) -> Response {
-    let resource_types = state
-        .compartments
-        .resource_type_names(&rt.id, helios_fhir::FhirVersion::default())
-        .await;
+    let resource_types = state.compartments.resource_type_names(&rt.id, rv.0).await;
     render(SearchPage {
         status: current_status(state.version, rv.0, &rt),
         i18n: I18n::new(locale),
@@ -1070,10 +1069,7 @@ async fn queries(
     rv: RequestVersion,
     rt: RequestTenant,
 ) -> Response {
-    let resource_types = state
-        .compartments
-        .resource_type_names(&rt.id, helios_fhir::FhirVersion::default())
-        .await;
+    let resource_types = state.compartments.resource_type_names(&rt.id, rv.0).await;
     render(QueriesPage {
         status: current_status(state.version, rv.0, &rt),
         i18n: I18n::new(locale),
@@ -1095,10 +1091,7 @@ async fn resources(
     rt: RequestTenant,
     Query(query): Query<ResourcesQuery>,
 ) -> Response {
-    let resource_types = state
-        .compartments
-        .resource_type_names(&rt.id, helios_fhir::FhirVersion::default())
-        .await;
+    let resource_types = state.compartments.resource_type_names(&rt.id, rv.0).await;
     render(ResourcesPage {
         status: current_status(state.version, rv.0, &rt),
         i18n: I18n::new(locale),
@@ -1128,16 +1121,14 @@ struct ParamsCatalogQuery {
 
 /// Parameter datalist for the search builder: the active parameters that
 /// apply to the given resource type (including `Resource` /
-/// `DomainResource`-level ones), from the default-version snapshot.
+/// `DomainResource`-level ones), from the selected version's snapshot.
 async fn query_params_catalog(
     State(state): State<WebState>,
     rt: RequestTenant,
+    rv: RequestVersion,
     Query(raw): Query<ParamsCatalogQuery>,
 ) -> Response {
-    let snapshot = state
-        .sp_catalog
-        .snapshot(&rt.id, helios_fhir::FhirVersion::default())
-        .await;
+    let snapshot = state.sp_catalog.snapshot(&rt.id, rv.0).await;
     let resource_type = raw.resource_type.unwrap_or_default();
     let mut params: Vec<ParamOption> = snapshot
         .params

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -296,6 +296,71 @@ async fn version_choice_persists_to_user_settings_and_redirects_back() {
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
 
+/// #562: the resource-type lists follow the sidebar's version choice
+/// end-to-end — selecting a version through `/ui/version` changes which
+/// compartment bundle the pickers enumerate. Ingredient exists only in R4B;
+/// EffectEvidenceSynthesis only in R4. Gated on the R4B feature (CI runs
+/// `--all-features`); a single-version build has nothing to flip.
+#[cfg(feature = "R4B")]
+#[tokio::test]
+async fn version_choice_changes_the_resource_type_lists() {
+    use helios_persistence::core::SettingsStore;
+
+    let backend = Arc::new({
+        let b = SqliteBackend::in_memory().expect("in-memory sqlite");
+        b.init_schema().expect("init schema");
+        b
+    });
+    let app = || {
+        helios_ui::mount_with_conformance_source(
+            Router::new(),
+            "9.9.9",
+            Some(std::path::PathBuf::from("../../data")),
+            helios_ui::NlSearch::default(),
+            None,
+            Some(backend.clone() as Arc<dyn SettingsStore>),
+            "default".to_string(),
+            Arc::new(helios_ui::StaticConformanceSource::from_data_dir(
+                std::path::Path::new("../../data"),
+            )),
+            FhirVersion::R4,
+            None,
+        )
+    };
+
+    // Default version (R4): the queries page's type rail carries the R4 set.
+    let res = app()
+        .oneshot(Request::get("/ui/queries").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let body = body_text(res).await;
+    // Anchored to the rail markup: bare `Ingredient` would also match R4's
+    // MedicinalProductIngredient.
+    assert!(body.contains(r#"data-rail-type="EffectEvidenceSynthesis""#));
+    assert!(!body.contains(r#"data-rail-type="Ingredient""#));
+
+    // Select R4B through the same endpoint the sidebar posts to.
+    let res = app()
+        .oneshot(
+            Request::post("/ui/version")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("version=R4B"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER);
+
+    // The same page now enumerates the R4B set.
+    let res = app()
+        .oneshot(Request::get("/ui/queries").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let body = body_text(res).await;
+    assert!(body.contains(r#"data-rail-type="Ingredient""#));
+    assert!(!body.contains(r#"data-rail-type="EffectEvidenceSynthesis""#));
+}
+
 #[tokio::test]
 async fn tenant_choice_persists_and_the_selector_follows_it() {
     use helios_persistence::core::SettingsStore;


### PR DESCRIPTION
Closes #562.

From Steve's review of the Bulk Export page (#538): the resource-type pickers (Search, Queries, Resources, Bulk Export) ignored the sidebar's FHIR-version selector. All four passed `FhirVersion::default()`, and `HttpConformanceSource` discarded its version argument entirely — the version was a cache key only, so the lists always reflected the seeded server default.

## What changed

**`HttpConformanceSource` is now genuinely version-aware.** During investigation it turned out the self-call alone can't do it: conformance seeding writes only `HFS_DEFAULT_FHIR_VERSION` into storage, and the FHIR search surface has no per-version filter, so there is nothing version-scoped for the HTTP call to ask for. The fetch therefore splits:

- **Server default version** → over HTTP as before (storage truth: spec set + tenant-stored customs). The request now also names the version on the Accept header (`fhirVersion` MIME parameter), so a future server-side filter slots in without a UI change.
- **Any other enabled version** → the shipped `data/` spec bundles, which are the authoritative set for those versions. Loaded off the async threads, cached per (tenant, version) by the existing catalogs.
- **No data dir configured** → the fetch fails loudly into the existing degraded-page path rather than serving the wrong version's set.

Known limit, documented on the source: tenant-stored *custom* conformance resources only exist for the seeded default, so they appear only under that version.

**Callers pass the request version.** The four pickers now pass `rv.0`; the query-builder parameter datalist follows the selected version too. The SearchParameter and Compartment viewers already passed a real version that production silently ignored — they now get what they asked for.

The old "version is a cache key only" caveats at `resource_type_names` and the Bulk Export call site are gone.

## Tests

- `non_default_versions_answer_from_the_spec_bundles` / `non_default_version_without_a_data_dir_fails_loudly` — unit tests on the split, proving no HTTP is touched (dead base URL). Gated on the `R4B` feature; CI's `--all-features` runs them.
- `http_fetch_follows_next_links` now also asserts the Accept header carries the version (the stub returns 406 without it).
- `version_choice_changes_the_resource_type_lists` — end-to-end: POST `/ui/version` flips R4→R4B and the Queries rail swaps `EffectEvidenceSynthesis` (R4-only) for `Ingredient` (R4B-only). Assertions anchored to the rail markup — bare `Ingredient` would match R4's `MedicinalProductIngredient`.
- Full `cargo test -p helios-ui` green with default features and with `--features R4B`; clippy clean; `cargo check -p helios-hfs` green.

## Notes

- `tokio` (features `rt` only) moves from dev-dependency to dependency for `spawn_blocking` — already in the tree via axum/reqwest, zero new transitive weight.