### PR TITLE
fix(ui): dashboard card names the effective FHIR version, worded "used for"

### DIFF
--- a/crates/observability/src/dashboard.rs
+++ b/crates/observability/src/dashboard.rs
@@ -13,11 +13,11 @@
 //!
 //! ## Scope and trust
 //!
-//! The registered provider reports counts for a **single tenant** (the server's
-//! default tenant) and is consumed only by the operator dashboard. Per-tenant
-//! counts are deliberately never exported to the public Prometheus `/metrics`
-//! endpoint (see [`crate::metrics`]); this snapshot is a separate, operator-facing
-//! surface.
+//! Each snapshot reports counts for the single tenant passed to [`snapshot`]
+//! (#344) and is consumed only by the operator dashboard. Per-tenant counts
+//! are deliberately never exported to the public Prometheus `/metrics`
+//! endpoint (see [`crate::metrics`]); this snapshot is a separate,
+//! operator-facing surface.
 //!
 //! ## Time resolution
 //!
@@ -154,7 +154,9 @@ pub struct ExportJobCounts {
 /// FHIR types — so this crate stays dependency-light.
 #[derive(Clone, Debug, Default)]
 pub struct DashboardSnapshot {
-    /// Default FHIR version the server serves (e.g. `"R4"`).
+    /// Default FHIR version the server serves (e.g. `"R4"`), fixed when the
+    /// provider is constructed. The UI's dashboard card does not render this:
+    /// it shows the request's effective version instead (#553).
     pub fhir_version: String,
     /// Total non-deleted resources across all types for the default tenant.
     pub total_resources: u64,

--- a/crates/rest/src/dashboard.rs
+++ b/crates/rest/src/dashboard.rs
@@ -7,9 +7,9 @@
 //! and registers it in [`crate::build_app`]; the UI reads the resulting snapshot
 //! through the storage-agnostic `helios-observability` registry.
 //!
-//! The single-tenant scope matches the operator dashboard: figures reflect the
-//! server's **default tenant** only, and are never exported to the public
-//! Prometheus `/metrics` endpoint (per the design in
+//! Figures are scoped per snapshot call to the requesting tenant (#344; the
+//! server's default tenant is only the empty-id fallback), and are never
+//! exported to the public Prometheus `/metrics` endpoint (per the design in
 //! [`helios_observability::metrics`]). The same [`resource_count_series`] helper
 //! also backs the authenticated `/console/metrics/resource-counts` JSON handler,
 //! so the cumulative-bucketing semantics live in exactly one place.

--- a/crates/ui/e2e/pages/api.ts
+++ b/crates/ui/e2e/pages/api.ts
@@ -6,14 +6,20 @@ import type { APIRequestContext } from "@playwright/test";
 
 const FHIR_JSON = "application/fhir+json";
 
-/** POST a resource; returns the server-assigned id. */
+/** POST a resource; returns the server-assigned id. `tenant` scopes the write
+ * via `X-Tenant-ID` (#553 — the default-tenant routes need no header). */
 export async function createResource(
   request: APIRequestContext,
   type: string,
   body: Record<string, unknown>,
+  tenant?: string,
 ): Promise<string> {
   const res = await request.post(`/${type}`, {
-    headers: { "Content-Type": FHIR_JSON, Accept: FHIR_JSON },
+    headers: {
+      "Content-Type": FHIR_JSON,
+      Accept: FHIR_JSON,
+      ...(tenant ? { "X-Tenant-ID": tenant } : {}),
+    },
     data: { resourceType: type, ...body },
   });
   if (!res.ok()) throw new Error(`create ${type} -> ${res.status()}: ${await res.text()}`);
@@ -73,12 +79,13 @@ export async function waitSearchable(
   request: APIRequestContext,
   type: string,
   id: string,
+  tenant?: string,
   timeoutMs = 15_000,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     const res = await request.get(`/${type}?_id=${id}&_summary=count`, {
-      headers: { Accept: FHIR_JSON },
+      headers: { Accept: FHIR_JSON, ...(tenant ? { "X-Tenant-ID": tenant } : {}) },
     });
     if (res.ok() && (((await res.json()).total as number) ?? 0) >= 1) return;
     if (Date.now() > deadline) {

--- a/crates/ui/e2e/pages/chrome.ts
+++ b/crates/ui/e2e/pages/chrome.ts
@@ -90,4 +90,54 @@ export class AppChrome {
       .click();
     await this.page.waitForLoadState("networkidle");
   }
+
+  /** The tenant disclosure at the top of the sidebar (#344). Only rendered on
+   * multi-tenant installs — a second provisioned tenant, or a non-default
+   * stored choice (`show_tenant_picker`, crates/ui/src/lib.rs) — so specs
+   * must provision a tenant before reaching for it. It is the only
+   * `details.menu` that is a direct child of the sidebar; the version
+   * disclosure lives inside `.sidebar__foot`. */
+  get tenantSelector(): Locator {
+    return this.page.locator("aside.sidebar > details.menu");
+  }
+
+  /** Opens the tenant disclosure and waits for its option list — the options
+   * are htmx-lazy (`hx-get=/ui/tenant/options` on the first toggle), so the
+   * forms only exist after that swap lands. Both waits are bounded: the
+   * config sets no actionTimeout, so an unbounded wait here would hang until
+   * the test timeout with no useful failure location (#553). */
+  async openTenantSelector(): Promise<void> {
+    await this.tenantSelector.waitFor({ timeout: 30_000 });
+    if ((await this.tenantSelector.getAttribute("open")) === null) {
+      await this.tenantSelector.locator("summary").click();
+    }
+    // state: "attached", not the "visible" default — the per-option tenant
+    // inputs are type=hidden, so a visibility wait would never resolve.
+    await this.tenantSelector
+      .locator("form input[name='tenant']")
+      .first()
+      .waitFor({ state: "attached", timeout: 30_000 });
+  }
+
+  /** The tenant id the sidebar currently marks as active. */
+  async currentTenant(): Promise<string> {
+    await this.openTenantSelector();
+    const value = await this.tenantSelector
+      .locator("form:has(button[aria-current='true']) input[name='tenant']")
+      .getAttribute("value");
+    if (!value) throw new Error("no tenant is marked current in the sidebar");
+    return value;
+  }
+
+  /** Submits the sidebar's `POST /ui/tenant` for the given tenant id — the
+   * same round trip the disclosure's own form does. The choice persists
+   * server-side (user-global settings), so specs that switch MUST switch
+   * back before finishing or they leak the tenant into later specs. */
+  async selectTenant(tenant: string): Promise<void> {
+    await this.openTenantSelector();
+    await this.tenantSelector
+      .locator(`form:has(input[value='${tenant}']) button[type='submit']`)
+      .click();
+    await this.page.waitForLoadState("networkidle");
+  }
 }

--- a/crates/ui/e2e/pages/dashboard.ts
+++ b/crates/ui/e2e/pages/dashboard.ts
@@ -12,6 +12,11 @@ export class DashboardPage {
   get statCards(): Locator {
     return this.page.locator(".card.stat");
   }
+  /** The "Resource types" card; its `.stat__sub` names the effective FHIR
+   * version ("used for R4", #553). */
+  get resourceTypesCard(): Locator {
+    return this.page.locator(".card.stat", { hasText: "Resource types" });
+  }
   get exportJobsCard(): Locator {
     return this.page.locator("a.card.stat", { hasText: "Export jobs" });
   }

--- a/crates/ui/e2e/pages/tenants.ts
+++ b/crates/ui/e2e/pages/tenants.ts
@@ -39,10 +39,11 @@ export class TenantsPage {
     await this.addForm.locator("button[type=submit]").click();
     // Provisioning runs in the background (#581): the POST returns as soon as
     // the id is accepted, and the row shows a spinner until `register_tenant`
-    // + the conformance seed finish (~90s measured on this backend). Wait for
-    // the row to settle into its deletable, spinner-free state rather than
-    // just appearing.
-    await this.row(id).locator("[hx-delete]").waitFor({ timeout: 150_000 });
+    // + the conformance seed finish (~90s measured on CI's backend; NTFS dev
+    // machines have been seen to exceed 150s — #553). Wait for the row to
+    // settle into its deletable, spinner-free state rather than just
+    // appearing; the wait is event-driven, so fast disks pay nothing extra.
+    await this.row(id).locator("[hx-delete]").waitFor({ timeout: 300_000 });
     // Collapse the slide-over so its panel stops overlaying the table below.
     // The server already closes it on acceptance (well before settlement),
     // so this is normally a no-op — kept for callers/backends where it isn't.

--- a/crates/ui/e2e/tests/dashboard-multiversion.spec.ts
+++ b/crates/ui/e2e/tests/dashboard-multiversion.spec.ts
@@ -47,7 +47,13 @@ test("switching version changes the dashboard's full type set (membership and co
   // The Resources rail already exposes the complete per-version type list
   // (`resource_type_names()`), independent of the dashboard code path —
   // reading it for R4 and R5 gives ground truth to check the dashboard
-  // picker against, not a value baked into the test.
+  // picker against, not a value baked into the test. Pin R4 explicitly
+  // first: the effective version otherwise starts at the server's seed
+  // (HFS_DEFAULT_FHIR_VERSION — R6 in CI's dedicated job), and an R6 set
+  // masquerading as "R4 ground truth" makes the final R4 assertion demand
+  // an R6-only type of the R4 picker (#553; surfaced when the moving R6
+  // spec build gained DeviceAlert).
+  await chrome.selectVersion("R4");
   await resources.goto();
   const r4Types = new Set(await resources.railTypes());
 
@@ -80,6 +86,32 @@ test("switching version changes the dashboard's full type set (membership and co
   await dashboard.openPicker();
   await expect(dashboard.pickerOption(onlyInR4[0])).toBeVisible();
   await expect(dashboard.pickerOption(onlyInR5[0])).toHaveCount(0);
+});
+
+test("the Resource types card names the selected version, not the boot-time default", async ({
+  dashboard,
+  chrome,
+}) => {
+  // #553: the card's sub-line used to render DashboardSnapshot.fhir_version,
+  // which the provider pins to the boot-time default — so after a sidebar
+  // switch the card and the selector two labels away disagreed. It now
+  // renders the same per-request Status source as the sidebar.
+  const options = await chrome.versionOptions();
+  const before = await chrome.currentVersion();
+  const requested = options.find((v) => v !== before);
+  if (!requested) test.skip(true, "no second compiled version to request instead of the seed");
+
+  await dashboard.goto();
+  await expect(dashboard.resourceTypesCard.locator(".stat__sub")).toHaveText(`used for ${before}`);
+
+  await chrome.selectVersion(requested!);
+  await dashboard.goto();
+  await expect(dashboard.resourceTypesCard.locator(".stat__sub")).toHaveText(
+    `used for ${requested}`,
+  );
+
+  // Restore, so later specs meet the server on the version we found it with.
+  await chrome.selectVersion(before);
 });
 
 test("the picker follows the requested version, not the server's boot-time default", async ({

--- a/crates/ui/e2e/tests/dashboard-tenants.spec.ts
+++ b/crates/ui/e2e/tests/dashboard-tenants.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from "../pages/fixtures";
+import { createResource, waitSearchable } from "../pages/api";
+import type { DashboardPage } from "../pages/dashboard";
+
+// #553: the dashboard snapshot is tenant-scoped (build_index_page ->
+// dashboard::snapshot(window, &tenant.id, ...) — crates/ui/src/lib.rs), but
+// until this spec nothing proved it end to end. It drives the sidebar's own
+// tenant switch and asserts the counts, picker, and chart follow the selected
+// tenant — and that one tenant's resources never surface in another's
+// dashboard.
+//
+// Cost note: provisioning a tenant seeds the conformance packs in the
+// background (~1.4k resources, ~90s on SQLite/NTFS — see tenants.spec.ts), so
+// this file creates ONE extra tenant and pays that cost once. The marker
+// types are chosen to be unused by every other spec in the suite (Flag in the
+// default tenant, Basic in the extra one), so membership assertions cannot
+// collide with state other files leave behind on the shared server.
+
+// Backends whose primary store has no count read path (S3) cannot feed the
+// dashboard's counts or chart; the matrix sets this flag for them and this
+// spec stands down entirely — every assertion here reads counts.
+const noChartData = process.env.HFS_E2E_NO_CHART_DATA === "1";
+
+// Unique per run: a re-run against a long-lived dev server then provisions a
+// fresh tenant instead of colliding with the last run's — the exact Basic
+// count below stays valid, and addTenant never hits the duplicate-id error.
+// (The suite's own webServer boots a throwaway DB, where this is moot.)
+const EXTRA_TENANT = `dash-553-${Date.now().toString(36)}`;
+
+// The tenant choice persists server-side in the user-global settings document
+// (POST /ui/tenant), so a spec that fails mid-switch would leak the extra
+// tenant into every later spec. Always leave the suite on the default tenant.
+test.afterEach(async ({ page, chrome }) => {
+  await page.goto("/ui", { waitUntil: "networkidle" });
+  try {
+    if ((await chrome.tenantSelector.count()) > 0 && (await chrome.currentTenant()) !== "default") {
+      await chrome.selectTenant("default");
+    }
+  } catch {
+    // No picker (single-tenant phase) — nothing to restore.
+  }
+});
+
+/** Reloads until the picker's option list shows the type — outlasts the 15s
+ * dashboard snapshot cache after seeding, like DashboardPage.waitForSeries. */
+async function untilPickerShows(dashboard: DashboardPage, type: string): Promise<void> {
+  for (let attempt = 0; attempt < 12; attempt++) {
+    await dashboard.openPicker();
+    if ((await dashboard.pickerOption(type).count()) > 0) return;
+    await dashboard.page.waitForTimeout(2000);
+    await dashboard.page.reload({ waitUntil: "networkidle" });
+  }
+  throw new Error(`the type picker never offered ${type}`);
+}
+
+test("the dashboard's counts and chart follow the selected tenant, with no leakage either way", async ({
+  request,
+  dashboard,
+  chrome,
+  tenants,
+}) => {
+  test.skip(noChartData, "no count read path on this backend");
+  // Tenant provisioning dominates (see the cost note); its settle-wait alone
+  // may take up to 300s on a slow disk, and the afterEach tenant restore
+  // spends from the same budget.
+  test.setTimeout(600_000);
+
+  // A marker only the default tenant has.
+  const flagId = await createResource(request, "Flag", {
+    status: "active",
+    code: { text: "dashboard tenant isolation (#553)" },
+    subject: { display: "e2e-553" },
+  });
+  await waitSearchable(request, "Flag", flagId);
+
+  // Provision the extra tenant through the maintenance page, then give it
+  // three markers of its own — a count nothing else in the suite can move.
+  await tenants.goto();
+  await tenants.addTenant(EXTRA_TENANT);
+  for (let i = 0; i < 3; i++) {
+    const id = await createResource(
+      request,
+      "Basic",
+      { code: { text: `553 marker ${i}` } },
+      EXTRA_TENANT,
+    );
+    await waitSearchable(request, "Basic", id, EXTRA_TENANT);
+  }
+
+  // The default tenant's dashboard: its own marker, none of the other's.
+  await dashboard.goto();
+  await untilPickerShows(dashboard, "Flag");
+  await expect(dashboard.pickerOption("Basic")).toHaveCount(0);
+
+  // Switch tenants through the sidebar — the same round trip a user makes.
+  await chrome.selectTenant(EXTRA_TENANT);
+  expect(await chrome.currentTenant()).toBe(EXTRA_TENANT);
+
+  // The extra tenant's dashboard: its marker with its exact count, and no
+  // trace of the default tenant's marker.
+  await dashboard.goto();
+  await untilPickerShows(dashboard, "Basic");
+  await expect(dashboard.pickerOption("Basic").locator(".chart-pick__count")).toHaveText("3");
+  await expect(dashboard.pickerOption("Flag")).toHaveCount(0);
+
+  // The chart follows too: charting the marker plots a real series whose
+  // legend total is the tenant's own count.
+  await dashboard.goto("?types=Basic");
+  await dashboard.waitForSeries();
+  const legendEntry = dashboard.legendItems.filter({ hasText: "Basic" });
+  await expect(legendEntry).toHaveCount(1);
+  await expect(legendEntry.locator(".chart-legend__total")).toHaveText("3");
+
+  // And back: the default tenant's dashboard is exactly as we left it —
+  // switching forth and back leaks nothing in either direction.
+  await chrome.selectTenant("default");
+  await dashboard.goto();
+  await untilPickerShows(dashboard, "Flag");
+  await expect(dashboard.pickerOption("Basic")).toHaveCount(0);
+});

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -343,7 +343,10 @@ impl TerminologyNavigation {
 }
 
 impl Status {
-    /// The default FHIR version's display label (`"R4"`, `"R5"`, â€¦).
+    /// Display label (`"R4"`, `"R5"`, â€¦) of the request's effective FHIR
+    /// version â€” the user's stored choice when one is set, else the server
+    /// default. Rendered by the sidebar selector and the dashboard's
+    /// "Resource types" card (#553).
     pub(crate) fn fhir_version_label(&self) -> &'static str {
         self.fhir_version.as_str()
     }
@@ -415,13 +418,14 @@ impl Status {
 /// Dashboard headline metrics rendered by `pages/index.html` (design: Figma
 /// "Dashboard V1.1").
 ///
-/// `resource_types`, `stored_resources`, `fhir_version`, `export_jobs`,
-/// `import_jobs`, and `chart_total` are derived from the live
-/// [`DashboardSnapshot`] (default tenant). `uptime` is the process uptime from
-/// `helios_observability::uptime` (#540); in a cluster it describes only the
-/// node that served this request.
+/// `resource_types`, `stored_resources`, `export_jobs`, `import_jobs`, and
+/// `chart_total` are derived from the live [`DashboardSnapshot`], scoped to
+/// the request's effective tenant (#344). The card's version label is NOT
+/// here: it renders from [`Status`], the same per-request source as the
+/// sidebar selector, so the two can never disagree (#553). `uptime` is the
+/// process uptime from `helios_observability::uptime` (#540); in a cluster it
+/// describes only the node that served this request.
 struct DashboardMetrics {
-    fhir_version: String,
     resource_types: String,
     stored_resources: String,
     /// Bulk-export jobs for the tenant; `None` renders the unavailable state.
@@ -1843,7 +1847,6 @@ fn build_dashboard(
         .collect();
 
     let metrics = DashboardMetrics {
-        fhir_version: snapshot.fhir_version.clone(),
         resource_types: snapshot.distinct_types.to_string(),
         stored_resources: compact_count(snapshot.total_resources),
         export_jobs: snapshot.export_jobs,

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -139,10 +139,10 @@
 
     <!--
       FHIR version selector (#343). A <details> disclosure like the tenant
-      selector, so it works without JavaScript. The label is the server's
-      default version; each option re-loads the current page with `?version=` —
-      the pages with a version dimension (SearchParameters, Compartments)
-      switch, the rest ignore it.
+      selector, so it works without JavaScript. The label is the effective
+      version for this request — the user's stored choice when one is set,
+      else the server default (#553); each option POSTs /ui/version to
+      persist a new choice and reloads the current page.
     -->
     <div class="sidebar__foot">
       <details class="menu menu--up">

--- a/crates/ui/templates/pages/index.html
+++ b/crates/ui/templates/pages/index.html
@@ -9,7 +9,9 @@
   <article class="card stat">
     <span class="stat__label">{{ i18n.t("card-resource-types") }}</span>
     <span class="stat__value">{{ metrics.resource_types }}</span>
-    <span class="stat__sub">{{ i18n.t_arg("card-resource-types-sub", "version", metrics.fhir_version.to_string()) }}</span>
+    {# The effective request version, same source as the sidebar selector —
+       never the snapshot's boot-time default (#553). #}
+    <span class="stat__sub">{{ i18n.t_arg("card-resource-types-sub", "version", status.fhir_version_label().to_string()) }}</span>
   </article>
   <article class="card stat">
     <span class="stat__label">{{ i18n.t("card-stored-resources") }}</span>
@@ -129,7 +131,7 @@
   <div class="chart-empty">{{ i18n.t("chart-empty") }}</div>
   {% else %}
   <!--
-    Server-rendered from the live per-type cumulative counts (default tenant),
+    Server-rendered from the live per-type cumulative counts (active tenant),
     supplied via helios_observability::dashboard. Axis geometry is computed in
     the handler; see crates/ui/src/lib.rs::build_chart. The wrapper hosts the
     tooltip (assets/dashboard.js) — a hover readout layered on top; the chart

--- a/crates/ui/tests/dashboard_multiversion_http.rs
+++ b/crates/ui/tests/dashboard_multiversion_http.rs
@@ -80,6 +80,54 @@ async fn sidebar_lists_every_compiled_fhir_version() {
     }
 }
 
+/// #553: the "Resource types" card's sub-line names the effective request
+/// version and reads "used for", not "enabled for" — the figure above it
+/// counts types with stored data, not a configuration state.
+#[tokio::test]
+async fn resource_types_card_reads_used_for_the_effective_version() {
+    let response = app()
+        .oneshot(Request::get("/ui").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(
+        html.contains("used for R4"),
+        "the Resource types card should read \"used for R4\" on the default build"
+    );
+}
+
+/// #553: switching the sidebar version moves the card's version label with it.
+/// Before this, the card was pinned to the server's boot-time default
+/// (`DashboardSnapshot::fhir_version`) while the sidebar followed the user's
+/// stored choice — two different versions on one page.
+#[cfg(feature = "R4B")]
+#[tokio::test]
+async fn resource_types_card_follows_the_selected_version() {
+    let app = app();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/ui/version")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("version=R4B"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+
+    let response = app
+        .oneshot(Request::get("/ui").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(
+        html.contains("used for R4B"),
+        "the card's version label should follow the selected version, not the boot-time default"
+    );
+}
+
 /// #600: the dashboard's "View all resources" union (#599) follows the
 /// *request's* resolved FHIR version, not the server's default, through the
 /// same `POST /ui/version` the sidebar submits. `Ingredient` joined the spec

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -145,7 +145,7 @@ fhir-version = FHIR { $version }
 fhir-version-heading = FHIR-Version
 
 card-resource-types = Ressourcentypen
-card-resource-types-sub = aktiviert für { $version }
+card-resource-types-sub = verwendet für { $version }
 card-stored-resources = Gespeicherte Ressourcen
 card-stored-resources-sub = im aktiven Tenant
 card-export-jobs = Export-Jobs

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -149,7 +149,7 @@ fhir-version = FHIR { $version }
 fhir-version-heading = FHIR version
 
 card-resource-types = Resource types
-card-resource-types-sub = enabled for { $version }
+card-resource-types-sub = used for { $version }
 card-stored-resources = Stored resources
 card-stored-resources-sub = across active tenant
 card-export-jobs = Export jobs

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -145,7 +145,7 @@ fhir-version = FHIR { $version }
 fhir-version-heading = Versión FHIR
 
 card-resource-types = Tipos de recursos
-card-resource-types-sub = habilitados para { $version }
+card-resource-types-sub = usados para { $version }
 card-stored-resources = Recursos almacenados
 card-stored-resources-sub = en el tenant activo
 card-export-jobs = Trabajos de exportación


### PR DESCRIPTION
Closes #553.

## What changed

**The bug (issue section 2a) was real, and is fixed at the source.** The "Resource types" card rendered `DashboardSnapshot.fhir_version`, which `StorageDashboardProvider::new` pins to `config.default_fhir_version` once at server startup — while the sidebar selector two labels away renders the per-request `RequestVersion`. After a sidebar switch the two disagreed on one page. The card now renders `status.fhir_version_label()` — the exact same per-request `Status` source the sidebar uses — so card/sidebar disagreement is structurally impossible, and the redundant `DashboardMetrics.fhir_version` field is deleted (Askama's compile-time template checking guarantees no consumer was missed). This also fixes the sample-data path, which hardcoded "R4".

**Copy change:** `card-resource-types-sub` reads "used for { $version }" (en), "usados para" (es), "verwendet für" (de) — the figure counts stored resource types, not a configuration state.

**Decision recorded (acceptance criterion 4):** the card shows the **user's selected version**, not the server default. Rationale: the type catalog, sidebar, and the existing "picker follows the requested version" e2e contract already treat the selection as authoritative. The counts remain cross-version (`count_all_types` has no version filter in any backend); version-scoping them would need a version parameter through `DashboardProvider::snapshot`, the snapshot cache key, and version-filtered count queries in all four backends — noted as a possible follow-up, deliberately not done here. The snapshot cache key needs **no** change: nothing version-dependent is rendered from the cached payload anymore.

**Stale docs:** the "(default tenant)" comment on `DashboardMetrics` plus five more stale sites found while verifying (module docs in `helios-rest`/`helios-observability` dashboard modules, the sidebar-selector comment in `base.html`, `fhir_version_label`'s doc, the chart comment in `index.html`).

## Tests

- **Inner ring (new):** `dashboard_multiversion_http.rs` — the card reads "used for R4" on the default build, and follows a `POST /ui/version` switch to R4B (R4B-gated). Both watched failing before the fix.
- **e2e version (new):** `dashboard-multiversion.spec.ts` asserts the card follows a sidebar switch and not the boot-time default.
- **e2e tenants (new):** `dashboard-tenants.spec.ts` — counts, picker, and chart follow the sidebar-selected tenant; a tenant's markers never appear in the other's dashboard, in either direction. Uses suite-unique marker types (`Flag`/`Basic`), a per-run unique tenant id, and new `AppChrome` tenant-picker helpers mirroring the version ones; `api.ts` seeding gains an `X-Tenant-ID` parameter.
- **Pre-existing test repaired:** the multiversion type-set test read its "R4 ground truth" from whatever version the server seeds — under CI's `HFS_DEFAULT_FHIR_VERSION=R6` pin its final R4 assertion demands an R6-only type of the R4 picker, exposed when the moving R6 spec build gained `DeviceAlert`. It now pins R4 explicitly before reading the baseline.
- `addTenant`'s settle ceiling raised 150s → 300s (NTFS dev machines exceed 150s; the wait is event-driven, fast disks pay nothing).

Verified locally: `helios-ui` suite green on the default R4 build (179 tests) and the R4B leg; all 10 existing dashboard browser tests green; the tenant spec green; the multiversion leg 4/4 against a CI-identical `R4,R4B,R5,R6` build pinned to R6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
