### PR TITLE
fix(ui): make SearchParameter rows clickable

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2185,6 +2185,10 @@ a.pill {
   background: var(--accent-soft);
 }
 
+.data-table[data-row-navigation] tbody tr {
+  cursor: pointer;
+}
+
 .row-link {
   display: flex;
   flex-direction: column;

--- a/crates/ui/assets/search-parameters.js
+++ b/crates/ui/assets/search-parameters.js
@@ -1,0 +1,63 @@
+/*
+ * SearchParameter result-row navigation (#610).
+ *
+ * The first cell keeps the row's only real link for keyboard, assistive
+ * technology, and no-JavaScript navigation. This handler only extends that
+ * link's pointer target to the rest of the row.
+ */
+(function () {
+  "use strict";
+
+  var table = document.querySelector("table[data-row-navigation]");
+  if (!table || !table.tBodies.length) return;
+  var body = table.tBodies[0];
+  var interactive = [
+    "a",
+    "button",
+    "input",
+    "select",
+    "textarea",
+    "label",
+    "summary",
+    '[role="button"]',
+    '[role="link"]',
+    '[contenteditable]:not([contenteditable="false"])',
+  ].join(",");
+
+  function rowContainsSelection(row) {
+    var selection = window.getSelection && window.getSelection();
+    if (!selection || selection.isCollapsed) return false;
+    return Boolean(
+      (selection.anchorNode && row.contains(selection.anchorNode)) ||
+      (selection.focusNode && row.contains(selection.focusNode))
+    );
+  }
+
+  body.addEventListener("click", function (event) {
+    var target = event.target;
+    if (!target || !target.closest) return;
+    var row = target.closest("tr");
+    if (!row || !body.contains(row)) return;
+
+    // A drag may end over the real link. Cancel its native activation too.
+    if (rowContainsSelection(row)) {
+      event.preventDefault();
+      return;
+    }
+
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey ||
+      event.altKey ||
+      target.closest(interactive)
+    ) {
+      return;
+    }
+
+    var link = row.querySelector("a.row-link[href]");
+    if (link) link.click();
+  });
+})();

--- a/crates/ui/templates/pages/search-parameters.html
+++ b/crates/ui/templates/pages/search-parameters.html
@@ -83,7 +83,7 @@
 
     <section class="card">
       <div class="table-wrap">
-        <table class="data-table" aria-label="{{ i18n.t("sp-heading") }}">
+        <table class="data-table" data-row-navigation aria-label="{{ i18n.t("sp-heading") }}">
           <thead>
             <tr>
               <th>{{ i18n.t("sp-col-code") }}</th>
@@ -208,5 +208,6 @@
 </div>
 
 <script src="/ui/assets/resource-filter.js" defer></script>
+<script src="/ui/assets/search-parameters.js" defer></script>
 <script src="/ui/assets/conformance-crud.js" defer></script>
 {% endblock %}

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -205,11 +205,26 @@ async fn search_parameters_page_serves_the_registry_view() {
     assert_eq!(response.status(), StatusCode::OK);
     let html = body_text(response).await;
     assert!(html.contains("<!doctype html>"));
+    assert!(html.contains("<title>Search Parameters — Helios FHIR Server</title>"));
+    assert!(html.contains(r#"<h1 class="page-head__title">Search Parameters</h1>"#));
+    assert!(html.contains(
+        r#"<table class="data-table" data-row-navigation aria-label="Search Parameters">"#
+    ));
+    assert!(html.contains(r#"<script src="/ui/assets/search-parameters.js" defer></script>"#));
     // The Resource Filter rail and the facet rows are server-rendered.
     assert!(html.contains(r#"id="sp-rail-list""#));
     assert!(html.contains("base=Patient"));
     // Real registry data, not placeholders: Patient supports `name`.
     assert!(html.contains("http://hl7.org/fhir/SearchParameter/Patient-name"));
+    // Each result row keeps exactly one native link for keyboard and no-JS use.
+    let table_body = html
+        .split_once("<tbody>")
+        .and_then(|(_, rest)| rest.split_once("</tbody>"))
+        .map(|(body, _)| body)
+        .expect("SearchParameter table body");
+    let row_count = table_body.matches("<tr").count();
+    assert!(row_count > 0);
+    assert_eq!(table_body.matches(r#"class="row-link""#).count(), row_count);
     // This page, not Home, carries aria-current in the sidebar.
     assert!(html.contains(r#"href="/ui/search-parameters" aria-current="page""#));
 }

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -220,7 +220,7 @@ queries-unavailable = Saved queries are unavailable: this server's storage backe
 
 ## SearchParameter viewer (#238)
 
-sp-heading = Search parameters
+sp-heading = Search Parameters
 sp-lede = Browse the parameters this server resolves searches against, filtered by base resource type. Stored parameters can be created, edited, and deleted; the registry picks changes up per tenant.
 sp-version-label = FHIR version
 sp-spec-missing = The full spec bundle (search-parameters-*.json) was not found in the data directory — only the minimal embedded fallback parameters are shown.


### PR DESCRIPTION
## What changed

- Match the English Search Parameters heading with the sidebar label.
- Let pointer clicks anywhere in a result row follow its existing link.
- Keep one native link per row for keyboard and no-JavaScript navigation.
- Skip row navigation while the user selects text or interacts with a nested control.

## Testing

- `cargo check -p helios-ui`
- `cargo test -p helios-ui --test router_http search_parameters_page_serves_the_registry_view`
- Manual browser QA covered every table cell, text selection, keyboard navigation, htmx history, JavaScript-disabled navigation, and the English, Spanish, and German labels.

Closes #610