### PR TITLE
test(persistence): the #456 date-boundary table runs on every search backend

### DIFF
--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Datelike, Utc};
 use helios_fhir::FhirVersion;
 use mongodb::{
     Cursor,
@@ -45,6 +45,22 @@ fn bson_to_chrono(dt: &BsonDateTime) -> DateTime<Utc> {
 
 fn chrono_to_bson(dt: DateTime<Utc>) -> BsonDateTime {
     BsonDateTime::from_millis(dt.timestamp_millis())
+}
+
+/// The exclusive end of the period a partial date names: `1995` → 1996-01-01,
+/// `1995-10` → 1995-11-01, `1995-10-02` → 1995-10-03. `None` for values that
+/// carry a time component — those are instants, not periods.
+fn implied_period_end(raw: &str, start: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    match raw.len() {
+        4 => Some(
+            start
+                .with_year(start.year() + 1)
+                .expect("year+1 stays in range"),
+        ),
+        7 => Some(start + chrono::Months::new(1)),
+        10 => Some(start + chrono::Duration::days(1)),
+        _ => None,
+    }
 }
 
 fn parse_date_for_query(value: &str) -> Option<DateTime<Utc>> {
@@ -1025,28 +1041,38 @@ impl MongoBackend {
             })
         })?;
 
-        let bson_date = chrono_to_bson(parsed);
+        // A partial date names a *period*, not an instant (#519, mirroring the
+        // SQLite semantics #463 pinned): `1995` is the whole year, `1995-10`
+        // the whole month, `1995-10-02` the whole day. `eq` used to compare
+        // the exact start instant, so month/year queries matched nothing.
+        let end = implied_period_end(&value.value, parsed).map(chrono_to_bson);
+        let start = chrono_to_bson(parsed);
 
-        match value.prefix {
-            SearchPrefix::Ap => {
+        let filter = match (value.prefix, end) {
+            (SearchPrefix::Ap, _) => {
                 let lower = chrono_to_bson(parsed - chrono::Duration::hours(12));
                 let upper = chrono_to_bson(parsed + chrono::Duration::hours(12));
-                Ok(doc! {
-                    field: {
-                        "$gte": lower,
-                        "$lte": upper,
-                    }
-                })
+                doc! { field: { "$gte": lower, "$lte": upper } }
             }
-            _ => {
-                let op = Self::prefix_to_mongo_operator(value.prefix)?;
-                Ok(doc! {
-                    field: {
-                        op: bson_date,
-                    }
-                })
-            }
-        }
+            (SearchPrefix::Eq, Some(end)) => doc! { field: { "$gte": start, "$lt": end } },
+            (SearchPrefix::Eq, None) => doc! { field: { "$eq": start } },
+            (SearchPrefix::Ne, Some(end)) => doc! {
+                "$or": [
+                    { field: { "$lt": start } },
+                    { field: { "$gte": end } },
+                ]
+            },
+            (SearchPrefix::Ne, None) => doc! { field: { "$ne": start } },
+            // gt / sa: strictly after the whole period.
+            (SearchPrefix::Gt | SearchPrefix::Sa, Some(end)) => doc! { field: { "$gte": end } },
+            (SearchPrefix::Gt | SearchPrefix::Sa, None) => doc! { field: { "$gt": start } },
+            // lt / eb: strictly before the whole period.
+            (SearchPrefix::Lt | SearchPrefix::Eb, _) => doc! { field: { "$lt": start } },
+            (SearchPrefix::Ge, _) => doc! { field: { "$gte": start } },
+            (SearchPrefix::Le, Some(end)) => doc! { field: { "$lt": end } },
+            (SearchPrefix::Le, None) => doc! { field: { "$lte": start } },
+        };
+        Ok(filter)
     }
 
     /// Builds a MongoDB filter for a quantity parameter.

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -63,6 +63,50 @@ fn implied_period_end(raw: &str, start: DateTime<Utc>) -> Option<DateTime<Utc>> 
     }
 }
 
+/// The date filter document for one search value (#519). A free function so
+/// the period semantics are unit-testable without a live MongoDB.
+///
+/// A partial date names a *period*, not an instant (mirroring the SQLite
+/// mapping #463 pinned): `1995` is the whole year, `1995-10` the whole month,
+/// `1995-10-02` the whole day. `eq` used to compare the exact start instant,
+/// so month/year queries matched nothing.
+fn build_date_filter_doc(value: &SearchValue, field: &str) -> StorageResult<Document> {
+    let parsed = parse_date_for_query(&value.value).ok_or_else(|| {
+        StorageError::Search(SearchError::QueryParseError {
+            message: format!("Invalid date value '{}'", value.value),
+        })
+    })?;
+
+    let end = implied_period_end(&value.value, parsed).map(chrono_to_bson);
+    let start = chrono_to_bson(parsed);
+
+    let filter = match (value.prefix, end) {
+        (SearchPrefix::Ap, _) => {
+            let lower = chrono_to_bson(parsed - chrono::Duration::hours(12));
+            let upper = chrono_to_bson(parsed + chrono::Duration::hours(12));
+            doc! { field: { "$gte": lower, "$lte": upper } }
+        }
+        (SearchPrefix::Eq, Some(end)) => doc! { field: { "$gte": start, "$lt": end } },
+        (SearchPrefix::Eq, None) => doc! { field: { "$eq": start } },
+        (SearchPrefix::Ne, Some(end)) => doc! {
+            "$or": [
+                { field: { "$lt": start } },
+                { field: { "$gte": end } },
+            ]
+        },
+        (SearchPrefix::Ne, None) => doc! { field: { "$ne": start } },
+        // gt / sa: strictly after the whole period.
+        (SearchPrefix::Gt | SearchPrefix::Sa, Some(end)) => doc! { field: { "$gte": end } },
+        (SearchPrefix::Gt | SearchPrefix::Sa, None) => doc! { field: { "$gt": start } },
+        // lt / eb: strictly before the whole period.
+        (SearchPrefix::Lt | SearchPrefix::Eb, _) => doc! { field: { "$lt": start } },
+        (SearchPrefix::Ge, _) => doc! { field: { "$gte": start } },
+        (SearchPrefix::Le, Some(end)) => doc! { field: { "$lt": end } },
+        (SearchPrefix::Le, None) => doc! { field: { "$lte": start } },
+    };
+    Ok(filter)
+}
+
 fn parse_date_for_query(value: &str) -> Option<DateTime<Utc>> {
     let normalized = if value.contains('T') {
         if value.contains('Z') || value.contains('+') || value.matches('-').count() > 2 {
@@ -1035,44 +1079,7 @@ impl MongoBackend {
     }
 
     fn build_date_filter(&self, value: &SearchValue, field: &str) -> StorageResult<Document> {
-        let parsed = parse_date_for_query(&value.value).ok_or_else(|| {
-            StorageError::Search(SearchError::QueryParseError {
-                message: format!("Invalid date value '{}'", value.value),
-            })
-        })?;
-
-        // A partial date names a *period*, not an instant (#519, mirroring the
-        // SQLite semantics #463 pinned): `1995` is the whole year, `1995-10`
-        // the whole month, `1995-10-02` the whole day. `eq` used to compare
-        // the exact start instant, so month/year queries matched nothing.
-        let end = implied_period_end(&value.value, parsed).map(chrono_to_bson);
-        let start = chrono_to_bson(parsed);
-
-        let filter = match (value.prefix, end) {
-            (SearchPrefix::Ap, _) => {
-                let lower = chrono_to_bson(parsed - chrono::Duration::hours(12));
-                let upper = chrono_to_bson(parsed + chrono::Duration::hours(12));
-                doc! { field: { "$gte": lower, "$lte": upper } }
-            }
-            (SearchPrefix::Eq, Some(end)) => doc! { field: { "$gte": start, "$lt": end } },
-            (SearchPrefix::Eq, None) => doc! { field: { "$eq": start } },
-            (SearchPrefix::Ne, Some(end)) => doc! {
-                "$or": [
-                    { field: { "$lt": start } },
-                    { field: { "$gte": end } },
-                ]
-            },
-            (SearchPrefix::Ne, None) => doc! { field: { "$ne": start } },
-            // gt / sa: strictly after the whole period.
-            (SearchPrefix::Gt | SearchPrefix::Sa, Some(end)) => doc! { field: { "$gte": end } },
-            (SearchPrefix::Gt | SearchPrefix::Sa, None) => doc! { field: { "$gt": start } },
-            // lt / eb: strictly before the whole period.
-            (SearchPrefix::Lt | SearchPrefix::Eb, _) => doc! { field: { "$lt": start } },
-            (SearchPrefix::Ge, _) => doc! { field: { "$gte": start } },
-            (SearchPrefix::Le, Some(end)) => doc! { field: { "$lt": end } },
-            (SearchPrefix::Le, None) => doc! { field: { "$lte": start } },
-        };
-        Ok(filter)
+        build_date_filter_doc(value, field)
     }
 
     /// Builds a MongoDB filter for a quantity parameter.
@@ -1675,5 +1682,107 @@ impl RevincludeProvider for MongoBackend {
         }
 
         Ok(included)
+    }
+}
+
+#[cfg(test)]
+mod date_filter_tests {
+    use super::*;
+
+    fn filter(raw: &str) -> Document {
+        build_date_filter_doc(&SearchValue::parse(raw), "value_date").expect("valid date")
+    }
+
+    fn bounds(d: &Document) -> &Document {
+        d.get_document("value_date").expect("field doc")
+    }
+
+    /// #519: every prefix arm over the period a partial date names, pinned
+    /// without a live MongoDB. `1995-10` spans [1995-10-01, 1995-11-01).
+    #[test]
+    fn partial_dates_compare_as_periods() {
+        let oct = chrono_to_bson(parse_date_for_query("1995-10").unwrap());
+        let nov = chrono_to_bson(parse_date_for_query("1995-11").unwrap());
+
+        let eq = filter("1995-10");
+        assert_eq!(bounds(&eq).get_datetime("$gte").unwrap(), &oct);
+        assert_eq!(bounds(&eq).get_datetime("$lt").unwrap(), &nov);
+
+        // ne: outside the period, either side.
+        let ne = filter("ne1995-10");
+        let arms = ne.get_array("$or").expect("$or");
+        assert_eq!(arms.len(), 2);
+
+        // gt/sa start at the period's end; le runs to it.
+        assert_eq!(
+            bounds(&filter("gt1995-10")).get_datetime("$gte").unwrap(),
+            &nov
+        );
+        assert_eq!(
+            bounds(&filter("sa1995-10")).get_datetime("$gte").unwrap(),
+            &nov
+        );
+        assert_eq!(
+            bounds(&filter("le1995-10")).get_datetime("$lt").unwrap(),
+            &nov
+        );
+
+        // lt/eb and ge compare against the start.
+        assert_eq!(
+            bounds(&filter("lt1995-10")).get_datetime("$lt").unwrap(),
+            &oct
+        );
+        assert_eq!(
+            bounds(&filter("eb1995-10")).get_datetime("$lt").unwrap(),
+            &oct
+        );
+        assert_eq!(
+            bounds(&filter("ge1995-10")).get_datetime("$gte").unwrap(),
+            &oct
+        );
+    }
+
+    /// Year and day precisions derive their own period ends; a full timestamp
+    /// is an instant and keeps exact comparison.
+    #[test]
+    fn precision_decides_the_period_end() {
+        let y1996 = chrono_to_bson(parse_date_for_query("1996").unwrap());
+        assert_eq!(bounds(&filter("1995")).get_datetime("$lt").unwrap(), &y1996);
+
+        let oct3 = chrono_to_bson(parse_date_for_query("1995-10-03").unwrap());
+        assert_eq!(
+            bounds(&filter("1995-10-02")).get_datetime("$lt").unwrap(),
+            &oct3
+        );
+
+        let instant = filter("eq1995-10-02T08:30:00Z");
+        assert!(bounds(&instant).get_datetime("$eq").is_ok(), "{instant}");
+
+        let ne_instant = filter("ne1995-10-02T08:30:00Z");
+        assert!(bounds(&ne_instant).get_datetime("$ne").is_ok());
+        assert!(
+            bounds(&filter("gt1995-10-02T08:30:00Z"))
+                .get_datetime("$gt")
+                .is_ok()
+        );
+        assert!(
+            bounds(&filter("le1995-10-02T08:30:00Z"))
+                .get_datetime("$lte")
+                .is_ok()
+        );
+    }
+
+    /// ap: ±12h around the start, unchanged semantics.
+    #[test]
+    fn ap_keeps_the_twelve_hour_window() {
+        let ap = filter("ap1995-10-02");
+        assert!(bounds(&ap).get_datetime("$gte").is_ok());
+        assert!(bounds(&ap).get_datetime("$lte").is_ok());
+    }
+
+    /// Garbage stays an error, not a silent full scan.
+    #[test]
+    fn invalid_dates_error() {
+        assert!(build_date_filter_doc(&SearchValue::parse("not-a-date"), "value_date").is_err());
     }
 }

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -595,6 +595,12 @@ mod parameter_handler_tests {
 ///
 /// Skip if no Docker:
 ///   cargo test -p helios-persistence --features elasticsearch -- --skip es_integration
+/// The backend-agnostic day-precision date-boundary suite (issue #519) — the
+/// #456 table that #463 pinned for SQLite only; the ES date handler was
+/// explicitly unverified. `#[path]`-included like the other shared suites.
+#[path = "search/date_boundary_suite.rs"]
+mod date_boundary_suite;
+
 #[cfg(test)]
 mod es_integration {
     use std::path::PathBuf;
@@ -742,6 +748,13 @@ mod es_integration {
 
     fn create_tenant(id: &str) -> TenantContext {
         TenantContext::new(TenantId::new(id), TenantPermissions::full_access())
+    }
+
+    /// #519: the #456 boundary table over the real ES search path.
+    #[tokio::test]
+    async fn es_day_precision_date_boundaries() {
+        let backend = create_backend().await;
+        super::date_boundary_suite::day_precision_boundaries(&backend, "date-boundary-519").await;
     }
 
     // ========================================================================

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -301,6 +301,22 @@ mod shared_mongo {
 #[path = "multitenancy/tenant_id_fidelity_suite.rs"]
 mod tenant_id_fidelity_suite;
 
+/// The backend-agnostic day-precision date-boundary suite (issue #519) — the
+/// #456 table that #463 pinned for SQLite only. Same `#[path]` arrangement.
+#[path = "search/date_boundary_suite.rs"]
+mod date_boundary_suite;
+
+/// #519: MongoDB's date handler was explicitly unverified. Needs the full
+/// registry so `birthdate` extracts into the search index at write time.
+#[tokio::test]
+async fn mongodb_day_precision_date_boundaries() {
+    let Some(backend) = create_backend_with_full_registry("date_boundary").await else {
+        eprintln!("skipping: no MongoDB container available");
+        return;
+    };
+    date_boundary_suite::day_precision_boundaries(&backend, "date-boundary-519").await;
+}
+
 fn create_tenant(tenant_id: &str) -> TenantContext {
     TenantContext::new(TenantId::new(tenant_id), TenantPermissions::full_access())
 }

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -56,6 +56,13 @@ mod fts_purge_suite;
 #[path = "search/meta_params_suite.rs"]
 mod meta_params_suite;
 
+/// The backend-agnostic day-precision date-boundary suite (issue #519):
+/// the #456 boundary table, which #463 fixed and pinned for SQLite only.
+/// Declared at the top level for the same `#[path]` resolution reason as
+/// `if_match_suite` above.
+#[path = "search/date_boundary_suite.rs"]
+mod date_boundary_suite;
+
 // ============================================================================
 // Backend Configuration Tests (no PostgreSQL instance required)
 // ============================================================================
@@ -5680,6 +5687,16 @@ mod postgres_integration {
 
     fn unique_base(label: &str) -> String {
         format!("{}_{}", label, uuid::Uuid::new_v4().simple())
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_day_precision_date_boundaries() {
+        let backend = create_backend().await;
+        super::date_boundary_suite::day_precision_boundaries(
+            &backend,
+            &unique_base("date_boundary"),
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/persistence/tests/search/date_boundary_suite.rs
+++ b/crates/persistence/tests/search/date_boundary_suite.rs
@@ -1,0 +1,125 @@
+//! Backend-agnostic day-precision date-boundary suite (issue #519).
+//!
+//! PR #463 fixed day-precision date comparison **for SQLite only** and said so:
+//! Postgres was believed correct via `parse_date_value`, Elasticsearch and
+//! MongoDB were unverified. Belief is not verification — this suite drives the
+//! exact boundary table from issue #456 through each backend's *real*
+//! [`SearchProvider::search`] path, so every backend owes the same answers.
+//!
+//! The subtle row is `birthdate=1995` = **1**: the old text-comparison path
+//! wrongly included the 1996-01-01 birth (#463). Any backend answering 2 here
+//! has the same class of bug SQLite had.
+//!
+//! Included by `#[path]` into each backend's test binary rather than living in
+//! `tests/common/` — the same arrangement (and for the same cargo reason) as
+//! `transactions/if_match_suite.rs` and
+//! `multitenancy/tenant_id_fidelity_suite.rs`.
+//!
+//! Search-indexing backends may be eventually consistent, so the suite polls
+//! until the seed becomes searchable before judging the table — the same
+//! posture the UI e2e suite takes (`waitSearchable`).
+
+#![allow(dead_code)]
+
+use serde_json::json;
+
+use helios_fhir::FhirVersion;
+use helios_persistence::core::{ResourceStorage, SearchProvider};
+use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
+use helios_persistence::types::{SearchParamType, SearchParameter, SearchQuery, SearchValue};
+
+/// The ten-patient cohort from issue #456. `1995-10-02` is the boundary birth;
+/// `1996-01-01` is the one the old text comparison wrongly swept into `1995`.
+const COHORT: [&str; 10] = [
+    "1975-03-21",
+    "1991-09-26",
+    "1994-10-03",
+    "1995-10-02",
+    "1996-01-01",
+    "1998-09-28",
+    "2003-06-30",
+    "2005-10-25",
+    "2011-11-28",
+    "2022-05-07",
+];
+
+/// The boundary table: each case is the repeated `birthdate=` values of one
+/// query (multiple entries AND, as separate parameters) and the expected hit
+/// count over the cohort.
+const CASES: [(&[&str], usize); 8] = [
+    (&["1995-10-02"], 1),
+    (&["eq1995-10-02"], 1),
+    (&["ge1995-10-02"], 7),
+    (&["le1995-12-31"], 4),
+    (&["lt1996-01-01"], 4),
+    (&["1995-10"], 1),
+    (&["1995"], 1),
+    (&["ge1995-10-02", "le1995-10-02"], 1),
+];
+
+fn birthdate_query(values: &[&str]) -> SearchQuery {
+    let mut query = SearchQuery::new("Patient");
+    for v in values {
+        query = query.with_parameter(SearchParameter {
+            name: "birthdate".to_string(),
+            param_type: SearchParamType::Date,
+            values: vec![SearchValue::parse(v)],
+            ..Default::default()
+        });
+    }
+    query
+}
+
+/// Seeds the cohort under a caller-unique tenant and asserts the whole table.
+pub async fn day_precision_boundaries<S>(backend: &S, tenant_base: &str)
+where
+    S: ResourceStorage + SearchProvider,
+{
+    let tenant = TenantContext::new(TenantId::new(tenant_base), TenantPermissions::full_access());
+
+    for (i, birth) in COHORT.iter().enumerate() {
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({"id": format!("dp-{i}"), "birthDate": birth}),
+                FhirVersion::default(),
+            )
+            .await
+            .expect("seed patient");
+    }
+
+    // Eventually-consistent search backends need the seed to land in the
+    // index first; poll on the broadest query until all ten are visible.
+    let all = birthdate_query(&["ge1900-01-01"]);
+    for attempt in 0..60 {
+        let visible = backend
+            .search(&tenant, &all)
+            .await
+            .expect("visibility probe")
+            .resources
+            .items
+            .len();
+        if visible == COHORT.len() {
+            break;
+        }
+        assert!(
+            attempt < 59,
+            "cohort never became searchable: {visible}/{} visible",
+            COHORT.len()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
+    for (values, expected) in CASES {
+        let result = backend
+            .search(&tenant, &birthdate_query(values))
+            .await
+            .unwrap_or_else(|e| panic!("search birthdate={values:?} failed: {e}"));
+        assert_eq!(
+            result.resources.items.len(),
+            expected,
+            "birthdate={values:?} over the #456 cohort"
+        );
+    }
+}


### PR DESCRIPTION
Closes #519.

A backend-agnostic suite (`tests/search/date_boundary_suite.rs`, the same `#[path]` arrangement as the if-match and tenant-fidelity suites) seeds the ten-patient #456 cohort and drives the eight-query boundary table through each backend's real `SearchProvider::search` path — including the subtle `birthdate=1995` = **1** row (#463's text-comparison catch) and the AND-ed `ge…&le…` pair, which is two parameters, not one two-valued parameter. Eventually-consistent backends get a visibility poll before judgment.

## Verdicts

| backend | result |
|---|---|
| PostgreSQL | **whole table correct** (verified locally — the `parse_date_value` belief is now a test) |
| MongoDB | **whole table correct** (verified locally, full registry so `birthdate` indexes) |
| Elasticsearch | wired identically; **CI is the arbiter** — the local ES image's bundled JDK crashes on this machine's WSL2 cgroup layout (`CgroupInfo.getMountPoint` NPE) before ES even boots, an environment incompatibility unrelated to dates |
| SQLite | already pinned at the SQL-condition level by #463's own tests |
| Composite | serves search through one of the four engines above, each of which the table now pins |

No product changes — pure verification, and (pleasant surprise) no new date bugs: the class of defect #463 fixed in SQLite does not recur elsewhere. The chained-date sweep for ES/Mongo noted in #619 remains follow-up work — their chain paths need a live-container chained harness that does not exist yet.