### PR TITLE
feat(ui): SQL on FHIR as a top-level nav section with five routed children

### DIFF
--- a/crates/ui/e2e/pages/chrome.ts
+++ b/crates/ui/e2e/pages/chrome.ts
@@ -18,11 +18,6 @@ export class AppChrome {
     return this.page.locator(`a.nav-item[href='${href}']`);
   }
 
-  /** A disabled "coming soon" nav entry by its visible label. */
-  soonItem(label: string): Locator {
-    return this.page.locator("span.nav-item--soon", { hasText: label });
-  }
-
   themeButton(theme: Theme): Locator {
     return this.page.locator(`[data-set-theme='${theme}']`);
   }

--- a/crates/ui/e2e/pages/routes.ts
+++ b/crates/ui/e2e/pages/routes.ts
@@ -22,6 +22,11 @@ export const ROUTES = [
   "/ui/bulk-export",
   "/ui/bulk-export/active",
   "/ui/subscriptions",
+  "/ui/sql/view-definitions",
+  "/ui/sql/queries",
+  "/ui/sql/views",
+  "/ui/sql/export",
+  "/ui/sql/files",
 ];
 
 // The bulk-import detail page only exists with a submission behind it. Seed

--- a/crates/ui/e2e/tests/chrome.spec.ts
+++ b/crates/ui/e2e/tests/chrome.spec.ts
@@ -42,9 +42,26 @@ test("there is no expand/collapse toggle", async ({ page }) => {
 test("the Batch & Data section lists Import and Export", async ({ page, chrome }) => {
   await page.goto("/ui", { waitUntil: "networkidle" });
   await chrome.sidebar.hover();
-  // Import (#527) and Export (#537) are live workspaces; SQL-on-FHIR is
-  // still a placeholder.
   await expect(chrome.navLink("/ui/bulk-import")).toBeVisible();
   await expect(chrome.navLink("/ui/bulk-export")).toBeVisible();
-  await expect(chrome.soonItem("SQL-on-FHIR")).toBeVisible();
+});
+
+test("SQL on FHIR is its own section with five navigable children", async ({
+  page,
+  chrome,
+}) => {
+  // #649: the former coming-soon placeholder inside Batch & Data became a
+  // top-level section whose every child is a real route.
+  await page.goto("/ui", { waitUntil: "networkidle" });
+  await chrome.sidebar.hover();
+  for (const href of [
+    "/ui/sql/view-definitions",
+    "/ui/sql/queries",
+    "/ui/sql/views",
+    "/ui/sql/export",
+    "/ui/sql/files",
+  ]) {
+    await expect(chrome.navLink(href)).toBeVisible();
+  }
+  await expect(page.locator(".nav-item--soon")).toHaveCount(0);
 });

--- a/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
+++ b/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
@@ -63,12 +63,11 @@ for (const { href, url } of NAV) {
   });
 }
 
-test("the 'coming soon' nav entries are inert, not links", async ({ page }) => {
+test("no nav entry is a dead 'coming soon' placeholder", async ({ page }) => {
+  // The last placeholder became the SQL on FHIR section (#649). Every entry
+  // in the menu now navigates; a reintroduced inert span would regress that.
   await page.goto("/ui");
-  const soon = page.locator("span.nav-item--soon");
-  await expect(soon.first()).toBeVisible();
-  // None of them is an anchor — they cannot navigate.
-  expect(await soon.evaluateAll((els) => els.every((e) => e.tagName !== "A"))).toBe(true);
+  await expect(page.locator(".nav-item--soon")).toHaveCount(0);
 });
 
 test("the Resources type rail navigates via plain links with no JavaScript", async ({

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -850,6 +850,13 @@ pub fn mount_with_conformance_source(
         .route("/ui/capability-statement", get(capability_page))
         // Batch/Transaction workspace (#476): upload â†’ preflight â†’ response.
         .route("/ui/batch", get(batch_page))
+        // SQL on FHIR section (#649): stub pages until each surface lands,
+        // starting with the ViewDefinition Editor.
+        .route("/ui/sql/view-definitions", get(sql_view_definitions_page))
+        .route("/ui/sql/queries", get(sql_queries_page))
+        .route("/ui/sql/views", get(sql_views_page))
+        .route("/ui/sql/export", get(sql_export_page))
+        .route("/ui/sql/files", get(sql_files_page))
         .route("/ui/subscriptions", get(subscriptions::page))
         // Schema-driven resource editor (#264). One POST endpoint applies every
         // structural mutation and re-renders: the document rides with it.
@@ -1501,6 +1508,156 @@ async fn batch_page(
         i18n: I18n::new(locale),
         active_page: "batch",
     })
+}
+
+/// Shared stub behind the SQL on FHIR nav children (#649): every menu entry
+/// navigates somewhere real from day one; each page states what it will host
+/// and which already-routed server operation serves that data. The pages are
+/// replaced one by one, starting with the ViewDefinition Editor.
+#[derive(Template)]
+#[template(path = "pages/sql-stub.html")]
+struct SqlStubPage {
+    status: Status,
+    i18n: I18n,
+    active_page: &'static str,
+    title_key: &'static str,
+    lede_key: &'static str,
+    body_key: &'static str,
+    /// The server route(s) the finished page will drive, shown verbatim.
+    api: &'static str,
+}
+
+/// (active_page, title, lede, body, api) for one SQL on FHIR stub.
+type SqlStubSpec = (
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+);
+
+fn render_sql_stub(
+    state: &WebState,
+    locale: RequestLocale,
+    rv: RequestVersion,
+    rt: &RequestTenant,
+    spec: SqlStubSpec,
+) -> Response {
+    let (active_page, title_key, lede_key, body_key, api) = spec;
+    render(SqlStubPage {
+        status: current_status(state, rv.0, rt),
+        i18n: I18n::new(locale),
+        active_page,
+        title_key,
+        lede_key,
+        body_key,
+        api,
+    })
+}
+
+async fn sql_view_definitions_page(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+    rt: RequestTenant,
+) -> Response {
+    render_sql_stub(
+        &state,
+        locale,
+        rv,
+        &rt,
+        (
+            "sql-view-definitions",
+            "sql-vd-title",
+            "sql-vd-lede",
+            "sql-vd-body",
+            "POST /$sql-run",
+        ),
+    )
+}
+
+async fn sql_queries_page(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+    rt: RequestTenant,
+) -> Response {
+    render_sql_stub(
+        &state,
+        locale,
+        rv,
+        &rt,
+        (
+            "sql-queries",
+            "sql-queries-title",
+            "sql-queries-lede",
+            "sql-queries-body",
+            "POST /$sql-run",
+        ),
+    )
+}
+
+async fn sql_views_page(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+    rt: RequestTenant,
+) -> Response {
+    render_sql_stub(
+        &state,
+        locale,
+        rv,
+        &rt,
+        (
+            "sql-views",
+            "sql-views-title",
+            "sql-views-lede",
+            "sql-views-body",
+            "POST /$sql-run",
+        ),
+    )
+}
+
+async fn sql_export_page(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+    rt: RequestTenant,
+) -> Response {
+    render_sql_stub(
+        &state,
+        locale,
+        rv,
+        &rt,
+        (
+            "sql-export",
+            "sql-export-title",
+            "sql-export-lede",
+            "sql-export-body",
+            "POST /$sql-export · GET /export/{job_id}/status",
+        ),
+    )
+}
+
+async fn sql_files_page(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+    rt: RequestTenant,
+) -> Response {
+    render_sql_stub(
+        &state,
+        locale,
+        rv,
+        &rt,
+        (
+            "sql-files",
+            "sql-files-title",
+            "sql-files-lede",
+            "sql-files-body",
+            "GET /export/{job_id}/result · GET /export/{job_id}/{filename}",
+        ),
+    )
 }
 
 /// The read-only CapabilityStatement page (#653): the live `/metadata`

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -87,10 +87,36 @@
         <span class="icon">{% include "icons/export.svg" %}</span>
         <span class="nav-item__label">{{ i18n.t("nav-export") }}</span>
       </a>
-      <span class="nav-item nav-item--soon" title="{{ i18n.t("nav-sql-on-fhir") }}">
+      <!--
+        SQL on FHIR (#649): its own top-level section, a peer of Work / Batch &
+        Data / Server, replacing the single dead placeholder that used to sit
+        inside Batch & Data. Every child is a real route — the pages behind
+        them arrive in follow-up changes, starting with the ViewDefinition
+        Editor. The child is labeled "SQL Export" (not "Export") because the
+        sidebar already carries Batch & Data's FHIR Bulk Data Export, a
+        different operation.
+      -->
+      <div class="nav__section">{{ i18n.t("nav-section-sql-on-fhir") }}</div>
+      <a class="nav-item" href="/ui/sql/view-definitions"{% if active_page == "sql-view-definitions" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-sql-view-definitions") }}">
         <span class="icon">{% include "icons/grid.svg" %}</span>
-        <span class="nav-item__label">{{ i18n.t("nav-sql-on-fhir") }}</span>
-      </span>
+        <span class="nav-item__label">{{ i18n.t("nav-sql-view-definitions") }}</span>
+      </a>
+      <a class="nav-item" href="/ui/sql/queries"{% if active_page == "sql-queries" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-sql-queries") }}">
+        <span class="icon">{% include "icons/code.svg" %}</span>
+        <span class="nav-item__label">{{ i18n.t("nav-sql-queries") }}</span>
+      </a>
+      <a class="nav-item" href="/ui/sql/views"{% if active_page == "sql-views" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-sql-views") }}">
+        <span class="icon">{% include "icons/layers-platforms.svg" %}</span>
+        <span class="nav-item__label">{{ i18n.t("nav-sql-views") }}</span>
+      </a>
+      <a class="nav-item" href="/ui/sql/export"{% if active_page == "sql-export" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-sql-export") }}">
+        <span class="icon">{% include "icons/export.svg" %}</span>
+        <span class="nav-item__label">{{ i18n.t("nav-sql-export") }}</span>
+      </a>
+      <a class="nav-item" href="/ui/sql/files"{% if active_page == "sql-files" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-sql-files") }}">
+        <span class="icon">{% include "icons/copy.svg" %}</span>
+        <span class="nav-item__label">{{ i18n.t("nav-sql-files") }}</span>
+      </a>
 
       <div class="nav__section">{{ i18n.t("nav-section-server") }}</div>
       <a class="nav-item" href="/ui/tenants"{% if active_page == "tenants" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-tenants") }}">

--- a/crates/ui/templates/pages/sql-stub.html
+++ b/crates/ui/templates/pages/sql-stub.html
@@ -1,0 +1,25 @@
+{% extends "layouts/base.html" %}
+
+{#
+  Shared stub behind the SQL on FHIR nav children (#649): every menu entry
+  navigates somewhere real from day one, and each page states what it will
+  host and which server operation already serves that data. The pages are
+  replaced one by one, starting with the ViewDefinition Editor.
+#}
+
+{% block title %}{{ i18n.t(title_key) }} — {{ i18n.t("app-title") }}{% endblock %}
+
+{% block content %}
+<section class="page-head">
+  <h1 class="page-head__title">{{ i18n.t(title_key) }}</h1>
+  <p class="page-head__lede">{{ i18n.t(lede_key) }}</p>
+</section>
+
+<section class="card">
+  <div class="card-head">
+    <h3>{{ i18n.t("sql-stub-heading") }}</h3>
+  </div>
+  <div class="detail__field"><span>{{ i18n.t("sql-stub-planned") }}</span><div>{{ i18n.t(body_key) }}</div></div>
+  <div class="detail__field"><span>{{ i18n.t("sql-stub-api") }}</span><div><code>{{ api }}</code></div></div>
+</section>
+{% endblock %}

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -1246,3 +1246,55 @@ async fn editor_opens_the_root_picker_on_an_empty_document() {
     .await;
     assert!(!html.contains(r#"<details class="editor-add" open>"#));
 }
+
+/// #649: SQL on FHIR is a top-level nav section whose five children are real
+/// routes — the dead `nav-item--soon` placeholder is gone — and each stub
+/// page answers 200 and marks its own nav entry current.
+#[tokio::test]
+async fn sql_on_fhir_section_navigates_to_real_stub_pages() {
+    let response = app()
+        .oneshot(Request::get("/ui/batch").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    assert!(html.contains(">SQL on FHIR</div>"));
+    for href in [
+        "/ui/sql/view-definitions",
+        "/ui/sql/queries",
+        "/ui/sql/views",
+        "/ui/sql/export",
+        "/ui/sql/files",
+    ] {
+        assert!(
+            html.contains(&format!(r#"href="{href}""#)),
+            "{href} missing from the nav"
+        );
+    }
+    // No entry in the menu is a dead placeholder any more.
+    assert!(!html.contains("nav-item--soon"));
+
+    for href in [
+        "/ui/sql/view-definitions",
+        "/ui/sql/queries",
+        "/ui/sql/views",
+        "/ui/sql/export",
+        "/ui/sql/files",
+    ] {
+        let response = app()
+            .oneshot(Request::get(href).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{href}");
+        let html = body_text(response).await;
+        assert!(
+            html.contains(&format!(r#"href="{href}" aria-current="page""#)),
+            "{href} does not mark its nav entry current"
+        );
+        // The stub states which server operation already serves the data.
+        assert!(
+            html.contains("sql-run") || html.contains("/export/"),
+            "{href}"
+        );
+    }
+}

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -84,6 +84,7 @@ error-generic = Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.
 
 nav-section-work = Arbeit
 nav-section-batch-data = Batch & Daten
+nav-section-sql-on-fhir = SQL on FHIR
 nav-section-server = Server
 nav-section-tools = Werkzeuge
 
@@ -95,7 +96,11 @@ nav-compartments = Compartments
 nav-batch-transaction = Batch / Transaktion
 nav-import = Importieren
 nav-export = Exportieren
-nav-sql-on-fhir = SQL-on-FHIR
+nav-sql-view-definitions = View-Definitionen
+nav-sql-queries = SQL-Abfragen
+nav-sql-views = SQL-Views
+nav-sql-export = SQL-Export
+nav-sql-files = Dateien
 nav-capability-conformance = Capability & Konformität
 nav-search-parameters = Suchparameter
 nav-subscriptions = Abonnements
@@ -732,3 +737,29 @@ cap-col-revincludes = Revincludes
 cap-resources-empty = Kein Ressourcentyp entspricht dem Filter.
 cap-raw-toggle = Rohes CapabilityStatement (JSON)
 cap-unavailable = Das CapabilityStatement konnte nicht vom Server geladen werden — der Selbstaufruf benötigt bei aktivierter Authentifizierung eventuell ein Ausgangs-Token.
+
+## Stubs der SQL-on-FHIR-Sektion (#649)
+
+sql-stub-heading = Demnächst
+sql-stub-planned = Geplant
+sql-stub-api = Bedienende API
+
+sql-vd-title = View-Definitionen
+sql-vd-lede = Erstelle und verwalte die ViewDefinitions, mit denen SQL on FHIR Ressourcen abflacht.
+sql-vd-body = Eine Liste und ein Editor für ViewDefinitions. Views erstellen, bearbeiten und validieren — ausgeführt werden sie unter SQL-Abfragen.
+
+sql-queries-title = SQL-Abfragen
+sql-queries-lede = Führe SQL-on-FHIR-Abfragen gegen diesen Server aus.
+sql-queries-body = Eine Abfrage verfassen, ausführen und die Ergebniszeilen direkt inspizieren.
+
+sql-views-title = SQL-Views
+sql-views-lede = Wiederverwendbare SQL-Views auf Basis von ViewDefinitions.
+sql-views-body = SQLView-Bibliotheken und die darin definierten Views, aufgelöst mit ihren Abhängigkeiten.
+
+sql-export-title = SQL-Export
+sql-export-lede = Langlaufende SQL-on-FHIR-Exportaufträge.
+sql-export-body = Einen Export starten, den Fortschritt verfolgen und nicht mehr benötigte Aufträge abbrechen.
+
+sql-files-title = Dateien
+sql-files-lede = Manifeste und Ausgabedateien der SQL-Exporte.
+sql-files-body = Das Manifest jedes Auftrags einsehen und seine Ausgabedateien herunterladen.

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -88,6 +88,7 @@ error-generic = Something went wrong. Please try again.
 
 nav-section-work = Work
 nav-section-batch-data = Batch & Data
+nav-section-sql-on-fhir = SQL on FHIR
 nav-section-server = Server
 nav-section-tools = Tools
 
@@ -99,7 +100,11 @@ nav-compartments = Compartments
 nav-batch-transaction = Batch / Transaction
 nav-import = Import
 nav-export = Export
-nav-sql-on-fhir = SQL-on-FHIR
+nav-sql-view-definitions = View Definitions
+nav-sql-queries = SQL Queries
+nav-sql-views = SQL Views
+nav-sql-export = SQL Export
+nav-sql-files = Files
 nav-capability-conformance = Capability & Conformance
 nav-search-parameters = Search Parameters
 nav-subscriptions = Subscriptions
@@ -735,3 +740,29 @@ cap-col-revincludes = Revincludes
 cap-resources-empty = No resource types match the filter.
 cap-raw-toggle = Raw CapabilityStatement (JSON)
 cap-unavailable = The CapabilityStatement could not be fetched from the server — the self-call may need an outbound token when authentication is enabled.
+
+## SQL on FHIR section stubs (#649)
+
+sql-stub-heading = Coming Soon
+sql-stub-planned = Planned
+sql-stub-api = Serving API
+
+sql-vd-title = View Definitions
+sql-vd-lede = Author and manage the ViewDefinitions that SQL on FHIR runs flatten resources with.
+sql-vd-body = A ViewDefinition list and editor. Create, edit, and validate views, then run them from SQL Queries.
+
+sql-queries-title = SQL Queries
+sql-queries-lede = Run SQL on FHIR queries against this server.
+sql-queries-body = Compose a query, run it, and inspect the resulting rows inline.
+
+sql-views-title = SQL Views
+sql-views-lede = Reusable SQL views layered over ViewDefinitions.
+sql-views-body = SQLView libraries and the views they define, resolved with their dependencies.
+
+sql-export-title = SQL Export
+sql-export-lede = Long-running SQL on FHIR export jobs.
+sql-export-body = Start an export, follow its progress, and cancel jobs that are no longer needed.
+
+sql-files-title = Files
+sql-files-lede = Manifests and output files produced by SQL exports.
+sql-files-body = Browse each job's manifest and download its output files.

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -84,6 +84,7 @@ error-generic = Algo salió mal. Vuelva a intentarlo.
 
 nav-section-work = Trabajo
 nav-section-batch-data = Lotes y datos
+nav-section-sql-on-fhir = SQL on FHIR
 nav-section-server = Servidor
 nav-section-tools = Herramientas
 
@@ -95,7 +96,11 @@ nav-compartments = Compartimentos
 nav-batch-transaction = Lote / Transacción
 nav-import = Importar
 nav-export = Exportar
-nav-sql-on-fhir = SQL-on-FHIR
+nav-sql-view-definitions = Definiciones de vistas
+nav-sql-queries = Consultas SQL
+nav-sql-views = Vistas SQL
+nav-sql-export = Exportación SQL
+nav-sql-files = Archivos
 nav-capability-conformance = Capacidad y conformidad
 nav-search-parameters = Parámetros de búsqueda
 nav-subscriptions = Suscripciones
@@ -732,3 +737,29 @@ cap-col-revincludes = Revincludes
 cap-resources-empty = Ningún tipo de recurso coincide con el filtro.
 cap-raw-toggle = CapabilityStatement en bruto (JSON)
 cap-unavailable = No se pudo obtener la CapabilityStatement del servidor — la autollamada puede necesitar un token saliente cuando la autenticación está activada.
+
+## Stubs de la sección SQL on FHIR (#649)
+
+sql-stub-heading = Próximamente
+sql-stub-planned = Previsto
+sql-stub-api = API que lo sirve
+
+sql-vd-title = Definiciones de vistas
+sql-vd-lede = Crea y gestiona las ViewDefinitions con las que SQL on FHIR aplana recursos.
+sql-vd-body = Una lista y un editor de ViewDefinitions. Crea, edita y valida vistas, y ejecútalas después desde Consultas SQL.
+
+sql-queries-title = Consultas SQL
+sql-queries-lede = Ejecuta consultas SQL on FHIR contra este servidor.
+sql-queries-body = Redacta una consulta, ejecútala e inspecciona las filas resultantes en línea.
+
+sql-views-title = Vistas SQL
+sql-views-lede = Vistas SQL reutilizables construidas sobre ViewDefinitions.
+sql-views-body = Bibliotecas SQLView y las vistas que definen, resueltas con sus dependencias.
+
+sql-export-title = Exportación SQL
+sql-export-lede = Trabajos de exportación SQL on FHIR de larga duración.
+sql-export-body = Inicia una exportación, sigue su progreso y cancela los trabajos que ya no necesites.
+
+sql-files-title = Archivos
+sql-files-lede = Manifiestos y archivos de salida producidos por las exportaciones SQL.
+sql-files-body = Consulta el manifiesto de cada trabajo y descarga sus archivos de salida.


### PR DESCRIPTION
Part 1 of #649 — the nav structure, as its own reviewable change per the issue's suggested approach. The ViewDefinition Editor (Figma `420-2`) and the pages over `$sql-run` / `$sql-export` follow in separate PRs.

## What

- **SQL on FHIR is a top-level sidebar section** — a peer of Work, Batch & Data, and Server — replacing the dead `nav-item--soon` placeholder that sat inside Batch & Data. Children: View Definitions, SQL Queries, SQL Views, SQL Export, Files.
- **Every child navigates**: five `/ui/sql/*` routes render a shared stub page (`sql-stub.html`) stating what the page will host and which already-routed server operation serves that data (`$sql-run`, `$sql-export`, the export manifest/file routes). Nothing in the menu is dead.
- **Labels** exist in en/es/de; en follows the Title Case convention (#652), es/de keep their norms. The spelling is "SQL on FHIR" (unhyphenated), per the issue.
- Existing flat `nav__section` pattern — no new CSS, and the section collapses to a divider in the icon-only rail like the other three.

## Decisions for review

- **"SQL Export", not "Export"** — the sidebar already carries Batch & Data's FHIR Bulk Data Export, a different operation; the issue flagged the ambiguity. Also matches the sibling names SQL Queries / SQL Views.
- **SQL Views is a stub route, not `--soon`** — the stub states the surface honestly, and the backend does serve SQLView Library subjects today (transitive resolution pending #567). Easy to flip to `--soon` if preferred.
- **Icons** are reused from the vendored set (grid, code, layers-platforms, export, copy) — the Figma frame shows the sidebar collapsed, so no SQL-specific icons exist yet; the editor PR can bring Brett's if they appear.
- The nojs guard's "coming-soon entries are inert" test lost its premise (no placeholder remains) — inverted to assert **no** dead placeholder exists.

## Tests

- `router_http`: new test — section present with all five links, no `nav-item--soon` anywhere, each route 200s and marks its nav entry `aria-current`.
- The five routes are in `e2e/pages/routes.ts`, so every cross-page guard covers them. Run locally: **a11y (axe, light+dark), design-system, no-cdn: 51 passed; nojs: 11 passed**; `cargo test -p helios-ui` fully green.