### PR TITLE
fix(ui): one error treatment, next to the button that raised it

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1262,16 +1262,27 @@ button.pill {
 }
 
 .field__hint--error {
-  color: rgb(220 38 38);
+  color: var(--danger);
 }
 
-.form-error {
-  margin-bottom: 12px;
+/* The one error treatment (#676): danger tokens, so it holds in both themes.
+   Block by default; the inline variant sits next to the button that raised
+   the error. */
+.alert {
+  display: block;
+  margin: 0 0 12px;
   padding: 10px 14px;
+  border: 1px solid var(--danger);
   border-radius: 10px;
-  background: rgb(220 38 38 / 10%);
-  color: #dc2626;
-  font-size: 14px;
+  background: var(--danger-soft);
+  color: var(--danger);
+  font-size: 13px;
+}
+
+.alert--inline {
+  display: inline-block;
+  margin: 0;
+  padding: 5px 10px;
 }
 
 .col-num {
@@ -1725,15 +1736,6 @@ button.pill {
   color: var(--muted);
 }
 
-.query-error {
-  margin: 0 0 12px;
-  padding: 10px 14px;
-  font-size: 13px;
-  color: var(--text);
-  background: var(--accent-soft);
-  border: 1px solid var(--accent);
-  border-radius: 10px;
-}
 
 @media (max-width: 900px) {
   .query-form {
@@ -1900,8 +1902,9 @@ button.pill {
 .history__banner--same { color: var(--muted); }
 
 .history__banner--error {
-  background: var(--accent-soft);
-  border-color: var(--accent);
+  background: var(--danger-soft);
+  border-color: var(--danger);
+  color: var(--danger);
 }
 
 /* ---- the diff ---- */
@@ -3206,8 +3209,9 @@ button.pill {
 }
 
 .nl-answer--error {
-  background: var(--input-bg);
-  border-color: var(--muted);
+  background: var(--danger-soft);
+  border-color: var(--danger);
+  color: var(--danger);
 }
 
 .nl-answer__caveats-heading {
@@ -3546,16 +3550,8 @@ button.pill {
 }
 .editor-validity--ok { color: var(--accent); }
 
-.editor__parse-error {
-  padding: 12px 14px;
-  margin-bottom: 12px;
-  font-size: 13px;
-  background: var(--input-bg);
-  border: 1px solid var(--muted);
-  border-radius: 10px;
-}
 
-.editor__parse-error code {
+.alert code {
   display: block;
   margin-top: 6px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -3667,7 +3663,7 @@ button.pill {
 .editor-row__error {
   margin: 2px 0 4px 0;
   font-size: 12px;
-  color: #cf222e;
+  color: var(--danger);
 }
 
 /* ---- "what can I add here?" ---- */
@@ -4030,11 +4026,11 @@ button.pill {
   background: #eaf6ec;
 }
 .modal__status--error {
-  color: #cf222e;
+  color: var(--danger);
   font-weight: 600;
-  background: #ffebe9;
-  border-top: 1px solid #ffcdca;
-  border-bottom: 1px solid #ffcdca;
+  background: var(--danger-soft);
+  border-top: 1px solid var(--danger);
+  border-bottom: 1px solid var(--danger);
 }
 
 .modal__body {
@@ -4577,10 +4573,6 @@ button.pill {
   color: var(--muted);
 }
 
-.batch-error {
-  margin-top: 10px;
-  color: var(--danger);
-}
 
 .batch-json {
   margin: 0;

--- a/crates/ui/assets/conformance-crud.js
+++ b/crates/ui/assets/conformance-crud.js
@@ -25,7 +25,15 @@
       })
       .catch(function (error) {
         btn.disabled = false;
-        window.alert(btn.dataset.failed + " (" + error.message + ")");
+        /* The shared error treatment, next to the button that failed (#676) —
+           not a native alert dialog. Replaced on the next attempt. */
+        var existing = btn.parentNode.querySelector(".alert");
+        if (existing) existing.remove();
+        var note = document.createElement("span");
+        note.className = "alert alert--inline";
+        note.setAttribute("role", "alert");
+        note.textContent = btn.dataset.failed + " (" + error.message + ")";
+        btn.insertAdjacentElement("afterend", note);
       });
   });
 })();

--- a/crates/ui/e2e/tests/batch.spec.ts
+++ b/crates/ui/e2e/tests/batch.spec.ts
@@ -56,6 +56,9 @@ test("a transaction bundle uploads, previews, executes, and reports", async ({ p
   await expect(page.locator("#batch-json")).toBeVisible();
   await page.locator("#batch-tab-actions").click();
 
+  // The execute error slot lives inside the footer, next to its button (#676).
+  await expect(page.locator(".batch-footer #batch-execute-error")).toHaveCount(1);
+
   // Execute: outcomes per entry plus the aggregate summary.
   await page.locator("#batch-execute").click();
   await expect(page.locator("#batch-response")).toBeVisible();

--- a/crates/ui/e2e/tests/tenants.spec.ts
+++ b/crates/ui/e2e/tests/tenants.spec.ts
@@ -64,7 +64,7 @@ test.describe("tenants", () => {
     await tenants.addForm.locator("input[name=id]").fill(id);
     await tenants.addForm.locator("input[name=display_name]").fill("Second");
     await tenants.addForm.locator("button[type=submit]").click();
-    await expect(page.locator("#tenant-rows .form-error")).toContainText("already exists");
+    await expect(page.locator("#tenant-rows .alert")).toContainText("already exists");
     await expect(tenants.addForm.locator("input[name=id]")).toHaveValue(id);
     await expect(tenants.addForm.locator("input[name=display_name]")).toHaveValue("Second");
   });

--- a/crates/ui/templates/pages/batch.html
+++ b/crates/ui/templates/pages/batch.html
@@ -38,7 +38,7 @@
       <span>{{ i18n.t("batch-drop-browse") }}</span>
     </button>
     <input type="file" id="batch-file" accept=".json,application/json,application/fhir+json" hidden>
-    <p class="batch-error" id="batch-upload-error" role="alert" hidden></p>
+    <p class="alert" id="batch-upload-error" role="alert" hidden></p>
   </section>
 
   <!-- ============ Stage 2: preflight ============ -->
@@ -72,11 +72,13 @@
       <pre class="batch-json" id="batch-json" hidden></pre>
     </div>
 
+    <!-- The error renders inside the footer, next to the button that raised
+         it (#676) — not as detached text at the end of the page. -->
     <div class="batch-footer">
       <button type="button" class="btn" id="batch-cancel">{{ i18n.t("batch-cancel") }}</button>
+      <p class="alert alert--inline" id="batch-execute-error" role="alert" hidden></p>
       <button type="button" class="btn btn--primary" id="batch-execute">{{ i18n.t("batch-execute") }}</button>
     </div>
-    <p class="batch-error" id="batch-execute-error" role="alert" hidden></p>
   </section>
 
   <!-- ============ Stage 3: response ============ -->

--- a/crates/ui/templates/partials/editor-body.html
+++ b/crates/ui/templates/partials/editor-body.html
@@ -19,7 +19,7 @@
 </form>
 
 {% if let Some(message) = parse_error %}
-<div class="editor__parse-error" role="alert">
+<div class="alert" role="alert">
   <strong>{{ i18n.t("editor-invalid-json") }}</strong>
   <code>{{ message }}</code>
 </div>

--- a/crates/ui/templates/partials/search-builder.html
+++ b/crates/ui/templates/partials/search-builder.html
@@ -10,7 +10,7 @@
   The builder rows are hidden until the script hydrates them; the URL input
   alone is the no-JS baseline.
 -->
-<p class="query-error" id="search-error" role="alert" hidden></p>
+<p class="alert" id="search-error" role="alert" hidden></p>
 
 <form id="saved-query-form" class="query-builder" autocomplete="off">
   <div class="query-builder__row">

--- a/crates/ui/templates/partials/tenant_rows.html
+++ b/crates/ui/templates/partials/tenant_rows.html
@@ -1,5 +1,5 @@
 {% if let Some(msg) = error %}
-<div class="form-error" role="alert">{{ msg }}</div>
+<div class="alert" role="alert">{{ msg }}</div>
 {% endif %}
 
 {% if polling %}

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -744,7 +744,7 @@ async fn editor_validates_on_every_mutation_and_anchors_the_issue() {
 async fn editor_keeps_the_users_text_when_the_json_is_broken() {
     let html = edit("doc=%7B%22resourceType%22%3A&op=").await;
 
-    assert!(html.contains("editor__parse-error"));
+    assert!(html.contains("class=\"alert\""));
     // Their text is handed straight back, not discarded.
     assert!(html.contains("resourceType"));
 }

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -168,13 +168,13 @@ async fn create_rejects_invalid_id_and_conflicts() {
 
     // Invalid id → the fragment carries an error banner, not a new row.
     let (_, bad) = post_form(&router, "id=has%20space").await;
-    assert!(bad.contains("form-error"));
+    assert!(bad.contains("alert"));
 
     // Valid create, settle, then a duplicate → conflict surfaced as a banner.
     post_form(&router, "id=acme").await;
     wait_settled(&router).await;
     let (_, dup) = post_form(&router, "id=acme").await;
-    assert!(dup.contains("form-error"));
+    assert!(dup.contains("alert"));
     assert!(dup.contains("already exists"));
 }
 
@@ -260,11 +260,11 @@ async fn storage_failure_renders_the_error_banner_not_a_silent_empty_table() {
 
     let (status, body) = get(&router, "/ui/tenants/rows?q=").await;
     assert_eq!(status, StatusCode::OK);
-    assert!(body.contains("form-error"), "rows fragment: {body}");
+    assert!(body.contains("alert"), "rows fragment: {body}");
 
     let (status, body) = post_form(&router, "id=acme&display_name=").await;
     assert_eq!(status, StatusCode::OK);
-    assert!(body.contains("form-error"), "create fragment: {body}");
+    assert!(body.contains("alert"), "create fragment: {body}");
 
     let res = router
         .clone()
@@ -277,7 +277,7 @@ async fn storage_failure_renders_the_error_banner_not_a_silent_empty_table() {
         .unwrap();
     assert_eq!(res.status(), StatusCode::OK);
     let body = body_text(res).await;
-    assert!(body.contains("form-error"), "delete fragment: {body}");
+    assert!(body.contains("alert"), "delete fragment: {body}");
 }
 
 #[tokio::test]
@@ -532,7 +532,7 @@ async fn delete_refuses_the_reserved_system_tenant() {
     // The page reports the refusal in its error banner rather than 500-ing.
     let body = body_text(res).await;
     assert!(
-        body.contains("form-error"),
+        body.contains("alert"),
         "the refusal must surface as an error banner, got: {body}"
     );
 


### PR DESCRIPTION
Closes #676. Stacked on #698 (the batch pair) — they touch the same files; retargets as the stack merges.

## One component

`.alert` in `app.css`, built from `--danger` / `--danger-soft` so it renders correctly in both themes, plus `.alert--inline` for next-to-the-button placement. `role="alert"` throughout.

## Migrations

- **Standalone blocks onto the component, per-page rules deleted**: `.form-error` (tenant rows), `.query-error` (search builder), `.editor__parse-error`, and both batch error slots.
- **Modifiers riding existing bases keep their names but drop the wrong colors for the danger tokens**: `.history__banner--error` and `.nl-answer--error` (were accent-blue / muted — read as informational), `.modal__status--error` and `.editor-row__error` (hardcoded light-mode hex with no dark counterpart), `.field__hint--error`. Full markup unification of these bases would churn their layout contracts for no visual difference — the treatment is now identical.
- **Placement**: `#batch-execute-error` renders inside `.batch-footer` next to Execute, instead of detached text after a thousand-pixel entry list (the issue's screenshot case).
- **`window.alert()` is gone**: the conformance viewers' delete failure inserts the shared component beside the button that failed, replaced on the next attempt.

## Tests

- Playwright placement assertion: the execute-error slot lives inside the footer (regression guard the issue asked for).
- Assertions on the old class names updated (`tenants_http`, `router_http`, `tenants.spec.ts`).
- **Full chromium project (166 passed, incl. axe color-contrast on the new danger combinations in light and dark) + nojs (11) green locally**; full `helios-ui` Rust suite and clippy clean.