### PR TITLE
style: unbreak the Linting job on main (rustfmt + macOS precedence guard)

### DIFF
--- a/crates/hts/scripts/check-canonical-precedence.sh
+++ b/crates/hts/scripts/check-canonical-precedence.sh
@@ -17,6 +17,10 @@ cd "$(dirname "$0")/.."
 # `code_systems.version`, …) so a query cannot dodge the guard by renaming its
 # alias — the earlier three-literal form let exactly that slip through.
 #
+# The exclusion pattern tolerates a repeated slash: BSD grep (the macOS lint
+# runners) prints `src//backends/mod.rs` for a `src/` root, so a literal
+# `src/backends/mod.rs` filter missed it and the guard failed on macOS only.
+#
 # `backends/mod.rs` is the one sanctioned home of the ordering: the shared
 # helpers there emit `COALESCE({alias}.version, '') DESC` with a `{alias}`
 # placeholder, which does not match the concrete-alias pattern anyway, but it is
@@ -24,7 +28,7 @@ cd "$(dirname "$0")/.."
 # rewritten to use a literal alias.
 if hits=$(grep -rnE --include=*.rs \
         "COALESCE\(([A-Za-z_][A-Za-z0-9_]*\.)?version, ''\) DESC" \
-        src/ 2>/dev/null | grep -v 'src/backends/mod.rs'); then
+        src/ 2>/dev/null | grep -vE 'src/+backends/mod\.rs'); then
     echo "ERROR: hand-rolled same-URL ordering found." >&2
     echo "Use crate::backends::cs_precedence_order_by() / vs_precedence_order_by() instead." >&2
     echo "See crates/hts/docs/ig-publisher-compatibility.md §2a (issue #200)." >&2

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -1038,7 +1038,10 @@ impl helios_observability::subscriptions::SubscriptionsProvider for EngineSubscr
             .map(|s| {
                 let ws_clients = matches!(s.channel.channel_type, ChannelType::Websocket)
                     .then(|| self.engine.ws_manager().client_count(&s.tenant_id, &s.id));
-                let window = self.engine.delivery_stats().window(&s.tenant_id, &s.id, now);
+                let window = self
+                    .engine
+                    .delivery_stats()
+                    .window(&s.tenant_id, &s.id, now);
                 SubscriptionRow {
                     id: s.id,
                     topic_url: s.topic_url,

--- a/crates/subscriptions/src/delivery_stats.rs
+++ b/crates/subscriptions/src/delivery_stats.rs
@@ -99,7 +99,9 @@ impl DeliveryStats {
             .rings
             .entry((tenant.to_string(), id.to_string()))
             .or_insert_with(|| Mutex::new([Bucket::default(); BUCKET_COUNT]));
-        let mut ring = entry.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut ring = entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let bucket = &mut ring[index];
         if bucket.start != start {
             // The slot's old half-hour aged out of the window; reuse it.
@@ -140,7 +142,10 @@ mod tests {
             }
         );
         // Another subscription is untouched.
-        assert_eq!(stats.window("t", "other", T0 + 30), DeliveryWindow::default());
+        assert_eq!(
+            stats.window("t", "other", T0 + 30),
+            DeliveryWindow::default()
+        );
     }
 
     #[test]

--- a/crates/subscriptions/src/lib.rs
+++ b/crates/subscriptions/src/lib.rs
@@ -33,10 +33,10 @@ pub mod topics;
 
 // Re-export key types for convenience.
 pub use channels::messaging::MessagingChannel;
-pub use delivery_stats::{DeliveryStats, DeliveryWindow};
 pub use channels::ws_manager::WebSocketManager;
 pub use channels::ws_token::WsBindingTokenManager;
 pub use config::{MessagingSettings, SubscriptionConfig};
+pub use delivery_stats::{DeliveryStats, DeliveryWindow};
 pub use engine::SubscriptionEngine;
 pub use error::SubscriptionError;
 pub use event::{ResourceEvent, ResourceEventType};

--- a/crates/ui/src/subscriptions.rs
+++ b/crates/ui/src/subscriptions.rs
@@ -88,8 +88,12 @@ pub async fn page(
     // Tenant-wide delivery figures for the DELIVERED IN 24 H card (#586).
     let delivered_total: u64 = source_rows.iter().map(|r| r.delivered_24h).sum();
     let first_try_total: u64 = source_rows.iter().map(|r| r.first_try_24h).sum();
-    let rate = (delivered_total > 0)
-        .then(|| format!("{:.1}", first_try_total as f64 * 100.0 / delivered_total as f64));
+    let rate = (delivered_total > 0).then(|| {
+        format!(
+            "{:.1}",
+            first_try_total as f64 * 100.0 / delivered_total as f64
+        )
+    });
 
     let mut rows: Vec<SubscriptionRowView> = source_rows
         .into_iter()

--- a/crates/ui/tests/subscriptions_http.rs
+++ b/crates/ui/tests/subscriptions_http.rs
@@ -127,7 +127,10 @@ async fn the_page_goes_from_unavailable_to_the_live_dashboard() {
     );
 
     // Cards: 1 failing, 1 idle, 1 active, 4,500 notifications.
-    assert!(html.contains("4,493"), "delivered card sums the 24h counters");
+    assert!(
+        html.contains("4,493"),
+        "delivered card sums the 24h counters"
+    );
     assert!(html.contains("96.2"), "first-try rate renders");
 
     // Rows: the failing subscription leads (worst first), the idle websocket


### PR DESCRIPTION
The Linting job is red on main and therefore on every open PR — including #593, which changes no Rust at all. Two independent causes.

### 1. `cargo fmt --all -- --check` fails on main

The delivery-stats work (#586, merged as #588) landed with five files unformatted:

- `crates/rest/src/lib.rs` — method chain in the subscription-row builder
- `crates/subscriptions/src/delivery_stats.rs` — a `lock()` chain and an `assert_eq!`
- `crates/subscriptions/src/lib.rs` — `pub use` ordering
- `crates/ui/src/subscriptions.rs` — the first-try-rate `then()` closure
- `crates/ui/tests/subscriptions_http.rs` — an `assert!` with a message

The diff is verbatim `cargo fmt` output. No logic changes.

### 2. The HTS canonical-precedence guard (#200) fails on macOS runners

`grep -r … src/` prints paths as `src//backends/mod.rs` under BSD grep, so the literal `grep -v 'src/backends/mod.rs'` exclusion never matched and the script flagged the two sanctioned test constants living in the very file it is meant to exclude. The lint job runs on a `[self-hosted]` pool with both Linux and macOS runners, so this passed or failed depending on where the job landed — every recent green was a Linux leg, and #593's red landed on macOS. The exclusion is now a regex that tolerates the repeated slash.

This one was latent behind the fmt failure: fixing only the formatting would have moved the red one step down the job.

### Verification

- `cargo fmt --all -- --check` — clean
- `crates/hts/scripts/check-canonical-precedence.sh` — exits 0 (run on macOS, the leg that was failing)
- `cargo clippy --all-targets --all-features` with the CI flag set — clean

https://claude.ai/code/session_0172oQyVFqtG8stqBPZXriVe