### PR TITLE
fix(ui): keep query modifier panels on their own row

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2897,10 +2897,8 @@ button.pill {
   align-self: flex-start;
 }
 
-/* Chaining rows (#394): forward chains and _has carry extra controls, so
- * they wrap; the shared input skin comes from the selectors above. */
-.builder-row--chain,
-.builder-row--has {
+/* Condition rows can grow a full-width modifier panel. */
+#builder-conditions > .builder-row {
   flex-wrap: wrap;
 }
 
@@ -4136,6 +4134,8 @@ button.pill {
 
 .builder-row__modpanel {
   flex-basis: 100%;
+  min-width: 0;
+  max-width: 100%;
   display: flex;
   flex-wrap: wrap;
   gap: 6px;

--- a/crates/ui/e2e/tests/queries.spec.ts
+++ b/crates/ui/e2e/tests/queries.spec.ts
@@ -274,22 +274,185 @@ test.describe("query builder", () => {
     expect(opts).not.toContain(":in");
   });
 
-  test("the MODIFY panel explains chips and clicking one applies it", async ({
-    queries,
-  }) => {
+  test("the MODIFY panel explains its chips", async ({ queries }) => {
     await queries.builder.setUrl("Patient?name=ann");
     const row = queries.builder.conditionRows.first();
+    await expect(row).toHaveAttribute("data-mod-type", "string");
     await row.locator("[data-toggle-mods]").click();
     const panel = row.locator(".builder-row__modpanel");
     await expect(panel).toBeVisible();
     const chip = panel.locator("[data-mod-chip=contains]");
     await expect(chip).toContainText(":contains");
     await expect(chip).toContainText("anywhere");
-
-    await chip.click();
-    await expect(row.locator(".builder-row__modifier")).toHaveValue("contains");
-    await expect(queries.builder.url).toHaveValue("GET /Patient?name:contains=ann");
   });
+
+  const modifierLayoutScenarios = [
+    {
+      name: "desktop string with two OR values in Spanish",
+      width: 1280,
+      lang: "es",
+      query: "Patient?name=ann,anne",
+      modType: "string",
+      requiredChip: "contains",
+      interaction: {
+        chip: "contains",
+        url: "GET /Patient?name:contains=ann,anne",
+      },
+    },
+    {
+      name: "token just above the responsive breakpoint in German",
+      width: 901,
+      lang: "de",
+      query: "Patient?gender=male",
+      modType: "token",
+      requiredChip: "of-type",
+    },
+    {
+      name: "unknown parameter at a narrow width in English",
+      width: 760,
+      lang: "en",
+      query: "Patient?custom-param=value",
+      requiredChip: "above",
+      wraps: true,
+    },
+  ];
+
+  for (const scenario of modifierLayoutScenarios) {
+    test(`the MODIFY panel preserves layout for ${scenario.name}`, async ({
+      page,
+      queries,
+    }) => {
+      await page.setViewportSize({ width: scenario.width, height: 900 });
+      await page.goto(`/ui/queries?lang=${scenario.lang}`, { waitUntil: "networkidle" });
+      await expect(page.locator("html")).toHaveAttribute("lang", scenario.lang);
+      await queries.builder.setUrl(scenario.query);
+
+      const row = queries.builder.conditionRows.first();
+      if ("modType" in scenario) {
+        await expect(row).toHaveAttribute("data-mod-type", scenario.modType);
+      }
+
+      const primaryControls = row.locator(
+        ".builder-row__key, .builder-row__modifier, .builder-row__values, " +
+          ".builder-row__or, .builder-row__adv, [data-remove-row]",
+      );
+      const primaryBounds = () =>
+        primaryControls.evaluateAll((elements) => {
+          const rowRect = elements[0].closest(".builder-row")!.getBoundingClientRect();
+          return elements.map((element) => {
+            const rect = element.getBoundingClientRect();
+            return [
+              rect.x - rowRect.x,
+              rect.y - rowRect.y,
+              rect.width,
+              rect.height,
+            ].map(Math.round);
+          });
+        });
+
+      const before = await primaryBounds();
+      const toggle = row.locator("[data-toggle-mods]");
+      await toggle.click();
+      const panel = row.locator(".builder-row__modpanel");
+      await expect(panel).toBeVisible();
+      await expect(panel.locator(`[data-mod-chip='${scenario.requiredChip}']`)).toBeVisible();
+
+      expect(await primaryBounds()).toEqual(before);
+      const geometry = await row.evaluate((element) => {
+        const rowRect = element.getBoundingClientRect();
+        const relativeBox = (node: Element, parentRect = rowRect) => {
+          const rect = node.getBoundingClientRect();
+          return {
+            x: rect.x - parentRect.x,
+            y: rect.y - parentRect.y,
+            width: rect.width,
+            height: rect.height,
+          };
+        };
+        const panel = element.querySelector(".builder-row__modpanel")!;
+        const panelBox = relativeBox(panel);
+        const panelClientRect = panel.getBoundingClientRect();
+        const visibleLeaves = Array.from(
+          element.querySelectorAll(
+            ".builder-row__key, .builder-row__modifier, .builder-row__value, " +
+              ".builder-row__remove--or, .builder-row__or, .builder-row__adv, [data-remove-row]",
+          ),
+        ).filter((leaf) => {
+          const style = getComputedStyle(leaf);
+          return style.display !== "none" && style.visibility !== "hidden";
+        });
+        const leafBoxes = visibleLeaves.map((leaf) => relativeBox(leaf));
+        const chips = Array.from(panel.querySelectorAll(".builder-row__modchip")).map((chip) =>
+          relativeBox(chip, panelClientRect),
+        );
+        const overlaps = (
+          first: ReturnType<typeof relativeBox>,
+          second: ReturnType<typeof relativeBox>,
+        ) =>
+          first.x < second.x + second.width - 1 &&
+          first.x + first.width > second.x + 1 &&
+          first.y < second.y + second.height - 1 &&
+          first.y + first.height > second.y + 1;
+        const pairwiseClear = (boxes: ReturnType<typeof relativeBox>[]) =>
+          boxes.every((box, index) => boxes.slice(index + 1).every((other) => !overlaps(box, other)));
+        const within = (box: ReturnType<typeof relativeBox>, width: number, height: number) =>
+          box.x >= -1 &&
+          box.y >= -1 &&
+          box.x + box.width <= width + 1 &&
+          box.y + box.height <= height + 1;
+        const valueWidths = Array.from(element.querySelectorAll(".builder-row__value")).map(
+          (value) => value.getBoundingClientRect().width,
+        );
+        return {
+          panelBelowControls:
+            panelBox.y >= Math.max(...leafBoxes.map((box) => box.y + box.height)) - 1,
+          panelFullWidth:
+            Math.abs(panelBox.x) <= 1 && Math.abs(panelBox.width - rowRect.width) <= 1,
+          noOverflow:
+            element.scrollWidth <= element.clientWidth + 1 &&
+            panel.scrollWidth <= panel.clientWidth + 1,
+          controlsDoNotOverlap: pairwiseClear(leafBoxes),
+          chipsDoNotOverlap: pairwiseClear(chips),
+          controlsContained: leafBoxes.every((box) =>
+            within(box, rowRect.width, rowRect.height),
+          ),
+          panelContained: within(panelBox, rowRect.width, rowRect.height),
+          chipsContained: chips.every((box) =>
+            within(box, panelClientRect.width, panelClientRect.height),
+          ),
+          minimumValueWidth: Math.min(...valueWidths),
+          chipsWrap: chips.some((chip) => chip.y >= chips[0].y + chips[0].height - 1),
+        };
+      });
+
+      expect(geometry).toMatchObject({
+        panelBelowControls: true,
+        panelFullWidth: true,
+        noOverflow: true,
+        controlsDoNotOverlap: true,
+        chipsDoNotOverlap: true,
+        controlsContained: true,
+        panelContained: true,
+        chipsContained: true,
+      });
+      expect(geometry.minimumValueWidth).toBeGreaterThan(120);
+      if ("wraps" in scenario) expect(geometry.chipsWrap).toBe(true);
+
+      if ("interaction" in scenario) {
+        const chip = panel.locator(`[data-mod-chip='${scenario.interaction.chip}']`);
+        await chip.click();
+        await expect(chip).toHaveAttribute("aria-pressed", "true");
+        await expect(row.locator(".builder-row__modifier")).toHaveValue(
+          scenario.interaction.chip,
+        );
+        await expect(queries.builder.url).toHaveValue(scenario.interaction.url);
+      }
+
+      await toggle.click();
+      await expect(panel).toBeHidden();
+      expect(await primaryBounds()).toEqual(before);
+    });
+  }
 
   /* ---- results sort + typed columns (#416) ---------------------------- */
 


### PR DESCRIPTION
Fixes #641.

## What changed

- Allow direct condition rows to wrap so an expanded modifier panel gets its own full-width flex line.
- Constrain the panel to the condition row, allowing modifier chips to wrap without compressing the value fields or displacing the row actions.
- Keep the primary controls in the same position when the panel opens and closes.
- Query parsing, serialization, and modifier selection logic are unchanged.

## Regression coverage

The Playwright coverage exercises three layouts:

| Viewport | Locale | Parameter | Case |
| --- | --- | --- | --- |
| 1280 px | Spanish | `name` | String parameter with two OR values |
| 901 px | German | `gender` | Token parameter above the responsive breakpoint |
| 760 px | English | `custom-param` | Unknown parameter with the complete chip set |

The tests check that:

- the panel starts below the primary controls and spans the condition row;
- fields, actions, and chips remain contained and do not overlap;
- the row and panel have no horizontal overflow;
- value inputs retain a usable width;
- chips wrap at the narrow viewport;
- the primary controls keep their geometry after opening and closing the panel;
- selecting `:contains` still updates the modifier control and serialized URL.

## Evidence

### Before

<img width="1332" height="768" alt="Expanded modifier panel on main collapsing the value inputs" src="https://github.com/user-attachments/assets/39517159-6dd5-4a64-a5ef-9500df70609a" />

The modifier panel remains on the primary flex line and collapses the two value inputs.

### After

<img width="1333" height="768" alt="Corrected modifier panel on its own row with value inputs intact" src="https://github.com/user-attachments/assets/9d1740f4-2604-4e60-aae1-acb22c0f63f3" />

The controls retain their width and alignment while the modifier panel occupies a separate row.

<details>
<summary>Additional locale and responsive checks</summary>

<img width="1333" height="768" alt="Corrected German token parameter modifier panel" src="https://github.com/user-attachments/assets/d7c5e8a0-f1e5-4c16-86bb-5ae1c192263d" />

German token parameter with localized modifier copy.

<img width="1333" height="768" alt="Corrected unknown parameter at an emulated 760 pixel viewport" src="https://github.com/user-attachments/assets/d3979dab-db9e-4e32-840f-7dd0cfcc9166" />

Unknown parameter at an emulated 760 px viewport, with chips wrapping inside the row.

</details>

## Verification

- New geometry regression against `main`: 2 failed, 1 passed. The 1280 px and 901 px cases reproduced the issue; the 760 px case already wrapped on `main`.
- `npx playwright test tests/queries.spec.ts --project=chromium --grep 'MODIFY panel'`: 4 passed
- `npx playwright test tests/queries.spec.ts --project=chromium`: 26 passed
- `npx playwright test --project=chromium`: 148 passed, 7 skipped, 0 failed
- `cargo build -p helios-hfs --features ui`: passed
- `git diff --check`: passed
- Manual Chrome verification through Computer Use with Spanish, German, and English examples

## FHIR and backend scope

The production change is limited to shared CSS. It does not modify Rust, templates, browser-side query logic, search execution, persistence, serialization, metadata, or FHIR-version-specific code.

The same layout serves R4, R4B, R5, and R6 across every configured storage backend, so this change does not trigger the backend and FHIR-version matrix. Manual verification used R4 with SQLite.
