### PR TITLE
fix(ui): bulk-import submit failures report the real request and fail the submission

### DIFF
--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -197,6 +197,7 @@ fn status_label(i18n: &I18n, status: &str) -> String {
         "in-progress" => i18n.t("bulk-import-status-in-progress"),
         "stopped" => i18n.t("bulk-import-status-stopped"),
         "completed" => i18n.t("bulk-import-status-completed"),
+        "failed" => i18n.t("bulk-import-status-failed"),
         _ => i18n.t("bulk-import-status-not-started"),
     }
 }
@@ -667,15 +668,22 @@ async fn backend_services_token(client_id: &str, token_url: &str) -> Result<Stri
         .ok_or_else(|| "token response carried no access_token".to_string())
 }
 
-/// POSTs a kick-off to the recipient, returning `(status, body-excerpt)`.
+/// The URL a submission's kick-off is POSTed to — the one failure messages
+/// must name (#686).
+fn kickoff_target(submission: &Submission) -> String {
+    format!(
+        "{}/$bulk-submit",
+        submission.recipient_base_url.trim_end_matches('/')
+    )
+}
+
+/// POSTs a kick-off to the recipient, returning
+/// `(status, content-type, body-excerpt)`.
 async fn post_kickoff(
     submission: &Submission,
     parameters: &Value,
-) -> Result<(u16, String), String> {
-    let target = format!(
-        "{}/$bulk-submit",
-        submission.recipient_base_url.trim_end_matches('/')
-    );
+) -> Result<(u16, String, String), String> {
+    let target = kickoff_target(submission);
     let mut request = reqwest::Client::new()
         .post(&target)
         .header("Content-Type", "application/fhir+json")
@@ -686,11 +694,56 @@ async fn post_kickoff(
         let token = backend_services_token(&submission.client_id, &submission.token_url).await?;
         request = request.bearer_auth(token);
     }
-    let response = request.send().await.map_err(|e| e.to_string())?;
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("POST {target} failed: {e}"))?;
     let status = response.status().as_u16();
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
     let mut body = response.text().await.unwrap_or_default();
-    body.truncate(300);
-    Ok((status, body))
+    body.truncate(2000);
+    Ok((status, content_type, body))
+}
+
+/// Summarizes an error response for the log (#686): an OperationOutcome's own
+/// explanation when one came back; otherwise the content type and, for
+/// non-markup bodies, a short excerpt — raw HTML is never pasted.
+fn summarize_error_body(content_type: &str, body: &str) -> String {
+    if let Ok(outcome) = serde_json::from_str::<Value>(body)
+        && outcome.get("resourceType").and_then(Value::as_str) == Some("OperationOutcome")
+        && let Some(explained) = outcome
+            .get("issue")
+            .and_then(Value::as_array)
+            .and_then(|issues| {
+                issues.iter().find_map(|i| {
+                    i.get("diagnostics")
+                        .and_then(Value::as_str)
+                        .or_else(|| i.get("details")?.get("text")?.as_str())
+                })
+            })
+    {
+        return explained.to_string();
+    }
+    let kind = content_type.split(';').next().unwrap_or("").trim();
+    if kind.contains("html") || body.trim_start().starts_with('<') {
+        return format!(
+            "the response was {} ({} bytes), not a FHIR resource — is the recipient a Bulk Data Submit endpoint?",
+            if kind.is_empty() { "markup" } else { kind },
+            body.len()
+        );
+    }
+    let mut excerpt = body.trim().replace('\n', " ");
+    excerpt.truncate(160);
+    if excerpt.is_empty() {
+        format!("empty {kind} response")
+    } else {
+        format!("{kind}: {excerpt}")
+    }
 }
 
 /// Kicks off recipient-side status tracking: `POST $bulk-submit-status`
@@ -851,7 +904,7 @@ async fn submit_one_with_id(submission: &mut Submission, id: &str, mid: &str) {
     );
     let parameters = kickoff_parameters(submission, id, "in-progress", Some(&m), None);
     match post_kickoff(submission, &parameters).await {
-        Ok((status, _)) if (200..300).contains(&status) => {
+        Ok((status, _, _)) if (200..300).contains(&status) => {
             push_log(
                 submission,
                 format!("Manifest accepted by the recipient ({status})."),
@@ -875,23 +928,29 @@ async fn submit_one_with_id(submission: &mut Submission, id: &str, mid: &str) {
                 }
             }
         }
-        Ok((status, body)) => {
-            push_log(submission, "Bulk Submit request failed!".to_string());
+        Ok((status, content_type, body)) => {
+            // Name the request that actually failed — the kick-off POST, not
+            // the manifest URL, which HFS never called (#686).
             push_log(
                 submission,
                 format!(
-                    "Failed to submit manifest {}: {status} {}",
+                    "POST {} → {status}: {} (manifest {})",
+                    kickoff_target(submission),
+                    summarize_error_body(&content_type, &body),
                     m.manifest_url,
-                    body.replace('\n', " ")
                 ),
             );
+            submission.status = "failed".to_string();
         }
         Err(e) => {
-            push_log(submission, "Bulk Submit request failed!".to_string());
             push_log(
                 submission,
-                format!("Failed to submit manifest {}: {e}", m.manifest_url),
+                format!(
+                    "Bulk Submit request failed: {e} (manifest {})",
+                    m.manifest_url
+                ),
             );
+            submission.status = "failed".to_string();
         }
     }
 }
@@ -928,14 +987,17 @@ async fn set_status(
         push_log(&mut s, format!("Marking submission {status}..."));
         let parameters = kickoff_parameters(&s, &id, status, None, None);
         match post_kickoff(&s, &parameters).await {
-            Ok((code, _)) if (200..300).contains(&code) => {
+            Ok((code, _, _)) if (200..300).contains(&code) => {
                 push_log(&mut s, format!("Recipient acknowledged ({code})."));
                 s.status = status.to_string();
             }
-            Ok((code, body)) => {
+            Ok((code, content_type, body)) => {
                 push_log(
                     &mut s,
-                    format!("Recipient rejected the status change: {code} {body}"),
+                    format!(
+                        "Recipient rejected the status change: {code}: {}",
+                        summarize_error_body(&content_type, &body)
+                    ),
                 );
             }
             Err(e) => {
@@ -1050,16 +1112,19 @@ pub async fn replace_manifest(
             let parameters =
                 kickoff_parameters(&s, &id, "in-progress", Some(&replacement), Some(&old_url));
             match post_kickoff(&s, &parameters).await {
-                Ok((code, _)) if (200..300).contains(&code) => {
+                Ok((code, _, _)) if (200..300).contains(&code) => {
                     push_log(&mut s, format!("Replacement accepted ({code})."));
                     let mut entry = serde_json::to_value(&replacement).unwrap_or(Value::Null);
                     entry["lastSubmittedAt"] = json!(now_stamp());
                     s.manifests.insert(mid, entry);
                 }
-                Ok((code, body)) => {
+                Ok((code, content_type, body)) => {
                     push_log(
                         &mut s,
-                        format!("Replacement rejected: {code} {}", body.replace('\n', " ")),
+                        format!(
+                            "Replacement rejected: {code}: {}",
+                            summarize_error_body(&content_type, &body)
+                        ),
                     );
                 }
                 Err(e) => {
@@ -1106,16 +1171,19 @@ pub async fn abort_manifest(
             let parameters =
                 kickoff_parameters(&s, &id, "in-progress", Some(&empty), Some(&old_url));
             match post_kickoff(&s, &parameters).await {
-                Ok((code, _)) if (200..300).contains(&code) => {
+                Ok((code, _, _)) if (200..300).contains(&code) => {
                     push_log(&mut s, format!("Abort accepted ({code})."));
                     if let Some(entry) = s.manifests.get_mut(&mid) {
                         entry["abortedAt"] = json!(now_stamp());
                     }
                 }
-                Ok((code, body)) => {
+                Ok((code, content_type, body)) => {
                     push_log(
                         &mut s,
-                        format!("Abort rejected: {code} {}", body.replace('\n', " ")),
+                        format!(
+                            "Abort rejected: {code}: {}",
+                            summarize_error_body(&content_type, &body)
+                        ),
                     );
                 }
                 Err(e) => {

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -274,9 +274,12 @@ async fn a_rejected_kickoff_is_logged_as_a_failure() {
     post_form(&ctx, &format!("{detail_path}/submit-all"), "").await;
 
     let (_, html) = get(&ctx, &detail_path).await;
-    assert!(html.contains("Bulk Submit request failed!"));
-    assert!(html.contains("404"));
-    assert!(html.contains("Not Started"), "status unchanged on failure");
+    // The log names the request that failed — the kick-off POST, with the
+    // manifest as context — and the submission reads Failed (#686).
+    assert!(html.contains("$bulk-submit → 404"));
+    assert!(html.contains("(manifest http://test.com)"));
+    assert!(html.contains("Failed"), "status shows the failure");
+    assert!(!html.contains("Not Started"));
 }
 
 fn urlencode(s: &str) -> String {
@@ -707,8 +710,9 @@ async fn an_unreachable_recipient_fails_the_manifest_submit() {
     post_form(&ctx, &format!("{detail_path}/submit-all"), "").await;
 
     let (_, html) = get(&ctx, &detail_path).await;
-    assert!(html.contains("Bulk Submit request failed!"));
-    assert!(html.contains("Failed to submit manifest"));
+    assert!(html.contains("Bulk Submit request failed:"));
+    assert!(html.contains("$bulk-submit"), "the failed target is named");
+    assert!(html.contains("Failed"), "status shows the failure");
 }
 
 /// A recipient implementing the full status flow: kick-off returns a
@@ -965,4 +969,39 @@ async fn aborting_one_manifest_replaces_it_with_the_empty_manifest() {
 
     let (_, html) = get(&ctx, &detail_path).await;
     assert!(html.contains("Abort accepted (200)"));
+}
+
+/// #686's repro: a recipient that is a plain static file server answers 501
+/// with an HTML error page. The log explains instead of pasting markup.
+#[tokio::test]
+async fn a_non_fhir_recipient_error_is_summarized_not_pasted() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let recipient = Router::new().fallback(|| async {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+            "<!DOCTYPE HTML><html><body><h1>Error response</h1><p>Error code: 501</p></body></html>",
+        )
+    });
+    tokio::spawn(async move { axum::serve(listener, recipient).await.unwrap() });
+    let ctx = ctx(&format!("http://{addr}"));
+
+    let (_, detail_path, _) = post_form(&ctx, "/ui/bulk-import", "name=Static&auth=none").await;
+    post_form(
+        &ctx,
+        &format!("{detail_path}/manifests"),
+        "manifest_url=http%3A%2F%2Fone.example%2Fm.json",
+    )
+    .await;
+    post_form(&ctx, &format!("{detail_path}/submit-all"), "").await;
+
+    let (_, html) = get(&ctx, &detail_path).await;
+    assert!(html.contains("$bulk-submit → 501"));
+    assert!(
+        html.contains("not a FHIR resource"),
+        "explains the mismatch"
+    );
+    assert!(!html.contains("Error code: 501"), "markup is not pasted");
+    assert!(html.contains("Failed"));
 }

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -580,6 +580,7 @@ bulk-import-status-not-started = Nicht gestartet
 bulk-import-status-in-progress = In Bearbeitung
 bulk-import-status-stopped = Angehalten
 bulk-import-status-completed = Abgeschlossen
+bulk-import-status-failed = Fehlgeschlagen
 bulk-import-detail-recipient = Datenempfänger
 bulk-import-detail-id = Submission-ID
 bulk-import-detail-submitter = Einreicher

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -583,6 +583,7 @@ bulk-import-status-not-started = Not Started
 bulk-import-status-in-progress = In Progress
 bulk-import-status-stopped = Stopped
 bulk-import-status-completed = Completed
+bulk-import-status-failed = Failed
 bulk-import-detail-recipient = Data Recipient
 bulk-import-detail-id = Submission ID
 bulk-import-detail-submitter = Submitter

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -580,6 +580,7 @@ bulk-import-status-not-started = Sin iniciar
 bulk-import-status-in-progress = En curso
 bulk-import-status-stopped = Detenida
 bulk-import-status-completed = Completada
+bulk-import-status-failed = Fallido
 bulk-import-detail-recipient = Receptor de datos
 bulk-import-detail-id = ID de submission
 bulk-import-detail-submitter = Remitente


### PR DESCRIPTION
Closes #686. Stacked on #696 (recipient = `HFS_BASE_URL`), which removes the misconfiguration that made this failure mode easy to hit; this PR fixes how any recipient failure is reported.

## The three defects

1. **The log now names the request that failed**: `POST {recipient}/$bulk-submit → {status}`, with the manifest URL as context (`(manifest …)`), not as the subject. The old message blamed the manifest URL, which HFS never called with POST.
2. **Error bodies are summarized, never pasted**: an OperationOutcome's `diagnostics` (or `details.text`) when one came back; otherwise the content type — and for markup, *"the response was text/html (N bytes), not a FHIR resource — is the recipient a Bulk Data Submit endpoint?"* with no HTML inlined. The same summary now backs the status-change, replacement, and abort rejection lines, which had the same raw-paste problem.
3. **Failure is visible in the status**: both failure branches set `failed`, `status_label` gains the arm, and `bulk-import-status-failed` exists in en/es/de — a failed submit no longer reads "Not Started".

## Tests

- Updated the rejected-kickoff and unreachable-recipient tests to the new message shape and the Failed status.
- New test reproducing the issue's exact scenario: a recipient that answers like Python's `http.server` (501 + HTML error page) — asserts the explanation appears, the markup does not, and the submission reads Failed.
- `bulk_import_http`: 22/22; full `helios-ui` suite and clippy green.