### PR TITLE
fix(ui): preserve comparators per date OR alternative

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2863,6 +2863,7 @@ button.pill {
 
 .builder-row__key,
 .builder-row__modifier,
+.builder-row__comparator,
 .builder-row__value {
   height: 32px;
   padding: 0 10px;
@@ -2886,6 +2887,12 @@ button.pill {
   color: var(--muted);
 }
 
+.builder-row__comparator {
+  flex-shrink: 0;
+  width: 72px;
+  color: var(--muted);
+}
+
 .builder-row__value {
   flex: 1;
   min-width: 0;
@@ -2895,6 +2902,7 @@ button.pill {
 
 .builder-row__key:focus,
 .builder-row__modifier:focus,
+.builder-row__comparator:focus,
 .builder-row__value:focus {
   border-color: var(--accent);
 }
@@ -4101,7 +4109,7 @@ button.pill {
   flex-direction: column;
   gap: 6px;
   flex: 1;
-  min-width: 0;
+  min-width: 230px;
 }
 
 .builder-row__orvalue {

--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -165,6 +165,15 @@
   /* Comparator prefixes live on the value (ge2020-01-01), not the key. */
   var PREFIXES = ["eq", "ne", "gt", "ge", "lt", "le", "sa", "eb", "ap"];
   var PREFIX_RE = /^(eq|ne|gt|ge|lt|le|sa|eb|ap)(?=[\d])/;
+
+  function parsePrefixedValue(raw) {
+    var match = PREFIX_RE.exec(raw || "");
+    return {
+      comparator: match ? match[1] : "",
+      value: match ? raw.slice(2) : raw,
+    };
+  }
+
   var catalogType = null;
 
   /* Per-type parameter metadata from the catalog fragment's data attributes:
@@ -344,17 +353,40 @@
     });
   }
 
-  /* Modifier select + value input + remove button, shared by every row kind. */
   /* One value input inside a row's OR stack (#414). The per-value remove
-   * only renders when the stack has siblings. */
-  function orValueInput(host, value, wire, escapeError) {
+   * only renders when the stack has siblings. Comparator prefixes belong to
+   * each value, so every alternative owns its own select (#630). */
+  function orValueInput(host, value, wire, escapeError, allowComparator) {
+    allowComparator = allowComparator !== false;
+    var parsed = allowComparator
+      ? parsePrefixedValue(value)
+      : { comparator: "", value: value };
+    var parsedWire =
+      wire === undefined
+        ? null
+        : allowComparator
+          ? parsePrefixedValue(wire)
+          : { comparator: "", value: wire };
     var wrap = document.createElement("span");
     wrap.className = "builder-row__orvalue";
+    var comparator = document.createElement("select");
+    comparator.className = "builder-row__comparator";
+    comparator.setAttribute("aria-label", sections.dataset.msgMatchIs);
+    option(comparator, "", sections.dataset.msgMatchIs, !parsed.comparator);
+    PREFIXES.forEach(function (prefix) {
+      option(comparator, prefix, prefix, parsed.comparator === prefix);
+    });
+    comparator.hidden = !parsed.comparator;
+    wrap.appendChild(comparator);
     var input = document.createElement("input");
     input.className = "builder-row__value";
-    input.value = value;
+    input.value = parsed.value;
     if (wire !== undefined) {
-      input.dataset.fhirWire = wire;
+      /* The comparator is represented by the sibling select. Keeping it in
+       * the preserved wire value would duplicate it when only that select is
+       * edited (for example, `gege1980-01-01`). */
+      input.dataset.fhirWire =
+        parsedWire.comparator === parsed.comparator ? parsedWire.value : wire;
       input.dataset.fhirDirty = "false";
     } else {
       input.dataset.fhirDirty = "true";
@@ -404,22 +436,36 @@
     if (!modifier) return;
     var selected = modifier.value;
     var mods = applicableMods(paramType);
-    var prefixes = applicablePrefixes(paramType);
     modifier.textContent = "";
     option(modifier, "", sections.dataset.msgMatchIs, !selected);
     mods.forEach(function (m) {
       option(modifier, m, ":" + m, selected === m);
     });
-    prefixes.forEach(function (p) {
-      option(modifier, p, p, selected === p);
-    });
     /* A modifier from a pasted URL stays selectable even when the type
      * would not offer it. */
-    if (selected && mods.indexOf(selected) < 0 && prefixes.indexOf(selected) < 0) {
+    if (selected && mods.indexOf(selected) < 0) {
       option(modifier, selected, ":" + selected, true);
     }
     var panel = row.querySelector(".builder-row__modpanel");
     if (panel) fillModPanel(panel, row, mods);
+  }
+
+  /* Re-gates the per-value comparator selects without discarding an explicit
+   * prefix from a pasted URL whose parameter type is unknown or unexpected. */
+  function refreshComparatorControls(row, paramType) {
+    var prefixes = applicablePrefixes(paramType);
+    row.querySelectorAll(".builder-row__comparator").forEach(function (comparator) {
+      var selected = comparator.value;
+      comparator.textContent = "";
+      option(comparator, "", sections.dataset.msgMatchIs, !selected);
+      prefixes.forEach(function (prefix) {
+        option(comparator, prefix, prefix, selected === prefix);
+      });
+      if (selected && prefixes.indexOf(selected) < 0) {
+        option(comparator, selected, selected, true);
+      }
+      comparator.hidden = prefixes.length === 0 && !selected;
+    });
   }
 
   /* Best-effort param type for a row's modifier target, from the cached
@@ -433,12 +479,10 @@
       return (((PARAM_META[t] || {})[leaf] || {}).type) || "";
     }
     if (row.classList.contains("builder-row--chain")) {
-      var chainLeaf = leafEl.value.trim();
-      for (var cached in PARAM_META) {
-        var m = PARAM_META[cached][chainLeaf];
-        if (m) return m.type;
-      }
-      return "";
+      /* refillLeaf resolves this against the chain's actual target types.
+       * Do not guess from unrelated resource registries that happen to use
+       * the same search-parameter code. */
+      return row.dataset.modType || "";
     }
     var key = row.querySelector(".builder-row__key");
     if (!key) return "";
@@ -446,11 +490,13 @@
   }
 
   /* Re-gates a row's modifier controls when its param type changed. */
-  function regateModifiers(row) {
-    var t = rowParamType(row);
-    if (row.dataset.modType === t) return;
-    row.dataset.modType = t;
-    refreshModifierControls(row, t);
+  function regateModifiers(row, resolvedType) {
+    var t = arguments.length > 1 ? resolvedType : rowParamType(row);
+    if (row.dataset.modType !== t) {
+      row.dataset.modType = t;
+      refreshModifierControls(row, t);
+    }
+    refreshComparatorControls(row, t);
   }
 
   /* The MODIFY panel: each applicable modifier as a chip with its
@@ -483,11 +529,17 @@
 
   /* FHIR's OR is a comma list on one parameter (`name=Smith,Jones`): the
    * value column stacks one input per alternative, plus the `+ or` button. */
-  function appendValues(row, rawValue) {
+  function appendValues(row, rawValue, allowComparators) {
     var host = document.createElement("span");
     host.className = "builder-row__values";
     fhirSearchValue.parseAlternatives(rawValue).alternatives.forEach(function (alternative) {
-      orValueInput(host, alternative.value, alternative.wire, alternative.error);
+      orValueInput(
+        host,
+        alternative.value,
+        alternative.wire,
+        alternative.error,
+        allowComparators,
+      );
     });
     row.appendChild(host);
 
@@ -502,23 +554,15 @@
   function appendTail(row, part) {
     var value = part.value;
     var selectedMod = part.modifier;
-    var prefix = PREFIX_RE.exec(value);
-    if (!selectedMod && prefix) {
-      selectedMod = prefix[1];
-      value = value.slice(2);
-    }
     var modifier = document.createElement("select");
     modifier.className = "builder-row__modifier";
     option(modifier, "", sections.dataset.msgMatchIs, !selectedMod);
     COLON_MODIFIERS.forEach(function (m) {
       option(modifier, m, ":" + m, selectedMod === m);
     });
-    PREFIXES.forEach(function (p) {
-      option(modifier, p, p, selectedMod === p);
-    });
     row.appendChild(modifier);
 
-    appendValues(row, value);
+    appendValues(row, value, !selectedMod);
 
     var adv = document.createElement("button");
     adv.type = "button";
@@ -575,6 +619,7 @@
     appendTail(row, part);
 
     var base = sections.dataset.type || "";
+    var leafRefillSeq = 0;
 
     /* Candidate resource types feeding hop k: the selected type of the
      * previous hop, else all of its registry targets (base type at k=0). */
@@ -647,21 +692,29 @@
     }
 
     function refillLeaf() {
+      var refillSeq = ++leafRefillSeq;
+      var leafCode = leaf.input.value.trim();
       leafTypes(function (types) {
         var pending = types.length;
         var codes = [];
         var anyRef = false;
-        if (!pending) return;
+        var resolvedTypes = [];
+        if (!pending) {
+          if (refillSeq === leafRefillSeq) regateModifiers(row, "");
+          return;
+        }
         types.forEach(function (t) {
           fetchParams(t).then(function (meta) {
             Object.keys(meta).forEach(function (code) {
               if (codes.indexOf(code) < 0) codes.push(code);
             });
-            var m = meta[leaf.input.value.trim()];
+            var m = meta[leafCode];
             if (m && m.type === "reference") anyRef = true;
-            if (--pending === 0) {
+            if (m && resolvedTypes.indexOf(m.type) < 0) resolvedTypes.push(m.type);
+            if (--pending === 0 && refillSeq === leafRefillSeq) {
               fillList(leaf.list, codes.sort());
               deeper.hidden = !anyRef;
+              regateModifiers(row, resolvedTypes.length === 1 ? resolvedTypes[0] : "");
             }
           });
         });
@@ -750,10 +803,16 @@
     appendTail(row, part);
 
     var base = sections.dataset.type || "";
+    var paramsRefillSeq = 0;
     function refillParams() {
+      var refillSeq = ++paramsRefillSeq;
       var t = type.input.value.trim();
-      if (!t) return;
+      if (!t) {
+        regateModifiers(row, "");
+        return;
+      }
       fetchParams(t).then(function (meta) {
+        if (refillSeq !== paramsRefillSeq) return;
         var codes = Object.keys(meta).sort();
         /* The link must be a reference param that can point at the base
          * type; params with no declared targets stay offered. */
@@ -766,9 +825,14 @@
           }),
         );
         fillList(leaf.list, codes);
+        regateModifiers(row, ((meta[leaf.input.value.trim()] || {}).type) || "");
       });
     }
     type.input.addEventListener("input", refillParams);
+    leaf.input.addEventListener("input", function () {
+      var meta = PARAM_META[type.input.value.trim()] || {};
+      regateModifiers(row, ((meta[leaf.input.value.trim()] || {}).type) || "");
+    });
     refillParams();
 
     return row;
@@ -917,15 +981,10 @@
       row.appendChild(drill);
     }
 
-    /* Comparator prefixes render in the modifier select but are rejoined
-     * onto the value; colon modifiers are rejoined onto the key. */
+    /* Colon modifiers are joined onto the key. Comparator prefixes are owned
+     * by each value alternative and rendered by appendValues. */
     var value = part.value;
     var selectedMod = part.modifier;
-    var prefix = PREFIX_RE.exec(value);
-    if (!selectedMod && prefix) {
-      selectedMod = prefix[1];
-      value = value.slice(2);
-    }
 
     if (kind !== "control") {
       var modifier = document.createElement("select");
@@ -937,15 +996,12 @@
         COLON_MODIFIERS.forEach(function (m) {
           option(modifier, m, ":" + m, selectedMod === m);
         });
-        PREFIXES.forEach(function (p) {
-          option(modifier, p, p, selectedMod === p);
-        });
       }
       row.appendChild(modifier);
     }
 
     if (kind === "condition") {
-      appendValues(row, value);
+      appendValues(row, value, !selectedMod);
       var adv = document.createElement("button");
       adv.type = "button";
       adv.className = "builder-row__adv";
@@ -1105,19 +1161,24 @@
       if (!key) return;
       var modifierEl = row.querySelector(".builder-row__modifier");
       var mod = modifierEl ? modifierEl.value : "";
-      var isPrefix = PREFIXES.indexOf(mod) >= 0;
       var values = [];
-      var isCondition = !!row.querySelector(".builder-row__values");
-      row.querySelectorAll(".builder-row__value").forEach(function (vi) {
-        var wire = isCondition
-          ? serializedConditionAlternative(vi)
-          : vi.value.trim() || null;
-        if (wire === null) return;
-        if (isPrefix && !PREFIX_RE.test(wire)) wire = mod + wire;
-        values.push(wire);
-      });
+      var alternatives = row.querySelectorAll(".builder-row__orvalue");
+      if (alternatives.length) {
+        alternatives.forEach(function (alternative) {
+          var input = alternative.querySelector(".builder-row__value");
+          var wire = serializedConditionAlternative(input);
+          if (wire === null) return;
+          var comparator = alternative.querySelector(".builder-row__comparator");
+          values.push((comparator ? comparator.value : "") + wire);
+        });
+      } else {
+        row.querySelectorAll(".builder-row__value").forEach(function (vi) {
+          var v = vi.value.trim();
+          if (v) values.push(v);
+        });
+      }
       var value = values.join(",");
-      if (!isPrefix && mod) key += ":" + mod;
+      if (mod) key += ":" + mod;
       parts.push(key + "=" + value);
     });
     urlInput.value =
@@ -1129,15 +1190,36 @@
   if (sections && urlInput) {
     urlInput.addEventListener("change", renderBuilder);
     sections.addEventListener("input", function (event) {
-      if (event.target.closest(".builder-row")) {
+      var row = event.target.closest(".builder-row");
+      if (row) {
         if (event.target.classList.contains("builder-row__value")) {
           event.target.dataset.fhirDirty = "true";
           delete event.target.dataset.fhirEscapeError;
         }
+        /* Key modifiers and value comparators occupied one select before
+         * #630, so preserve their mutual exclusion when either is edited. */
+        if (event.target.classList.contains("builder-row__comparator") && event.target.value) {
+          var rowModifier = row.querySelector(".builder-row__modifier");
+          if (rowModifier) {
+            rowModifier.value = "";
+            var rowPanel = row.querySelector(".builder-row__modpanel");
+            if (rowPanel) {
+              fillModPanel(rowPanel, row, applicableMods(row.dataset.modType || ""));
+            }
+          }
+        } else if (event.target.classList.contains("builder-row__modifier") && event.target.value) {
+          row.querySelectorAll(".builder-row__comparator").forEach(function (comparator) {
+            comparator.value = "";
+          });
+          var modifierPanel = row.querySelector(".builder-row__modpanel");
+          if (modifierPanel) {
+            fillModPanel(modifierPanel, row, applicableMods(row.dataset.modType || ""));
+          }
+        }
         updateUrl();
         if (event.target.classList.contains("builder-row__key")) {
           refreshChainAffordances();
-          regateModifiers(event.target.closest(".builder-row"));
+          regateModifiers(row);
         }
       }
     });
@@ -1169,6 +1251,11 @@
         var chipRow = modChip.closest(".builder-row");
         var sel = chipRow.querySelector(".builder-row__modifier");
         sel.value = sel.value === modChip.dataset.modChip ? "" : modChip.dataset.modChip;
+        if (sel.value) {
+          chipRow.querySelectorAll(".builder-row__comparator").forEach(function (comparator) {
+            comparator.value = "";
+          });
+        }
         fillModPanel(
           chipRow.querySelector(".builder-row__modpanel"),
           chipRow,
@@ -1180,8 +1267,11 @@
       var removeOr = event.target.closest("[data-remove-or]");
       var add = event.target.closest("[data-add]");
       if (addOr) {
-        var orHost = addOr.closest(".builder-row").querySelector(".builder-row__values");
-        orValueInput(orHost, "").focus();
+        var orRow = addOr.closest(".builder-row");
+        var orHost = orRow.querySelector(".builder-row__values");
+        var addedValue = orValueInput(orHost, "");
+        refreshComparatorControls(orRow, orRow.dataset.modType || "");
+        addedValue.focus();
         return;
       }
       if (removeOr) {
@@ -1205,19 +1295,19 @@
         var from = drillFrom.closest(".builder-row");
         var refParam = from.querySelector(".builder-row__key").value.trim();
         var keptMod = from.querySelector(".builder-row__modifier").value;
-        var keptIsPrefix = PREFIXES.indexOf(keptMod) >= 0;
         var keptValues = [];
-        from.querySelectorAll(".builder-row__value").forEach(function (input) {
+        from.querySelectorAll(".builder-row__orvalue").forEach(function (alternative) {
+          var input = alternative.querySelector(".builder-row__value");
           var wire = serializedConditionAlternative(input);
           if (wire === null) return;
-          if (keptIsPrefix && !PREFIX_RE.test(wire)) wire = keptMod + wire;
-          keptValues.push(wire);
+          var comparator = alternative.querySelector(".builder-row__comparator");
+          keptValues.push((comparator ? comparator.value : "") + wire);
         });
         var chain = chainRow({
           kind: "chain",
           hops: [{ ref: refParam, type: "" }],
           key: "",
-          modifier: keptIsPrefix ? "" : keptMod,
+          modifier: keptMod,
           value: keptValues.join(","),
         });
         from.replaceWith(chain);
@@ -1339,46 +1429,66 @@
     });
   }
 
-  function plainValue(part) {
+  function plainValues(part) {
     var raw = part.value || "";
     var mod = part.modifier || "";
     if (mod === "missing" && (raw === "true" || raw === "false")) {
-      return { verb: PLAIN.missing[raw], value: "", showValue: false };
+      return [{ verb: PLAIN.missing[raw], value: "", showValue: false }];
     }
     var alternatives = fhirSearchValue
       .parseAlternatives(raw)
       .alternatives.map(function (alternative) {
-        var prefix = mod ? null : PREFIX_RE.exec(alternative.value);
-        var verbKey = mod || (prefix ? prefix[1] : "");
-        return {
-          value: prefix ? alternative.value.slice(2) : alternative.value,
-          verb:
-            PLAIN.verbs[verbKey] != null ? PLAIN.verbs[verbKey] : PLAIN.verbs[""],
-        };
+        var parsed = mod
+          ? { comparator: "", value: alternative.value }
+          : parsePrefixedValue(alternative.value);
+        var verbKey = mod || parsed.comparator;
+        var verb = PLAIN.verbs[verbKey] != null ? PLAIN.verbs[verbKey] : PLAIN.verbs[""];
+        var quoted = parsed.value ? "\u201C" + parsed.value + "\u201D" : "";
+        return { verb: verb, value: quoted, showValue: quoted !== "" };
       })
       .filter(function (alternative) {
-        return !!alternative.value;
+        return alternative.showValue;
       });
-    var verb = alternatives.length
-      ? alternatives[0].verb
-      : PLAIN.verbs[mod] != null
-        ? PLAIN.verbs[mod]
-        : PLAIN.verbs[""];
-    var joined = alternatives
-      .map(function (alternative, index) {
-        var quoted = "\u201C" + alternative.value + "\u201D";
-        return index > 0 && alternative.verb !== verb
-          ? alternative.verb + " " + quoted
-          : quoted;
-      })
-      .join(" " + PLAIN.or + " ");
-    return { verb: verb, value: joined, showValue: joined !== "" };
+    if (alternatives.length) return alternatives;
+    return [
+      {
+        verb: PLAIN.verbs[mod] != null ? PLAIN.verbs[mod] : PLAIN.verbs[""],
+        value: "",
+        showValue: false,
+      },
+    ];
   }
 
-  function renderPlainClause(withValue, withoutValue, args, plain) {
-    args.verb = plain.verb;
-    if (plain.showValue) args.value = plain.value;
-    return tpl(plain.showValue ? withValue : withoutValue, args);
+  function renderPlainClause(withValue, withoutValue, args, alternatives) {
+    var groups = [];
+    alternatives.forEach(function (alternative) {
+      var previous = groups[groups.length - 1];
+      if (
+        previous &&
+        previous.verb === alternative.verb &&
+        previous.showValue &&
+        alternative.showValue
+      ) {
+        previous.value += " " + PLAIN.or + " " + alternative.value;
+      } else {
+        groups.push({
+          verb: alternative.verb,
+          value: alternative.value,
+          showValue: alternative.showValue,
+        });
+      }
+    });
+    return groups
+      .map(function (group) {
+        var clauseArgs = {};
+        Object.keys(args).forEach(function (key) {
+          clauseArgs[key] = args[key];
+        });
+        clauseArgs.verb = group.verb;
+        if (group.showValue) clauseArgs.value = group.value;
+        return tpl(group.showValue ? withValue : withoutValue, clauseArgs);
+      })
+      .join(" " + PLAIN.or + " ");
   }
 
   function updatePlain() {
@@ -1398,14 +1508,14 @@
           })
           .concat([part.key])
           .join(PLAIN.arrow + " ");
-        var cv = plainValue(part);
+        var cv = plainValues(part);
         clauses.push(
           renderPlainClause(PLAIN.clause, PLAIN.clauseNoValue, { path: path }, cv),
         );
         return;
       }
       if (part.kind === "has") {
-        var hv = plainValue(part);
+        var hv = plainValues(part);
         clauses.push(
           renderPlainClause(
             PLAIN.has,
@@ -1443,7 +1553,7 @@
         return;
       }
       if (CONTROL_KEYS.indexOf(part.key) >= 0 || !part.key) return;
-      var v = plainValue(part);
+      var v = plainValues(part);
       clauses.push(
         renderPlainClause(PLAIN.clause, PLAIN.clauseNoValue, { path: part.key }, v),
       );

--- a/crates/ui/e2e/tests/queries.spec.ts
+++ b/crates/ui/e2e/tests/queries.spec.ts
@@ -362,17 +362,139 @@ test.describe("query builder", () => {
     await expect(queries.builder.url).toHaveValue("GET /Patient?family=a,,b");
   });
 
-  test("comparator OR values keep a prefix per alternative", async ({ queries }) => {
-    await queries.builder.setUrl("Patient?birthdate=ge1980-01-01,le1990-12-31");
+  test("modifier values that resemble comparators remain literal", async ({ queries }) => {
+    await queries.builder.setUrl("Patient?name:exact=ge1980,le1990");
     const row = queries.builder.conditionRows.first();
-    await expect(row.locator(".builder-row__value")).toHaveCount(2);
+    const comparators = row.locator(".builder-row__comparator");
+    const values = row.locator(".builder-row__value");
+
+    await expect(row.locator(".builder-row__modifier")).toHaveValue("exact");
+    await expect(comparators.nth(0)).toHaveValue("");
+    await expect(comparators.nth(1)).toHaveValue("");
+    await expect(values.nth(0)).toHaveValue("ge1980");
+    await expect(values.nth(1)).toHaveValue("le1990");
     await expect(queries.page.locator("#query-plain-text")).toContainText(
-      "birthdate is on or after “1980-01-01” or is on or before “1990-12-31”",
+      "name is exactly “ge1980” or “le1990”",
     );
-    // The second alternative keeps its own comparator on round-trip.
-    await row.locator(".builder-row__value").nth(0).fill("ge1985-01-01");
+
+    await values.nth(0).fill("ge1981");
     await expect(queries.builder.url).toHaveValue(
-      "GET /Patient?birthdate=ge1985-01-01,le1990-12-31",
+      "GET /Patient?name:exact=ge1981,le1990",
+    );
+  });
+
+  const mixedComparatorOrders = [
+    {
+      name: "le then ge",
+      query: "Patient?birthdate=le1979-12-31,ge1980-01-02",
+      comparators: ["le", "ge"],
+      values: ["1979-12-31", "1980-01-02"],
+      narration:
+        "birthdate is on or before “1979-12-31” or birthdate is on or after “1980-01-02”",
+    },
+    {
+      name: "ge then le",
+      query: "Patient?birthdate=ge1980-01-02,le1979-12-31",
+      comparators: ["ge", "le"],
+      values: ["1980-01-02", "1979-12-31"],
+      narration:
+        "birthdate is on or after “1980-01-02” or birthdate is on or before “1979-12-31”",
+    },
+  ];
+
+  for (const scenario of mixedComparatorOrders) {
+    test(`mixed date comparators hydrate independently: ${scenario.name}`, async ({ queries }) => {
+      await queries.builder.setUrl(scenario.query);
+      const row = queries.builder.conditionRows.first();
+      const alternatives = row.locator(".builder-row__orvalue");
+      const comparators = row.locator(".builder-row__comparator");
+      const values = row.locator(".builder-row__value");
+
+      await expect(alternatives).toHaveCount(2);
+      await expect(comparators).toHaveCount(2);
+      await expect(comparators.nth(0)).toHaveValue(scenario.comparators[0]);
+      await expect(comparators.nth(1)).toHaveValue(scenario.comparators[1]);
+      await expect(comparators.nth(0)).toBeVisible();
+      await expect(comparators.nth(1)).toBeVisible();
+      await expect(values.nth(0)).toHaveValue(scenario.values[0]);
+      await expect(values.nth(1)).toHaveValue(scenario.values[1]);
+      await values.nth(0).fill(scenario.values[0]);
+      await expect(queries.builder.url).toHaveValue(`GET /${scenario.query}`);
+      await expect(queries.page.locator("#query-plain-text")).toContainText(
+        scenario.narration,
+      );
+    });
+  }
+
+  test("editing one date comparator leaves its sibling unchanged", async ({ queries }) => {
+    await queries.builder.setUrl("Patient?birthdate=le1979-12-31,ge1980-01-02");
+    const row = queries.builder.conditionRows.first();
+    const comparators = row.locator(".builder-row__comparator");
+    const values = row.locator(".builder-row__value");
+
+    await comparators.nth(1).selectOption("gt");
+    await expect(comparators.nth(0)).toHaveValue("le");
+    await expect(comparators.nth(1)).toHaveValue("gt");
+    await expect(queries.builder.url).toHaveValue(
+      "GET /Patient?birthdate=le1979-12-31,gt1980-01-02",
+    );
+    await expect(queries.page.locator("#query-plain-text")).toContainText(
+      "birthdate is on or before “1979-12-31” or birthdate is after “1980-01-02”",
+    );
+
+    await values.nth(0).fill("1978-12-31");
+    await expect(queries.builder.url).toHaveValue(
+      "GET /Patient?birthdate=le1978-12-31,gt1980-01-02",
+    );
+    await expect(comparators.nth(1)).toHaveValue("gt");
+  });
+
+  test("adding and removing date alternatives keeps comparators with their values", async ({
+    queries,
+  }) => {
+    await queries.builder.setUrl("Patient?birthdate=le1979-12-31");
+    const row = queries.builder.conditionRows.first();
+
+    await row.locator("[data-add-or]").click();
+    const alternatives = row.locator(".builder-row__orvalue");
+    await expect(alternatives).toHaveCount(2);
+    await expect(alternatives.nth(1).locator(".builder-row__comparator")).toHaveValue("");
+    await alternatives.nth(1).locator(".builder-row__comparator").selectOption("ge");
+    await alternatives.nth(1).locator(".builder-row__value").fill("1980-01-02");
+    await expect(queries.builder.url).toHaveValue(
+      "GET /Patient?birthdate=le1979-12-31,ge1980-01-02",
+    );
+
+    await alternatives.nth(0).locator("[data-remove-or]").click();
+    await expect(alternatives).toHaveCount(1);
+    await expect(alternatives.first().locator(".builder-row__comparator")).toHaveValue("ge");
+    await expect(alternatives.first().locator(".builder-row__value")).toHaveValue(
+      "1980-01-02",
+    );
+    await expect(queries.builder.url).toHaveValue("GET /Patient?birthdate=ge1980-01-02");
+  });
+
+  test("date comparators stay available in forward and reverse chains", async ({
+    queries,
+  }) => {
+    await queries.builder.setUrl("Patient?link:Patient.birthdate=1980-01-02");
+    const chain = queries.builder.chainRows.first();
+    const chainComparator = chain.locator(".builder-row__comparator");
+    await expect(chain).toHaveAttribute("data-mod-type", "date");
+    await expect(chainComparator).toBeVisible();
+    await chainComparator.selectOption("ge");
+    await expect(queries.builder.url).toHaveValue(
+      "GET /Patient?link:Patient.birthdate=ge1980-01-02",
+    );
+
+    await queries.builder.setUrl("Patient?_has:Observation:patient:date=2020-01-01");
+    const reverseChain = queries.builder.hasRows.first();
+    const reverseComparator = reverseChain.locator(".builder-row__comparator");
+    await expect(reverseChain).toHaveAttribute("data-mod-type", "date");
+    await expect(reverseComparator).toBeVisible();
+    await reverseComparator.selectOption("le");
+    await expect(queries.builder.url).toHaveValue(
+      "GET /Patient?_has:Observation:patient:date=le2020-01-01",
     );
   });
 
@@ -402,6 +524,21 @@ test.describe("query builder", () => {
     await expect(chip).toContainText("anywhere");
   });
 
+  test("choosing a comparator clears the active modifier chip", async ({ queries }) => {
+    await queries.builder.setUrl("Patient?birthdate=1980-01-02");
+    const row = queries.builder.conditionRows.first();
+    await row.locator("[data-toggle-mods]").click();
+    const missingChip = row.locator("[data-mod-chip=missing]");
+
+    await missingChip.click();
+    await expect(missingChip).toHaveAttribute("aria-pressed", "true");
+    await row.locator(".builder-row__comparator").selectOption("ge");
+
+    await expect(row.locator(".builder-row__modifier")).toHaveValue("");
+    await expect(missingChip).toHaveAttribute("aria-pressed", "false");
+    await expect(queries.builder.url).toHaveValue("GET /Patient?birthdate=ge1980-01-02");
+  });
+
   const modifierLayoutScenarios = [
     {
       name: "desktop string with two OR values in Spanish",
@@ -422,6 +559,14 @@ test.describe("query builder", () => {
       query: "Patient?gender=male",
       modType: "token",
       requiredChip: "of-type",
+    },
+    {
+      name: "date alternatives with independent comparators",
+      width: 901,
+      lang: "en",
+      query: "Patient?birthdate=le1979-12-31,ge1980-01-02",
+      modType: "date",
+      requiredChip: "missing",
     },
     {
       name: "unknown parameter at a narrow width in English",
@@ -490,7 +635,8 @@ test.describe("query builder", () => {
         const panelClientRect = panel.getBoundingClientRect();
         const visibleLeaves = Array.from(
           element.querySelectorAll(
-            ".builder-row__key, .builder-row__modifier, .builder-row__value, " +
+            ".builder-row__key, .builder-row__modifier, .builder-row__comparator, " +
+              ".builder-row__value, " +
               ".builder-row__remove--or, .builder-row__or, .builder-row__adv, [data-remove-row]",
           ),
         ).filter((leaf) => {


### PR DESCRIPTION
## Summary

- give every comma-separated OR alternative its own comparator control
- keep comparator prefixes separate from visible date values during hydration
- serialize and narrate every alternative using its own comparator
- preserve comparator support in chained and `_has` searches
- keep key modifiers and value comparators mutually exclusive and synchronized
- maintain a non-overlapping responsive layout

## Evidence

The queries below were hydrated without pressing **Run**, so the screenshots compare the builder state without changing backend data.

### `le`, then `ge`

Before: one shared `le` control, `ge` embedded in the second visible value, and both alternatives narrated as "on or before."

After: independent `le` and `ge` controls, clean date values, and a distinct narration for each boundary.

| Before | After |
|---|---|
| <img width="1399" height="768" alt="Before: one shared le comparator leaves ge embedded in the second date value" src="https://github.com/user-attachments/assets/ba20fc3c-30e6-448f-822f-0d5d296b39b4" /> | <img width="1400" height="768" alt="After: independent le and ge comparator controls with clean values and correct narration" src="https://github.com/user-attachments/assets/92e036de-4846-44b0-b613-fa8530866627" /> |

### `ge`, then `le`

Before: one shared `ge` control, `le` embedded in the second visible value, and both alternatives narrated as "on or after."

After: independent `ge` and `le` controls, clean date values, and narration that follows the reversed order.

| Before | After |
|---|---|
| <img width="1399" height="768" alt="Before: one shared ge comparator leaves le embedded in the second date value" src="https://github.com/user-attachments/assets/ac337d5a-1508-4be8-929c-abcd80f85e3b" /> | <img width="1400" height="768" alt="After: independent ge and le comparator controls with clean values and correct narration" src="https://github.com/user-attachments/assets/baa746d0-f4d4-4307-b708-6053b5b6d368" /> |

The baseline screenshots were captured through Computer Use. When the macOS window-capture service later stopped exposing application windows (`cgWindowNotFound`), the after screenshots were captured with the project's Playwright browser as a documented fallback. All four files remain outside the repository.

## Test plan

- `cargo test -p helios-ui --lib -j1` — 74 passed
- `npx playwright test tests/queries.spec.ts --project=chromium` — 32 passed
- `npx playwright test tests/a11y.spec.ts tests/no-cdn.spec.ts --project=chromium` — 35 passed
- `cargo check -p helios-ui --features R4B -j1`
- `cargo check -p helios-ui --features R5 -j1`
- `DOCS_RS=1 cargo check -p helios-ui --features R6 -j1`
- `node --check crates/ui/assets/saved-queries.js`
- `git diff --check`

This is a client-side query-builder change. It does not alter search execution or storage-backend code; the same UI asset is served for every backend.

Closes #630
