### PR TITLE
fix(ui): clean up the bulk-export form layout and Group ID enablement

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1048,10 +1048,12 @@ a.pill {
   color: var(--muted);
 }
 
-/* Space the count out from the link label when a .toolbar__count sits
-   inside a .btn (e.g. "Active Exports N") (#608). */
+/* A .toolbar__count inside a .btn (e.g. "Active Exports N") stays plain and
+   matches the label color; only the gap separates it from the text (#608). */
 .btn .toolbar__count {
   margin-left: 8px;
+  color: inherit;
+  font-variant-numeric: tabular-nums;
 }
 
 .toolbar__search {
@@ -1573,6 +1575,7 @@ a.pill {
   border-radius: 9px;
   box-shadow: var(--surface-shadow);
   cursor: pointer;
+  text-decoration: none;
 }
 
 .btn:hover {

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1048,6 +1048,12 @@ a.pill {
   color: var(--muted);
 }
 
+/* Space the count out from the link label when a .toolbar__count sits
+   inside a .btn (e.g. "Active Exports N") (#608). */
+.btn .toolbar__count {
+  margin-left: 8px;
+}
+
 .toolbar__search {
   display: flex;
   align-items: center;
@@ -2316,6 +2322,33 @@ a.pill {
   max-height: calc(100vh - 110px);
   padding: 16px;
   overflow-y: auto;
+}
+
+/* Full-width form sections (bulk export): the flex/gap/padding of .detail
+   without its sticky sidebar behavior (#608). */
+.form-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+}
+
+/* Vertical gap between the stacked .form-panel/table-card sections of the
+   bulk export form (#608). */
+.bulk-export-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* The Group ID field only applies to the Group scope; hide it otherwise.
+   Browsers without :has() keep it always visible — today's behavior. */
+.bulk-export-form .field--group-id {
+  display: none;
+}
+
+.bulk-export-form:has(input[name="scope"][value="group"]:checked) .field--group-id {
+  display: block;
 }
 
 .detail__title {

--- a/crates/ui/templates/pages/bulk-export.html
+++ b/crates/ui/templates/pages/bulk-export.html
@@ -21,9 +21,14 @@
 <div class="card notice">{{ message }}</div>
 {% when None %}{% endmatch %}
 
-<form method="post" action="/ui/bulk-export">
-  <section class="card detail">
+<form method="post" action="/ui/bulk-export" class="bulk-export-form">
+  <section class="card form-panel">
     <h2 class="toolbar__title">{{ i18n.t("bulk-export-scope") }}</h2>
+    <label class="field">
+      <span class="field__label">{{ i18n.t("bulk-export-field-name") }}</span>
+      <input class="field__input" type="text" name="name" autocomplete="off"
+             placeholder="{{ i18n.t("bulk-export-field-name-placeholder") }}">
+    </label>
     <label class="field">
       <input type="radio" name="scope" value="system" checked>
       <b>{{ i18n.t("bulk-export-scope-system") }}</b>
@@ -39,15 +44,10 @@
       <b>{{ i18n.t("bulk-export-scope-group") }}</b>
       <span class="field__hint">{{ i18n.t("bulk-export-scope-group-hint") }}</span>
     </label>
-    <label class="field">
+    <label class="field field--group-id">
       <span class="field__label">{{ i18n.t("bulk-export-field-group-id") }}</span>
       <input class="field__input" type="text" name="group_id" autocomplete="off">
       <span class="field__hint">{{ i18n.t("bulk-export-field-group-id-hint") }}</span>
-    </label>
-    <label class="field">
-      <span class="field__label">{{ i18n.t("bulk-export-field-name") }}</span>
-      <input class="field__input" type="text" name="name" autocomplete="off"
-             placeholder="{{ i18n.t("bulk-export-field-name-placeholder") }}">
     </label>
   </section>
 
@@ -55,15 +55,15 @@
     <div class="toolbar">
       <h2 class="toolbar__title">{{ i18n.t("bulk-export-types") }}</h2>
     </div>
+    <p class="field__hint">{{ i18n.t("bulk-export-types-hint") }}</p>
     <div class="typegrid">
       {% for t in resource_types %}
       <label class="typegrid__item"><input type="checkbox" name="types" value="{{ t }}"> {{ t }}</label>
       {% endfor %}
     </div>
-    <p class="field__hint">{{ i18n.t("bulk-export-types-hint") }}</p>
   </section>
 
-  <section class="card detail">
+  <section class="card form-panel">
     <h2 class="toolbar__title">{{ i18n.t("bulk-export-narrow") }}</h2>
     <label class="field">
       <span class="field__label">{{ i18n.t("bulk-export-field-elements") }}</span>

--- a/crates/ui/tests/bulk_export_http.rs
+++ b/crates/ui/tests/bulk_export_http.rs
@@ -148,6 +148,32 @@ async fn the_export_page_offers_scopes_types_and_filters() {
 }
 
 #[tokio::test]
+async fn the_export_page_uses_form_panels_with_name_and_hint_up_top() {
+    let (base, _) = serve().await;
+    let (status, html) = get_text(&base, "/ui/bulk-export").await;
+    assert_eq!(status, 200);
+
+    // The form sections use the non-sticky .form-panel, not the sticky
+    // .detail sidebar layout (#608).
+    assert!(html.contains("card form-panel"));
+    assert!(!html.contains("card detail"));
+
+    // The Name field comes before the scope radios in the first panel.
+    let name_pos = html.find(r#"name="name""#).expect("name field present");
+    let scope_pos = html.find(r#"name="scope""#).expect("scope radios present");
+    assert!(name_pos < scope_pos, "Name should precede the scope radios");
+
+    // The types hint sits above the checkbox grid, not below it.
+    let hint_pos = html
+        .find("Leave everything unchecked to export every type.")
+        .expect("types hint present");
+    let grid_pos = html
+        .find(r#"class="typegrid""#)
+        .expect("types grid present");
+    assert!(hint_pos < grid_pos, "hint should precede the types grid");
+}
+
+#[tokio::test]
 async fn starting_a_system_export_kicks_off_and_tracks_the_job() {
     let (base, mock) = serve().await;
 


### PR DESCRIPTION
﻿Fixes #608

- Both form sections render as `card form-panel` (a copy of `.detail` without the sticky/max-height behavior), so they no longer float over the page while scrolling.
- The Name field moves to the top of the first panel, ahead of the scope radios.
- The resource-types hint sits directly under the Resource Types heading, above the checkbox grid.
- The Group ID field only shows when scope = Group, via a pure-CSS `:has()` rule (no JS needed; the input carries no `required`, so hidden submission stays safe).
- The count on the Active exports header link gets its 8px gap and stays plain text in the label color; `.btn` now resets `text-decoration` so anchor-styled buttons never show an underline.

Checks: cargo fmt/clippy/test/build green; new HTTP test asserts the panel classes and the Name/hint ordering (`bulk_export_http` 6/6); manual walkthrough of the form incl. a live export run.
