### PR TITLE
fix(ui): pin the resource editor dialog to a fixed rectangle

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -3781,7 +3781,11 @@ button.filter-rail__item {
   display: flex;
   flex-direction: column;
   width: min(1200px, 100%);
-  max-height: 90vh;
+  /* A fixed height, not a ceiling (#607): the dialog occupies the same
+     rectangle whichever pane is showing, so switching Edit/History or a
+     status message appearing never moves the header. The taller pane
+     scrolls inside .modal__body. */
+  height: 90vh;
   background: var(--bg-content);
   border: 1px solid var(--surface-border);
   border-radius: 18px;
@@ -3871,6 +3875,7 @@ button.filter-rail__item {
 }
 
 .modal__body {
+  flex: 1;
   padding: 16px 18px;
   overflow-y: auto;
 }
@@ -3886,7 +3891,7 @@ button.filter-rail__item {
 }
 
 @media (max-width: 900px) {
-  .modal__box { max-height: 96vh; }
+  .modal__box { height: 96vh; }
   .modal__head { flex-wrap: wrap; }
 }
 }

--- a/crates/ui/e2e/tests/resources.spec.ts
+++ b/crates/ui/e2e/tests/resources.spec.ts
@@ -79,3 +79,37 @@ test("a created resource can be deleted from its modal", async ({ resources, pag
   });
   expect(res.status()).toBe(410);
 });
+
+test("the dialog stays put across tab switches and status messages", async ({
+  resources,
+  page,
+  request,
+}) => {
+  const id = await createResource(request, "Patient", { name: [{ family: "Anchored" }] });
+  await waitSearchable(request, "Patient", id);
+  await resources.goto("Patient");
+  await page.locator("input.query-builder__url[name=url]").fill(`Patient?_id=${id}`);
+  await page.locator("[data-intent='run']").click();
+  await page.locator("#query-results-body a.url").first().click();
+  await resources.modal.waitOpen();
+
+  // The dialog occupies a fixed rectangle (#607): switching panes or a
+  // status message appearing changes what is inside, never where it sits.
+  const head = page.locator(".modal__head");
+  const before = await head.boundingBox();
+  if (!before) throw new Error("modal header has no box");
+
+  await page.locator('[data-modal-tab="history"]').click();
+  await expect(page.locator('[data-modal-pane="history"]')).toBeVisible();
+  const onHistory = await head.boundingBox();
+  expect(onHistory?.y).toBe(before.y);
+  expect(onHistory?.height).toBe(before.height);
+
+  await page.locator('[data-modal-tab="edit"]').click();
+  await expect(page.locator('[data-modal-pane="edit"]')).toBeVisible();
+
+  await page.click("#resource-save");
+  await expect(page.locator("#resource-modal-status")).not.toBeEmpty();
+  const withStatus = await head.boundingBox();
+  expect(withStatus?.y).toBe(before.y);
+});


### PR DESCRIPTION
Closes #607.

Option 2 from the issue — the one that fully answers "they should start at the same y coordinate":

- `.modal__box` takes `height: 90vh` (and `96vh` under the 900px media query) in place of the bare `max-height`, so the dialog occupies the same rectangle whichever pane is active — top edge, bottom edge, and the status bar included.
- `.modal__body` takes `flex: 1` so the pane area absorbs the fixed height and its existing `overflow-y: auto` scrolls the taller pane instead of resizing the dialog.

On the short-resource caveat: the dialog is the 1200px editor workspace (guided form + JSON grid), which always has substance — the stable rectangle reads better than a dialog that breathes with each tab switch. `.modal__box` has a single consumer (the resources dialog), so nothing else inherits the fixed height.

New Playwright spec asserts the header bounding box is identical across Edit→History→Edit and while a save status message is showing. Full resources + editor-sync suites green locally (19 specs).