### PR TITLE
fix(persistence): spec seeding no longer invalidates per-tenant registries on every create

### DIFF
--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -684,12 +684,13 @@ impl ResourceStorage for MongoBackend {
         self.index_resource(&db, tenant_id, resource_type, &id, &resource, &mut session)
             .await?;
 
-        // An active SearchParameter write changes a tenant's overlay: refresh
-        // the stored-param cache (which the per-tenant loader reads) and drop
-        // the cached registries. Draft copies (the seeded spec set) never
-        // overlay, so skip them — avoids an O(n²) reload storm during seeding.
+        // An overlay-affecting SearchParameter write: refresh the stored-param
+        // cache (which the per-tenant loader reads) and drop the cached
+        // registries. Seeded spec copies never affect the overlay (see
+        // `create_affects_overlay`), which keeps bulk seeding from triggering
+        // an O(n²) reload storm.
         if resource_type == "SearchParameter"
-            && crate::search::search_parameter_create_affects_overlay(&resource)
+            && self.tenant_registries().create_affects_overlay(&resource)
         {
             if let Err(e) = self.reload_stored_cache().await {
                 tracing::warn!("SearchParameter cache reload failed: {e}");

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -157,12 +157,12 @@ impl ResourceStorage for PostgresBackend {
         self.index_resource(&client, tenant_id, resource_type, &id, &resource)
             .await?;
 
-        // An *active* SearchParameter write changes a tenant's overlay: reload
-        // the stored cache and drop the per-tenant registries so they rebuild.
-        // Draft copies (the seeded spec set) never overlay, so skip them and
-        // avoid an O(n²) reload storm during bulk seeding.
+        // An overlay-affecting SearchParameter write: reload the stored cache
+        // and drop the per-tenant registries so they rebuild. Seeded spec
+        // copies never affect the overlay (see `create_affects_overlay`),
+        // which keeps bulk seeding from triggering an O(n²) reload storm.
         if resource_type == "SearchParameter"
-            && crate::search::search_parameter_create_affects_overlay(&resource)
+            && self.tenant_registries().create_affects_overlay(&resource)
         {
             if let Err(e) = self.reload_stored_cache().await {
                 tracing::warn!("SearchParameter cache reload failed: {e}");

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -204,12 +204,13 @@ impl ResourceStorage for SqliteBackend {
         // Index the resource for search
         self.index_resource(&conn, tenant_id, resource_type, &id, &resource)?;
 
-        // An *active* SearchParameter write changes this tenant's overlay — drop
-        // its cached registry so the next access rebuilds from storage. Draft
-        // copies (e.g. the seeded spec set) never overlay, so skip them and
-        // avoid an O(n²) rebuild storm during bulk seeding.
+        // An overlay-affecting SearchParameter write changes this tenant's
+        // registry — drop the cached copy so the next access rebuilds from
+        // storage. Seeded spec copies never affect the overlay (see
+        // `create_affects_overlay`), which keeps bulk seeding from triggering
+        // an O(n²) rebuild storm.
         if resource_type == "SearchParameter"
-            && crate::search::search_parameter_create_affects_overlay(&resource)
+            && self.tenant_registries().create_affects_overlay(&resource)
         {
             self.tenant_registries().invalidate(tenant_id);
         }
@@ -1112,9 +1113,10 @@ impl SqliteBackend {
         self.delete_search_index(&conn, tenant_id, resource_type, id)?;
         self.index_resource(&conn, tenant_id, resource_type, id, &resource)?;
 
-        // A restored *active* SearchParameter re-enters this tenant's overlay.
+        // A restored overlay-affecting SearchParameter re-enters this tenant's
+        // overlay.
         if resource_type == "SearchParameter"
-            && crate::search::search_parameter_create_affects_overlay(&resource)
+            && self.tenant_registries().create_affects_overlay(&resource)
         {
             self.tenant_registries().invalidate(tenant_id);
         }

--- a/crates/persistence/src/search/mod.rs
+++ b/crates/persistence/src/search/mod.rs
@@ -95,8 +95,6 @@ pub use seeder::{
     SeedOutcome, seed_spec_compartment_definitions, seed_spec_search_parameters,
     seed_tenant_conformance,
 };
-pub use tenant_registries::{
-    StoredParamLoader, TenantSearchRegistries, search_parameter_create_affects_overlay,
-};
+pub use tenant_registries::{StoredParamLoader, TenantSearchRegistries};
 pub use text_fold::fold_text;
 pub use writer::SearchIndexWriter;

--- a/crates/persistence/src/search/tenant_registries.rs
+++ b/crates/persistence/src/search/tenant_registries.rs
@@ -34,16 +34,6 @@ use crate::search::{SearchParameterDefinition, SearchParameterRegistry};
 /// no store, e.g. S3).
 pub type StoredParamLoader = Arc<dyn Fn(&str) -> Vec<SearchParameterDefinition> + Send + Sync>;
 
-/// Whether creating this `SearchParameter` resource can change a tenant's
-/// overlay. Only `status: active` params are registered into per-tenant
-/// registries, so a create of any other status (notably the `draft` spec copies
-/// seeded into every tenant) need not invalidate the cache — which keeps bulk
-/// seeding from triggering an O(n²) rebuild storm. Update/delete are rare and
-/// invalidate unconditionally.
-pub fn search_parameter_create_affects_overlay(resource: &serde_json::Value) -> bool {
-    resource.get("status").and_then(|s| s.as_str()) == Some("active")
-}
-
 /// A shared base registry plus lazily-built, cached per-tenant registries.
 ///
 /// Backends hold `Arc<TenantSearchRegistries>` in place of the former single
@@ -104,6 +94,26 @@ impl TenantSearchRegistries {
             .write()
             .insert(tenant_id.to_string(), arc.clone());
         arc
+    }
+
+    /// Whether creating this `SearchParameter` resource can change a tenant's
+    /// overlay. Only `status: active` params are registered into per-tenant
+    /// registries, so a create of any other status need not invalidate the
+    /// cache. Neither can an active param whose canonical `url` is already
+    /// registered in the shared base: the overlay rebuild ignores duplicate
+    /// URLs, so registering it is a no-op. That second check is what keeps
+    /// spec seeding from triggering an O(n²) rebuild storm — every seeded copy
+    /// is in the base by construction, and R6's bundle ships them as `active`
+    /// (R4's are all `draft`), so the status check alone does not cover it
+    /// (#667). Update/delete are rare and invalidate unconditionally.
+    pub fn create_affects_overlay(&self, resource: &serde_json::Value) -> bool {
+        if resource.get("status").and_then(|s| s.as_str()) != Some("active") {
+            return false;
+        }
+        match resource.get("url").and_then(|u| u.as_str()) {
+            Some(url) => self.base.read().get_by_url(url).is_none(),
+            None => true,
+        }
     }
 
     /// Drops a tenant's cached registry so the next access rebuilds it from
@@ -207,6 +217,42 @@ mod tests {
                 .get_param("Patient", "name")
                 .is_some()
         );
+    }
+
+    #[test]
+    fn create_affects_overlay_requires_active_status_and_a_url_new_to_the_base() {
+        let regs = registries_with(HashMap::new());
+        let param = |status: &str, url: &str| {
+            serde_json::json!({
+                "resourceType": "SearchParameter",
+                "status": status,
+                "url": url,
+                "code": "name",
+                "base": ["Patient"],
+            })
+        };
+
+        // The R4 spec-bundle shape: seeded copies are draft.
+        assert!(!regs.create_affects_overlay(&param(
+            "draft",
+            "http://acme.health/fhir/SearchParameter/patient-nickname"
+        )));
+        // The R6 spec-bundle shape (#667): seeded copies are active, but their
+        // canonical URL is already registered in the base.
+        assert!(!regs.create_affects_overlay(&param(
+            "active",
+            "http://hl7.org/fhir/SearchParameter/Patient-name"
+        )));
+        // A user-POSTed active param with a new URL changes the overlay.
+        assert!(regs.create_affects_overlay(&param(
+            "active",
+            "http://acme.health/fhir/SearchParameter/patient-nickname"
+        )));
+        // No URL at all: invalidate rather than guess.
+        assert!(regs.create_affects_overlay(&serde_json::json!({
+            "resourceType": "SearchParameter",
+            "status": "active",
+        })));
     }
 
     #[test]


### PR DESCRIPTION
Closes #667

## What

`TenantSearchRegistries::create_affects_overlay` (formerly the free function `search_parameter_create_affects_overlay`) now requires both `status: active` **and** a canonical `url` not already registered in the shared base registry before a `SearchParameter` create invalidates a tenant's cached registry. All four call sites (SQLite create + restore, Postgres create, MongoDB create) go through it.

## Why

Spec conformance seeding (#235) writes every spec SearchParameter into storage on first boot, and the guard assumed those copies are `status: draft`. That holds for R4, but R6's bundle ships **1243 of 1264 entries as `active`** — so under R6 every seeded create invalidated the tenant registry and the next create rebuilt it from scratch (base clone + re-read of all stored params so far). O(n²): the multi-version R6 first boot took minutes and the `ui-tests` multi-version job flaked against its 120 s `webServer` timeout (seen on #663; #659 passed the same day by machine luck).

A create whose url is already in the base can never change the overlay — the overlay rebuild ignores duplicate canonical urls — so skipping invalidation for it is behavior-preserving, on every backend and every FHIR version. A user-POSTed active param with a new url still invalidates exactly as before.

## Measured

Empty SQLite store, `--features R4,R4B,R5,R6,ui,sqlite`, `HFS_DEFAULT_FHIR_VERSION=R6` (Windows debug build):

| | before | after |
|---|---|---|
| first boot to `Server listening` | 4 m 17 s | 1 m 53 s |
| `shadows an existing definition` warnings | 2 395 | 4 |
| warm boot (seeded store) | ~0.5 s | ~0.5 s |

The remaining ~110 s is the real cost of 1 266 sequential SQLite creates on this machine (fsync-bound); the CI runner does that part considerably faster.

## Tests

- New unit test covering the four guard cases (draft, active-with-base-url, active-with-new-url, active-without-url).
- `cargo test -p helios-persistence`: green (800 lib + integration suites).