### PR TITLE
feat(ui): the bulk-import recipient is always HFS_BASE_URL

### DIFF
--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -682,6 +682,7 @@ async fn serve(
             outbound_auth,
             config.default_fhir_version,
             config.terminology_server.clone(),
+            config.base_url.clone(),
         )
     };
     #[cfg(not(all(feature = "ui", not(feature = "headless"))))]

--- a/crates/ui/e2e/pages/routes.ts
+++ b/crates/ui/e2e/pages/routes.ts
@@ -29,7 +29,7 @@ export const ROUTES = [
 // append it to ROUTES so the detail layout is guarded too.
 export async function seedBulkImportDetail(request: APIRequestContext): Promise<string> {
   const res = await request.post("/ui/bulk-import", {
-    form: { name: "e2e-guard", recipient_base_url: "http://127.0.0.1:9/fhir" },
+    form: { name: "e2e-guard" },
     maxRedirects: 0,
   });
   const location = res.headers()["location"];

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -210,6 +210,9 @@ struct BulkImportPage {
     available: bool,
     rows: Vec<SubmissionRow>,
     error: Option<String>,
+    /// Where every new submission goes (`HFS_BASE_URL`, #689) — shown in the
+    /// dialog so the fixed recipient is visible, not invisible.
+    recipient: String,
 }
 
 #[derive(Template)]
@@ -284,14 +287,13 @@ pub async fn page(
         available,
         rows,
         error: None,
+        recipient: state.public_base_url.trim_end_matches('/').to_string(),
     })
 }
 
 #[derive(Deserialize)]
 pub struct CreateForm {
     pub name: String,
-    #[serde(default)]
-    pub recipient_base_url: String,
     #[serde(default)]
     pub auth: String,
     #[serde(default)]
@@ -322,11 +324,10 @@ pub async fn create(
     };
     let submission = Submission {
         name: form.name.trim().to_string(),
-        recipient_base_url: form
-            .recipient_base_url
-            .trim()
-            .trim_end_matches('/')
-            .to_string(),
+        // The recipient is always this server's HFS_BASE_URL (#689) — typing
+        // it per submission is how a submission ended up pointed at something
+        // that is not a Bulk Data Submit endpoint (#686).
+        recipient_base_url: state.public_base_url.trim_end_matches('/').to_string(),
         auth: if form.auth == "backend-services" {
             form.auth
         } else {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -126,6 +126,10 @@ struct WebState {
     /// Server data directory (`HFS_DATA_DIR`), used to seed a newly-provisioned
     /// tenant's conformance resources from the tenant-maintenance page.
     data_dir: Option<PathBuf>,
+    /// The server's public base URL (`HFS_BASE_URL`) — what Bulk Import
+    /// submissions target as their recipient (#689). Distinct from the
+    /// loopback self-call base the conformance source uses.
+    public_base_url: String,
     /// The server's default FHIR version, used when seeding a new tenant.
     fhir_version: helios_fhir::FhirVersion,
     /// The server's default tenant id â€” the fallback when no stored choice
@@ -787,6 +791,7 @@ pub fn mount(
     outbound_auth: Arc<dyn helios_auth::outbound::OutboundAuthProvider>,
     fhir_version: helios_fhir::FhirVersion,
     terminology: Option<String>,
+    public_base_url: String,
 ) -> Router {
     let source: Arc<dyn ConformanceSource> = Arc::new(conformance::HttpConformanceSource::new(
         self_base_url,
@@ -805,6 +810,7 @@ pub fn mount(
         source,
         fhir_version,
         terminology,
+        public_base_url,
     )
 }
 
@@ -825,6 +831,7 @@ pub fn mount_with_conformance_source(
     source: Arc<dyn ConformanceSource>,
     fhir_version: helios_fhir::FhirVersion,
     terminology: Option<String>,
+    public_base_url: String,
 ) -> Router {
     let nl_enabled = nl.enabled;
 
@@ -960,6 +967,7 @@ pub fn mount_with_conformance_source(
         fhir_version,
         default_tenant,
         terminology,
+        public_base_url,
     };
 
     router

--- a/crates/ui/templates/pages/bulk-import.html
+++ b/crates/ui/templates/pages/bulk-import.html
@@ -25,11 +25,11 @@
           <span class="field__label">{{ i18n.t("bulk-import-field-name") }}</span>
           <input class="field__input" type="text" name="name" required autocomplete="off">
         </label>
+        <!-- The recipient is fixed to this server's HFS_BASE_URL (#689);
+             shown so the target is visible, not typed. -->
         <label class="field">
           <span class="field__label">{{ i18n.t("bulk-import-field-recipient") }}</span>
-          <input class="field__input" type="url" name="recipient_base_url" required
-                 autocomplete="off" placeholder="http://localhost:8080">
-          <span class="field__hint">{{ i18n.t("bulk-import-field-recipient-hint") }}</span>
+          <span class="field__hint">{{ recipient }}</span>
         </label>
 
         <label class="field">

--- a/crates/ui/tests/bulk_export_http.rs
+++ b/crates/ui/tests/bulk_export_http.rs
@@ -100,6 +100,7 @@ async fn serve() -> (String, MockExport) {
         )),
         FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -21,7 +21,23 @@ fn settings_store() -> Arc<dyn SettingsStore> {
     Arc::new(backend)
 }
 
-fn app(settings: &Arc<dyn SettingsStore>) -> Router {
+/// One test's world: the settings store and the recipient base the router is
+/// mounted with — the recipient is fixed server-side now (#689), so tests
+/// that need the kickoff to reach their mock recipient mount with its URL.
+struct Ctx {
+    settings: Arc<dyn SettingsStore>,
+    recipient: String,
+}
+
+fn ctx(recipient: &str) -> Ctx {
+    Ctx {
+        settings: settings_store(),
+        recipient: recipient.to_string(),
+    }
+}
+
+fn app(ctx: &Ctx) -> Router {
+    let settings = &ctx.settings;
     helios_ui::mount_with_conformance_source(
         Router::new(),
         "9.9.9",
@@ -33,6 +49,7 @@ fn app(settings: &Arc<dyn SettingsStore>) -> Router {
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
         None,
+        ctx.recipient.clone(),
     )
 }
 
@@ -41,8 +58,8 @@ async fn body_text(response: axum::response::Response) -> String {
     String::from_utf8(bytes.to_vec()).unwrap()
 }
 
-async fn get(settings: &Arc<dyn SettingsStore>, uri: &str) -> (StatusCode, String) {
-    let res = app(settings)
+async fn get(ctx: &Ctx, uri: &str) -> (StatusCode, String) {
+    let res = app(ctx)
         .oneshot(Request::get(uri).body(Body::empty()).unwrap())
         .await
         .unwrap();
@@ -51,12 +68,8 @@ async fn get(settings: &Arc<dyn SettingsStore>, uri: &str) -> (StatusCode, Strin
 }
 
 /// POSTs a form and returns `(status, Location header, body)`.
-async fn post_form(
-    settings: &Arc<dyn SettingsStore>,
-    uri: &str,
-    form: &str,
-) -> (StatusCode, String, String) {
-    let res = app(settings)
+async fn post_form(ctx: &Ctx, uri: &str, form: &str) -> (StatusCode, String, String) {
+    let res = app(ctx)
         .oneshot(
             Request::post(uri)
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
@@ -76,13 +89,8 @@ async fn post_form(
 }
 
 /// Creates a submission and returns its detail path (`/ui/bulk-import/{id}`).
-async fn create_submission(settings: &Arc<dyn SettingsStore>) -> String {
-    let (status, location, _) = post_form(
-        settings,
-        "/ui/bulk-import",
-        "name=BrettTest&recipient_base_url=http%3A%2F%2Flocalhost%3A9%2F&auth=none",
-    )
-    .await;
+async fn create_submission(ctx: &Ctx) -> String {
+    let (status, location, _) = post_form(ctx, "/ui/bulk-import", "name=BrettTest&auth=none").await;
     assert_eq!(status, StatusCode::SEE_OTHER);
     assert!(location.starts_with("/ui/bulk-import/"), "{location}");
     location
@@ -90,8 +98,8 @@ async fn create_submission(settings: &Arc<dyn SettingsStore>) -> String {
 
 #[tokio::test]
 async fn the_list_page_renders_and_offers_creation() {
-    let settings = settings_store();
-    let (status, html) = get(&settings, "/ui/bulk-import").await;
+    let ctx = ctx("http://localhost:9/");
+    let (status, html) = get(&ctx, "/ui/bulk-import").await;
     assert_eq!(status, StatusCode::OK);
     assert!(html.contains("Bulk Import"));
     assert!(html.contains("New Submission"));
@@ -100,10 +108,10 @@ async fn the_list_page_renders_and_offers_creation() {
 
 #[tokio::test]
 async fn creating_a_submission_lands_on_its_detail_page() {
-    let settings = settings_store();
-    let detail_path = create_submission(&settings).await;
+    let ctx = ctx("http://localhost:9/");
+    let detail_path = create_submission(&ctx).await;
 
-    let (status, html) = get(&settings, &detail_path).await;
+    let (status, html) = get(&ctx, &detail_path).await;
     assert_eq!(status, StatusCode::OK);
     assert!(html.contains("BrettTest"));
     assert!(html.contains("Not Started"));
@@ -114,17 +122,17 @@ async fn creating_a_submission_lands_on_its_detail_page() {
     assert!(html.contains("Add Manifest"));
 
     // And the list now shows it.
-    let (_, list) = get(&settings, "/ui/bulk-import").await;
+    let (_, list) = get(&ctx, "/ui/bulk-import").await;
     assert!(list.contains("BrettTest"));
 }
 
 #[tokio::test]
 async fn manifests_can_be_added_and_removed() {
-    let settings = settings_store();
-    let detail_path = create_submission(&settings).await;
+    let ctx = ctx("http://localhost:9/");
+    let detail_path = create_submission(&ctx).await;
 
     let (status, location, _) = post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests"),
         "manifest_url=http%3A%2F%2F10.2.1.890%2Fmanifest.local",
     )
@@ -132,7 +140,7 @@ async fn manifests_can_be_added_and_removed() {
     assert_eq!(status, StatusCode::SEE_OTHER);
     assert_eq!(location, detail_path);
 
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("http://10.2.1.890/manifest.local"));
     assert!(html.contains("Submit All"));
 
@@ -145,28 +153,24 @@ async fn manifests_can_be_added_and_removed() {
         .expect("manifest id in form action")
         .to_string();
 
-    let (status, _, _) = post_form(
-        &settings,
-        &format!("{detail_path}/manifests/{mid}/delete"),
-        "",
-    )
-    .await;
+    let (status, _, _) =
+        post_form(&ctx, &format!("{detail_path}/manifests/{mid}/delete"), "").await;
     assert_eq!(status, StatusCode::SEE_OTHER);
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("No manifests yet"));
 }
 
 #[tokio::test]
 async fn deleting_a_submission_returns_to_the_list() {
-    let settings = settings_store();
-    let detail_path = create_submission(&settings).await;
+    let ctx = ctx("http://localhost:9/");
+    let detail_path = create_submission(&ctx).await;
 
-    let (status, location, _) = post_form(&settings, &format!("{detail_path}/delete"), "").await;
+    let (status, location, _) = post_form(&ctx, &format!("{detail_path}/delete"), "").await;
     assert_eq!(status, StatusCode::SEE_OTHER);
     assert_eq!(location, "/ui/bulk-import");
 
     // The detail page for a deleted submission redirects back to the list.
-    let res = app(&settings)
+    let res = app(&ctx)
         .oneshot(Request::get(&detail_path).body(Body::empty()).unwrap())
         .await
         .unwrap();
@@ -204,26 +208,18 @@ async fn mock_recipient(
 
 #[tokio::test]
 async fn submitting_a_manifest_posts_the_kickoff_and_logs_the_outcome() {
-    let settings = settings_store();
     let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+    let ctx = ctx(&recipient_url);
 
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        &format!(
-            "name=Alice&recipient_base_url={}&auth=none",
-            urlencode(&recipient_url)
-        ),
-    )
-    .await;
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Alice&auth=none").await;
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests"),
         "manifest_url=http%3A%2F%2Fexample.org%2Fexports%2Fmanifest.json&output_format=application%2Ffhir%2Bndjson",
     )
     .await;
 
-    let (status, _, _) = post_form(&settings, &format!("{detail_path}/submit-all"), "").await;
+    let (status, _, _) = post_form(&ctx, &format!("{detail_path}/submit-all"), "").await;
     assert_eq!(status, StatusCode::SEE_OTHER);
 
     // The recipient saw a spec-shaped kick-off.
@@ -257,7 +253,7 @@ async fn submitting_a_manifest_posts_the_kickoff_and_logs_the_outcome() {
     );
 
     // The log recorded the attempt and the submission moved to In Progress.
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("Submitting manifest"));
     assert!(html.contains("accepted by the recipient (200)"));
     assert!(html.contains("In Progress"));
@@ -265,27 +261,19 @@ async fn submitting_a_manifest_posts_the_kickoff_and_logs_the_outcome() {
 
 #[tokio::test]
 async fn a_rejected_kickoff_is_logged_as_a_failure() {
-    let settings = settings_store();
     let (recipient_url, _) = mock_recipient(StatusCode::NOT_FOUND).await;
+    let ctx = ctx(&recipient_url);
 
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        &format!(
-            "name=Alice&recipient_base_url={}&auth=none",
-            urlencode(&recipient_url)
-        ),
-    )
-    .await;
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Alice&auth=none").await;
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests"),
         "manifest_url=http%3A%2F%2Ftest.com",
     )
     .await;
-    post_form(&settings, &format!("{detail_path}/submit-all"), "").await;
+    post_form(&ctx, &format!("{detail_path}/submit-all"), "").await;
 
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("Bulk Submit request failed!"));
     assert!(html.contains("404"));
     assert!(html.contains("Not Started"), "status unchanged on failure");
@@ -297,30 +285,22 @@ fn urlencode(s: &str) -> String {
 
 #[tokio::test]
 async fn a_single_manifest_can_be_submitted_from_its_row() {
-    let settings = settings_store();
     let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+    let ctx = ctx(&recipient_url);
 
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        &format!(
-            "name=Solo&recipient_base_url={}&auth=none",
-            urlencode(&recipient_url)
-        ),
-    )
-    .await;
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Solo&auth=none").await;
     for url in [
         "http%3A%2F%2Fone.example%2Fm.json",
         "http%3A%2F%2Ftwo.example%2Fm.json",
     ] {
         post_form(
-            &settings,
+            &ctx,
             &format!("{detail_path}/manifests"),
             &format!("manifest_url={url}"),
         )
         .await;
     }
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     let marker = format!("{detail_path}/manifests/");
     let mid = html
         .split(&marker)
@@ -329,12 +309,8 @@ async fn a_single_manifest_can_be_submitted_from_its_row() {
         .expect("manifest id")
         .to_string();
 
-    let (status, _, _) = post_form(
-        &settings,
-        &format!("{detail_path}/manifests/{mid}/submit"),
-        "",
-    )
-    .await;
+    let (status, _, _) =
+        post_form(&ctx, &format!("{detail_path}/manifests/{mid}/submit"), "").await;
     assert_eq!(status, StatusCode::SEE_OTHER);
 
     // Only the one manifest went out.
@@ -343,26 +319,18 @@ async fn a_single_manifest_can_be_submitted_from_its_row() {
 
 #[tokio::test]
 async fn abort_and_complete_send_status_only_kickoffs() {
-    let settings = settings_store();
     let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+    let ctx = ctx(&recipient_url);
 
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        &format!(
-            "name=Lifecycle&recipient_base_url={}&auth=none",
-            urlencode(&recipient_url)
-        ),
-    )
-    .await;
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Lifecycle&auth=none").await;
 
-    post_form(&settings, &format!("{detail_path}/abort"), "").await;
-    let (_, html) = get(&settings, &detail_path).await;
+    post_form(&ctx, &format!("{detail_path}/abort"), "").await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("Stopped"));
     assert!(html.contains("Recipient acknowledged (200)"));
 
-    post_form(&settings, &format!("{detail_path}/complete"), "").await;
-    let (_, html) = get(&settings, &detail_path).await;
+    post_form(&ctx, &format!("{detail_path}/complete"), "").await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("Completed"));
 
     // Status-only kick-offs carry no manifestUrl.
@@ -392,57 +360,36 @@ async fn abort_and_complete_send_status_only_kickoffs() {
 
 #[tokio::test]
 async fn a_rejected_status_change_keeps_the_status_and_logs_it() {
-    let settings = settings_store();
     let (recipient_url, _) = mock_recipient(StatusCode::CONFLICT).await;
+    let ctx = ctx(&recipient_url);
 
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        &format!(
-            "name=Reject&recipient_base_url={}&auth=none",
-            urlencode(&recipient_url)
-        ),
-    )
-    .await;
-    post_form(&settings, &format!("{detail_path}/abort"), "").await;
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Reject&auth=none").await;
+    post_form(&ctx, &format!("{detail_path}/abort"), "").await;
 
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("Recipient rejected the status change: 409"));
     assert!(html.contains("Not Started"));
 }
 
 #[tokio::test]
 async fn an_unreachable_recipient_fails_the_status_change() {
-    let settings = settings_store();
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        "name=Gone&recipient_base_url=http%3A%2F%2F127.0.0.1%3A9%2F&auth=none",
-    )
-    .await;
-    post_form(&settings, &format!("{detail_path}/abort"), "").await;
+    let ctx = ctx("http://localhost:9/");
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Gone&auth=none").await;
+    post_form(&ctx, &format!("{detail_path}/abort"), "").await;
 
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("Status change failed:"));
     assert!(html.contains("Not Started"));
 }
 
 #[tokio::test]
 async fn manifest_options_ride_the_kickoff() {
-    let settings = settings_store();
     let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+    let ctx = ctx(&recipient_url);
 
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        &format!(
-            "name=Options&recipient_base_url={}&auth=none",
-            urlencode(&recipient_url)
-        ),
-    )
-    .await;
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Options&auth=none").await;
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests"),
         "manifest_url=http%3A%2F%2Fone.example%2Fm.json\
          &fhir_base_url=http%3A%2F%2Fbase.example%2Ffhir\
@@ -450,7 +397,7 @@ async fn manifest_options_ride_the_kickoff() {
          &file_request_headers=Authorization%3A%20Bearer%20abc%0AX-Trace%3A%201",
     )
     .await;
-    post_form(&settings, &format!("{detail_path}/submit-all"), "").await;
+    post_form(&ctx, &format!("{detail_path}/submit-all"), "").await;
 
     let bodies = received.lock().unwrap().clone();
     assert_eq!(bodies.len(), 1);
@@ -504,6 +451,7 @@ async fn the_page_degrades_without_a_settings_store() {
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     );
     let res = app
         .clone()
@@ -519,7 +467,7 @@ async fn the_page_degrades_without_a_settings_store() {
         .oneshot(
             Request::post("/ui/bulk-import")
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
-                .body(Body::from("name=X&recipient_base_url=http%3A%2F%2Fx"))
+                .body(Body::from("name=X"))
                 .unwrap(),
         )
         .await
@@ -554,13 +502,13 @@ async fn mock_token_endpoint(status: StatusCode, body: &'static str) -> String {
 /// and nothing else in this binary reads the variable.
 #[tokio::test]
 async fn backend_services_auth_mints_and_attaches_tokens() {
-    let settings = settings_store();
+    let ctx = ctx("http://localhost:9/");
     let token_url = mock_token_endpoint(StatusCode::OK, r#"{"access_token":"tok-123"}"#).await;
 
     // Phase 1 — no key configured: the gap is reported, not swallowed.
     unsafe { std::env::remove_var("HFS_BULK_SUBMIT_PRIVATE_KEY") };
     let (status, _, html) = post_form(
-        &settings,
+        &ctx,
         "/ui/bulk-import/test-auth",
         &format!("client_id=alice&token_url={}", urlencode(&token_url)),
     )
@@ -572,7 +520,7 @@ async fn backend_services_auth_mints_and_attaches_tokens() {
 
     // Phase 2 — missing client id fails before any signing.
     let (_, _, html) = post_form(
-        &settings,
+        &ctx,
         "/ui/bulk-import/test-auth",
         &format!("client_id=&token_url={}", urlencode(&token_url)),
     )
@@ -581,7 +529,7 @@ async fn backend_services_auth_mints_and_attaches_tokens() {
 
     // Phase 3 — a working endpoint: the mint succeeds.
     let (_, _, html) = post_form(
-        &settings,
+        &ctx,
         "/ui/bulk-import/test-auth",
         &format!("client_id=alice&token_url={}", urlencode(&token_url)),
     )
@@ -592,7 +540,7 @@ async fn backend_services_auth_mints_and_attaches_tokens() {
     let denied =
         mock_token_endpoint(StatusCode::BAD_REQUEST, r#"{"error":"invalid_client"}"#).await;
     let (_, _, html) = post_form(
-        &settings,
+        &ctx,
         "/ui/bulk-import/test-auth",
         &format!("client_id=alice&token_url={}", urlencode(&denied)),
     )
@@ -602,7 +550,7 @@ async fn backend_services_auth_mints_and_attaches_tokens() {
     // Phase 5 — a token response without access_token is an error.
     let empty = mock_token_endpoint(StatusCode::OK, r#"{"scope":"none"}"#).await;
     let (_, _, html) = post_form(
-        &settings,
+        &ctx,
         "/ui/bulk-import/test-auth",
         &format!("client_id=alice&token_url={}", urlencode(&empty)),
     )
@@ -612,37 +560,42 @@ async fn backend_services_auth_mints_and_attaches_tokens() {
     // Phase 6 — a backend-services submission attaches the Bearer token to
     // the kick-off it POSTs at the recipient.
     let (recipient_url, seen_auth) = mock_recipient_capturing_auth().await;
+    // Same settings (the registered signing key lives there), phase-local
+    // recipient: the kick-off must reach this phase's capturing mock.
+    let ctx = Ctx {
+        settings: Arc::clone(&ctx.settings),
+        recipient: recipient_url.clone(),
+    };
     let (_, detail_path, _) = post_form(
-        &settings,
+        &ctx,
         "/ui/bulk-import",
         &format!(
-            "name=Authy&recipient_base_url={}&auth=backend-services&client_id=alice&token_url={}",
-            urlencode(&recipient_url),
+            "name=Authy&auth=backend-services&client_id=alice&token_url={}",
             urlencode(&token_url)
         ),
     )
     .await;
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests"),
         "manifest_url=http%3A%2F%2Fone.example%2Fm.json",
     )
     .await;
-    post_form(&settings, &format!("{detail_path}/submit-all"), "").await;
+    post_form(&ctx, &format!("{detail_path}/submit-all"), "").await;
 
     assert_eq!(
         seen_auth.lock().unwrap().as_deref(),
         Some("Bearer tok-123"),
         "the kick-off carried the minted token"
     );
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("accepted by the recipient (200)"));
 
     // Phase 7 — the RS384 signing path works with an RSA key.
     unsafe { std::env::set_var("HFS_BULK_SUBMIT_PRIVATE_KEY", TEST_RSA_KEY) };
     unsafe { std::env::set_var("HFS_BULK_SUBMIT_SIGNING_ALG", "RS384") };
     let (_, _, html) = post_form(
-        &settings,
+        &ctx,
         "/ui/bulk-import/test-auth",
         &format!("client_id=alice&token_url={}", urlencode(&token_url)),
     )
@@ -712,7 +665,7 @@ async fn mock_recipient_capturing_auth() -> (String, Arc<std::sync::Mutex<Option
 
 #[tokio::test]
 async fn unknown_ids_redirect_instead_of_crashing() {
-    let settings = settings_store();
+    let ctx = ctx("http://localhost:9/");
     let ghost = "/ui/bulk-import/00000000-0000-4000-8000-000000000000";
 
     for uri in [
@@ -722,26 +675,18 @@ async fn unknown_ids_redirect_instead_of_crashing() {
         format!("{ghost}/submit-all"),
         format!("{ghost}/abort"),
     ] {
-        let (status, _, _) = post_form(&settings, &uri, "manifest_url=http%3A%2F%2Fx").await;
+        let (status, _, _) = post_form(&ctx, &uri, "manifest_url=http%3A%2F%2Fx").await;
         assert_eq!(status, StatusCode::SEE_OTHER, "{uri}");
     }
 }
 
 #[tokio::test]
 async fn a_missing_manifest_id_submits_nothing() {
-    let settings = settings_store();
     let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        &format!(
-            "name=Ghost&recipient_base_url={}&auth=none",
-            urlencode(&recipient_url)
-        ),
-    )
-    .await;
+    let ctx = ctx(&recipient_url);
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Ghost&auth=none").await;
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests/no-such-manifest/submit"),
         "",
     )
@@ -751,22 +696,17 @@ async fn a_missing_manifest_id_submits_nothing() {
 
 #[tokio::test]
 async fn an_unreachable_recipient_fails_the_manifest_submit() {
-    let settings = settings_store();
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        "name=Down&recipient_base_url=http%3A%2F%2F127.0.0.1%3A9%2F&auth=none",
-    )
-    .await;
+    let ctx = ctx("http://localhost:9/");
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Down&auth=none").await;
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests"),
         "manifest_url=http%3A%2F%2Fone.example%2Fm.json",
     )
     .await;
-    post_form(&settings, &format!("{detail_path}/submit-all"), "").await;
+    post_form(&ctx, &format!("{detail_path}/submit-all"), "").await;
 
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("Bulk Submit request failed!"));
     assert!(html.contains("Failed to submit manifest"));
 }
@@ -845,27 +785,24 @@ use axum::response::IntoResponse;
 
 #[tokio::test]
 async fn status_polling_tracks_progress_and_lands_the_result() {
-    let settings = settings_store();
     let (recipient_url, kickoffs) = mock_recipient_with_status().await;
+    let ctx = ctx(&recipient_url);
 
     let (_, detail_path, _) = post_form(
-        &settings,
+        &ctx,
         "/ui/bulk-import",
-        &format!(
-            "name=Polling&recipient_base_url={}&auth=none&submitter_system=http%3A%2F%2Fexample.org%2Fsubmitters&submitter_value=acme&submission_id=pinned-42",
-            urlencode(&recipient_url)
-        ),
+        "name=Polling&auth=none&submitter_system=http%3A%2F%2Fexample.org%2Fsubmitters&submitter_value=acme&submission_id=pinned-42",
     )
     .await;
     assert!(detail_path.ends_with("/pinned-42"), "{detail_path}");
 
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests"),
         "manifest_url=http%3A%2F%2Fone.example%2Fm.json",
     )
     .await;
-    post_form(&settings, &format!("{detail_path}/submit-all"), "").await;
+    post_form(&ctx, &format!("{detail_path}/submit-all"), "").await;
 
     // The submit kick-off carried the pinned id and the custom submitter,
     // and the status kick-off went out with the same identity.
@@ -883,18 +820,18 @@ async fn status_polling_tracks_progress_and_lands_the_result() {
 
     // First status fetch: one poll happens -> 202 progress recorded, and the
     // fragment keeps polling.
-    let (status, html) = get(&settings, &format!("{detail_path}/status")).await;
+    let (status, html) = get(&ctx, &format!("{detail_path}/status")).await;
     assert_eq!(status, StatusCode::OK);
     assert!(html.contains("processing 0% complete"), "{html}");
     assert!(html.contains("every 5s"), "keeps polling: {html}");
 
     // Second fetch: the mock flips to 200 -> result summary, polling stops.
-    let (_, html) = get(&settings, &format!("{detail_path}/status")).await;
+    let (_, html) = get(&ctx, &format!("{detail_path}/status")).await;
     assert!(!html.contains("every 5s"), "polling stopped: {html}");
     assert!(html.contains("Output files"), "{html}");
 
     // The log recorded the whole journey and the detail shows the summary.
-    let (_, detail) = get(&settings, &detail_path).await;
+    let (_, detail) = get(&ctx, &detail_path).await;
     assert!(detail.contains("Bulk status kick-off request"));
     assert!(detail.contains("got 200 OK"));
 }
@@ -904,8 +841,8 @@ async fn status_polling_tracks_progress_and_lands_the_result() {
 /// working through it.
 #[tokio::test]
 async fn the_keys_endpoint_redirects_to_the_well_known_jwks() {
-    let settings = settings_store();
-    let res = app(&settings)
+    let ctx = ctx("http://localhost:9/");
+    let res = app(&ctx)
         .oneshot(
             Request::get("/ui/bulk-import/keys")
                 .body(Body::empty())
@@ -924,8 +861,8 @@ async fn the_keys_endpoint_redirects_to_the_well_known_jwks() {
 
 #[tokio::test]
 async fn the_empty_manifest_is_served() {
-    let settings = settings_store();
-    let (status, body) = get(&settings, "/ui/bulk-import/empty-manifest.json").await;
+    let ctx = ctx("http://localhost:9/");
+    let (status, body) = get(&ctx, "/ui/bulk-import/empty-manifest.json").await;
     assert_eq!(status, StatusCode::OK);
     let m: serde_json::Value = serde_json::from_str(&body).unwrap();
     assert_eq!(m["output"].as_array().unwrap().len(), 0);
@@ -934,24 +871,16 @@ async fn the_empty_manifest_is_served() {
 
 #[tokio::test]
 async fn replacing_a_manifest_sends_replaces_manifest_url() {
-    let settings = settings_store();
     let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        &format!(
-            "name=R&recipient_base_url={}&auth=none",
-            urlencode(&recipient_url)
-        ),
-    )
-    .await;
+    let ctx = ctx(&recipient_url);
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=R&auth=none").await;
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests"),
         "manifest_url=http%3A%2F%2Fold.example%2Fm.json",
     )
     .await;
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     let marker = format!("{detail_path}/manifests/");
     let mid = html
         .split(&marker)
@@ -961,7 +890,7 @@ async fn replacing_a_manifest_sends_replaces_manifest_url() {
         .to_string();
 
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests/{mid}/replace"),
         "manifest_url=http%3A%2F%2Fnew.example%2Fm.json",
     )
@@ -986,31 +915,23 @@ async fn replacing_a_manifest_sends_replaces_manifest_url() {
         "http://old.example/m.json"
     );
 
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("http://new.example/m.json"));
     assert!(html.contains("Replacement accepted (200)"));
 }
 
 #[tokio::test]
 async fn aborting_one_manifest_replaces_it_with_the_empty_manifest() {
-    let settings = settings_store();
     let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
-    let (_, detail_path, _) = post_form(
-        &settings,
-        "/ui/bulk-import",
-        &format!(
-            "name=A&recipient_base_url={}&auth=none",
-            urlencode(&recipient_url)
-        ),
-    )
-    .await;
+    let ctx = ctx(&recipient_url);
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=A&auth=none").await;
     post_form(
-        &settings,
+        &ctx,
         &format!("{detail_path}/manifests"),
         "manifest_url=http%3A%2F%2Fold.example%2Fm.json",
     )
     .await;
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     let marker = format!("{detail_path}/manifests/");
     let mid = html
         .split(&marker)
@@ -1019,12 +940,7 @@ async fn aborting_one_manifest_replaces_it_with_the_empty_manifest() {
         .unwrap()
         .to_string();
 
-    post_form(
-        &settings,
-        &format!("{detail_path}/manifests/{mid}/abort"),
-        "",
-    )
-    .await;
+    post_form(&ctx, &format!("{detail_path}/manifests/{mid}/abort"), "").await;
 
     let bodies = received.lock().unwrap().clone();
     assert_eq!(bodies.len(), 1);
@@ -1047,6 +963,6 @@ async fn aborting_one_manifest_replaces_it_with_the_empty_manifest() {
         "http://old.example/m.json"
     );
 
-    let (_, html) = get(&settings, &detail_path).await;
+    let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("Abort accepted (200)"));
 }

--- a/crates/ui/tests/dashboard_multiversion_http.rs
+++ b/crates/ui/tests/dashboard_multiversion_http.rs
@@ -51,6 +51,7 @@ fn app() -> Router {
         )),
         FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
 }
 

--- a/crates/ui/tests/dashboard_uptime_http.rs
+++ b/crates/ui/tests/dashboard_uptime_http.rs
@@ -25,6 +25,7 @@ fn app() -> Router {
         )),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
 }
 

--- a/crates/ui/tests/dashboard_view_all_types_http.rs
+++ b/crates/ui/tests/dashboard_view_all_types_http.rs
@@ -105,6 +105,7 @@ fn app() -> Router {
         )),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
 }
 

--- a/crates/ui/tests/i18n_http.rs
+++ b/crates/ui/tests/i18n_http.rs
@@ -26,6 +26,7 @@ fn app() -> Router {
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
 }
 

--- a/crates/ui/tests/rail_counts_http.rs
+++ b/crates/ui/tests/rail_counts_http.rs
@@ -31,6 +31,7 @@ fn app() -> Router {
         )),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
 }
 

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -41,6 +41,7 @@ fn app_with(nl: helios_ui::NlSearch) -> Router {
         )),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
 }
 
@@ -221,6 +222,7 @@ async fn non_ui_paths_fall_through_to_the_fhir_app() {
         std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
     .oneshot(Request::get("/Patient").body(Body::empty()).unwrap())
     .await
@@ -280,6 +282,7 @@ async fn capability_statement_page_renders_summary_and_degrades() {
         std::sync::Arc::new(source),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     );
 
     let response = app
@@ -408,6 +411,7 @@ async fn compartments_degrade_to_a_warning_when_the_fetch_is_empty() {
         helios_fhir::FhirVersion::R4,
         // No terminology server: this test is about the conformance fetch.
         None,
+        "http://localhost:8080".to_string(),
     )
     .oneshot(
         Request::get("/ui/compartments")
@@ -945,6 +949,7 @@ fn app_with_terminology(terminology: Option<String>) -> Router {
         )),
         helios_fhir::FhirVersion::R4,
         terminology,
+        "http://localhost:8080".to_string(),
     )
 }
 

--- a/crates/ui/tests/subscriptions_http.rs
+++ b/crates/ui/tests/subscriptions_http.rs
@@ -35,6 +35,7 @@ fn app() -> Router {
         )),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
 }
 

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -48,6 +48,7 @@ fn app(store: &Arc<dyn ResourceStorage>) -> Router {
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
 }
 
@@ -218,6 +219,7 @@ async fn page_reports_registry_unavailable_without_a_store() {
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     )
     .oneshot(Request::get("/ui/tenants").body(Body::empty()).unwrap())
     .await
@@ -300,6 +302,7 @@ async fn version_choice_persists_to_user_settings_and_redirects_back() {
         Arc::new(helios_ui::StaticConformanceSource::empty()),
         FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     );
 
     // Selecting a version persists it and bounces back to the referring page.
@@ -368,6 +371,7 @@ async fn version_choice_changes_the_resource_type_lists() {
             )),
             FhirVersion::R4,
             None,
+            "http://localhost:8080".to_string(),
         )
     };
 
@@ -429,6 +433,7 @@ async fn tenant_choice_persists_and_the_selector_follows_it() {
             Arc::new(helios_ui::StaticConformanceSource::empty()),
             FhirVersion::R4,
             None,
+            "http://localhost:8080".to_string(),
         )
     };
 

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -552,7 +552,6 @@ bulk-import-new = Neue Submission
 bulk-import-create-title = Bulk Submission anlegen
 bulk-import-field-name = Name der Submission
 bulk-import-field-recipient = Basis-URL des Empfängers
-bulk-import-field-recipient-hint = Die Basis-URL des Servers, an den die Daten übermittelt werden.
 bulk-import-auth = Authentifizierung
 bulk-import-auth-hint = Wie gegenüber dem Empfängerserver authentifiziert wird.
 bulk-import-auth-none = Keine

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -555,7 +555,6 @@ bulk-import-new = New Submission
 bulk-import-create-title = Create Bulk Submission
 bulk-import-field-name = Submission name
 bulk-import-field-recipient = Recipient base URL
-bulk-import-field-recipient-hint = This is the base URL of the server where the data will be submitted.
 bulk-import-auth = Authentication
 bulk-import-auth-hint = How to authenticate to the recipient server.
 bulk-import-auth-none = None

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -552,7 +552,6 @@ bulk-import-new = Nueva submission
 bulk-import-create-title = Crear Bulk Submission
 bulk-import-field-name = Nombre de la submission
 bulk-import-field-recipient = URL base del receptor
-bulk-import-field-recipient-hint = La URL base del servidor donde se enviarán los datos.
 bulk-import-auth = Autenticación
 bulk-import-auth-hint = Cómo autenticarse ante el servidor receptor.
 bulk-import-auth-none = Ninguna


### PR DESCRIPTION
Closes #689. Stacked on #695 (the dialog-polish trio) — retargets to `main` when it merges.

## What

- The Create Bulk Submission dialog **no longer asks for a Recipient base URL**. Every new submission's recipient is the server's `HFS_BASE_URL`.
- Per the issue's note that the resolved recipient should not be invisible: the dialog **shows the fixed destination** where the input used to be, and the detail page keeps rendering the stored recipient read-only.
- Submissions created before this change keep the recipient they were created with — the kick-off code reads the stored field either way.

## How

`HFS_BASE_URL` was not available to the UI crate (the mount only received the loopback self-call base, deliberately distinct). `mount`/`mount_with_conformance_source` gain a `public_base_url` parameter, `hfs` passes `config.base_url`, `WebState` carries it, and `create()` stamps it (trailing slash trimmed). `CreateForm.recipient_base_url` is gone; the field and its hint left the template and all three catalogs.

## Tests

`bulk_import_http` now mounts per-test through a `Ctx { settings, recipient }`: the kick-off tests point the mount at their mock recipient (the multi-phase auth test re-mounts phase-locally with the same settings store, since the registered signing key lives there). e2e seeding drops the form field. All 21 `bulk_import_http` tests, the full `helios-ui` suite, clippy, the bulk-import Playwright spec, and the nojs sweep are green locally.