### PR TITLE
fix(ui): let every page use the full pane width

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -606,7 +606,6 @@ button.menu__option {
 .content {
   flex: 1;
   padding: 24px 32px 32px;
-  max-width: 1161px;
 }
 
 /* ---------- Cards ---------- */
@@ -1906,11 +1905,6 @@ a.pill {
 }
 @layer components {
 /* ---- Registry viewers: shared filter layout (#237/#238) ----------------- */
-
-/* These pages want the full pane width; .content keeps its dashboard cap. */
-.content--wide {
-  max-width: none;
-}
 
 .notice {
   margin: 0 0 16px;

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -926,6 +926,10 @@ a.pill {
    the vertical guide the script moves along the buckets. */
 .chart-wrap {
   position: relative;
+  /* The svg scales its viewBox (text included) with rendered width; cap it so
+     axis labels stay near their designed size on wide panes. */
+  max-width: 1440px;
+  margin: 0 auto;
 }
 
 .chart-tip {

--- a/crates/ui/templates/pages/compartments.html
+++ b/crates/ui/templates/pages/compartments.html
@@ -2,8 +2,6 @@
 
 {% block title %}{{ i18n.t("cmp-heading") }} — {{ i18n.t("app-title") }}{% endblock %}
 
-{% block content_class %} content--wide{% endblock %}
-
 {% block content %}
 <section class="page-head">
   <h1 class="page-head__title">{{ i18n.t("cmp-heading") }}</h1>

--- a/crates/ui/templates/pages/editor.html
+++ b/crates/ui/templates/pages/editor.html
@@ -2,8 +2,6 @@
 
 {% block title %}{{ i18n.t("editor-heading") }} — {{ i18n.t("app-title") }}{% endblock %}
 
-{% block content_class %} content--wide{% endblock %}
-
 {% block content %}
 <!--
   Resource editor (#264), following the Figma "Resources - Edit" frame: the

--- a/crates/ui/templates/pages/history.html
+++ b/crates/ui/templates/pages/history.html
@@ -2,8 +2,6 @@
 
 {% block title %}{{ i18n.t("history-heading") }} — {{ i18n.t("app-title") }}{% endblock %}
 
-{% block content_class %} content--wide{% endblock %}
-
 {% block content %}
 <!--
   History & Versions (#236), following the Figma "History & Versions" frame: the

--- a/crates/ui/templates/pages/queries.html
+++ b/crates/ui/templates/pages/queries.html
@@ -2,8 +2,6 @@
 
 {% block title %}{{ i18n.t("queries-heading") }} — {{ i18n.t("app-title") }}{% endblock %}
 
-{% block content_class %} content--wide{% endblock %}
-
 {% block content %}
 <section class="page-head">
   <h1 class="page-head__title">{{ i18n.t("queries-heading") }}</h1>

--- a/crates/ui/templates/pages/resources.html
+++ b/crates/ui/templates/pages/resources.html
@@ -3,7 +3,6 @@
 {% block title %}{{ i18n.t("resources-heading") }} — {{ i18n.t("app-title") }}{% endblock %}
 
 {% block body_class %}has-nav-panel{% endblock %}
-{% block content_class %} content--wide{% endblock %}
 
 <!--
   Resources workspace (#282), following Brett's "Resources" frame (Figma

--- a/crates/ui/templates/pages/search-parameters.html
+++ b/crates/ui/templates/pages/search-parameters.html
@@ -2,8 +2,6 @@
 
 {% block title %}{{ i18n.t("sp-heading") }} — {{ i18n.t("app-title") }}{% endblock %}
 
-{% block content_class %} content--wide{% endblock %}
-
 {% block content %}
 <section class="page-head">
   <h1 class="page-head__title">{{ i18n.t("sp-heading") }}</h1>

--- a/crates/ui/templates/pages/search.html
+++ b/crates/ui/templates/pages/search.html
@@ -2,8 +2,6 @@
 
 {% block title %}{{ i18n.t("search-heading") }} — {{ i18n.t("app-title") }}{% endblock %}
 
-{% block content_class %} content--wide{% endblock %}
-
 {% block content %}
 <section class="page-head">
   <h1 class="page-head__title">{{ i18n.t("search-heading") }}</h1>


### PR DESCRIPTION
Fixes #584

- Remove the 1161px `max-width` cap on `.content` so every page uses the full pane width, and drop the now-redundant `content--wide` opt-out (the CSS rule plus the `content_class` block in the 7 pages that used it). The empty `content_class` hook in `base.html` stays.
- Cap the dashboard chart wrapper at 1440px, centered: the chart svg scales its fixed `0 0 1060 H` viewBox with rendered width, so uncapped panes blew the axis labels up (found during manual validation at wide viewports).

Checks: cargo fmt/clippy/test/build green; zero remaining `content--wide` references; manual pass at 1920/~2560 across /ui, /ui/tenants, /ui/resources, /ui/search and /ui/batch (no horizontal scroll, consistent width when navigating between pages, chart labels at their designed size).