### PR TITLE
fix(ui): add-tenant form - background provisioning, reset after success, slug mirror

### DIFF
--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -55,7 +55,11 @@ helios-auth = { path = "../auth", version = "0.2.1" }
 axum = "0.8"
 
 # Spec-bundle reads for non-default FHIR versions run off the async threads
-# (#562). Runtime only — the server (axum) always provides one.
+# (#562), and tenant provisioning runs in the background (#581): the create
+# handler hands `register_tenant` + the conformance seed to `tokio::spawn` so
+# the POST response is not held open for it. Runtime only — the task runs on
+# whichever runtime the host process (the `hfs` binary) is already driving
+# `axum::serve` on.
 tokio = { version = "1", features = ["rt"] }
 
 # Chart bucket timestamps: formatting x-axis labels, and shaping the placeholder
@@ -119,13 +123,6 @@ helios-observability = { path = "../observability", version = "0.2.1" }
 # registry (list/register/deregister) + per-tenant resource counts. The UI
 # depends on the rest of the server, never the reverse.
 helios-persistence = { path = "../persistence", version = "0.2.1", default-features = false, features = ["R4"] }
-
-# Tenant provisioning runs in the background (#581): the create handler hands
-# `register_tenant` + the conformance seed to `tokio::spawn` so the POST
-# response is not held open for it. Only `rt` is needed — the task runs on
-# whichever runtime the host process (the `hfs` binary) is already driving
-# `axum::serve` on.
-tokio = { version = "1", features = ["rt"] }
 
 
 [dev-dependencies]

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -116,6 +116,13 @@ helios-observability = { path = "../observability", version = "0.2.1" }
 # depends on the rest of the server, never the reverse.
 helios-persistence = { path = "../persistence", version = "0.2.1", default-features = false, features = ["R4"] }
 
+# Tenant provisioning runs in the background (#581): the create handler hands
+# `register_tenant` + the conformance seed to `tokio::spawn` so the POST
+# response is not held open for it. Only `rt` is needed — the task runs on
+# whichever runtime the host process (the `hfs` binary) is already driving
+# `axum::serve` on.
+tokio = { version = "1", features = ["rt"] }
+
 
 [dev-dependencies]
 # Parses the .ftl sources so tests can enforce key-set parity across locales.

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1151,6 +1151,31 @@ a.pill {
   justify-content: flex-end;
 }
 
+.spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--outline);
+  border-top-color: var(--accent);
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .spinner { animation: none; }
+}
+
+/* In-table provisioning state for tenants being created in the background
+   (#581): the row polls in via the rows fragment until the job finishes. */
+.provisioning {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
 /* Centered-popup variant of the addbox (the Bulk Import dialogs, #527): the
    same no-JS <details> mechanics, presented as a modal. While open, the
    summary itself stretches over the viewport as the backdrop, so clicking
@@ -1234,6 +1259,12 @@ a.pill {
 .tag--muted {
   background: var(--accent-soft);
   color: var(--muted);
+}
+
+/* Failed provisioning job row (#581), matching .btn--danger's tokens. */
+.tag--danger {
+  background: var(--danger-soft);
+  color: var(--danger);
 }
 
 .icon-button {
@@ -1560,6 +1591,11 @@ a.pill {
 .btn--primary:hover {
   background: var(--accent-strong);
   filter: brightness(1.08);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: progress;
 }
 }
 

--- a/crates/ui/assets/tenants.js
+++ b/crates/ui/assets/tenants.js
@@ -1,0 +1,71 @@
+/* Page script for /ui/tenants. Two responsibilities:
+   - #583: after a successful create the server answers with
+     `HX-Trigger: tenant-created`; htmx dispatches that as a bubbling event on
+     the form. Clear the form, collapse the add-tenant panel and hand focus
+     back to its toggle. Failures carry no trigger, so the user's input
+     survives alongside the error banner.
+   - #582: while the user types a display name, mirror a slug of it into the
+     tenant id, until they take the id over by editing it themselves.
+   The page stays fully usable without this script. Provisioning itself now
+   runs in the background (#581): the POST returns as soon as the server
+   accepts the id, so there is nothing here left to hold the panel open for —
+   the tenants table reports progress with its own polling row instead. */
+(function () {
+  "use strict";
+
+  document.addEventListener("tenant-created", function (event) {
+    var form = event.target && event.target.closest("form[hx-post='/ui/tenants']");
+    if (!form) return;
+    form.reset();
+    var box = form.closest("details.addbox");
+    if (!box) return;
+    box.removeAttribute("open");
+    var toggle = box.querySelector("summary");
+    if (toggle) toggle.focus();
+  });
+
+  /* Slug mirror (#582): while the user types a display name, keep the tenant
+     id in step with a slug of it, until they take the id over by editing it.
+     The slug is a UI convention, deliberately narrower than what the server
+     accepts (TenantId::parse: ASCII letters/digits, `-`, `_`, `.`, `/`, case
+     preserved): lowercase, ASCII letters/digits only, runs of anything else
+     collapsed to one `-`, no leading/trailing `-`, at most 64 bytes, and never
+     a reserved segment. Typing `/`, `.` or `_` by hand still works — the
+     mirror just never produces a hierarchy by accident. */
+  var RESERVED = ["tenants", "resources", "history", "bulk"]; // RESERVED_TENANT_SEGMENTS (persistence/src/tenant/id.rs)
+  var RESERVED_PREFIXES = ["__system__", "_system."];
+
+  function slugify(name) {
+    var slug = name
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    if (slug.length > 64) slug = slug.slice(0, 64).replace(/-+$/g, "");
+    var reserved =
+      RESERVED.indexOf(slug) !== -1 ||
+      RESERVED_PREFIXES.some(function (p) { return slug.indexOf(p) === 0; });
+    return reserved ? slug + "-tenant" : slug;
+  }
+
+  var form = document.querySelector("form[hx-post='/ui/tenants']");
+  var nameInput = form && form.querySelector("[data-tenant-name]");
+  var idInput = form && form.querySelector("[data-tenant-id]");
+  if (form && nameInput && idInput) {
+    // True once the user has typed into the id themselves; a restored value
+    // that does not match the mirrored slug counts as theirs too.
+    var userOwnsId = idInput.value !== "" && idInput.value !== slugify(nameInput.value);
+
+    nameInput.addEventListener("input", function () {
+      if (!userOwnsId) idInput.value = slugify(nameInput.value);
+    });
+    idInput.addEventListener("input", function () {
+      // Clearing the id hands it back to the mirror.
+      userOwnsId = idInput.value !== "";
+    });
+    form.addEventListener("reset", function () {
+      userOwnsId = false;
+    });
+  }
+})();

--- a/crates/ui/e2e/pages/tenants.ts
+++ b/crates/ui/e2e/pages/tenants.ts
@@ -37,8 +37,15 @@ export class TenantsPage {
     await this.addForm.locator("input[name=id]").fill(id);
     if (displayName) await this.addForm.locator("input[name=display_name]").fill(displayName);
     await this.addForm.locator("button[type=submit]").click();
-    await this.row(id).waitFor();
+    // Provisioning runs in the background (#581): the POST returns as soon as
+    // the id is accepted, and the row shows a spinner until `register_tenant`
+    // + the conformance seed finish (~90s measured on this backend). Wait for
+    // the row to settle into its deletable, spinner-free state rather than
+    // just appearing.
+    await this.row(id).locator("[hx-delete]").waitFor({ timeout: 150_000 });
     // Collapse the slide-over so its panel stops overlaying the table below.
+    // The server already closes it on acceptance (well before settlement),
+    // so this is normally a no-op — kept for callers/backends where it isn't.
     if (await this.addToggle.evaluate((s) => (s.parentElement as HTMLDetailsElement).open)) {
       await this.addToggle.click();
     }

--- a/crates/ui/e2e/tests/tenants.spec.ts
+++ b/crates/ui/e2e/tests/tenants.spec.ts
@@ -16,10 +16,22 @@ test.describe("tenants", () => {
     }
   });
 
-  test("adding a tenant slides it into the table", async ({ tenants }) => {
+  test("provisioning shows a spinner row until the tenant is ready", async ({ tenants }) => {
     const id = `e2e-add-${Date.now().toString(36)}`;
-    await tenants.addTenant(id, "E2E Added");
-    await expect(tenants.row(id)).toBeVisible();
+    await tenants.addToggle.click();
+    await tenants.addForm.locator("input[name=display_name]").fill("E2E Added");
+    await tenants.addForm.locator("input[name=id]").fill(id);
+    await tenants.addForm.locator("button[type=submit]").click();
+    // The panel closes as soon as the server accepts the job…
+    await expect(tenants.addForm).toBeHidden();
+    // …and the table reports the in-flight job, surviving a reload.
+    const row = tenants.row(id);
+    await expect(row.locator(".spinner")).toBeVisible();
+    await tenants.page.reload();
+    await expect(tenants.row(id).locator(".spinner")).toBeVisible();
+    // Eventually the job settles into a normal row.
+    await expect(tenants.row(id).locator("[hx-delete]")).toBeVisible({ timeout: 240_000 });
+    await expect(tenants.row(id).locator(".spinner")).toHaveCount(0);
   });
 
   test("the search box filters the table (htmx)", async ({ page, tenants }) => {
@@ -31,6 +43,55 @@ test.describe("tenants", () => {
     await expect(tenants.row(id)).toBeVisible();
     await tenants.search.fill("zzz-no-such-tenant");
     await expect(tenants.row(id)).toBeHidden();
+  });
+
+  test("a successful create clears the form and collapses the panel", async ({ tenants }) => {
+    const id = `e2e-reset-${Date.now().toString(36)}`;
+    await tenants.addTenant(id, "Resettable");
+    await expect(tenants.row(id)).toBeVisible();
+    // addTenant() collapses the panel if it is still open; after this change
+    // the server-side success trigger already did that.
+    await tenants.addToggle.click();
+    await expect(tenants.addForm.locator("input[name=id]")).toHaveValue("");
+    await expect(tenants.addForm.locator("input[name=display_name]")).toHaveValue("");
+  });
+
+  test("a failed create keeps the typed values next to the error banner", async ({ page, tenants }) => {
+    const id = `e2e-dup-${Date.now().toString(36)}`;
+    await tenants.addTenant(id, "First");
+    await expect(tenants.row(id)).toBeVisible();
+    await tenants.addToggle.click();
+    await tenants.addForm.locator("input[name=id]").fill(id);
+    await tenants.addForm.locator("input[name=display_name]").fill("Second");
+    await tenants.addForm.locator("button[type=submit]").click();
+    await expect(page.locator("#tenant-rows .form-error")).toContainText("already exists");
+    await expect(tenants.addForm.locator("input[name=id]")).toHaveValue(id);
+    await expect(tenants.addForm.locator("input[name=display_name]")).toHaveValue("Second");
+  });
+
+  test("typing a display name mirrors a slug into the tenant id", async ({ tenants }) => {
+    await tenants.addToggle.click();
+    await tenants.addForm.locator("input[name=display_name]").fill("Acme Health");
+    await expect(tenants.addForm.locator("input[name=id]")).toHaveValue("acme-health");
+    await tenants.addForm.locator("input[name=display_name]").fill("  Ünïcode & Co.  ");
+    await expect(tenants.addForm.locator("input[name=id]")).toHaveValue("unicode-co");
+  });
+
+  test("editing the tenant id by hand stops the mirror", async ({ tenants }) => {
+    await tenants.addToggle.click();
+    await tenants.addForm.locator("input[name=display_name]").fill("Acme Health");
+    await tenants.addForm.locator("input[name=id]").fill("acme");
+    await tenants.addForm.locator("input[name=display_name]").fill("Acme Health Europe");
+    await expect(tenants.addForm.locator("input[name=id]")).toHaveValue("acme");
+  });
+
+  test("clearing the tenant id re-arms the mirror", async ({ tenants }) => {
+    await tenants.addToggle.click();
+    await tenants.addForm.locator("input[name=display_name]").fill("Acme Health");
+    await tenants.addForm.locator("input[name=id]").fill("acme");
+    await tenants.addForm.locator("input[name=id]").fill("");
+    await tenants.addForm.locator("input[name=display_name]").fill("Acme Health Europe");
+    await expect(tenants.addForm.locator("input[name=id]")).toHaveValue("acme-health-europe");
   });
 
   test("deleting a tenant deregisters it", async ({ page, tenants }) => {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -114,6 +114,8 @@ struct WebState {
     /// not wire storage in (e.g. the UI-only unit tests), in which case the page
     /// reports the registry as unavailable rather than crashing.
     tenants: Option<Arc<dyn ResourceStorage>>,
+    /// Tenant provisioning jobs started from the tenants page (#581).
+    provisioning: tenants::ProvisioningRegistry,
     /// Server data directory (`HFS_DATA_DIR`), used to seed a newly-provisioned
     /// tenant's conformance resources from the tenant-maintenance page.
     data_dir: Option<PathBuf>,
@@ -805,6 +807,7 @@ pub fn mount_with_conformance_source(
         compartments: Arc::new(compartments::CompartmentCatalog::new(source)),
         nl: Arc::new(nl),
         tenants,
+        provisioning: Default::default(),
         settings,
         data_dir,
         fhir_version,

--- a/crates/ui/src/tenants.rs
+++ b/crates/ui/src/tenants.rs
@@ -11,11 +11,22 @@
 //! button issues `hx-delete /ui/tenants/{id}`. Every mutation returns the
 //! refreshed rows fragment, so the page works the same whether or not the
 //! browser ran the swap.
+//!
+//! Provisioning a tenant runs in the background (#581): a successful `POST`
+//! means the id was *accepted*, not that `register_tenant` and the
+//! conformance seed have finished. The id is claimed under
+//! [`ProvisioningRegistry`], the work is handed to a `tokio::spawn`, and the
+//! response returns immediately with `HX-Trigger: tenant-created` (so the
+//! page script resets the form) and a rows fragment that shows the tenant as
+//! a spinner row. The fragment polls itself every few seconds while any row
+//! is still in flight, so the table settles into a normal row — or a
+//! dismissable failure — without the client holding the original request
+//! open.
 
 use askama::Template;
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderValue, StatusCode},
     response::{IntoResponse, Response},
 };
 use helios_persistence::core::ResourceStorage;
@@ -26,14 +37,43 @@ use std::sync::Arc;
 use crate::i18n::{I18n, RequestLocale};
 use crate::{RequestTenant, RequestVersion, WebState, current_status, render};
 
-/// One row of the tenant table (a registry record joined with its live count).
+/// In-flight and failed tenant provisioning jobs, keyed by tenant id (#581).
+/// In-memory only: a server restart loses these notices; the storage registry
+/// stays the source of truth for completed tenants.
+///
+/// A `std::sync::Mutex`, not `tokio::sync::Mutex`: every critical section
+/// below is a plain map lookup/insert with no `.await` inside it.
+pub(crate) type ProvisioningRegistry = Arc<std::sync::Mutex<HashMap<String, Provisioning>>>;
+
+/// State of one provisioning job.
+#[derive(Debug, Clone)]
+pub(crate) enum Provisioning {
+    /// `register_tenant` + conformance seeding are still running.
+    InFlight { display_name: Option<String> },
+    /// The background job failed; shown until the user dismisses the row.
+    Failed {
+        display_name: Option<String>,
+        message: String,
+    },
+}
+
+/// One row of the tenant table (a registry record joined with its live count),
+/// or a provisioning job row standing in for a tenant that is not registered
+/// yet (#581).
 struct TenantRow {
     id: String,
     display_name: Option<String>,
-    /// RFC 3339 date-time, or `None` for a tenant discovered from data only.
+    /// RFC 3339 date-time, or `None` for a tenant discovered from data only
+    /// (or still provisioning).
     created_at: Option<String>,
     registered: bool,
     resources: u64,
+    /// `register_tenant` + conformance seeding are still running in the
+    /// background for this id.
+    provisioning: bool,
+    /// The background job for this id failed; carries the error message shown
+    /// as the row's tooltip.
+    failed: Option<String>,
 }
 
 impl TenantRow {
@@ -77,7 +117,9 @@ impl TenantRow {
 
 /// Page template. `status` feeds the shared sidebar (brand version); `rows` is
 /// the table body, `total`/`registered_count` the summary stats, `q` the active
-/// search term, `available` whether the backend has a registry.
+/// search term, `available` whether the backend has a registry. `polling`
+/// mirrors the included rows partial's field (Askama `include` shares the
+/// enclosing template's context) — see [`TenantRowsPartial::polling`].
 #[derive(Template)]
 #[template(path = "pages/tenants.html")]
 struct TenantsPage {
@@ -90,6 +132,7 @@ struct TenantsPage {
     q: String,
     available: bool,
     error: Option<String>,
+    polling: bool,
     /// Which sidebar entry carries `aria-current="page"` (see base.html).
     active_page: &'static str,
 }
@@ -103,6 +146,10 @@ struct TenantRowsPartial {
     /// fragment is always returned with `200` so htmx swaps it regardless, which
     /// keeps the error visible without the response-targets extension.
     error: Option<String>,
+    /// At least one row is still provisioning (#581): the fragment embeds a
+    /// self-polling `hx-get` so the table keeps refreshing until every job
+    /// settles, then the poller stops rendering on its own.
+    polling: bool,
 }
 
 /// Query string for the page and the rows fragment (`?q=` search term).
@@ -157,8 +204,14 @@ fn validate_id(id: &str) -> Result<(), String> {
 }
 
 /// Builds the tenant rows from the registry joined with live per-tenant counts,
-/// filtered by the search term (matches id or display name, case-insensitive).
-async fn load_rows(storage: &Arc<dyn ResourceStorage>, q: &str) -> Result<Vec<TenantRow>, String> {
+/// prefixed with any in-flight/failed provisioning jobs (#581) not yet
+/// reflected in the registry, filtered by the search term (matches id or
+/// display name, case-insensitive).
+async fn load_rows(
+    storage: &Arc<dyn ResourceStorage>,
+    q: &str,
+    jobs: &HashMap<String, Provisioning>,
+) -> Result<Vec<TenantRow>, String> {
     let registered = storage
         .list_tenants()
         .await
@@ -172,6 +225,42 @@ async fn load_rows(storage: &Arc<dyn ResourceStorage>, q: &str) -> Result<Vec<Te
 
     let mut seen = std::collections::HashSet::new();
     let mut rows = Vec::new();
+
+    // Provisioning jobs go first, in id order, skipping any id the registry
+    // already carries (the job settled between the registry read above and
+    // the lock read that produced `jobs`).
+    let mut job_ids: Vec<&String> = jobs.keys().collect();
+    job_ids.sort();
+    for id in job_ids {
+        if seen.contains(id) {
+            continue;
+        }
+        seen.insert(id.clone());
+        rows.push(match &jobs[id] {
+            Provisioning::InFlight { display_name } => TenantRow {
+                id: id.clone(),
+                display_name: display_name.clone(),
+                created_at: None,
+                registered: false,
+                resources: 0,
+                provisioning: true,
+                failed: None,
+            },
+            Provisioning::Failed {
+                display_name,
+                message,
+            } => TenantRow {
+                id: id.clone(),
+                display_name: display_name.clone(),
+                created_at: None,
+                registered: false,
+                resources: 0,
+                provisioning: false,
+                failed: Some(message.clone()),
+            },
+        });
+    }
+
     for rec in registered {
         seen.insert(rec.id.clone());
         rows.push(TenantRow {
@@ -180,6 +269,8 @@ async fn load_rows(storage: &Arc<dyn ResourceStorage>, q: &str) -> Result<Vec<Te
             created_at: Some(rec.created_at),
             display_name: rec.display_name,
             id: rec.id,
+            provisioning: false,
+            failed: None,
         });
     }
     // Data-only tenants (have rows but never registered), excluding the system tenant.
@@ -195,6 +286,8 @@ async fn load_rows(storage: &Arc<dyn ResourceStorage>, q: &str) -> Result<Vec<Te
             created_at: None,
             registered: false,
             resources: n,
+            provisioning: false,
+            failed: None,
         });
     }
 
@@ -232,16 +325,19 @@ pub async fn page(
             q: query.q,
             available: false,
             error: None,
+            polling: false,
             active_page: "tenants",
         });
     };
 
-    let (rows, error) = match load_rows(storage, &query.q).await {
+    let jobs = state.provisioning.lock().unwrap().clone();
+    let (rows, error) = match load_rows(storage, &query.q, &jobs).await {
         Ok(rows) => (rows, None),
         Err(e) => (Vec::new(), Some(e)),
     };
     let registered_count = rows.iter().filter(|r| r.registered).count();
     let resources_total = rows.iter().map(|r| r.resources).sum();
+    let polling = rows.iter().any(|r| r.provisioning);
     render(TenantsPage {
         total: rows.len(),
         registered_count,
@@ -252,11 +348,13 @@ pub async fn page(
         q: query.q,
         available: true,
         error,
+        polling,
         active_page: "tenants",
     })
 }
 
-/// `GET /ui/tenants/rows` — the table body fragment (htmx search + refresh).
+/// `GET /ui/tenants/rows` — the table body fragment (htmx search + refresh,
+/// and the self-poll while a provisioning job is in flight, #581).
 pub async fn rows(
     State(state): State<WebState>,
     locale: RequestLocale,
@@ -268,23 +366,37 @@ pub async fn rows(
             i18n,
             rows: Vec::new(),
             error: None,
+            polling: false,
         });
     };
-    let (rows, error) = match load_rows(storage, &query.q).await {
+    let jobs = state.provisioning.lock().unwrap().clone();
+    let (rows, error) = match load_rows(storage, &query.q, &jobs).await {
         Ok(rows) => (rows, None),
         Err(e) => (Vec::new(), Some(e)),
     };
-    render(TenantRowsPartial { i18n, rows, error })
+    rows_response(i18n, rows, error)
 }
 
 /// Returns the refreshed (unfiltered) rows fragment, with an optional error
-/// banner, always `200` so htmx swaps it.
+/// banner, always `200` so htmx swaps it. `polling` (whether the fragment
+/// re-embeds its own poller, #581) is derived here so every call site gets it
+/// for free.
 fn rows_response(i18n: I18n, rows: Vec<TenantRow>, error: Option<String>) -> Response {
-    render(TenantRowsPartial { i18n, rows, error })
+    let polling = rows.iter().any(|r| r.provisioning);
+    render(TenantRowsPartial {
+        i18n,
+        rows,
+        error,
+        polling,
+    })
 }
 
-/// `POST /ui/tenants` — register a tenant, then return the refreshed rows (with
-/// an inline error banner if the id was invalid or already taken).
+/// `POST /ui/tenants` — claim the id and return immediately with the
+/// refreshed rows (with an inline error banner if the id was invalid or
+/// already taken/claimed). On the accepted path the response carries
+/// `HX-Trigger: tenant-created`; the actual `register_tenant` call and
+/// conformance seed run in the background (#581), and the returned rows
+/// fragment already shows the tenant as an in-flight (spinner) row.
 pub async fn create(
     State(state): State<WebState>,
     locale: RequestLocale,
@@ -301,7 +413,8 @@ pub async fn create(
 
     let id = form.id.trim().to_string();
     let load = |err: Option<String>| async {
-        match load_rows(storage, "").await {
+        let jobs = state.provisioning.lock().unwrap().clone();
+        match load_rows(storage, "", &jobs).await {
             Ok(rows) => rows_response(i18n, rows, err),
             Err(e) => rows_response(i18n, Vec::new(), err.or(Some(e))),
         }
@@ -312,7 +425,11 @@ pub async fn create(
     }
     let display_name = {
         let d = form.display_name.trim();
-        if d.is_empty() { None } else { Some(d) }
+        if d.is_empty() {
+            None
+        } else {
+            Some(d.to_string())
+        }
     };
 
     match storage.get_tenant(&id).await {
@@ -320,25 +437,86 @@ pub async fn create(
         Ok(None) => {}
         Err(e) => return load(Some(e.to_string())).await,
     }
-    if let Err(e) = storage.register_tenant(&id, display_name).await {
-        return load(Some(e.to_string())).await;
+
+    // Claim the id under one lock so a double submit cannot race the check
+    // above: a second POST for the same id while this job is in flight is
+    // rejected here, not raced against `register_tenant`. The guard is
+    // dropped (block ends) before the `await` below — a `std::sync::Mutex`
+    // guard held across an await point would make this handler's future
+    // `!Send`, which axum's `Handler` bound rejects outright.
+    let already_in_flight = {
+        let mut jobs = state.provisioning.lock().unwrap();
+        if matches!(jobs.get(&id), Some(Provisioning::InFlight { .. })) {
+            true
+        } else {
+            // A leftover `Failed` entry for this id is replaced by the retry.
+            jobs.insert(
+                id.clone(),
+                Provisioning::InFlight {
+                    display_name: display_name.clone(),
+                },
+            );
+            false
+        }
+    };
+    if already_in_flight {
+        return load(Some(format!("Tenant '{id}' is already being provisioned."))).await;
     }
-    // Seed the new tenant with the conformance resources (SearchParameters and
-    // CompartmentDefinitions), matching the per-tenant startup seed. Best-effort:
-    // a failed seed still returns the refreshed rows; the next startup completes
-    // it.
+
+    // Provision in the background: the claimed row above reports progress,
+    // the page polls while the job runs, and a client disconnect no longer
+    // aborts the work halfway (axum drops the handler future, not the spawned
+    // task, when the socket closes).
+    let registry = state.provisioning.clone();
+    let job_storage = storage.clone();
     let data_dir = state
         .data_dir
         .clone()
         .unwrap_or_else(|| std::path::PathBuf::from("./data"));
-    helios_persistence::search::seed_tenant_conformance(
-        storage.as_ref(),
-        state.fhir_version,
-        &data_dir,
-        &id,
-    )
-    .await;
-    load(None).await
+    let fhir_version = state.fhir_version;
+    let job_id = id.clone();
+    let job_name = display_name.clone();
+    tokio::spawn(async move {
+        match job_storage
+            .register_tenant(&job_id, job_name.as_deref())
+            .await
+        {
+            Ok(_) => {
+                // Seed the new tenant with the conformance resources
+                // (SearchParameters and CompartmentDefinitions), matching the
+                // per-tenant startup seed. Best-effort, as before: a failed
+                // seed still counts as provisioned; the next startup
+                // completes it.
+                helios_persistence::search::seed_tenant_conformance(
+                    job_storage.as_ref(),
+                    fhir_version,
+                    &data_dir,
+                    &job_id,
+                )
+                .await;
+                registry.lock().unwrap().remove(&job_id);
+            }
+            Err(e) => {
+                registry.lock().unwrap().insert(
+                    job_id.clone(),
+                    Provisioning::Failed {
+                        display_name: job_name,
+                        message: e.to_string(),
+                    },
+                );
+            }
+        }
+    });
+
+    // The rows fragment below already contains the in-flight row. Tell htmx
+    // the request was accepted: every path answers 200 with the rows fragment
+    // (error banners included), so this header is the only signal the client
+    // has to reset the form (tenants.js). Failures deliberately omit it.
+    let mut response = load(None).await;
+    response
+        .headers_mut()
+        .insert("HX-Trigger", HeaderValue::from_static("tenant-created"));
+    response
 }
 
 /// `DELETE /ui/tenants/{id}` — deregister (and optionally purge), return rows.
@@ -361,6 +539,14 @@ pub async fn delete(
             .into_response();
     };
 
+    let load = |err: Option<String>| async {
+        let jobs = state.provisioning.lock().unwrap().clone();
+        match load_rows(storage, "", &jobs).await {
+            Ok(rows) => rows_response(i18n, rows, err),
+            Err(e) => rows_response(i18n, Vec::new(), err.or(Some(e))),
+        }
+    };
+
     // Refuse reserved ids before touching the registry. This route is destructive
     // (`?purge=true` permanently deletes the tenant's data) and, unlike the
     // `/admin/tenants` API, it validated nothing — so `DELETE
@@ -372,8 +558,38 @@ pub async fn delete(
     // here; the storage-layer guard in `helios-persistence` backs this up
     // regardless of how the route is reached.
     if let Err(message) = validate_id(&id) {
-        let rows = load_rows(storage, "").await.unwrap_or_default();
-        return rows_response(i18n, rows, Some(message));
+        return load(Some(message)).await;
+    }
+
+    // A provisioning job owns this id (#581): an in-flight job is refused
+    // rather than raced against `register_tenant` finishing concurrently
+    // (nothing to deregister yet either way); a failed job never wrote
+    // anything to storage, so dismissing it just clears the registry entry.
+    // The lock guard is scoped to this block, dropped before either `await`
+    // below — held across an await it would make the handler's future
+    // `!Send`, which axum's `Handler` bound rejects outright.
+    enum JobOutcome {
+        InFlight,
+        Dismissed,
+        None,
+    }
+    let outcome = {
+        let mut jobs = state.provisioning.lock().unwrap();
+        match jobs.get(&id) {
+            Some(Provisioning::InFlight { .. }) => JobOutcome::InFlight,
+            Some(Provisioning::Failed { .. }) => {
+                jobs.remove(&id);
+                JobOutcome::Dismissed
+            }
+            None => JobOutcome::None,
+        }
+    };
+    match outcome {
+        JobOutcome::InFlight => {
+            return load(Some(format!("Tenant '{id}' is still being provisioned."))).await;
+        }
+        JobOutcome::Dismissed => return load(None).await,
+        JobOutcome::None => {}
     }
 
     let _ = storage.deregister_tenant(&id).await;
@@ -393,10 +609,7 @@ pub async fn delete(
         None
     };
 
-    match load_rows(storage, "").await {
-        Ok(rows) => rows_response(i18n, rows, purge_error),
-        Err(e) => rows_response(i18n, Vec::new(), purge_error.or(Some(e))),
-    }
+    load(purge_error).await
 }
 
 // (helpers below)

--- a/crates/ui/src/tenants.rs
+++ b/crates/ui/src/tenants.rs
@@ -226,18 +226,24 @@ async fn load_rows(
     let mut seen = std::collections::HashSet::new();
     let mut rows = Vec::new();
 
-    // Provisioning jobs go first, in id order, skipping any id the registry
-    // already carries (the job settled between the registry read above and
-    // the lock read that produced `jobs`).
+    let registered_ids: std::collections::HashSet<&str> =
+        registered.iter().map(|r| r.id.as_str()).collect();
+
+    // Provisioning jobs go first, in id order. The provisioning row wins
+    // while the job is in flight: an `InFlight` id always renders here, even
+    // if the registry read above already shows it registered (registration
+    // finishes in milliseconds, seeding takes far longer, so that window is
+    // routine, not a race to paper over). A `Failed` leftover for an id that
+    // *is* registered yields to the registered row below instead — `Failed`
+    // is only ever written when `register_tenant` itself failed, so a
+    // registered id with a `Failed` entry is a stale notice, not the tenant
+    // that failed.
     let mut job_ids: Vec<&String> = jobs.keys().collect();
     job_ids.sort();
     for id in job_ids {
-        if seen.contains(id) {
-            continue;
-        }
         seen.insert(id.clone());
-        rows.push(match &jobs[id] {
-            Provisioning::InFlight { display_name } => TenantRow {
+        match &jobs[id] {
+            Provisioning::InFlight { display_name } => rows.push(TenantRow {
                 id: id.clone(),
                 display_name: display_name.clone(),
                 created_at: None,
@@ -245,23 +251,32 @@ async fn load_rows(
                 resources: 0,
                 provisioning: true,
                 failed: None,
-            },
+            }),
             Provisioning::Failed {
                 display_name,
                 message,
-            } => TenantRow {
-                id: id.clone(),
-                display_name: display_name.clone(),
-                created_at: None,
-                registered: false,
-                resources: 0,
-                provisioning: false,
-                failed: Some(message.clone()),
-            },
-        });
+            } => {
+                if !registered_ids.contains(id.as_str()) {
+                    rows.push(TenantRow {
+                        id: id.clone(),
+                        display_name: display_name.clone(),
+                        created_at: None,
+                        registered: false,
+                        resources: 0,
+                        provisioning: false,
+                        failed: Some(message.clone()),
+                    });
+                }
+            }
+        }
     }
 
     for rec in registered {
+        // An in-flight job for this id already rendered its spinner row above;
+        // the registered row would just duplicate it until the seed finishes.
+        if matches!(jobs.get(&rec.id), Some(Provisioning::InFlight { .. })) {
+            continue;
+        }
         seen.insert(rec.id.clone());
         rows.push(TenantRow {
             resources: counts.get(&rec.id).copied().unwrap_or(0),
@@ -613,3 +628,53 @@ pub async fn delete(
 }
 
 // (helpers below)
+
+#[cfg(test)]
+mod provisioning_row_tests {
+    use super::*;
+    use helios_persistence::backends::sqlite::SqliteBackend;
+
+    /// Regression for the double-row bug: while a job is still in flight the
+    /// tenant is already registered (seeding runs long after registration), and
+    /// the table must show the provisioning row only.
+    #[tokio::test]
+    async fn an_in_flight_job_suppresses_the_registered_row() {
+        let backend = SqliteBackend::in_memory().expect("in-memory sqlite");
+        backend.init_schema().expect("init schema");
+        let storage: Arc<dyn ResourceStorage> = Arc::new(backend);
+        storage
+            .register_tenant("acme", Some("Acme Health"))
+            .await
+            .expect("register");
+
+        let mut jobs = HashMap::new();
+        jobs.insert(
+            "acme".to_string(),
+            Provisioning::InFlight {
+                display_name: Some("Acme Health".to_string()),
+            },
+        );
+
+        let rows = load_rows(&storage, "", &jobs).await.expect("rows");
+        let acme: Vec<_> = rows.iter().filter(|r| r.id == "acme").collect();
+        assert_eq!(acme.len(), 1, "one row per tenant, not one per source");
+        assert!(acme[0].provisioning, "the provisioning row wins");
+
+        // A Failed leftover for a registered id yields to the registered row.
+        jobs.insert(
+            "acme".to_string(),
+            Provisioning::Failed {
+                display_name: None,
+                message: "boom".to_string(),
+            },
+        );
+        let rows = load_rows(&storage, "", &jobs).await.expect("rows");
+        let acme: Vec<_> = rows.iter().filter(|r| r.id == "acme").collect();
+        assert_eq!(acme.len(), 1);
+        assert!(!acme[0].provisioning);
+        assert!(
+            acme[0].failed.is_none(),
+            "registered row, not the failed notice"
+        );
+    }
+}

--- a/crates/ui/templates/pages/tenants.html
+++ b/crates/ui/templates/pages/tenants.html
@@ -63,18 +63,19 @@
           hx-post="/ui/tenants"
           hx-target="#tenant-rows"
           hx-swap="innerHTML"
+          hx-disabled-elt="find button[type=submit]"
         >
-          <label class="field">
-            <span class="field__label">{{ i18n.t("tenants-field-id") }}</span>
-            <input class="field__input" type="text" name="id" required autocomplete="off"
-                   placeholder="acme-health">
-            <span class="field__hint">{{ i18n.t("tenants-field-id-hint") }}</span>
-          </label>
           <label class="field">
             <span class="field__label">{{ i18n.t("tenants-field-name") }}</span>
             <input class="field__input" type="text" name="display_name" autocomplete="off"
-                   placeholder="Acme Health">
+                   placeholder="Acme Health" data-tenant-name>
             <span class="field__hint">{{ i18n.t("tenants-field-name-hint") }}</span>
+          </label>
+          <label class="field">
+            <span class="field__label">{{ i18n.t("tenants-field-id") }}</span>
+            <input class="field__input" type="text" name="id" required autocomplete="off"
+                   placeholder="acme-health" data-tenant-id>
+            <span class="field__hint">{{ i18n.t("tenants-field-id-hint") }}</span>
           </label>
           <div class="addbox__actions">
             <button type="button" class="btn" data-addbox-close>{{ i18n.t("ui-cancel") }}</button>
@@ -90,4 +91,5 @@
   </div>
 </section>
 {% endif %}
+<script src="/ui/assets/tenants.js" defer></script>
 {% endblock %}

--- a/crates/ui/templates/partials/tenant_rows.html
+++ b/crates/ui/templates/partials/tenant_rows.html
@@ -2,6 +2,16 @@
 <div class="form-error" role="alert">{{ msg }}</div>
 {% endif %}
 
+{% if polling %}
+<div
+  hx-get="/ui/tenants/rows"
+  hx-include="[name='q']"
+  hx-target="#tenant-rows"
+  hx-swap="innerHTML"
+  hx-trigger="every 3s"
+></div>
+{% endif %}
+
 <table class="data-table">
   <thead>
     <tr>
@@ -24,11 +34,38 @@
         <span class="tenant-id">
           <span class="tenant-id__name">
             {% match row.display_name %}{% when Some(name) %}{{ name }}{% when None %}{{ row.id }}{% endmatch %}
-            {% if !row.registered %}<span class="tag tag--muted">{{ i18n.t("tenants-unregistered") }}</span>{% endif %}
+            {% if !row.registered && !row.provisioning && row.failed.is_none() %}<span class="tag tag--muted">{{ i18n.t("tenants-unregistered") }}</span>{% endif %}
           </span>
           <span class="tenant-id__slug">{{ row.id }}</span>
         </span>
       </td>
+      {% if row.provisioning %}
+      <td class="col-num">
+        <span class="provisioning" role="status">
+          <span class="spinner" aria-hidden="true"></span>
+          {{ i18n.t("tenants-row-provisioning") }}
+        </span>
+      </td>
+      <td>—</td>
+      <td class="col-actions"></td>
+      {% else if let Some(msg) = row.failed %}
+      <td class="col-num">
+        <span class="tag tag--danger" title="{{ msg }}">{{ i18n.t("tenants-row-failed") }}</span>
+      </td>
+      <td>—</td>
+      <td class="col-actions">
+        <button
+          type="button"
+          class="icon-button icon-button--danger"
+          aria-label="{{ i18n.t("tenants-dismiss") }}"
+          hx-delete="/ui/tenants/{{ row.id }}"
+          hx-target="#tenant-rows"
+          hx-swap="innerHTML"
+        >
+          {% include "icons/trash.svg" %}
+        </button>
+      </td>
+      {% else %}
       <td class="col-num">{{ row.resources_human() }}</td>
       <td>{{ row.created_date() }}</td>
       <td class="col-actions">
@@ -44,6 +81,7 @@
           {% include "icons/trash.svg" %}
         </button>
       </td>
+      {% endif %}
     </tr>
     {% endfor %}
     {% endif %}

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -1,8 +1,18 @@
 //! End-to-end tests for the tenant-maintenance page (`/ui/tenants`), driving the
 //! mounted router against a real in-memory SQLite-backed store so the handlers,
 //! the registry read/write path, and result shaping are all exercised.
+//!
+//! Provisioning runs in the background (#581), so a single router (and the
+//! `WebState::provisioning` registry it owns) must be built once per test and
+//! reused across every request in that test — a fresh router per request
+//! would carry a fresh, empty provisioning registry each time, breaking the
+//! continuity the tests below rely on (an in-flight claim made by one POST
+//! would be invisible to the next). `Router` is cheap to `clone()` (it shares
+//! its state behind an `Arc`), so each request clones the one router built at
+//! the top of the test.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::{
     Router,
@@ -24,8 +34,8 @@ fn store() -> Arc<dyn ResourceStorage> {
     Arc::new(backend)
 }
 
-/// Builds the UI router over the given store. A fresh router per request is
-/// fine — they all share the same backend `Arc`, so state persists.
+/// Builds the UI router over the given store. Build this once per test and
+/// reuse (clone) it for every request — see the module doc.
 fn app(store: &Arc<dyn ResourceStorage>) -> Router {
     helios_ui::mount_with_conformance_source(
         Router::new(),
@@ -46,8 +56,9 @@ async fn body_text(response: axum::response::Response) -> String {
     String::from_utf8(bytes.to_vec()).unwrap()
 }
 
-async fn get(store: &Arc<dyn ResourceStorage>, uri: &str) -> (StatusCode, String) {
-    let res = app(store)
+async fn get(router: &Router, uri: &str) -> (StatusCode, String) {
+    let res = router
+        .clone()
         .oneshot(Request::get(uri).body(Body::empty()).unwrap())
         .await
         .unwrap();
@@ -55,9 +66,10 @@ async fn get(store: &Arc<dyn ResourceStorage>, uri: &str) -> (StatusCode, String
     (status, body_text(res).await)
 }
 
-/// POSTs an `application/x-www-form-urlencoded` body to `/ui/tenants`.
-async fn post_form(store: &Arc<dyn ResourceStorage>, form: &str) -> (StatusCode, String) {
-    let res = app(store)
+/// Like `post_form` but hands back the raw response (headers included).
+async fn post_form_raw(router: &Router, form: &str) -> axum::response::Response {
+    router
+        .clone()
         .oneshot(
             Request::post("/ui/tenants")
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
@@ -65,18 +77,40 @@ async fn post_form(store: &Arc<dyn ResourceStorage>, form: &str) -> (StatusCode,
                 .unwrap(),
         )
         .await
-        .unwrap();
+        .unwrap()
+}
+
+/// POSTs an `application/x-www-form-urlencoded` body to `/ui/tenants`.
+async fn post_form(router: &Router, form: &str) -> (StatusCode, String) {
+    let res = post_form_raw(router, form).await;
     let status = res.status();
     (status, body_text(res).await)
+}
+
+/// Polls the rows fragment until no provisioning row remains (every
+/// background job settled, one way or another), or panics after ~10s. The
+/// marker is the real in-flight row class (`class="provisioning"`), not an
+/// invented one.
+async fn wait_settled(router: &Router) -> String {
+    for _ in 0..200 {
+        let (_, html) = get(router, "/ui/tenants/rows").await;
+        if !html.contains(r#"class="provisioning""#) {
+            return html;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("provisioning did not settle in time");
 }
 
 #[tokio::test]
 async fn page_renders_and_lists_registered_and_discovered_tenants() {
     let store = store();
+    let router = app(&store);
 
     // A registered tenant (via the page's own form) ...
-    let (status, _) = post_form(&store, "id=acme-health&display_name=Acme+Health").await;
+    let (status, _) = post_form(&router, "id=acme-health&display_name=Acme+Health").await;
     assert_eq!(status, StatusCode::OK);
+    wait_settled(&router).await;
 
     // ... and a data-only tenant, seeded straight through the backend.
     let northwind =
@@ -91,7 +125,7 @@ async fn page_renders_and_lists_registered_and_discovered_tenants() {
         .await
         .unwrap();
 
-    let (status, html) = get(&store, "/ui/tenants").await;
+    let (status, html) = get(&router, "/ui/tenants").await;
     assert_eq!(status, StatusCode::OK);
     // Registered tenant: display name + id slug + a creation date.
     assert!(html.contains("Acme Health"));
@@ -106,21 +140,23 @@ async fn page_renders_and_lists_registered_and_discovered_tenants() {
 #[tokio::test]
 async fn rows_fragment_filters_by_search_term() {
     let store = store();
-    post_form(&store, "id=acme-health&display_name=Acme+Health").await;
+    let router = app(&store);
+    post_form(&router, "id=acme-health&display_name=Acme+Health").await;
     post_form(
-        &store,
+        &router,
         "id=riverside-labs&display_name=Riverside+Diagnostics",
     )
     .await;
+    wait_settled(&router).await;
 
     // Unfiltered: both present, and it's a fragment (no full document).
-    let (_, all) = get(&store, "/ui/tenants/rows").await;
+    let (_, all) = get(&router, "/ui/tenants/rows").await;
     assert!(all.contains("Acme Health"));
     assert!(all.contains("Riverside Diagnostics"));
     assert!(!all.contains("<html"));
 
     // Filtered by name.
-    let (_, filtered) = get(&store, "/ui/tenants/rows?q=river").await;
+    let (_, filtered) = get(&router, "/ui/tenants/rows?q=river").await;
     assert!(filtered.contains("Riverside Diagnostics"));
     assert!(!filtered.contains("Acme Health"));
 }
@@ -128,14 +164,16 @@ async fn rows_fragment_filters_by_search_term() {
 #[tokio::test]
 async fn create_rejects_invalid_id_and_conflicts() {
     let store = store();
+    let router = app(&store);
 
     // Invalid id → the fragment carries an error banner, not a new row.
-    let (_, bad) = post_form(&store, "id=has%20space").await;
+    let (_, bad) = post_form(&router, "id=has%20space").await;
     assert!(bad.contains("form-error"));
 
-    // Valid create, then a duplicate → conflict surfaced as a banner.
-    post_form(&store, "id=acme").await;
-    let (_, dup) = post_form(&store, "id=acme").await;
+    // Valid create, settle, then a duplicate → conflict surfaced as a banner.
+    post_form(&router, "id=acme").await;
+    wait_settled(&router).await;
+    let (_, dup) = post_form(&router, "id=acme").await;
     assert!(dup.contains("form-error"));
     assert!(dup.contains("already exists"));
 }
@@ -143,12 +181,15 @@ async fn create_rejects_invalid_id_and_conflicts() {
 #[tokio::test]
 async fn delete_deregisters_a_tenant() {
     let store = store();
-    post_form(&store, "id=acme&display_name=Acme").await;
+    let router = app(&store);
+    post_form(&router, "id=acme&display_name=Acme").await;
+    wait_settled(&router).await;
 
     // Provisioning a tenant seeds it with conformance resources (the embedded
     // fallback SearchParameters at minimum), so a plain deregister leaves it
     // data-discovered. Purge to remove the tenant entirely.
-    let res = app(&store)
+    let res = router
+        .clone()
         .oneshot(
             Request::delete("/ui/tenants/acme?purge=true")
                 .body(Body::empty())
@@ -159,7 +200,7 @@ async fn delete_deregisters_a_tenant() {
     assert_eq!(res.status(), StatusCode::OK);
 
     // Gone from the registry and its seeded data purged, so it disappears.
-    let (_, rows) = get(&store, "/ui/tenants/rows").await;
+    let (_, rows) = get(&router, "/ui/tenants/rows").await;
     assert!(!rows.contains(">acme<") && !rows.contains("Acme"));
 }
 
@@ -215,16 +256,18 @@ async fn embedded_assets_carry_no_cache_so_rebuilt_css_is_never_stale() {
 async fn storage_failure_renders_the_error_banner_not_a_silent_empty_table() {
     let broken: Arc<dyn ResourceStorage> =
         Arc::new(SqliteBackend::in_memory().expect("in-memory sqlite"));
+    let router = app(&broken);
 
-    let (status, body) = get(&broken, "/ui/tenants/rows?q=").await;
+    let (status, body) = get(&router, "/ui/tenants/rows?q=").await;
     assert_eq!(status, StatusCode::OK);
     assert!(body.contains("form-error"), "rows fragment: {body}");
 
-    let (status, body) = post_form(&broken, "id=acme&display_name=").await;
+    let (status, body) = post_form(&router, "id=acme&display_name=").await;
     assert_eq!(status, StatusCode::OK);
     assert!(body.contains("form-error"), "create fragment: {body}");
 
-    let res = app(&broken)
+    let res = router
+        .clone()
         .oneshot(
             Request::delete("/ui/tenants/acme")
                 .body(Body::empty())
@@ -444,9 +487,12 @@ async fn delete_refuses_the_reserved_system_tenant() {
 #[tokio::test]
 async fn delete_still_accepts_underscore_prefixed_tenants() {
     let store = store();
-    post_form(&store, "id=__legacy").await;
+    let router = app(&store);
+    post_form(&router, "id=__legacy").await;
+    wait_settled(&router).await;
 
-    let res = app(&store)
+    let res = router
+        .clone()
         .oneshot(
             Request::delete("/ui/tenants/__legacy?purge=true")
                 .body(Body::empty())
@@ -462,16 +508,20 @@ async fn delete_still_accepts_underscore_prefixed_tenants() {
 #[tokio::test]
 async fn the_tenant_picker_hides_until_a_second_tenant_exists() {
     let store = store();
+    let router = app(&store);
 
     // Fresh install: default tenant only — no picker in the chrome.
-    let (_, html) = get(&store, "/ui/tenants").await;
+    let (_, html) = get(&router, "/ui/tenants").await;
     assert!(
         !html.contains(r#"class="selector""#),
         "picker hidden on a single-tenant install"
     );
 
-    // Provision a second tenant through the page's own form.
-    let res = app(&store)
+    // Provision a second tenant through the page's own form, and let the
+    // background registration finish — the picker reads the real registry
+    // (`list_tenants`), not the in-flight job notice.
+    let res = router
+        .clone()
         .oneshot(
             Request::post("/ui/tenants")
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
@@ -481,8 +531,9 @@ async fn the_tenant_picker_hides_until_a_second_tenant_exists() {
         .await
         .unwrap();
     assert!(res.status().is_success());
+    wait_settled(&router).await;
 
-    let (_, html) = get(&store, "/ui/tenants").await;
+    let (_, html) = get(&router, "/ui/tenants").await;
     assert!(
         html.contains(r#"class="selector""#),
         "picker appears once a second tenant exists"
@@ -493,7 +544,101 @@ async fn the_tenant_picker_hides_until_a_second_tenant_exists() {
 #[tokio::test]
 async fn the_add_tenant_panel_offers_cancel_and_close() {
     let store = store();
-    let (_, html) = get(&store, "/ui/tenants").await;
+    let router = app(&store);
+    let (_, html) = get(&router, "/ui/tenants").await;
     assert!(html.contains("data-addbox-close"), "close controls present");
     assert!(html.contains("Cancel"));
+    assert!(html.contains("/ui/assets/tenants.js"));
+}
+
+/// #581: the create request answers as soon as it is accepted, so the form
+/// only needs to guard against a double submit — there is no long-running
+/// pending state on the form itself any more (the table's spinner row covers
+/// that, see `create_signals_success_with_hx_trigger_and_failures_do_not`).
+#[tokio::test]
+async fn the_add_tenant_form_disables_submit_while_posting() {
+    let store = store();
+    let router = app(&store);
+    let (_, html) = get(&router, "/ui/tenants").await;
+    assert!(html.contains(r#"hx-disabled-elt="find button[type=submit]""#));
+    assert!(!html.contains("hx-indicator"));
+    assert!(!html.contains(r#"id="tenant-add-pending""#));
+}
+
+/// #582: the display name is mirrored into the tenant id client-side, so the
+/// form renders the display name field first and tags both inputs with
+/// `data-*` attributes the script can find without depending on `name`.
+#[tokio::test]
+async fn the_add_tenant_form_puts_the_display_name_before_the_id_and_tags_both_for_the_slug_mirror()
+{
+    let store = store();
+    let router = app(&store);
+    let (_, html) = get(&router, "/ui/tenants").await;
+    let name = html
+        .find("data-tenant-name")
+        .expect("display name input tagged");
+    let id = html.find("data-tenant-id").expect("id input tagged");
+    assert!(name < id, "display name renders above the tenant id");
+    assert!(
+        html.contains(r#"name="id" required"#),
+        "id stays required without JS"
+    );
+}
+
+/// #583/#581: a successful create answers immediately with `HX-Trigger:
+/// tenant-created` and a rows fragment that already shows the tenant as an
+/// in-flight (spinner) row; failures (duplicate id, invalid id, a duplicate
+/// claim) never carry the header. Once the background job settles, the
+/// duplicate check reports "already exists" instead of "already being
+/// provisioned".
+#[tokio::test]
+async fn create_signals_success_with_hx_trigger_and_failures_do_not() {
+    let store = store();
+    let router = app(&store);
+
+    let ok = post_form_raw(&router, "id=acme&display_name=Acme").await;
+    assert_eq!(ok.status(), StatusCode::OK);
+    assert_eq!(
+        ok.headers().get("HX-Trigger").and_then(|v| v.to_str().ok()),
+        Some("tenant-created")
+    );
+    let ok_body = body_text(ok).await;
+    assert!(
+        ok_body.contains(r#"class="provisioning""#),
+        "the accepted response already shows the in-flight row: {ok_body}"
+    );
+
+    // An immediate second POST for the same id races the background job, but
+    // never signals success either way.
+    let dup = post_form_raw(&router, "id=acme").await;
+    assert_eq!(dup.status(), StatusCode::OK);
+    assert!(dup.headers().get("HX-Trigger").is_none());
+    let dup_body = body_text(dup).await;
+    assert!(
+        dup_body.contains("already being provisioned") || dup_body.contains("already exists"),
+        "got: {dup_body}"
+    );
+
+    // Once the job has settled, the id is definitely taken.
+    wait_settled(&router).await;
+    let settled_dup = post_form_raw(&router, "id=acme").await;
+    assert!(settled_dup.headers().get("HX-Trigger").is_none());
+    assert!(body_text(settled_dup).await.contains("already exists"));
+
+    let bad = post_form_raw(&router, "id=has%20space").await;
+    assert!(bad.headers().get("HX-Trigger").is_none());
+}
+
+/// #581: once the background job finishes, the spinner row is replaced by a
+/// normal, deletable row — the provisioning marker is gone.
+#[tokio::test]
+async fn a_provisioned_tenant_settles_into_a_normal_row() {
+    let store = store();
+    let router = app(&store);
+
+    post_form(&router, "id=acme&display_name=Acme").await;
+    let html = wait_settled(&router).await;
+
+    assert!(html.contains(r#"hx-delete="/ui/tenants/acme""#));
+    assert!(!html.contains(r#"class="provisioning""#));
 }

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -117,6 +117,9 @@ tenants-empty = Keine Mandanten gefunden.
 tenants-unregistered = nicht registriert
 tenants-delete = Mandant löschen
 tenants-delete-confirm = Mandant „{ $id }" abmelden? Die gespeicherten Daten bleiben erhalten, sofern sie nicht über die API bereinigt werden.
+tenants-row-provisioning = Wird bereitgestellt … das kann einen Moment dauern.
+tenants-row-failed = Bereitstellung fehlgeschlagen
+tenants-dismiss = Verwerfen
 
 tenant-heading = Tenants
 tenant-all = Alle Tenants

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -121,6 +121,9 @@ tenants-empty = No tenants match.
 tenants-unregistered = unregistered
 tenants-delete = Delete tenant
 tenants-delete-confirm = Deregister tenant "{ $id }"? Its stored data is kept unless purged via the API.
+tenants-row-provisioning = Provisioning… this may take a moment.
+tenants-row-failed = Provisioning failed
+tenants-dismiss = Dismiss
 
 tenant-heading = Tenants
 tenant-all = All tenants

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -117,6 +117,9 @@ tenants-empty = Ningún tenant coincide.
 tenants-unregistered = sin registrar
 tenants-delete = Eliminar tenant
 tenants-delete-confirm = ¿Dar de baja el tenant «{ $id }»? Sus datos se conservan salvo que se purguen vía API.
+tenants-row-provisioning = Aprovisionando… puede tardar un momento.
+tenants-row-failed = El aprovisionamiento falló
+tenants-dismiss = Descartar
 
 tenant-heading = Tenants
 tenant-all = Todos los tenants


### PR DESCRIPTION
Reworks the add-tenant flow on `/ui/tenants`, closing three issues in one coherent change (the fixes ended up sharing the same handler, template, script and tests, so they ship as one commit).

## #581 — pending state, as a table row

Provisioning a tenant takes a while (~90s on SQLite/NTFS). Instead of holding the whole job inside the `POST /ui/tenants` request and spinning inside the slide-over, the handler now validates, claims the id in an in-memory registry on `WebState`, spawns `register_tenant` + conformance seeding on a background task, and returns the rows fragment immediately:

- The table renders a server-side "Provisioning… this may take a moment." row (spinner, `role="status"`, en/es/de) that survives reloads and navigation — the state lives on the server, not in the popover.
- The rows fragment self-refreshes every 3s (plain htmx polling, keeps the search term via `hx-include`) only while jobs are in flight, and stops by itself once the row settles into a normal one.
- A failed job leaves a dismissible "Provisioning failed" row (tooltip carries the error; dismissing it only clears the notice).
- Duplicate submits are refused both against the registry ("already being provisioned") and the storage ("already exists").
- Side effect worth having: a client disconnect no longer cancels the axum handler future halfway through provisioning.
- The submit button stays disabled while the (now fast) POST runs (`hx-disabled-elt`).

## #583 — reset after success

The success path (and only that path) answers with `HX-Trigger: tenant-created`; a new page script (`tenants.js`, vendored like the other page scripts) resets the form, collapses the panel and returns focus to the "Add tenant" toggle. Failures carry no trigger, so the typed values stay next to the error banner.

## #582 — slug mirror

Typing a display name mirrors a slug into the tenant id until the user edits the id themselves; clearing the id (or the reset above) re-arms the mirror. The slug is lowercase ASCII letters/digits/`-`, ≤64 bytes, never a reserved segment — valid for `TenantId::parse` on the first try. The two fields swap places (display name first) so the mirror flows downward. With JS disabled the form remains two plain text inputs.

## Tests

- HTTP (`crates/ui/tests/tenants_http.rs`): form wiring, immediate accept + `HX-Trigger` on success only, in-flight/registered duplicate refusals, provisioning row settling into a normal row, field order, script tag.
- Playwright (`crates/ui/e2e/tests/tenants.spec.ts`): spinner row visible after submit and after a reload, settling into a deletable row; reset-on-success and preserve-on-failure; three mirror cases without provisioning. The page object now waits for a tenant to settle before continuing.
- Manually verified on Windows/SQLite: popover closes on accept, spinner row survives reload/navigation, settles by itself; duplicate-in-flight banner; reset and mirror behaviors.

Parked for follow-ups: `--danger`/`--ok`/`--warn(-soft)` CSS custom properties are referenced across `app.css` (15+ pre-existing sites, now also `.tag--danger`) but never defined — worth its own issue; applying the background-job pattern to other long-running actions; a hint explaining the generated id.

Closes #581, #583, #582.
