### PR TITLE
fix(persistence): chained search honors comparator prefixes, type-guarded

### DIFF
--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -633,7 +633,17 @@ impl ChainedSearchProvider for PostgresBackend {
         let parsed = builder
             .parse_chain(chain)
             .map_err(|e| internal_error(format!("Failed to parse chain: {}", e)))?;
-        let parsed_value = crate::types::SearchValue::parse(value);
+        // Strip the comparator prefix only when the terminal parameter's type
+        // admits one: dates/numbers/quantities compare, but a string value
+        // like `family=Levine` must never be misread as le + "vine" (#258).
+        let candidate = crate::types::SearchValue::parse(value);
+        let parsed_value = if candidate.prefix != crate::types::SearchPrefix::Eq
+            && candidate.prefix.is_valid_for(parsed.terminal_type)
+        {
+            candidate
+        } else {
+            crate::types::SearchValue::eq(value)
+        };
         let fragment = builder.build_forward_chain_sql(&parsed, &parsed_value)?;
 
         let sql = format!(

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -743,8 +743,18 @@ impl ChainedSearchProvider for SqliteBackend {
             }
         };
 
-        // Build the SQL fragment
-        let search_value = SearchValue::eq(value);
+        // Build the SQL fragment. The chained value still carries its
+        // comparator prefix (`patient.birthdate=le1956-07-14`); strip it only
+        // when the terminal parameter's type admits one, so a string value
+        // like `family=Levine` is never misread as le + "vine" (#258).
+        let candidate = crate::types::SearchValue::parse(value);
+        let search_value = if candidate.prefix != crate::types::SearchPrefix::Eq
+            && candidate.prefix.is_valid_for(parsed.terminal_type)
+        {
+            candidate
+        } else {
+            SearchValue::eq(value)
+        };
         let fragment = match builder.build_forward_chain_sql(&parsed, &search_value) {
             Ok(f) => f,
             Err(e) => {
@@ -1919,6 +1929,60 @@ mod tests {
     // ========================================================================
     // ChainedSearchProvider Tests
     // ========================================================================
+
+    /// #258: a chained value keeps its comparator prefix when the terminal
+    /// parameter compares (dates), and never loses its head to one when it
+    /// does not (a family name starting with a valid prefix pair).
+    #[tokio::test]
+    async fn test_resolve_chain_comparator_prefix() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({"id": "p1", "birthDate": "1950-04-12", "name": [{"family": "Levine"}]}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({"id": "o1", "subject": {"reference": "Patient/p1"}}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        // The comparator reaches the date comparison: le on a later date
+        // matches, gt1900 matches everyone, le on an earlier date excludes.
+        let ids = backend
+            .resolve_chain(&tenant, "Observation", "subject.birthdate", "le1956-07-14")
+            .await
+            .unwrap();
+        assert_eq!(ids, vec!["o1".to_string()], "le includes the 1950 birth");
+        let ids = backend
+            .resolve_chain(&tenant, "Observation", "subject.birthdate", "gt1900-01-01")
+            .await
+            .unwrap();
+        assert_eq!(ids, vec!["o1".to_string()], "gt1900 matches every patient");
+        let ids = backend
+            .resolve_chain(&tenant, "Observation", "subject.birthdate", "le1940-01-01")
+            .await
+            .unwrap();
+        assert!(ids.is_empty(), "le on an earlier date excludes");
+
+        // A string value beginning with a valid prefix pair stays whole:
+        // family=Levine must not become le + "vine".
+        let ids = backend
+            .resolve_chain(&tenant, "Observation", "subject.family", "Levine")
+            .await
+            .unwrap();
+        assert_eq!(ids, vec!["o1".to_string()], "Levine matches, unclipped");
+    }
 
     #[tokio::test]
     async fn test_resolve_chain_simple() {


### PR DESCRIPTION
Closes #258.

The silent-empty from the issue, plus its mirror image found on the way:

- **SQLite** forced `SearchValue::eq` onto the raw chained value, so `patient.birthdate=le1956-07-14` compared dates against the literal string `le1956-07-14` — zero rows, no error. `gt1900-01-01` returning nothing was exactly this.
- **Postgres** had the inverse bug: unconditional `SearchValue::parse`, so a chained *string* value starting with a valid prefix pair — `family=Levine` — lost its head to `le` + `vine`.

Both call sites now strip the prefix only when the parsed chain's **terminal parameter type** admits one (number/date/quantity via `SearchPrefix::is_valid_for`) — the same rule direct search applies. The terminal SQL arms (`build_date_condition`/`build_number_condition`) already honored `value.prefix`; only the call sites were wrong, so the fix is two guarded parses.

Test drives `resolve_chain` through the issue's repro (le includes, `gt1900` matches everyone, le on an earlier date excludes) and the Levine-stays-whole guard. Full `-p helios-persistence --features sqlite` suite green (792), clippy clean on both backends. The ES/Mongo chain paths ride different code (registry-driven, no raw-eq call site) — the multi-backend verification pass tracked in #519 is the natural place to sweep them with the same repro.