### PR TITLE
ci: renormalize reused workspaces after checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,16 @@ jobs:
         with:
           clean: false
 
+      # With `clean: false` a reused workspace keeps files materialized under
+      # whatever line-ending rules held when they were first checked out —
+      # checkout's `--force` only rewrites files whose blob changed. Rewrite
+      # the whole tree from the index so the current .gitattributes rules
+      # (eol=lf on the byte-embedded UI content, #671) apply on every run;
+      # on Windows agents a stale CRLF template otherwise fails every
+      # multi-line assertion of rendered HTML.
+      - name: Renormalize the working tree
+        run: git checkout-index --all --force
+
       - name: Install Rust toolchain (Linux/macOS)
         if: runner.os != 'Windows'
         uses: dtolnay/rust-toolchain@stable
@@ -385,6 +395,16 @@ jobs:
         with:
           clean: false
 
+      # With `clean: false` a reused workspace keeps files materialized under
+      # whatever line-ending rules held when they were first checked out —
+      # checkout's `--force` only rewrites files whose blob changed. Rewrite
+      # the whole tree from the index so the current .gitattributes rules
+      # (eol=lf on the byte-embedded UI content, #671) apply on every run;
+      # on Windows agents a stale CRLF template otherwise fails every
+      # multi-line assertion of rendered HTML.
+      - name: Renormalize the working tree
+        run: git checkout-index --all --force
+
       - name: Install Rust toolchain (Linux/macOS)
         if: runner.os != 'Windows'
         uses: dtolnay/rust-toolchain@stable
@@ -454,6 +474,16 @@ jobs:
         uses: actions/checkout@v5
         with:
           clean: false
+
+      # With `clean: false` a reused workspace keeps files materialized under
+      # whatever line-ending rules held when they were first checked out —
+      # checkout's `--force` only rewrites files whose blob changed. Rewrite
+      # the whole tree from the index so the current .gitattributes rules
+      # (eol=lf on the byte-embedded UI content, #671) apply on every run;
+      # on Windows agents a stale CRLF template otherwise fails every
+      # multi-line assertion of rendered HTML.
+      - name: Renormalize the working tree
+        run: git checkout-index --all --force
 
       - name: Install Rust toolchain (Linux/macOS)
         if: runner.os != 'Windows'
@@ -541,6 +571,16 @@ jobs:
         uses: actions/checkout@v5
         with:
           clean: false
+
+      # With `clean: false` a reused workspace keeps files materialized under
+      # whatever line-ending rules held when they were first checked out —
+      # checkout's `--force` only rewrites files whose blob changed. Rewrite
+      # the whole tree from the index so the current .gitattributes rules
+      # (eol=lf on the byte-embedded UI content, #671) apply on every run;
+      # on Windows agents a stale CRLF template otherwise fails every
+      # multi-line assertion of rendered HTML.
+      - name: Renormalize the working tree
+        run: git checkout-index --all --force
 
       - name: Install Rust toolchain (Linux/macOS)
         if: runner.os != 'Windows'
@@ -680,6 +720,16 @@ jobs:
         uses: actions/checkout@v5
         with:
           clean: false
+
+      # With `clean: false` a reused workspace keeps files materialized under
+      # whatever line-ending rules held when they were first checked out —
+      # checkout's `--force` only rewrites files whose blob changed. Rewrite
+      # the whole tree from the index so the current .gitattributes rules
+      # (eol=lf on the byte-embedded UI content, #671) apply on every run;
+      # on Windows agents a stale CRLF template otherwise fails every
+      # multi-line assertion of rendered HTML.
+      - name: Renormalize the working tree
+        run: git checkout-index --all --force
 
       - name: Install Rust toolchain (Linux/macOS)
         if: runner.os != 'Windows'


### PR DESCRIPTION
Follow-up to #671. The `.gitattributes` fix merged with #659, yet `Test Rust` on #673 failed again on `github-agent4` at 15:52Z — after the merge.

**Why**: the self-hosted jobs check out with `clean: false` (deliberate, for incremental-build reuse), and checkout's `--force` only rewrites files whose **blob** changed. A workspace first checked out before the `.gitattributes` existed therefore keeps its CRLF-materialized templates indefinitely — the attribute never gets a chance to apply — and on the Windows agent every multi-line assertion of rendered HTML keeps failing.

**Fix**: one step after checkout in each of the five `ci.yml` jobs:

~~~yaml
- name: Renormalize the working tree
  run: git checkout-index --all --force
~~~

`checkout-index -a -f` rewrites the whole tree from the index under the *current* attribute rules on every run. It costs seconds, is a no-op on healthy workspaces, and is cross-platform. This PR's own `Test Rust` run validates it if it lands on the Windows agent (the pull_request workflow comes from the merge ref).

Once merged, a re-run of #673's `Test Rust` goes green on any agent.