### PR TITLE
fix(search): contain the abstract-prefix strip to expressions that mean it

### DIFF
--- a/crates/fhir/src/search/loader.rs
+++ b/crates/fhir/src/search/loader.rs
@@ -724,10 +724,15 @@ mod tests {
         let loader = SearchParameterLoader::new(FhirVersion::default());
         let params = loader.load_embedded().unwrap();
 
-        assert!(!params.is_empty());
-        assert!(
-            params.len() <= 10,
-            "Minimal fallback should have ~10 params"
+        // Exact, not `<=`: an upper bound alone passes when fallbacks are
+        // *lost*, which is the direction that breaks indexing. The six
+        // `Resource`-level parameters below plus `url`/`version` for each of
+        // `ViewDefinition` and `Library`.
+        assert_eq!(
+            params.len(),
+            10,
+            "Minimal fallback set changed; update this count and the names below: {:?}",
+            params.iter().map(|p| &p.code).collect::<Vec<_>>()
         );
 
         // The whole `Resource`-level meta set, asserted by name. `_source` was
@@ -742,10 +747,17 @@ mod tests {
             "_security",
             "_source",
         ] {
-            let def = params
-                .iter()
-                .find(|p| p.code == code)
-                .unwrap_or_else(|| panic!("Should have {code} parameter"));
+            // Exactly one definition per code, not merely at least one: a
+            // feature-gated duplicate would shadow-conflict at registration and
+            // `.find()` would happily accept it.
+            let matches: Vec<_> = params.iter().filter(|p| p.code == code).collect();
+            assert_eq!(
+                matches.len(),
+                1,
+                "Should have exactly one {code} fallback, got {}",
+                matches.len()
+            );
+            let def = matches[0];
             assert!(
                 !def.expression.starts_with("Resource."),
                 "{code} fallback expression must be resource-relative, got {:?}",

--- a/crates/fhir/src/search/mod.rs
+++ b/crates/fhir/src/search/mod.rs
@@ -21,7 +21,7 @@ pub mod types;
 pub use errors::{LoaderError, RegistryError};
 pub use loader::SearchParameterLoader;
 pub use registry::{
-    CompositeComponentDef, SearchParameterDefinition, SearchParameterRegistry,
+    ABSTRACT_BASE_TYPES, CompositeComponentDef, SearchParameterDefinition, SearchParameterRegistry,
     SearchParameterSource, SearchParameterStatus, resolve_param_targets, resolve_param_type,
 };
 pub use types::SearchParamType;

--- a/crates/fhir/src/search/registry.rs
+++ b/crates/fhir/src/search/registry.rs
@@ -224,9 +224,19 @@ impl SearchParameterDefinition {
     pub fn applies_to(&self, resource_type: &str) -> bool {
         self.base
             .iter()
-            .any(|b| b == resource_type || b == "Resource" || b == "DomainResource")
+            .any(|b| b == resource_type || ABSTRACT_BASE_TYPES.contains(&b.as_str()))
     }
 }
+
+/// The abstract base types every FHIR resource conforms to.
+///
+/// A `SearchParameter.base` naming one of these applies to every resource, and
+/// a FHIRPath expression may likewise be written against one of them instead of
+/// a concrete type (`Resource.meta.source`). Both readings are the same set, so
+/// it lives here once rather than being re-spelled at each use site: the
+/// registry's [`SearchParameterDefinition::applies_to`], the index extractor's
+/// prefix strip, and the UI's extension-context list all consult it.
+pub const ABSTRACT_BASE_TYPES: [&str; 2] = ["Resource", "DomainResource"];
 
 /// In-memory registry of SearchParameter definitions.
 ///

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -2521,18 +2521,7 @@ impl PostgresBackend {
         for (name, value) in params {
             let param_type = self
                 .lookup_param_type(&registry, resource_type, name)
-                .unwrap_or({
-                    match name.as_str() {
-                        "_id" => SearchParamType::Token,
-                        "_lastUpdated" => SearchParamType::Date,
-                        "_tag" | "_profile" | "_security" => SearchParamType::Token,
-                        "identifier" => SearchParamType::Token,
-                        "patient" | "subject" | "encounter" | "performer" | "author"
-                        | "requester" | "recorder" | "asserter" | "practitioner"
-                        | "organization" | "location" | "device" => SearchParamType::Reference,
-                        _ => SearchParamType::String,
-                    }
-                });
+                .unwrap_or_else(|| crate::search::fallback_param_type(name));
 
             search_params.push(SearchParameter {
                 name: name.clone(),

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -382,16 +382,24 @@ impl QueryBuilder {
         param: &SearchParameter,
         param_offset: usize,
     ) -> Option<SqlFragment> {
-        // Handle special parameters. `_tag`/`_profile`/`_security`/`_source`
-        // are NOT special on the query side: the extractor indexes them from
-        // meta like any typed parameter (rows in search_index under their own
-        // param_name), so they take the regular token/uri path below. Routing
+        // Handle special parameters. `_tag`/`_profile`/`_security`/`_source`/
+        // `_language` are NOT special on the query side: the extractor indexes
+        // them from `meta` (and, for `_language`, from `Resource.language`)
+        // like any typed parameter — rows in search_index under their own
+        // param_name — so they take the regular token/uri path below. Routing
         // them into the special handler silently dropped the condition and
-        // returned the unfiltered result set (#474).
+        // returned the unfiltered result set (#474). `_language` is indexed
+        // only on R5/R6, where the spec first defines it; on R4/R4B it is not
+        // a registered parameter and never reaches here.
+        //
+        // Anything added to this list must have a working regular path, and
+        // anything left off it must have an arm in
+        // `build_special_parameter_condition` — the `_ => None` fallback there
+        // drops the filter rather than narrowing it.
         if param.name.starts_with('_')
             && !matches!(
                 param.name.as_str(),
-                "_tag" | "_profile" | "_security" | "_source"
+                "_tag" | "_profile" | "_security" | "_source" | "_language"
             )
         {
             return self.build_special_parameter_condition(param, param_offset);
@@ -969,6 +977,71 @@ mod tests {
 
         assert_eq!(frag.sql, "0");
         assert!(frag.params.is_empty());
+    }
+
+    /// Every indexed `_`-prefixed parameter must produce a real condition.
+    ///
+    /// `build_special_parameter_condition`'s `_ => None` arm *drops* the
+    /// parameter rather than narrowing it, so a search whose only filter is a
+    /// missing arm answers with every resource of the type — the #474 failure
+    /// mode. `_language` (R5/R6) is indexed by the extractor exactly like the
+    /// `meta` set and so belongs on the regular token path with them; before
+    /// this it fell through to the `None` arm.
+    #[test]
+    fn indexed_meta_parameters_are_not_dropped() {
+        let builder = QueryBuilder::new("tenant1", "Patient");
+
+        for (name, param_type, value) in [
+            ("_language", SearchParamType::Token, "en-US"),
+            ("_source", SearchParamType::Uri, "http://example.org/src"),
+            ("_tag", SearchParamType::Token, "http://sys|t1"),
+            ("_profile", SearchParamType::Uri, "http://example.org/sd"),
+            ("_security", SearchParamType::Token, "http://sys|R"),
+        ] {
+            let param = SearchParameter {
+                name: name.to_string(),
+                param_type,
+                modifier: None,
+                values: vec![SearchValue::eq(value)],
+                chain: vec![],
+                components: vec![],
+            };
+
+            let fragment = builder
+                .build_parameter_condition(&param, 2)
+                .unwrap_or_else(|| {
+                    panic!("{name} produced no condition — the filter would be dropped")
+                });
+            assert!(
+                fragment.sql.contains(&format!("param_name = '{name}'")),
+                "{name} should read its own search_index rows, got: {}",
+                fragment.sql
+            );
+        }
+    }
+
+    /// `_in` never reaches the index — nothing writes rows for it, and the
+    /// SQLite special-parameter path has no arm for it, so a query naming it
+    /// would silently return the whole type. `helios-rest` rejects it before
+    /// the backend is asked; this pins the backend half of that contract so a
+    /// future "just let it through" change has to confront the drop. Update it
+    /// when membership resolution lands (#638).
+    #[test]
+    fn membership_parameter_has_no_backend_condition() {
+        let builder = QueryBuilder::new("tenant1", "Patient");
+        let param = SearchParameter {
+            name: "_in".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::eq("List/42")],
+            chain: vec![],
+            components: vec![],
+        };
+
+        assert!(
+            builder.build_parameter_condition(&param, 2).is_none(),
+            "_in must not be answered by the index; it is rejected at the REST layer"
+        );
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -2919,23 +2919,11 @@ impl SqliteBackend {
         let mut search_params = Vec::with_capacity(params.len());
 
         for (name, value) in params {
-            // Look up the parameter definition to get its type
+            // Look up the parameter definition to get its type, falling back to
+            // the shared registry-miss guess when it is not registered.
             let param_type = self
                 .lookup_param_type(&registry, resource_type, name)
-                .unwrap_or({
-                    // Fallback for common parameters when not in registry
-                    match name.as_str() {
-                        "_id" => SearchParamType::Token,
-                        "_lastUpdated" => SearchParamType::Date,
-                        "_tag" | "_profile" | "_security" => SearchParamType::Token,
-                        "identifier" => SearchParamType::Token,
-                        // Common reference parameters across many resource types
-                        "patient" | "subject" | "encounter" | "performer" | "author"
-                        | "requester" | "recorder" | "asserter" | "practitioner"
-                        | "organization" | "location" | "device" => SearchParamType::Reference,
-                        _ => SearchParamType::String, // Default fallback
-                    }
-                });
+                .unwrap_or_else(|| crate::search::fallback_param_type(name));
 
             search_params.push(SearchParameter {
                 name: name.clone(),

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -208,16 +208,7 @@ impl CompositeStorage {
     }
 
     fn infer_conditional_param_type(name: &str) -> SearchParamType {
-        match name {
-            "_id" => SearchParamType::Token,
-            "_lastUpdated" => SearchParamType::Date,
-            "_tag" | "_profile" | "_security" | "identifier" => SearchParamType::Token,
-            "patient" | "subject" | "encounter" | "performer" | "author" | "requester"
-            | "recorder" | "asserter" | "practitioner" | "organization" | "location" | "device" => {
-                SearchParamType::Reference
-            }
-            _ => SearchParamType::String,
-        }
+        crate::search::fallback_param_type(name)
     }
 
     async fn find_conditional_matches(

--- a/crates/persistence/src/search/extractor.rs
+++ b/crates/persistence/src/search/extractor.rs
@@ -2,9 +2,11 @@
 //!
 //! Uses FHIRPath expressions to extract searchable values from FHIR resources.
 
-use std::collections::HashMap;
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
+use helios_fhir::search::ABSTRACT_BASE_TYPES;
 use helios_fhirpath::EvaluationContext;
 use helios_fhirpath_support::EvaluationResult;
 use parking_lot::RwLock;
@@ -137,14 +139,22 @@ impl SearchParameterExtractor {
             }
         }
 
-        // Also extract common Resource-level parameters
-        let common_params = {
-            let registry = self.registry.read();
-            registry.get_active_params("Resource")
-        };
+        // Also extract the parameters registered against an abstract base. The
+        // registry buckets parameters by each declared `base`, so a definition
+        // with `base: ["DomainResource"]` (`_text`) lands in its own bucket and
+        // is invisible to a lookup of "Resource" alone — both bases have to be
+        // consulted, or half of `ABSTRACT_BASE_TYPES` is dead weight.
+        let mut seen: HashSet<String> = params.iter().map(|p| p.code.clone()).collect();
+        for base in ABSTRACT_BASE_TYPES {
+            let common_params = {
+                let registry = self.registry.read();
+                registry.get_active_params(base)
+            };
 
-        for param in &common_params {
-            if !params.iter().any(|p| p.code == param.code) {
+            for param in &common_params {
+                if !seen.insert(param.code.clone()) {
+                    continue;
+                }
                 match self.extract_for_param(resource, param) {
                     Ok(values) => results.extend(values),
                     Err(e) => {
@@ -207,6 +217,10 @@ impl SearchParameterExtractor {
         resource: &Value,
         param: &SearchParameterDefinition,
     ) -> Result<Vec<ExtractedValue>, ExtractionError> {
+        if NON_INDEXABLE_PARAM_CODES.contains(&param.code.as_str()) {
+            return Ok(Vec::new());
+        }
+
         // Composite parameters are indexed component-by-component, with all the
         // components of one composite instance sharing a `composite_group`.
         if matches!(param.param_type, SearchParamType::Composite) {
@@ -333,16 +347,16 @@ impl SearchParameterExtractor {
     /// apply to every resource, so the prefix is stripped instead of being matched
     /// literally — see [`strip_abstract_base_prefix`].
     fn filter_expression_for_resource(&self, expression: &str, resource_type: &str) -> String {
-        // Split by | and filter to parts starting with our resource type
-        let parts: Vec<String> = expression
-            .split('|')
-            .map(|p| p.trim())
+        // Split into union members at top level only, then keep the ones that
+        // apply to this resource type.
+        let parts: Vec<String> = split_union_members(expression)
+            .into_iter()
             .filter_map(|p| {
                 // Abstract-base parts first: when `resource_type` is itself
                 // "Resource", the literal prefix match below would keep the
                 // unevaluable form.
                 if let Some(rest) = strip_abstract_base_prefix(p) {
-                    return Some(rest);
+                    return Some(rest.into_owned());
                 }
                 // Check if this part starts with our resource type
                 let matches_type = p.starts_with(resource_type)
@@ -409,9 +423,81 @@ impl SearchParameterExtractor {
     }
 }
 
-/// Abstract base types every FHIR resource conforms to. A SearchParameter
-/// expression may be written against one of them instead of a concrete type.
-const ABSTRACT_BASE_TYPES: [&str; 2] = ["Resource", "DomainResource"];
+/// Search parameters whose spec `expression` names an element that is *not*
+/// the data they filter on. They must never produce index rows, whatever the
+/// expression says.
+///
+/// `_in` (R5/R6) is the whole set today. It carries `expression:
+/// "Resource.id"`, but the parameter means "this resource is a member of the
+/// referenced List or Group" — the id is a placeholder, not a filter target.
+/// Indexing it writes one reference row per resource pointing at the resource
+/// itself, so `?_in=42` would match `Patient/42` through the ordinary bare-id
+/// reference branch and answer a membership question with an identity test,
+/// while every reindex adds a junk row per resource. Membership resolution is
+/// not implemented (#638); `helios-rest` rejects `_in` outright rather than
+/// answer it wrongly.
+///
+/// This list is deliberately about *expressions that lie*, not about
+/// `_`-prefixed parameters in general: `_id`, `_lastUpdated` and the `meta`
+/// set carry truthful expressions and are indexed normally, and the
+/// `SearchParamType::Special` parameters (`_filter`, `_has`, `_text`, …) ship
+/// with an empty expression and are already skipped below.
+const NON_INDEXABLE_PARAM_CODES: [&str; 1] = ["_in"];
+
+/// Splits a FHIRPath expression into its top-level union (`|`) members.
+///
+/// A plain `split('|')` also cuts inside string literals and parentheses, and
+/// the fragments it leaves are not parseable FHIRPath. That used to be
+/// harmless — an unbalanced fragment matched no resource-type prefix and was
+/// dropped — but the abstract-base strip accepts a fragment on its prefix
+/// alone, so `Resource.x.where(v = 'a|b')` would hand the evaluator
+/// `x.where(v = 'a`, whose parse error aborts extraction for *every* member of
+/// that parameter, concrete ones included.
+///
+/// A `|` inside `(...)`, `[...]`, `'...'` (with `\'` escapes) or a backtick
+/// delimited identifier therefore stays part of its member. Members are
+/// returned trimmed.
+fn split_union_members(expression: &str) -> Vec<&str> {
+    let bytes = expression.as_bytes();
+    let mut members = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0i32;
+    let mut quote: Option<u8> = None;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+        match quote {
+            Some(q) => {
+                // Skip an escaped character whole, so `\'` does not close the
+                // literal and `\\` does not swallow the quote that follows.
+                if c == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                b'\'' | b'`' => quote = Some(c),
+                b'(' | b'[' => depth += 1,
+                b')' | b']' => depth -= 1,
+                // `depth <= 0` rather than `== 0`: an expression with more
+                // closing than opening parens must still split into members
+                // rather than collapsing into one.
+                b'|' if depth <= 0 => {
+                    members.push(expression[start..i].trim());
+                    start = i + 1;
+                }
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    members.push(expression[start..].trim());
+    members
+}
 
 /// Strips a leading abstract base type from one union member of a FHIRPath
 /// expression, returning the resource-relative remainder.
@@ -425,20 +511,41 @@ const ABSTRACT_BASE_TYPES: [&str; 2] = ["Resource", "DomainResource"];
 /// expressions apply to every resource, the prefix is dropped and the rest is
 /// evaluated relative to the resource.
 ///
+/// Leading parentheses are carried across, so a parenthesized member
+/// (`(Resource.meta.source)`) strips to `(meta.source)` rather than falling
+/// through and silently extracting nothing. The closing parens sit in the
+/// untouched remainder, so the member stays balanced.
+///
 /// Returns `None` for parts that are not abstract-base-prefixed, so concrete
-/// prefixes (`Patient.name`) keep their normal filtering behaviour.
-fn strip_abstract_base_prefix(part: &str) -> Option<String> {
+/// prefixes (`Patient.name`) keep their normal filtering behaviour. The common
+/// case borrows from `part`; only the forms needing reassembly allocate.
+fn strip_abstract_base_prefix(part: &str) -> Option<Cow<'_, str>> {
+    let open = part.len() - part.trim_start_matches('(').len();
+    let (parens, body) = part.split_at(open);
+    let body = body.trim_start();
+
     for base in ABSTRACT_BASE_TYPES {
-        if let Some(rest) = part.strip_prefix(base) {
-            if let Some(path) = rest.strip_prefix('.') {
-                return Some(path.to_string());
-            }
+        let Some(rest) = body.strip_prefix(base) else {
+            continue;
+        };
+        let stripped: Cow<'_, str> = if let Some(path) = rest.strip_prefix('.') {
+            Cow::Borrowed(path)
+        } else if rest.is_empty() {
             // The bare type name selects the resource itself (composite base
             // expressions use this form, e.g. `Observation`).
-            if rest.is_empty() {
-                return Some("$this".to_string());
-            }
-        }
+            Cow::Borrowed("$this")
+        } else if rest.starts_with(')') {
+            Cow::Owned(format!("$this{rest}"))
+        } else {
+            // A concrete type that merely starts with the same letters
+            // (`ResourceThing.name`) is not an abstract base.
+            continue;
+        };
+        return Some(if parens.is_empty() {
+            stripped
+        } else {
+            Cow::Owned(format!("{parens}{stripped}"))
+        });
     }
     None
 }
@@ -636,7 +743,11 @@ mod tests {
     }
 
     fn create_test_extractor() -> SearchParameterExtractor {
-        let loader = SearchParameterLoader::new(FhirVersion::R4);
+        create_test_extractor_for(FhirVersion::R4)
+    }
+
+    fn create_test_extractor_for(version: FhirVersion) -> SearchParameterExtractor {
+        let loader = SearchParameterLoader::new(version);
         let mut registry = SearchParameterRegistry::new();
 
         // Load minimal fallback
@@ -1003,6 +1114,179 @@ mod tests {
             ),
             "Patient.name | meta.source"
         );
+
+        // A parenthesized member keeps its parens and stays balanced. Before
+        // this, `(Resource.meta.source)` matched neither branch, the whole
+        // expression came back unchanged, and it evaluated to nothing — the
+        // #523 symptom, silently.
+        assert_eq!(
+            extractor.filter_expression_for_resource("(Resource.meta.source)", "Patient"),
+            "(meta.source)"
+        );
+        assert_eq!(
+            extractor.filter_expression_for_resource("((Resource.meta.source))", "Patient"),
+            "((meta.source))"
+        );
+        assert_eq!(
+            extractor.filter_expression_for_resource("(Resource)", "Patient"),
+            "($this)"
+        );
+        let source_carrier = json!({
+            "resourceType": "Patient",
+            "id": "p1",
+            "meta": {"source": "http://example.org/src"}
+        });
+        let evaluated = extractor
+            .evaluate_fhirpath(&source_carrier, "(meta.source)")
+            .expect("the stripped form must parse and evaluate");
+        assert_eq!(evaluated.len(), 1);
+    }
+
+    /// `|` inside a string literal or parentheses is data, not a union
+    /// separator.
+    #[test]
+    fn union_split_respects_literals_and_parens() {
+        assert_eq!(
+            split_union_members("Patient.name | Observation.code"),
+            vec!["Patient.name", "Observation.code"]
+        );
+        assert_eq!(
+            split_union_members("Patient.telecom.where(system = 'a|b')"),
+            vec!["Patient.telecom.where(system = 'a|b')"]
+        );
+        assert_eq!(
+            split_union_members("Patient.a.where(v = 'x|y') | Observation.b"),
+            vec!["Patient.a.where(v = 'x|y')", "Observation.b"]
+        );
+        // An escaped quote does not end the literal.
+        assert_eq!(
+            split_union_members(r"Patient.a.where(v = 'it\'s|fine')"),
+            vec![r"Patient.a.where(v = 'it\'s|fine')"]
+        );
+        // Backtick-delimited identifiers behave like literals.
+        assert_eq!(
+            split_union_members("Patient.`odd|name`"),
+            vec!["Patient.`odd|name`"]
+        );
+    }
+
+    /// A `|` inside a `Resource.`-prefixed member used to be split anyway,
+    /// handing the evaluator an unbalanced fragment. The parse error aborts
+    /// `extract_for_param`, so **every** member of that parameter — the
+    /// concrete ones included — stopped being indexed.
+    #[test]
+    fn literal_pipe_in_abstract_member_does_not_break_extraction() {
+        let extractor = create_test_extractor();
+
+        let expr = "Patient.name | Resource.meta.tag.where(code = 'a|b')";
+        let filtered = extractor.filter_expression_for_resource(expr, "Patient");
+        assert_eq!(filtered, "Patient.name | meta.tag.where(code = 'a|b')");
+
+        let patient = json!({
+            "resourceType": "Patient",
+            "id": "p1",
+            "name": [{"family": "Smith"}],
+            "meta": {"tag": [{"code": "a|b"}]}
+        });
+        // The whole filtered expression must parse; the pre-fix fragment
+        // `meta.tag.where(code = 'a` does not.
+        let values = extractor
+            .evaluate_fhirpath(&patient, &filtered)
+            .expect("the filtered expression must parse");
+        assert!(!values.is_empty());
+    }
+
+    /// The `DomainResource` half of `ABSTRACT_BASE_TYPES` has to be reachable:
+    /// the registry buckets a definition under each declared `base`, so
+    /// `base: ["DomainResource"]` lands in its own bucket that a lookup of
+    /// `"Resource"` alone never sees.
+    #[test]
+    fn domain_resource_based_parameters_are_extracted() {
+        let extractor = create_test_extractor();
+        {
+            let mut registry = extractor.registry.write();
+            registry
+                .register(
+                    SearchParameterDefinition::new(
+                        "http://example.org/SearchParameter/DomainResource-narrative-status",
+                        "narrative-status",
+                        SearchParamType::Token,
+                        "DomainResource.text.status",
+                    )
+                    .with_base(vec!["DomainResource"]),
+                )
+                .expect("register DomainResource-based parameter");
+        }
+
+        let patient = json!({
+            "resourceType": "Patient",
+            "id": "p1",
+            "text": {"status": "generated", "div": "<div>x</div>"}
+        });
+
+        let values = extractor.extract(&patient, "Patient").unwrap();
+        let found: Vec<_> = values
+            .iter()
+            .filter(|v| v.param_name == "narrative-status")
+            .collect();
+        assert_eq!(
+            found.len(),
+            1,
+            "a DomainResource-based parameter should be indexed, got {values:?}"
+        );
+    }
+
+    /// `_in` (R5/R6) carries the spec's placeholder `Resource.id` expression.
+    /// Indexing it writes one self-referential row per resource, and
+    /// `?_in=42` then matches `Patient/42` through the ordinary bare-id
+    /// reference branch — a membership question answered with an identity
+    /// test. `_language`, whose expression is truthful, must still be indexed.
+    #[cfg(feature = "R5")]
+    #[test]
+    fn r5_membership_parameter_is_not_indexed_but_language_is() {
+        let extractor = create_test_extractor_for(FhirVersion::R5);
+
+        // Both are registered on R5; only one of them may reach the index.
+        {
+            let registry = extractor.registry.read();
+            for code in ["_in", "_language"] {
+                assert!(
+                    registry.get_param("Resource", code).is_some(),
+                    "{code} should be a registered R5 Resource-level parameter"
+                );
+            }
+        }
+
+        let patient = json!({
+            "resourceType": "Patient",
+            "id": "p1",
+            "language": "en-US"
+        });
+
+        let values = extractor.extract(&patient, "Patient").unwrap();
+
+        assert!(
+            !values.iter().any(|v| v.param_name == "_in"),
+            "_in must never be indexed, got {:?}",
+            values
+                .iter()
+                .filter(|v| v.param_name == "_in")
+                .collect::<Vec<_>>()
+        );
+
+        let language: Vec<_> = values
+            .iter()
+            .filter(|v| v.param_name == "_language")
+            .collect();
+        assert_eq!(
+            language.len(),
+            1,
+            "_language should be indexed exactly once"
+        );
+        match &language[0].value {
+            IndexValue::Token { code, .. } => assert_eq!(code, "en-US"),
+            other => panic!("_language should index as a token, got {other:?}"),
+        }
     }
 
     /// Every `Resource`-level meta parameter must produce a positive index row —

--- a/crates/persistence/src/search/mod.rs
+++ b/crates/persistence/src/search/mod.rs
@@ -85,7 +85,7 @@ pub use loader::SearchParameterLoader;
 pub use range::{implicit_precision, implicit_range};
 pub use registry::{
     RegistryUpdate, SearchParameterDefinition, SearchParameterRegistry, SearchParameterSource,
-    SearchParameterStatus, resolve_param_targets, resolve_param_type,
+    SearchParameterStatus, fallback_param_type, resolve_param_targets, resolve_param_type,
 };
 pub use reindex::{
     ReindexOperation, ReindexProgress, ReindexRequest, ReindexSource, ReindexStatus, ReindexTarget,

--- a/crates/persistence/src/search/registry.rs
+++ b/crates/persistence/src/search/registry.rs
@@ -26,6 +26,39 @@ pub fn resolve_param_type(
     helios_fhir::search::registry::resolve_param_type(registry, resource_type, name, &strs)
 }
 
+/// The type to assume for a search parameter the registry does not know.
+///
+/// Conditional operations (`If-None-Exist`, conditional update/delete) parse a
+/// raw query string with no `SearchParameter` definition to hand, so a
+/// registry miss has to be guessed. The guess decides which index *column* the
+/// query reads, so it must agree with the type the extractor wrote the row
+/// under: guessing `String` for `_source` sends the query to `value_string`
+/// while the row lives in `value_uri`, the match never fires, and
+/// `If-None-Exist: Patient?_source=…` creates a duplicate on every request
+/// rather than being the idempotency guard it exists to be.
+///
+/// The `_`-prefixed entries therefore mirror the embedded fallback definitions
+/// in [`crate::search::loader`] exactly — including `_profile` as `Uri`, which
+/// is what the embedded definition declares on every FHIR version even though
+/// R5 and R6 re-type the spec's own copy as `reference`. The bare names below
+/// are heuristics for the most common resource-level parameters, and `String`
+/// remains the last-resort default.
+///
+/// This is a fallback, not a lookup: callers consult the registry first and
+/// only land here when that misses.
+pub fn fallback_param_type(name: &str) -> SearchParamType {
+    match name {
+        "_id" | "_tag" | "_security" | "identifier" => SearchParamType::Token,
+        "_lastUpdated" => SearchParamType::Date,
+        "_profile" | "_source" => SearchParamType::Uri,
+        "patient" | "subject" | "encounter" | "performer" | "author" | "requester" | "recorder"
+        | "asserter" | "practitioner" | "organization" | "location" | "device" => {
+            SearchParamType::Reference
+        }
+        _ => SearchParamType::String,
+    }
+}
+
 /// Update notification for registry changes. Kept here as a stub for any
 /// callers that still re-export it; the broadcast machinery was removed
 /// during the move (no subscribers existed).

--- a/crates/persistence/tests/search_param_seeding.rs
+++ b/crates/persistence/tests/search_param_seeding.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use helios_fhir::FhirVersion;
 use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
 use helios_persistence::core::{ResourceStorage, SearchProvider};
-use helios_persistence::search::seed_spec_search_parameters;
+use helios_persistence::search::{SearchParameterLoader, seed_spec_search_parameters};
 use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
 use serde_json::json;
 
@@ -181,13 +181,17 @@ async fn seeding_with_missing_spec_bundle_seeds_only_fallbacks() {
         seed_spec_search_parameters(&backend, FhirVersion::R4, empty_dir.path(), "default")
             .await
             .expect("seed fallbacks");
-    // Only the handful of embedded fallbacks are seeded — no spec set. The
-    // upper bound tracks `get_minimal_fallback_parameters`: five meta-level
-    // params plus `_source` (added with #523), plus ViewDefinition/Library
-    // url+version.
-    assert!(
-        outcome.created > 0 && outcome.created <= 10,
-        "expected only embedded fallbacks, got {outcome:?}"
+    // Only the embedded fallbacks are seeded — no spec set. Derived from
+    // `load_embedded()` rather than written as a bound, so the assertion fails
+    // when a fallback is *lost* as loudly as when the spec set leaks in; an
+    // upper bound only catches the second.
+    let expected = SearchParameterLoader::new(FhirVersion::R4)
+        .load_embedded()
+        .expect("embedded fallbacks")
+        .len();
+    assert_eq!(
+        outcome.created, expected,
+        "expected exactly the {expected} embedded fallbacks, got {outcome:?}"
     );
     assert_eq!(outcome.failed, 0);
 }

--- a/crates/rest/README.md
+++ b/crates/rest/README.md
@@ -134,6 +134,16 @@ the background and is polled via `/$reindex-status/[job_id]`.
   deployment, poll the node you kicked off against.
 - The `s3` backend standalone has no search index of any kind, so `$reindex`
   there returns `501`. Every other backend and composite supports it.
+- The same applies after a **server upgrade that adds a parameter to the
+  built-in set**, not just after an operator edits one. Resources written
+  before the upgrade were extracted under the old definitions and have no index
+  rows for the new parameter, so it matches nothing on that older data until a
+  `$reindex` runs. Two current cases: `_source` (`meta.source`), which no
+  version of the server indexed before [#523], and `_language`
+  (`Resource.language`) on R5/R6. Neither returns an error on stale data — it
+  simply under-matches, which is the failure mode a reindex exists to clear.
+
+[#523]: https://github.com/HeliosSoftware/hfs/issues/523
 
 Both operations emit BALP `AuditEvent`s — purge on completion or failure,
 reindex at start and at its terminal state (complete / cancel / fail, outcome

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -187,7 +187,16 @@ where
     // (named queries) is not implemented by any backend. (`_list` is implemented
     // via list resolution; `_score` as an output/`_sort` concept; `_contained` /
     // `_containedType` are parsed below and gated per backend capability.)
-    const UNSUPPORTED_PARAMS: [&str; 1] = ["_query"];
+    //
+    // `_in` (R5/R6) asks whether a resource is a member of a referenced List or
+    // Group; resolving that is not implemented (#638). It cannot be left to fall
+    // through, because it *is* a registered parameter of type `reference` on
+    // those versions — so `Prefer: handling=lenient` would not drop it, and the
+    // backends would answer it with whatever their reference path makes of the
+    // spec's placeholder `Resource.id` expression: an identity test on
+    // PostgreSQL, an unfiltered result set on SQLite. Use `_list` for List
+    // membership.
+    const UNSUPPORTED_PARAMS: [&str; 2] = ["_query", "_in"];
     if let Some((key, _)) = pairs
         .iter()
         .find(|(k, _)| UNSUPPORTED_PARAMS.contains(&k.as_str()))

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -851,6 +851,29 @@ mod string_search {
     }
 
     #[tokio::test]
+    async fn test_membership_parameter_in_is_rejected() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        // `_in` asks whether the resource belongs to a referenced List or
+        // Group. That is unimplemented, and it must not fall through: on R5/R6
+        // it is a registered `reference` parameter, so lenient handling would
+        // not drop it and the spec's placeholder `Resource.id` expression makes
+        // the backends answer a membership question with an identity test
+        // (PostgreSQL) or with the entire resource type (SQLite). Rejecting is
+        // the only answer that is not silently wrong (#535).
+        let response = server
+            .get("/Patient?_in=42")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let body: Value = response.json();
+        assert_eq!(body["resourceType"], "OperationOutcome");
+        assert_eq!(body["issue"][0]["code"], "invalid");
+    }
+
+    #[tokio::test]
     async fn test_modifier_invalid_for_param_type_returns_400() {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;

--- a/crates/ui/src/editor.rs
+++ b/crates/ui/src/editor.rs
@@ -568,14 +568,13 @@ fn build_rows(ctx: &RowCtx<'_>, path: &[Step], depth: usize, out: &mut Vec<Row>)
                 .as_ref()
                 .and_then(|schema| schema.type_.clone())
                 .unwrap_or_default();
-            let contexts = [
-                resource_type,
-                dotted.as_str(),
-                type_context.as_str(),
-                "Element",
-                "Resource",
-                "DomainResource",
-            ];
+            // The abstract bases come from the shared list so this stays one
+            // statement of that set rather than a third hand-copy of it.
+            let contexts: Vec<&str> = [resource_type, dotted.as_str(), type_context.as_str()]
+                .into_iter()
+                .chain(["Element"])
+                .chain(helios_fhir::search::ABSTRACT_BASE_TYPES)
+                .collect();
             registry
                 .extensions_applicable(&contexts)
                 .into_iter()


### PR DESCRIPTION
Fixes #535 — all ten findings from the [#534 review](https://github.com/HeliosSoftware/hfs/pull/534#pullrequestreview-4900834047).

## Root cause

#534's prefix strip activates on the prefix alone, not on the audited meta set. That set turned out to be the *smaller* half of what carries a `Resource.` prefix: R5/R6 ship two more such parameters, and both broke.

It is also worth recording what actually fixed #523, because it was not the strip. `SearchParameterRegistry::register` rejects a duplicate canonical URL outright, and the embedded fallbacks load before the spec bundle — so the spec's `Resource.`-prefixed `_id`/`_lastUpdated`/`_tag`/`_profile`/`_security`/`_source` never register at all once a fallback exists. #534's other half, adding the `_source` fallback, is what made `_source` index. In a server with a spec bundle the strip's entire net effect was to switch on `_in` and `_language`.

## Blocking-grade

**1. `_in` indexed the resource's own id.** Its expression is `Resource.id`, but the parameter means "this resource is a member of the referenced List or Group" — the id is a placeholder, not a filter target. Stripped and evaluated it wrote one self-referential reference row per resource, so `GET /Patient?_in=42` matched `Patient/42` through the ordinary bare-id reference branch, and every `$reindex` added a junk row per resource.

It is now skipped at extraction (`NON_INDEXABLE_PARAM_CODES`) **and** rejected at the REST layer alongside `_query`. Both halves are needed: un-indexing alone is not safe, because on R5/R6 `_in` *is* a registered `reference` parameter, so `Prefer: handling=lenient` would not drop it as unknown and the self link would claim it had been applied — while SQLite would answer it with the whole resource type. Implementing it properly is #638.

**2. `_language` diverged by backend.** Newly indexed, correct on PostgreSQL, but SQLite routed it to `build_special_parameter_condition`'s `_ => None` arm, which *drops* the filter rather than narrowing it, and returned every resource of the type. That is the #474 failure mode, reintroduced on a parameter #534 had just switched on. It joins the exemption list with the meta set.

**3. Conditional writes duplicated on `_source`.** Typed as String while the extractor writes Uri rows, so `If-None-Exist: Patient?_source=…` queried `value_string`, never matched, and created a duplicate on every request — the exact opposite of what the idempotency guard exists for. The three hand-copied fallback tables collapse into one `fallback_param_type`.

Fixing `_source` surfaced the same latent mismatch in **`_profile`**: the tables said Token, but the embedded definition that wins registration — and so the extractor — says Uri on every version, including R5/R6 where the spec's own copy is `reference`. Corrected in the same helper.

## Correctness, lower severity

**4.** `split_union_members` splits `|` only at paren depth 0 and outside `'…'` / backtick literals. The old `split('|')` cut inside literals too; the unbalanced fragment used to be harmless (it matched no resource-type prefix and was dropped), but the abstract strip accepts a fragment on its prefix alone, so one member's parse error aborted extraction for **every** member of that parameter, concrete ones included.

**5.** Leading parens carry across the strip, so `(Resource.meta.source)` yields `(meta.source)` rather than falling through and silently extracting nothing.

**6.** `extract()` iterates `ABSTRACT_BASE_TYPES` instead of looking up `"Resource"` alone. The registry buckets a definition under each declared `base`, so `base: ["DomainResource"]` landed in a bucket nothing consulted.

**7.** `$reindex` docs note that pre-upgrade resources have no `_source` or `_language` rows and under-match until a reindex runs — a failure mode that returns no error, only fewer results.

## Robustness

**8.** Loader and seeding bounds derive from `load_embedded().len()` and assert exactly one definition per code. `<= 10` passed if a fallback was *lost* — the direction that breaks indexing — and `.find()` accepted a feature-gated duplicate.

**9.** `ABSTRACT_BASE_TYPES` hoisted to `helios_fhir::search`, consumed by `applies_to`, the extractor, and `ui/editor.rs`.

**10.** `strip_abstract_base_prefix` returns `Option<Cow<'_, str>>`, borrowing on the common path. **The deeper root cause is untouched**: the FHIRPath evaluator still resolves a leading type identifier by exact match with no subsumption, and this remains a patch in one consumer.

## Coverage

Both blocking fixes are pinned by tests **confirmed to fail without them**. Reverting the `_language` exemption:

```
_language produced no condition — the filter would be dropped
```

Reverting the `_in` skip, showing the junk row itself:

```
_in must never be indexed, got [ExtractedValue { param_name: "_in",
  param_type: Reference, value: Reference { reference: "p1", ... } }]
```

New tests: `r5_membership_parameter_is_not_indexed_but_language_is` (R5-gated, so it runs under CI's `--all-features`), `indexed_meta_parameters_are_not_dropped`, `membership_parameter_has_no_backend_condition`, `union_split_respects_literals_and_parens`, `literal_pipe_in_abstract_member_does_not_break_extraction`, `domain_resource_based_parameters_are_extracted`, `test_membership_parameter_in_is_rejected`, plus parenthesized cases added to the existing strip test.

## Verification

- helios-persistence lib: **845 passed** (`sqlite,postgres,R4,R4B,R5,R6`)
- SQLite suites: `sqlite_tests` 85 / `search_suite` 103 / `crud_suite` 82 / `search_param_seeding` 6
- helios-fhir search 25; helios-rest `search_integration` 111; full rest/fhir/ui suites green
- `cargo build --workspace --all-features`, `cargo fmt --check`, and clippy under the CI flag set with `-D warnings`: clean

**Not run locally:** the PostgreSQL, Elasticsearch and MongoDB container-backed integration tests need Docker; CI covers them.

https://claude.ai/code/session_018FhD4aQRNHkPJ5HXvDSJps
