### PR TITLE
Fix conflicting Resources bookmark type state

### DIFF
--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -1058,10 +1058,28 @@
       });
   }
 
-  /* The last URL the rows themselves produced. A native `change` can fire on
-   * the URL input after `updateUrl` rewrote it programmatically (the browser's
-   * dirty-value flag survives), and rebuilding the rows mid-interaction would
-   * yank focus and drop in-flight edits — so re-parsing skips its own echo. */
+  /* Keeps every type-dependent Resources control on the type parsed from the
+   * query URL. Search and Saved Queries share this script and the rail, but do
+   * not render the Resources panel or Create button, so those updates are
+   * deliberately conditional. This helper never rewrites or runs the query. */
+  function syncTypeContext(type) {
+    markRailType(type);
+    var panel = document.getElementById("resources");
+    if (!panel) return;
+    panel.dataset.selectedType = type;
+    var createBtn = document.getElementById("resource-create");
+    if (createBtn && createBtn.dataset.msgCreate) {
+      var label = createBtn.querySelector(".resources-create__label");
+      if (label) label.textContent = createBtn.dataset.msgCreate.replace("{type}", type);
+    }
+  }
+
+  /* The next URL echo the rows themselves may produce. A native `change` can
+   * fire on the URL input after `updateUrl` rewrote it programmatically (the
+   * browser's dirty-value flag survives), and rebuilding the rows
+   * mid-interaction would yank focus and drop in-flight edits. The marker is
+   * one-shot: any other render invalidates it so a later external URL cannot
+   * match stale state. */
   var lastSerialized = null;
 
   function builderHasEscapeError() {
@@ -1088,16 +1106,20 @@
   /* URL → rows. */
   function renderBuilder() {
     if (!sections || !urlInput) return;
-    if (urlInput.value === lastSerialized) return;
+    var isSerializedEcho = urlInput.value === lastSerialized;
+    lastSerialized = null;
     var parsed = parseSearchUrl(urlInput.value);
     if (!parsed) {
       sections.hidden = true;
       markRailType(null);
       return;
     }
+    // Context sync must precede the echo guard: even a URL whose rows are
+    // already current may have arrived with conflicting Resources state (#626).
+    syncTypeContext(parsed.type);
+    if (isSerializedEcho) return;
     sections.hidden = false;
     sections.dataset.type = parsed.type;
-    markRailType(parsed.type);
     loadCatalog(parsed.type);
 
     var hosts = builderHosts();
@@ -1371,14 +1393,6 @@
    * panel and the button are absent on the Saved Queries / Search pages,
    * where this rail only drives the search. */
   function selectType(type) {
-    var panel = document.getElementById("resources");
-    if (panel) panel.dataset.selectedType = type;
-    var createBtn = document.getElementById("resource-create");
-    if (createBtn && createBtn.dataset.msgCreate) {
-      var label = createBtn.querySelector(".resources-create__label");
-      if (label) label.textContent = createBtn.dataset.msgCreate.replace("{type}", type);
-    }
-    markRailType(type);
     urlInput.value = "GET /" + type;
     renderBuilder();
     runSearch("/" + encodeURIComponent(type), false);

--- a/crates/ui/e2e/tests/resources.spec.ts
+++ b/crates/ui/e2e/tests/resources.spec.ts
@@ -63,12 +63,105 @@ test("selecting a type updates the Create label and the URL", async ({ resources
   await expect(resources.builder.url).toHaveValue("GET /Observation");
 });
 
+test("switching away and back cannot reuse a stale builder serialization", async ({
+  resources,
+  page,
+}) => {
+  await resources.goto("Patient");
+  const builderMode = page.locator("[data-mode-btn='builder']");
+  if (await builderMode.count()) await builderMode.click();
+  await resources.builder.addButton("condition").click();
+  const firstRow = resources.builder.conditionRows.first();
+  await firstRow.locator(".builder-row__key").fill("name");
+  await firstRow.locator(".builder-row__value").fill("BeforeSwitch");
+  await expect(resources.builder.url).toHaveValue("GET /Patient?name=BeforeSwitch");
+
+  await firstRow.locator("[data-remove-row]").click();
+  await expect(resources.builder.conditionRows).toHaveCount(0);
+  await expect(resources.builder.url).toHaveValue("GET /Patient");
+
+  await resources.pickType("Observation");
+  await resources.pickType("Patient");
+  await expect(resources.builder.url).toHaveValue("GET /Patient");
+  await expect(resources.builder.sections).toHaveAttribute("data-type", "Patient");
+  await expect(page.locator("#query-plain-text")).toContainText("Patient");
+
+  await resources.builder.addButton("condition").click();
+  const patientRow = resources.builder.conditionRows.first();
+  await patientRow.locator(".builder-row__key").fill("name");
+  await patientRow.locator(".builder-row__value").fill("AfterSwitch");
+  await expect(resources.builder.url).toHaveValue("GET /Patient?name=AfterSwitch");
+  await expect(page.locator("#query-plain-text")).toContainText("AfterSwitch");
+});
+
 test("a ?url= deep link still wins over the default Patient context", async ({ resources, page }) => {
   await page.goto("/ui/resources?url=" + encodeURIComponent("/Observation?status=final"), {
     waitUntil: "networkidle",
   });
   await expect(resources.builder.url).toHaveValue("GET /Observation?status=final");
+  await expect(resources.railItem("Observation")).toHaveAttribute("aria-current", "true");
+  await expect(resources.createLabel).toHaveText("Create new Observation");
   await resources.results.waitShown();
+});
+
+test("a conflicting Resources bookmark uses the query URL type everywhere after reload", async ({
+  resources,
+  page,
+  request,
+}) => {
+  const patientId = await createResource(request, "Patient", {
+    name: [{ family: "NavAlpha" }],
+  });
+  await waitSearchable(request, "Patient", patientId);
+
+  const bookmark =
+    "/ui/resources?type=Observation&url=" + encodeURIComponent("/Patient?name=NavAlpha");
+
+  const expectPatientContext = async () => {
+    await expect(resources.railItem("Patient")).toHaveAttribute("aria-current", "true");
+    await expect(resources.railItem("Observation")).not.toHaveAttribute("aria-current", "true");
+    await expect(page.locator("#resources")).toHaveAttribute("data-selected-type", "Patient");
+    await expect(resources.createLabel).toHaveText("Create new Patient");
+    await expect(resources.builder.url).toHaveValue("GET /Patient?name=NavAlpha");
+    await expect(page.locator("#query-plain")).toBeVisible();
+    await expect(page.locator("#query-plain-text")).toContainText("Patient");
+    await expect(page.locator("#query-plain-text")).toContainText("NavAlpha");
+    await resources.results.waitShown();
+    await expect(
+      page.locator(`#query-results-body a.url[href='/Patient/${patientId}']`),
+    ).toBeVisible();
+    await expect(resources.results.openTab).toHaveAttribute("href", "/Patient?name=NavAlpha");
+  };
+
+  const expectCreateDraft = async (type: string) => {
+    await resources.openCreate();
+    await expect(resources.modal.subject).toContainText(type);
+    expect((await resources.modal.editor.currentDoc()).resourceType).toBe(type);
+    await resources.modal.close();
+  };
+
+  await page.goto(bookmark, { waitUntil: "networkidle" });
+  await expectPatientContext();
+  await expectCreateDraft("Patient");
+
+  await page.reload({ waitUntil: "networkidle" });
+  await expectPatientContext();
+  await expectCreateDraft("Patient");
+
+  await resources.pickType("Observation");
+  await expect(page).toHaveURL(/\/ui\/resources\?type=Observation$/);
+  expect(new URL(page.url()).searchParams.has("url")).toBe(false);
+
+  await page.reload({ waitUntil: "networkidle" });
+  await expect(resources.railItem("Observation")).toHaveAttribute("aria-current", "true");
+  await expect(resources.railItem("Patient")).not.toHaveAttribute("aria-current", "true");
+  await expect(page.locator("#resources")).toHaveAttribute("data-selected-type", "Observation");
+  await expect(resources.createLabel).toHaveText("Create new Observation");
+  await expect(resources.builder.url).toHaveValue("GET /Observation");
+  await expect(page.locator("#query-plain-text")).toContainText("Observation");
+  await resources.results.waitShown();
+  await expect(resources.results.openTab).toHaveAttribute("href", "/Observation");
+  await expectCreateDraft("Observation");
 });
 
 // Long type names (#605): the button truncates instead of widening the page


### PR DESCRIPTION
Closes #626.

## Summary

- Treat the resource type parsed from a valid `url` parameter as authoritative when a Resources bookmark also contains a conflicting `type` parameter.
- Synchronize the active rail item, Create action and draft, builder, narration, results, and Open target through the same render path.
- Consume the builder's serialized-URL echo marker after one render so later type switches cannot reuse stale builder state.
- Add regressions for conflicting bookmarks, reloads, explicit type selection, Create drafts, and switching away and back after a builder edit.

## Compatibility

- Preserves the existing precedence established by #605: `url` wins over `type` when both are present.
- Existing `url` deep links and normal rail navigation continue to work.
- Invalid URL handling, server-side parsing, URL canonicalization, documentation, and localization are unchanged.

## Validation

- JavaScript syntax check passed.
- UI crate and HTTP integration tests passed.
- Resources and Queries Chromium suites: 57 passed.
- Full Chromium project: 168 passed, 7 skipped, 0 failed.
- Independent review completed with no remaining actionable findings.

## Browser QA

Before the change, the conflicting bookmark searched Patient while Create still targeted Observation, including after reload. After the change, every consumer follows Patient; selecting Observation removes the stale `url` parameter and remains coherent after reload.

### Before

The conflicting bookmark searches Patient while the active rail item and Create action still target Observation.

![Before: conflicting bookmark](https://github.com/user-attachments/assets/4bad7b74-e508-4052-b2ab-bf7a6227cfaa)

Create opens an Observation draft.

![Before: Observation draft](https://github.com/user-attachments/assets/6ad463de-1d39-4cdf-b99f-a80149dd0788)

Reloading restores the same conflict.

![Before: conflict after reload](https://github.com/user-attachments/assets/a262366a-0504-40d1-8444-a1796351025e)

### After

The bookmark now keeps every Resources consumer on Patient.

![After: coherent Patient bookmark](https://github.com/user-attachments/assets/a6c22777-f11d-4951-8b68-0f21dae950df)

Create opens a Patient draft.

![After: Patient draft](https://github.com/user-attachments/assets/64a02780-c244-442a-8539-503ff8bb431a)

Selecting Observation removes the stale `url` parameter and stays coherent after reload.

![After: coherent Observation after reload](https://github.com/user-attachments/assets/a3b06307-ce82-4acb-a15a-15f02cde3243)

Create now opens an Observation draft for that state.

![After: Observation draft](https://github.com/user-attachments/assets/5cdac487-8c30-4409-b932-82575388f0fc)
