### PR TITLE
fix(ui): reveal truncated resource type names

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2126,8 +2126,9 @@ button.pill {
 
 /* Long resource type names (e.g. "MedicinalProductContraindication", 32
    chars) truncate with an ellipsis instead of colliding with the count or
-   forcing horizontal scroll on the rail; the full name stays available via
-   `title` (#604). */
+   forcing horizontal scroll on the rail. `title` is the no-JS fallback;
+   resource-filter.js replaces it with a visible hover/keyboard tooltip when
+   the label is actually truncated (#604, #634). */
 .filter-rail__label {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2151,6 +2152,30 @@ button.pill {
   font-size: 11px;
   color: var(--muted);
   font-variant-numeric: tabular-nums;
+}
+
+/* Appended to <body> and positioned from the focused/hovered rail item so the
+   full label is not clipped by the rail's scrolling overflow. One shared
+   tooltip serves both the main list and cloneNode()-based Recent items. */
+.filter-rail__tooltip {
+  position: fixed;
+  z-index: 1000;
+  max-width: min(320px, calc(100vw - 16px));
+  padding: 6px 9px;
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--surface-shadow);
+  color: var(--text-strong);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+}
+
+.filter-rail__tooltip[hidden] {
+  display: none;
 }
 
 .filter-rail__note {

--- a/crates/ui/assets/resource-filter.js
+++ b/crates/ui/assets/resource-filter.js
@@ -85,6 +85,163 @@
   renderRecents();
 })();
 
+/* A native `title` exposes truncated names to a pointer, but not visibly to a
+   keyboard user. Replace that fallback with one body-level tooltip whenever
+   a rail label is genuinely clipped (#634). Keeping the tooltip outside the
+   scrolling rail avoids overflow clipping, and delegation means the cloned
+   Recently used items follow the same path without duplicate ids. */
+(function () {
+  "use strict";
+
+  var ITEM_SELECTOR = "a.filter-rail__item[data-full-name]";
+  var tooltip = document.createElement("div");
+  var activeItem = null;
+  var hoveredItem = null;
+  var focusedItem = null;
+  tooltip.className = "filter-rail__tooltip";
+  tooltip.id = "filter-rail-tooltip";
+  tooltip.setAttribute("role", "tooltip");
+  tooltip.hidden = true;
+  document.body.appendChild(tooltip);
+
+  /* `title` remains useful when JavaScript is unavailable. Once this richer
+     tooltip is active, remove it to avoid two competing hover bubbles. */
+  document.querySelectorAll(ITEM_SELECTOR).forEach(function (item) {
+    item.removeAttribute("title");
+  });
+
+  function hide(item) {
+    if (item && item !== activeItem) return;
+    if (activeItem) activeItem.removeAttribute("aria-describedby");
+    activeItem = null;
+    tooltip.hidden = true;
+  }
+
+  function show(item) {
+    var label = item && item.querySelector(".filter-rail__label");
+    var fullName = item && item.getAttribute("data-full-name");
+    /* HTMX can replace Search Parameters rail items after the initial sweep;
+       remove their fallback lazily as well. */
+    if (item) item.removeAttribute("title");
+    if (!label || !fullName || label.scrollWidth <= label.clientWidth + 1) {
+      hide();
+      return;
+    }
+
+    var itemRect = item.getBoundingClientRect();
+    if (
+      itemRect.bottom <= 0
+      || itemRect.top >= window.innerHeight
+      || itemRect.right <= 0
+      || itemRect.left >= window.innerWidth
+    ) {
+      hide();
+      return;
+    }
+
+    if (activeItem && activeItem !== item) {
+      activeItem.removeAttribute("aria-describedby");
+    }
+    activeItem = item;
+    activeItem.setAttribute("aria-describedby", tooltip.id);
+    tooltip.textContent = fullName;
+    tooltip.hidden = false;
+
+    var tooltipRect = tooltip.getBoundingClientRect();
+    var gap = 8;
+    var rightFits = itemRect.right + gap + tooltipRect.width <= window.innerWidth - gap;
+    var leftFits = itemRect.left - gap - tooltipRect.width >= gap;
+    var left;
+    var top;
+
+    if (rightFits || leftFits) {
+      left = rightFits
+        ? itemRect.right + gap
+        : itemRect.left - tooltipRect.width - gap;
+      top = Math.min(
+        Math.max(gap, itemRect.top + (itemRect.height - tooltipRect.height) / 2),
+        window.innerHeight - tooltipRect.height - gap
+      );
+    } else {
+      /* In the stacked <=1100px layout there may be no room beside the rail.
+         Place the tooltip below (or above) so it never covers the trigger or
+         its right-aligned count. */
+      left = Math.min(
+        Math.max(gap, itemRect.left),
+        window.innerWidth - tooltipRect.width - gap
+      );
+      top = itemRect.bottom + gap;
+      if (top + tooltipRect.height > window.innerHeight - gap) {
+        top = Math.max(gap, itemRect.top - tooltipRect.height - gap);
+      }
+    }
+
+    tooltip.style.left = left + "px";
+    tooltip.style.top = top + "px";
+  }
+
+  function closestItem(target) {
+    return target instanceof Element ? target.closest(ITEM_SELECTOR) : null;
+  }
+
+  function refresh() {
+    if (
+      focusedItem
+      && (!focusedItem.isConnected || document.activeElement !== focusedItem)
+    ) {
+      focusedItem = null;
+    }
+    if (
+      hoveredItem
+      && (!hoveredItem.isConnected || !hoveredItem.matches(":hover"))
+    ) {
+      hoveredItem = null;
+    }
+    var item = focusedItem || hoveredItem;
+    if (item) show(item);
+    else hide();
+  }
+
+  document.addEventListener("mouseover", function (event) {
+    var item = closestItem(event.target);
+    if (!item) return;
+    hoveredItem = item;
+    refresh();
+  });
+
+  document.addEventListener("mouseout", function (event) {
+    var item = closestItem(event.target);
+    var related = event.relatedTarget;
+    if (!item || (related instanceof Node && item.contains(related))) return;
+    if (hoveredItem === item) hoveredItem = null;
+    refresh();
+  });
+
+  document.addEventListener("focusin", function (event) {
+    var item = closestItem(event.target);
+    if (!item) return;
+    focusedItem = item;
+    refresh();
+  });
+
+  document.addEventListener("focusout", function (event) {
+    var item = closestItem(event.target);
+    if (!item) return;
+    if (focusedItem === item) focusedItem = null;
+    refresh();
+  });
+
+  window.addEventListener("resize", refresh);
+  var scrollFrame = null;
+  document.addEventListener("scroll", function () {
+    if (scrollFrame !== null) return;
+    scrollFrame = window.requestAnimationFrame(function () {
+      scrollFrame = null;
+      refresh();
+    });
+  }, true);
+})();
+
 /* Reveal the selected type on arrival: the rail list scrolls itself so the
    `aria-current` item (the deep-linked type, or the default Patient the page
    scripts mark on load) sits near the middle of the list instead of below

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -2489,8 +2489,14 @@ mod tests {
         assert!(html.contains("data-addbox-close"));
         // Resource picker rail (#541): a real link per type, server-marked
         // current; no count without a dashboard provider.
-        assert!(html.contains(r#"data-type="Patient" href="/ui/queries?type=Patient""#));
-        assert!(html.contains(r#"data-type="Observation" href="/ui/queries?type=Observation""#));
+        assert!(html.contains(
+            r#"data-type="Patient" data-full-name="Patient"
+   href="/ui/queries?type=Patient""#
+        ));
+        assert!(html.contains(
+            r#"data-type="Observation" data-full-name="Observation"
+   href="/ui/queries?type=Observation""#
+        ));
         assert!(!html.contains(r#"class="count""#));
         // Saved Queries has no nav entry any more (#282 folded search / editor
         // / history / saved-queries into Resources); the route still renders.

--- a/crates/ui/templates/pages/search-parameters.html
+++ b/crates/ui/templates/pages/search-parameters.html
@@ -71,8 +71,9 @@
         <span class="count">{{ view.rail_all.count }}</span>
       </a>
       {% for item in view.rail %}
-      <a class="filter-rail__item" data-type="{{ item.name }}" href="{{ item.href }}"{% if item.current %} aria-current="true"{% endif %}>
-        <span>{{ item.name }}</span>
+      <a class="filter-rail__item" data-type="{{ item.name }}" data-full-name="{{ item.name }}"
+         href="{{ item.href }}" title="{{ item.name }}"{% if item.current %} aria-current="true"{% endif %}>
+        <span class="filter-rail__label">{{ item.name }}</span>
         <span class="count">{{ item.count }}</span>
       </a>
       {% endfor %}

--- a/crates/ui/templates/partials/type_rail.html
+++ b/crates/ui/templates/partials/type_rail.html
@@ -1,6 +1,7 @@
 {% macro rail_items(entries) %}
 {% for e in entries %}
-<a class="filter-rail__item" data-type="{{ e.name }}" href="{{ e.href }}" title="{{ e.name }}"{% if e.current %} aria-current="true"{% endif %}>
+<a class="filter-rail__item" data-type="{{ e.name }}" data-full-name="{{ e.name }}"
+   href="{{ e.href }}" title="{{ e.name }}"{% if e.current %} aria-current="true"{% endif %}>
   <span class="filter-rail__label">{{ e.name }}</span>
   {% if let Some(c) = e.count %}<span class="count">{{ c }}</span>{% endif %}
 </a>

--- a/crates/ui/tests/rail_counts_http.rs
+++ b/crates/ui/tests/rail_counts_http.rs
@@ -148,5 +148,20 @@ async fn the_rail_goes_from_no_counts_to_server_rendered_counts() {
             encounter.contains(">0<"),
             "{path}: a type with no stored resources still renders 0: {encounter}"
         );
+        let long_name = "MedicinalProductUndesirableEffect";
+        let long_item = rail_item(&html, long_name);
+        assert!(
+            long_item.contains(&format!(r#"data-full-name="{long_name}""#)),
+            "{path}: the full name feeds the shared hover/focus tooltip: {long_item}"
+        );
+        assert!(
+            long_item.contains(&format!(r#"title="{long_name}""#)),
+            "{path}: the no-JS tooltip fallback remains available: {long_item}"
+        );
+        assert!(
+            long_item.contains(&format!(r#">{long_name}</span>"#))
+                && long_item.contains(r#"<span class="count">0</span>"#),
+            "{path}: the accessible name and count remain separate: {long_item}"
+        );
     }
 }

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -251,6 +251,14 @@ async fn search_parameters_page_serves_the_registry_view() {
     // "All types" now renders twice: the new section heading, and the
     // existing "clear filter" row it sits above.
     assert_eq!(html.matches(">All types<").count(), 2);
+    let long_name = "MedicinalProductUndesirableEffect";
+    assert!(html.contains(&format!(
+        r#"data-type="{long_name}" data-full-name="{long_name}""#
+    )));
+    assert!(html.contains(&format!(r#"title="{long_name}""#)));
+    assert!(html.contains(&format!(
+        r#"<span class="filter-rail__label">{long_name}</span>"#
+    )));
 }
 
 #[tokio::test]
@@ -765,7 +773,8 @@ async fn resources_deep_links_focus_the_selected_type() {
     // pattern shared with Search Parameters), not a full-height menu panel.
     assert!(html.contains(r#"data-selected-type="Observation""#));
     assert!(html.contains(
-        r#"data-type="Observation" href="/ui/resources?type=Observation" title="Observation" aria-current="true""#
+        r#"data-type="Observation" data-full-name="Observation"
+   href="/ui/resources?type=Observation" title="Observation" aria-current="true""#
     ));
     assert!(html.contains(r#"class="filter-rail" id="resources""#));
     // Create and the builder prefill both follow the deep-linked type.


### PR DESCRIPTION
## Summary

Fixes the remaining usability issue with long FHIR resource type names in the UI sidebars.

Long labels continue to use ellipsis so resource counts remain visible and right-aligned. When a label is actually truncated, its complete value is now exposed through an accessible tooltip on both pointer hover and keyboard focus.

Closes #634.

## Intent

```text
Long resource type
        |
        v
+------------------------------+
| MedicinalProductUnde...  12  |  Count remains visible
+------------------------------+
          |
          +-- hover ---------+
          |                  |
          +-- keyboard focus +--> Full name tooltip
                                 "MedicinalProductUndesirableEffect"
```

## Changes

- Add the complete resource type name as escaped metadata on sidebar items.
- Display a single body-level tooltip only when the visible label is truncated.
- Support pointer hover and keyboard focus independently.
- Keep the tooltip within the viewport and away from the resource count.
- Recalculate tooltip placement while scrolling and hide it for disconnected or off-screen triggers.
- Remove the redundant native browser tooltip when JavaScript is active while preserving `title` as a no-JavaScript fallback.
- Support sidebar entries inserted or replaced through HTMX.
- Apply the behavior to filtered resources, recently accessed resources, and Search Parameters.
- Add regression coverage for long labels, multi-digit counts, and accessible markup.

## Before and after

| Before | After |
| --- | --- |
| Keyboard focus leaves the recent item truncated and does not expose its complete name. | Keyboard focus reveals the complete name while preserving the visible two-digit count. |
| <img width="700" alt="Before: truncated recent resource type without full-name discovery" src="https://github.com/user-attachments/assets/3eed4f6d-5b9f-4995-a4cd-77cfdfe5f675" /> | <img width="700" alt="After: accessible tooltip showing the complete resource type name on keyboard focus" src="https://github.com/user-attachments/assets/aa42e1aa-66c7-450a-896f-c68fa4544975" /> |

<details>
<summary>Additional visual evidence</summary>

### Pointer hover — light theme

<img width="900" alt="Long resource name tooltip on pointer hover in the light theme" src="https://github.com/user-attachments/assets/0c3ab323-3412-4335-954c-bbed4f0b07b1" />

### Pointer hover — dark theme

<img width="900" alt="Long resource name tooltip on pointer hover in the dark theme" src="https://github.com/user-attachments/assets/585353d3-9745-4258-b721-39538a1d28a7" />

### Near the 1100 px responsive breakpoint

<img width="900" alt="Tooltip placement near the responsive breakpoint without overlapping the resource count" src="https://github.com/user-attachments/assets/3d83530f-004f-462d-a719-cd14ad504766" />

### Search Parameters after HTMX rendering

<img width="900" alt="Keyboard-accessible tooltip in the Search Parameters sidebar after HTMX rendering" src="https://github.com/user-attachments/assets/d0ac6c44-75c3-4aa2-bef3-4c0fb7ab41fe" />

</details>

## Testing

Automated checks:

- `cargo fmt --all --check`
- `node --check crates/ui/assets/resource-filter.js`
- `cargo test -p helios-ui --test rail_counts_http --test router_http`
  - `rail_counts_http`: 1 passed
  - `router_http`: 47 passed
- `git diff --check`

Visual regression verification was performed using Computer Use, without Playwright, covering:

- pointer hover;
- keyboard focus;
- recently accessed resource types;
- multi-digit resource counts;
- light and dark themes;
- desktop layout near the 1100 px responsive breakpoint;
- Search Parameters content rendered through HTMX.

## Accessibility

- The complete name is available to keyboard users through focus.
- `aria-describedby` is added only while the tooltip is active.
- Focus and hover states can coexist without hiding each other's tooltip.
- Tooltip content is populated with `textContent`.
- Without JavaScript, the native `title` attribute remains as a fallback.

## Review

A transversal code review was completed with a second agent. It covered accessibility semantics, hover/focus composition, HTMX lifecycle behavior, responsive placement, scrolling, disconnected DOM nodes, and output escaping.

Final result: approved with no blocking, high, or medium-severity findings.
