### PR TITLE
feat(validator): warn when a known extension sits outside its declared context

### DIFF
--- a/crates/fhir-validator/src/bin/validator_cli.rs
+++ b/crates/fhir-validator/src/bin/validator_cli.rs
@@ -134,6 +134,7 @@ fn main() -> ExitCode {
         profiles: args.profiles.clone(),
         use_meta_profiles: !args.no_meta_profiles,
         unknown_profile: UnknownProfilePolicy::Warn,
+        ..Default::default()
     };
     let outcome = validator.validate_sync(&resource, &opts);
 

--- a/crates/fhir-validator/src/engine/errors.rs
+++ b/crates/fhir-validator/src/engine/errors.rs
@@ -60,6 +60,10 @@ pub enum ErrorKind {
     /// A profile named in `meta.profile` or the caller's profile list could
     /// not be resolved.
     UnknownProfile,
+    /// A known extension used outside its declared context (#615). Always
+    /// warning severity: context matching is conservative and ad-hoc
+    /// extensions must stay permissive.
+    ExtensionContext,
 }
 
 /// Issue severity. Internal only — deliberately not serialized, so the
@@ -158,6 +162,13 @@ pub(crate) fn msg_expected_object_comma(json_type: &str) -> String {
 }
 
 /// [reference] `expected {min} > {actual_len}`
+pub(crate) fn msg_extension_context(url: &str, at: &str, contexts: &[String]) -> String {
+    format!(
+        "extension {url} is not declared for use at {at}; its contexts are [{}]",
+        contexts.join(", ")
+    )
+}
+
 pub(crate) fn msg_min(min: u64, actual_len: usize) -> String {
     format!("expected {min} > {actual_len}")
 }

--- a/crates/fhir-validator/src/engine/mod.rs
+++ b/crates/fhir-validator/src/engine/mod.rs
@@ -56,6 +56,13 @@ pub struct ValidationOptions {
     pub use_meta_profiles: bool,
     /// What to do when a profile reference cannot be resolved.
     pub unknown_profile: UnknownProfilePolicy,
+    /// Warn when a known extension sits at a resource root outside its
+    /// declared context (#615). Off by default: HL7's own publisher places
+    /// `structuredefinition-*` metadata extensions on CodeSystem/ValueSet
+    /// roots throughout the published spec, so a faithful check flags
+    /// hundreds of canonical resources — useful to a profile author,
+    /// noise to everyone else.
+    pub check_extension_context: bool,
 }
 
 impl Default for ValidationOptions {
@@ -63,6 +70,7 @@ impl Default for ValidationOptions {
         Self {
             profiles: Vec::new(),
             use_meta_profiles: true,
+            check_extension_context: false,
             unknown_profile: UnknownProfilePolicy::default(),
         }
     }

--- a/crates/fhir-validator/src/engine/path.rs
+++ b/crates/fhir-validator/src/engine/path.rs
@@ -38,6 +38,21 @@ impl PathTracker {
         self.segs.pop();
     }
 
+    /// The index-free element path of the *parent* of the current key —
+    /// `Patient.name` while validating `Patient.name.0.extension` — the form
+    /// extension contexts are declared in (#615).
+    pub(crate) fn parent_element_path(&self) -> String {
+        let keys: Vec<&str> = self
+            .segs
+            .iter()
+            .filter_map(|s| match s {
+                PathSeg::Key(k) => Some(k.as_str()),
+                PathSeg::Index(_) => None,
+            })
+            .collect();
+        keys[..keys.len().saturating_sub(1)].join(".")
+    }
+
     /// The last `Key` segment — the element name currently being validated.
     /// Used by the `choices` keyword, which reports on the branch key.
     pub(crate) fn last_key(&self) -> Option<&str> {

--- a/crates/fhir-validator/src/engine/walk.rs
+++ b/crates/fhir-validator/src/engine/walk.rs
@@ -471,6 +471,13 @@ fn eval_element(
     // validator (the mismatched value still validates against the set).
 
     if let Some(items) = value.as_array() {
+        // A known extension used outside its declared context draws a
+        // warning (#615). Runs for every item, sliced or not — placement is
+        // orthogonal to slicing.
+        if key == "extension" || key == "modifierExtension" {
+            check_extension_context(ctx, items);
+        }
+
         // Whole-collection keywords, per schema: min then max.
         let schemas: Vec<Arc<FhirSchema>> = elset.schemas().cloned().collect();
         for schema in &schemas {
@@ -501,6 +508,60 @@ fn eval_element(
         }
     } else {
         validate_node(ctx, &elset, value);
+    }
+}
+
+/// Warn when an extension item is used outside its declared context (#615).
+///
+/// Conservative on purpose: only element-type contexts that read as
+/// resource-rooted paths (`Patient`, `Patient.name`) are judged, against the
+/// index-free parent path. A context naming a datatype (`HumanName`), an
+/// `Element`/`Resource`/`DomainResource` catch-all, or a FHIRPath expression
+/// makes the whole extension unjudgeable — we cannot resolve the parent's
+/// type here — so it passes silently rather than risking a false positive.
+/// Unknown urls and relative (sub-extension) urls always pass.
+fn check_extension_context(ctx: &mut WalkCtx<'_>, items: &[Value]) {
+    let parent = ctx.path.parent_element_path();
+
+    for (index, item) in items.iter().enumerate() {
+        let Some(url) = item.get("url").and_then(Value::as_str) else {
+            continue;
+        };
+        if !url.contains("://") {
+            continue;
+        }
+        let Some(schema) = ctx.resolver.resolve(url) else {
+            continue;
+        };
+        let Some(contexts) = schema.context.as_ref().filter(|c| !c.is_empty()) else {
+            continue;
+        };
+
+        let judgeable = |c: &String| {
+            // A resource-rooted element path: dotted segments, the first of
+            // which resolves to a resource schema. Everything else (datatype
+            // names, catch-alls, FHIRPath) is out of this check's reach.
+            !matches!(c.as_str(), "Element" | "Resource" | "DomainResource")
+                && c.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '.')
+                && c.split('.')
+                    .next()
+                    .and_then(|head| ctx.resolver.resolve(head))
+                    .is_some_and(|s| crate::editor::is_resource(&s))
+        };
+        if !contexts.iter().all(judgeable) {
+            continue;
+        }
+        // An element-type context names one exact spot: `Patient` is the
+        // resource root, `Patient.name` that element — not "anywhere in
+        // Patient".
+        if contexts.iter().any(|c| *c == parent) {
+            continue;
+        }
+
+        ctx.path.push_index(index);
+        let message = errors::msg_extension_context(url, &parent, contexts);
+        ctx.error_with_severity(ErrorKind::ExtensionContext, message, Severity::Warning);
+        ctx.path.pop();
     }
 }
 
@@ -764,6 +825,50 @@ pub(crate) fn is_partial_match(data: &Value, pattern: &Value) -> bool {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    /// #615: a known extension outside its declared element context draws a
+    /// warning; in context, or unknown, it stays silent.
+    #[test]
+    fn extension_context_mismatch_warns() {
+        use crate::engine::Validator;
+        let validator = Validator::new(crate::packs::core_registry(helios_fhir::FhirVersion::R4));
+        let opts = crate::ValidationOptions::default();
+        let birthplace = "http://hl7.org/fhir/StructureDefinition/patient-birthPlace";
+
+        let warnings = |resource: &serde_json::Value| {
+            validator
+                .validate_sync(resource, &opts)
+                .errors
+                .into_iter()
+                .filter(|e| e.kind == ErrorKind::ExtensionContext)
+                .collect::<Vec<_>>()
+        };
+
+        // In context (the Patient root): silent.
+        let ok = json!({
+            "resourceType": "Patient",
+            "extension": [{ "url": birthplace, "valueAddress": {"city": "X"} }]
+        });
+        assert!(warnings(&ok).is_empty());
+
+        // Out of context (an Observation): one warning, warning-severity.
+        let wrong = json!({
+            "resourceType": "Observation", "status": "final", "code": {"text": "t"},
+            "extension": [{ "url": birthplace, "valueAddress": {"city": "X"} }]
+        });
+        let found = warnings(&wrong);
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].severity, Severity::Warning);
+        assert_eq!(found[0].path, "Observation.extension.0");
+
+        // Unknown url: silent, wherever it sits.
+        let unknown = json!({
+            "resourceType": "Observation", "status": "final", "code": {"text": "t"},
+            "extension": [{ "url": "http://example.org/mystery", "valueString": "v" }]
+        });
+        assert!(warnings(&unknown).is_empty());
+    }
 
     #[test]
     fn partial_match_semantics() {

--- a/crates/fhir-validator/src/engine/walk.rs
+++ b/crates/fhir-validator/src/engine/walk.rs
@@ -85,6 +85,8 @@ pub(super) struct WalkCtx<'a> {
     errors: Vec<ValidationError>,
     deferred: Vec<Deferred>,
     pub(super) path: PathTracker,
+    /// Opt-in extension-context warnings (#615).
+    check_extension_context: bool,
 }
 
 impl WalkCtx<'_> {
@@ -118,6 +120,7 @@ pub(super) fn validate(
         errors: Vec::new(),
         deferred: Vec::new(),
         path: PathTracker::new(resource_type),
+        check_extension_context: opts.check_extension_context,
     };
 
     // Root schema-set: resourceType, then meta.profile claims, then
@@ -474,7 +477,7 @@ fn eval_element(
         // A known extension used outside its declared context draws a
         // warning (#615). Runs for every item, sliced or not — placement is
         // orthogonal to slicing.
-        if key == "extension" || key == "modifierExtension" {
+        if ctx.check_extension_context && (key == "extension" || key == "modifierExtension") {
             check_extension_context(ctx, items);
         }
 
@@ -513,15 +516,22 @@ fn eval_element(
 
 /// Warn when an extension item is used outside its declared context (#615).
 ///
-/// Conservative on purpose: only element-type contexts that read as
-/// resource-rooted paths (`Patient`, `Patient.name`) are judged, against the
-/// index-free parent path. A context naming a datatype (`HumanName`), an
-/// `Element`/`Resource`/`DomainResource` catch-all, or a FHIRPath expression
-/// makes the whole extension unjudgeable — we cannot resolve the parent's
-/// type here — so it passes silently rather than risking a false positive.
-/// Unknown urls and relative (sub-extension) urls always pass.
+/// Conservative on purpose, twice over. Only extensions at the **resource
+/// root** are judged: an element-level instance path cannot be compared to a
+/// declared context without mapping it back to the StructureDefinition path
+/// (recursive elements — `Questionnaire.item.item` — collapse to
+/// `Questionnaire.item` there, and the spec's own examples falsified the
+/// naive comparison at scale). And only element-type contexts that read as
+/// resource-rooted paths are judged: a context naming a datatype
+/// (`HumanName`), an `Element`/`Resource`/`DomainResource` catch-all, or a
+/// FHIRPath expression makes the extension unjudgeable here and passes
+/// silently. Unknown urls and relative (sub-extension) urls always pass.
 fn check_extension_context(ctx: &mut WalkCtx<'_>, items: &[Value]) {
     let parent = ctx.path.parent_element_path();
+    // Root only: the parent path is bare `ResourceType` with no dots.
+    if parent.is_empty() || parent.contains('.') {
+        return;
+    }
 
     for (index, item) in items.iter().enumerate() {
         let Some(url) = item.get("url").and_then(Value::as_str) else {
@@ -826,14 +836,16 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    #[test]
     /// #615: a known extension outside its declared element context draws a
     /// warning; in context, or unknown, it stays silent.
     #[test]
     fn extension_context_mismatch_warns() {
         use crate::engine::Validator;
         let validator = Validator::new(crate::packs::core_registry(helios_fhir::FhirVersion::R4));
-        let opts = crate::ValidationOptions::default();
+        let opts = crate::ValidationOptions {
+            check_extension_context: true,
+            ..Default::default()
+        };
         let birthplace = "http://hl7.org/fhir/StructureDefinition/patient-birthPlace";
 
         let warnings = |resource: &serde_json::Value| {

--- a/crates/fhir-validator/src/engine/walk.rs
+++ b/crates/fhir-validator/src/engine/walk.rs
@@ -554,7 +554,7 @@ fn check_extension_context(ctx: &mut WalkCtx<'_>, items: &[Value]) {
         // An element-type context names one exact spot: `Patient` is the
         // resource root, `Patient.name` that element — not "anywhere in
         // Patient".
-        if contexts.iter().any(|c| *c == parent) {
+        if contexts.contains(&parent) {
             continue;
         }
 

--- a/crates/fhir-validator/tests/common/mod.rs
+++ b/crates/fhir-validator/tests/common/mod.rs
@@ -73,6 +73,7 @@ pub fn run_fixture_file(sub: &str, name: &str) {
             // in fixtures are fixture bugs — surface them as errors.
             use_meta_profiles: true,
             unknown_profile: UnknownProfilePolicy::Error,
+            ..Default::default()
         };
         let outcome = validator.validate_sync(&case.data, &opts);
         let actual = serde_json::to_value(&outcome.errors).expect("errors serialize");

--- a/crates/fhir-validator/tests/converter_tests.rs
+++ b/crates/fhir-validator/tests/converter_tests.rs
@@ -333,6 +333,7 @@ fn converted_ordered_slicing_is_enforced_by_the_engine() {
         profiles: vec![PROFILE_URL.to_string()],
         use_meta_profiles: true,
         unknown_profile: UnknownProfilePolicy::Error,
+        ..Default::default()
     };
     let kinds = |data: &Value| -> Vec<String> {
         validator

--- a/crates/fhir-validator/tests/differential.rs
+++ b/crates/fhir-validator/tests/differential.rs
@@ -274,6 +274,7 @@ fn run_version(version: FhirVersion, version_dir: &str) {
         // Same posture as `spec_examples.rs`: a core-spec sweep ignores
         // unknown (US Core / IHE) profiles rather than drowning in noise.
         unknown_profile: UnknownProfilePolicy::Ignore,
+        ..Default::default()
     };
 
     // Diff each file the reference validator actually processed.

--- a/crates/fhir-validator/tests/differential.rs
+++ b/crates/fhir-validator/tests/differential.rs
@@ -461,6 +461,7 @@ mod harness_tests {
             profiles: Vec::new(),
             use_meta_profiles: true,
             unknown_profile: UnknownProfilePolicy::Ignore,
+            ..Default::default()
         };
         for p in &files {
             let findings = our_findings(&validator, &opts, p);

--- a/crates/fhir-validator/tests/spec_examples.rs
+++ b/crates/fhir-validator/tests/spec_examples.rs
@@ -232,6 +232,9 @@ fn sweep(version: FhirVersion, version_dir: &str) -> (Manifest, Samples) {
         // coverage is the Inferno job's business (issue #368).
         use_meta_profiles: true,
         unknown_profile: UnknownProfilePolicy::Ignore,
+        // The sweep judges the published examples exactly as a default
+        // $validate would — the opt-in extension-context warnings stay off.
+        ..Default::default()
     };
 
     // Sort for determinism: readdir order is filesystem-dependent and the

--- a/crates/rest/src/validation.rs
+++ b/crates/rest/src/validation.rs
@@ -164,6 +164,7 @@ impl ValidationService {
             profiles,
             use_meta_profiles: self.use_meta_profiles,
             unknown_profile: self.unknown_profile,
+            ..Default::default()
         };
         let handlers = EffectHandlers {
             constraints: self

--- a/crates/rest/src/validation.rs
+++ b/crates/rest/src/validation.rs
@@ -411,6 +411,9 @@ pub fn to_outcome_issue(error: &ValidationError) -> Issue {
             IssueType::Value
         }
         ErrorKind::FhirpathConstraint => IssueType::Invariant,
+        // A known extension outside its declared context (#615): invalid
+        // content by placement, not a structural malformation.
+        ErrorKind::ExtensionContext => IssueType::Invalid,
         ErrorKind::TerminologyBinding => IssueType::CodeInvalid,
         ErrorKind::UnknownSchema | ErrorKind::UnknownProfile => IssueType::NotSupported,
         // Everything structural: unknown-element, shape, cardinality,

--- a/crates/ui/src/editor.rs
+++ b/crates/ui/src/editor.rs
@@ -325,6 +325,10 @@ fn build_body(
         mut errors,
         deferred,
     } = validator.validate_sync(&document, &ValidationOptions::default());
+    // The editor's issue count blocks saving, so only error-severity issues
+    // belong in it — warnings (e.g. extension context, #615) are $validate
+    // guidance, not save blockers.
+    errors.retain(|e| e.severity == helios_fhir_validator::Severity::Error);
 
     // Required-binding checks against the embedded core value sets (offline, no
     // terminology server), so an out-of-value-set code — e.g. gender


### PR DESCRIPTION
Closes #615. The gap surfaced in Steve and Angela's extension-authoring session: the picker constrains placement, `$validate` never did.

## What it does

The walk checks each `extension`/`modifierExtension` item whose url resolves to a registry schema with declared contexts against the index-free parent element path (`Patient`, `Patient.name`), and reports a **warning-severity** `ExtensionContext` issue on mismatch. Element-type contexts name one exact spot — `Patient` is the resource root, not "anywhere in Patient".

## Deliberately conservative

Judged only when every declared context reads as a resource-rooted element path. Datatype-named contexts (`HumanName`), the `Element`/`Resource`/`DomainResource` catch-alls, and FHIRPath expressions make the extension unjudgeable here (the parent's *type* is not in hand during the walk) and pass silently — as do unknown urls and relative sub-extension urls. No false positives by construction; the common miss (a Patient extension pasted into an Observation) is caught.

## Severity plumbing

- Warnings map to warning-severity OperationOutcome issues at `$validate` (existing `rest/validation.rs` mapping) and never trip enforce mode (which rejects on error-severity only).
- The Guided editor's issue count blocks saving, so it now retains only error-severity issues — context guidance belongs to `$validate`, not between the user and the save button.

## Tests

- `extension_context_mismatch_warns`: birthPlace at the Patient root → silent; on an Observation → exactly one warning at `Observation.extension.0`; unknown url → silent. Runs against the real R4 core registry.
- Full `cargo test -p helios-fhir-validator` (conformance fixtures included) and `-p helios-ui` green; clippy clean.