### PR TITLE
feat(ui): View Definitions workspace — rail, JSON editor, $sql-run preview

### DIFF
--- a/crates/ui/e2e/tests/sql-view-definitions.spec.ts
+++ b/crates/ui/e2e/tests/sql-view-definitions.spec.ts
@@ -1,0 +1,36 @@
+// View Definitions workspace (#649): a stored ViewDefinition lists in the
+// rail, its JSON lands in the editor, Run previews rows through $sql-run, and
+// Create New offers the starter document. Everything here is plain links and
+// forms, so it also holds with JavaScript disabled (the nojs sweep loads the
+// route; the flows are exercised in the chromium project only).
+import { expect, test } from "../pages/fixtures";
+import { createResource } from "../pages/api";
+
+test("a stored ViewDefinition lists, edits, and previews rows", async ({ page, request }) => {
+  const patientId = await createResource(request, "Patient", {
+    name: [{ family: "ViewDefE2E" }],
+  });
+  const vdId = await createResource(request, "ViewDefinition", {
+    name: "e2e_patients",
+    status: "active",
+    resource: "Patient",
+    select: [{ column: [{ name: "id", path: "getResourceKey()" }] }],
+  });
+
+  await page.goto(`/ui/sql/view-definitions?vd=${vdId}`);
+  // The rail entry, selected; the editor holds the view's JSON.
+  await expect(page.locator(`#vd-rail-list [data-type='${vdId}']`)).toHaveAttribute(
+    "aria-current",
+    "true",
+  );
+  await expect(page.locator("textarea[name='json']")).toContainText("e2e_patients");
+
+  // Run previews the output; the seeded patient's key is among the rows.
+  await page.locator("a[href*='run=1']").click();
+  await expect(page.locator(".data-table")).toBeVisible();
+  await expect(page.locator(".data-table td", { hasText: patientId }).first()).toBeVisible();
+
+  // Create New swaps the editor to the starter document.
+  await page.goto("/ui/sql/view-definitions?vd=new");
+  await expect(page.locator("textarea[name='json']")).toContainText("new_view");
+});

--- a/crates/ui/src/conformance.rs
+++ b/crates/ui/src/conformance.rs
@@ -44,6 +44,35 @@ pub trait ConformanceSource: Send + Sync {
         let _ = (version, tenant);
         Err("metadata is not available from this source".to_string())
     }
+
+    /// Runs `$sql-run` with `view_definition` as the inline subject and
+    /// returns the output rows (`_format=json`), or an `Err` message the page
+    /// shows in place of the results table (#649).
+    async fn sql_run(
+        &self,
+        view_definition: &Value,
+        limit: usize,
+        version: FhirVersion,
+        tenant: &str,
+    ) -> Result<Vec<Value>, String> {
+        let _ = (view_definition, limit, version, tenant);
+        Err("$sql-run is not available from this source".to_string())
+    }
+
+    /// Creates (`id: None`) or updates one resource through the server's own
+    /// FHIR API and returns the stored resource. Backs the ViewDefinition
+    /// editor's plain-form save, which must work without JavaScript (#649).
+    async fn save_resource(
+        &self,
+        resource_type: &str,
+        id: Option<&str>,
+        resource: Value,
+        version: FhirVersion,
+        tenant: &str,
+    ) -> Result<Value, String> {
+        let _ = (resource_type, id, resource, version, tenant);
+        Err("saving is not available from this source".to_string())
+    }
 }
 
 /// Reads conformance resources from the server's own FHIR API over HTTP.
@@ -219,6 +248,124 @@ impl ConformanceSource for HttpConformanceSource {
         }
         Ok(resources)
     }
+
+    /// `POST /$sql-run` on the loopback base with the ViewDefinition as the
+    /// inline subject (the handler's raw-resource shorthand for a Parameters
+    /// body). Storage holds the seeded default version only, so any other
+    /// version degrades with a message rather than running against the wrong
+    /// data.
+    async fn sql_run(
+        &self,
+        view_definition: &Value,
+        limit: usize,
+        version: FhirVersion,
+        tenant: &str,
+    ) -> Result<Vec<Value>, String> {
+        if version != self.default_version {
+            return Err(format!(
+                "$sql-run reads stored data, which holds the server default (FHIR {}); switch the sidebar back to run this view",
+                self.default_version.as_str(),
+            ));
+        }
+        let url = format!("{}/$sql-run?_format=json&_limit={limit}", self.base_url);
+        let mut request = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .json(view_definition);
+        if !tenant.is_empty() {
+            request = request.header("X-Tenant-ID", tenant);
+        }
+        let request = self
+            .outbound_auth
+            .authorize(request, &self.base_url)
+            .await
+            .map_err(|e| format!("outbound auth failed: {e}"))?;
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("request to {url} failed: {e}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            // $sql-run explains its 4xx in an OperationOutcome; surface its
+            // diagnostics so an invalid view reads as more than a status code.
+            let detail = response
+                .json::<Value>()
+                .await
+                .ok()
+                .and_then(|o| outcome_diagnostics(&o))
+                .map(|d| format!(": {d}"))
+                .unwrap_or_default();
+            return Err(format!("$sql-run returned {status}{detail}"));
+        }
+        response
+            .json::<Vec<Value>>()
+            .await
+            .map_err(|e| format!("parsing $sql-run rows failed: {e}"))
+    }
+
+    async fn save_resource(
+        &self,
+        resource_type: &str,
+        id: Option<&str>,
+        resource: Value,
+        version: FhirVersion,
+        tenant: &str,
+    ) -> Result<Value, String> {
+        let url = match id {
+            Some(id) => format!("{}/{resource_type}/{id}", self.base_url),
+            None => format!("{}/{resource_type}", self.base_url),
+        };
+        let accept = format!(
+            "application/fhir+json; fhirVersion={}",
+            version.as_mime_param()
+        );
+        let mut request = match id {
+            Some(_) => self.client.put(&url),
+            None => self.client.post(&url),
+        }
+        .header("Content-Type", accept.clone())
+        .header("Accept", accept)
+        .json(&resource);
+        if !tenant.is_empty() {
+            request = request.header("X-Tenant-ID", tenant);
+        }
+        let request = self
+            .outbound_auth
+            .authorize(request, &self.base_url)
+            .await
+            .map_err(|e| format!("outbound auth failed: {e}"))?;
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("request to {url} failed: {e}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            let detail = response
+                .json::<Value>()
+                .await
+                .ok()
+                .and_then(|o| outcome_diagnostics(&o))
+                .map(|d| format!(": {d}"))
+                .unwrap_or_default();
+            return Err(format!("saving to {url} returned {status}{detail}"));
+        }
+        response
+            .json()
+            .await
+            .map_err(|e| format!("parsing the saved resource failed: {e}"))
+    }
+}
+
+/// The first issue diagnostics of an OperationOutcome, if that is what this is.
+fn outcome_diagnostics(outcome: &Value) -> Option<String> {
+    outcome
+        .get("issue")?
+        .as_array()?
+        .iter()
+        .find_map(|i| i.get("diagnostics").and_then(Value::as_str))
+        .map(String::from)
 }
 
 /// The `next` page URL of a searchset Bundle, if any.
@@ -264,6 +411,7 @@ fn extract_bundle_resources(bundle: &Value) -> Vec<Value> {
 pub struct StaticConformanceSource {
     map: HashMap<(String, FhirVersion), Vec<Value>>,
     metadata: Option<Value>,
+    sql_rows: Option<Result<Vec<Value>, String>>,
 }
 
 impl StaticConformanceSource {
@@ -272,12 +420,19 @@ impl StaticConformanceSource {
         Self {
             map: HashMap::new(),
             metadata: None,
+            sql_rows: None,
         }
     }
 
     /// Seeds the CapabilityStatement `metadata()` answers with (#653).
     pub fn with_metadata(mut self, statement: Value) -> Self {
         self.metadata = Some(statement);
+        self
+    }
+
+    /// Seeds what `sql_run()` answers (#649): `Ok` rows or the `Err` message.
+    pub fn with_sql_run(mut self, outcome: Result<Vec<Value>, String>) -> Self {
+        self.sql_rows = Some(outcome);
         self
     }
 
@@ -334,6 +489,37 @@ impl ConformanceSource for StaticConformanceSource {
         self.metadata
             .clone()
             .ok_or_else(|| "no metadata seeded".to_string())
+    }
+
+    async fn sql_run(
+        &self,
+        _view_definition: &Value,
+        limit: usize,
+        _version: FhirVersion,
+        _tenant: &str,
+    ) -> Result<Vec<Value>, String> {
+        match &self.sql_rows {
+            Some(Ok(rows)) => Ok(rows.iter().take(limit).cloned().collect()),
+            Some(Err(e)) => Err(e.clone()),
+            None => Err("no $sql-run outcome seeded".to_string()),
+        }
+    }
+
+    /// Echoes the resource back with an id, so the save handler's redirect
+    /// (and a test's assertion on it) has something stable to point at.
+    async fn save_resource(
+        &self,
+        _resource_type: &str,
+        id: Option<&str>,
+        mut resource: Value,
+        _version: FhirVersion,
+        _tenant: &str,
+    ) -> Result<Value, String> {
+        let id = id.unwrap_or("static-created").to_string();
+        if let Some(map) = resource.as_object_mut() {
+            map.insert("id".to_string(), Value::String(id));
+        }
+        Ok(resource)
     }
 }
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -48,6 +48,7 @@ mod history;
 mod i18n;
 mod json_view;
 mod search_params;
+mod sql_views;
 mod subscriptions;
 mod tenants;
 
@@ -850,9 +851,12 @@ pub fn mount_with_conformance_source(
         .route("/ui/capability-statement", get(capability_page))
         // Batch/Transaction workspace (#476): upload â†’ preflight â†’ response.
         .route("/ui/batch", get(batch_page))
-        // SQL on FHIR section (#649): stub pages until each surface lands,
-        // starting with the ViewDefinition Editor.
-        .route("/ui/sql/view-definitions", get(sql_view_definitions_page))
+        // SQL on FHIR section (#649). View Definitions is the live workspace;
+        // the rest are stub pages until each surface lands.
+        .route(
+            "/ui/sql/view-definitions",
+            get(sql_view_definitions_page).post(sql_view_definitions_save),
+        )
         .route("/ui/sql/queries", get(sql_queries_page))
         .route("/ui/sql/views", get(sql_views_page))
         .route("/ui/sql/export", get(sql_export_page))
@@ -1555,25 +1559,247 @@ fn render_sql_stub(
     })
 }
 
+/// The View Definitions workspace (#649, Figma `420-2`): a filter rail of the
+/// tenant's stored ViewDefinitions, the selected one as editable JSON, and a
+/// `$sql-run` preview of its output. Save and Duplicate are plain form posts
+/// (they work without JavaScript); Delete rides `conformance-crud.js` like
+/// the other conformance viewers.
+#[derive(Template)]
+#[template(path = "pages/sql-view-definitions.html")]
+struct SqlViewDefinitionsPage {
+    status: Status,
+    i18n: I18n,
+    active_page: &'static str,
+    rail: Vec<sql_views::VdSummary>,
+    /// The rail's server-side name filter, echoed back into the search box.
+    filter: String,
+    /// The list fetch failed — the page says so instead of showing an empty rail.
+    degraded: Option<String>,
+    /// `?vd=` (or the first entry): id, name, and pretty JSON. `None` only
+    /// when the store holds no views and none is being created.
+    selected: Option<SelectedVd>,
+    /// `?vd=new`: the JSON below is the starter document, not a stored view.
+    is_new: bool,
+    results: Option<sql_views::RunTable>,
+    run_error: Option<String>,
+    save_error: Option<String>,
+    saved: bool,
+}
+
+struct SelectedVd {
+    id: String,
+    name: String,
+    json: String,
+}
+
+#[derive(Deserialize, Default)]
+struct SqlVdQuery {
+    vd: Option<String>,
+    filter: Option<String>,
+    run: Option<String>,
+    saved: Option<String>,
+}
+
 async fn sql_view_definitions_page(
     State(state): State<WebState>,
     locale: RequestLocale,
     rv: RequestVersion,
     rt: RequestTenant,
+    Query(query): Query<SqlVdQuery>,
 ) -> Response {
-    render_sql_stub(
-        &state,
-        locale,
-        rv,
-        &rt,
+    let filter = query.filter.unwrap_or_default();
+    let (mut rail, degraded) = match state
+        .conformance
+        .fetch("ViewDefinition", rv.0, &rt.id)
+        .await
+    {
+        Ok(resources) => (resources, None),
+        Err(error) => {
+            tracing::warn!("ViewDefinition self-fetch failed: {error}");
+            (Vec::new(), Some(error))
+        }
+    };
+    let summaries = {
+        let mut s = sql_views::summarize(&rail);
+        if !filter.is_empty() {
+            let needle = filter.to_lowercase();
+            s.retain(|e| {
+                e.name.to_lowercase().contains(&needle)
+                    || e.resource.to_lowercase().contains(&needle)
+            });
+        }
+        s
+    };
+
+    let is_new = query.vd.as_deref() == Some("new");
+    let (selected, selected_value) = if is_new {
         (
-            "sql-view-definitions",
-            "sql-vd-title",
-            "sql-vd-lede",
-            "sql-vd-body",
-            "POST /$sql-run",
-        ),
-    )
+            Some(SelectedVd {
+                id: String::new(),
+                name: String::new(),
+                json: sql_views::starter_view_definition(),
+            }),
+            None,
+        )
+    } else {
+        // ?vd=<id>, defaulting to the first rail entry. The full resource is
+        // taken from the fetch — no second round trip.
+        let wanted = query
+            .vd
+            .clone()
+            .or_else(|| summaries.first().map(|e| e.id.clone()));
+        let found = wanted.and_then(|id| {
+            rail.iter()
+                .position(|vd| vd.get("id").and_then(serde_json::Value::as_str) == Some(&id))
+        });
+        match found.map(|i| rail.swap_remove(i)) {
+            Some(vd) => {
+                let id = vd
+                    .get("id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let name = vd
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(&id)
+                    .to_string();
+                let json = serde_json::to_string_pretty(&vd).unwrap_or_default();
+                (Some(SelectedVd { id, name, json }), Some(vd))
+            }
+            None => (None, None),
+        }
+    };
+
+    // `?run=1` previews the selected view through $sql-run — a plain link, so
+    // it works without JavaScript. Capped: this is a preview, not an export.
+    let (results, run_error) = match (&selected_value, query.run.as_deref() == Some("1")) {
+        (Some(vd), true) => match state.conformance.sql_run(vd, 50, rv.0, &rt.id).await {
+            Ok(rows) => (Some(sql_views::build_table(vd, &rows)), None),
+            Err(error) => (None, Some(error)),
+        },
+        _ => (None, None),
+    };
+
+    render(SqlViewDefinitionsPage {
+        status: current_status(&state, rv.0, &rt),
+        i18n: I18n::new(locale),
+        active_page: "sql-view-definitions",
+        rail: summaries,
+        filter,
+        degraded,
+        selected,
+        is_new,
+        results,
+        run_error,
+        save_error: None,
+        saved: query.saved.as_deref() == Some("1"),
+    })
+}
+
+#[derive(Deserialize)]
+struct SqlVdSaveForm {
+    /// Empty for a create; the stored id for an update.
+    #[serde(default)]
+    id: String,
+    json: String,
+    /// `save` or `duplicate` — the two submit buttons of the one form.
+    #[serde(default)]
+    action: String,
+}
+
+/// Saves the editor's JSON through the server's own FHIR API and bounces back
+/// to the page with the stored view selected. A parse or server error
+/// re-renders the page with the submitted text preserved, so nothing typed is
+/// lost. Plain form semantics throughout — no JavaScript required.
+async fn sql_view_definitions_save(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+    rt: RequestTenant,
+    axum::Form(form): axum::Form<SqlVdSaveForm>,
+) -> Response {
+    let error_page =
+        |save_error: String, json: String, is_new: bool, id: String| SqlViewDefinitionsPage {
+            status: current_status(&state, rv.0, &rt),
+            i18n: I18n::new(locale),
+            active_page: "sql-view-definitions",
+            rail: Vec::new(),
+            filter: String::new(),
+            degraded: None,
+            selected: Some(SelectedVd {
+                name: if is_new { String::new() } else { id.clone() },
+                id,
+                json,
+            }),
+            is_new,
+            results: None,
+            run_error: None,
+            save_error: Some(save_error),
+            saved: false,
+        };
+
+    let duplicate = form.action == "duplicate";
+    let mut resource: serde_json::Value = match serde_json::from_str(form.json.trim()) {
+        Ok(value) => value,
+        Err(e) => {
+            return render(error_page(
+                format!("invalid JSON: {e}"),
+                form.json,
+                form.id.is_empty(),
+                form.id,
+            ));
+        }
+    };
+    if resource
+        .get("resourceType")
+        .and_then(serde_json::Value::as_str)
+        != Some("ViewDefinition")
+    {
+        return render(error_page(
+            "the document must have resourceType \"ViewDefinition\"".to_string(),
+            form.json,
+            form.id.is_empty(),
+            form.id,
+        ));
+    }
+
+    let id = if duplicate || form.id.is_empty() {
+        // A create must not carry a stored id; a duplicate also gets a fresh
+        // name so the two are tellable apart in the rail.
+        if let Some(map) = resource.as_object_mut() {
+            map.remove("id");
+            if duplicate && let Some(name) = map.get("name").and_then(serde_json::Value::as_str) {
+                let copy = format!("{name}_copy");
+                map.insert("name".to_string(), serde_json::Value::String(copy));
+            }
+        }
+        None
+    } else {
+        // The path id is authoritative for an update; the body must agree.
+        if let Some(map) = resource.as_object_mut() {
+            map.insert("id".to_string(), serde_json::Value::String(form.id.clone()));
+        }
+        Some(form.id.clone())
+    };
+
+    match state
+        .conformance
+        .save_resource("ViewDefinition", id.as_deref(), resource, rv.0, &rt.id)
+        .await
+    {
+        Ok(stored) => {
+            let stored_id = stored
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            axum::response::Redirect::to(&format!(
+                "/ui/sql/view-definitions?vd={stored_id}&saved=1"
+            ))
+            .into_response()
+        }
+        Err(error) => render(error_page(error, form.json, id.is_none(), form.id)),
+    }
 }
 
 async fn sql_queries_page(

--- a/crates/ui/src/sql_views.rs
+++ b/crates/ui/src/sql_views.rs
@@ -1,0 +1,181 @@
+//! View models for the SQL on FHIR View Definitions workspace (#649).
+//!
+//! The page lists the tenant's stored `ViewDefinition`s in a filter rail,
+//! shows the selected one as editable JSON, and previews its output through
+//! `$sql-run`. Everything here is a pure function over resource JSON; the
+//! fetching and running live behind [`crate::ConformanceSource`].
+
+use serde_json::Value;
+
+/// One rail entry: a stored ViewDefinition summarized for the picker.
+pub(crate) struct VdSummary {
+    pub id: String,
+    pub name: String,
+    /// The FHIR resource type the view flattens (`ViewDefinition.resource`).
+    pub resource: String,
+}
+
+/// Summarizes fetched ViewDefinitions into rail entries, sorted by name.
+/// Resources without an `id` are unreachable by the page's `?vd=` selection
+/// and are dropped rather than rendered as dead rows.
+pub(crate) fn summarize(resources: &[Value]) -> Vec<VdSummary> {
+    let mut entries: Vec<VdSummary> = resources
+        .iter()
+        .filter_map(|vd| {
+            let id = vd.get("id")?.as_str()?.to_string();
+            let name = vd
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(&id)
+                .to_string();
+            let resource = vd
+                .get("resource")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            Some(VdSummary { id, name, resource })
+        })
+        .collect();
+    entries.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+    entries
+}
+
+/// The view's output column names, in declaration order: a depth-first walk of
+/// `select[].column[].name` through nested `select` and `unionAll` branches.
+/// This is the authoritative column order — `_format=json` rows are objects,
+/// whose key order is not something to depend on.
+pub(crate) fn column_names(view_definition: &Value) -> Vec<String> {
+    let mut names = Vec::new();
+    collect_columns(view_definition.get("select"), &mut names);
+    names
+}
+
+fn collect_columns(select: Option<&Value>, names: &mut Vec<String>) {
+    let Some(selects) = select.and_then(Value::as_array) else {
+        return;
+    };
+    for s in selects {
+        if let Some(columns) = s.get("column").and_then(Value::as_array) {
+            for c in columns {
+                if let Some(name) = c.get("name").and_then(Value::as_str) {
+                    if !names.iter().any(|n| n == name) {
+                        names.push(name.to_string());
+                    }
+                }
+            }
+        }
+        collect_columns(s.get("select"), names);
+        collect_columns(s.get("unionAll"), names);
+    }
+}
+
+/// The `$sql-run` preview, shaped for a `data-table`.
+pub(crate) struct RunTable {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+/// Tables the JSON rows under the view's declared columns. A column missing
+/// from a row renders empty; a row key the view does not declare (or, with no
+/// declared columns at all, every key of the first row) extends the header, so
+/// nothing the server returned is silently dropped.
+pub(crate) fn build_table(view_definition: &Value, rows: &[Value]) -> RunTable {
+    let mut columns = column_names(view_definition);
+    for row in rows {
+        if let Some(map) = row.as_object() {
+            for key in map.keys() {
+                if !columns.iter().any(|c| c == key) {
+                    columns.push(key.clone());
+                }
+            }
+        }
+    }
+    let rows = rows
+        .iter()
+        .map(|row| {
+            columns
+                .iter()
+                .map(|c| cell_text(row.get(c)))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    RunTable { columns, rows }
+}
+
+/// A cell's display text: strings verbatim, `null`/absent empty, anything
+/// else (numbers, booleans, arrays from collection columns) as compact JSON.
+fn cell_text(value: Option<&Value>) -> String {
+    match value {
+        None | Some(Value::Null) => String::new(),
+        Some(Value::String(s)) => s.clone(),
+        Some(other) => other.to_string(),
+    }
+}
+
+/// The starter document behind "Create New" — the smallest runnable view.
+pub(crate) fn starter_view_definition() -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "resourceType": "ViewDefinition",
+        "name": "new_view",
+        "status": "draft",
+        "resource": "Patient",
+        "select": [
+            { "column": [ { "name": "id", "path": "getResourceKey()" } ] }
+        ]
+    }))
+    .expect("static JSON serializes")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn summaries_sort_by_name_and_skip_idless_resources() {
+        let vds = vec![
+            json!({"id": "b", "name": "blood_pressure", "resource": "Observation"}),
+            json!({"name": "unsaved_no_id", "resource": "Patient"}),
+            json!({"id": "a", "name": "active_patients", "resource": "Patient"}),
+            json!({"id": "x", "resource": "Patient"}),
+        ];
+        let rail = summarize(&vds);
+        let names: Vec<&str> = rail.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, ["active_patients", "blood_pressure", "x"]);
+        assert_eq!(rail[0].resource, "Patient");
+    }
+
+    #[test]
+    fn column_order_follows_the_select_walk_not_the_row_objects() {
+        let vd = json!({
+            "resource": "Patient",
+            "select": [
+                { "column": [ {"name": "id", "path": "id"}, {"name": "name", "path": "name.family"} ] },
+                { "unionAll": [ { "column": [ {"name": "zip", "path": "address.postalCode"} ] } ] }
+            ]
+        });
+        assert_eq!(column_names(&vd), ["id", "name", "zip"]);
+
+        let rows = vec![json!({"zip": "10001", "name": "Doe", "id": "p1", "extra": 7})];
+        let table = build_table(&vd, &rows);
+        // Declared order first, then whatever the server added.
+        assert_eq!(table.columns, ["id", "name", "zip", "extra"]);
+        assert_eq!(table.rows[0], ["p1", "Doe", "10001", "7"]);
+    }
+
+    #[test]
+    fn cells_render_strings_verbatim_and_null_empty() {
+        let vd = json!({"select": [{ "column": [{"name": "a", "path": "x"}, {"name": "b", "path": "y"}] }]});
+        let rows = vec![json!({"a": null, "b": [1, 2]})];
+        let table = build_table(&vd, &rows);
+        assert_eq!(table.rows[0], ["", "[1,2]"]);
+    }
+
+    #[test]
+    fn the_starter_document_parses_and_declares_a_column() {
+        let vd: Value = serde_json::from_str(&starter_view_definition()).unwrap();
+        assert_eq!(vd["resourceType"], "ViewDefinition");
+        assert_eq!(column_names(&vd), ["id"]);
+    }
+}

--- a/crates/ui/templates/pages/sql-view-definitions.html
+++ b/crates/ui/templates/pages/sql-view-definitions.html
@@ -1,0 +1,134 @@
+{% extends "layouts/base.html" %}
+
+{#
+  View Definitions workspace (#649, Figma 420-2): rail of stored
+  ViewDefinitions, the selected one as editable JSON, and a $sql-run preview.
+  Save/Duplicate are submit buttons of one plain form (POST back to this
+  route); Run is a plain link (?run=1); Delete rides conformance-crud.js like
+  the other conformance viewers. Everything works without JavaScript.
+#}
+
+{% block title %}{{ i18n.t("sql-vd-title") }} — {{ i18n.t("app-title") }}{% endblock %}
+
+{% block body_class %}app-shell{% endblock %}
+{% block content_class %} content--app{% endblock %}
+
+{% block content %}
+<section class="page-head page-head--row">
+  <div>
+    <h1 class="page-head__title">{{ i18n.t("sql-vd-title") }}</h1>
+    <p class="page-head__lede">{{ i18n.t("sql-vd-lede") }}</p>
+  </div>
+  <a class="btn btn--primary" href="/ui/sql/view-definitions?vd=new">{{ i18n.t("vd-new") }}</a>
+</section>
+
+{% if let Some(message) = degraded %}
+<p class="notice notice--warn">{{ i18n.t("vd-degraded") }} {{ message }}</p>
+{% endif %}
+{% if saved %}
+<p class="notice">{{ i18n.t("vd-saved") }}</p>
+{% endif %}
+
+<div class="filter-layout">
+  <aside class="filter-rail" aria-label="{{ i18n.t("vd-rail-label") }}">
+    <div class="filter-rail__heading">{{ i18n.t("vd-rail-heading") }}</div>
+    <form class="filter-rail__search" method="get" action="/ui/sql/view-definitions" role="search">
+      {% if let Some(sel) = selected %}{% if !sel.id.is_empty() %}
+      <input type="hidden" name="vd" value="{{ sel.id }}">
+      {% endif %}{% endif %}
+      <span class="icon">{% include "icons/search.svg" %}</span>
+      <input type="search" name="filter" value="{{ filter }}"
+             placeholder="{{ i18n.t("vd-filter") }}" aria-label="{{ i18n.t("vd-filter") }}">
+    </form>
+    <div class="filter-rail__list" id="vd-rail-list">
+      {% for item in rail %}
+      <a class="filter-rail__item" data-type="{{ item.id }}" data-full-name="{{ item.name }}"
+         href="/ui/sql/view-definitions?vd={{ item.id }}" title="{{ item.name }}"
+         {%- if let Some(sel) = selected %}{% if sel.id == item.id %} aria-current="true"{% endif %}{% endif %}>
+        <span class="filter-rail__label">{{ item.name }}</span>
+        <span class="count">{{ item.resource }}</span>
+      </a>
+      {% endfor %}
+      {% if rail.is_empty() %}
+      <p class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("vd-none") }}</p>
+      {% endif %}
+    </div>
+  </aside>
+
+  <div>
+    {% if let Some(sel) = selected %}
+    <section class="page-head page-head--row">
+      <div>
+        <h1 class="page-head__title">{% if is_new %}{{ i18n.t("vd-new-title") }}{% else %}{{ sel.name }}{% endif %}</h1>
+      </div>
+      <div>
+        {% if !is_new %}
+        <a class="btn" href="/ui/sql/view-definitions?vd={{ sel.id }}&run=1">{{ i18n.t("vd-run") }}</a>
+        <button type="button" class="btn btn--danger" data-crud-delete
+                data-type="ViewDefinition" data-id="{{ sel.id }}"
+                data-confirm="{{ i18n.t_arg("vd-delete-confirm", "name", sel.name.to_string()) }}"
+                data-failed="{{ i18n.t("vd-delete-failed") }}"
+                data-redirect="/ui/sql/view-definitions">{{ i18n.t("vd-delete") }}</button>
+        {% endif %}
+      </div>
+    </section>
+
+    {% if let Some(error) = save_error %}
+    <p class="notice notice--warn">{{ error }}</p>
+    {% endif %}
+
+    <section class="card">
+      <div class="card-head">
+        <h3>{{ i18n.t("vd-json-heading") }}</h3>
+      </div>
+      <form method="post" action="/ui/sql/view-definitions">
+        <input type="hidden" name="id" value="{{ sel.id }}">
+        <textarea class="field__input" name="json" rows="18" spellcheck="false"
+                  aria-label="{{ i18n.t("vd-json-heading") }}">{{ sel.json }}</textarea>
+        <div class="card-head">
+          <button type="submit" class="btn btn--primary" name="action" value="save">{{ i18n.t("vd-save") }}</button>
+          {% if !is_new %}
+          <button type="submit" class="btn" name="action" value="duplicate">{{ i18n.t("vd-duplicate") }}</button>
+          {% endif %}
+        </div>
+      </form>
+    </section>
+
+    {% if let Some(error) = run_error %}
+    <p class="notice notice--warn">{{ i18n.t("vd-run-failed") }} {{ error }}</p>
+    {% endif %}
+    {% if let Some(table) = results %}
+    <section class="card table-card">
+      <div class="card-head">
+        <h3>{{ i18n.t("vd-results-heading") }}</h3>
+      </div>
+      <div class="table-wrap">
+        <table class="data-table">
+          <thead>
+            <tr>{% for c in table.columns %}<th>{{ c }}</th>{% endfor %}</tr>
+          </thead>
+          <tbody>
+            {% for row in table.rows %}
+            <tr>{% for cell in row %}<td>{{ cell }}</td>{% endfor %}</tr>
+            {% endfor %}
+            {% if table.rows.is_empty() %}
+            <tr class="data-table__empty"><td colspan="{{ table.columns.len() }}">{{ i18n.t("vd-results-empty") }}</td></tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+    </section>
+    {% endif %}
+    {% else %}
+    <section class="card">
+      <div class="card-head">
+        <h3>{{ i18n.t("vd-none") }}</h3>
+      </div>
+      <p class="page-head__lede">{{ i18n.t("vd-empty-lede") }}</p>
+    </section>
+    {% endif %}
+  </div>
+</div>
+
+<script src="/ui/assets/conformance-crud.js" defer></script>
+{% endblock %}

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -1291,10 +1291,150 @@ async fn sql_on_fhir_section_navigates_to_real_stub_pages() {
             html.contains(&format!(r#"href="{href}" aria-current="page""#)),
             "{href} does not mark its nav entry current"
         );
-        // The stub states which server operation already serves the data.
-        assert!(
-            html.contains("sql-run") || html.contains("/export/"),
-            "{href}"
-        );
+        // A stub states which server operation already serves the data; View
+        // Definitions is the live workspace and asserts its own content in
+        // `view_definitions_workspace_lists_edits_and_previews`.
+        if href != "/ui/sql/view-definitions" {
+            assert!(
+                html.contains("sql-run") || html.contains("/export/"),
+                "{href}"
+            );
+        }
     }
+}
+
+/// #649: the View Definitions workspace lists stored views in the rail
+/// (name-sorted, first selected), edits the selection as JSON, offers the
+/// starter document under Create New, and previews rows through $sql-run in
+/// the view's declared column order.
+#[tokio::test]
+async fn view_definitions_workspace_lists_edits_and_previews() {
+    let vds = vec![
+        serde_json::json!({"resourceType": "ViewDefinition", "id": "vd2", "name": "blood_pressure",
+            "resource": "Observation",
+            "select": [{"column": [{"name": "id", "path": "getResourceKey()"}]}]}),
+        serde_json::json!({"resourceType": "ViewDefinition", "id": "vd1", "name": "active_patients",
+            "resource": "Patient",
+            "select": [{"column": [{"name": "id", "path": "getResourceKey()"},
+                                    {"name": "family", "path": "name.family.first()"}]}]}),
+    ];
+    let source = helios_ui::StaticConformanceSource::empty()
+        .with("ViewDefinition", helios_fhir::FhirVersion::R4, vds)
+        .with_sql_run(Ok(vec![serde_json::json!({"family": "Doe", "id": "p1"})]));
+    let app = helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        Some(std::path::PathBuf::from("../../data")),
+        nl(true, true),
+        None,
+        None,
+        "default".to_string(),
+        std::sync::Arc::new(source),
+        helios_fhir::FhirVersion::R4,
+        None,
+    );
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/ui/sql/view-definitions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    // Both rail entries, and the name-sorted first one selected by default.
+    assert!(html.contains(r#"href="/ui/sql/view-definitions?vd=vd1""#));
+    assert!(html.contains(r#"href="/ui/sql/view-definitions?vd=vd2""#));
+    assert!(html.contains("active_patients"));
+    assert!(html.contains(r#"name="json""#));
+    // Delete goes through the shared conformance CRUD script.
+    assert!(html.contains(r#"data-crud-delete"#));
+    assert!(html.contains("/ui/assets/conformance-crud.js"));
+
+    // ?run=1 previews through $sql-run: declared column order, row rendered.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/ui/sql/view-definitions?vd=vd1&run=1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(html.contains("<th>id</th><th>family</th>"));
+    assert!(html.contains("<td>p1</td><td>Doe</td>"));
+
+    // Create New offers the starter document in the editor.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/ui/sql/view-definitions?vd=new")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(html.contains("new_view"));
+    assert!(html.contains("getResourceKey()"));
+}
+
+/// #649: Save is a plain form post — a valid document redirects to the stored
+/// view, a broken one re-renders with the submitted text preserved so nothing
+/// typed is lost.
+#[tokio::test]
+async fn view_definitions_save_roundtrips_and_rejects_bad_json() {
+    let source = helios_ui::StaticConformanceSource::empty().with(
+        "ViewDefinition",
+        helios_fhir::FhirVersion::R4,
+        Vec::new(),
+    );
+    let app = helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        Some(std::path::PathBuf::from("../../data")),
+        nl(true, true),
+        None,
+        None,
+        "default".to_string(),
+        std::sync::Arc::new(source),
+        helios_fhir::FhirVersion::R4,
+        None,
+    );
+
+    let body = "id=&action=save&json=%7B%22resourceType%22%3A%22ViewDefinition%22%2C%22name%22%3A%22x%22%7D";
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/ui/sql/view-definitions")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        response.headers()["location"],
+        "/ui/sql/view-definitions?vd=static-created&saved=1"
+    );
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/ui/sql/view-definitions")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("id=&action=save&json=%7Bnope"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    assert!(html.contains("invalid JSON"));
+    assert!(html.contains("{nope"));
 }

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -746,7 +746,6 @@ sql-stub-api = Bedienende API
 
 sql-vd-title = View-Definitionen
 sql-vd-lede = Erstelle und verwalte die ViewDefinitions, mit denen SQL on FHIR Ressourcen abflacht.
-sql-vd-body = Eine Liste und ein Editor für ViewDefinitions. Views erstellen, bearbeiten und validieren — ausgeführt werden sie unter SQL-Abfragen.
 
 sql-queries-title = SQL-Abfragen
 sql-queries-lede = Führe SQL-on-FHIR-Abfragen gegen diesen Server aus.
@@ -763,3 +762,25 @@ sql-export-body = Einen Export starten, den Fortschritt verfolgen und nicht mehr
 sql-files-title = Dateien
 sql-files-lede = Manifeste und Ausgabedateien der SQL-Exporte.
 sql-files-body = Das Manifest jedes Auftrags einsehen und seine Ausgabedateien herunterladen.
+
+## View-Definitionen-Arbeitsbereich (#649)
+
+vd-new = Neu erstellen
+vd-new-title = Neue View-Definition
+vd-rail-label = View-Definitionen
+vd-rail-heading = View-Definitionen
+vd-filter = Views filtern
+vd-none = Noch keine View-Definitionen.
+vd-empty-lede = Lege mit „Neu erstellen" die erste ViewDefinition an.
+vd-degraded = Die Liste der View-Definitionen konnte nicht geladen werden.
+vd-saved = Gespeichert.
+vd-run = Ausführen
+vd-run-failed = Die Ausführung der View ist fehlgeschlagen.
+vd-save = Speichern
+vd-duplicate = Duplizieren
+vd-delete = Löschen
+vd-delete-confirm = View-Definition „{ $name }" löschen? Das kann nicht rückgängig gemacht werden.
+vd-delete-failed = Die View-Definition konnte nicht gelöscht werden.
+vd-json-heading = Definition (JSON)
+vd-results-heading = Ergebnisse
+vd-results-empty = Die View hat keine Zeilen erzeugt.

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -749,7 +749,6 @@ sql-stub-api = Serving API
 
 sql-vd-title = View Definitions
 sql-vd-lede = Author and manage the ViewDefinitions that SQL on FHIR runs flatten resources with.
-sql-vd-body = A ViewDefinition list and editor. Create, edit, and validate views, then run them from SQL Queries.
 
 sql-queries-title = SQL Queries
 sql-queries-lede = Run SQL on FHIR queries against this server.
@@ -766,3 +765,25 @@ sql-export-body = Start an export, follow its progress, and cancel jobs that are
 sql-files-title = Files
 sql-files-lede = Manifests and output files produced by SQL exports.
 sql-files-body = Browse each job's manifest and download its output files.
+
+## View Definitions workspace (#649)
+
+vd-new = Create New
+vd-new-title = New View Definition
+vd-rail-label = View definitions
+vd-rail-heading = View Definitions
+vd-filter = Filter views
+vd-none = No view definitions yet.
+vd-empty-lede = Create your first ViewDefinition with Create New.
+vd-degraded = The view definition list could not be loaded.
+vd-saved = Saved.
+vd-run = Run
+vd-run-failed = Running the view failed.
+vd-save = Save
+vd-duplicate = Duplicate
+vd-delete = Delete
+vd-delete-confirm = Delete view definition "{ $name }"? This cannot be undone.
+vd-delete-failed = Deleting the view definition failed.
+vd-json-heading = Definition (JSON)
+vd-results-heading = Results
+vd-results-empty = The view produced no rows.

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -746,7 +746,6 @@ sql-stub-api = API que lo sirve
 
 sql-vd-title = Definiciones de vistas
 sql-vd-lede = Crea y gestiona las ViewDefinitions con las que SQL on FHIR aplana recursos.
-sql-vd-body = Una lista y un editor de ViewDefinitions. Crea, edita y valida vistas, y ejecútalas después desde Consultas SQL.
 
 sql-queries-title = Consultas SQL
 sql-queries-lede = Ejecuta consultas SQL on FHIR contra este servidor.
@@ -763,3 +762,25 @@ sql-export-body = Inicia una exportación, sigue su progreso y cancela los traba
 sql-files-title = Archivos
 sql-files-lede = Manifiestos y archivos de salida producidos por las exportaciones SQL.
 sql-files-body = Consulta el manifiesto de cada trabajo y descarga sus archivos de salida.
+
+## Espacio de definiciones de vistas (#649)
+
+vd-new = Crear nueva
+vd-new-title = Nueva definición de vista
+vd-rail-label = Definiciones de vistas
+vd-rail-heading = Definiciones de vistas
+vd-filter = Filtrar vistas
+vd-none = Aún no hay definiciones de vistas.
+vd-empty-lede = Crea tu primera ViewDefinition con «Crear nueva».
+vd-degraded = No se pudo cargar la lista de definiciones de vistas.
+vd-saved = Guardado.
+vd-run = Ejecutar
+vd-run-failed = La ejecución de la vista falló.
+vd-save = Guardar
+vd-duplicate = Duplicar
+vd-delete = Eliminar
+vd-delete-confirm = ¿Eliminar la definición de vista «{ $name }»? Esta acción no se puede deshacer.
+vd-delete-failed = No se pudo eliminar la definición de vista.
+vd-json-heading = Definición (JSON)
+vd-results-heading = Resultados
+vd-results-empty = La vista no produjo filas.


### PR DESCRIPTION
Part 2 of #649, stacked on #673 (the nav structure) — it retargets to `main` automatically when #673 merges. The remaining stub pages (SQL Queries, SQL Views, SQL Export, Files) follow.

## What

`/ui/sql/view-definitions` goes from stub to the live workspace of Figma `420-2`:

- **Rail**: the tenant's stored ViewDefinitions, name-sorted, with a server-side name/resource filter; the selected entry marked `aria-current`.
- **Editor**: the selected view as pretty JSON in a textarea. **Save** and **Duplicate** are submit buttons of one plain form posting back to the route — success redirects to the stored view (`?vd=<id>&saved=1`), a parse or server error re-renders with the submitted text preserved. **Create New** offers a minimal starter document.
- **Preview**: **Run** is a plain link (`?run=1`) that posts the view as `$sql-run`'s inline subject (`_format=json`, capped at 50 rows) and tables the rows. Column order comes from a depth-first walk of the view's `select` tree — never from row-object key order — and undeclared row keys extend the header rather than being dropped. `$sql-run` failures surface the OperationOutcome diagnostics.
- **Delete** rides the shared `conformance-crud.js`, like the other conformance viewers.

Every flow works without JavaScript.

## How

`ConformanceSource` grows two default-`Err` methods, mirroring how `metadata()` landed for #653: `sql_run` and `save_resource`, both implemented by the HTTP source on the loopback base with outbound auth, and by the static test double (seeded rows; echoed saves). Listing the views is the existing generic `fetch("ViewDefinition")`. Non-default sidebar versions degrade with a message — storage holds the seeded default only.

## Tests

- `sql_views` unit tests: summarizing/sorting, the select-tree column walk, cell rendering, the starter document.
- `router_http`: workspace render (rail, selection, editor, delete wiring), `$sql-run` preview order, Create New, save redirect, bad-JSON re-render.
- New e2e spec seeds a Patient + ViewDefinition over the API and drives rail → editor → Run → rows end to end against the real server.
- Local runs: `cargo test -p helios-ui` fully green; Playwright a11y (light+dark) / design-system / no-cdn / nojs / new spec all green.