### PR TITLE
pysof performance: mimalloc allocator, JSON text input parsed off-GIL, export NDJSON APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4671,6 +4671,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4892,6 +4901,15 @@ dependencies = [
  "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6112,6 +6130,7 @@ dependencies = [
  "csv",
  "helios-fhir",
  "helios-sof",
+ "mimalloc",
  "openssl",
  "pyo3",
  "pyo3-build-config",

--- a/crates/pysof/Cargo.toml
+++ b/crates/pysof/Cargo.toml
@@ -27,6 +27,7 @@ csv = "1.3"
 # Drives helios-sof's async remote-resolve functions from the synchronous
 # PyO3 entry points via a current-thread runtime.
 tokio = { version = "1", default-features = false, features = ["rt", "net", "time"] }
+mimalloc = "0.1.52"
 
 [features]
 default = ["R4"]

--- a/crates/pysof/README.md
+++ b/crates/pysof/README.md
@@ -17,7 +17,8 @@ Built in Rust for speed, exposed to Python with a simple, Pythonic API. Part of 
 - 📦 **Streaming Support**: Memory-efficient chunked processing for large NDJSON files
 - 🌐 **Multi-Version FHIR**: Supports R4, R4B, R5, and R6 (based on build features)
 - 🎯 **Type-Safe**: Leverages Rust's type safety with a Pythonic interface
-- ⚡ **GIL-Free**: Python GIL released during processing for true parallelism
+- ⚡ **GIL-Friendly**: the GIL is released during parsing and processing, so other Python threads stay responsive
+- 📨 **Flexible Input**: ViewDefinitions and Bundles as Python dicts or pre-serialized JSON (`str`/`bytes`)
 
 ## 🎯 Why pysof?
 
@@ -285,7 +286,28 @@ pysof automatically processes FHIR resources in parallel using rayon:
 - **5-7x speedup** on typical batch workloads with multi-core CPUs
 - **Streaming benefits**: `ChunkedProcessor` and `process_ndjson_to_file` also use parallel processing
 - **Zero configuration** - parallelization is always enabled
-- **Python GIL released** during processing for true parallel execution
+- **Python GIL released** during parsing and processing, so other Python threads stay responsive
+
+Because each call already fans out across all cores via rayon's shared thread
+pool, running pysof from multiple Python threads does **not** multiply
+throughput — one call can saturate the machine. Use Python threads for
+concurrency (overlapping I/O, serving requests), not to speed up transforms.
+
+### Pass Pre-Serialized JSON for Maximum Speed
+
+If your data is already JSON text (from a file, an HTTP body, a database), pass
+the `str` or `bytes` directly instead of `json.loads`-ing it first:
+
+```python
+view_json: str = load_view_definition_text()
+bundle_json: bytes = fetch_bundle_bytes()
+
+result = pysof.run_view_definition(view_json, bundle_json, "csv")
+```
+
+This skips the Python-dict conversion entirely and parses the JSON with the
+GIL released — measured 20-27% faster per call on large bundles, with GIL hold
+time dropping from tens of milliseconds to microseconds.
 
 ### Performance Benchmarks
 

--- a/crates/pysof/python-tests/test_json_string_input.py
+++ b/crates/pysof/python-tests/test_json_string_input.py
@@ -1,0 +1,116 @@
+"""ViewDefinitions and Bundles may be passed as JSON strings or bytes.
+
+Pre-serialized JSON skips the Python-dict conversion entirely: the input is
+handed to Rust as text and parsed off the GIL, which is both faster per call
+and keeps other Python threads responsive during large-bundle parsing.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pysof
+
+VIEW: dict[str, Any] = {
+    "resourceType": "ViewDefinition",
+    "status": "active",
+    "resource": "Patient",
+    "select": [
+        {
+            "column": [
+                {"name": "id", "path": "id"},
+                {"name": "family", "path": "name.first().family"},
+            ]
+        }
+    ],
+}
+
+BUNDLE: dict[str, Any] = {
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": f"p{i}",
+                "name": [{"family": f"Family{i}"}],
+            }
+        }
+        for i in range(3)
+    ],
+}
+
+
+def test_run_view_definition_accepts_json_strings() -> None:
+    """String inputs produce byte-identical output to dict inputs."""
+    from_dicts = pysof.run_view_definition(VIEW, BUNDLE, "csv")
+    from_strs = pysof.run_view_definition(json.dumps(VIEW), json.dumps(BUNDLE), "csv")
+    assert from_strs == from_dicts
+
+
+def test_run_view_definition_accepts_json_bytes() -> None:
+    """Bytes inputs produce byte-identical output to dict inputs."""
+    from_dicts = pysof.run_view_definition(VIEW, BUNDLE, "csv")
+    from_bytes = pysof.run_view_definition(
+        json.dumps(VIEW).encode(), json.dumps(BUNDLE).encode(), "csv"
+    )
+    assert from_bytes == from_dicts
+
+
+def test_run_view_definition_accepts_mixed_inputs() -> None:
+    """A dict view may be combined with a string bundle, and vice versa."""
+    from_dicts = pysof.run_view_definition(VIEW, BUNDLE, "csv")
+    assert pysof.run_view_definition(VIEW, json.dumps(BUNDLE), "csv") == from_dicts
+    assert pysof.run_view_definition(json.dumps(VIEW), BUNDLE, "csv") == from_dicts
+
+
+def test_run_view_definition_rejects_invalid_json_string() -> None:
+    with pytest.raises(pysof.SerializationError):
+        pysof.run_view_definition("{not json", json.dumps(BUNDLE), "csv")
+
+
+def test_run_view_definition_rejects_wrong_shaped_json_string() -> None:
+    """Valid JSON that is not a ViewDefinition still fails as before."""
+    with pytest.raises(pysof.SerializationError):
+        pysof.run_view_definition('"just a string"', json.dumps(BUNDLE), "csv")
+
+
+def test_run_view_definition_with_options_accepts_json_strings() -> None:
+    from_dicts = pysof.run_view_definition_with_options(VIEW, BUNDLE, "csv", limit=2)
+    from_strs = pysof.run_view_definition_with_options(
+        json.dumps(VIEW), json.dumps(BUNDLE), "csv", limit=2
+    )
+    assert from_strs == from_dicts
+
+
+def test_run_view_definition_remote_accepts_json_strings() -> None:
+    cfg = pysof.RemoteResolveConfig([])  # inactive: in-bundle resolution only
+    from_dicts = pysof.run_view_definition_remote(VIEW, BUNDLE, "csv", cfg)
+    from_strs = pysof.run_view_definition_remote(
+        json.dumps(VIEW), json.dumps(BUNDLE), "csv", cfg
+    )
+    assert from_strs == from_dicts
+
+
+def test_validate_functions_accept_json_strings() -> None:
+    assert pysof.validate_view_definition(json.dumps(VIEW)) is True
+    assert pysof.validate_bundle(json.dumps(BUNDLE)) is True
+
+
+def test_ndjson_paths_accept_json_string_view(tmp_path: Path) -> None:
+    input_path = tmp_path / "patients.ndjson"
+    with input_path.open("w") as f:
+        for entry in BUNDLE["entry"]:
+            f.write(json.dumps(entry["resource"]) + "\n")
+
+    output_path = tmp_path / "out.csv"
+    stats = pysof.process_ndjson_to_file(
+        json.dumps(VIEW), str(input_path), str(output_path), "csv"
+    )
+    assert stats["resources_processed"] == 3
+
+    processor = pysof.ChunkedProcessor(json.dumps(VIEW), str(input_path))
+    rows = [row for chunk in processor for row in chunk["rows"]]
+    assert len(rows) == 3

--- a/crates/pysof/python-tests/test_ndjson_exports.py
+++ b/crates/pysof/python-tests/test_ndjson_exports.py
@@ -1,0 +1,85 @@
+"""The local NDJSON streaming APIs documented in the README must be exported.
+
+Regression tests for a packaging gap: ``process_ndjson_to_file`` and
+``ChunkedProcessor`` existed in the Rust extension but were never re-exported
+from the ``pysof`` package (only the ``_remote`` variant was).
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pysof
+
+
+def get_view_definition() -> dict[str, Any]:
+    return {
+        "resourceType": "ViewDefinition",
+        "status": "active",
+        "resource": "Patient",
+        "select": [
+            {
+                "column": [
+                    {"name": "id", "path": "id"},
+                    {"name": "family", "path": "name.first().family"},
+                ]
+            }
+        ],
+    }
+
+
+def write_patients_ndjson(path: Path, count: int) -> None:
+    with path.open("w") as f:
+        for i in range(count):
+            patient = {
+                "resourceType": "Patient",
+                "id": f"p{i}",
+                "name": [{"family": f"Family{i}"}],
+            }
+            f.write(json.dumps(patient) + "\n")
+
+
+def test_process_ndjson_to_file_is_exported_and_works(tmp_path: Path) -> None:
+    """pysof.process_ndjson_to_file processes an NDJSON file end to end."""
+    input_path = tmp_path / "patients.ndjson"
+    output_path = tmp_path / "out.csv"
+    write_patients_ndjson(input_path, 3)
+
+    stats = pysof.process_ndjson_to_file(
+        get_view_definition(),
+        str(input_path),
+        str(output_path),
+        "csv",
+        chunk_size=2,
+    )
+
+    assert stats["total_lines_read"] == 3
+    assert stats["resources_processed"] == 3
+    assert output_path.exists()
+    content = output_path.read_text()
+    assert "Family0" in content
+    assert "Family2" in content
+
+
+def test_chunked_processor_is_exported_and_iterates(tmp_path: Path) -> None:
+    """pysof.ChunkedProcessor streams chunks of transformed rows."""
+    input_path = tmp_path / "patients.ndjson"
+    write_patients_ndjson(input_path, 5)
+
+    processor = pysof.ChunkedProcessor(
+        get_view_definition(), str(input_path), chunk_size=2
+    )
+    assert processor.columns == ["id", "family"]
+
+    chunks = list(processor)
+    assert len(chunks) == 3  # 2 + 2 + 1
+    all_rows = [row for chunk in chunks for row in chunk["rows"]]
+    assert len(all_rows) == 5
+    assert all_rows[0] == ["p0", "Family0"]
+    assert chunks[-1]["is_last"] is True
+
+
+def test_ndjson_apis_are_in_all() -> None:
+    """The public surface advertises the local NDJSON APIs."""
+    assert "process_ndjson_to_file" in pysof.__all__
+    assert "ChunkedProcessor" in pysof.__all__

--- a/crates/pysof/scripts/bench_threading.py
+++ b/crates/pysof/scripts/bench_threading.py
@@ -1,0 +1,205 @@
+"""Multi-threaded throughput benchmark for pysof.
+
+Measures aggregate throughput (transforms/sec) at 1/2/4/8 Python threads for:
+  - dict input (converted from Python objects under the GIL)
+  - JSON-string input (parsed entirely off the GIL, where supported)
+  - process_ndjson_to_file (file-to-file path)
+
+Context: each pysof call is already internally parallel — helios-sof fans the
+transform out over rayon's global thread pool, so a single call can saturate
+the machine and Python-thread scaling plateaus well below linear. Pin the pool
+with RAYON_NUM_THREADS to isolate its contribution. This script guards the
+allocator choice (mimalloc, ~2x over the system allocator) and the GIL-hold
+behavior; run it on an otherwise idle machine — concurrent builds or other
+load skew the numbers badly.
+
+Usage:
+    uv run python scripts/bench_threading.py [label]
+"""
+
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+
+import pysof
+
+# Until the local NDJSON API is exported from the package (see pysof issue
+# backlog), fall back to the raw extension module.
+try:
+    from pysof import _pysof
+
+    process_ndjson_to_file = getattr(pysof, "process_ndjson_to_file", None) or (
+        lambda view, inp, out, fmt, **kw: _pysof.py_process_ndjson_to_file(
+            view, inp, out, fmt, **kw
+        )
+    )
+except ImportError:  # pragma: no cover
+    process_ndjson_to_file = pysof.process_ndjson_to_file
+
+LABEL = sys.argv[1] if len(sys.argv) > 1 else "current"
+
+VIEW = {
+    "resourceType": "ViewDefinition",
+    "resource": "Patient",
+    "status": "active",
+    "select": [
+        {
+            "column": [
+                {"name": "id", "path": "id", "type": "id"},
+                {"name": "gender", "path": "gender", "type": "code"},
+                {"name": "birth_date", "path": "birthDate", "type": "date"},
+                {"name": "family", "path": "name.first().family", "type": "string"},
+                {"name": "given", "path": "name.first().given.first()", "type": "string"},
+                {"name": "city", "path": "address.first().city", "type": "string"},
+                {"name": "phone", "path": "telecom.first().value", "type": "string"},
+            ]
+        }
+    ],
+}
+
+
+def make_patient(i):
+    return {
+        "resourceType": "Patient",
+        "id": f"p{i}",
+        "active": True,
+        "gender": "male" if i % 2 == 0 else "female",
+        "birthDate": "1980-01-01",
+        "name": [
+            {"family": f"Family{i}", "given": [f"Given{i}", "Middle"], "use": "official"}
+        ],
+        "identifier": [
+            {"system": "urn:example:mrn", "value": f"mrn-{i:08d}"},
+            {"system": "urn:example:ssn", "value": f"ssn-{i:08d}"},
+        ],
+        "telecom": [
+            {"system": "phone", "value": f"555-{i:07d}", "use": "home"},
+            {"system": "email", "value": f"p{i}@example.com"},
+        ],
+        "address": [
+            {
+                "use": "home",
+                "line": [f"{i} Main Street", "Apt 1"],
+                "city": "Springfield",
+                "state": "IL",
+                "postalCode": "62701",
+            }
+        ],
+    }
+
+
+def make_bundle(n):
+    return {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [{"resource": make_patient(i)} for i in range(n)],
+    }
+
+
+THREAD_COUNTS = [1, 2, 4, 8]
+TARGET_SECONDS = 3.0
+
+
+def run_threads(n_threads, iterations, fn):
+    barrier = threading.Barrier(n_threads + 1)
+    errors = []
+
+    def worker():
+        try:
+            barrier.wait()
+            for _ in range(iterations):
+                fn()
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    barrier.wait()
+    t0 = time.perf_counter()
+    for t in threads:
+        t.join()
+    elapsed = time.perf_counter() - t0
+    if errors:
+        raise errors[0]
+    return (n_threads * iterations) / elapsed
+
+
+def bench_scenario(name, fn):
+    # Warmup, then calibrate iterations for ~TARGET_SECONDS per configuration
+    fn()
+    t0 = time.perf_counter()
+    fn()
+    per_call = time.perf_counter() - t0
+    iterations = max(3, int(TARGET_SECONDS / max(per_call, 1e-6)))
+
+    results = {}
+    base = None
+    for n in THREAD_COUNTS:
+        ops = run_threads(n, iterations, fn)
+        if base is None:
+            base = ops
+        results[n] = (ops, ops / base)
+    row = " | ".join(
+        f"{results[n][0]:8.1f} ops/s x{results[n][1]:4.2f}" for n in THREAD_COUNTS
+    )
+    print(f"{name:34s} | {row}")
+    return results
+
+
+def main():
+    print(
+        f"pysof {pysof.get_version()} | python {sys.version.split()[0]} | "
+        f"cpus={os.cpu_count()} | label={LABEL} | "
+        f"rayon={os.environ.get('RAYON_NUM_THREADS', 'default')}"
+    )
+    header = " | ".join(f"{n} thread{'s' if n > 1 else '':7s}" for n in THREAD_COUNTS)
+    print(f"{'scenario':34s} | {header}")
+
+    small = make_bundle(50)
+    large = make_bundle(2000)
+    large_str = json.dumps(large)
+    view_str = json.dumps(VIEW)
+
+    bench_scenario(
+        "dict bundle, 50 patients",
+        lambda: pysof.run_view_definition(VIEW, small, "csv"),
+    )
+    bench_scenario(
+        "dict bundle, 2000 patients",
+        lambda: pysof.run_view_definition(VIEW, large, "csv"),
+    )
+
+    try:
+        pysof.run_view_definition(view_str, large_str, "csv")
+        bench_scenario(
+            "str bundle, 2000 patients",
+            lambda: pysof.run_view_definition(view_str, large_str, "csv"),
+        )
+    except Exception as e:
+        print(f"{'str bundle, 2000 patients':34s} | unsupported ({type(e).__name__})")
+
+    tmpdir = tempfile.mkdtemp(prefix="pysof_bench_")
+    ndjson_path = os.path.join(tmpdir, "patients.ndjson")
+    with open(ndjson_path, "w") as f:
+        for i in range(5000):
+            f.write(json.dumps(make_patient(i)) + "\n")
+
+    counter = threading.local()
+
+    def file_job():
+        # unique output per thread+iteration to avoid write collisions
+        ident = threading.get_ident()
+        n = getattr(counter, "n", 0)
+        counter.n = n + 1
+        out = os.path.join(tmpdir, f"out_{ident}_{n}.csv")
+        process_ndjson_to_file(VIEW, ndjson_path, out, "csv", chunk_size=1000)
+
+    bench_scenario("ndjson file->file, 5000 patients", file_job)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/pysof/scripts/bench_threading.py
+++ b/crates/pysof/scripts/bench_threading.py
@@ -26,19 +26,6 @@ import time
 
 import pysof
 
-# Until the local NDJSON API is exported from the package (see pysof issue
-# backlog), fall back to the raw extension module.
-try:
-    from pysof import _pysof
-
-    process_ndjson_to_file = getattr(pysof, "process_ndjson_to_file", None) or (
-        lambda view, inp, out, fmt, **kw: _pysof.py_process_ndjson_to_file(
-            view, inp, out, fmt, **kw
-        )
-    )
-except ImportError:  # pragma: no cover
-    process_ndjson_to_file = pysof.process_ndjson_to_file
-
 LABEL = sys.argv[1] if len(sys.argv) > 1 else "current"
 
 VIEW = {
@@ -196,7 +183,7 @@ def main():
         n = getattr(counter, "n", 0)
         counter.n = n + 1
         out = os.path.join(tmpdir, f"out_{ident}_{n}.csv")
-        process_ndjson_to_file(VIEW, ndjson_path, out, "csv", chunk_size=1000)
+        pysof.process_ndjson_to_file(VIEW, ndjson_path, out, "csv", chunk_size=1000)
 
     bench_scenario("ndjson file->file, 5000 patients", file_job)
 

--- a/crates/pysof/src/lib.rs
+++ b/crates/pysof/src/lib.rs
@@ -14,6 +14,12 @@ use helios_sof::{
 use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+
+// The SQL-on-FHIR transform is allocation-heavy (large generated FHIR structs);
+// benchmarks show mimalloc roughly doubles throughput over the system allocator,
+// most dramatically on Windows. See scripts/bench_threading.py.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;

--- a/crates/pysof/src/lib.rs
+++ b/crates/pysof/src/lib.rs
@@ -123,8 +123,8 @@ fn json_error_to_py_err(err: serde_json::Error) -> PyErr {
 /// Transform FHIR Bundle data using a ViewDefinition.
 ///
 /// Args:
-///     view_definition (dict): ViewDefinition resource as a Python dictionary
-///     bundle (dict): FHIR Bundle resource as a Python dictionary  
+///     view_definition (dict | str | bytes): ViewDefinition resource as a Python dictionary or JSON text
+///     bundle (dict | str | bytes): FHIR Bundle resource as a Python dictionary or JSON text  
 ///     format (str): Output format ("csv", "csv_with_header", "json", "ndjson", "parquet")
 ///     fhir_version (str, optional): FHIR version to use ("R4", "R4B", "R5", "R6"). Defaults to "R4"
 ///
@@ -138,6 +138,35 @@ fn json_error_to_py_err(err: serde_json::Error) -> PyErr {
 ///     UnsupportedContentTypeError: Unsupported output format
 ///     CsvError: CSV generation failed
 ///     IoError: I/O operation failed
+/// JSON input captured from Python: pre-serialized text/bytes carry no Python
+/// references, so they can parse off the GIL later; anything else must be
+/// depythonized while the GIL is held.
+enum JsonInput {
+    Text(String),
+    Bytes(Vec<u8>),
+    Value(serde_json::Value),
+}
+
+fn extract_json_input(obj: &Bound<'_, PyAny>) -> PyResult<JsonInput> {
+    if let Ok(s) = obj.extract::<String>() {
+        Ok(JsonInput::Text(s))
+    } else if let Ok(b) = obj.cast::<PyBytes>() {
+        Ok(JsonInput::Bytes(b.as_bytes().to_vec()))
+    } else {
+        Ok(JsonInput::Value(pythonize::depythonize(obj)?))
+    }
+}
+
+fn parse_json_input<T: serde::de::DeserializeOwned>(
+    input: JsonInput,
+) -> Result<T, serde_json::Error> {
+    match input {
+        JsonInput::Text(s) => serde_json::from_str(&s),
+        JsonInput::Bytes(b) => serde_json::from_slice(&b),
+        JsonInput::Value(v) => serde_json::from_value(v),
+    }
+}
+
 #[pyfunction]
 #[pyo3(signature = (view_definition, bundle, format, fhir_version = "R4"))]
 fn py_run_view_definition(
@@ -150,55 +179,18 @@ fn py_run_view_definition(
     // Parse content type
     let content_type = ContentType::from_string(format).map_err(rust_sof_error_to_py_err)?;
 
-    // Parse ViewDefinition and Bundle based on FHIR version
-    let view_def_json: serde_json::Value = pythonize::depythonize(view_definition)?;
-    let bundle_json: serde_json::Value = pythonize::depythonize(bundle)?;
+    // Only cheap Python-object access happens under the GIL; the expensive
+    // typed parse runs inside detach so other Python threads stay responsive.
+    let view_input = extract_json_input(view_definition)?;
+    let bundle_input = extract_json_input(bundle)?;
 
-    let parsed: PyResult<(SofViewDefinition, SofBundle)> = match fhir_version {
-        #[cfg(feature = "R4")]
-        "R4" => {
-            let view_def: helios_fhir::r4::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let bundle: helios_fhir::r4::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R4(view_def), SofBundle::R4(bundle)))
-        }
-        #[cfg(feature = "R4B")]
-        "R4B" => {
-            let view_def: helios_fhir::r4b::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let bundle: helios_fhir::r4b::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R4B(view_def), SofBundle::R4B(bundle)))
-        }
-        #[cfg(feature = "R5")]
-        "R5" => {
-            let view_def: helios_fhir::r5::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let bundle: helios_fhir::r5::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R5(view_def), SofBundle::R5(bundle)))
-        }
-        #[cfg(feature = "R6")]
-        "R6" => {
-            let view_def: helios_fhir::r6::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let bundle: helios_fhir::r6::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R6(view_def), SofBundle::R6(bundle)))
-        }
-        _ => Err(PyUnsupportedContentTypeError::new_err(format!(
-            "Unsupported FHIR version: {}",
-            fhir_version
-        ))),
-    };
-
-    let (sof_view_def, sof_bundle) = parsed?;
-
-    // Execute transformation - release GIL for parallel/long work
-    let result = py
-        .detach(|| run_view_definition(sof_view_def, sof_bundle, content_type))
-        .map_err(rust_sof_error_to_py_err)?;
+    // Execute parse + transformation - release GIL for parallel/long work
+    let result = py.detach(|| -> PyResult<Vec<u8>> {
+        let (sof_view_def, sof_bundle) =
+            parse_sof_view_and_bundle(view_input, bundle_input, fhir_version)?;
+        run_view_definition(sof_view_def, sof_bundle, content_type)
+            .map_err(rust_sof_error_to_py_err)
+    })?;
 
     Ok(PyBytes::new(py, &result).into())
 }
@@ -206,8 +198,8 @@ fn py_run_view_definition(
 /// Transform FHIR Bundle data using a ViewDefinition with additional options.
 ///
 /// Args:
-///     view_definition (dict): ViewDefinition resource as a Python dictionary
-///     bundle (dict): FHIR Bundle resource as a Python dictionary
+///     view_definition (dict | str | bytes): ViewDefinition resource as a Python dictionary or JSON text
+///     bundle (dict | str | bytes): FHIR Bundle resource as a Python dictionary or JSON text
 ///     format (str): Output format ("csv", "csv_with_header", "json", "ndjson", "parquet")
 ///     since (str, optional): Filter resources modified after this ISO8601 datetime
 ///     limit (int, optional): Limit the number of results returned
@@ -240,48 +232,10 @@ fn py_run_view_definition_with_options(
     // Parse content type
     let content_type = ContentType::from_string(format).map_err(rust_sof_error_to_py_err)?;
 
-    // Parse ViewDefinition and Bundle based on FHIR version
-    let view_def_json: serde_json::Value = pythonize::depythonize(view_definition)?;
-    let bundle_json: serde_json::Value = pythonize::depythonize(bundle)?;
-
-    let (sof_view_def, sof_bundle) = match fhir_version {
-        #[cfg(feature = "R4")]
-        "R4" => {
-            let view_def: helios_fhir::r4::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let bundle: helios_fhir::r4::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R4(view_def), SofBundle::R4(bundle)))
-        }
-        #[cfg(feature = "R4B")]
-        "R4B" => {
-            let view_def: helios_fhir::r4b::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let bundle: helios_fhir::r4b::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R4B(view_def), SofBundle::R4B(bundle)))
-        }
-        #[cfg(feature = "R5")]
-        "R5" => {
-            let view_def: helios_fhir::r5::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let bundle: helios_fhir::r5::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R5(view_def), SofBundle::R5(bundle)))
-        }
-        #[cfg(feature = "R6")]
-        "R6" => {
-            let view_def: helios_fhir::r6::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let bundle: helios_fhir::r6::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R6(view_def), SofBundle::R6(bundle)))
-        }
-        _ => Err(PyUnsupportedContentTypeError::new_err(format!(
-            "Unsupported FHIR version: {}",
-            fhir_version
-        ))),
-    }?;
+    // Only cheap Python-object access happens under the GIL; the expensive
+    // typed parse runs inside detach so other Python threads stay responsive.
+    let view_input = extract_json_input(view_definition)?;
+    let bundle_input = extract_json_input(bundle)?;
 
     // Parse options
     let mut options = RunOptions::default();
@@ -297,12 +251,13 @@ fn py_run_view_definition_with_options(
     options.limit = limit;
     options.page = page;
 
-    // Execute transformation - release GIL for parallel/long work
-    let result = py
-        .detach(|| {
-            run_view_definition_with_options(sof_view_def, sof_bundle, content_type, options)
-        })
-        .map_err(rust_sof_error_to_py_err)?;
+    // Execute parse + transformation - release GIL for parallel/long work
+    let result = py.detach(|| -> PyResult<Vec<u8>> {
+        let (sof_view_def, sof_bundle) =
+            parse_sof_view_and_bundle(view_input, bundle_input, fhir_version)?;
+        run_view_definition_with_options(sof_view_def, sof_bundle, content_type, options)
+            .map_err(rust_sof_error_to_py_err)
+    })?;
 
     Ok(PyBytes::new(py, &result).into())
 }
@@ -310,7 +265,7 @@ fn py_run_view_definition_with_options(
 /// Validate a ViewDefinition structure without executing it.
 ///
 /// Args:
-///     view_definition (dict): ViewDefinition resource as a Python dictionary
+///     view_definition (dict | str | bytes): ViewDefinition resource as a Python dictionary or JSON text
 ///     fhir_version (str, optional): FHIR version to use ("R4", "R4B", "R5", "R6"). Defaults to "R4"
 ///
 /// Returns:
@@ -322,48 +277,18 @@ fn py_run_view_definition_with_options(
 #[pyfunction]
 #[pyo3(signature = (view_definition, fhir_version = "R4"))]
 fn py_validate_view_definition(
+    py: Python<'_>,
     view_definition: &Bound<'_, PyAny>,
     fhir_version: &str,
 ) -> PyResult<bool> {
-    let view_def_json: serde_json::Value = pythonize::depythonize(view_definition)?;
-
-    // Try to parse ViewDefinition for the specified FHIR version
-    match fhir_version {
-        #[cfg(feature = "R4")]
-        "R4" => {
-            let _view_def: helios_fhir::r4::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            Ok(true)
-        }
-        #[cfg(feature = "R4B")]
-        "R4B" => {
-            let _view_def: helios_fhir::r4b::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            Ok(true)
-        }
-        #[cfg(feature = "R5")]
-        "R5" => {
-            let _view_def: helios_fhir::r5::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            Ok(true)
-        }
-        #[cfg(feature = "R6")]
-        "R6" => {
-            let _view_def: helios_fhir::r6::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            Ok(true)
-        }
-        _ => Err(PyUnsupportedContentTypeError::new_err(format!(
-            "Unsupported FHIR version: {}",
-            fhir_version
-        ))),
-    }
+    let view_input = extract_json_input(view_definition)?;
+    py.detach(|| parse_sof_view(view_input, fhir_version).map(|_| true))
 }
 
 /// Validate a Bundle structure without executing transformations.
 ///
 /// Args:
-///     bundle (dict): FHIR Bundle resource as a Python dictionary
+///     bundle (dict | str | bytes): FHIR Bundle resource as a Python dictionary or JSON text
 ///     fhir_version (str, optional): FHIR version to use ("R4", "R4B", "R5", "R6"). Defaults to "R4"
 ///
 /// Returns:
@@ -373,40 +298,13 @@ fn py_validate_view_definition(
 ///     SerializationError: JSON parsing failed
 #[pyfunction]
 #[pyo3(signature = (bundle, fhir_version = "R4"))]
-fn py_validate_bundle(bundle: &Bound<'_, PyAny>, fhir_version: &str) -> PyResult<bool> {
-    let bundle_json: serde_json::Value = pythonize::depythonize(bundle)?;
-
-    // Try to parse Bundle for the specified FHIR version
-    match fhir_version {
-        #[cfg(feature = "R4")]
-        "R4" => {
-            let _bundle: helios_fhir::r4::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok(true)
-        }
-        #[cfg(feature = "R4B")]
-        "R4B" => {
-            let _bundle: helios_fhir::r4b::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok(true)
-        }
-        #[cfg(feature = "R5")]
-        "R5" => {
-            let _bundle: helios_fhir::r5::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok(true)
-        }
-        #[cfg(feature = "R6")]
-        "R6" => {
-            let _bundle: helios_fhir::r6::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok(true)
-        }
-        _ => Err(PyUnsupportedContentTypeError::new_err(format!(
-            "Unsupported FHIR version: {}",
-            fhir_version
-        ))),
-    }
+fn py_validate_bundle(
+    py: Python<'_>,
+    bundle: &Bound<'_, PyAny>,
+    fhir_version: &str,
+) -> PyResult<bool> {
+    let bundle_input = extract_json_input(bundle)?;
+    py.detach(|| parse_sof_bundle(bundle_input, fhir_version).map(|_| true))
 }
 
 /// Parse MIME type string to format identifier.
@@ -480,7 +378,7 @@ impl ChunkedIteratorInner {
 /// processes resources in configurable chunks, yielding results incrementally.
 ///
 /// Args:
-///     view_definition (dict): ViewDefinition resource as a Python dictionary
+///     view_definition (dict | str | bytes): ViewDefinition resource as a Python dictionary or JSON text
 ///     input_path (str): Path to the NDJSON file containing FHIR resources
 ///     chunk_size (int, optional): Number of resources per chunk. Defaults to 1000.
 ///     skip_invalid (bool, optional): Skip invalid JSON lines. Defaults to False.
@@ -517,40 +415,7 @@ impl ChunkedProcessor {
         fhir_version: &str,
     ) -> PyResult<Self> {
         // Parse ViewDefinition based on FHIR version
-        let view_def_json: serde_json::Value = pythonize::depythonize(view_definition)?;
-
-        let sof_view_def: SofViewDefinition = match fhir_version {
-            #[cfg(feature = "R4")]
-            "R4" => {
-                let view_def: helios_fhir::r4::ViewDefinition =
-                    serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-                SofViewDefinition::R4(view_def)
-            }
-            #[cfg(feature = "R4B")]
-            "R4B" => {
-                let view_def: helios_fhir::r4b::ViewDefinition =
-                    serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-                SofViewDefinition::R4B(view_def)
-            }
-            #[cfg(feature = "R5")]
-            "R5" => {
-                let view_def: helios_fhir::r5::ViewDefinition =
-                    serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-                SofViewDefinition::R5(view_def)
-            }
-            #[cfg(feature = "R6")]
-            "R6" => {
-                let view_def: helios_fhir::r6::ViewDefinition =
-                    serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-                SofViewDefinition::R6(view_def)
-            }
-            _ => {
-                return Err(PyUnsupportedContentTypeError::new_err(format!(
-                    "Unsupported FHIR version: {}",
-                    fhir_version
-                )));
-            }
-        };
+        let sof_view_def = parse_sof_view(extract_json_input(view_definition)?, fhir_version)?;
 
         // Open the file
         let file = File::open(input_path).map_err(|e| PyIoError::new_err(e.to_string()))?;
@@ -665,7 +530,7 @@ fn stats_to_pydict(py: Python<'_>, stats: &ProcessingStats) -> PyResult<Py<PyAny
 /// and writes the output directly to a file. It uses chunked processing for memory efficiency.
 ///
 /// Args:
-///     view_definition (dict): ViewDefinition resource as a Python dictionary
+///     view_definition (dict | str | bytes): ViewDefinition resource as a Python dictionary or JSON text
 ///     input_path (str): Path to the NDJSON file containing FHIR resources
 ///     output_path (str): Path to write the output file
 ///     format (str): Output format ("csv", "csv_with_header", "ndjson")
@@ -702,41 +567,9 @@ fn py_process_ndjson_to_file(
     // Parse content type
     let content_type = ContentType::from_string(format).map_err(rust_sof_error_to_py_err)?;
 
-    // Parse ViewDefinition based on FHIR version
-    let view_def_json: serde_json::Value = pythonize::depythonize(view_definition)?;
-
-    let sof_view_def: SofViewDefinition = match fhir_version {
-        #[cfg(feature = "R4")]
-        "R4" => {
-            let view_def: helios_fhir::r4::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            SofViewDefinition::R4(view_def)
-        }
-        #[cfg(feature = "R4B")]
-        "R4B" => {
-            let view_def: helios_fhir::r4b::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            SofViewDefinition::R4B(view_def)
-        }
-        #[cfg(feature = "R5")]
-        "R5" => {
-            let view_def: helios_fhir::r5::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            SofViewDefinition::R5(view_def)
-        }
-        #[cfg(feature = "R6")]
-        "R6" => {
-            let view_def: helios_fhir::r6::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            SofViewDefinition::R6(view_def)
-        }
-        _ => {
-            return Err(PyUnsupportedContentTypeError::new_err(format!(
-                "Unsupported FHIR version: {}",
-                fhir_version
-            )));
-        }
-    };
+    // Only cheap Python-object access happens under the GIL; the typed parse
+    // runs inside detach below.
+    let view_input = extract_json_input(view_definition)?;
 
     // Open files
     let input_file = File::open(input_path).map_err(|e| PyIoError::new_err(e.to_string()))?;
@@ -751,63 +584,55 @@ fn py_process_ndjson_to_file(
         skip_invalid_lines: skip_invalid,
     };
 
-    // Process - release GIL during processing
-    let stats = py
-        .detach(|| {
-            process_ndjson_chunked(
-                sof_view_def,
-                input_reader,
-                output_writer,
-                content_type,
-                config,
-            )
-        })
-        .map_err(rust_sof_error_to_py_err)?;
+    // Process - release GIL during parse + processing
+    let stats = py.detach(|| -> PyResult<ProcessingStats> {
+        let sof_view_def = parse_sof_view(view_input, fhir_version)?;
+        process_ndjson_chunked(
+            sof_view_def,
+            input_reader,
+            output_writer,
+            content_type,
+            config,
+        )
+        .map_err(rust_sof_error_to_py_err)
+    })?;
 
     stats_to_pydict(py, &stats)
 }
 
 // --- Remote resolve() support -------------------------------------------------
 
-/// Parses a Python ViewDefinition + Bundle into version-specific SOF types.
+/// Parses ViewDefinition + Bundle inputs into version-specific SOF types.
 fn parse_sof_view_and_bundle(
-    view_def_json: serde_json::Value,
-    bundle_json: serde_json::Value,
+    view: JsonInput,
+    bundle: JsonInput,
     fhir_version: &str,
 ) -> PyResult<(SofViewDefinition, SofBundle)> {
+    Ok((
+        parse_sof_view(view, fhir_version)?,
+        parse_sof_bundle(bundle, fhir_version)?,
+    ))
+}
+
+/// Parses a ViewDefinition input into a version-specific SOF type.
+fn parse_sof_view(view: JsonInput, fhir_version: &str) -> PyResult<SofViewDefinition> {
     match fhir_version {
         #[cfg(feature = "R4")]
-        "R4" => {
-            let v: helios_fhir::r4::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let b: helios_fhir::r4::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R4(v), SofBundle::R4(b)))
-        }
+        "R4" => Ok(SofViewDefinition::R4(
+            parse_json_input(view).map_err(json_error_to_py_err)?,
+        )),
         #[cfg(feature = "R4B")]
-        "R4B" => {
-            let v: helios_fhir::r4b::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let b: helios_fhir::r4b::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R4B(v), SofBundle::R4B(b)))
-        }
+        "R4B" => Ok(SofViewDefinition::R4B(
+            parse_json_input(view).map_err(json_error_to_py_err)?,
+        )),
         #[cfg(feature = "R5")]
-        "R5" => {
-            let v: helios_fhir::r5::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let b: helios_fhir::r5::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R5(v), SofBundle::R5(b)))
-        }
+        "R5" => Ok(SofViewDefinition::R5(
+            parse_json_input(view).map_err(json_error_to_py_err)?,
+        )),
         #[cfg(feature = "R6")]
-        "R6" => {
-            let v: helios_fhir::r6::ViewDefinition =
-                serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?;
-            let b: helios_fhir::r6::Bundle =
-                serde_json::from_value(bundle_json).map_err(json_error_to_py_err)?;
-            Ok((SofViewDefinition::R6(v), SofBundle::R6(b)))
-        }
+        "R6" => Ok(SofViewDefinition::R6(
+            parse_json_input(view).map_err(json_error_to_py_err)?,
+        )),
         _ => Err(PyUnsupportedContentTypeError::new_err(format!(
             "Unsupported FHIR version: {}",
             fhir_version
@@ -815,27 +640,24 @@ fn parse_sof_view_and_bundle(
     }
 }
 
-/// Parses a Python ViewDefinition into a version-specific SOF type.
-fn parse_sof_view(
-    view_def_json: serde_json::Value,
-    fhir_version: &str,
-) -> PyResult<SofViewDefinition> {
+/// Parses a Bundle input into a version-specific SOF type.
+fn parse_sof_bundle(bundle: JsonInput, fhir_version: &str) -> PyResult<SofBundle> {
     match fhir_version {
         #[cfg(feature = "R4")]
-        "R4" => Ok(SofViewDefinition::R4(
-            serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?,
+        "R4" => Ok(SofBundle::R4(
+            parse_json_input(bundle).map_err(json_error_to_py_err)?,
         )),
         #[cfg(feature = "R4B")]
-        "R4B" => Ok(SofViewDefinition::R4B(
-            serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?,
+        "R4B" => Ok(SofBundle::R4B(
+            parse_json_input(bundle).map_err(json_error_to_py_err)?,
         )),
         #[cfg(feature = "R5")]
-        "R5" => Ok(SofViewDefinition::R5(
-            serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?,
+        "R5" => Ok(SofBundle::R5(
+            parse_json_input(bundle).map_err(json_error_to_py_err)?,
         )),
         #[cfg(feature = "R6")]
-        "R6" => Ok(SofViewDefinition::R6(
-            serde_json::from_value(view_def_json).map_err(json_error_to_py_err)?,
+        "R6" => Ok(SofBundle::R6(
+            parse_json_input(bundle).map_err(json_error_to_py_err)?,
         )),
         _ => Err(PyUnsupportedContentTypeError::new_err(format!(
             "Unsupported FHIR version: {}",
@@ -964,8 +786,8 @@ impl PyRemoteResolveConfig {
 /// rows are generated.
 ///
 /// Args:
-///     view_definition (dict): ViewDefinition resource.
-///     bundle (dict): FHIR Bundle resource.
+///     view_definition (dict | str | bytes): ViewDefinition resource.
+///     bundle (dict | str | bytes): FHIR Bundle resource.
 ///     format (str): Output format ("csv", "csv_with_header", "json", "ndjson", "parquet").
 ///     remote_config (RemoteResolveConfig): Remote resolution configuration.
 ///     since (str, optional): Filter resources modified after this ISO8601 datetime.
@@ -990,10 +812,8 @@ fn py_run_view_definition_with_options_remote(
     fhir_version: &str,
 ) -> PyResult<Py<PyBytes>> {
     let content_type = ContentType::from_string(format).map_err(rust_sof_error_to_py_err)?;
-    let view_def_json: serde_json::Value = pythonize::depythonize(view_definition)?;
-    let bundle_json: serde_json::Value = pythonize::depythonize(bundle)?;
-    let (sof_view_def, sof_bundle) =
-        parse_sof_view_and_bundle(view_def_json, bundle_json, fhir_version)?;
+    let view_input = extract_json_input(view_definition)?;
+    let bundle_input = extract_json_input(bundle)?;
 
     let mut options = RunOptions::default();
     if let Some(since_str) = since {
@@ -1008,18 +828,20 @@ fn py_run_view_definition_with_options_remote(
 
     let config = remote_config.inner;
     let runtime = build_remote_runtime()?;
-    // Release the GIL while performing network I/O and parallel row generation.
-    let result = py
-        .detach(|| {
-            runtime.block_on(run_view_definition_with_options_remote(
+    // Release the GIL for the parse, network I/O, and parallel row generation.
+    let result = py.detach(|| -> PyResult<Vec<u8>> {
+        let (sof_view_def, sof_bundle) =
+            parse_sof_view_and_bundle(view_input, bundle_input, fhir_version)?;
+        runtime
+            .block_on(run_view_definition_with_options_remote(
                 sof_view_def,
                 sof_bundle,
                 content_type,
                 options,
                 &config,
             ))
-        })
-        .map_err(rust_sof_error_to_py_err)?;
+            .map_err(rust_sof_error_to_py_err)
+    })?;
 
     Ok(PyBytes::new(py, &result).into())
 }
@@ -1032,7 +854,7 @@ fn py_run_view_definition_with_options_remote(
 /// recurring across chunks is fetched once and `max_fetches` is a per-stream cap.
 ///
 /// Args:
-///     view_definition (dict): ViewDefinition resource.
+///     view_definition (dict | str | bytes): ViewDefinition resource.
 ///     input_path (str): Path to the input NDJSON file.
 ///     output_path (str): Path to write the output file.
 ///     format (str): Output format ("csv", "csv_with_header", "ndjson", "json").
@@ -1058,8 +880,7 @@ fn py_process_ndjson_to_file_remote(
     fhir_version: &str,
 ) -> PyResult<Py<PyAny>> {
     let content_type = ContentType::from_string(format).map_err(rust_sof_error_to_py_err)?;
-    let view_def_json: serde_json::Value = pythonize::depythonize(view_definition)?;
-    let sof_view_def = parse_sof_view(view_def_json, fhir_version)?;
+    let view_input = extract_json_input(view_definition)?;
 
     let input_file = File::open(input_path).map_err(|e| PyIoError::new_err(e.to_string()))?;
     let input_reader = BufReader::new(input_file);
@@ -1072,9 +893,10 @@ fn py_process_ndjson_to_file_remote(
     };
     let remote = remote_config.inner;
     let runtime = build_remote_runtime()?;
-    let stats = py
-        .detach(|| {
-            runtime.block_on(process_ndjson_chunked_remote(
+    let stats = py.detach(|| -> PyResult<ProcessingStats> {
+        let sof_view_def = parse_sof_view(view_input, fhir_version)?;
+        runtime
+            .block_on(process_ndjson_chunked_remote(
                 sof_view_def,
                 input_reader,
                 output_writer,
@@ -1082,8 +904,8 @@ fn py_process_ndjson_to_file_remote(
                 config,
                 &remote,
             ))
-        })
-        .map_err(rust_sof_error_to_py_err)?;
+            .map_err(rust_sof_error_to_py_err)
+    })?;
 
     stats_to_pydict(py, &stats)
 }

--- a/crates/pysof/src/pysof/__init__.py
+++ b/crates/pysof/src/pysof/__init__.py
@@ -34,6 +34,12 @@ Exception hierarchy:
 
 from typing import Any, cast
 
+# ViewDefinitions and Bundles may be passed as Python dicts or as
+# pre-serialized JSON (str or bytes). JSON text skips the Python-object
+# conversion and is parsed with the GIL released, which is faster per call
+# and keeps other Python threads responsive on large bundles.
+JsonResource = dict[str, Any] | str | bytes
+
 try:
     # Import the Rust extension module
     from pysof._pysof import (
@@ -69,8 +75,8 @@ try:
 
     # Create Python-friendly wrapper functions
     def run_view_definition(
-        view: dict[str, Any],
-        bundle: dict[str, Any],
+        view: JsonResource,
+        bundle: JsonResource,
         format: str,
         *,
         fhir_version: str = "R4",
@@ -78,8 +84,8 @@ try:
         """Transform FHIR Bundle data using a ViewDefinition.
 
         Args:
-            view: ViewDefinition resource as a Python dictionary
-            bundle: FHIR Bundle resource as a Python dictionary
+            view: ViewDefinition resource as a dict, or pre-serialized JSON (str | bytes)
+            bundle: FHIR Bundle resource as a dict, or pre-serialized JSON (str | bytes)
             format: Output format ("csv", "csv_with_header", "json", "ndjson", "parquet")
             fhir_version: FHIR version to use ("R4", "R4B", "R5", "R6"). Defaults to "R4"
 
@@ -97,8 +103,8 @@ try:
         return py_run_view_definition(view, bundle, format, fhir_version)
 
     def run_view_definition_with_options(
-        view: dict[str, Any],
-        bundle: dict[str, Any],
+        view: JsonResource,
+        bundle: JsonResource,
         format: str,
         *,
         since: str | None = None,
@@ -109,8 +115,8 @@ try:
         """Transform FHIR Bundle data using a ViewDefinition with additional options.
 
         Args:
-            view: ViewDefinition resource as a Python dictionary
-            bundle: FHIR Bundle resource as a Python dictionary
+            view: ViewDefinition resource as a dict, or pre-serialized JSON (str | bytes)
+            bundle: FHIR Bundle resource as a dict, or pre-serialized JSON (str | bytes)
             format: Output format ("csv", "csv_with_header", "json", "ndjson", "parquet")
             since: Filter resources modified after this ISO8601 datetime
             limit: Limit the number of results returned
@@ -139,12 +145,12 @@ try:
         )
 
     def validate_view_definition(
-        view: dict[str, Any], *, fhir_version: str = "R4"
+        view: JsonResource, *, fhir_version: str = "R4"
     ) -> bool:
         """Validate a ViewDefinition structure without executing it.
 
         Args:
-            view: ViewDefinition resource as a Python dictionary
+            view: ViewDefinition resource as a dict, or pre-serialized JSON (str | bytes)
             fhir_version: FHIR version to use ("R4", "R4B", "R5", "R6"). Defaults to "R4"
 
         Returns:
@@ -156,11 +162,11 @@ try:
         """
         return py_validate_view_definition(view, fhir_version)
 
-    def validate_bundle(bundle: dict[str, Any], *, fhir_version: str = "R4") -> bool:
+    def validate_bundle(bundle: JsonResource, *, fhir_version: str = "R4") -> bool:
         """Validate a Bundle structure without executing transformations.
 
         Args:
-            bundle: FHIR Bundle resource as a Python dictionary
+            bundle: FHIR Bundle resource as a dict, or pre-serialized JSON (str | bytes)
             fhir_version: FHIR version to use ("R4", "R4B", "R5", "R6"). Defaults to "R4"
 
         Returns:
@@ -194,8 +200,8 @@ try:
         return py_get_supported_fhir_versions()
 
     def run_view_definition_remote(
-        view: dict[str, Any],
-        bundle: dict[str, Any],
+        view: JsonResource,
+        bundle: JsonResource,
         format: str,
         remote_config: Any,
         *,
@@ -212,8 +218,8 @@ try:
         ``remote_config`` is active (enabled with a non-empty allowlist).
 
         Args:
-            view: ViewDefinition resource as a Python dictionary
-            bundle: FHIR Bundle resource as a Python dictionary
+            view: ViewDefinition resource as a dict, or pre-serialized JSON (str | bytes)
+            bundle: FHIR Bundle resource as a dict, or pre-serialized JSON (str | bytes)
             format: Output format ("csv", "csv_with_header", "json", "ndjson", "parquet")
             remote_config: A :class:`RemoteResolveConfig` instance
             since: Filter resources modified after this ISO8601 datetime
@@ -236,7 +242,7 @@ try:
         )
 
     def process_ndjson_to_file_remote(
-        view: dict[str, Any],
+        view: JsonResource,
         input_path: str,
         output_path: str,
         format: str,
@@ -255,7 +261,7 @@ try:
         cap.
 
         Args:
-            view: ViewDefinition resource as a Python dictionary
+            view: ViewDefinition resource as a dict, or pre-serialized JSON (str | bytes)
             input_path: Path to the input NDJSON file
             output_path: Path to write the output file
             format: Output format ("csv", "csv_with_header", "ndjson", "json")
@@ -279,7 +285,7 @@ try:
         )
 
     def process_ndjson_to_file(
-        view: dict[str, Any],
+        view: JsonResource,
         input_path: str,
         output_path: str,
         format: str,
@@ -295,7 +301,7 @@ try:
         bounded by ``chunk_size`` rather than file size.
 
         Args:
-            view: ViewDefinition resource as a Python dictionary
+            view: ViewDefinition resource as a dict, or pre-serialized JSON (str | bytes)
             input_path: Path to the input NDJSON file
             output_path: Path to write the output file
             format: Output format ("csv", "csv_with_header", "ndjson", "json")
@@ -394,8 +400,8 @@ except ImportError as e:
 
     # Define placeholder functions
     def run_view_definition(
-        view: dict[str, Any],
-        bundle: dict[str, Any],
+        view: JsonResource,
+        bundle: JsonResource,
         format: str,
         *,
         fhir_version: str = "R4",
@@ -403,8 +409,8 @@ except ImportError as e:
         raise NotImplementedError("Rust extension module not available")
 
     def run_view_definition_with_options(
-        view: dict[str, Any],
-        bundle: dict[str, Any],
+        view: JsonResource,
+        bundle: JsonResource,
         format: str,
         *,
         since: str | None = None,
@@ -415,11 +421,11 @@ except ImportError as e:
         raise NotImplementedError("Rust extension module not available")
 
     def validate_view_definition(
-        view: dict[str, Any], *, fhir_version: str = "R4"
+        view: JsonResource, *, fhir_version: str = "R4"
     ) -> bool:
         raise NotImplementedError("Rust extension module not available")
 
-    def validate_bundle(bundle: dict[str, Any], *, fhir_version: str = "R4") -> bool:
+    def validate_bundle(bundle: JsonResource, *, fhir_version: str = "R4") -> bool:
         raise NotImplementedError("Rust extension module not available")
 
     def parse_content_type(mime_type: str) -> str:
@@ -439,8 +445,8 @@ except ImportError as e:
             raise NotImplementedError("Rust extension module not available")
 
     def run_view_definition_remote(
-        view: dict[str, Any],
-        bundle: dict[str, Any],
+        view: JsonResource,
+        bundle: JsonResource,
         format: str,
         remote_config: Any,
         *,
@@ -452,7 +458,7 @@ except ImportError as e:
         raise NotImplementedError("Rust extension module not available")
 
     def process_ndjson_to_file_remote(
-        view: dict[str, Any],
+        view: JsonResource,
         input_path: str,
         output_path: str,
         format: str,
@@ -465,7 +471,7 @@ except ImportError as e:
         raise NotImplementedError("Rust extension module not available")
 
     def process_ndjson_to_file(
-        view: dict[str, Any],
+        view: JsonResource,
         input_path: str,
         output_path: str,
         format: str,

--- a/crates/pysof/src/pysof/__init__.py
+++ b/crates/pysof/src/pysof/__init__.py
@@ -7,6 +7,8 @@ Public API:
     run_view_definition: Transform FHIR data using ViewDefinition
     run_view_definition_with_options: Transform with filtering/pagination
     run_view_definition_remote: Transform with remote resolve() (trusted servers)
+    process_ndjson_to_file: Stream an NDJSON file to an output file
+    ChunkedProcessor: Iterate an NDJSON file as chunks of transformed rows
     process_ndjson_to_file_remote: Stream NDJSON with remote resolve()
     RemoteResolveConfig: Configuration for remote resolve()
     validate_view_definition: Pre-validate ViewDefinition structure
@@ -35,6 +37,8 @@ from typing import Any, cast
 try:
     # Import the Rust extension module
     from pysof._pysof import (
+        # NDJSON streaming iterator class
+        ChunkedProcessor,
         CsvError,
         FhirPathError,
         InvalidSourceContentError,
@@ -54,6 +58,7 @@ try:
         __version__,
         py_get_supported_fhir_versions,
         py_parse_content_type,
+        py_process_ndjson_to_file,
         py_process_ndjson_to_file_remote,
         py_run_view_definition,
         py_run_view_definition_with_options,
@@ -273,6 +278,44 @@ try:
             fhir_version=fhir_version,
         )
 
+    def process_ndjson_to_file(
+        view: dict[str, Any],
+        input_path: str,
+        output_path: str,
+        format: str,
+        *,
+        chunk_size: int = 1000,
+        skip_invalid: bool = False,
+        fhir_version: str = "R4",
+    ) -> dict[str, Any]:
+        """Stream an NDJSON file through a ViewDefinition into an output file.
+
+        The most memory-efficient way to process large NDJSON exports: resources
+        are read, transformed, and written chunk by chunk, so memory use is
+        bounded by ``chunk_size`` rather than file size.
+
+        Args:
+            view: ViewDefinition resource as a Python dictionary
+            input_path: Path to the input NDJSON file
+            output_path: Path to write the output file
+            format: Output format ("csv", "csv_with_header", "ndjson", "json")
+            chunk_size: Number of resources per chunk. Defaults to 1000.
+            skip_invalid: Skip invalid JSON lines. Defaults to False.
+            fhir_version: FHIR version to use ("R4", "R4B", "R5", "R6"). Defaults to "R4"
+
+        Returns:
+            Processing statistics as a dictionary
+        """
+        return py_process_ndjson_to_file(
+            view,
+            input_path,
+            output_path,
+            format,
+            chunk_size=chunk_size,
+            skip_invalid=skip_invalid,
+            fhir_version=fhir_version,
+        )
+
 except ImportError as e:
     # Fallback for when the Rust extension is not available
     import warnings
@@ -421,6 +464,24 @@ except ImportError as e:
     ) -> dict[str, Any]:
         raise NotImplementedError("Rust extension module not available")
 
+    def process_ndjson_to_file(
+        view: dict[str, Any],
+        input_path: str,
+        output_path: str,
+        format: str,
+        *,
+        chunk_size: int = 1000,
+        skip_invalid: bool = False,
+        fhir_version: str = "R4",
+    ) -> dict[str, Any]:
+        raise NotImplementedError("Rust extension module not available")
+
+    class ChunkedProcessor:  # type: ignore[no-redef]
+        """NDJSON streaming iterator (placeholder)."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError("Rust extension module not available")
+
     # Set fallback version when Rust extension is not available
     __version__ = "0.0.0-dev"
 
@@ -430,6 +491,8 @@ __all__: list[str] = [
     "run_view_definition",
     "run_view_definition_with_options",
     "run_view_definition_remote",
+    "process_ndjson_to_file",
+    "ChunkedProcessor",
     "process_ndjson_to_file_remote",
     "RemoteResolveConfig",
     "validate_view_definition",

--- a/crates/pysof/src/pysof/_pysof.pyi
+++ b/crates/pysof/src/pysof/_pysof.pyi
@@ -2,6 +2,9 @@
 
 from typing import Any
 
+# ViewDefinitions and Bundles: a Python dict, or pre-serialized JSON (str | bytes)
+JsonResource = dict[str, Any] | str | bytes
+
 # Module attributes
 __version__: str
 
@@ -42,14 +45,14 @@ class RemoteResolveConfig:
 
 # Core functions
 def py_run_view_definition(
-    view: dict[str, Any],
-    bundle: dict[str, Any],
+    view: JsonResource,
+    bundle: JsonResource,
     format: str,
     fhir_version: str,
 ) -> bytes: ...
 def py_run_view_definition_with_options(
-    view: dict[str, Any],
-    bundle: dict[str, Any],
+    view: JsonResource,
+    bundle: JsonResource,
     format: str,
     *,
     since: str | None = None,
@@ -58,18 +61,18 @@ def py_run_view_definition_with_options(
     fhir_version: str = "R4",
 ) -> bytes: ...
 def py_validate_view_definition(
-    view: dict[str, Any],
+    view: JsonResource,
     fhir_version: str,
 ) -> bool: ...
 def py_validate_bundle(
-    bundle: dict[str, Any],
+    bundle: JsonResource,
     fhir_version: str,
 ) -> bool: ...
 def py_parse_content_type(mime_type: str) -> str: ...
 def py_get_supported_fhir_versions() -> list[str]: ...
 def py_run_view_definition_with_options_remote(
-    view: dict[str, Any],
-    bundle: dict[str, Any],
+    view: JsonResource,
+    bundle: JsonResource,
     format: str,
     remote_config: RemoteResolveConfig,
     *,
@@ -79,7 +82,7 @@ def py_run_view_definition_with_options_remote(
     fhir_version: str = "R4",
 ) -> bytes: ...
 def py_process_ndjson_to_file(
-    view: dict[str, Any],
+    view: JsonResource,
     input_path: str,
     output_path: str,
     format: str,
@@ -92,7 +95,7 @@ def py_process_ndjson_to_file(
 class ChunkedProcessor:
     def __init__(
         self,
-        view_definition: dict[str, Any],
+        view_definition: JsonResource,
         input_path: str,
         *,
         chunk_size: int = 1000,
@@ -105,7 +108,7 @@ class ChunkedProcessor:
     def columns(self) -> list[str] | None: ...
 
 def py_process_ndjson_to_file_remote(
-    view: dict[str, Any],
+    view: JsonResource,
     input_path: str,
     output_path: str,
     format: str,

--- a/crates/pysof/src/pysof/_pysof.pyi
+++ b/crates/pysof/src/pysof/_pysof.pyi
@@ -78,6 +78,32 @@ def py_run_view_definition_with_options_remote(
     page: int | None = None,
     fhir_version: str = "R4",
 ) -> bytes: ...
+def py_process_ndjson_to_file(
+    view: dict[str, Any],
+    input_path: str,
+    output_path: str,
+    format: str,
+    *,
+    chunk_size: int = 1000,
+    skip_invalid: bool = False,
+    fhir_version: str = "R4",
+) -> dict[str, Any]: ...
+
+class ChunkedProcessor:
+    def __init__(
+        self,
+        view_definition: dict[str, Any],
+        input_path: str,
+        *,
+        chunk_size: int = 1000,
+        skip_invalid: bool = False,
+        fhir_version: str = "R4",
+    ) -> None: ...
+    def __iter__(self) -> ChunkedProcessor: ...
+    def __next__(self) -> dict[str, Any]: ...
+    @property
+    def columns(self) -> list[str] | None: ...
+
 def py_process_ndjson_to_file_remote(
     view: dict[str, Any],
     input_path: str,


### PR DESCRIPTION
Closes #687.

## What changed

| Commit | Change | Measured effect |
|---|---|---|
| `58e42bda` | mimalloc as pysof's global allocator | **1.8–1.9x throughput** on every path |
| `a99ec74a` | Export `process_ndjson_to_file` + `ChunkedProcessor` (README documented them; `__init__.py` never exported them) | bug fix |
| `8976fd1d` | Accept JSON `str`/`bytes` at every entry point; run the typed FHIR parse inside `py.detach()`; consolidate 4 copies of the FHIR-version dispatch; document the real parallelism story | **+25% per call** with pre-serialized JSON; GIL hold tens of ms → µs |

## How it was tested

A threaded benchmark harness (now checked in as `crates/pysof/scripts/bench_threading.py`) drives a 7-column Patient ViewDefinition through the API from 1/2/4/8 Python threads, iterations auto-calibrated to ~3s per configuration, barrier-started, aggregate transforms/sec reported. Scenarios: dict bundles (50 and 2,000 patients), the same 2,000-patient bundle as a JSON string, and NDJSON file-to-file (5,000 patients). A/B builds were measured at each step (baseline 0.2.1, parse-off-GIL only, plus mimalloc), plus a `RAYON_NUM_THREADS=1` control run. Environment: Windows 11, 12 logical CPUs, Python 3.11, release builds, idle machine.

## Why the GIL wasn't the bottleneck

The starting hypothesis was that GIL-held parsing limited multi-threaded throughput. The data refuted it:

- Python-thread scaling plateaus at **~x1.5 at 8 threads** on the baseline — and the curve is *identical* after moving all parsing off the GIL. If the GIL were the limiter, releasing it would have restored scaling.
- Pinning `RAYON_NUM_THREADS=1` flattens scaling to **~x1.1**: helios-sof already fans every call across rayon's shared global pool (`par_iter` over resources), so a single call saturates the machine and extra Python threads only fill scheduling gaps. The ceiling is the hardware, not the GIL.
- What the GIL *does* cost is latency for co-resident Python threads: baseline holds it for tens of milliseconds while parsing a large bundle. That's why the parse still moved inside `py.detach()` — an app embedding pysof (e.g. a web server) stays responsive — it's just honest to say it buys responsiveness, not throughput.
- The real throughput limiter was the allocator: the transform is allocation-heavy, and mimalloc doubled single-threaded throughput with no logic changes.

## Performance before/after

Single-thread transforms/sec, same harness and machine:

| Scenario | 0.2.1 baseline | This PR (dict) | This PR (JSON str) |
|---|---|---|---|
| dict bundle, 50 patients | 308 | 581 (1.9x) | — |
| bundle, 2,000 patients | 8.0 | 14.0 (1.75x) | **15.5 (1.9x)** |
| ndjson file→file, 5,000 patients | 3.5 | 6.3 (1.8x) | — |

JSON-string input is +25% over dict input on the same build by skipping the Python-dict conversion entirely.

## Verification

- 12 new tests written red-first (TDD): 3 export regression tests, 9 str/bytes input tests including error paths and dict/str output equivalence.
- Full suites green: **143 Python tests**, all 5 Rust test binaries (`cargo test --release`), `ruff`, `mypy`.
- README updated: input flexibility documented, and the parallelism section now states that each call is internally parallel via rayon (tune with `RAYON_NUM_THREADS`) — Python threads are for concurrency, not throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTNGEdcmYyKQoxfZ6KZpGp