### PR TITLE
fix(ui): keep escaped commas as one FHIR search value

### DIFF
--- a/.github/workflows/ui-tests-matrix.yml
+++ b/.github/workflows/ui-tests-matrix.yml
@@ -2,14 +2,17 @@ name: UI Tests (backend matrix)
 
 # The heavy ring of the UI test pyramid: the same Playwright + axe-core browser
 # suite that ui-tests.yml runs against SQLite, but replayed against every
-# supported storage backend — because a rendering, search, or history bug can
+# search-capable storage mode — because a rendering, search, or history bug can
 # surface on Postgres or Mongo and stay invisible on SQLite. Modeled on the
 # Inferno backend matrix (inferno-subscription.yml): hfs is built once with all
 # backends, runs on the runner host against containerized stores, and the
 # browser (in the Playwright container) drives it over the runner's IP.
 #
 # Manual + nightly only — it needs the remote Docker host and cloud secrets and
-# takes minutes; ui-tests.yml stays the fast per-PR gate.
+# takes minutes; ui-tests.yml stays the fast per-PR gate. This R4 backend axis
+# is deliberately orthogonal to ui-tests.yml's R4/R4B/R5/R6 SQLite contract:
+# the escaped-value codec and REST alternative boundary execute before storage
+# dispatch, so crossing both axes would repeat the same contract 28 times.
 
 on:
   workflow_dispatch:
@@ -86,13 +89,22 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        backend: [sqlite, sqlite-elasticsearch, postgres, mongodb, s3-elasticsearch]
+        backend:
+          - sqlite
+          - sqlite-elasticsearch
+          - postgres
+          - postgres-elasticsearch
+          - mongodb
+          - mongodb-elasticsearch
+          - s3-elasticsearch
         include:
           - { backend: sqlite, hfs_port: 19080 }
           - { backend: sqlite-elasticsearch, hfs_port: 19081 }
           - { backend: postgres, hfs_port: 19082 }
-          - { backend: mongodb, hfs_port: 19083 }
-          - { backend: s3-elasticsearch, hfs_port: 19084 }
+          - { backend: postgres-elasticsearch, hfs_port: 19083 }
+          - { backend: mongodb, hfs_port: 19084 }
+          - { backend: mongodb-elasticsearch, hfs_port: 19085 }
+          - { backend: s3-elasticsearch, hfs_port: 19086 }
     env:
       HFS_PORT: ${{ matrix.hfs_port }}
       RESULTS_DIR: ui-matrix-results/${{ matrix.backend }}
@@ -124,7 +136,7 @@ jobs:
           echo "Docker host IP: $EFFECTIVE_DOCKER_HOST_IP"
 
       - name: Start Elasticsearch
-        if: matrix.backend == 'sqlite-elasticsearch' || matrix.backend == 's3-elasticsearch'
+        if: contains(matrix.backend, 'elasticsearch')
         run: |
           # Every container this workflow starts carries hfs-ci=true and the
           # run id. Container names here are run-id-scoped, so a leak can never
@@ -163,9 +175,9 @@ jobs:
           exit 1
 
       - name: Start PostgreSQL
-        if: matrix.backend == 'postgres'
+        if: matrix.backend == 'postgres' || matrix.backend == 'postgres-elasticsearch'
         run: |
-          PG_CONTAINER="pg-ui-matrix-${{ github.run_id }}-${{ github.run_attempt }}"
+          PG_CONTAINER="pg-ui-matrix-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -fv "$PG_CONTAINER" 2>/dev/null || true
           docker run -d --name "$PG_CONTAINER" -p 0:5432 \
             --label hfs-ci=true \
@@ -197,9 +209,9 @@ jobs:
           exit 1
 
       - name: Start MongoDB replica set
-        if: matrix.backend == 'mongodb'
+        if: matrix.backend == 'mongodb' || matrix.backend == 'mongodb-elasticsearch'
         run: |
-          MONGO_CONTAINER="mongo-ui-matrix-${{ github.run_id }}-${{ github.run_attempt }}"
+          MONGO_CONTAINER="mongo-ui-matrix-${{ matrix.backend }}-${{ github.run_id }}-${{ github.run_attempt }}"
           docker rm -fv "$MONGO_CONTAINER" 2>/dev/null || true
           docker run -d --name "$MONGO_CONTAINER" -p 0:27017 \
             --label hfs-ci=true \
@@ -318,11 +330,13 @@ jobs:
           # the default asynchronous sync races the specs (nightly reds since
           # the SearchParameter CRUD spec landed). Synchronous puts the write
           # in ES before the API responds; the specs' waitSearchable covers
-          # the index-refresh window that remains. Only on the sqlite leg:
-          # against real S3 the extra per-write latency tipped the seed-heavy
-          # dashboard specs over their budgets (run 62), so that leg stays
-          # asynchronous and leans on the polls alone.
-          if [ "${{ matrix.backend }}" = "sqlite-elasticsearch" ]; then
+          # the index-refresh window that remains. Only the S3 composite stays
+          # asynchronous: against real S3 the extra per-write latency tipped
+          # the seed-heavy dashboard specs over their budgets (run 62), so
+          # that leg stays asynchronous and leans on the polls alone.
+          if [ "${{ matrix.backend }}" = "sqlite-elasticsearch" ] || \
+             [ "${{ matrix.backend }}" = "postgres-elasticsearch" ] || \
+             [ "${{ matrix.backend }}" = "mongodb-elasticsearch" ]; then
             export HFS_COMPOSITE_SYNC_MODE=synchronous
           fi
 
@@ -330,6 +344,15 @@ jobs:
             HFS_STORAGE_BACKEND=sqlite-elasticsearch \
             HFS_ELASTICSEARCH_NODES="http://$DOCKER_HOST_IP:$ES_PORT" \
             ./target/debug/hfs --database-url :memory: --log-level info --port "$HFS_PORT" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          elif [ "${{ matrix.backend }}" = "postgres-elasticsearch" ]; then
+            HFS_STORAGE_BACKEND=postgres-elasticsearch \
+            HFS_PG_HOST="$DOCKER_HOST_IP" \
+            HFS_PG_PORT="$PG_PORT" \
+            HFS_PG_DBNAME=helios \
+            HFS_PG_USER=helios \
+            HFS_PG_PASSWORD=helios \
+            HFS_ELASTICSEARCH_NODES="http://$DOCKER_HOST_IP:$ES_PORT" \
+            ./target/debug/hfs --log-level info --port "$HFS_PORT" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
           elif [ "${{ matrix.backend }}" = "postgres" ]; then
             HFS_STORAGE_BACKEND=postgres \
             HFS_PG_HOST="$DOCKER_HOST_IP" \
@@ -342,6 +365,12 @@ jobs:
             HFS_STORAGE_BACKEND=mongodb \
             HFS_DATABASE_URL="mongodb://$DOCKER_HOST_IP:$MONGO_PORT/?replicaSet=rs0&directConnection=true" \
             HFS_MONGODB_DATABASE="helios_ui_matrix_${{ github.run_id }}_${{ github.run_attempt }}" \
+            ./target/debug/hfs --log-level info --port "$HFS_PORT" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
+          elif [ "${{ matrix.backend }}" = "mongodb-elasticsearch" ]; then
+            HFS_STORAGE_BACKEND=mongodb-elasticsearch \
+            HFS_DATABASE_URL="mongodb://$DOCKER_HOST_IP:$MONGO_PORT/?replicaSet=rs0&directConnection=true" \
+            HFS_MONGODB_DATABASE="helios_ui_matrix_${{ github.run_id }}_${{ github.run_attempt }}" \
+            HFS_ELASTICSEARCH_NODES="http://$DOCKER_HOST_IP:$ES_PORT" \
             ./target/debug/hfs --log-level info --port "$HFS_PORT" --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
           elif [ "${{ matrix.backend }}" = "s3-elasticsearch" ]; then
             HFS_STORAGE_BACKEND=s3-elasticsearch \
@@ -428,6 +457,7 @@ jobs:
             --label github.run_id=${{ github.run_id }} \
             --label github.workflow=ui-tests-matrix \
             --shm-size=2g -w /work "$PLAYWRIGHT_IMAGE" sleep 3600
+          docker cp crates/ui/assets "$PW_CONTAINER":/work/assets
           docker cp crates/ui/e2e "$PW_CONTAINER":/work/e2e
           # The ES composites index asynchronously: specs that assert an
           # immediate post-write search relax to a bounded poll under this
@@ -447,7 +477,7 @@ jobs:
             -e HFS_E2E_EVENTUAL_SEARCH="$EVENTUAL" \
             -e HFS_E2E_NO_CHART_DATA="$NO_CHART" \
             -e HFS_E2E_NO_TRANSACTIONS="$NO_TX" -w /work/e2e "$PW_CONTAINER" \
-            bash -c "npm ci && npx playwright test"
+            bash -c "npm ci && npm run test:unit && npx playwright test"
 
       - name: Copy Playwright report out
         if: always()

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -84,12 +84,13 @@ jobs:
             --label github.run_id=${{ github.run_id }} \
             --label github.workflow=ui-tests \
             --shm-size=2g -w /work "$PLAYWRIGHT_IMAGE" sleep 3600
-          docker exec "$RUN_CONTAINER" mkdir -p /work/target/debug /work/crates/ui
+          docker exec "$RUN_CONTAINER" mkdir -p /work/target/debug /work/crates/ui/assets
           docker cp target/debug/hfs "$RUN_CONTAINER":/work/target/debug/hfs
           docker cp data "$RUN_CONTAINER":/work/data
+          docker cp crates/ui/assets/. "$RUN_CONTAINER":/work/crates/ui/assets
           docker cp crates/ui/e2e "$RUN_CONTAINER":/work/crates/ui/e2e
           docker exec -e CI=1 -w /work/crates/ui/e2e "$RUN_CONTAINER" \
-            bash -c "npm ci && npx playwright test"
+            bash -c "npm ci && npm run test:unit && npx playwright test"
 
       - name: Copy Playwright report out
         if: always()
@@ -138,13 +139,13 @@ jobs:
 
           reap "$RUN_CONTAINER"
 
-  # T3 (#600): one extra leg, not a version matrix — builds hfs with every
-  # FHIR version feature and runs only the dedicated multi-version spec
-  # against it, so the sidebar's resource-type selector is proven against a
-  # real multi-version binary and not just the single-version default the
-  # `ui-tests` job above (and the rest of this suite) builds. Split into a
-  # build + test job, artifact-handed-off, the same shape
-  # ui-tests-matrix.yml uses for its backend matrix.
+  # Build once with every FHIR version, then boot that binary once per default
+  # version for the complete escaped-value contract. This is intentionally the
+  # version axis of an orthogonal matrix: ui-tests-matrix.yml covers all seven
+  # search-capable storage modes on R4, because the codec and REST alternative
+  # boundary run before backend dispatch. The R6 leg also retains #600's
+  # dedicated selector coverage. Split into build + test jobs,
+  # artifact-handed-off, like ui-tests-matrix.yml's backend matrix.
   ui-multiversion-build:
     name: Build HFS (multi-version + ui)
     runs-on: [self-hosted, Linux]
@@ -177,14 +178,18 @@ jobs:
           retention-days: 1
 
   ui-multiversion-tests:
-    name: helios-ui browser suite (multi-version selector)
+    name: escaped-comma smoke (${{ matrix.fhir_version }})
     needs: ui-multiversion-build
     runs-on: [self-hosted, Linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        fhir_version: [R4, R4B, R5, R6]
     env:
       # Job-scoped override of the workflow-level RUN_CONTAINER: this job runs
       # concurrently with `ui-tests` above and must not fight it for the same
       # container name on the shared remote Docker host.
-      RUN_CONTAINER: ui-e2e-multiversion-${{ github.run_id }}-${{ github.run_attempt }}
+      RUN_CONTAINER: ui-e2e-${{ matrix.fhir_version }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -200,7 +205,7 @@ jobs:
       - name: Make HFS binary executable
         run: chmod +x target/debug/hfs
 
-      - name: Run browser suite (Playwright) — multi-version spec only
+      - name: Run escaped-comma smoke for the selected FHIR version
         run: |
           set -euo pipefail
           docker rm -fv "$RUN_CONTAINER" 2>/dev/null || true
@@ -209,29 +214,63 @@ jobs:
             --label github.run_id=${{ github.run_id }} \
             --label github.workflow=ui-tests \
             --shm-size=2g -w /work "$PLAYWRIGHT_IMAGE" sleep 3600
-          docker exec "$RUN_CONTAINER" mkdir -p /work/target/debug /work/crates/ui
+          docker exec "$RUN_CONTAINER" mkdir -p /work/target/debug /work/crates/ui/assets
           docker cp target/debug/hfs "$RUN_CONTAINER":/work/target/debug/hfs
           docker cp data "$RUN_CONTAINER":/work/data
+          docker cp crates/ui/assets/. "$RUN_CONTAINER":/work/crates/ui/assets
           docker cp crates/ui/e2e "$RUN_CONTAINER":/work/crates/ui/e2e
-          # Pinned away from the build's natural first-enabled version (R4) so
-          # this leg also catches an "always the seed" regression (#600).
-          # boot.mjs forwards its whole environment to the spawned hfs
-          # process unchanged, so no boot.mjs change was needed for this.
-          docker exec -e CI=1 -e HFS_DEFAULT_FHIR_VERSION=R6 -w /work/crates/ui/e2e "$RUN_CONTAINER" \
-            bash -c "npm ci && npx playwright test tests/dashboard-multiversion.spec.ts"
+          # Search uses the server default rather than the sidebar selection,
+          # so each matrix leg must boot HFS with the version under test.
+          # Keep the pre-existing selector regression on the R6 leg too.
+          docker exec -e CI=1 \
+            -e HFS_DEFAULT_FHIR_VERSION=${{ matrix.fhir_version }} \
+            -w /work/crates/ui/e2e "$RUN_CONTAINER" bash -c '
+              set -euo pipefail
+              npm ci
+              npm run test:unit
+              HFS_E2E_PORT=8080 node boot.mjs >/tmp/hfs-escaped-comma.log 2>&1 &
+              server_pid=$!
+              cleanup() { kill -TERM "$server_pid" 2>/dev/null || true; }
+              trap cleanup EXIT
+              ready=0
+              for _ in $(seq 1 180); do
+                if ! kill -0 "$server_pid" 2>/dev/null; then break; fi
+                if node -e "fetch(\"http://127.0.0.1:8080/ui\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"; then
+                  ready=1
+                  break
+                fi
+                sleep 1
+              done
+              if [ "$ready" -ne 1 ]; then
+                cat /tmp/hfs-escaped-comma.log
+                exit 1
+              fi
+              HFS_E2E_BASE_URL=http://127.0.0.1:8080 \
+                npx playwright test tests/queries.spec.ts \
+                  --grep "escaped commas|literal commas|malformed FHIR|empty alternatives|drilling preserves"
+              if [ "$HFS_DEFAULT_FHIR_VERSION" = R6 ]; then
+                HFS_E2E_BASE_URL=http://127.0.0.1:8080 \
+                  npx playwright test tests/dashboard-multiversion.spec.ts
+              fi
+            '
 
       - name: Copy Playwright report out
         if: always()
         run: |
+          mkdir -p "./crates/ui/e2e/multiversion-results-${{ matrix.fhir_version }}"
           docker cp "$RUN_CONTAINER":/work/crates/ui/e2e/playwright-report \
-            ./crates/ui/e2e/playwright-report-multiversion 2>/dev/null || true
+            "./crates/ui/e2e/multiversion-results-${{ matrix.fhir_version }}/playwright-report" \
+            2>/dev/null || true
+          docker cp "$RUN_CONTAINER":/tmp/hfs-escaped-comma.log \
+            "./crates/ui/e2e/multiversion-results-${{ matrix.fhir_version }}/hfs.log" \
+            2>/dev/null || true
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-multiversion
-          path: crates/ui/e2e/playwright-report-multiversion/
+          name: playwright-report-${{ matrix.fhir_version }}
+          path: crates/ui/e2e/multiversion-results-${{ matrix.fhir_version }}/
           retention-days: 7
 
       - name: Remove Playwright container

--- a/crates/rest/src/extractors/search_query_builder.rs
+++ b/crates/rest/src/extractors/search_query_builder.rs
@@ -813,6 +813,18 @@ mod tests {
         // Escaped backslash is unescaped; other escapes (\|) are preserved.
         assert_eq!(split_unescaped_commas("a\\\\b"), vec!["a\\b"]);
         assert_eq!(split_unescaped_commas("sys\\|code"), vec!["sys\\|code"]);
+        assert_eq!(split_unescaped_commas("left\\$right"), vec!["left\\$right"]);
+        assert_eq!(split_unescaped_commas("a\\,b,c"), vec!["a,b", "c"]);
+        assert_eq!(split_unescaped_commas("a\\\\,b"), vec!["a\\", "b"]);
+        assert_eq!(
+            split_unescaped_commas("Muñoz\\,García"),
+            vec!["Muñoz,García"]
+        );
+        // Keep empty alternatives visible to validation instead of silently
+        // dropping them at this syntax boundary.
+        assert_eq!(split_unescaped_commas("a,,b"), vec!["a", "", "b"]);
+        assert_eq!(split_unescaped_commas(",a"), vec!["", "a"]);
+        assert_eq!(split_unescaped_commas("a,"), vec!["a", ""]);
         // Surrounding whitespace is trimmed.
         assert_eq!(split_unescaped_commas(" a , b "), vec!["a", "b"]);
     }

--- a/crates/ui/assets/fhir-search-value.js
+++ b/crates/ui/assets/fhir-search-value.js
@@ -1,0 +1,109 @@
+/*
+ * FHIR search-value escaping shared by the visual query builder.
+ *
+ * This codec starts after URL percent-decoding. It owns only the FHIR layer:
+ * unescaped commas separate OR alternatives. A literal comma is displayed as
+ * itself because one input already represents one alternative. Other valid
+ * escapes (`\\`, `\|`, and `\$`) stay visible because the generic input does
+ * not model token or composite segments separately; retaining their escape
+ * syntax also keeps every edited value reversible.
+ */
+(function (root, factory) {
+  "use strict";
+
+  var codec = factory();
+  if (typeof module === "object" && module.exports) module.exports = codec;
+  if (root) root.HfsFhirSearchValue = codec;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  function parseAlternatives(wireValue) {
+    var input = wireValue == null ? "" : String(wireValue);
+    var alternatives = [];
+    var value = "";
+    var wire = "";
+    var error = null;
+
+    function finish() {
+      alternatives.push({ value: value, wire: wire, error: error });
+      value = "";
+      wire = "";
+      error = null;
+    }
+
+    for (var i = 0; i < input.length; i++) {
+      var current = input[i];
+      if (current === ",") {
+        finish();
+        continue;
+      }
+      if (current !== "\\") {
+        value += current;
+        wire += current;
+        continue;
+      }
+
+      wire += current;
+      if (i + 1 >= input.length) {
+        value += current;
+        error = error || "trailing-escape";
+        continue;
+      }
+
+      var escaped = input[++i];
+      wire += escaped;
+      if (escaped === ",") {
+        value += ",";
+      } else if (escaped === "\\") {
+        value += "\\\\";
+      } else if (escaped === "|" || escaped === "$") {
+        value += "\\" + escaped;
+      } else {
+        value += "\\" + escaped;
+        error = error || "invalid-escape";
+      }
+    }
+    finish();
+
+    return {
+      alternatives: alternatives,
+      error: alternatives.some(function (alternative) {
+        return !!alternative.error;
+      })
+        ? "invalid-escape"
+        : null,
+    };
+  }
+
+  function serializeAlternative(value) {
+    var input = value == null ? "" : String(value);
+    var wire = "";
+    for (var i = 0; i < input.length; i++) {
+      var current = input[i];
+      if (current === "\\") {
+        var next = input[i + 1];
+        if (next === "\\" || next === "|" || next === "$") {
+          wire += "\\" + next;
+          i++;
+        } else {
+          wire += "\\\\";
+        }
+      } else if (current === ",") {
+        wire += "\\,";
+      } else {
+        wire += current;
+      }
+    }
+    return wire;
+  }
+
+  function serializeAlternatives(values) {
+    return (values || []).map(serializeAlternative).join(",");
+  }
+
+  return {
+    parseAlternatives: parseAlternatives,
+    serializeAlternative: serializeAlternative,
+    serializeAlternatives: serializeAlternatives,
+  };
+});

--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -29,6 +29,9 @@
 (function () {
   "use strict";
 
+  var fhirSearchValue = window.HfsFhirSearchValue;
+  if (!fhirSearchValue) throw new Error("FHIR search-value codec is missing");
+
   var SETTINGS = "/_user/settings";
   /* The effective tenant, stamped by the server (#344); FHIR calls carry it. */
   var TENANT = (document.querySelector('meta[name="hfs-tenant"]') || {}).content || "";
@@ -344,12 +347,19 @@
   /* Modifier select + value input + remove button, shared by every row kind. */
   /* One value input inside a row's OR stack (#414). The per-value remove
    * only renders when the stack has siblings. */
-  function orValueInput(host, value) {
+  function orValueInput(host, value, wire, escapeError) {
     var wrap = document.createElement("span");
     wrap.className = "builder-row__orvalue";
     var input = document.createElement("input");
     input.className = "builder-row__value";
     input.value = value;
+    if (wire !== undefined) {
+      input.dataset.fhirWire = wire;
+      input.dataset.fhirDirty = "false";
+    } else {
+      input.dataset.fhirDirty = "true";
+    }
+    if (escapeError) input.dataset.fhirEscapeError = escapeError;
     input.placeholder = sections.dataset.msgValue;
     input.spellcheck = false;
     wrap.appendChild(input);
@@ -476,8 +486,8 @@
   function appendValues(row, rawValue) {
     var host = document.createElement("span");
     host.className = "builder-row__values";
-    rawValue.split(",").forEach(function (v) {
-      orValueInput(host, v);
+    fhirSearchValue.parseAlternatives(rawValue).alternatives.forEach(function (alternative) {
+      orValueInput(host, alternative.value, alternative.wire, alternative.error);
     });
     row.appendChild(host);
 
@@ -998,6 +1008,27 @@
    * yank focus and drop in-flight edits — so re-parsing skips its own echo. */
   var lastSerialized = null;
 
+  function builderHasEscapeError() {
+    return !!(
+      sections && sections.querySelector(".builder-row__value[data-fhir-escape-error]")
+    );
+  }
+
+  function showEscapeError() {
+    showError(null, messages.msgInvalidFhirEscape);
+  }
+
+  function serializedConditionAlternative(input) {
+    var visual = input.value.trim();
+    var isClean = input.dataset.fhirDirty !== "true";
+    if (!visual) {
+      return isClean && input.dataset.fhirWire !== undefined ? input.dataset.fhirWire : null;
+    }
+    return isClean && input.dataset.fhirWire !== undefined
+      ? input.dataset.fhirWire
+      : fhirSearchValue.serializeAlternative(visual);
+  }
+
   /* URL → rows. */
   function renderBuilder() {
     if (!sections || !urlInput) return;
@@ -1023,11 +1054,18 @@
     });
     refreshChainAffordances();
     updatePlain();
+    if (builderHasEscapeError()) showEscapeError();
+    else clearError();
   }
 
   /* Rows → URL. */
   function updateUrl() {
     if (!sections || !urlInput) return;
+    if (builderHasEscapeError()) {
+      showEscapeError();
+      return;
+    }
+    clearError();
     var type = sections.dataset.type || "";
     var parts = [];
     sections.querySelectorAll(".builder-row").forEach(function (row) {
@@ -1069,11 +1107,14 @@
       var mod = modifierEl ? modifierEl.value : "";
       var isPrefix = PREFIXES.indexOf(mod) >= 0;
       var values = [];
+      var isCondition = !!row.querySelector(".builder-row__values");
       row.querySelectorAll(".builder-row__value").forEach(function (vi) {
-        var v = vi.value.trim();
-        if (!v) return;
-        if (isPrefix && !PREFIX_RE.test(v)) v = mod + v;
-        values.push(v);
+        var wire = isCondition
+          ? serializedConditionAlternative(vi)
+          : vi.value.trim() || null;
+        if (wire === null) return;
+        if (isPrefix && !PREFIX_RE.test(wire)) wire = mod + wire;
+        values.push(wire);
       });
       var value = values.join(",");
       if (!isPrefix && mod) key += ":" + mod;
@@ -1089,6 +1130,10 @@
     urlInput.addEventListener("change", renderBuilder);
     sections.addEventListener("input", function (event) {
       if (event.target.closest(".builder-row")) {
+        if (event.target.classList.contains("builder-row__value")) {
+          event.target.dataset.fhirDirty = "true";
+          delete event.target.dataset.fhirEscapeError;
+        }
         updateUrl();
         if (event.target.classList.contains("builder-row__key")) {
           refreshChainAffordances();
@@ -1153,15 +1198,27 @@
       } else if (drillFrom) {
         /* Convert the condition row into a forward-chain row for its
          * reference param, keeping the value the user already typed. */
+        if (builderHasEscapeError()) {
+          showEscapeError();
+          return;
+        }
         var from = drillFrom.closest(".builder-row");
         var refParam = from.querySelector(".builder-row__key").value.trim();
-        var kept = from.querySelector(".builder-row__value").value.trim();
+        var keptMod = from.querySelector(".builder-row__modifier").value;
+        var keptIsPrefix = PREFIXES.indexOf(keptMod) >= 0;
+        var keptValues = [];
+        from.querySelectorAll(".builder-row__value").forEach(function (input) {
+          var wire = serializedConditionAlternative(input);
+          if (wire === null) return;
+          if (keptIsPrefix && !PREFIX_RE.test(wire)) wire = keptMod + wire;
+          keptValues.push(wire);
+        });
         var chain = chainRow({
           kind: "chain",
           hops: [{ ref: refParam, type: "" }],
           key: "",
-          modifier: "",
-          value: kept,
+          modifier: keptIsPrefix ? "" : keptMod,
+          value: keptValues.join(","),
         });
         from.replaceWith(chain);
         chain.querySelector(".builder-row__cparam").focus();
@@ -1288,16 +1345,31 @@
     if (mod === "missing" && (raw === "true" || raw === "false")) {
       return { verb: PLAIN.missing[raw], value: "", showValue: false };
     }
-    var alternatives = raw.split(",").filter(Boolean).map(function (v) {
-      var p = PREFIX_RE.exec(v);
-      return p ? v.slice(2) : v;
-    });
-    var prefix = PREFIX_RE.exec(raw);
-    var verbKey = mod || (prefix ? prefix[1] : "");
-    var verb = PLAIN.verbs[verbKey] != null ? PLAIN.verbs[verbKey] : PLAIN.verbs[""];
+    var alternatives = fhirSearchValue
+      .parseAlternatives(raw)
+      .alternatives.map(function (alternative) {
+        var prefix = mod ? null : PREFIX_RE.exec(alternative.value);
+        var verbKey = mod || (prefix ? prefix[1] : "");
+        return {
+          value: prefix ? alternative.value.slice(2) : alternative.value,
+          verb:
+            PLAIN.verbs[verbKey] != null ? PLAIN.verbs[verbKey] : PLAIN.verbs[""],
+        };
+      })
+      .filter(function (alternative) {
+        return !!alternative.value;
+      });
+    var verb = alternatives.length
+      ? alternatives[0].verb
+      : PLAIN.verbs[mod] != null
+        ? PLAIN.verbs[mod]
+        : PLAIN.verbs[""];
     var joined = alternatives
-      .map(function (v) {
-        return "\u201C" + v + "\u201D";
+      .map(function (alternative, index) {
+        var quoted = "\u201C" + alternative.value + "\u201D";
+        return index > 0 && alternative.verb !== verb
+          ? alternative.verb + " " + quoted
+          : quoted;
       })
       .join(" " + PLAIN.or + " ");
     return { verb: verb, value: joined, showValue: joined !== "" };
@@ -1764,7 +1836,7 @@
   }
 
   function render(doc) {
-    clearError();
+    if (!builderHasEscapeError()) clearError();
     renderRecent(doc);
     /* The Search page renders the builder and the recent list but no saved
      * list; there is nothing further to draw there. */

--- a/crates/ui/e2e/package.json
+++ b/crates/ui/e2e/package.json
@@ -5,6 +5,7 @@
   "description": "Browser-level (Playwright + axe-core) conformance tests for crates/ui (helios-ui). Self-contained: nothing here touches the cargo workspace.",
   "scripts": {
     "test": "playwright test",
+    "test:unit": "node --test unit/*.test.cjs",
     "test:ui": "playwright test --ui",
     "report": "playwright show-report",
     "install-browsers": "playwright install --with-deps chromium"

--- a/crates/ui/e2e/playwright.config.ts
+++ b/crates/ui/e2e/playwright.config.ts
@@ -8,6 +8,14 @@ const PORT = Number(process.env.HFS_E2E_PORT || 8080);
 // external server and skip booting our own (see webServer, below).
 const externalBase = process.env.HFS_E2E_BASE_URL;
 const baseURL = externalBase || `http://127.0.0.1:${PORT}`;
+// Chromium withholds secure-context APIs such as navigator.clipboard from the
+// backend matrix's plain-HTTP Docker-host IP. The suite grants clipboard
+// permissions in the relevant test; this flag makes that grant effective for
+// the one external test origin without weakening HFS or skipping coverage.
+const insecureExternalOrigin =
+  externalBase && new URL(externalBase).protocol === "http:"
+    ? new URL(externalBase).origin
+    : undefined;
 
 export default defineConfig({
   testDir: "./tests",
@@ -22,6 +30,16 @@ export default defineConfig({
   use: {
     baseURL,
     trace: "on-first-retry",
+    ...(insecureExternalOrigin
+      ? {
+          // The legacy headless shell ignores Chromium's secure-origin
+          // allowlist; the full Chromium channel honors it in headless mode.
+          channel: "chromium",
+          launchOptions: {
+            args: [`--unsafely-treat-insecure-origin-as-secure=${insecureExternalOrigin}`],
+          },
+        }
+      : {}),
   },
   projects: [
     {

--- a/crates/ui/e2e/tests/dashboard.spec.ts
+++ b/crates/ui/e2e/tests/dashboard.spec.ts
@@ -132,6 +132,7 @@ test("\"View all resources\" offers empty types, charts a flat line at 0, and ke
   page,
   dashboard,
 }) => {
+  test.skip(noChartData, "no count read path on this backend");
   await dashboard.goto();
   await dashboard.waitForSeries();
 

--- a/crates/ui/e2e/tests/queries.spec.ts
+++ b/crates/ui/e2e/tests/queries.spec.ts
@@ -150,6 +150,25 @@ test.describe("query builder", () => {
       .toBeGreaterThan(1);
   });
 
+  test("drilling preserves a literal comma and every real OR alternative", async ({
+    queries,
+  }) => {
+    await queries.builder.setUrl("Patient?general-practitioner=a%5C%2Cb,c");
+    const row = queries.builder.conditionRows.first();
+    const drill = queries.builder.drillButton(row);
+    await expect(drill).toBeVisible();
+    await drill.click();
+
+    const chain = queries.builder.chainRows.first();
+    await expect(chain.locator(".builder-row__value")).toHaveCount(2);
+    await expect(chain.locator(".builder-row__value").nth(0)).toHaveValue("a,b");
+    await expect(chain.locator(".builder-row__value").nth(1)).toHaveValue("c");
+    await chain.locator(".builder-row__cparam").fill("name");
+    await expect(queries.builder.url).toHaveValue(
+      "GET /Patient?general-practitioner.name=a\\,b,c",
+    );
+  });
+
   test("a _has query hydrates into a reverse-chain row and round-trips", async ({
     queries,
   }) => {
@@ -235,6 +254,92 @@ test.describe("query builder", () => {
     await expect(queries.builder.url).toHaveValue("GET /Patient?name=Smith,Garcia");
   });
 
+  test("escaped commas stay one visual value through narration, editing and Run", async ({
+    queries,
+    request,
+  }) => {
+    const tag = Date.now().toString(36);
+    const literalName = `Comma,Literal-${tag}`;
+    const escapedName = encodeURIComponent(literalName.replace(",", "\\,"));
+    const literal = await createResource(request, "Patient", {
+      name: [{ family: literalName }],
+    });
+    const comma = await createResource(request, "Patient", {
+      name: [{ family: `Comma-${tag}` }],
+    });
+    const literalWord = await createResource(request, "Patient", {
+      name: [{ family: `Literal-${tag}` }],
+    });
+    for (const id of [literal, comma, literalWord]) {
+      await waitSearchable(request, "Patient", id);
+    }
+
+    await queries.goto();
+    await queries.builder.setUrl(`Patient?name:exact=${escapedName}`);
+    const row = queries.builder.conditionRows.first();
+    const value = row.locator(".builder-row__value");
+    await expect(value).toHaveCount(1);
+    await expect(value).toHaveValue(literalName);
+    await expect(queries.page.locator("#query-plain-text")).toContainText(
+      `name is exactly “${literalName}”`,
+    );
+    await expect(queries.page.locator("#query-plain-text")).not.toContainText("” or “");
+
+    const requestSent = queries.page.waitForRequest((candidate) => {
+      const url = new URL(candidate.url());
+      return url.pathname === "/Patient" && url.searchParams.has("name:exact");
+    });
+    await queries.builder.runButton.click();
+    const sent = await requestSent;
+    expect(new URL(sent.url()).searchParams.get("name:exact")).toBe(
+      literalName.replace(",", "\\,"),
+    );
+    await queries.results.waitShown();
+    await expect(queries.results.rows).toHaveCount(1);
+    await expect(queries.results.rows.first()).toContainText(literal);
+
+    await value.fill(`Comma,Edited-${tag}`);
+    await expect(queries.builder.url).toHaveValue(
+      `GET /Patient?name:exact=Comma\\,Edited-${tag}`,
+    );
+  });
+
+  test("literal commas coexist with real OR values in conditions, chains and _has", async ({
+    queries,
+  }) => {
+    await queries.builder.setUrl("Patient?name=a%5C%2Cb,c");
+    let row = queries.builder.conditionRows.first();
+    await expect(row.locator(".builder-row__value")).toHaveCount(2);
+    await expect(row.locator(".builder-row__value").nth(0)).toHaveValue("a,b");
+    await expect(row.locator(".builder-row__value").nth(1)).toHaveValue("c");
+    await row.locator("[data-remove-or]").nth(1).click();
+    await expect(queries.builder.url).toHaveValue("GET /Patient?name=a\\,b");
+
+    await queries.builder.setUrl("Patient?general-practitioner.name=a%5C%2Cb,c");
+    row = queries.builder.chainRows.first();
+    await expect(row.locator(".builder-row__value")).toHaveCount(2);
+    await expect(row.locator(".builder-row__value").nth(0)).toHaveValue("a,b");
+
+    await queries.builder.setUrl("Patient?_has:Observation:patient:code=a%5C%2Cb,c");
+    row = queries.builder.hasRows.first();
+    await expect(row.locator(".builder-row__value")).toHaveCount(2);
+    await expect(row.locator(".builder-row__value").nth(0)).toHaveValue("a,b");
+  });
+
+  test("malformed FHIR escapes keep the GET unchanged until corrected", async ({ queries }) => {
+    await queries.builder.setUrl("Patient?name=a%5Cx");
+    const row = queries.builder.conditionRows.first();
+    await expect(queries.builder.error).toBeVisible();
+    await expect(queries.builder.error).toContainText("invalid FHIR escape");
+
+    await row.locator(".builder-row__key").fill("family");
+    await expect(queries.builder.url).toHaveValue("Patient?name=a%5Cx");
+
+    await row.locator(".builder-row__value").fill("a\\x");
+    await expect(queries.builder.error).toBeHidden();
+    await expect(queries.builder.url).toHaveValue("GET /Patient?family=a\\\\x");
+  });
+
   test("the + or button stacks a value; the per-value × removes it", async ({
     queries,
   }) => {
@@ -249,10 +354,21 @@ test.describe("query builder", () => {
     await expect(queries.builder.url).toHaveValue("GET /Patient?name=Jones");
   });
 
+  test("unchanged empty alternatives survive an unrelated visual edit", async ({ queries }) => {
+    await queries.builder.setUrl("Patient?name=a,,b");
+    const row = queries.builder.conditionRows.first();
+    await expect(row.locator(".builder-row__value")).toHaveCount(3);
+    await row.locator(".builder-row__key").fill("family");
+    await expect(queries.builder.url).toHaveValue("GET /Patient?family=a,,b");
+  });
+
   test("comparator OR values keep a prefix per alternative", async ({ queries }) => {
     await queries.builder.setUrl("Patient?birthdate=ge1980-01-01,le1990-12-31");
     const row = queries.builder.conditionRows.first();
     await expect(row.locator(".builder-row__value")).toHaveCount(2);
+    await expect(queries.page.locator("#query-plain-text")).toContainText(
+      "birthdate is on or after “1980-01-01” or is on or before “1990-12-31”",
+    );
     // The second alternative keeps its own comparator on round-trip.
     await row.locator(".builder-row__value").nth(0).fill("ge1985-01-01");
     await expect(queries.builder.url).toHaveValue(
@@ -580,5 +696,62 @@ test.describe("query builder", () => {
 
     await queries.builder.recentToggle.click();
     await expect(queries.builder.recentPanel).toContainText(/Patient/);
+  });
+
+  test("escaped commas survive Copy, Saved and Recent reloads", async ({
+    context,
+    page,
+    queries,
+  }) => {
+    const tag = Date.now().toString(36);
+    const name = `Escaped comma ${tag}`;
+    const query = `Patient?name:exact=Copy%5C%2C${tag}`;
+    const getQuery = `GET /${query}`;
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await queries.builder.setUrl(query);
+    await queries.builder.copyButton.click();
+    await expect
+      .poll(async () => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe(query);
+
+    await queries.builder.nameInput.fill(name);
+    await queries.builder.saveButton.click();
+    await expect(queries.savedList).toContainText(name);
+
+    await page.reload({ waitUntil: "networkidle" });
+    await queries.builder.recentToggle.click();
+    await queries.builder.recentPanel.locator("[data-saved-load]", { hasText: name }).click();
+    await expect(queries.builder.url).toHaveValue(getQuery);
+    await expect(queries.builder.conditionRows.first().locator(".builder-row__value")).toHaveValue(
+      `Copy,${tag}`,
+    );
+
+    const recentSaved = page.waitForResponse((response) => {
+      const request = response.request();
+      return (
+        new URL(response.url()).pathname === "/_user/settings" &&
+        request.method() === "PATCH" &&
+        response.ok()
+      );
+    });
+    const requestSent = page.waitForRequest((candidate) => {
+      const url = new URL(candidate.url());
+      return url.pathname === "/Patient" && url.searchParams.has("name:exact");
+    });
+    await queries.builder.runButton.click();
+    const [, sent] = await Promise.all([
+      recentSaved,
+      requestSent,
+      queries.results.waitShown(),
+    ]);
+    expect(new URL(sent.url()).searchParams.get("name:exact")).toBe(`Copy\\,${tag}`);
+    await page.reload({ waitUntil: "networkidle" });
+    await queries.builder.recentToggle.click();
+    await queries.builder.recentPanel.getByRole("button", { name: getQuery, exact: true }).click();
+    await expect(queries.builder.url).toHaveValue(getQuery);
+    await expect(queries.builder.conditionRows.first().locator(".builder-row__value")).toHaveValue(
+      `Copy,${tag}`,
+    );
   });
 });

--- a/crates/ui/e2e/unit/fhir-search-value-codec.test.cjs
+++ b/crates/ui/e2e/unit/fhir-search-value-codec.test.cjs
@@ -1,0 +1,74 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const codec = require("../../assets/fhir-search-value.js");
+
+function values(wire) {
+  return codec.parseAlternatives(wire).alternatives.map((alternative) => alternative.value);
+}
+
+test("splits only unescaped commas", () => {
+  assert.deepEqual(values("a,b"), ["a", "b"]);
+  assert.deepEqual(values("a\\,b"), ["a,b"]);
+  assert.deepEqual(values("a\\,b,c"), ["a,b", "c"]);
+  assert.deepEqual(values("a\\\\,b"), ["a\\\\", "b"]);
+});
+
+test("preserves visible backslash, token and composite escapes", () => {
+  assert.deepEqual(values("a\\\\b"), ["a\\\\b"]);
+  assert.deepEqual(values("system\\|value"), ["system\\|value"]);
+  assert.deepEqual(values("left\\$right"), ["left\\$right"]);
+  assert.deepEqual(values("Muñoz\\,García"), ["Muñoz,García"]);
+});
+
+test("keeps exact wire alternatives for unchanged inputs", () => {
+  const parsed = codec.parseAlternatives("a\\,b,c\\|d");
+  assert.deepEqual(
+    parsed.alternatives.map((alternative) => alternative.wire),
+    ["a\\,b", "c\\|d"],
+  );
+});
+
+test("serializes edited visual values back to FHIR escaping", () => {
+  assert.equal(codec.serializeAlternative("a,b"), "a\\,b");
+  assert.equal(codec.serializeAlternative("a\\b"), "a\\\\b");
+  assert.equal(codec.serializeAlternative("a\\\\b"), "a\\\\b");
+  assert.equal(codec.serializeAlternative("system\\|value"), "system\\|value");
+  assert.equal(codec.serializeAlternative("left\\$right"), "left\\$right");
+  assert.equal(codec.serializeAlternatives(["a,b", "c"]), "a\\,b,c");
+});
+
+test("round-trips adjacent escaped backslashes and structural separators", () => {
+  for (const wire of ["a\\\\|b", "a\\\\$b", "a\\\\\\|b", "a\\\\\\$b"]) {
+    const visual = values(wire)[0];
+    assert.equal(codec.serializeAlternative(visual), wire);
+  }
+});
+
+test("reports malformed FHIR escapes without dropping their text", () => {
+  const trailing = codec.parseAlternatives("a\\");
+  assert.equal(trailing.error, "invalid-escape");
+  assert.equal(trailing.alternatives[0].error, "trailing-escape");
+  assert.equal(trailing.alternatives[0].value, "a\\");
+  assert.equal(trailing.alternatives[0].wire, "a\\");
+
+  const unknown = codec.parseAlternatives("a\\x");
+  assert.equal(unknown.error, "invalid-escape");
+  assert.equal(unknown.alternatives[0].error, "invalid-escape");
+  assert.equal(unknown.alternatives[0].value, "a\\x");
+  assert.equal(unknown.alternatives[0].wire, "a\\x");
+});
+
+test("characterizes empty alternatives", () => {
+  assert.deepEqual(values("a,,b"), ["a", "", "b"]);
+  assert.deepEqual(values(",a"), ["", "a"]);
+  assert.deepEqual(values("a,"), ["a", ""]);
+});
+
+test("percent decoding stays outside the FHIR codec", () => {
+  const decoded = decodeURIComponent("Comma%5C%2CLiteral");
+  assert.deepEqual(values(decoded), ["Comma,Literal"]);
+  assert.deepEqual(values("Comma%5C%2CLiteral"), ["Comma%5C%2CLiteral"]);
+  assert.equal(decodeURIComponent("%255C"), "%5C");
+  assert.equal(decodeURIComponent("%2B"), "+");
+});

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -2477,7 +2477,12 @@ mod tests {
 
         assert!(html.contains(r#"id="saved-query-form""#));
         assert!(html.contains(r#"id="saved-queries""#));
+        assert!(html.contains("/ui/assets/fhir-search-value.js"));
         assert!(html.contains("/ui/assets/saved-queries.js"));
+        assert!(
+            html.find("/ui/assets/fhir-search-value.js") < html.find("/ui/assets/saved-queries.js"),
+            "the FHIR search-value codec must load before its consumer"
+        );
         // Search Builder: the featured GET URL input, both submit intents,
         // and the Recent dropdown shell the script hydrates.
         assert!(html.contains(r#"name="url""#));
@@ -2550,6 +2555,14 @@ mod tests {
         // parameter suggestions come from the server-rendered datalist.
         assert!(source.contains("application/fhir+json"));
         assert!(source.contains("/ui/queries/params"));
+    }
+
+    #[test]
+    fn fhir_search_value_codec_is_embedded() {
+        let file = Assets::get("fhir-search-value.js").expect("FHIR search-value codec embedded");
+        let source = std::str::from_utf8(&file.data).expect("FHIR search-value codec is UTF-8");
+        assert!(source.contains("parseAlternatives"));
+        assert!(source.contains("serializeAlternative"));
     }
 
     /// The builder's datalist fragment is fed by the SearchParameter

--- a/crates/ui/templates/pages/queries.html
+++ b/crates/ui/templates/pages/queries.html
@@ -69,6 +69,7 @@
   </div>
 </div>
 
+<script src="/ui/assets/fhir-search-value.js" defer></script>
 <script src="/ui/assets/saved-queries.js" defer></script>
 <script src="/ui/assets/resource-filter.js" defer></script>
 {% endblock %}

--- a/crates/ui/templates/pages/resources.html
+++ b/crates/ui/templates/pages/resources.html
@@ -172,6 +172,7 @@ HFS_NL_SEARCH_MODEL={{ nl.model }}</code></pre>
   </div>
 </div>
 
+<script src="/ui/assets/fhir-search-value.js" defer></script>
 <script src="/ui/assets/saved-queries.js" defer></script>
 {% if nl.configured %}<script src="/ui/assets/nl-search.js" defer></script>{% endif %}
 <script src="/ui/assets/resource-filter.js" defer></script>

--- a/crates/ui/templates/pages/search.html
+++ b/crates/ui/templates/pages/search.html
@@ -118,6 +118,7 @@ HFS_NL_SEARCH_MODEL={{ nl.model }}</code></pre>
   </div>
 </div>
 
+<script src="/ui/assets/fhir-search-value.js" defer></script>
 <script src="/ui/assets/saved-queries.js" defer></script>
 {% if nl.configured %}<script src="/ui/assets/nl-search.js" defer></script>{% endif %}
 <script src="/ui/assets/resource-filter.js" defer></script>

--- a/crates/ui/templates/partials/search-messages.html
+++ b/crates/ui/templates/partials/search-messages.html
@@ -12,5 +12,6 @@
      data-msg-rename-prompt="{{ i18n.t("queries-rename-prompt") }}"
      data-msg-confirm-delete="{{ i18n.t_arg("queries-confirm-delete", "name", "{name}".to_string()) }}"
      data-msg-invalid-url="{{ i18n.t("queries-invalid-url") }}"
+     data-msg-invalid-fhir-escape="{{ i18n.t("queries-invalid-fhir-escape") }}"
      data-msg-unavailable="{{ i18n.t("queries-unavailable") }}"
      data-msg-error="{{ i18n.t("error-generic") }}"></div>

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -173,7 +173,11 @@ async fn status_is_a_fragment_for_htmx_and_varies_on_the_header() {
 
 #[tokio::test]
 async fn embedded_assets_are_served() {
-    for asset in ["/ui/assets/htmx.min.js", "/ui/assets/app.css"] {
+    for asset in [
+        "/ui/assets/htmx.min.js",
+        "/ui/assets/app.css",
+        "/ui/assets/fhir-search-value.js",
+    ] {
         let response = app()
             .oneshot(Request::get(asset).body(Body::empty()).unwrap())
             .await

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -335,6 +335,7 @@ queries-recent = Zuletzt
 queries-recent-heading = Letzte Suchen
 queries-recent-empty = Noch keine letzten Suchen — führe eine aus, um sie hier einzutragen.
 queries-invalid-url = Gib eine Suche wie GET /Patient?name=smith ein — der Ressourcentyp kommt aus dem Pfad.
+queries-invalid-fhir-escape = Diese Abfrage enthält eine ungültige FHIR-Escapesequenz. Korrigiere den maskierten Wert, bevor du ihn visuell bearbeitest.
 
 queries-conditions = Bedingungen
 queries-add-condition = Bedingung hinzufügen

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -339,6 +339,7 @@ queries-recent = Recent
 queries-recent-heading = Recent searches
 queries-recent-empty = No recent searches yet — Run one to record it here.
 queries-invalid-url = Enter a search like GET /Patient?name=smith — the resource type comes from the path.
+queries-invalid-fhir-escape = This query contains an invalid FHIR escape. Correct the escaped value before editing it visually.
 
 queries-conditions = Conditions
 queries-add-condition = Add condition

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -335,6 +335,7 @@ queries-recent = Recientes
 queries-recent-heading = Búsquedas recientes
 queries-recent-empty = Aún no hay búsquedas recientes — ejecuta una para registrarla aquí.
 queries-invalid-url = Escribe una búsqueda como GET /Patient?name=smith — el tipo de recurso sale de la ruta.
+queries-invalid-fhir-escape = Esta consulta contiene un escape FHIR no válido. Corrige el valor escapado antes de editarlo visualmente.
 
 queries-conditions = Condiciones
 queries-add-condition = Añadir condición


### PR DESCRIPTION
Fixes #637

## Summary

The query builder treated every comma as an OR separator, including commas escaped according to the FHIR search syntax. For example, `Comma%5C%2CLiteral` hydrated as two inputs and produced an incorrect plain-language description.

This change adds one shared FHIR search-value codec and uses it for query hydration, narration, and visual reserialization.

## What changed

- Parse only unescaped commas as alternative-value separators.
- Decode `\,` and `\\` when displaying a value in one builder input.
- Preserve `\|` and `\$` for downstream token and composite parsing.
- Escape literal commas and backslashes when writing an input back to the GET query.
- Apply the codec to regular, chained, and `_has` condition rows.
- Keep URI percent-decoding separate from FHIR search-value decoding.
- Leave comma-based controls such as `_elements` unchanged.
- Show a translated validation error for malformed escapes.
- Preserve the original GET query and block visual reserialization until malformed input is corrected.

The same codec now drives hydration, narration, and serialization, so these paths cannot disagree about where an OR alternative starts.

## Example

Input query:

~~~http
GET /Patient?name:exact=Comma%5C%2CLiteral
~~~

Builder state:

~~~text
Comma,Literal
~~~

After editing the value to `Comma,Edited`, the builder emits:

~~~http
GET /Patient?name:exact=Comma\,Edited
~~~

## Test coverage

- [x] FHIR search-value codec unit tests: 8 passed
- [x] Complete saved-query browser spec: 32 passed
- [x] Escaped-value browser contract on R4: 6 passed
- [x] Escaped-value browser contract on R4B: 6 passed
- [x] Escaped-value browser contract on R5: 6 passed
- [x] Escaped-value browser contract on R6: 6 passed
- [x] `cargo test -p helios-ui`
- [x] REST alternative-boundary test with R4, R4B, R5, and R6 enabled
- [x] `cargo fmt --check`
- [x] JavaScript syntax, workflow YAML, and whitespace checks
- [x] GitHub `UI Tests (backend matrix)` workflow on this branch

The permanent CI coverage uses an orthogonal matrix:

- R4, R4B, R5, and R6 against SQLite
- R4 against SQLite, SQLite + Elasticsearch, PostgreSQL, PostgreSQL + Elasticsearch, MongoDB, MongoDB + Elasticsearch, and S3 + Elasticsearch

Standalone S3 is excluded because HFS does not support search in that mode.

The backend workflow was not run locally because no Docker daemon was available. The [manual backend-matrix run](https://github.com/HeliosSoftware/hfs/actions/runs/32767359961) completed successfully on this branch.

## Review

Two independent review passes covered URI versus FHIR escaping ownership, parser and serializer symmetry, normal/chained/`_has` conditions, Copy/Save/Saved/Recent/Run flows, all supported FHIR versions, all search-capable storage modes, malformed input handling, and Elasticsearch eventual consistency.

Both reviewers completed a final recheck with no open findings.

## Manual evidence

The screenshots below were captured through Computer Use. Playwright was not used to generate this evidence.

### Before

An escaped comma is incorrectly rendered as two OR values.
<img width="1332" height="768" alt="before" src="https://github.com/user-attachments/assets/380eb87a-8101-4d70-b104-592ba1333bcc" />

### After hydration

The escaped comma hydrates as one input and the narration describes one exact value.

<img width="1332" height="768" alt="after-hydration" src="https://github.com/user-attachments/assets/509136b8-df5a-4818-b639-a536a1353b7e" />

### After running the search

The request returns the single patient whose name is `Comma,Literal`.

<img width="1332" height="768" alt="after-run" src="https://github.com/user-attachments/assets/d8a3b596-13ae-45d0-8565-0f6d96362347" />

### After editing

Editing the value to `Comma,Edited` serializes the literal comma back as `Comma\,Edited`.

<img width="1332" height="768" alt="after-edit" src="https://github.com/user-attachments/assets/dcd88590-3e2d-48f5-8a29-4c14e5a17464" />