### PR TITLE
fix(search): correct SQLite :missing behavior and backend parity

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/backend.rs
+++ b/crates/persistence/src/backends/elasticsearch/backend.rs
@@ -637,8 +637,7 @@ impl ElasticsearchBackend {
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],
             SearchParamType::Uri => vec!["contains", "below", "above", "missing"],
-            SearchParamType::Composite => vec!["missing"],
-            SearchParamType::Special => vec![],
+            SearchParamType::Composite | SearchParamType::Special => vec![],
         }
     }
 }
@@ -647,6 +646,15 @@ impl ElasticsearchBackend {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn missing_is_not_advertised_for_composite_or_special_parameters() {
+        assert!(ElasticsearchBackend::modifiers_for_type(SearchParamType::Composite).is_empty());
+        assert!(ElasticsearchBackend::modifiers_for_type(SearchParamType::Special).is_empty());
+        assert!(
+            ElasticsearchBackend::modifiers_for_type(SearchParamType::String).contains(&"missing")
+        );
+    }
 
     #[test]
     fn test_config_defaults() {

--- a/crates/persistence/src/backends/elasticsearch/search/modifier_handlers.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/modifier_handlers.rs
@@ -17,17 +17,22 @@ pub fn build_missing_clause(param: &SearchParameter) -> Option<Value> {
         .map(|v| v.value == "true")
         .unwrap_or(true);
 
-    let path = nested_path_for_type(param.param_type);
-    let name_field = format!("{}.name", path);
-
-    let exists_query = json!({
-        "nested": {
-            "path": path,
-            "query": {
-                "term": { name_field: &param.name }
-            }
+    let exists_query = match param.name.as_str() {
+        "_id" => json!({ "exists": { "field": "resource_id" } }),
+        "_lastUpdated" => json!({ "exists": { "field": "last_updated" } }),
+        _ => {
+            let path = nested_path_for_type(param.param_type);
+            let name_field = format!("{}.name", path);
+            json!({
+                "nested": {
+                    "path": path,
+                    "query": {
+                        "term": { name_field: &param.name }
+                    }
+                }
+            })
         }
-    });
+    };
 
     if is_missing {
         // Resource does NOT have this parameter

--- a/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
@@ -185,6 +185,13 @@ impl<'a> EsQueryBuilder<'a> {
 
     /// Builds a clause for a single search parameter.
     fn build_parameter_clause(&self, param: &SearchParameter) -> Option<Value> {
+        // Presence is independent of the parameter's ordinary value syntax.
+        // Resolve it before `_id` and `_lastUpdated`, which would otherwise
+        // interpret the boolean literal as an ID or date value.
+        if param.modifier == Some(SearchModifier::Missing) {
+            return modifier_handlers::build_missing_clause(param);
+        }
+
         // Handle special parameters
         match param.name.as_str() {
             "_id" => return self.build_id_clause(param),
@@ -192,11 +199,6 @@ impl<'a> EsQueryBuilder<'a> {
             "_text" => return fts::build_text_clause(param),
             "_content" => return fts::build_content_clause(param),
             _ => {}
-        }
-
-        // Handle :missing modifier
-        if param.modifier == Some(SearchModifier::Missing) {
-            return modifier_handlers::build_missing_clause(param);
         }
 
         // Dispatch based on parameter type
@@ -424,6 +426,29 @@ mod tests {
         let es_query = builder.build(&query);
         let body_str = serde_json::to_string(&es_query.body).unwrap();
         assert!(body_str.contains("resource_id"));
+    }
+
+    #[test]
+    fn missing_precedes_id_and_last_updated_dispatch() {
+        let builder = EsQueryBuilder::new("acme", "Patient", "hfs_acme_patient".to_string());
+
+        for (name, param_type, field) in [
+            ("_id", SearchParamType::Token, "resource_id"),
+            ("_lastUpdated", SearchParamType::Date, "last_updated"),
+        ] {
+            let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+                name: name.to_string(),
+                param_type,
+                modifier: Some(SearchModifier::Missing),
+                values: vec![SearchValue::eq("false")],
+                chain: vec![],
+                components: vec![],
+            });
+            let es_query = builder.build(&query);
+            let clause = &es_query.body["query"]["bool"]["must"][0];
+
+            assert_eq!(clause["exists"]["field"], field);
+        }
     }
 
     fn not_param(values: Vec<SearchValue>) -> SearchQuery {

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -677,7 +677,8 @@ impl MongoBackend {
         for param in &query.parameters {
             if matches!(
                 param.modifier,
-                Some(SearchModifier::Above)
+                Some(SearchModifier::Missing)
+                    | Some(SearchModifier::Above)
                     | Some(SearchModifier::Below)
                     | Some(SearchModifier::In)
                     | Some(SearchModifier::NotIn)
@@ -1784,5 +1785,33 @@ mod date_filter_tests {
     #[test]
     fn invalid_dates_error() {
         assert!(build_date_filter_doc(&SearchValue::parse("not-a-date"), "value_date").is_err());
+    }
+}
+
+#[cfg(test)]
+mod query_support_tests {
+    use super::*;
+    use crate::backends::mongodb::MongoBackendConfig;
+
+    #[test]
+    fn missing_is_rejected_before_type_specific_value_parsing() {
+        let backend = MongoBackend::new(MongoBackendConfig::default()).unwrap();
+        let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "birthdate".to_string(),
+            param_type: SearchParamType::Date,
+            modifier: Some(SearchModifier::Missing),
+            values: vec![SearchValue::eq("true")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let error = backend.validate_query_support(&query).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::Search(SearchError::UnsupportedModifier {
+                ref modifier,
+                ..
+            }) if modifier == "missing"
+        ));
     }
 }

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -958,8 +958,7 @@ impl PostgresBackend {
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],
             SearchParamType::Uri => vec!["contains", "below", "above", "missing"],
-            SearchParamType::Composite => vec!["missing"],
-            SearchParamType::Special => vec![],
+            SearchParamType::Composite | SearchParamType::Special => vec![],
         }
     }
 }
@@ -967,6 +966,13 @@ impl PostgresBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_is_not_advertised_for_composite_or_special_parameters() {
+        assert!(PostgresBackend::modifiers_for_type(SearchParamType::Composite).is_empty());
+        assert!(PostgresBackend::modifiers_for_type(SearchParamType::Special).is_empty());
+        assert!(PostgresBackend::modifiers_for_type(SearchParamType::String).contains(&"missing"));
+    }
 
     // ── config builders (#355) ────────────────────────────────
 

--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -664,8 +664,10 @@ impl PostgresQueryBuilder {
 
     /// Builds an `id IN/NOT IN` condition for the `:missing` modifier.
     ///
-    /// `param:missing=true` matches resources with **no** `search_index` entry
-    /// for the parameter; `:missing=false` matches resources that **have** one.
+    /// `param:missing=true` matches resources with **no top-level** `search_index`
+    /// entry for the parameter; `:missing=false` matches resources that **have**
+    /// one. Index rows extracted from contained resources do not establish
+    /// presence on their container.
     /// Uses only the always-present `$1`/`$2` (tenant, resource type) bind
     /// params, so it adds no parameters to the surrounding query.
     fn build_missing_condition(param: &SearchParameter) -> SqlFragment {
@@ -674,10 +676,14 @@ impl PostgresQueryBuilder {
             .first()
             .map(|v| v.value == "true")
             .unwrap_or(false);
-        let inner = format!(
-            "SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND param_name = '{}'",
-            param.name
-        );
+        let inner = match param.name.as_str() {
+            "_id" => "SELECT id FROM resources WHERE tenant_id = $1 AND resource_type = $2 AND id IS NOT NULL".to_string(),
+            "_lastUpdated" => "SELECT id FROM resources WHERE tenant_id = $1 AND resource_type = $2 AND last_updated IS NOT NULL".to_string(),
+            _ => format!(
+                "SELECT resource_id FROM search_index WHERE tenant_id = $1 AND resource_type = $2 AND is_contained = FALSE AND param_name = '{}'",
+                param.name
+            ),
+        };
         let sql = if is_missing {
             format!("id NOT IN ({})", inner)
         } else {
@@ -2271,5 +2277,49 @@ mod tests {
         assert!(frag.sql.contains("value_identifier_type_system = $4"));
         assert!(frag.sql.contains("value_identifier_type_code = $5"));
         assert_eq!(frag.params.len(), 3);
+    }
+
+    #[test]
+    fn missing_ignores_index_rows_from_contained_resources() {
+        let param = SearchParameter {
+            name: "gender".to_string(),
+            param_type: SearchParamType::Token,
+            modifier: Some(SearchModifier::Missing),
+            values: vec![SearchValue::eq("false")],
+            chain: vec![],
+            components: vec![],
+        };
+        let query = SearchQuery::new("Patient").with_parameter(param);
+        let fragment = PostgresQueryBuilder::build_search_query(&query, 2)
+            .expect(":missing must produce a condition");
+
+        assert!(
+            fragment.sql.contains("is_contained = FALSE"),
+            "contained-resource index rows must not establish presence: {}",
+            fragment.sql
+        );
+    }
+
+    #[test]
+    fn missing_metadata_uses_authoritative_resource_columns() {
+        for (name, param_type, column) in [
+            ("_id", SearchParamType::Token, "id"),
+            ("_lastUpdated", SearchParamType::Date, "last_updated"),
+        ] {
+            let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+                name: name.to_string(),
+                param_type,
+                modifier: Some(SearchModifier::Missing),
+                values: vec![SearchValue::eq("false")],
+                chain: vec![],
+                components: vec![],
+            });
+            let fragment = PostgresQueryBuilder::build_search_query(&query, 2)
+                .expect(":missing must produce a condition");
+
+            assert!(fragment.sql.contains("FROM resources"));
+            assert!(fragment.sql.contains(&format!("{column} IS NOT NULL")));
+            assert!(!fragment.sql.contains("FROM search_index"));
+        }
     }
 }

--- a/crates/persistence/src/backends/postgres/search_impl.rs
+++ b/crates/persistence/src/backends/postgres/search_impl.rs
@@ -17,7 +17,7 @@ use crate::core::{
     ChainedSearchProvider, IncludeProvider, MultiTypeSearchProvider, ResourceStorage,
     RevincludeProvider, SearchProvider, SearchResult, TextSearchProvider,
 };
-use crate::error::{BackendError, QueryErrorExt, StorageError, StorageResult};
+use crate::error::{BackendError, QueryErrorExt, SearchError, StorageError, StorageResult};
 use crate::tenant::TenantContext;
 use crate::types::{
     CursorDirection, CursorValue, IncludeDirective, Page, PageCursor, PageInfo, Pagination,
@@ -36,6 +36,21 @@ fn internal_error(message: String) -> StorageError {
     })
 }
 
+fn reject_contained_missing(query: &SearchQuery) -> StorageResult<()> {
+    if query.contained != crate::types::ContainedMode::Off
+        && query
+            .parameters
+            .iter()
+            .any(|param| matches!(param.modifier, Some(crate::types::SearchModifier::Missing)))
+    {
+        return Err(StorageError::Search(SearchError::QueryParseError {
+            message: "PostgreSQL does not support :missing with _contained=true or both"
+                .to_string(),
+        }));
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl SearchProvider for PostgresBackend {
     async fn search(
@@ -43,6 +58,8 @@ impl SearchProvider for PostgresBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
+        reject_contained_missing(query)?;
+
         // `_contained` search uses a dedicated path (different index columns and
         // heterogeneous result types); standard search handles `_contained=false`.
         if query.contained != crate::types::ContainedMode::Off {
@@ -286,6 +303,8 @@ impl SearchProvider for PostgresBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<u64> {
+        reject_contained_missing(query)?;
+
         let client = self.get_client().await?;
         let tenant_id = tenant.tenant_id().as_str();
         let resource_type = &query.resource_type;

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -764,8 +764,7 @@ impl SqliteBackend {
             SearchParamType::Number => vec!["missing"],
             SearchParamType::Quantity => vec!["missing"],
             SearchParamType::Uri => vec!["contains", "below", "above", "missing"],
-            SearchParamType::Composite => vec!["missing"],
-            SearchParamType::Special => vec![],
+            SearchParamType::Composite | SearchParamType::Special => vec![],
         }
     }
 }
@@ -905,5 +904,9 @@ mod tests {
         let uri_mods = SqliteBackend::modifiers_for_type(SearchParamType::Uri);
         assert!(uri_mods.contains(&"below"));
         assert!(uri_mods.contains(&"above"));
+
+        // FHIR excludes composite/combination parameters from `:missing`.
+        assert!(SqliteBackend::modifiers_for_type(SearchParamType::Composite).is_empty());
+        assert!(SqliteBackend::modifiers_for_type(SearchParamType::Special).is_empty());
     }
 }

--- a/crates/persistence/src/backends/sqlite/search/modifier_handlers.rs
+++ b/crates/persistence/src/backends/sqlite/search/modifier_handlers.rs
@@ -8,18 +8,21 @@ use super::query_builder::SqlFragment;
 
 /// Handles the :missing modifier for any parameter type.
 pub fn build_missing_condition(param: &SearchParameter, is_missing: bool) -> SqlFragment {
+    let indexed_resources = match param.name.as_str() {
+        "_id" => "SELECT id FROM resources WHERE tenant_id = ?1 AND resource_type = ?2 AND id IS NOT NULL".to_string(),
+        "_lastUpdated" => "SELECT id FROM resources WHERE tenant_id = ?1 AND resource_type = ?2 AND last_updated IS NOT NULL".to_string(),
+        _ => format!(
+            "SELECT resource_id FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND param_name = '{}' AND is_contained = 0",
+            param.name
+        ),
+    };
+
     if is_missing {
         // Missing = true: resources with NO index entry for this param
-        SqlFragment::new(format!(
-            "resource_id NOT IN (SELECT resource_id FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND param_name = '{}')",
-            param.name
-        ))
+        SqlFragment::new(format!("resource_id NOT IN ({indexed_resources})"))
     } else {
         // Missing = false: resources WITH an index entry for this param
-        SqlFragment::new(format!(
-            "resource_id IN (SELECT resource_id FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND param_name = '{}')",
-            param.name
-        ))
+        SqlFragment::new(format!("resource_id IN ({indexed_resources})"))
     }
 }
 
@@ -30,7 +33,7 @@ pub fn is_missing_modifier(modifier: &Option<SearchModifier>) -> bool {
 
 /// Extracts the boolean value for :missing modifier.
 pub fn get_missing_value(value: &str) -> bool {
-    value.to_lowercase() == "true"
+    value == "true"
 }
 
 #[cfg(test)]
@@ -53,6 +56,7 @@ mod tests {
 
         assert!(frag.sql.contains("NOT IN"));
         assert!(frag.sql.contains("param_name = 'name'"));
+        assert!(frag.sql.contains("is_contained = 0"));
     }
 
     #[test]
@@ -70,6 +74,30 @@ mod tests {
 
         assert!(!frag.sql.contains("NOT IN"));
         assert!(frag.sql.contains("resource_id IN"));
+        assert!(frag.sql.contains("is_contained = 0"));
+    }
+
+    #[test]
+    fn test_missing_metadata_uses_authoritative_resource_columns() {
+        for (name, column) in [("_id", "id"), ("_lastUpdated", "last_updated")] {
+            let param = SearchParameter {
+                name: name.to_string(),
+                param_type: if name == "_id" {
+                    SearchParamType::Token
+                } else {
+                    SearchParamType::Date
+                },
+                modifier: Some(SearchModifier::Missing),
+                values: vec![SearchValue::eq("false")],
+                chain: vec![],
+                components: vec![],
+            };
+
+            let fragment = build_missing_condition(&param, false);
+            assert!(fragment.sql.contains("FROM resources"));
+            assert!(fragment.sql.contains(&format!("{column} IS NOT NULL")));
+            assert!(!fragment.sql.contains("FROM search_index"));
+        }
     }
 
     #[test]
@@ -82,9 +110,9 @@ mod tests {
     #[test]
     fn test_get_missing_value() {
         assert!(get_missing_value("true"));
-        assert!(get_missing_value("TRUE"));
-        assert!(get_missing_value("True"));
         assert!(!get_missing_value("false"));
+        assert!(!get_missing_value("TRUE"));
+        assert!(!get_missing_value("True"));
         assert!(!get_missing_value("False"));
         assert!(!get_missing_value("anything-else"));
     }

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -1096,6 +1096,21 @@ mod tests {
     }
 
     #[test]
+    fn missing_parameter_without_values_is_ignored() {
+        let builder = QueryBuilder::new("tenant1", "Patient");
+        let param = SearchParameter {
+            name: "birthdate".to_string(),
+            param_type: SearchParamType::Date,
+            modifier: Some(SearchModifier::Missing),
+            values: vec![],
+            chain: vec![],
+            components: vec![],
+        };
+
+        assert!(builder.build_parameter_condition(&param, 2).is_none());
+    }
+
+    #[test]
     fn test_order_by_default() {
         let builder = QueryBuilder::new("tenant1", "Patient");
         let query = SearchQuery::new("Patient");

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -10,6 +10,7 @@ use crate::types::{
     SearchValue, strip_reference_version,
 };
 
+use super::modifier_handlers::{build_missing_condition, get_missing_value, is_missing_modifier};
 use super::parameter_handlers::{
     CompositeHandler, DateHandler, NumberHandler, QuantityHandler, ReferenceHandler, StringHandler,
     TokenHandler, UriHandler,
@@ -382,6 +383,18 @@ impl QueryBuilder {
         param: &SearchParameter,
         param_offset: usize,
     ) -> Option<SqlFragment> {
+        if param.values.is_empty() {
+            return None;
+        }
+
+        // `:missing` is a resource-level presence test. Resolve it before the
+        // composite and ordinary value paths so it is not wrapped in a subquery
+        // that simultaneously requires an index row for the same parameter.
+        if is_missing_modifier(&param.modifier) {
+            let is_missing = get_missing_value(&param.values[0].value);
+            return Some(build_missing_condition(param, is_missing));
+        }
+
         // Handle special parameters. `_tag`/`_profile`/`_security`/`_source`/
         // `_language` are NOT special on the query side: the extractor indexes
         // them from `meta` (and, for `_language`, from `Resource.language`)
@@ -732,11 +745,6 @@ impl QueryBuilder {
         value: &SearchValue,
         param_offset: usize,
     ) -> Option<SqlFragment> {
-        // Handle :missing modifier
-        if let Some(SearchModifier::Missing) = &param.modifier {
-            return self.build_missing_condition(param, value);
-        }
-
         // Build condition based on parameter type
         let fragment = match param.param_type {
             SearchParamType::String => {
@@ -777,29 +785,6 @@ impl QueryBuilder {
             None
         } else {
             Some(fragment)
-        }
-    }
-
-    /// Builds a condition for the :missing modifier.
-    fn build_missing_condition(
-        &self,
-        param: &SearchParameter,
-        value: &SearchValue,
-    ) -> Option<SqlFragment> {
-        let is_missing = value.value.to_lowercase() == "true";
-
-        if is_missing {
-            // Missing = true: resources with NO index entry for this param
-            Some(SqlFragment::new(format!(
-                "resource_id NOT IN (SELECT resource_id FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND param_name = '{}')",
-                param.name
-            )))
-        } else {
-            // Missing = false: resources WITH an index entry for this param
-            Some(SqlFragment::new(format!(
-                "resource_id IN (SELECT resource_id FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND param_name = '{}')",
-                param.name
-            )))
         }
     }
 
@@ -1073,6 +1058,41 @@ mod tests {
         let fragment = builder.build(&query);
 
         assert!(fragment.sql.contains("param_name = 'name'"));
+    }
+
+    #[test]
+    fn missing_parameter_bypasses_generic_value_wrapper() {
+        let builder = QueryBuilder::new("tenant1", "Patient");
+
+        for (value, membership) in [("true", "NOT IN"), ("false", "IN")] {
+            let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+                name: "birthdate".to_string(),
+                param_type: SearchParamType::Date,
+                modifier: Some(SearchModifier::Missing),
+                values: vec![SearchValue::eq(value)],
+                chain: vec![],
+                components: vec![],
+            });
+
+            let fragment = builder.build(&query);
+
+            assert!(
+                fragment.sql.contains(&format!("resource_id {membership}")),
+                "{value}: {}",
+                fragment.sql
+            );
+            assert_eq!(
+                fragment.sql.matches("param_name = 'birthdate'").count(),
+                1,
+                ":missing must not be wrapped in a second birthdate membership query: {}",
+                fragment.sql
+            );
+            assert!(
+                fragment.sql.contains("is_contained = 0"),
+                "contained rows must not establish top-level presence: {}",
+                fragment.sql
+            );
+        }
     }
 
     #[test]

--- a/crates/persistence/src/backends/sqlite/search_impl.rs
+++ b/crates/persistence/src/backends/sqlite/search_impl.rs
@@ -18,7 +18,7 @@ use crate::core::{
     ChainedSearchProvider, IncludeProvider, MultiTypeSearchProvider, ResourceStorage,
     RevincludeProvider, SearchProvider, SearchResult,
 };
-use crate::error::{BackendError, QueryErrorExt, StorageError, StorageResult};
+use crate::error::{BackendError, QueryErrorExt, SearchError, StorageError, StorageResult};
 use crate::tenant::TenantContext;
 use crate::types::{
     CursorDirection, CursorValue, IncludeDirective, Page, PageCursor, PageInfo,
@@ -34,6 +34,20 @@ fn internal_error(message: String) -> StorageError {
         message,
         source: None,
     })
+}
+
+fn reject_contained_missing(query: &SearchQuery) -> StorageResult<()> {
+    if query.contained != crate::types::ContainedMode::Off
+        && query
+            .parameters
+            .iter()
+            .any(|param| matches!(param.modifier, Some(crate::types::SearchModifier::Missing)))
+    {
+        return Err(StorageError::Search(SearchError::QueryParseError {
+            message: "SQLite does not support :missing with _contained=true or both".to_string(),
+        }));
+    }
+    Ok(())
 }
 
 /// Binds the cursor's boundary sort value as `?3`, typed per the sort key kind.
@@ -76,6 +90,8 @@ impl SearchProvider for SqliteBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
+        reject_contained_missing(query)?;
+
         // `_contained` search uses a dedicated path (different index columns and
         // heterogeneous result types); standard search handles `_contained=false`.
         if query.contained != crate::types::ContainedMode::Off {
@@ -342,6 +358,8 @@ impl SearchProvider for SqliteBackend {
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<u64> {
+        reject_contained_missing(query)?;
+
         let conn = self.get_connection()?;
         let tenant_id = tenant.tenant_id().as_str();
         let resource_type = &query.resource_type;

--- a/crates/persistence/src/types/search_params.rs
+++ b/crates/persistence/src/types/search_params.rs
@@ -136,7 +136,20 @@ impl SearchModifier {
             // (it negates a code match). Our backends only implement it for
             // token; advertising it for other types was incorrect.
             SearchModifier::Not => param_type == SearchParamType::Token,
-            SearchModifier::Missing => true, // Valid for all types
+            // `:missing` tests whether a single-element search parameter has an
+            // indexed value. FHIR excludes composite/combination parameters;
+            // special parameters do not have the single-element semantics this
+            // modifier requires.
+            SearchModifier::Missing => matches!(
+                param_type,
+                SearchParamType::String
+                    | SearchParamType::Token
+                    | SearchParamType::Date
+                    | SearchParamType::Number
+                    | SearchParamType::Quantity
+                    | SearchParamType::Reference
+                    | SearchParamType::Uri
+            ),
             // `:above`/`:below` are defined for token, uri, and reference.
             // Reference uses URL/path-prefix hierarchy (canonical `|version`
             // comparison is not implemented).
@@ -890,9 +903,21 @@ mod tests {
         // `:not` is token-only per the FHIR spec.
         assert!(SearchModifier::Not.is_valid_for(SearchParamType::Token));
         assert!(!SearchModifier::Not.is_valid_for(SearchParamType::String));
-        // `:missing` is valid for every parameter type.
-        assert!(SearchModifier::Missing.is_valid_for(SearchParamType::String));
-        assert!(SearchModifier::Missing.is_valid_for(SearchParamType::Reference));
+        // `:missing` is valid for ordinary single-element parameter types, but
+        // not for composite/combination or special parameters.
+        for param_type in [
+            SearchParamType::String,
+            SearchParamType::Token,
+            SearchParamType::Date,
+            SearchParamType::Number,
+            SearchParamType::Quantity,
+            SearchParamType::Reference,
+            SearchParamType::Uri,
+        ] {
+            assert!(SearchModifier::Missing.is_valid_for(param_type));
+        }
+        assert!(!SearchModifier::Missing.is_valid_for(SearchParamType::Composite));
+        assert!(!SearchModifier::Missing.is_valid_for(SearchParamType::Special));
         // `:in`/`:not-in` are token-only per the FHIR spec (not uri).
         assert!(SearchModifier::In.is_valid_for(SearchParamType::Token));
         assert!(!SearchModifier::In.is_valid_for(SearchParamType::Uri));

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -1729,6 +1729,96 @@ mod es_integration {
     // ========================================================================
 
     #[tokio::test]
+    async fn es_integration_search_missing_modifier() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("missing-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "with-birthdate",
+                    "birthDate": "1980-01-15"
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "without-birthdate"
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        backend
+            .refresh_index("missing-tenant", "Patient")
+            .await
+            .unwrap();
+
+        let query = |value: &str| {
+            SearchQuery::new("Patient").with_parameter(SearchParameter {
+                name: "birthdate".to_string(),
+                param_type: SearchParamType::Date,
+                modifier: Some(SearchModifier::Missing),
+                values: vec![SearchValue::eq(value)],
+                chain: vec![],
+                components: vec![],
+            })
+        };
+
+        let missing = backend.search(&tenant, &query("true")).await.unwrap();
+        let missing_ids: Vec<&str> = missing.resources.items.iter().map(|r| r.id()).collect();
+        assert_eq!(missing_ids, vec!["without-birthdate"]);
+
+        let present = backend.search(&tenant, &query("false")).await.unwrap();
+        let present_ids: Vec<&str> = present.resources.items.iter().map(|r| r.id()).collect();
+        assert_eq!(present_ids, vec!["with-birthdate"]);
+
+        for (name, param_type) in [
+            ("_id", SearchParamType::Token),
+            ("_lastUpdated", SearchParamType::Date),
+        ] {
+            let metadata_query = |is_missing| {
+                SearchQuery::new("Patient").with_parameter(SearchParameter {
+                    name: name.to_string(),
+                    param_type,
+                    modifier: Some(SearchModifier::Missing),
+                    values: vec![SearchValue::boolean(is_missing)],
+                    chain: vec![],
+                    components: vec![],
+                })
+            };
+
+            let missing = backend
+                .search(&tenant, &metadata_query(true))
+                .await
+                .unwrap();
+            assert!(missing.resources.items.is_empty(), "{name}:missing=true");
+
+            let present = backend
+                .search(&tenant, &metadata_query(false))
+                .await
+                .unwrap();
+            let mut ids: Vec<&str> = present.resources.items.iter().map(|r| r.id()).collect();
+            ids.sort();
+            assert_eq!(ids, vec!["with-birthdate", "without-birthdate"]);
+        }
+    }
+
+    #[tokio::test]
     async fn es_integration_search_by_name() {
         use helios_persistence::core::SearchProvider;
         use helios_persistence::types::{
@@ -2791,8 +2881,8 @@ mod es_integration {
     async fn es_integration_contained_search() {
         use helios_persistence::core::SearchProvider;
         use helios_persistence::types::{
-            ContainedMode, ContainedReturn, SearchParamType, SearchParameter, SearchQuery,
-            SearchValue,
+            ContainedMode, ContainedReturn, SearchModifier, SearchParamType, SearchParameter,
+            SearchQuery, SearchValue,
         };
 
         let backend = create_backend().await;
@@ -2808,12 +2898,20 @@ mod es_integration {
                     "status": "final",
                     "code": { "coding": [{ "system": "http://loinc.org", "code": "1234-5" }] },
                     "subject": { "reference": "#p1" },
-                    "contained": [{
-                        "resourceType": "Patient",
-                        "id": "p1",
-                        "name": [{ "family": "Smith", "given": ["Contained"] }],
-                        "gender": "male"
-                    }]
+                    "contained": [
+                        {
+                            "resourceType": "Patient",
+                            "id": "p1",
+                            "name": [{ "family": "Smith", "given": ["Contained"] }],
+                            "gender": "male"
+                        },
+                        {
+                            "resourceType": "Patient",
+                            "id": "p2",
+                            "name": [{ "family": "Jones", "given": ["Contained"] }],
+                            "birthDate": "1980-01-15"
+                        }
+                    ]
                 }),
                 FhirVersion::default(),
             )
@@ -2895,6 +2993,32 @@ mod es_integration {
         let mut both_urls: Vec<String> = both.resources.items.iter().map(|r| r.url()).collect();
         both_urls.sort();
         assert_eq!(both_urls, vec!["Observation/obs1", "Patient/top1"]);
+
+        let missing_query = |is_missing| {
+            let mut q = SearchQuery::new("Patient");
+            q.contained = ContainedMode::On;
+            q.contained_return = ContainedReturn::Contained;
+            q.parameters.push(SearchParameter {
+                name: "birthdate".to_string(),
+                param_type: SearchParamType::Date,
+                modifier: Some(SearchModifier::Missing),
+                values: vec![SearchValue::boolean(is_missing)],
+                chain: vec![],
+                components: vec![],
+            });
+            q
+        };
+
+        let missing = backend.search(&tenant, &missing_query(true)).await.unwrap();
+        let missing_ids: Vec<&str> = missing.resources.items.iter().map(|r| r.id()).collect();
+        assert_eq!(missing_ids, vec!["p1"]);
+
+        let present = backend
+            .search(&tenant, &missing_query(false))
+            .await
+            .unwrap();
+        let present_ids: Vec<&str> = present.resources.items.iter().map(|r| r.id()).collect();
+        assert_eq!(present_ids, vec!["p2"]);
     }
 
     #[tokio::test]

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -2367,8 +2367,10 @@ mod postgres_integration {
     #[tokio::test]
     async fn postgres_integration_search_missing_modifier() {
         use helios_persistence::core::SearchProvider;
+        use helios_persistence::error::{SearchError, StorageError};
         use helios_persistence::types::{
-            SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue,
+            ContainedMode, SearchModifier, SearchParamType, SearchParameter, SearchQuery,
+            SearchValue,
         };
 
         let backend = create_backend().await;
@@ -2392,6 +2394,23 @@ mod postgres_integration {
             )
             .await
             .unwrap();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "container-no-gender",
+                    "contained": [{
+                        "resourceType": "Patient",
+                        "id": "contained-with-gender",
+                        "gender": "female"
+                    }]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
 
         let missing = |present: &str| {
             SearchQuery::new("Patient").with_parameter(SearchParameter {
@@ -2405,13 +2424,18 @@ mod postgres_integration {
         };
 
         let result = backend.search(&tenant, &missing("true")).await.unwrap();
-        let ids: Vec<String> = result
+        let mut ids: Vec<String> = result
             .resources
             .items
             .iter()
             .map(|r| r.id().to_string())
             .collect();
-        assert_eq!(ids, vec!["no-gender"], "gender:missing=true → no-gender");
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["container-no-gender", "no-gender"],
+            "gender:missing=true must ignore gender indexed only from contained resources"
+        );
 
         let result = backend.search(&tenant, &missing("false")).await.unwrap();
         let ids: Vec<String> = result
@@ -2425,6 +2449,45 @@ mod postgres_integration {
             vec!["with-gender"],
             "gender:missing=false → with-gender"
         );
+
+        for (name, param_type) in [
+            ("_id", SearchParamType::Token),
+            ("_lastUpdated", SearchParamType::Date),
+        ] {
+            let query = |is_missing| {
+                SearchQuery::new("Patient").with_parameter(SearchParameter {
+                    name: name.to_string(),
+                    param_type,
+                    modifier: Some(SearchModifier::Missing),
+                    values: vec![SearchValue::boolean(is_missing)],
+                    chain: vec![],
+                    components: vec![],
+                })
+            };
+
+            let missing = backend.search(&tenant, &query(true)).await.unwrap();
+            assert!(missing.resources.items.is_empty(), "{name}:missing=true");
+
+            let present = backend.search(&tenant, &query(false)).await.unwrap();
+            let mut ids: Vec<&str> = present.resources.items.iter().map(|r| r.id()).collect();
+            ids.sort();
+            assert_eq!(
+                ids,
+                vec!["container-no-gender", "no-gender", "with-gender"],
+                "{name}:missing=false"
+            );
+        }
+
+        let mut contained_missing = missing("true");
+        contained_missing.contained = ContainedMode::On;
+        let error = backend
+            .search(&tenant, &contained_missing)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::Search(SearchError::QueryParseError { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/persistence/tests/search/mod.rs
+++ b/crates/persistence/tests/search/mod.rs
@@ -7,6 +7,8 @@
 use std::path::PathBuf;
 
 #[cfg(feature = "sqlite")]
+use helios_fhir::FhirVersion;
+#[cfg(feature = "sqlite")]
 use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
 
 /// Builds an in-memory SQLite backend that has the spec `SearchParameter` set
@@ -21,6 +23,12 @@ use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
 /// correctly-configured builder.
 #[cfg(feature = "sqlite")]
 pub fn make_sqlite_backend() -> SqliteBackend {
+    make_sqlite_backend_for(FhirVersion::default_enabled())
+}
+
+/// Builds the same test backend with an explicit FHIR search-parameter set.
+#[cfg(feature = "sqlite")]
+pub fn make_sqlite_backend_for(fhir_version: FhirVersion) -> SqliteBackend {
     // CARGO_MANIFEST_DIR for these tests is crates/persistence.
     let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -29,6 +37,7 @@ pub fn make_sqlite_backend() -> SqliteBackend {
         .unwrap_or_else(|| PathBuf::from("data"));
 
     let config = SqliteBackendConfig {
+        fhir_version,
         data_dir: Some(data_dir),
         ..Default::default()
     };

--- a/crates/persistence/tests/search/modifier_tests.rs
+++ b/crates/persistence/tests/search/modifier_tests.rs
@@ -40,14 +40,33 @@ async fn test_missing_true() {
     let tenant = create_tenant();
 
     // Create patients - some with birthDate, some without
-    let with_date = json!({"resourceType": "Patient", "birthDate": "1980-01-15"});
-    let without_date = json!({"resourceType": "Patient", "name": [{"family": "No Date"}]});
+    let with_date =
+        json!({"resourceType": "Patient", "id": "with-date", "birthDate": "1980-01-15"});
+    let without_date = json!({
+        "resourceType": "Patient",
+        "id": "without-date",
+        "name": [{"family": "No Date"}]
+    });
+    let extension_only = json!({
+        "resourceType": "Patient",
+        "id": "extension-only",
+        "_birthDate": {
+            "extension": [{
+                "url": "http://example.org/fhir/StructureDefinition/birthdate-note",
+                "valueString": "withheld"
+            }]
+        }
+    });
     backend
         .create(&tenant, "Patient", with_date, FhirVersion::default())
         .await
         .unwrap();
     backend
         .create(&tenant, "Patient", without_date, FhirVersion::default())
+        .await
+        .unwrap();
+    backend
+        .create(&tenant, "Patient", extension_only, FhirVersion::default())
         .await
         .unwrap();
 
@@ -65,13 +84,13 @@ async fn test_missing_true() {
         .await
         .unwrap();
 
-    // Should only find patients without birthDate
-    for resource in &result.resources.items {
-        assert!(
-            resource.content().get("birthDate").is_none()
-                || resource.content()["birthDate"].is_null()
-        );
-    }
+    let mut ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec!["extension-only", "without-date"],
+        "birthdate:missing=true must include absent and extension-only primitives"
+    );
 }
 
 /// Test :missing=false finds resources with the element.
@@ -81,8 +100,13 @@ async fn test_missing_false() {
     let backend = create_sqlite_backend();
     let tenant = create_tenant();
 
-    let with_date = json!({"resourceType": "Patient", "birthDate": "1980-01-15"});
-    let without_date = json!({"resourceType": "Patient", "name": [{"family": "No Date"}]});
+    let with_date =
+        json!({"resourceType": "Patient", "id": "with-date", "birthDate": "1980-01-15"});
+    let without_date = json!({
+        "resourceType": "Patient",
+        "id": "without-date",
+        "name": [{"family": "No Date"}]
+    });
     backend
         .create(&tenant, "Patient", with_date, FhirVersion::default())
         .await
@@ -106,9 +130,265 @@ async fn test_missing_false() {
         .await
         .unwrap();
 
-    // Should only find patients with birthDate
-    for resource in &result.resources.items {
-        assert!(resource.content().get("birthDate").is_some());
+    let ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+    assert_eq!(
+        ids,
+        vec!["with-date"],
+        "birthdate:missing=false must return exactly the Patient with birthDate"
+    );
+}
+
+/// A value on a contained resource must not establish presence on its
+/// top-level container.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_missing_ignores_contained_resource_values() {
+    let backend = create_sqlite_backend();
+    let tenant = create_tenant();
+
+    backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "id": "container-without-date",
+                "contained": [{
+                    "resourceType": "Patient",
+                    "id": "contained-with-date",
+                    "birthDate": "1980-01-15"
+                }]
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+        name: "birthdate".to_string(),
+        param_type: SearchParamType::Date,
+        modifier: Some(SearchModifier::Missing),
+        values: vec![SearchValue::boolean(true)],
+        chain: vec![],
+        components: vec![],
+    });
+
+    let result = backend
+        .search(&tenant, &query.with_count(100))
+        .await
+        .unwrap();
+    let ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+
+    assert_eq!(ids, vec!["container-without-date"]);
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_missing_treats_empty_arrays_as_absent() {
+    let backend = create_sqlite_backend();
+    let tenant = create_tenant();
+
+    for resource in [
+        json!({
+            "resourceType": "Patient",
+            "id": "name-present",
+            "name": [{"family": "Present"}]
+        }),
+        json!({
+            "resourceType": "Patient",
+            "id": "name-empty-array",
+            "name": []
+        }),
+        json!({
+            "resourceType": "Patient",
+            "id": "name-absent"
+        }),
+    ] {
+        backend
+            .create(&tenant, "Patient", resource, FhirVersion::default())
+            .await
+            .unwrap();
+    }
+
+    let query = |is_missing| {
+        SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "name".to_string(),
+            param_type: SearchParamType::String,
+            modifier: Some(SearchModifier::Missing),
+            values: vec![SearchValue::boolean(is_missing)],
+            chain: vec![],
+            components: vec![],
+        })
+    };
+
+    let result = backend.search(&tenant, &query(true)).await.unwrap();
+    let mut missing_ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+    missing_ids.sort();
+    assert_eq!(missing_ids, vec!["name-absent", "name-empty-array"]);
+
+    let result = backend.search(&tenant, &query(false)).await.unwrap();
+    let present_ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+    assert_eq!(present_ids, vec!["name-present"]);
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_missing_supports_indexed_metadata_parameters() {
+    let backend = create_sqlite_backend();
+    let tenant = create_tenant();
+
+    backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "id": "with-tag",
+                "meta": {
+                    "tag": [{"system": "http://example.org/tags", "code": "reviewed"}]
+                }
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+    backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "id": "without-tag"
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let query = |is_missing| {
+        SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "_tag".to_string(),
+            param_type: SearchParamType::Token,
+            modifier: Some(SearchModifier::Missing),
+            values: vec![SearchValue::boolean(is_missing)],
+            chain: vec![],
+            components: vec![],
+        })
+    };
+
+    let missing = backend.search(&tenant, &query(true)).await.unwrap();
+    let missing_ids: Vec<&str> = missing.resources.items.iter().map(|r| r.id()).collect();
+    assert_eq!(missing_ids, vec!["without-tag"]);
+
+    let present = backend.search(&tenant, &query(false)).await.unwrap();
+    let present_ids: Vec<&str> = present.resources.items.iter().map(|r| r.id()).collect();
+    assert_eq!(present_ids, vec!["with-tag"]);
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_missing_uses_authoritative_id_and_last_updated_columns() {
+    let backend = create_sqlite_backend();
+    let tenant = create_tenant();
+
+    for id in ["metadata-a", "metadata-b"] {
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({"resourceType": "Patient", "id": id}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+    }
+
+    for (name, param_type) in [
+        ("_id", SearchParamType::Token),
+        ("_lastUpdated", SearchParamType::Date),
+    ] {
+        let query = |is_missing| {
+            SearchQuery::new("Patient").with_parameter(SearchParameter {
+                name: name.to_string(),
+                param_type,
+                modifier: Some(SearchModifier::Missing),
+                values: vec![SearchValue::boolean(is_missing)],
+                chain: vec![],
+                components: vec![],
+            })
+        };
+
+        let missing = backend.search(&tenant, &query(true)).await.unwrap();
+        assert!(missing.resources.items.is_empty(), "{name}:missing=true");
+
+        let present = backend.search(&tenant, &query(false)).await.unwrap();
+        let mut ids: Vec<&str> = present.resources.items.iter().map(|r| r.id()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["metadata-a", "metadata-b"]);
+    }
+}
+
+#[cfg(all(
+    feature = "sqlite",
+    feature = "R4",
+    feature = "R4B",
+    feature = "R5",
+    feature = "R6"
+))]
+#[tokio::test]
+async fn test_missing_across_all_fhir_versions() {
+    for version in [
+        FhirVersion::R4,
+        FhirVersion::R4B,
+        FhirVersion::R5,
+        FhirVersion::R6,
+    ] {
+        let backend = super::make_sqlite_backend_for(version);
+        let tenant = create_tenant();
+
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "with-date",
+                    "birthDate": "1980-01-15"
+                }),
+                version,
+            )
+            .await
+            .unwrap();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "without-date"
+                }),
+                version,
+            )
+            .await
+            .unwrap();
+
+        for (is_missing, expected) in [(true, "without-date"), (false, "with-date")] {
+            let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+                name: "birthdate".to_string(),
+                param_type: SearchParamType::Date,
+                modifier: Some(SearchModifier::Missing),
+                values: vec![SearchValue::boolean(is_missing)],
+                chain: vec![],
+                components: vec![],
+            });
+            let result = backend.search(&tenant, &query).await.unwrap();
+            let ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+            assert_eq!(
+                ids,
+                vec![expected],
+                "FHIR {version:?}, missing={is_missing}"
+            );
+        }
     }
 }
 

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -341,6 +341,37 @@ fn parse_search_parameter(
     // Check for chained parameters (e.g., "patient.name" or "subject:Patient.name")
     let (base_name, chain) = parse_chain(param_name);
 
+    // FHIR defines :missing as a single, case-sensitive boolean literal.
+    // Validate it before splitting comma-separated OR values so malformed
+    // inputs cannot silently become `missing=false` in a storage backend.
+    if matches!(modifier, Some(SearchModifier::Missing)) && !matches!(value, "true" | "false") {
+        return Err(RestError::InvalidParameter {
+            param: name.to_string(),
+            message: "the :missing modifier requires exactly 'true' or 'false'".to_string(),
+        });
+    }
+
+    // Full-text and other computed `_` parameters have no ordinary presence
+    // row in the search index. Treating them as index-backed would make
+    // `:missing=true` match every resource.
+    let registered = registry.get_param(resource_type, base_name).is_some()
+        || registry.get_param("Resource", base_name).is_some();
+    let has_presence_index = matches!(base_name, "_id" | "_lastUpdated")
+        || registered
+            && matches!(
+                base_name,
+                "_tag" | "_profile" | "_security" | "_source" | "_language"
+            );
+    if matches!(modifier, Some(SearchModifier::Missing))
+        && base_name.starts_with('_')
+        && !has_presence_index
+    {
+        return Err(RestError::InvalidParameter {
+            param: name.to_string(),
+            message: format!(":missing is not supported for parameter '{base_name}'"),
+        });
+    }
+
     // Parse the value(s) - multiple values separated by comma are ORed.
     // Prefix extraction (gt/lt/ge/le/sa/eb/ap/eq/ne) is only meaningful for
     // date/number/quantity types per FHIR. For tokens/strings/references/uris,
@@ -422,16 +453,6 @@ fn parse_search_parameter(
                     .collect();
             }
         }
-    }
-
-    // Handle :missing modifier specially
-    if param
-        .modifier
-        .as_ref()
-        .is_some_and(|m| *m == SearchModifier::Missing)
-    {
-        // The value should be "true" or "false"
-        param.values = vec![SearchValue::eq(value)];
     }
 
     Ok(param)
@@ -935,6 +956,94 @@ mod tests {
         assert_eq!(query.parameters.len(), 1);
         assert_eq!(query.parameters[0].name, "name");
         assert_eq!(query.parameters[0].modifier, Some(SearchModifier::Exact));
+    }
+
+    #[test]
+    fn test_missing_modifier_accepts_exact_boolean_literals() {
+        let registry = test_registry();
+
+        for value in ["true", "false"] {
+            let param =
+                parse_search_parameter("Patient", "birthdate:missing", value, &registry).unwrap();
+            assert_eq!(param.modifier, Some(SearchModifier::Missing));
+            assert_eq!(param.values.len(), 1);
+            assert_eq!(param.values[0].value, value);
+        }
+    }
+
+    #[test]
+    fn test_missing_modifier_rejects_non_boolean_literals() {
+        let registry = test_registry();
+
+        for value in ["", "TRUE", "False", "invalid", "true,false"] {
+            let error = parse_search_parameter("Patient", "birthdate:missing", value, &registry)
+                .unwrap_err();
+            assert!(
+                matches!(error, RestError::InvalidParameter { .. }),
+                "unexpected error for {value:?}: {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_missing_modifier_rejects_composite_parameters() {
+        let mut registry = test_registry();
+        registry
+            .register(
+                SearchParameterDefinition::new(
+                    "http://hl7.org/fhir/SearchParameter/Observation-code-value-quantity",
+                    "code-value-quantity",
+                    SearchParamType::Composite,
+                    "ignored",
+                )
+                .with_base(vec!["Observation"]),
+            )
+            .unwrap();
+
+        let error = parse_search_parameter(
+            "Observation",
+            "code-value-quantity:missing",
+            "true",
+            &registry,
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, RestError::InvalidParameter { .. }));
+    }
+
+    #[test]
+    fn test_missing_modifier_rejects_non_indexed_special_parameters() {
+        let registry = test_registry();
+
+        for name in ["_text:missing", "_content:missing"] {
+            let error = parse_search_parameter("Patient", name, "true", &registry).unwrap_err();
+            assert!(
+                matches!(error, RestError::InvalidParameter { .. }),
+                "unexpected error for {name}: {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_language_missing_requires_a_registered_search_parameter() {
+        let mut registry = test_registry();
+        assert!(parse_search_parameter("Patient", "_language:missing", "true", &registry).is_err());
+
+        registry
+            .register(
+                SearchParameterDefinition::new(
+                    "http://hl7.org/fhir/SearchParameter/Resource-language",
+                    "_language",
+                    SearchParamType::Token,
+                    "Resource.language",
+                )
+                .with_base(vec!["Resource"]),
+            )
+            .unwrap();
+
+        let param =
+            parse_search_parameter("Patient", "_language:missing", "true", &registry).unwrap();
+        assert_eq!(param.modifier, Some(SearchModifier::Missing));
     }
 
     #[test]

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -901,6 +901,107 @@ mod string_search {
 }
 
 // =============================================================================
+// :missing Modifier Tests
+// =============================================================================
+
+mod missing_modifier {
+    use super::*;
+
+    fn entry_ids(body: &Value) -> Vec<String> {
+        let mut ids: Vec<String> = get_bundle_entries(body)
+            .iter()
+            .map(|entry| {
+                entry["resource"]["id"]
+                    .as_str()
+                    .expect("search result must carry a logical id")
+                    .to_string()
+            })
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    #[tokio::test]
+    async fn test_missing_boolean_polarity_returns_exact_membership() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+        backend
+            .create(
+                &test_tenant(),
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "patient-without-birthdate",
+                    "active": true
+                }),
+                FhirVersion::R4,
+            )
+            .await
+            .expect("seed Patient without birthDate");
+
+        let missing = server
+            .get("/Patient?birthdate:missing=true&_total=accurate&_count=100")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        missing.assert_status_ok();
+        let missing_body: Value = missing.json();
+        assert_eq!(missing_body["total"], 1);
+        assert_eq!(entry_ids(&missing_body), vec!["patient-without-birthdate"]);
+
+        let present = server
+            .get("/Patient?birthdate:missing=false&_total=accurate&_count=100")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+        present.assert_status_ok();
+        let present_body: Value = present.json();
+        assert_eq!(present_body["total"], 4);
+        assert_eq!(
+            entry_ids(&present_body),
+            vec!["patient-1", "patient-2", "patient-3", "patient-4"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_requires_an_exact_boolean_literal() {
+        let (server, _) = create_test_server().await;
+
+        for value in ["invalid", "", "TRUE", "true,false"] {
+            let response = server
+                .get(&format!("/Patient?birthdate:missing={value}"))
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .await;
+
+            response.assert_status(StatusCode::BAD_REQUEST);
+            let body: Value = response.json();
+            assert_eq!(body["resourceType"], "OperationOutcome", "value={value:?}");
+            assert_eq!(body["issue"][0]["code"], "invalid", "value={value:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_missing_rejects_non_indexed_and_contained_searches() {
+        let (server, _) = create_test_server().await;
+
+        for query in [
+            "/Patient?_text:missing=true",
+            "/Patient?_content:missing=true",
+            "/Patient?_contained=true&birthdate:missing=true",
+            "/Patient?_contained=both&birthdate:missing=true",
+        ] {
+            let response = server
+                .get(query)
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .await;
+
+            response.assert_status(StatusCode::BAD_REQUEST);
+            let body: Value = response.json();
+            assert_eq!(body["resourceType"], "OperationOutcome", "query={query}");
+            assert_eq!(body["issue"][0]["code"], "invalid", "query={query}");
+        }
+    }
+}
+
+// =============================================================================
 // Token Search Tests
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- Resolve SQLite `:missing` at resource level before ordinary, composite, and type dispatch.
- Ignore contained index rows when checking top-level presence in SQLite and PostgreSQL.
- Use authoritative `_id` and `_lastUpdated` fields across SQLite, PostgreSQL, and Elasticsearch.
- Require exact `true` or `false` values and reject unsupported parameter combinations.
- Align capability behavior across SQLite, PostgreSQL, Elasticsearch, and MongoDB.

## Root cause

SQLite built the correct absence predicate, then wrapped it in a query that required an index row for the same parameter. `birthdate:missing=true` therefore required `birthdate` to be both present and absent.

The existing tests iterated over returned resources without asserting cardinality or IDs, so an empty result passed.

## Backend behavior

| Backend | Result |
| --- | --- |
| SQLite | Fixed |
| PostgreSQL | Existing behavior retained; contained-row isolation and metadata parity added |
| Elasticsearch | Existing ordinary behavior retained; metadata dispatch corrected |
| MongoDB | Explicit unsupported modifier |
| S3 | Search requires Elasticsearch |

## Verification

- `cargo test -p helios-persistence --features R4B,R5,R6,sqlite,postgres,elasticsearch,mongodb missing --lib`
- `cargo test -p helios-persistence --no-default-features --features R4,R4B,R5,R6,sqlite --test search_suite test_missing`
- `cargo test -p helios-rest --test search_integration missing_modifier`
- `cargo test -p helios-persistence --features postgres --test postgres_tests postgres_integration_search_missing_modifier`
- Computer Use against the SQLite UI with the existing dashboard seed

Elasticsearch unit coverage passed. The live test binary compiled, but Docker Desktop blocked before container creation in its credential helper.

## Evidence

### Before

![SQLite missing search returning zero results](https://github.com/user-attachments/assets/f2d16ef1-6636-41f8-9b81-3103c975c274)

### After

The captures below show `:missing=true` returning only the patient without `birthDate`, and `:missing=false` returning the 140 seeded patients with the field present.

Closes #632
<img width="1728" height="1117" alt="missing-true" src="https://github.com/user-attachments/assets/e93ba777-03c8-4873-8bda-a50ab411b204" />
<img width="1728" height="1117" alt="missing-false" src="https://github.com/user-attachments/assets/08d63810-ad09-4dd6-8348-d1a86533c427" />
