### PR TITLE
fix(build): pin byte-embedded UI content to LF checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Content that is embedded into the binary byte-verbatim (Askama templates,
+# fluent locales, rust-embed text assets) must check out with LF everywhere:
+# rendered output is compared against LF string literals in tests, and a CRLF
+# Windows checkout fails every multi-line assertion of rendered HTML (#671).
+# Binary assets (fonts, images) carry no attribute and stay untouched.
+crates/ui/templates/** text eol=lf
+crates/ui/assets/**/*.js text eol=lf
+crates/ui/assets/**/*.css text eol=lf
+locales/** text eol=lf


### PR DESCRIPTION
Closes #671

## What

A root `.gitattributes` pinning the byte-embedded UI content to LF checkouts:

- `crates/ui/templates/**` (Askama, compiled byte-verbatim)
- `crates/ui/assets/**/*.js` and `**/*.css` (rust-embed)
- `locales/**` (fluent)

Binary assets (fonts, images) carry no attribute and are untouched. The files are already LF in the index, so this changes nothing in history — only how they materialize in a working tree.

## Why

rustc normalizes CRLF to LF inside string literals, but Askama/rust-embed reproduce the working tree's bytes exactly. On a CRLF checkout (git-for-windows `autocrlf` default) every rendered page contains CRLF while every test literal contains LF, so each **multi-line exact-match assertion** of rendered HTML fails — `tests::queries_page_renders_shell_and_marks_nav_current` took down `Test Rust` on #659 when the job landed on the Windows agent `github-agent4`, and the same commit passes untouched on a Linux agent. Runner lottery, not the PR.

## Verified

On a Windows checkout: before the attribute, `queries_page_renders_shell_and_marks_nav_current` and `resources_deep_links_focus_the_selected_type` fail; after re-smudging the pinned trees (`rm` + `git checkout --`), both pass with no source change.

Note for Windows dev boxes: after pulling this, run `git rm -r --cached crates/ui/templates crates/ui/assets locales && git checkout -- .` (or re-clone) once so the pinned trees re-materialize with LF.