### PR TITLE
Fix stale query operators after changing search parameters

### DIFF
--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -175,12 +175,13 @@
   }
 
   var catalogType = null;
+  var catalogLoadSeq = 0;
 
   /* Per-type parameter metadata from the catalog fragment's data attributes:
    * type -> { code: { type: "reference"|..., targets: ["Patient", ...] } }.
    * Feeds the chaining controls; promise-cached so each type is fetched once. */
   var PARAM_META = {};
-  var paramMetaPromises = {};
+  var paramCatalogPromises = {};
   function parseCatalog(html) {
     var tpl = document.createElement("template");
     tpl.innerHTML = html;
@@ -193,10 +194,10 @@
     });
     return { meta: meta, datalist: tpl.content.querySelector("datalist") };
   }
-  function fetchParams(type) {
-    if (!type) return Promise.resolve({});
-    if (paramMetaPromises[type]) return paramMetaPromises[type];
-    paramMetaPromises[type] = fetch(
+  function fetchCatalog(type) {
+    if (!type) return Promise.resolve({ meta: {}, datalist: null });
+    if (paramCatalogPromises[type]) return paramCatalogPromises[type];
+    paramCatalogPromises[type] = fetch(
       "/ui/queries/params?type=" + encodeURIComponent(type),
       { credentials: "same-origin" },
     )
@@ -204,33 +205,44 @@
         return response.ok ? response.text() : null;
       })
       .then(function (html) {
-        if (!html) return {};
-        var parsed = parseCatalog(html);
+        var parsed = html
+          ? parseCatalog(html)
+          : { meta: {}, datalist: null };
         PARAM_META[type] = parsed.meta;
-        return parsed.meta;
+        return parsed;
+      })
+      .catch(function () {
+        PARAM_META[type] = {};
+        return { meta: {}, datalist: null };
       });
-    return paramMetaPromises[type];
+    return paramCatalogPromises[type];
+  }
+  function fetchParams(type) {
+    return fetchCatalog(type).then(function (catalog) {
+      return catalog.meta;
+    });
   }
 
   /* Swaps the parameter datalist for the current resource type. The
    * fragment is server-rendered from the SearchParameter registry. */
   function loadCatalog(type) {
-    if (!type || type === catalogType) return;
+    if (!type) return Promise.resolve({});
+    var loadSeq = ++catalogLoadSeq;
     catalogType = type;
-    fetch("/ui/queries/params?type=" + encodeURIComponent(type), {
-      credentials: "same-origin",
-    })
-      .then(function (response) {
-        return response.ok ? response.text() : null;
-      })
-      .then(function (html) {
-        if (!html) return;
-        var parsed = parseCatalog(html);
-        PARAM_META[type] = parsed.meta;
-        var current = document.getElementById("param-options");
-        if (parsed.datalist && current) current.replaceWith(parsed.datalist);
-        refreshChainAffordances();
-      });
+    return fetchCatalog(type).then(function (parsed) {
+      if (
+        loadSeq !== catalogLoadSeq ||
+        catalogType !== type ||
+        !sections ||
+        sections.dataset.type !== type
+      )
+        return parsed.meta;
+      var current = document.getElementById("param-options");
+      if (parsed.datalist && current)
+        current.replaceWith(parsed.datalist.cloneNode(true));
+      refreshChainAffordances();
+      return parsed.meta;
+    });
   }
 
   function splitQuery(query) {
@@ -410,15 +422,19 @@
    * prefixes only apply to the ordered families. Unknown or unregistered
    * params keep the full lists. */
   var MODS_BY_TYPE = {
-    string: ["exact", "contains", "missing"],
-    token: ["text", "not", "in", "not-in", "of-type", "missing"],
-    reference: ["identifier", "missing"],
-    uri: ["below", "above", "missing"],
+    string: ["exact", "contains", "text", "missing"],
+    token: [
+      "text", "not", "above", "below", "in", "not-in", "of-type", "missing",
+    ],
+    reference: [
+      "contains", "text", "above", "below", "identifier", "missing",
+    ],
+    uri: ["contains", "above", "below", "missing"],
     date: ["missing"],
     number: ["missing"],
     quantity: ["missing"],
-    composite: ["missing"],
-    special: ["missing"],
+    composite: [],
+    special: [],
   };
   var PREFIX_TYPES = ["date", "number", "quantity"];
 
@@ -430,32 +446,57 @@
     return PREFIX_TYPES.indexOf(paramType) >= 0 ? PREFIXES : [];
   }
 
-  /* Rebuilds a row's modifier select and MODIFY chips for its param type. */
+  function knownParamType(paramType) {
+    return Object.prototype.hasOwnProperty.call(MODS_BY_TYPE, paramType);
+  }
+
+  function compatibleModifier(modifier, paramType) {
+    if (!modifier) return true;
+    if ((MODS_BY_TYPE[paramType] || []).indexOf(modifier) >= 0) return true;
+    if (modifier === "text-advanced" || modifier === "code-text") {
+      return paramType === "token" || paramType === "reference";
+    }
+    return paramType === "reference" && /^[A-Z]/.test(modifier);
+  }
+
+  /* Rebuilds a row's modifier select and MODIFY chips for its param type.
+   * A known type discards an incompatible operator; unknown parameters keep
+   * pasted operators verbatim. */
   function refreshModifierControls(row, paramType) {
     var modifier = row.querySelector(".builder-row__modifier");
-    if (!modifier) return;
-    var selected = modifier.value;
+    if (!modifier) return false;
+    var originalSelected = modifier.value;
+    var selected = originalSelected;
+    var known = row.dataset.compatState === "known";
     var mods = applicableMods(paramType);
+    if (known && !compatibleModifier(selected, paramType)) selected = "";
     modifier.textContent = "";
     option(modifier, "", sections.dataset.msgMatchIs, !selected);
     mods.forEach(function (m) {
       option(modifier, m, ":" + m, selected === m);
     });
-    /* A modifier from a pasted URL stays selectable even when the type
-     * would not offer it. */
+    /* Compatibility-only and unknown modifiers remain selectable without
+     * becoming chips in the visible modifier matrix. */
     if (selected && mods.indexOf(selected) < 0) {
       option(modifier, selected, ":" + selected, true);
     }
     var panel = row.querySelector(".builder-row__modpanel");
     if (panel) fillModPanel(panel, row, mods);
+    return originalSelected !== selected;
   }
 
   /* Re-gates the per-value comparator selects without discarding an explicit
    * prefix from a pasted URL whose parameter type is unknown or unexpected. */
   function refreshComparatorControls(row, paramType) {
     var prefixes = applicablePrefixes(paramType);
+    var known = row.dataset.compatState === "known";
+    var changed = false;
     row.querySelectorAll(".builder-row__comparator").forEach(function (comparator) {
       var selected = comparator.value;
+      if (known && prefixes.indexOf(selected) < 0) {
+        changed = changed || !!selected;
+        selected = "";
+      }
       comparator.textContent = "";
       option(comparator, "", sections.dataset.msgMatchIs, !selected);
       prefixes.forEach(function (prefix) {
@@ -466,6 +507,36 @@
       }
       comparator.hidden = prefixes.length === 0 && !selected;
     });
+    return changed;
+  }
+
+  /* A modifier-bearing value is literal while the modifier is active, so its
+   * leading comparator was not split during hydration. If reconciliation
+   * removes that modifier and lands on an ordered type, move the prefix into
+   * the comparator control and keep the preserved wire value in step. */
+  function rehydrateComparatorPrefixes(row) {
+    var changed = false;
+    row.querySelectorAll(".builder-row__orvalue").forEach(function (alternative) {
+      var comparator = alternative.querySelector(".builder-row__comparator");
+      var input = alternative.querySelector(".builder-row__value");
+      var parsed = parsePrefixedValue(input.value);
+      if (!comparator || !parsed.comparator) return;
+      var wire = parsePrefixedValue(
+        input.dataset.fhirWire === undefined
+          ? input.value
+          : input.dataset.fhirWire,
+      );
+      comparator.value = parsed.comparator;
+      input.value = parsed.value;
+      if (wire.comparator === parsed.comparator) {
+        input.dataset.fhirWire = wire.value;
+      } else {
+        delete input.dataset.fhirWire;
+        input.dataset.fhirDirty = "true";
+      }
+      changed = true;
+    });
+    return changed;
   }
 
   /* Best-effort param type for a row's modifier target, from the cached
@@ -489,14 +560,106 @@
     return (((PARAM_META[base] || {})[key.value.trim()] || {}).type) || "";
   }
 
-  /* Re-gates a row's modifier controls when its param type changed. */
+  function builderCompatibilityPending() {
+    return !!(
+      compatibilitySyncQueued ||
+      (sections &&
+        sections.querySelector(".builder-row[data-compat-state='pending']"))
+    );
+  }
+
+  function builderConsumersBlocked() {
+    return (
+      builderCompatibilityPending() ||
+      !!(sections && !sections.hidden && builderHasEscapeError())
+    );
+  }
+
+  var pendingBuilderConsumers = [];
+  function syncBuilderAvailability() {
+    var pending = builderConsumersBlocked();
+    if (form) {
+      form.querySelectorAll("[data-intent]").forEach(function (control) {
+        control.disabled = pending;
+      });
+    }
+    var copy = document.getElementById("query-copy");
+    if (copy) copy.disabled = pending;
+    if (root) {
+      root
+        .querySelectorAll("button[data-action='run']")
+        .forEach(function (control) {
+          control.disabled = pending;
+        });
+    }
+    if (pending) return;
+    var ready = pendingBuilderConsumers;
+    pendingBuilderConsumers = [];
+    ready.forEach(function (consumer) {
+      if (consumer.revision === builderRevision) consumer.callback();
+    });
+  }
+
+  function consumeWhenBuilderReady(revision, callback) {
+    if (!builderConsumersBlocked()) {
+      if (revision === builderRevision) callback();
+      return;
+    }
+    pendingBuilderConsumers.push({ revision: revision, callback: callback });
+  }
+
+  var compatibilitySyncQueued = false;
+  var compatibilitySyncNeeded = false;
+  var compatibilitySyncGeneration = 0;
+  function resetCompatibilitySync() {
+    compatibilitySyncGeneration += 1;
+    compatibilitySyncQueued = false;
+    compatibilitySyncNeeded = false;
+  }
+  function queueCompatibilitySync(needsUpdate) {
+    compatibilitySyncNeeded = compatibilitySyncNeeded || !!needsUpdate;
+    if (compatibilitySyncQueued) return;
+    var generation = compatibilitySyncGeneration;
+    compatibilitySyncQueued = true;
+    Promise.resolve().then(function () {
+      if (generation !== compatibilitySyncGeneration) return;
+      compatibilitySyncQueued = false;
+      if (!builderCompatibilityPending()) {
+        var shouldUpdate = compatibilitySyncNeeded;
+        compatibilitySyncNeeded = false;
+        if (shouldUpdate && !builderUrlEdited) updateUrl();
+        syncBuilderAvailability();
+      }
+    });
+  }
+
+  function markCompatibilityPending(row) {
+    row.dataset.compatState = "pending";
+    syncBuilderAvailability();
+  }
+
+  function noteBuilderUserEdit() {
+    builderRevision += 1;
+    if (builderCompatibilityPending()) compatibilitySyncNeeded = true;
+  }
+
+  /* Settles one row as a known type or as unknown/ambiguous. Unknown rows
+   * remain permissive; known rows reconcile both key modifiers and value
+   * prefixes before the URL can be consumed. */
   function regateModifiers(row, resolvedType) {
     var t = arguments.length > 1 ? resolvedType : rowParamType(row);
-    if (row.dataset.modType !== t) {
-      row.dataset.modType = t;
-      refreshModifierControls(row, t);
+    var wasPending = row.dataset.compatState === "pending";
+    var known = knownParamType(t);
+    row.dataset.compatState = known ? "known" : "unknown";
+    row.dataset.modType = known ? t : "";
+    var modifierRemoved = refreshModifierControls(row, known ? t : "");
+    var changed = modifierRemoved;
+    changed = refreshComparatorControls(row, known ? t : "") || changed;
+    if (modifierRemoved && PREFIX_TYPES.indexOf(t) >= 0) {
+      changed = rehydrateComparatorPrefixes(row) || changed;
     }
-    refreshComparatorControls(row, t);
+    if (wasPending) queueCompatibilitySync(changed);
+    else syncBuilderAvailability();
   }
 
   /* The MODIFY panel: each applicable modifier as a chip with its
@@ -560,6 +723,9 @@
     COLON_MODIFIERS.forEach(function (m) {
       option(modifier, m, ":" + m, selectedMod === m);
     });
+    if (selectedMod && COLON_MODIFIERS.indexOf(selectedMod) < 0) {
+      option(modifier, selectedMod, ":" + selectedMod, true);
+    }
     row.appendChild(modifier);
 
     appendValues(row, value, !selectedMod);
@@ -617,6 +783,7 @@
     row.appendChild(deeper);
 
     appendTail(row, part);
+    markCompatibilityPending(row);
 
     var base = sections.dataset.type || "";
     var leafRefillSeq = 0;
@@ -694,13 +861,15 @@
     function refillLeaf() {
       var refillSeq = ++leafRefillSeq;
       var leafCode = leaf.input.value.trim();
+      markCompatibilityPending(row);
       leafTypes(function (types) {
         var pending = types.length;
         var codes = [];
         var anyRef = false;
         var resolvedTypes = [];
         if (!pending) {
-          if (refillSeq === leafRefillSeq) regateModifiers(row, "");
+          if (refillSeq === leafRefillSeq && row.isConnected)
+            regateModifiers(row, "");
           return;
         }
         types.forEach(function (t) {
@@ -711,7 +880,11 @@
             var m = meta[leafCode];
             if (m && m.type === "reference") anyRef = true;
             if (m && resolvedTypes.indexOf(m.type) < 0) resolvedTypes.push(m.type);
-            if (--pending === 0 && refillSeq === leafRefillSeq) {
+            if (
+              --pending === 0 &&
+              refillSeq === leafRefillSeq &&
+              row.isConnected
+            ) {
               fillList(leaf.list, codes.sort());
               deeper.hidden = !anyRef;
               regateModifiers(row, resolvedTypes.length === 1 ? resolvedTypes[0] : "");
@@ -745,7 +918,7 @@
         hops[k].type = typeSel.value;
         for (var j = k + 1; j < hops.length; j++) segRefill(j);
         refillLeaf();
-        updateUrl();
+        if (!builderCompatibilityPending()) updateUrl();
       });
 
       hopsHost.appendChild(seg);
@@ -765,8 +938,9 @@
       leaf.input.value = "";
       addSegment(hops.length - 1);
       refillLeaf();
+      noteBuilderUserEdit();
       leaf.input.focus();
-      updateUrl();
+      if (!builderCompatibilityPending()) updateUrl();
     });
 
     /* updateUrl reads the hops through the row's DOM state. */
@@ -801,18 +975,20 @@
     row.appendChild(leaf.input);
 
     appendTail(row, part);
+    markCompatibilityPending(row);
 
     var base = sections.dataset.type || "";
     var paramsRefillSeq = 0;
     function refillParams() {
       var refillSeq = ++paramsRefillSeq;
       var t = type.input.value.trim();
+      markCompatibilityPending(row);
       if (!t) {
         regateModifiers(row, "");
         return;
       }
       fetchParams(t).then(function (meta) {
-        if (refillSeq !== paramsRefillSeq) return;
+        if (refillSeq !== paramsRefillSeq || !row.isConnected) return;
         var codes = Object.keys(meta).sort();
         /* The link must be a reference param that can point at the base
          * type; params with no declared targets stay offered. */
@@ -829,10 +1005,7 @@
       });
     }
     type.input.addEventListener("input", refillParams);
-    leaf.input.addEventListener("input", function () {
-      var meta = PARAM_META[type.input.value.trim()] || {};
-      regateModifiers(row, ((meta[leaf.input.value.trim()] || {}).type) || "");
-    });
+    leaf.input.addEventListener("input", refillParams);
     refillParams();
 
     return row;
@@ -926,7 +1099,9 @@
    * reference, per the registry metadata for the current base type. */
   function refreshChainAffordances() {
     if (!sections) return;
-    var meta = PARAM_META[sections.dataset.type || ""] || {};
+    var type = sections.dataset.type || "";
+    var loaded = Object.prototype.hasOwnProperty.call(PARAM_META, type);
+    var meta = PARAM_META[type] || {};
     sections
       .querySelectorAll("#builder-conditions .builder-row")
       .forEach(function (row) {
@@ -935,9 +1110,14 @@
         var key = row.querySelector(".builder-row__key");
         var drill = row.querySelector("[data-chain-from]");
         if (!key || !drill) return;
+        if (!loaded) {
+          drill.hidden = true;
+          markCompatibilityPending(row);
+          return;
+        }
         var m = meta[key.value.trim()];
         drill.hidden = !(m && m.type === "reference");
-        regateModifiers(row);
+        regateModifiers(row, (m && m.type) || "");
       });
   }
 
@@ -996,6 +1176,9 @@
         COLON_MODIFIERS.forEach(function (m) {
           option(modifier, m, ":" + m, selectedMod === m);
         });
+        if (selectedMod && COLON_MODIFIERS.indexOf(selectedMod) < 0) {
+          option(modifier, selectedMod, ":" + selectedMod, true);
+        }
       }
       row.appendChild(modifier);
     }
@@ -1032,6 +1215,7 @@
       panel.className = "builder-row__modpanel";
       panel.hidden = true;
       row.appendChild(panel);
+      markCompatibilityPending(row);
     }
 
     return row;
@@ -1081,6 +1265,8 @@
    * one-shot: any other render invalidates it so a later external URL cannot
    * match stale state. */
   var lastSerialized = null;
+  var builderRevision = 0;
+  var builderUrlEdited = false;
 
   function builderHasEscapeError() {
     return !!(
@@ -1110,17 +1296,32 @@
     lastSerialized = null;
     var parsed = parseSearchUrl(urlInput.value);
     if (!parsed) {
+      resetCompatibilitySync();
+      builderRevision += 1;
+      builderUrlEdited = false;
       sections.hidden = true;
       markRailType(null);
+      sections
+        .querySelectorAll(".builder-row[data-compat-state='pending']")
+        .forEach(function (row) {
+          row.dataset.compatState = "unknown";
+        });
+      syncBuilderAvailability();
       return;
     }
     // Context sync must precede the echo guard: even a URL whose rows are
     // already current may have arrived with conflicting Resources state (#626).
     syncTypeContext(parsed.type);
-    if (isSerializedEcho) return;
+    if (isSerializedEcho) {
+      resetCompatibilitySync();
+      syncBuilderAvailability();
+      return;
+    }
+    resetCompatibilitySync();
+    builderRevision += 1;
+    builderUrlEdited = false;
     sections.hidden = false;
     sections.dataset.type = parsed.type;
-    loadCatalog(parsed.type);
 
     var hosts = builderHosts();
     Object.keys(hosts).forEach(function (kind) {
@@ -1131,6 +1332,8 @@
       hosts[kind].appendChild(builderRow(kind, part));
     });
     refreshChainAffordances();
+    syncBuilderAvailability();
+    loadCatalog(parsed.type);
     updatePlain();
     if (builderHasEscapeError()) showEscapeError();
     else clearError();
@@ -1139,8 +1342,14 @@
   /* Rows → URL. */
   function updateUrl() {
     if (!sections || !urlInput) return;
+    if (builderCompatibilityPending()) {
+      syncBuilderAvailability();
+      return;
+    }
+    compatibilitySyncNeeded = false;
     if (builderHasEscapeError()) {
       showEscapeError();
+      syncBuilderAvailability();
       return;
     }
     clearError();
@@ -1207,13 +1416,24 @@
       "GET /" + type + (parts.length ? "?" + parts.join("&") : "");
     lastSerialized = urlInput.value;
     updatePlain();
+    syncBuilderAvailability();
   }
 
   if (sections && urlInput) {
+    urlInput.addEventListener("input", function () {
+      builderRevision += 1;
+      builderUrlEdited = true;
+    });
     urlInput.addEventListener("change", renderBuilder);
     sections.addEventListener("input", function (event) {
       var row = event.target.closest(".builder-row");
       if (row) {
+        if (
+          row.classList.contains("builder-row--chain") &&
+          event.target.classList.contains("builder-row__ctype")
+        )
+          markCompatibilityPending(row);
+        noteBuilderUserEdit();
         if (event.target.classList.contains("builder-row__value")) {
           event.target.dataset.fhirDirty = "true";
           delete event.target.dataset.fhirEscapeError;
@@ -1238,11 +1458,10 @@
             fillModPanel(modifierPanel, row, applicableMods(row.dataset.modType || ""));
           }
         }
-        updateUrl();
         if (event.target.classList.contains("builder-row__key")) {
           refreshChainAffordances();
-          regateModifiers(row);
         }
+        if (!builderCompatibilityPending()) updateUrl();
       }
     });
     sections.addEventListener("click", function (event) {
@@ -1251,6 +1470,7 @@
       var toggleIterate = event.target.closest("[data-toggle-iterate]");
       var toggleMods = event.target.closest("[data-toggle-mods]");
       if (toggleIterate) {
+        noteBuilderUserEdit();
         var on = toggleIterate.getAttribute("aria-pressed") === "true";
         toggleIterate.setAttribute("aria-pressed", on ? "false" : "true");
         updateUrl();
@@ -1261,7 +1481,7 @@
       if (toggleMods) {
         var modRow = toggleMods.closest(".builder-row");
         var modPanel = modRow.querySelector(".builder-row__modpanel");
-        regateModifiers(modRow);
+        if (modRow.dataset.compatState !== "pending") regateModifiers(modRow);
         if (modPanel.hidden) {
           refreshModifierControls(modRow, modRow.dataset.modType || "");
         }
@@ -1270,6 +1490,7 @@
         return;
       }
       if (modChip) {
+        noteBuilderUserEdit();
         var chipRow = modChip.closest(".builder-row");
         var sel = chipRow.querySelector(".builder-row__modifier");
         sel.value = sel.value === modChip.dataset.modChip ? "" : modChip.dataset.modChip;
@@ -1289,6 +1510,7 @@
       var removeOr = event.target.closest("[data-remove-or]");
       var add = event.target.closest("[data-add]");
       if (addOr) {
+        noteBuilderUserEdit();
         var orRow = addOr.closest(".builder-row");
         var orHost = orRow.querySelector(".builder-row__values");
         var addedValue = orValueInput(orHost, "");
@@ -1297,6 +1519,7 @@
         return;
       }
       if (removeOr) {
+        noteBuilderUserEdit();
         var orWrap = removeOr.closest(".builder-row__orvalue");
         if (orWrap.parentElement.children.length > 1) {
           orWrap.remove();
@@ -1305,6 +1528,7 @@
         return;
       }
       if (remove) {
+        noteBuilderUserEdit();
         remove.closest(".builder-row").remove();
         updateUrl();
       } else if (drillFrom) {
@@ -1333,6 +1557,7 @@
           value: keptValues.join(","),
         });
         from.replaceWith(chain);
+        noteBuilderUserEdit();
         chain.querySelector(".builder-row__cparam").focus();
         updateUrl();
       } else if (add) {
@@ -1344,6 +1569,7 @@
             value: "",
           });
           builderHosts().include.appendChild(inc);
+          noteBuilderUserEdit();
           inc.querySelector(kind === "include-rev" ? ".builder-row__itype" : ".builder-row__iparam").focus();
           return;
         }
@@ -1357,6 +1583,7 @@
             value: "",
           });
           builderHosts().condition.appendChild(has);
+          noteBuilderUserEdit();
           has.querySelector(".builder-row__htype").focus();
           return;
         }
@@ -1367,6 +1594,8 @@
         };
         var row = builderRow(kind, part);
         builderHosts()[kind].appendChild(row);
+        noteBuilderUserEdit();
+        if (kind === "condition") refreshChainAffordances();
         row.querySelector(kind === "condition" ? ".builder-row__key" : ".builder-row__value").focus();
       }
     });
@@ -1964,7 +2193,10 @@
     renderRecent(doc);
     /* The Search page renders the builder and the recent list but no saved
      * list; there is nothing further to draw there. */
-    if (!root) return;
+    if (!root) {
+      syncBuilderAvailability();
+      return;
+    }
 
     var byType = savedQueries(doc);
     root.textContent = "";
@@ -2039,6 +2271,7 @@
       empty.textContent = messages.msgEmpty;
       root.appendChild(empty);
     }
+    syncBuilderAvailability();
   }
 
   /* Errors surface next to the query strip — the control they are almost
@@ -2102,15 +2335,24 @@
 
   /* Loads a query into the builder without running it. */
   function loadIntoBuilder(path) {
-    if (!urlInput) return;
+    if (!urlInput) return builderRevision;
     urlInput.value = "GET " + path;
     renderBuilder();
+    return builderRevision;
+  }
+
+  function runCurrentBuilderSearch(record) {
+    var parsed = parseSearchUrl(urlInput && urlInput.value);
+    if (!parsed) return false;
+    runSearch(searchPath(parsed.type, parsed.query), record);
+    return true;
   }
 
   /* Copy the query exactly as shown: what gets copied is what would run. */
   var copyButton = document.getElementById("query-copy");
   if (copyButton && navigator.clipboard) {
     copyButton.addEventListener("click", function () {
+      if (builderConsumersBlocked()) return;
       navigator.clipboard.writeText(urlInput.value || "");
     });
   } else if (copyButton) {
@@ -2134,11 +2376,13 @@
 
         if (target.dataset.action === "run") {
           var path = searchPath(resourceType, entry.query || "");
-          loadIntoBuilder(path);
-          runSearch(path, true);
-          mutate(resourceType, id, {
-            lastAccessedAt: new Date().toISOString(),
-            accessCount: (Number(entry.accessCount) || 0) + 1,
+          var revision = loadIntoBuilder(path);
+          consumeWhenBuilderReady(revision, function () {
+            if (!runCurrentBuilderSearch(true)) return;
+            mutate(resourceType, id, {
+              lastAccessedAt: new Date().toISOString(),
+              accessCount: (Number(entry.accessCount) || 0) + 1,
+            });
           });
         } else if (target.dataset.action === "rename") {
           var name = window.prompt(messages.msgRenamePrompt, entry.name || "");
@@ -2194,6 +2438,7 @@
   if (form) {
     form.addEventListener("submit", function (event) {
       event.preventDefault();
+      if (builderConsumersBlocked()) return;
       var intent =
         (event.submitter && event.submitter.dataset.intent) || "run";
       var parsed = parseSearchUrl(form.elements.url.value);
@@ -2243,10 +2488,10 @@
    * runs immediately — also what saved/recent entries could link to. */
   var deepLink = new URLSearchParams(window.location.search).get("url");
   if (deepLink && urlInput) {
-    loadIntoBuilder(deepLink.replace(/^GET\s+/i, ""));
-    var parsedDeep = parseSearchUrl(urlInput.value);
-    if (parsedDeep)
-      runSearch(searchPath(parsedDeep.type, parsedDeep.query), true);
+    var deepRevision = loadIntoBuilder(deepLink.replace(/^GET\s+/i, ""));
+    consumeWhenBuilderReady(deepRevision, function () {
+      runCurrentBuilderSearch(true);
+    });
   } else {
     // Resources opens in Patient (or `?type=`) context (#605): the same
     // path as a rail click, so the builder and results match the type the

--- a/crates/ui/e2e/pages/search-builder.ts
+++ b/crates/ui/e2e/pages/search-builder.ts
@@ -57,7 +57,11 @@ export class SearchBuilder {
   }
 
   async run(query: string): Promise<void> {
-    await this.url.fill(query);
+    await this.setUrl(query);
+    await this.page.waitForFunction(() => {
+      const button = document.querySelector<HTMLButtonElement>("[data-intent='run']");
+      return !!button && !button.disabled;
+    });
     await this.runButton.click();
   }
 

--- a/crates/ui/e2e/tests/queries.spec.ts
+++ b/crates/ui/e2e/tests/queries.spec.ts
@@ -1,6 +1,16 @@
 import { test, expect } from "../pages/fixtures";
 import { createResource, waitSearchable } from "../pages/api";
 
+function catalogHtml(
+  params: Array<{ code: string; type: string; targets?: string[] }>,
+): string {
+  const options = params.map(
+    ({ code, type, targets = [] }) =>
+      `<option value="${code}" data-type="${type}" data-targets="${targets.join(",")}"></option>`,
+  );
+  return `<datalist id="param-options">${options.join("")}</datalist>`;
+}
+
 // The Saved Queries workspace (/ui/queries): the shared query builder and the
 // in-page results table — run a query, add builder rows, page through results,
 // and see the datalist of parameters swap per type.
@@ -340,6 +350,40 @@ test.describe("query builder", () => {
     await expect(queries.builder.url).toHaveValue("GET /Patient?family=a\\\\x");
   });
 
+  test("operator cleanup keeps malformed escapes blocked until correction", async ({
+    page,
+    queries,
+  }) => {
+    const searches: string[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (request.method() === "GET" && url.pathname === "/Patient") {
+        searches.push(url.search);
+      }
+    });
+
+    await queries.builder.setUrl("Patient?name:contains=a%5Cx");
+    const row = queries.builder.conditionRows.first();
+    await row.locator(".builder-row__key").fill("gender");
+    await expect(row).toHaveAttribute("data-mod-type", "token");
+    await expect(row.locator(".builder-row__modifier")).toHaveValue("");
+    await expect(queries.builder.error).toBeVisible();
+    await expect(queries.builder.runButton).toBeDisabled();
+    await expect(queries.builder.saveButton).toBeDisabled();
+    await expect(queries.builder.copyButton).toBeDisabled();
+    await queries.builder.url.focus();
+    await page.keyboard.press("Enter");
+    expect(searches).toEqual([]);
+
+    await row.locator(".builder-row__value").fill("a\\x");
+    await expect(queries.builder.error).toBeHidden();
+    await expect(queries.builder.url).toHaveValue("GET /Patient?gender=a\\\\x");
+    await expect(queries.builder.runButton).toBeEnabled();
+    await expect(queries.builder.saveButton).toBeEnabled();
+    await expect(queries.builder.copyButton).toBeEnabled();
+    expect(searches).toEqual([]);
+  });
+
   test("the + or button stacks a value; the per-value × removes it", async ({
     queries,
   }) => {
@@ -510,6 +554,346 @@ test.describe("query builder", () => {
     const opts = await row.locator(".builder-row__modifier option").allTextContents();
     expect(opts).not.toContain("ge");
     expect(opts).not.toContain(":in");
+  });
+
+  test("changing a parameter removes incompatible modifiers before the query can run", async ({
+    page,
+    queries,
+  }) => {
+    const searches: string[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (request.method() === "GET" && url.pathname === "/Patient") {
+        searches.push(url.search);
+      }
+    });
+
+    await queries.builder.setUrl("Patient?name:contains=OrAlpha556");
+    const row = queries.builder.conditionRows.first();
+    await expect(row).toHaveAttribute("data-mod-type", "string");
+    await row.locator(".builder-row__key").fill("gender");
+
+    await expect(row).toHaveAttribute("data-mod-type", "token");
+    await expect(row.locator(".builder-row__modifier")).toHaveValue("");
+    await expect(queries.builder.url).toHaveValue("GET /Patient?gender=OrAlpha556");
+    await expect(page.locator("#query-plain-text")).toContainText(
+      "gender is “OrAlpha556”",
+    );
+    expect(searches).toEqual([]);
+
+    const sent = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return request.method() === "GET" && url.pathname === "/Patient";
+    });
+    await queries.builder.runButton.click();
+    expect(new URL((await sent).url()).search).toBe("?gender=OrAlpha556");
+  });
+
+  test("known parameter types expose the complete modifier matrix", async ({ page, queries }) => {
+    const scenarios = [
+      {
+        key: "string-param",
+        type: "string",
+        modifiers: ["exact", "contains", "text", "missing"],
+      },
+      {
+        key: "token-param",
+        type: "token",
+        modifiers: ["text", "not", "above", "below", "in", "not-in", "of-type", "missing"],
+      },
+      {
+        key: "reference-param",
+        type: "reference",
+        modifiers: ["contains", "text", "above", "below", "identifier", "missing"],
+      },
+      {
+        key: "uri-param",
+        type: "uri",
+        modifiers: ["contains", "above", "below", "missing"],
+      },
+      { key: "date-param", type: "date", modifiers: ["missing"] },
+      { key: "number-param", type: "number", modifiers: ["missing"] },
+      { key: "quantity-param", type: "quantity", modifiers: ["missing"] },
+      { key: "composite-param", type: "composite", modifiers: [] },
+      { key: "special-param", type: "special", modifiers: [] },
+    ];
+    await page.route("**/ui/queries/params?type=Matrix", async (route) => {
+      await route.fulfill({
+        contentType: "text/html",
+        body: catalogHtml(
+          scenarios.map(({ key, type }) => ({ code: key, type })),
+        ),
+      });
+    });
+
+    for (const scenario of scenarios) {
+      await queries.builder.setUrl(`Matrix?${scenario.key}=x`);
+      const row = queries.builder.conditionRows.first();
+      await expect(row).toHaveAttribute("data-mod-type", scenario.type);
+      const values = await row.locator(".builder-row__modifier option").evaluateAll((options) =>
+        options.slice(1).map((option) => (option as HTMLOptionElement).value),
+      );
+      expect(values).toEqual(scenario.modifiers);
+    }
+  });
+
+  test("compatibility-only and ambiguous modifiers are preserved only where valid", async ({
+    page,
+    queries,
+  }) => {
+    const catalogs: Record<
+      string,
+      Array<{ code: string; type: string; targets?: string[] }>
+    > = {
+      Matrix: [
+        { code: "string-param", type: "string" },
+        { code: "token-param", type: "token" },
+        { code: "reference-param", type: "reference" },
+        { code: "subject", type: "reference", targets: ["Left", "Right"] },
+      ],
+      Left: [{ code: "leaf", type: "string" }],
+      Right: [{ code: "leaf", type: "token" }],
+    };
+    await page.route("**/ui/queries/params?type=*", async (route) => {
+      const type = new URL(route.request().url()).searchParams.get("type") || "";
+      await route.fulfill({
+        contentType: "text/html",
+        body: catalogHtml(catalogs[type] || []),
+      });
+    });
+
+    const transitions = [
+      { modifier: "text-advanced", from: "token-param", to: "string-param" },
+      { modifier: "code-text", from: "reference-param", to: "string-param" },
+      { modifier: "Patient", from: "reference-param", to: "token-param" },
+    ];
+    for (const transition of transitions) {
+      await queries.builder.setUrl(
+        `Matrix?${transition.from}:${transition.modifier}=x`,
+      );
+      const row = queries.builder.conditionRows.first();
+      await expect(row.locator(".builder-row__modifier")).toHaveValue(
+        transition.modifier,
+      );
+      await row.locator(".builder-row__key").fill(transition.to);
+      await expect(row.locator(".builder-row__modifier")).toHaveValue("");
+      await expect(queries.builder.url).toHaveValue(
+        `GET /Matrix?${transition.to}=x`,
+      );
+    }
+
+    await queries.builder.setUrl("Matrix?subject.leaf:opaque=x");
+    const chain = queries.builder.chainRows.first();
+    await expect(chain).toHaveAttribute("data-compat-state", "unknown");
+    await expect(chain.locator(".builder-row__modifier")).toHaveValue("opaque");
+    await expect(queries.builder.url).toHaveValue("Matrix?subject.leaf:opaque=x");
+  });
+
+  test("removing a modifier rehydrates every ordered prefix exactly once", async ({
+    page,
+    queries,
+  }) => {
+    await page.route("**/ui/queries/params?type=Matrix", async (route) => {
+      await route.fulfill({
+        contentType: "text/html",
+        body: catalogHtml([
+          { code: "text-param", type: "string" },
+          { code: "ordered-param", type: "date" },
+        ]),
+      });
+    });
+
+    for (const prefix of ["eq", "ne", "gt", "ge", "lt", "le", "sa", "eb", "ap"]) {
+      await queries.builder.setUrl(
+        `Matrix?text-param:contains=${prefix}1980`,
+      );
+      const row = queries.builder.conditionRows.first();
+      await row.locator(".builder-row__key").fill("ordered-param");
+      await expect(row.locator(".builder-row__modifier")).toHaveValue("");
+      await expect(row.locator(".builder-row__comparator")).toHaveValue(prefix);
+      await expect(row.locator(".builder-row__value")).toHaveValue("1980");
+      await expect(queries.builder.url).toHaveValue(
+        `GET /Matrix?ordered-param=${prefix}1980`,
+      );
+      if (prefix === "eq") {
+        await row.locator(".builder-row__comparator").selectOption("le");
+        await expect(queries.builder.url).toHaveValue(
+          "GET /Matrix?ordered-param=le1980",
+        );
+      }
+    }
+  });
+
+  test("compatible modifiers survive while incompatible value prefixes are removed", async ({
+    queries,
+  }) => {
+    await queries.builder.setUrl("Patient?name:missing=true");
+    let row = queries.builder.conditionRows.first();
+    await expect(row).toHaveAttribute("data-mod-type", "string");
+    await row.locator(".builder-row__key").fill("gender");
+    await expect(row.locator(".builder-row__modifier")).toHaveValue("missing");
+    await expect(queries.builder.url).toHaveValue("GET /Patient?gender:missing=true");
+
+    await queries.builder.setUrl("Patient?birthdate=ge1980-01-01");
+    row = queries.builder.conditionRows.first();
+    await expect(row.locator(".builder-row__comparator")).toHaveValue("ge");
+    await row.locator(".builder-row__key").fill("gender");
+    await expect(row.locator(".builder-row__comparator")).toHaveValue("");
+    await expect(row.locator(".builder-row__comparator")).toBeHidden();
+    await expect(queries.builder.url).toHaveValue("GET /Patient?gender=1980-01-01");
+  });
+
+  test("forward and reverse chain leaves reconcile their operators", async ({ queries }) => {
+    await queries.builder.setUrl("Observation?subject:Patient.name:contains=ge1980");
+    let row = queries.builder.chainRows.first();
+    await expect(row).toHaveAttribute("data-mod-type", "string");
+    await row.locator(".builder-row__cparam").fill("birthdate");
+    await expect(row).toHaveAttribute("data-mod-type", "date");
+    await expect(row.locator(".builder-row__modifier")).toHaveValue("");
+    await expect(row.locator(".builder-row__comparator")).toHaveValue("ge");
+    await expect(row.locator(".builder-row__value")).toHaveValue("1980");
+    await expect(queries.builder.url).toHaveValue(
+      "GET /Observation?subject:Patient.birthdate=ge1980",
+    );
+
+    await queries.builder.setUrl("Patient?_has:Observation:patient:code:not=ge1980");
+    row = queries.builder.hasRows.first();
+    await expect(row).toHaveAttribute("data-mod-type", "token");
+    await row.locator(".builder-row__cparam").fill("date");
+    await expect(row).toHaveAttribute("data-mod-type", "date");
+    await expect(row.locator(".builder-row__modifier")).toHaveValue("");
+    await expect(row.locator(".builder-row__comparator")).toHaveValue("ge");
+    await expect(row.locator(".builder-row__value")).toHaveValue("1980");
+    await expect(queries.builder.url).toHaveValue(
+      "GET /Patient?_has:Observation:patient:date=ge1980",
+    );
+  });
+
+  test("pending catalog metadata blocks every builder consumer and coalesces one URL update", async ({
+    page,
+    queries,
+  }) => {
+    let releaseCatalog: () => void = () => {};
+    const catalogReleased = new Promise<void>((resolve) => {
+      releaseCatalog = resolve;
+    });
+    await page.route("**/ui/queries/params?type=Patient", async (route) => {
+      await catalogReleased;
+      await route.continue();
+    });
+    const searches: string[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (request.method() === "GET" && url.pathname === "/Patient") {
+        searches.push(url.search);
+      }
+    });
+
+    await queries.builder.setUrl("Patient?name:contains=OrAlpha556");
+    const row = queries.builder.conditionRows.first();
+    await row.locator(".builder-row__key").fill("gender");
+    await expect(row).toHaveAttribute("data-compat-state", "pending");
+    await expect(queries.builder.runButton).toBeDisabled();
+    await expect(queries.builder.saveButton).toBeDisabled();
+    await expect(queries.builder.copyButton).toBeDisabled();
+    await queries.builder.url.focus();
+    await page.keyboard.press("Enter");
+    expect(searches).toEqual([]);
+
+    releaseCatalog();
+    await expect(row).toHaveAttribute("data-compat-state", "known");
+    await expect(queries.builder.url).toHaveValue("GET /Patient?gender=OrAlpha556");
+    await expect(queries.builder.runButton).toBeEnabled();
+    expect(searches).toEqual([]);
+
+    const sent = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return request.method() === "GET" && url.pathname === "/Patient";
+    });
+    await queries.builder.runButton.click();
+    expect(new URL((await sent).url()).search).toBe("?gender=OrAlpha556");
+  });
+
+  test("removing the last pending row immediately releases builder consumers", async ({
+    page,
+    queries,
+  }) => {
+    let releaseCatalog: () => void = () => {};
+    const catalogReleased = new Promise<void>((resolve) => {
+      releaseCatalog = resolve;
+    });
+    await page.route("**/ui/queries/params?type=Patient", async (route) => {
+      await catalogReleased;
+      await route.continue();
+    });
+
+    await queries.builder.setUrl("Patient?name=x");
+    const row = queries.builder.conditionRows.first();
+    await expect(row).toHaveAttribute("data-compat-state", "pending");
+    await row.locator("[data-remove-row]").click();
+    await expect(queries.builder.conditionRows).toHaveCount(0);
+    await expect(queries.builder.url).toHaveValue("GET /Patient");
+    await expect(queries.builder.runButton).toBeEnabled();
+    await expect(queries.builder.saveButton).toBeEnabled();
+    await expect(queries.builder.copyButton).toBeEnabled();
+
+    releaseCatalog();
+    await expect(queries.builder.runButton).toBeEnabled();
+    await expect(queries.builder.url).toHaveValue("GET /Patient");
+  });
+
+  test("unknown parameters and catalog failures remain permissive", async ({ page, queries }) => {
+    await page.route("**/ui/queries/params?type=Patient", async (route) => {
+      await route.fulfill({ status: 503, body: "catalog unavailable" });
+    });
+
+    await queries.builder.setUrl("Patient?future-param:opaque=x");
+    const row = queries.builder.conditionRows.first();
+    await expect(row).toHaveAttribute("data-compat-state", "unknown");
+    await expect(row.locator(".builder-row__modifier")).toHaveValue("opaque");
+    await expect(queries.builder.url).toHaveValue("Patient?future-param:opaque=x");
+    await expect(queries.builder.runButton).toBeEnabled();
+  });
+
+  test("no-op catalog reconciliation preserves the exact loaded URL", async ({ queries }) => {
+    const exact = "GET /Patient?name:exact=Copy%5C%2C627";
+    await queries.builder.setUrl(exact);
+    const row = queries.builder.conditionRows.first();
+
+    await expect(row).toHaveAttribute("data-compat-state", "known");
+    await expect(row.locator(".builder-row__modifier")).toHaveValue("exact");
+    await expect(queries.builder.runButton).toBeEnabled();
+    await expect(queries.builder.url).toHaveValue(exact);
+  });
+
+  test("editing a pending deep link cancels its deferred auto-run", async ({ page, queries }) => {
+    let releaseCatalog: () => void = () => {};
+    const catalogReleased = new Promise<void>((resolve) => {
+      releaseCatalog = resolve;
+    });
+    await page.route("**/ui/queries/params?type=Patient", async (route) => {
+      await catalogReleased;
+      await route.continue();
+    });
+    const searches: string[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (request.method() === "GET" && url.pathname === "/Patient") {
+        searches.push(url.search);
+      }
+    });
+
+    const deepLink = encodeURIComponent("/Patient?name:contains=before");
+    await page.goto(`/ui/queries?url=${deepLink}`);
+    const row = queries.builder.conditionRows.first();
+    await expect(row).toHaveAttribute("data-compat-state", "pending");
+    await row.locator(".builder-row__value").fill("after");
+    releaseCatalog();
+
+    await expect(row).toHaveAttribute("data-compat-state", "known");
+    await expect(queries.builder.url).toHaveValue("GET /Patient?name:contains=after");
+    await expect(queries.builder.runButton).toBeEnabled();
+    expect(searches).toEqual([]);
   });
 
   test("the MODIFY panel explains its chips", async ({ queries }) => {


### PR DESCRIPTION
## Summary

- Reconcile modifiers and comparator prefixes whenever a search parameter resolves to a different type, including plain conditions, forward chains, and `_has` rows.
- Keep unknown and ambiguous parameters permissive while applying the complete supported modifier matrix to known parameter types.
- Block Run, Save, Copy, Enter, saved-query runs, and deep-link runs until asynchronous catalog resolution leaves the controls, URL, and narration consistent.
- Handle catalog failures and stale responses safely, preserve unchanged URL spelling, and cancel deferred auto-runs when the user edits the builder.

## Test plan

- `cargo build -p helios-hfs --features ui`
- `cargo test -p helios-ui`
- Full Chromium query-builder E2E suite
- Chromium Natural Language Search and Resources E2E suites
- Manual regression check for changing `name:contains` to `gender` without automatically running the query

Closes #627
