### PR TITLE
fix(ui): keep five recent resource types pinned above the rail

### DIFF
--- a/crates/ui/assets/resource-filter.js
+++ b/crates/ui/assets/resource-filter.js
@@ -30,7 +30,7 @@
 (function () {
   "use strict";
 
-  var MAX_RECENT = 3;
+  var MAX_RECENT = 5;
   var DEFAULT_LIST_ID = "sp-rail-list";
   var DEFAULT_ITEM_SELECTOR = "a.filter-rail__item";
   var DEFAULT_ATTR = "data-type";
@@ -246,15 +246,13 @@
    `aria-current` item (the deep-linked type, or the default Patient the page
    scripts mark on load) sits near the middle of the list instead of below
    the fold. Runs on window load, after the deferred page scripts have marked
-   the selection. When a recent-group clone also carries the mark, the last
-   match is the main-list occurrence, which is the one worth revealing. */
+   the selection. Recent clones live outside the scrolling list. */
 (function () {
   "use strict";
   window.addEventListener("load", function () {
     document.querySelectorAll(".filter-rail__list").forEach(function (list) {
-      var marked = list.querySelectorAll('[aria-current="true"]');
-      if (!marked.length) return;
-      var current = marked[marked.length - 1];
+      var current = list.querySelector('[aria-current="true"]');
+      if (!current) return;
       var offset =
         current.getBoundingClientRect().top - list.getBoundingClientRect().top;
       var target = list.scrollTop + offset - (list.clientHeight - current.offsetHeight) / 2;

--- a/crates/ui/e2e/pages/resources.ts
+++ b/crates/ui/e2e/pages/resources.ts
@@ -24,6 +24,9 @@ export class ResourcesPage {
   get railFilter(): Locator {
     return this.page.locator("#type-rail-filter");
   }
+  get typeList(): Locator {
+    return this.page.locator("#type-rail-list");
+  }
   get createButton(): Locator {
     return this.page.locator("#resource-create");
   }
@@ -32,9 +35,8 @@ export class ResourcesPage {
     return this.page.locator("#resource-create .resources-create__label");
   }
 
-  // Direct-child combinator: `#type-rail-recent` (the "Recently used" group,
-  // #603) nests inside `#type-rail-list` too, and its clones carry the same
-  // `data-type`. `>` keeps this scoped to the full, unfiltered list.
+  // Direct-child combinator keeps this scoped to the full, unfiltered list;
+  // recently-used clones live in the sibling group above the scroller.
   railItem(type: string): Locator {
     return this.page.locator(`#type-rail-list > [data-type='${type}']`);
   }
@@ -68,13 +70,14 @@ export class ResourcesPage {
   /** Separates Recently used from the general list (#603 follow-up): only
    * visible once the recent group actually has entries. */
   get recentDivider(): Locator {
-    return this.page.locator("#type-rail-list > .filter-rail__divider");
+    return this.page.locator("#type-rail-recent + .filter-rail__divider");
   }
   /** The general list's own section heading (#603 follow-up). */
   get generalHeading(): Locator {
-    return this.page.locator("#type-rail-list > .filter-rail__heading--group", {
-      hasText: "All types",
-    });
+    return this.page.locator(
+      "#type-rail-recent + .filter-rail__divider + .filter-rail__heading--group",
+      { hasText: "All types" },
+    );
   }
 
   async pickType(type: string): Promise<void> {

--- a/crates/ui/e2e/tests/resources.spec.ts
+++ b/crates/ui/e2e/tests/resources.spec.ts
@@ -131,13 +131,17 @@ test("every resource type is reachable — Create targets each one", async ({ re
 
 // "Recently used" group (#603): a per-browser convenience, populated by
 // resource-filter.js from explicit rail picks and re-rendered on load.
-test("the recently-used group tracks picks, most-recent-first, with counts matching the full list", async ({
+test("the recently-used group caps at five, keeps MRU order, deduplicates, and preserves counts", async ({
   resources,
 }) => {
   await resources.goto("Patient");
-  await resources.pickType("Encounter");
-  await resources.pickType("Observation");
-  await resources.pickType("Encounter"); // re-selection: moves to front, no duplicate
+  await resources.pickType("Account");
+  await resources.pickType("ActivityDefinition");
+  await resources.pickType("AdverseEvent");
+  await resources.pickType("AllergyIntolerance");
+  await resources.pickType("Appointment");
+  await resources.pickType("AppointmentResponse");
+  await resources.pickType("AllergyIntolerance"); // re-selection: moves to front, no duplicate
 
   // The group is client-rendered from localStorage on load, so it only
   // reflects the picks above once the page (re)loads.
@@ -150,13 +154,87 @@ test("the recently-used group tracks picks, most-recent-first, with counts match
 
   const types = await resources.recentGroup
     .locator("a.filter-rail__item[data-type]")
-    .evaluateAll((els) => els.map((e) => (e as HTMLElement).dataset.type));
-  expect(types).toEqual(["Encounter", "Observation"]);
+    .evaluateAll((els) => els.map((e) => (e as HTMLElement).dataset.type!));
+  expect(types).toEqual([
+    "AllergyIntolerance",
+    "AppointmentResponse",
+    "Appointment",
+    "AdverseEvent",
+    "ActivityDefinition",
+  ]);
 
   for (const type of types) {
     const listCount = await resources.count(type).textContent();
     const recentCount = await resources.recentItem(type).locator(".count").textContent();
     expect(recentCount).toBe(listCount);
+  }
+});
+
+test("the type rails keep recents and the All types heading fixed while type items scroll", async ({
+  resources,
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 700 });
+  await resources.goto("Account");
+  for (const type of [
+    "ActivityDefinition",
+    "AdverseEvent",
+    "AllergyIntolerance",
+    "Appointment",
+    "Observation",
+  ]) {
+    await resources.pickType(type);
+  }
+
+  for (const [name, path] of [
+    ["Resources", "/ui/resources?type=Account"],
+    ["Search", "/ui/search?type=Account"],
+    ["Saved queries", "/ui/queries?type=Account"],
+  ] as const) {
+    await test.step(name, async () => {
+      await page.goto(path, { waitUntil: "networkidle" });
+
+      const recent = resources.recentGroup;
+      const divider = resources.recentDivider;
+      const allTypes = resources.generalHeading;
+      const pinned = recent.or(divider).or(allTypes);
+      const list = resources.typeList;
+      const firstType = list.locator("a.filter-rail__item[data-type]").first();
+
+      await expect(recent).toBeVisible();
+      await expect(divider).toBeVisible();
+      await expect(allTypes).toBeVisible();
+
+      const pinnedTopsBefore = await pinned
+        .evaluateAll((elements) => elements.map((element) => element.getBoundingClientRect().top));
+      const firstTypeTopBefore = await firstType.evaluate(
+        (element) => element.getBoundingClientRect().top,
+      );
+      const before = await list.evaluate((element) => ({
+        scrollTop: element.scrollTop,
+        maxScrollTop: element.scrollHeight - element.clientHeight,
+      }));
+      expect(before.maxScrollTop).toBeGreaterThan(0);
+
+      await list.evaluate((element) => {
+        element.scrollTop = element.scrollHeight;
+      });
+      await expect.poll(() => list.evaluate((element) => element.scrollTop)).toBeGreaterThan(
+        before.scrollTop,
+      );
+
+      const pinnedTopsAfter = await pinned
+        .evaluateAll((elements) => elements.map((element) => element.getBoundingClientRect().top));
+      const firstTypeTopAfter = await firstType.evaluate(
+        (element) => element.getBoundingClientRect().top,
+      );
+
+      expect(pinnedTopsAfter).toHaveLength(pinnedTopsBefore.length);
+      pinnedTopsAfter.forEach((top, index) => {
+        expect(Math.abs(top - pinnedTopsBefore[index])).toBeLessThanOrEqual(1);
+      });
+      expect(firstTypeTopAfter).toBeLessThan(firstTypeTopBefore);
+    });
   }
 });
 
@@ -205,7 +283,6 @@ test("a created resource can be deleted from its modal", async ({ resources, pag
 
   // Open it in the modal by searching for it and clicking the result row.
   await resources.goto("Patient");
-  await resources.modal; // ensure page loaded
   await page.locator("input.query-builder__url[name=url]").fill(`Patient?_id=${id}`);
   await page.locator("[data-intent='run']").click();
   await page.locator(`#query-results-body a.url`).first().click();

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -2513,14 +2513,16 @@ mod tests {
         assert!(html.contains("data-addbox-close"));
         // Resource picker rail (#541): a real link per type, server-marked
         // current; no count without a dashboard provider.
-        assert!(html.contains(
-            r#"data-type="Patient" data-full-name="Patient"
-   href="/ui/queries?type=Patient""#
-        ));
-        assert!(html.contains(
-            r#"data-type="Observation" data-full-name="Observation"
-   href="/ui/queries?type=Observation""#
-        ));
+        for resource_type in ["Patient", "Observation"] {
+            let attributes =
+                format!(r#"data-type="{resource_type}" data-full-name="{resource_type}""#);
+            let href = format!(r#"href="/ui/queries?type={resource_type}""#);
+            assert!(
+                html.contains(&attributes),
+                "{resource_type} rail attributes"
+            );
+            assert!(html.contains(&href), "{resource_type} rail link");
+        }
         assert!(!html.contains(r#"class="count""#));
         // Saved Queries has no nav entry any more (#282 folded search / editor
         // / history / saved-queries into Resources); the route still renders.

--- a/crates/ui/templates/pages/queries.html
+++ b/crates/ui/templates/pages/queries.html
@@ -31,13 +31,13 @@
              placeholder="{{ i18n.t("queries-rail-filter") }}"
              aria-label="{{ i18n.t("queries-rail-filter") }}">
     </div>
+    <div class="filter-rail__group" id="type-rail-recent"
+         data-recent-key="hfs-recent-types" data-rail-list="type-rail-list" hidden>
+      <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("sp-rail-recent") }}</div>
+    </div>
+    <div class="filter-rail__divider" aria-hidden="true"></div>
+    <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("rail-all-types-heading") }}</div>
     <div class="filter-rail__list" id="type-rail-list">
-      <div class="filter-rail__group" id="type-rail-recent"
-           data-recent-key="hfs-recent-types" data-rail-list="type-rail-list" hidden>
-        <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("sp-rail-recent") }}</div>
-      </div>
-      <div class="filter-rail__divider" aria-hidden="true"></div>
-      <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("rail-all-types-heading") }}</div>
       {% call rail::rail_items(rail_entries) %}{% endcall %}
     </div>
   </aside>

--- a/crates/ui/templates/pages/resources.html
+++ b/crates/ui/templates/pages/resources.html
@@ -36,13 +36,13 @@
              placeholder="{{ i18n.t("queries-rail-filter") }}"
              aria-label="{{ i18n.t("queries-rail-filter") }}">
     </div>
+    <div class="filter-rail__group" id="type-rail-recent"
+         data-recent-key="hfs-recent-types" data-rail-list="type-rail-list" hidden>
+      <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("sp-rail-recent") }}</div>
+    </div>
+    <div class="filter-rail__divider" aria-hidden="true"></div>
+    <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("rail-all-types-heading") }}</div>
     <div class="filter-rail__list" id="type-rail-list">
-      <div class="filter-rail__group" id="type-rail-recent"
-           data-recent-key="hfs-recent-types" data-rail-list="type-rail-list" hidden>
-        <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("sp-rail-recent") }}</div>
-      </div>
-      <div class="filter-rail__divider" aria-hidden="true"></div>
-      <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("rail-all-types-heading") }}</div>
       {% call rail::rail_items(rail_entries) %}{% endcall %}
     </div>
   </aside>

--- a/crates/ui/templates/pages/search.html
+++ b/crates/ui/templates/pages/search.html
@@ -27,13 +27,13 @@
              placeholder="{{ i18n.t("queries-rail-filter") }}"
              aria-label="{{ i18n.t("queries-rail-filter") }}">
     </div>
+    <div class="filter-rail__group" id="type-rail-recent"
+         data-recent-key="hfs-recent-types" data-rail-list="type-rail-list" hidden>
+      <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("sp-rail-recent") }}</div>
+    </div>
+    <div class="filter-rail__divider" aria-hidden="true"></div>
+    <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("rail-all-types-heading") }}</div>
     <div class="filter-rail__list" id="type-rail-list">
-      <div class="filter-rail__group" id="type-rail-recent"
-           data-recent-key="hfs-recent-types" data-rail-list="type-rail-list" hidden>
-        <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("sp-rail-recent") }}</div>
-      </div>
-      <div class="filter-rail__divider" aria-hidden="true"></div>
-      <div class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("rail-all-types-heading") }}</div>
       {% call rail::rail_items(rail_entries) %}{% endcall %}
     </div>
   </aside>

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -49,6 +49,26 @@ async fn body_text(response: axum::response::Response) -> String {
     String::from_utf8(bytes.to_vec()).unwrap()
 }
 
+fn assert_recent_types_are_pinned_above_the_list(html: &str) {
+    let recent = html
+        .find(r#"id="type-rail-recent""#)
+        .expect("Recently used group");
+    let divider = html
+        .find(r#"class="filter-rail__divider""#)
+        .expect("recent-types divider");
+    let all_types = html.find(">All types<").expect("All types heading");
+    let list = html
+        .find(r#"id="type-rail-list""#)
+        .expect("scrollable type list");
+
+    assert!(recent < divider, "Recently used must precede its divider");
+    assert!(divider < all_types, "the divider must precede All types");
+    assert!(
+        all_types < list,
+        "Recently used and All types must stay outside the scrollable list"
+    );
+}
+
 #[tokio::test]
 async fn index_serves_the_full_landing_page() {
     let response = app()
@@ -474,6 +494,20 @@ async fn nl_search_configured_renders_the_translator_over_an_editable_query() {
     // there is no separate Search nav entry (#282).
 }
 
+#[tokio::test]
+async fn search_and_queries_pin_recent_types_above_the_scrollable_list() {
+    for path in ["/ui/search", "/ui/queries"] {
+        let response = app()
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        let html = body_text(response).await;
+        assert_recent_types_are_pinned_above_the_list(&html);
+    }
+}
+
 /* The resource editor (#264). The endpoint takes the whole in-flight document
  * plus one mutation and hands back the re-rendered body — so these drive it the
  * way the browser does. */
@@ -745,8 +779,7 @@ async fn resources_page_has_the_filter_search_and_create_button() {
     // A divider and an "All types" heading separate the Recently used group
     // from the general list (#603 follow-up), between the recent group and
     // the rail items.
-    assert!(html.contains(r#"class="filter-rail__divider""#));
-    assert!(html.contains(">All types<"));
+    assert_recent_types_are_pinned_above_the_list(&html);
     // The edit modal shell, with its Edit / History tabs.
     assert!(html.contains(r#"id="resource-modal""#));
     assert!(html.contains(r#"data-modal-tab="history""#));


### PR DESCRIPTION
Closes #651

## Summary

- Keep the five most recently selected resource types in MRU order.
- Pin Recently used, its divider, and the All types heading above the scrollable list.
- Apply the same rail structure to Resources, Search, and Saved queries.
- Simplify selected-type auto-reveal now that recent clones live outside the scroller.

## Test coverage

- Select six resource types and verify the five-entry cap, MRU ordering, deduplication, and count parity.
- Scroll the type rail on Resources, Search, and Saved queries and verify that only the type items move.
- Check the pinned structure for all three routes at the HTTP layer.

## Validation

- `cargo test -p helios-ui`
- `cargo fmt --all --check`
- `node --check crates/ui/assets/resource-filter.js`
- `git diff --check`
- `npx playwright test tests/resources.spec.ts tests/a11y.spec.ts --project=chromium` (48 passed)
- Manual QA with Computer Use in the English UI on Resources, Search, Saved queries, Search Parameters, and a deep-linked resource type

## Evidence

The before and after screenshots are attached in the Manual QA evidence comment below.