### PR TITLE
fix(ui): reorganize sidebar navigation

### DIFF
--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -2393,6 +2393,30 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_groups_compartments_under_server_and_labels_tools() {
+        for (locale, tools_label) in [("en", "Tools"), ("es", "Herramientas"), ("de", "Werkzeuge")]
+        {
+            let html = sample_index_page("1.2.3", 42, i18n(locale))
+                .render()
+                .expect("index renders");
+
+            assert!(html.contains(tools_label));
+        }
+
+        let html = sample_index_page("1.2.3", 42, i18n("en"))
+            .render()
+            .expect("index renders");
+        let server = html.find(">Server</div>").expect("Server section");
+        let compartments = html
+            .find(r#"href="/ui/compartments"#)
+            .expect("Compartments link");
+        let tools = html.find(">Tools</div>").expect("Tools section");
+
+        assert!(server < compartments && compartments < tools);
+        assert!(!html.contains("Admin / Ops"));
+    }
+
+    #[test]
     fn status_partial_is_fragment_not_full_page() {
         let html = StatusPartial {
             status: Status {

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -74,11 +74,6 @@
         <span class="icon">{% include "icons/layers.svg" %}</span>
         <span class="nav-item__label">{{ i18n.t("nav-resources") }}</span>
       </a>
-      <a class="nav-item" href="/ui/compartments"{% if active_page == "compartments" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-compartments") }}">
-        <span class="icon">{% include "icons/compartments.svg" %}</span>
-        <span class="nav-item__label">{{ i18n.t("nav-compartments") }}</span>
-      </a>
-
       <div class="nav__section">{{ i18n.t("nav-section-batch-data") }}</div>
       <a class="nav-item" href="/ui/batch"{% if active_page == "batch" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-batch-transaction") }}">
         <span class="icon">{% include "icons/layers.svg" %}</span>
@@ -110,12 +105,12 @@
         <span class="icon">{% include "icons/search.svg" %}</span>
         <span class="nav-item__label">{{ i18n.t("nav-search-parameters") }}</span>
       </a>
-      <span class="nav-item nav-item--soon" title="{{ i18n.t("nav-admin-ops") }}">
-        <span class="icon">{% include "icons/sliders.svg" %}</span>
-        <span class="nav-item__label">{{ i18n.t("nav-admin-ops") }}</span>
-      </span>
+      <a class="nav-item" href="/ui/compartments"{% if active_page == "compartments" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-compartments") }}">
+        <span class="icon">{% include "icons/compartments.svg" %}</span>
+        <span class="nav-item__label">{{ i18n.t("nav-compartments") }}</span>
+      </a>
 
-      <div class="nav__section">{{ i18n.t("nav-section-conditional") }}</div>
+      <div class="nav__section">{{ i18n.t("nav-section-tools") }}</div>
       {% if let Some(url) = status.terminology_url() %}
       <a class="nav-item" href="{{ url }}" target="_blank" rel="noopener noreferrer" hx-boost="false"
          aria-label="{{ i18n.t("nav-terminology-new-window") }}" title="{{ i18n.t("nav-terminology-new-window") }}">

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -85,7 +85,7 @@ error-generic = Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.
 nav-section-work = Arbeit
 nav-section-batch-data = Batch & Daten
 nav-section-server = Server
-nav-section-conditional = Bedingt
+nav-section-tools = Werkzeuge
 
 nav-home = Startseite
 nav-search = Suche
@@ -98,7 +98,6 @@ nav-export = Exportieren
 nav-sql-on-fhir = SQL-on-FHIR
 nav-capability-conformance = Capability & Konformität
 nav-search-parameters = Suchparameter
-nav-admin-ops = Admin / Betrieb
 nav-subscriptions = Abonnements
 nav-tenants = Mandanten
 

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -89,7 +89,7 @@ error-generic = Something went wrong. Please try again.
 nav-section-work = Work
 nav-section-batch-data = Batch & Data
 nav-section-server = Server
-nav-section-conditional = Conditional
+nav-section-tools = Tools
 
 nav-home = Home
 nav-search = Search
@@ -102,7 +102,6 @@ nav-export = Export
 nav-sql-on-fhir = SQL-on-FHIR
 nav-capability-conformance = Capability & Conformance
 nav-search-parameters = Search Parameters
-nav-admin-ops = Admin / Ops
 nav-subscriptions = Subscriptions
 nav-tenants = Tenants
 

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -85,7 +85,7 @@ error-generic = Algo salió mal. Vuelva a intentarlo.
 nav-section-work = Trabajo
 nav-section-batch-data = Lotes y datos
 nav-section-server = Servidor
-nav-section-conditional = Condicional
+nav-section-tools = Herramientas
 
 nav-home = Inicio
 nav-search = Buscar
@@ -98,7 +98,6 @@ nav-export = Exportar
 nav-sql-on-fhir = SQL-on-FHIR
 nav-capability-conformance = Capacidad y conformidad
 nav-search-parameters = Parámetros de búsqueda
-nav-admin-ops = Administración / Operaciones
 nav-subscriptions = Suscripciones
 nav-tenants = Tenants
 


### PR DESCRIPTION
Fixes #654.

## What changed

- Move **Compartments** from **Work** to **Server**, immediately after **Search Parameters**.
- Preserve the Compartments route, icon, and active-page behavior.
- Remove the unused **Admin / Ops** placeholder and its locale keys.
- Rename the semantic section key from `nav-section-conditional` to `nav-section-tools`.
- Translate the new section heading as **Tools**, **Herramientas**, and **Werkzeuge**.
- Add regression coverage for sidebar order, removed entries, and localized section headings.

## Evidence

### Before

<img width="1740" height="1100" alt="Before — English sidebar with Compartments under Work, Admin / Ops, and Conditional" src="https://github.com/user-attachments/assets/d8030ee1-e73a-4abc-8164-31f9c18a15c9" />


Compartments appeared under **Work**, **Admin / Ops** was present, and the final section was labeled **Conditional**.

### After

<img width="1740" height="1100" alt="After — English sidebar with Compartments under Server and Tools" src="https://github.com/user-attachments/assets/0b066e52-a623-4fa1-b40b-da5d1a94ff71" />


Compartments now appears under **Server**, immediately after Search Parameters. **Admin / Ops** is gone and the final section is labeled **Tools**.

<details>
<summary>Collapsed state and active navigation</summary>

### Collapsed sidebar — before

<img width="1740" height="1100" alt="Before — English collapsed sidebar" src="https://github.com/user-attachments/assets/2d0a1ff5-8ea8-413e-88b0-02a8560315ec" />


### Collapsed sidebar — after

<img width="1740" height="1100" alt="After — English collapsed sidebar with updated group spacing" src="https://github.com/user-attachments/assets/d7c082aa-12c8-4337-b870-c8dce9719fff" />


The icon-only rail keeps its section dividers and spacing after removing one Server entry.

### Active Compartments route

<img width="1740" height="1100" alt="English Compartments page with its Server navigation item active" src="https://github.com/user-attachments/assets/4c5afc71-c3e4-4f9e-945b-b7851747acca" />


Navigating to `/ui/compartments` still marks the moved entry as current.

</details>

## Localization

The semantic `nav-section-tools` key renders as:

- English: **Tools**
- Spanish: **Herramientas**
- German: **Werkzeuge**

<details>
<summary>Localized heading screenshots</summary>

### German

<img width="1740" height="1100" alt="German sidebar showing Werkzeuge" src="https://github.com/user-attachments/assets/92f78dc1-4e22-48ad-8a6c-1b16e0c4ca7b" />

### English

<img width="1740" height="1100" alt="English sidebar showing Tools" src="https://github.com/user-attachments/assets/38a9d357-fad2-487c-a625-1320894115fa" />

</details>

## Verification

- `cargo fmt --all --check`
- `cargo test -p helios-ui --lib` — 74 passed
- `cargo test -p helios-ui --test router_http` — 47 passed
- `git diff --check`
- Manual QA through Computer Use, without Playwright:
  - expanded and collapsed sidebar states;
  - Compartments navigation and active state;
  - removal of Admin / Ops;
  - English, Spanish, and German headings.

Manual verification used FHIR R4 with SQLite.

## Scope

This change only affects sidebar structure, localization, and regression coverage. It does not modify FHIR behavior, persistence, routes, or backend logic.

The existing `.nav-item--soon` styling remains because other placeholders tracked by #649 and #653 may still use it.


