### PR TITLE
fix(search): chained-search resolution drains every page

### DIFF
--- a/crates/persistence/src/search/chain_resolver.rs
+++ b/crates/persistence/src/search/chain_resolver.rs
@@ -130,6 +130,39 @@ fn intersect(mut sets: Vec<HashSet<String>>) -> HashSet<String> {
     acc
 }
 
+/// The resolver's internal page size. A balance between round trips and
+/// per-page memory; correctness never depends on it — [`search_all_pages`]
+/// drains every page.
+const RESOLVER_PAGE: u32 = 1000;
+
+/// Every match of `query`, across every page. The resolver's intermediate
+/// searches feed id rewrites, so letting a backend apply its default page
+/// size silently truncated every hop of every chain at 100 matches — both
+/// `patient.gender=female` and `=male` answered total=100 on a 21k-row
+/// Synthea set (#645).
+async fn search_all_pages<S>(
+    storage: &S,
+    tenant: &TenantContext,
+    query: SearchQuery,
+) -> StorageResult<Vec<crate::types::StoredResource>>
+where
+    S: SearchProvider + ?Sized,
+{
+    let mut items = Vec::new();
+    let mut offset: u32 = 0;
+    loop {
+        let mut page = query.clone().with_count(RESOLVER_PAGE);
+        page.offset = Some(offset);
+        let result = storage.search(tenant, &page).await?;
+        let got = result.resources.items.len();
+        items.extend(result.resources.items);
+        if got < RESOLVER_PAGE as usize {
+            return Ok(items);
+        }
+        offset += RESOLVER_PAGE;
+    }
+}
+
 /// Resolves a forward chain (e.g. `subject.organization.name=Hospital`) to a
 /// set of `base_type` resource ids, walking from the deepest target back out.
 ///
@@ -215,11 +248,9 @@ where
             chain: vec![],
             components: vec![],
         });
-        let result = storage.search(tenant, &terminal_query).await?;
+        let items = search_all_pages(storage, tenant, terminal_query).await?;
         current_refs.extend(
-            result
-                .resources
-                .items
+            items
                 .into_iter()
                 .map(|r| format!("{}/{}", r.resource_type(), r.id())),
         );
@@ -243,8 +274,8 @@ where
                 chain: vec![],
                 components: vec![],
             });
-            let r = storage.search(tenant, &query).await?;
-            next_refs.extend(r.resources.items.into_iter().map(|res| {
+            let items = search_all_pages(storage, tenant, query).await?;
+            next_refs.extend(items.into_iter().map(|res| {
                 if i == 0 {
                     res.id().to_string()
                 } else {
@@ -325,11 +356,11 @@ where
         })
     };
 
-    let result = storage.search(tenant, &source_query).await?;
+    let items = search_all_pages(storage, tenant, source_query).await?;
 
     let extractor = SearchParameterExtractor::new(storage.search_param_registry(tenant));
     let mut ids = Vec::new();
-    for resource in result.resources.items {
+    for resource in items {
         let refs = extract_references(
             &extractor,
             storage,

--- a/crates/persistence/tests/search/chained_tests.rs
+++ b/crates/persistence/tests/search/chained_tests.rs
@@ -257,3 +257,75 @@ async fn test_reverse_chaining_no_matches() {
 
     assert!(result.resources.is_empty());
 }
+
+/// #645: the resolver's intermediate searches must drain every page. With the
+/// terminal hop left at the backend's default page size, any hop matching
+/// more than 100 resources silently truncated the whole chain — both
+/// `patient.gender=female` and `=male` answered exactly total=100 on a
+/// Synthea set where each should have been in the thousands.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_chained_search_survives_hops_beyond_the_default_page() {
+    let backend = create_sqlite_backend();
+    let tenant = create_tenant();
+
+    // 150 female patients, one Observation each: the terminal hop
+    // (Patient?gender=female) matches more than one default page.
+    for i in 0..150 {
+        let pid = format!("chained-page-p{i}");
+        backend
+            .create_or_update(
+                &tenant,
+                "Patient",
+                &pid,
+                json!({"resourceType": "Patient", "id": pid, "gender": "female"}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        let oid = format!("chained-page-o{i}");
+        backend
+            .create_or_update(
+                &tenant,
+                "Observation",
+                &oid,
+                json!({"resourceType": "Observation", "id": oid, "status": "final",
+                       "code": {"text": "hr"},
+                       "subject": {"reference": format!("Patient/{pid}")}}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+    }
+
+    let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+        name: "patient".to_string(),
+        param_type: SearchParamType::Reference,
+        modifier: None,
+        values: vec![SearchValue::eq("female")],
+        chain: vec![ChainedParameter {
+            reference_param: "patient".to_string(),
+            target_type: Some("Patient".to_string()),
+            target_param: "gender".to_string(),
+        }],
+        components: vec![],
+    });
+
+    let rewritten = resolve_chains(&backend, &tenant, &query).await.unwrap();
+    let id_filter = rewritten
+        .parameters
+        .iter()
+        .find(|p| p.name == "_id")
+        .expect("chains rewrite into an _id filter");
+    assert_eq!(
+        id_filter.values.len(),
+        150,
+        "every matching id survives, not just the first page"
+    );
+
+    let result = backend
+        .search(&tenant, &rewritten.with_count(1000))
+        .await
+        .unwrap();
+    assert_eq!(result.resources.items.len(), 150);
+}

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -1342,6 +1342,7 @@ async fn view_definitions_workspace_lists_edits_and_previews() {
         std::sync::Arc::new(source),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     );
 
     let response = app
@@ -1414,6 +1415,7 @@ async fn view_definitions_save_roundtrips_and_rejects_bad_json() {
         std::sync::Arc::new(source),
         helios_fhir::FhirVersion::R4,
         None,
+        "http://localhost:8080".to_string(),
     );
 
     let body = "id=&action=save&json=%7B%22resourceType%22%3A%22ViewDefinition%22%2C%22name%22%3A%22x%22%7D";


### PR DESCRIPTION
Closes #645.

The resolver's internal searches (terminal hop, the walk back out, and the reverse-chain source) ran with no `count`, so every backend applied its default page size and each hop of every chain silently truncated at 100 matches. On #448's Synthea set (100 patients, 21k Observations), `Observation?patient.gender=female` **and** `=male` both answered exactly total=100 — the tell.

**Fix**: a `search_all_pages` helper pages every internal search until a short page arrives (page size 1000, but correctness no longer depends on it). All three call sites route through it; the rewritten `_id` filter now carries every matching id.

**Test**: 150 patients on one side of a hop — the rewritten `_id` filter carries all 150 and the executed search returns them, where the old resolver capped at 100. The existing chained suite stays green.