### PR TITLE
feat(ui): legend click focuses a chart series instead of removing it

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -839,6 +839,16 @@ button.pill {
 .chart .series--focused { stroke-width: 3; }
 .chart .series--receded { opacity: 0.25; }
 
+/* The invisible twin polyline inside each line's focus anchor: a 14px hit
+   corridor, since a 1.5px stroke is no click target. */
+.chart .series-hit {
+  stroke: transparent;
+  stroke-width: 14;
+  fill: none;
+  pointer-events: stroke;
+  cursor: pointer;
+}
+
 .chart-legend__item--focused {
   font-weight: 600;
   color: var(--text-strong);

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -834,6 +834,20 @@ button.pill {
 
 /* ---------- Functional chart (#555): multi-series, picker, tooltip -------- */
 
+/* Legend focus (#602): the focused line carries the weight, the rest recede
+   but stay on the chart at their true values. */
+.chart .series--focused { stroke-width: 3; }
+.chart .series--receded { opacity: 0.25; }
+
+.chart-legend__item--focused {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+.chart-legend__item--focused .chart-legend__dot {
+  outline: 2px solid var(--text-strong);
+  outline-offset: 1px;
+}
+
 /* Series palette: slot N styles both the polyline and its legend dot. */
 .chart .series--1 { stroke: var(--series-1); }
 .chart .series--2 { stroke: var(--series-2); }

--- a/crates/ui/e2e/pages/dashboard.ts
+++ b/crates/ui/e2e/pages/dashboard.ts
@@ -22,7 +22,7 @@ export class DashboardPage {
     return this.page.locator("svg.chart");
   }
   get seriesLines(): Locator {
-    return this.page.locator("svg.chart polyline");
+    return this.page.locator("svg.chart polyline.series");
   }
   windowOption(label: RegExp | string): Locator {
     return this.page.locator(".window-picker__option", { hasText: label });

--- a/crates/ui/e2e/tests/dashboard.spec.ts
+++ b/crates/ui/e2e/tests/dashboard.spec.ts
@@ -94,6 +94,23 @@ test("legend click focuses a series; clicking it again restores the shared view"
   await expect(page).not.toHaveURL(/focus=/);
   await expect(page.locator(".series--focused")).toHaveCount(0);
   expect(await dashboard.seriesLines.count()).toBe(before);
+
+  // The line itself is the same link: clicking a plotted series focuses it
+  // (native SVG anchor, via the widened hit corridor). Playwright's default
+  // click aims at the bounding-box centre — empty air for a polyline with
+  // pointer-events: stroke — so aim at an actual vertex, mapped from
+  // viewBox units to screen pixels.
+  const hit = page.locator(".series-hit").first();
+  const vertex = (await hit.getAttribute("points"))!.split(" ")[2].split(",").map(Number);
+  const svg = page.locator("svg.chart");
+  const viewBox = (await svg.getAttribute("viewBox"))!.split(" ").map(Number);
+  const svgBox = (await svg.boundingBox())!;
+  await page.mouse.click(
+    svgBox.x + (vertex[0] / viewBox[2]) * svgBox.width,
+    svgBox.y + (vertex[1] / viewBox[3]) * svgBox.height,
+  );
+  await expect(page).toHaveURL(/focus=/);
+  await expect(page.locator(".series--focused")).toHaveCount(1);
 });
 
 test("the picker filter narrows the offered types", async ({ dashboard }) => {

--- a/crates/ui/e2e/tests/dashboard.spec.ts
+++ b/crates/ui/e2e/tests/dashboard.spec.ts
@@ -68,14 +68,32 @@ test("the picker toggles types on, capped at the palette", async ({ page, dashbo
   }
   expect(await dashboard.seriesLines.count()).toBeGreaterThan(1);
   expect(await dashboard.seriesLines.count()).toBeLessThanOrEqual(6);
+});
 
-  // The legend removes: clicking an entry drops that series.
+test("legend click focuses a series; clicking it again restores the shared view", async ({
+  page,
+  dashboard,
+}) => {
+  test.skip(process.env.HFS_E2E_NO_CHART_DATA === "1", "no count read path on this backend");
+  await dashboard.goto();
+  await dashboard.waitForSeries();
   const before = await dashboard.seriesLines.count();
-  if (before > 1) {
-    await dashboard.legendItems.first().click();
-    await expect(page).toHaveURL(/types=/);
-    expect(await dashboard.seriesLines.count()).toBe(before - 1);
-  }
+  test.skip(before < 2, "focus needs at least two series");
+
+  // Focus: nothing is removed, the URL carries the focus, the focused line
+  // and legend entry are marked, the rest recede (#602).
+  await dashboard.legendItems.first().click();
+  await expect(page).toHaveURL(/focus=/);
+  expect(await dashboard.seriesLines.count()).toBe(before);
+  await expect(page.locator(".series--focused")).toHaveCount(1);
+  await expect(page.locator(".series--receded")).toHaveCount(before - 1);
+  await expect(page.locator(".chart-legend__item--focused")).toHaveCount(1);
+
+  // The way back is the same entry.
+  await page.locator(".chart-legend__item--focused").click();
+  await expect(page).not.toHaveURL(/focus=/);
+  await expect(page.locator(".series--focused")).toHaveCount(0);
+  expect(await dashboard.seriesLines.count()).toBe(before);
 });
 
 test("the picker filter narrows the offered types", async ({ dashboard }) => {

--- a/crates/ui/e2e/tests/nojs/dashboard.spec.ts
+++ b/crates/ui/e2e/tests/nojs/dashboard.spec.ts
@@ -13,7 +13,7 @@ test("the chart's controls work as plain links with JavaScript off", async ({ pa
   let series = 0;
   for (let attempt = 0; attempt < 12 && series === 0; attempt++) {
     await page.goto("/ui", { waitUntil: "domcontentloaded" });
-    series = await page.locator("svg.chart polyline").count();
+    series = await page.locator("svg.chart polyline.series").count();
     if (series === 0) await page.waitForTimeout(2000);
   }
   expect(series).toBeGreaterThan(0);
@@ -27,11 +27,11 @@ test("the chart's controls work as plain links with JavaScript off", async ({ pa
 
   // The legend is plain links too: clicking focuses a series without
   // removing anything (#602), and works with no script at all.
-  const plotted = await page.locator("svg.chart polyline").count();
+  const plotted = await page.locator("svg.chart polyline.series").count();
   if (plotted > 1) {
     await page.locator("a.chart-legend__item").first().click();
     await expect(page).toHaveURL(/focus=/);
-    expect(await page.locator("svg.chart polyline").count()).toBe(plotted);
+    expect(await page.locator("svg.chart polyline.series").count()).toBe(plotted);
     await page.locator(".chart-legend__item--focused").click();
     await expect(page).not.toHaveURL(/focus=/);
   }

--- a/crates/ui/e2e/tests/nojs/dashboard.spec.ts
+++ b/crates/ui/e2e/tests/nojs/dashboard.spec.ts
@@ -25,6 +25,17 @@ test("the chart's controls work as plain links with JavaScript off", async ({ pa
   await expect(page).toHaveURL(/types=/);
   await expect(page.locator("svg.chart")).toBeVisible();
 
+  // The legend is plain links too: clicking focuses a series without
+  // removing anything (#602), and works with no script at all.
+  const plotted = await page.locator("svg.chart polyline").count();
+  if (plotted > 1) {
+    await page.locator("a.chart-legend__item").first().click();
+    await expect(page).toHaveURL(/focus=/);
+    expect(await page.locator("svg.chart polyline").count()).toBe(plotted);
+    await page.locator(".chart-legend__item--focused").click();
+    await expect(page).not.toHaveURL(/focus=/);
+  }
+
   // Window selector and expand are links too.
   await page.locator(".window-picker__option", { hasText: "24h" }).click();
   await expect(page).toHaveURL(/window=24h/);

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -418,6 +418,9 @@ struct ChartSeriesView {
     color: usize,
     /// `"x,y x,y …"` coordinate list for the `<polyline>`.
     polyline: String,
+    /// Class suffix under a legend focus (#602): `" series--focused"`,
+    /// `" series--receded"`, or empty when nothing is focused.
+    emphasis: &'static str,
 }
 
 /// One row of the chart's tabular alternative: a bucket label and the
@@ -451,13 +454,16 @@ struct ChartView {
     pick_label: String,
 }
 
-/// One entry in the chart legend: a plotted series, with a link that removes
-/// it from the charted set (present only while more than one is plotted).
+/// One entry in the chart legend: a plotted series. While more than one is
+/// plotted the entry links to focusing that series — or, when it is already
+/// the focused one, back to the unfocused view (#602). Types leave the chart
+/// through the picker, never the legend.
 struct LegendEntry {
     resource_type: String,
     total: String,
     color: usize,
     href: Option<String>,
+    focused: bool,
 }
 
 /// One option in the chart's type picker: a link that toggles the type in or
@@ -1075,7 +1081,11 @@ async fn index(
         .and_then(|slug| DashboardWindow::from_slug(&slug))
         .unwrap_or_default();
     let expand = query_value(query.as_deref(), "expand").as_deref() == Some("1");
-    render(build_index_page(state.version, locale, types, window, expand, rv.0, &rt).await)
+    // `?focus=Type` marks one plotted series as the legend focus (#602);
+    // validation against the actually-plotted set happens in build_dashboard.
+    let focus = query_value(query.as_deref(), "focus")
+        .filter(|f| !f.is_empty() && f.chars().all(|c| c.is_ascii_alphanumeric()));
+    render(build_index_page(state.version, locale, types, window, expand, focus, rv.0, &rt).await)
 }
 
 /// Search page: natural language and the visual builder over one editable query.
@@ -1324,6 +1334,7 @@ async fn status(
                 Vec::new(),
                 DashboardWindow::default(),
                 false,
+                None,
                 rv.0,
                 &rt,
             )
@@ -1404,12 +1415,14 @@ async fn history_diff(locale: RequestLocale, axum::Form(form): axum::Form<DiffFo
 /// Assembles the landing page from the live dashboard snapshot, or from
 /// placeholder data when no provider is registered — in which case the page
 /// says so explicitly rather than presenting invented numbers as real (#555).
+#[allow(clippy::too_many_arguments)]
 async fn build_index_page(
     version: &'static str,
     locale: RequestLocale,
     types: Vec<String>,
     window: DashboardWindow,
     expand: bool,
+    focus: Option<String>,
     fhir_version: helios_fhir::FhirVersion,
     tenant: &RequestTenant,
 ) -> IndexPage {
@@ -1418,7 +1431,7 @@ async fn build_index_page(
     let live = helios_observability::dashboard::snapshot(window, &tenant.id, &types).await;
     let sample_data = live.is_none();
     let snapshot = live.unwrap_or_else(|| sample_snapshot(window));
-    let dash = build_dashboard(&snapshot, expand);
+    let dash = build_dashboard(&snapshot, expand, focus.as_deref());
     IndexPage {
         status,
         metrics: dash.metrics,
@@ -1443,13 +1456,24 @@ struct DashboardView {
     expand_href: String,
 }
 
-/// A `/ui` link carrying the whole chart state: charted set, window, and
-/// expansion. Every selector emits these so changing one control keeps the
-/// other two.
-fn dash_href(types: &[String], window: DashboardWindow, expand: bool) -> String {
+/// A `/ui` link carrying the whole chart state: charted set, window,
+/// expansion, and the focused series (#602). Every selector emits these so
+/// changing one control keeps the others.
+fn dash_href(
+    types: &[String],
+    window: DashboardWindow,
+    expand: bool,
+    focus: Option<&str>,
+) -> String {
     let mut href = format!("/ui?types={}&window={}", types.join(","), window.as_str());
     if expand {
         href.push_str("&expand=1");
+    }
+    // Focus survives a link only while the focused type is still charted.
+    if let Some(f) = focus
+        && types.iter().any(|t| t == f)
+    {
+        href.push_str(&format!("&focus={f}"));
     }
     href
 }
@@ -1458,14 +1482,22 @@ fn dash_href(types: &[String], window: DashboardWindow, expand: bool) -> String 
 /// and the three selectors (type picker, legend, time window) the template
 /// renders. The charted set is `snapshot.series` itself — the provider already
 /// resolved the request to real stored types.
-fn build_dashboard(snapshot: &DashboardSnapshot, expand: bool) -> DashboardView {
+fn build_dashboard(
+    snapshot: &DashboardSnapshot,
+    expand: bool,
+    focus: Option<&str>,
+) -> DashboardView {
     let charted: Vec<String> = snapshot
         .series
         .iter()
         .map(|s| s.resource_type.clone())
         .collect();
 
-    let chart = build_chart(&snapshot.series, snapshot.window, expand);
+    // Focus only means something for a plotted series (#602); anything else
+    // in the query renders the ordinary unfocused view.
+    let focus = focus.filter(|f| charted.iter().any(|c| c == f));
+
+    let chart = build_chart(&snapshot.series, snapshot.window, expand, focus);
 
     // The picker offers every stored type; each option toggles membership.
     let picker = snapshot
@@ -1493,32 +1525,37 @@ fn build_dashboard(snapshot: &DashboardSnapshot, expand: bool) -> DashboardView 
             PickerEntry {
                 resource_type: t.resource_type.clone(),
                 total: grouped(t.total),
-                href: dash_href(&toggled, snapshot.window, expand),
+                // dash_href drops the focus itself if this toggle removes
+                // the focused type.
+                href: dash_href(&toggled, snapshot.window, expand, focus),
                 selected,
             }
         })
         .collect();
 
     // The legend names each plotted series; while more than one is plotted,
-    // an entry doubles as its own remove link.
+    // an entry links to focusing that series — or back out of the focus when
+    // it already holds it (#602). Removal lives in the picker.
     let legend = snapshot
         .series
         .iter()
         .enumerate()
         .map(|(i, s)| {
+            let focused = focus == Some(s.resource_type.as_str());
             let href = (snapshot.series.len() > 1).then(|| {
-                let rest: Vec<String> = charted
-                    .iter()
-                    .filter(|c| **c != s.resource_type)
-                    .cloned()
-                    .collect();
-                dash_href(&rest, snapshot.window, expand)
+                let target = if focused {
+                    None
+                } else {
+                    Some(s.resource_type.as_str())
+                };
+                dash_href(&charted, snapshot.window, expand, target)
             });
             LegendEntry {
                 resource_type: s.resource_type.clone(),
                 total: grouped(s.total),
                 color: i % SERIES_COLORS + 1,
                 href,
+                focused,
             }
         })
         .collect();
@@ -1527,7 +1564,7 @@ fn build_dashboard(snapshot: &DashboardSnapshot, expand: bool) -> DashboardView 
         .into_iter()
         .map(|w| WindowEntry {
             label: w.as_str().to_string(),
-            href: dash_href(&charted, w, expand),
+            href: dash_href(&charted, w, expand, focus),
             active: w == snapshot.window,
         })
         .collect();
@@ -1551,7 +1588,7 @@ fn build_dashboard(snapshot: &DashboardSnapshot, expand: bool) -> DashboardView 
         legend,
         picker,
         windows,
-        expand_href: dash_href(&charted, snapshot.window, !expand),
+        expand_href: dash_href(&charted, snapshot.window, !expand, focus),
     }
 }
 
@@ -1572,8 +1609,16 @@ const CHART_MAX_SERIES: usize = 6;
 
 /// Computes the SVG geometry for one resource type's cumulative series. `window`
 /// decides only the x-axis label format — a calendar date over daily buckets, a
-/// UTC clock time over intraday ones.
-fn build_chart(all: &[DashboardSeries], window: DashboardWindow, expand: bool) -> ChartView {
+/// UTC clock time over intraday ones. Under a legend `focus` (#602) the y axis
+/// re-fits the focused series so a small type is legible next to a large one;
+/// the other series stay plotted at their true values, receded, and the plot
+/// clip-path cuts them where they exceed the focused scale.
+fn build_chart(
+    all: &[DashboardSeries],
+    window: DashboardWindow,
+    expand: bool,
+    focus: Option<&str>,
+) -> ChartView {
     let height = if expand {
         CHART_HEIGHT_EXPANDED
     } else {
@@ -1615,9 +1660,11 @@ fn build_chart(all: &[DashboardSeries], window: DashboardWindow, expand: bool) -
     let points = &plotted[0].points;
     let n = points.len() as i64;
 
-    // One y scale across every plotted series, so the curves are comparable.
+    // One y scale across every plotted series, so the curves are comparable —
+    // unless a series is focused, in which case the axis fits that series.
     let peak = plotted
         .iter()
+        .filter(|s| focus.is_none() || focus == Some(s.resource_type.as_str()))
         .flat_map(|s| s.points.iter().map(|p| p.cumulative))
         .max()
         .unwrap_or(0);
@@ -1646,6 +1693,11 @@ fn build_chart(all: &[DashboardSeries], window: DashboardWindow, expand: bool) -
                 .map(|(i, p)| format!("{},{}", x_at(i as i64), y_at(p.cumulative)))
                 .collect::<Vec<_>>()
                 .join(" "),
+            emphasis: match focus {
+                None => "",
+                Some(f) if f == s.resource_type => " series--focused",
+                Some(_) => " series--receded",
+            },
         })
         .collect();
 
@@ -1919,7 +1971,7 @@ mod tests {
 
     /// Builds an `IndexPage` from the sample snapshot for template-rendering tests.
     fn sample_index_page(version: &'static str, checked_at: u64, i18n: I18n) -> IndexPage {
-        let dash = build_dashboard(&sample_snapshot(DashboardWindow::default()), false);
+        let dash = build_dashboard(&sample_snapshot(DashboardWindow::default()), false, None);
         IndexPage {
             status: Status {
                 version,
@@ -1940,6 +1992,49 @@ mod tests {
             i18n,
             active_page: "home",
         }
+    }
+
+    /// #602: a legend focus keeps every series plotted, re-fits the y axis to
+    /// the focused one, and flips the focused entry's link into the way back.
+    #[test]
+    fn legend_focus_rescales_recedes_and_links_back() {
+        let snapshot = sample_snapshot(DashboardWindow::default());
+        let unfocused = build_dashboard(&snapshot, false, None);
+        // Patient is the smallest sample series, so focusing it must lower
+        // the axis ceiling relative to the shared (Observation-driven) scale.
+        let dash = build_dashboard(&snapshot, false, Some("Patient"));
+
+        assert_eq!(dash.chart.series.len(), unfocused.chart.series.len());
+        for s in &dash.chart.series {
+            if s.resource_type == "Patient" {
+                assert_eq!(s.emphasis, " series--focused");
+            } else {
+                assert_eq!(s.emphasis, " series--receded");
+            }
+        }
+        let top =
+            |d: &DashboardView| d.chart.y_ticks.first().map(|t| t.label.clone()).unwrap();
+        assert_ne!(top(&dash), top(&unfocused), "axis re-fits the focus");
+
+        let entry = |d: &DashboardView, t: &str| {
+            d.legend
+                .iter()
+                .find(|l| l.resource_type == t)
+                .expect("legend entry")
+                .href
+                .clone()
+                .expect("legend link")
+        };
+        // The focused entry links back out; the others move the focus.
+        assert!(entry(&dash, "Patient").ends_with("&focus=Patient") == false);
+        assert!(!entry(&dash, "Patient").contains("focus="));
+        assert!(entry(&dash, "Observation").contains("focus=Observation"));
+        // Nothing was removed: every legend link keeps the full charted set.
+        assert!(entry(&dash, "Observation").contains("Patient"));
+
+        // A focus that names an uncharted type renders the ordinary view.
+        let bogus = build_dashboard(&snapshot, false, Some("Nope"));
+        assert!(bogus.chart.series.iter().all(|s| s.emphasis.is_empty()));
     }
 
     #[test]
@@ -2185,7 +2280,7 @@ mod tests {
 
     #[test]
     fn dashboard_projects_snapshot_counts_and_chart() {
-        let dash = build_dashboard(&sample_snapshot(DashboardWindow::default()), false);
+        let dash = build_dashboard(&sample_snapshot(DashboardWindow::default()), false, None);
 
         // Every series the snapshot carries is plotted, on one shared y scale.
         assert!(dash.chart.has_data);
@@ -2195,7 +2290,8 @@ mod tests {
         assert!(dash.chart.types_label.contains("Observation"));
 
         // The legend names each plotted series; while several are plotted each
-        // entry is a remove link that drops exactly itself and keeps the window.
+        // entry is a focus link that keeps the whole charted set and the
+        // window (#602) — removal belongs to the picker.
         assert_eq!(dash.legend.len(), 4);
         let observation = dash
             .legend
@@ -2205,8 +2301,8 @@ mod tests {
         let href = observation
             .href
             .as_deref()
-            .expect("removable while several are plotted");
-        assert!(!href.contains("Observation"));
+            .expect("focusable while several are plotted");
+        assert!(href.contains("focus=Observation"));
         assert!(href.contains("Patient"));
         assert!(href.contains("window=30d"));
 
@@ -2229,7 +2325,7 @@ mod tests {
     /// active, and carries the charted type across a window switch.
     #[test]
     fn window_selector_marks_the_active_window_and_keeps_the_charted_type() {
-        let windows = build_dashboard(&sample_snapshot(DashboardWindow::LastHour), false).windows;
+        let windows = build_dashboard(&sample_snapshot(DashboardWindow::LastHour), false, None).windows;
 
         assert_eq!(windows.len(), DashboardWindow::ALL.len());
         assert_eq!(windows.iter().filter(|w| w.active).count(), 1);
@@ -2249,7 +2345,7 @@ mod tests {
     /// keeps calendar dates. Same series, different axis vocabulary.
     #[test]
     fn axis_labels_follow_the_window_resolution() {
-        let hour_chart = build_dashboard(&sample_snapshot(DashboardWindow::LastHour), false).chart;
+        let hour_chart = build_dashboard(&sample_snapshot(DashboardWindow::LastHour), false, None).chart;
         assert!(
             hour_chart
                 .x_ticks
@@ -2264,7 +2360,7 @@ mod tests {
         );
 
         let month_chart =
-            build_dashboard(&sample_snapshot(DashboardWindow::LastMonth), false).chart;
+            build_dashboard(&sample_snapshot(DashboardWindow::LastMonth), false, None).chart;
         assert!(
             month_chart.x_ticks.iter().all(|t| !t.label.contains(':')),
             "30d axis should read as a calendar date, got {:?}",
@@ -2283,7 +2379,7 @@ mod tests {
     fn every_window_renders_a_bounded_chart() {
         for window in DashboardWindow::ALL {
             let snapshot = sample_snapshot(window);
-            let chart = build_dashboard(&snapshot, false).chart;
+            let chart = build_dashboard(&snapshot, false, None).chart;
             assert!(chart.has_data, "{}", window.as_str());
             assert_eq!(snapshot.series[0].points.len(), window.points());
             assert!(
@@ -2300,7 +2396,7 @@ mod tests {
     /// buckets the axis labels sample.
     #[test]
     fn expand_grows_the_plot_and_the_carriers_stay_consistent() {
-        let dash = build_dashboard(&sample_snapshot(DashboardWindow::default()), true);
+        let dash = build_dashboard(&sample_snapshot(DashboardWindow::default()), true, None);
         assert!(dash.chart.expanded);
         assert_eq!(dash.chart.height, 520);
         assert!(dash.chart.x_ticks.iter().all(|t| t.label_y == 518));
@@ -2330,7 +2426,7 @@ mod tests {
             export_jobs: None,
             import_jobs_active: None,
         };
-        let dash = build_dashboard(&empty, false);
+        let dash = build_dashboard(&empty, false, None);
         assert!(!dash.chart.has_data);
         assert!(dash.chart.series.is_empty());
         assert!(dash.legend.is_empty());
@@ -2408,6 +2504,7 @@ mod tests {
             std::slice::from_ref(&series),
             DashboardWindow::default(),
             false,
+            None,
         );
 
         assert!(chart.has_data);
@@ -2435,6 +2532,7 @@ mod tests {
             std::slice::from_ref(&series),
             DashboardWindow::LastHour,
             false,
+            None,
         );
 
         assert!(chart.has_data);

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -421,6 +421,12 @@ struct ChartSeriesView {
     /// Class suffix under a legend focus (#602): `" series--focused"`,
     /// `" series--receded"`, or empty when nothing is focused.
     emphasis: &'static str,
+    /// The same focus/unfocus link the legend entry carries (#602): the line
+    /// itself is clickable, as a native SVG `<a>`. `None` while only one
+    /// series is plotted.
+    href: Option<String>,
+    /// Whether this series holds the focus — picks the link's label.
+    focused: bool,
 }
 
 /// One row of the chart's tabular alternative: a bucket label and the
@@ -1509,7 +1515,21 @@ fn build_dashboard(
     // in the query renders the ordinary unfocused view.
     let focus = focus.filter(|f| charted.iter().any(|c| c == f));
 
-    let chart = build_chart(&snapshot.series, snapshot.window, expand, focus);
+    let mut chart = build_chart(&snapshot.series, snapshot.window, expand, focus);
+
+    // The plotted lines carry the same focus links as their legend entries
+    // (#602): clicking a line focuses its series, clicking the focused one
+    // links back. Native SVG anchors, so the no-JS contract holds.
+    if chart.series.len() > 1 {
+        for s in &mut chart.series {
+            let target = if s.focused {
+                None
+            } else {
+                Some(s.resource_type.as_str())
+            };
+            s.href = Some(dash_href(&charted, snapshot.window, expand, target));
+        }
+    }
 
     // The picker offers every stored type; each option toggles membership.
     let picker = snapshot
@@ -1710,6 +1730,10 @@ fn build_chart(
                 Some(f) if f == s.resource_type => " series--focused",
                 Some(_) => " series--receded",
             },
+            // build_dashboard fills the focus link in; geometry stays the
+            // only concern here.
+            href: None,
+            focused: focus == Some(s.resource_type.as_str()),
         })
         .collect();
 
@@ -2042,6 +2066,21 @@ mod tests {
         assert!(entry(&dash, "Observation").contains("focus=Observation"));
         // Nothing was removed: every legend link keeps the full charted set.
         assert!(entry(&dash, "Observation").contains("Patient"));
+
+        // The plotted lines carry the same links as their legend entries:
+        // the focused one links back out, the others move the focus.
+        let line = |d: &DashboardView, t: &str| {
+            d.chart
+                .series
+                .iter()
+                .find(|s| s.resource_type == t)
+                .expect("series")
+                .href
+                .clone()
+                .expect("line link")
+        };
+        assert!(!line(&dash, "Patient").contains("focus="));
+        assert!(line(&dash, "Observation").contains("focus=Observation"));
 
         // A focus that names an uncharted type renders the ordinary view.
         let bogus = build_dashboard(&snapshot, false, Some("Nope"));

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -2061,7 +2061,6 @@ mod tests {
                 .expect("legend link")
         };
         // The focused entry links back out; the others move the focus.
-        assert!(entry(&dash, "Patient").ends_with("&focus=Patient") == false);
         assert!(!entry(&dash, "Patient").contains("focus="));
         assert!(entry(&dash, "Observation").contains("focus=Observation"));
         // Nothing was removed: every legend link keeps the full charted set.

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1085,7 +1085,19 @@ async fn index(
     // validation against the actually-plotted set happens in build_dashboard.
     let focus = query_value(query.as_deref(), "focus")
         .filter(|f| !f.is_empty() && f.chars().all(|c| c.is_ascii_alphanumeric()));
-    render(build_index_page(state.version, locale, types, window, expand, focus, rv.0, &rt).await)
+    render(
+        build_index_page(
+            state.version,
+            locale,
+            types,
+            window,
+            expand,
+            focus,
+            rv.0,
+            &rt,
+        )
+        .await,
+    )
 }
 
 /// Search page: natural language and the visual builder over one editable query.
@@ -2012,8 +2024,7 @@ mod tests {
                 assert_eq!(s.emphasis, " series--receded");
             }
         }
-        let top =
-            |d: &DashboardView| d.chart.y_ticks.first().map(|t| t.label.clone()).unwrap();
+        let top = |d: &DashboardView| d.chart.y_ticks.first().map(|t| t.label.clone()).unwrap();
         assert_ne!(top(&dash), top(&unfocused), "axis re-fits the focus");
 
         let entry = |d: &DashboardView, t: &str| {
@@ -2325,7 +2336,8 @@ mod tests {
     /// active, and carries the charted type across a window switch.
     #[test]
     fn window_selector_marks_the_active_window_and_keeps_the_charted_type() {
-        let windows = build_dashboard(&sample_snapshot(DashboardWindow::LastHour), false, None).windows;
+        let windows =
+            build_dashboard(&sample_snapshot(DashboardWindow::LastHour), false, None).windows;
 
         assert_eq!(windows.len(), DashboardWindow::ALL.len());
         assert_eq!(windows.iter().filter(|w| w.active).count(), 1);
@@ -2345,7 +2357,8 @@ mod tests {
     /// keeps calendar dates. Same series, different axis vocabulary.
     #[test]
     fn axis_labels_follow_the_window_resolution() {
-        let hour_chart = build_dashboard(&sample_snapshot(DashboardWindow::LastHour), false, None).chart;
+        let hour_chart =
+            build_dashboard(&sample_snapshot(DashboardWindow::LastHour), false, None).chart;
         assert!(
             hour_chart
                 .x_ticks

--- a/crates/ui/templates/pages/index.html
+++ b/crates/ui/templates/pages/index.html
@@ -127,7 +127,10 @@
     is complete without it.
   -->
   <div class="chart-wrap" id="chart-wrap">
-    <svg class="chart" viewBox="0 0 1060 {{ chart.height }}" role="img"
+    <!-- role=group, not img: the plotted lines are focus links (#602), and
+         an image must not contain interactive controls (axe
+         nested-interactive). The name stays on the group. -->
+    <svg class="chart" viewBox="0 0 1060 {{ chart.height }}" role="group"
          aria-label="{{ i18n.t("chart-title") }} — {{ chart.types_label }}">
       <defs>
         <!-- Under a legend focus the y axis fits the focused series; receded

--- a/crates/ui/templates/pages/index.html
+++ b/crates/ui/templates/pages/index.html
@@ -141,9 +141,21 @@
       <text class="axis-label" x="0" y="{{ tick.label_y }}">{{ tick.label }}</text>
       {% endfor %}
       {% for s in chart.series %}
+      {% if let Some(href) = s.href %}
+      <!-- The line is the same focus link as its legend entry — a native SVG
+           anchor, no script. The transparent twin widens the hit area. -->
+      <a href="{{ href }}"
+         aria-label="{{ s.resource_type }} — {% if s.focused %}{{ i18n.t("chart-unfocus-series") }}{% else %}{{ i18n.t("chart-focus-series") }}{% endif %}">
+        <polyline class="series series--{{ s.color }}{{ s.emphasis }}"
+                  data-series="{{ s.resource_type }}"
+                  clip-path="url(#chart-plot)" points="{{ s.polyline }}" />
+        <polyline class="series-hit" clip-path="url(#chart-plot)" points="{{ s.polyline }}" />
+      </a>
+      {% else %}
       <polyline class="series series--{{ s.color }}{{ s.emphasis }}"
                 data-series="{{ s.resource_type }}"
                 clip-path="url(#chart-plot)" points="{{ s.polyline }}" />
+      {% endif %}
       {% endfor %}
       {% for tick in chart.x_ticks %}
       <text class="axis-label" x="{{ tick.pos }}" y="{{ tick.label_y }}">{{ tick.label }}</text>

--- a/crates/ui/templates/pages/index.html
+++ b/crates/ui/templates/pages/index.html
@@ -129,12 +129,21 @@
   <div class="chart-wrap" id="chart-wrap">
     <svg class="chart" viewBox="0 0 1060 {{ chart.height }}" role="img"
          aria-label="{{ i18n.t("chart-title") }} — {{ chart.types_label }}">
+      <defs>
+        <!-- Under a legend focus the y axis fits the focused series; receded
+             series keep their true values and clip where they exceed it. -->
+        <clipPath id="chart-plot">
+          <rect x="40" y="0" width="1020" height="{{ chart.height }}" />
+        </clipPath>
+      </defs>
       {% for tick in chart.y_ticks %}
       <line class="grid-line" x1="40" y1="{{ tick.pos }}" x2="1060" y2="{{ tick.pos }}" />
       <text class="axis-label" x="0" y="{{ tick.label_y }}">{{ tick.label }}</text>
       {% endfor %}
       {% for s in chart.series %}
-      <polyline class="series series--{{ s.color }}" points="{{ s.polyline }}" />
+      <polyline class="series series--{{ s.color }}{{ s.emphasis }}"
+                data-series="{{ s.resource_type }}"
+                clip-path="url(#chart-plot)" points="{{ s.polyline }}" />
       {% endfor %}
       {% for tick in chart.x_ticks %}
       <text class="axis-label" x="{{ tick.pos }}" y="{{ tick.label_y }}">{{ tick.label }}</text>
@@ -170,14 +179,19 @@
 
   <!--
     Legend: one entry per plotted series, colored to match its line. While
-    more than one series is plotted, an entry is a link that removes it from
-    the charted set; types are added from the picker above.
+    more than one series is plotted, an entry is a link that focuses that
+    series — the y axis re-fits it and the others recede (#602); clicking
+    the focused entry restores the shared view. Types are added and removed
+    through the picker above, never here.
   -->
   <ul class="chart-legend">
     {% for item in legend %}
     <li>
       {% if let Some(href) = item.href %}
-      <a class="chart-legend__item" href="{{ href }}" title="{{ i18n.t("chart-remove-series") }}">
+      <a class="chart-legend__item{% if item.focused %} chart-legend__item--focused{% endif %}"
+         href="{{ href }}"
+         {% if item.focused %}aria-current="true"{% endif %}
+         title="{% if item.focused %}{{ i18n.t("chart-unfocus-series") }}{% else %}{{ i18n.t("chart-focus-series") }}{% endif %}">
         <span class="chart-legend__dot chart-legend__dot--{{ item.color }}" aria-hidden="true"></span>
         <span>{{ item.resource_type }}</span>
         <span class="chart-legend__total">{{ item.total }}</span>

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -154,7 +154,8 @@ chart-empty = Noch nichts darzustellen — gespeicherte Ressourcen erscheinen hi
 chart-sample-note = Beispieldaten: in diesem Build ist kein Live-Metrikanbieter registriert.
 chart-table-toggle = Als Tabelle anzeigen
 chart-table-when = Zeitpunkt
-chart-remove-series = Aus dem Diagramm entfernen
+chart-focus-series = Diese Serie fokussieren
+chart-unfocus-series = Alle Serien anzeigen
 
 ## Fußzeile
 

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -158,7 +158,8 @@ chart-empty = Nothing to chart yet — stored resources appear here as they are 
 chart-sample-note = Sample data: no live metrics provider is registered on this build.
 chart-table-toggle = View as table
 chart-table-when = Time
-chart-remove-series = Remove from chart
+chart-focus-series = Focus this series
+chart-unfocus-series = Show all series
 
 ## Footer
 

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -154,7 +154,8 @@ chart-empty = Nada que graficar todavía: los recursos almacenados aparecerán a
 chart-sample-note = Datos de muestra: esta build no tiene registrado un proveedor de métricas en vivo.
 chart-table-toggle = Ver como tabla
 chart-table-when = Momento
-chart-remove-series = Quitar del gráfico
+chart-focus-series = Enfocar esta serie
+chart-unfocus-series = Mostrar todas las series
 
 ## Pie de página
 


### PR DESCRIPTION
Closes #602. Implements the design decisions recorded on the issue (gesture, URL state, and the y-axis question).

## Behavior

- A legend entry links to `?focus=Type`; clicking the focused entry links back to the shared view. Single-select, Grafana-style. Plain links — the no-JS contract holds with zero script changes, and the focused view is shareable/back-button-friendly.
- **Focus re-fits the y axis to the focused series** (the "actually see Encounter next to Observation" option). The other series stay plotted at their true values, receded at 0.25 opacity, and a new plot `clipPath` cuts them where they exceed the focused scale — standard dashboard behavior when a y ceiling tightens.
- The focused line gets a heavier stroke; the focused legend entry gets bold text, an outlined dot, and `aria-current` — distinguishable by more than color (axe runs on this page in both themes, suite green).
- Focus rides every other chart control (window, expand, picker) and drops automatically when the picker removes the focused type — `dash_href` strips a focus its own type-set no longer contains.
- `chart-remove-series` → `chart-focus-series` / `chart-unfocus-series` in en/es/de. Removal stays in the picker, which was already the membership control.

## Tests

- Unit: axis rescale under focus, the focused/receded emphasis split, link inversion on the focused entry, full-set preservation, and the uncharted-focus fallback; the old legend-remove assertion updated to the new contract.
- e2e: new `legend click focuses…` spec (URL, series count unchanged, marker classes, way back); the nojs project now clicks the legend with JavaScript off. The new specs carry the `HFS_E2E_NO_CHART_DATA` guard inline so they stand down on the s3 matrix leg regardless of merge order with #595.
- `cargo test -p helios-ui` + dashboard/a11y/nojs Playwright suites green locally.

Heads-up for review: touches the same `dashboard.spec.ts` region as #595's skip guards — hunks are disjoint, so whichever merges second should reconcile cleanly.