### PR TITLE
feat(ui): shared busy indicator, applied to Batch/Transaction (#679)

### DIFF
--- a/.claude/skills/work-with-ui/SKILL.md
+++ b/.claude/skills/work-with-ui/SKILL.md
@@ -81,12 +81,16 @@ through to the normal REST surface.
 - `templates/partials/` — htmx-swappable fragments, no `<html>` wrapper;
   `{% include %}`d into pages so the first render and the swap emit identical markup.
 - `templates/icons/*.svg` — Figma exports, fills normalized to `currentColor`, inlined.
-- `assets/` — `htmx.min.js` (pinned), `app.css`, `fonts/`, `logo.png`, and the
-  per-page scripts: `theme.js`, `editor.js`, `resources.js`, `saved-queries.js`,
-  `batch.js`, `history.js`, `nl-search.js`, `resource-filter.js`, `conformance-crud.js`.
+- `assets/` — `htmx.min.js` (pinned), `app.css`, `fonts/`, `logo.png`, the
+  shared `busy.js` (#679, the crate's one exported global `window.hfsBusy`),
+  and the per-page scripts: `theme.js`, `editor.js`, `resources.js`,
+  `saved-queries.js`, `batch.js`, `history.js`, `nl-search.js`,
+  `resource-filter.js`, `conformance-crud.js`.
 
 `theme.js` loads **without `defer`**, before first paint, to avoid a FOUC; every
-other script is `defer`.
+other script is `defer`. Busy/working states go through `hfsBusy` for
+fetch-driven code and `hx-disabled-elt` for htmx controls — see
+`crates/ui/README.md` § Busy states.
 
 ## Rules of the road
 

--- a/crates/ui/README.md
+++ b/crates/ui/README.md
@@ -96,13 +96,17 @@ note the version bump in the commit.
 ### Client-side scripts
 
 Each is a small, self-contained IIFE. Page-specific scripts load with `defer`;
-`json-view.js` loads from the shared layout because its delegated behavior is
-used across workspaces. `theme.js` loads **without `defer`**, before first paint,
-to avoid a flash of the wrong theme.
+`json-view.js` and `busy.js` load from the shared layout because their behavior
+is used across workspaces — `busy.js` ahead of every page script (defer runs in
+document order) because page scripts call into it. `theme.js` loads **without
+`defer`**, before first paint, to avoid a flash of the wrong theme. `busy.js`
+is the crate's one exported global (`window.hfsBusy`): unlike the closed IIFEs
+it exists to be called by the others.
 
 | Asset | Owns |
 |---|---|
 | `theme.js` | Light/dark preference: stored choice → OS preference, plus the top-bar toggle |
+| `busy.js` | The shared busy states (#679): `during(buttons, work)` and `region(el, label)` |
 | `saved-queries.js` | Saved queries, the visual search builder, and the `/_user/settings` read/modify/write cycle |
 | `editor.js` | The schema-driven editor loop — posts the document to `/ui/editor/render` and swaps in the server's HTML |
 | `json-view.js` | Delegated folding and accessibility state for every server-rendered JSON view |
@@ -217,9 +221,30 @@ These are the shared primitives. Before styling anything, reach for one; add to
 | `.tabs`, `.tab`, `.tab--on` | Tab strip. |
 | `.filter-rail`, `.nav-panel` | Left rails: the filter list inside a page; the type panel flush against the sidebar. |
 | `.icon-button`, `.icon-button--danger` | Bare icon action (table rows). |
+| `.busy-status` > `.spinner` | Inline working state: the ring plus a short label, `role="status"` in the markup so it announces. |
 
 Starting a new page: copy `templates/pages/_scaffold.html` (or crib
 `tenants.html`, the smallest real page). Both compose only this vocabulary.
+
+### Busy states
+
+One convention for "this control is doing something" (#679), in two lanes:
+
+- **Fetch-driven scripts** call `window.hfsBusy` (`assets/busy.js`).
+  `during(buttons, work)` disables the controls, stamps `aria-busy="true"`,
+  and clears when the promise `work()` returns settles — pass a *function*,
+  never a promise, so the re-entrancy guard runs before the request exists;
+  a `work()` that navigates away returns a promise that never settles.
+  `region(el, label)` reveals a pre-rendered `.busy-status` element and
+  labels its `[data-busy-label]`; `opts.region`/`opts.label` on `during` tie
+  one to the same lifetime. The CSS ring keys off `aria-busy`, so the
+  visuals cannot ship without the semantics; reduced motion gets the same
+  ring as a static glyph. The `::after` ring must keep `content: ""` — CSS
+  generated *text* would join the accessible name.
+- **htmx controls** use `hx-disabled-elt` (#581); `hx-indicator` is
+  deliberately absent (the tenants tests pin this). A pending state that
+  outlives the request belongs in the swapped fragment, like the tenants
+  provisioning row.
 
 ---
 

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1233,7 +1233,8 @@ textarea.field__input {
   justify-content: flex-end;
 }
 
-.spinner {
+.spinner,
+.btn[aria-busy="true"]::after {
   width: 14px;
   height: 14px;
   border-radius: 50%;
@@ -1245,15 +1246,43 @@ textarea.field__input {
   to { transform: rotate(360deg); }
 }
 @media (prefers-reduced-motion: reduce) {
-  .spinner { animation: none; }
+  .spinner,
+  .btn[aria-busy="true"]::after { animation: none; }
 }
 
-/* In-table provisioning state for tenants being created in the background
-   (#581): the row polls in via the rows fragment until the job finishes. */
-.provisioning {
+/* The busy button (#679), driven by busy.js: the label yields its space to
+   the ring — width stays put, the accessible name stays in the tree. Under
+   reduced motion the ring remains as a static glyph (the animation stops
+   above); a merely-dimmed label would read as disabled, not working. */
+.btn[aria-busy="true"] {
+  position: relative;
+  color: transparent;
+  cursor: progress;
+}
+
+.btn[aria-busy="true"]::after {
+  content: "";
+  position: absolute;
+  top: calc(50% - 7px);
+  left: calc(50% - 7px);
+}
+
+/* The ring must not inherit accent-on-accent on the filled button — the
+   track all but vanishes in dark theme. Explicit white, not currentColor:
+   the button's color is transparent while busy. */
+.btn--primary[aria-busy="true"]::after {
+  border-color: rgb(255 255 255 / 45%);
+  border-top-color: #ffffff;
+}
+
+/* Inline working state (#679): spinner plus a short label, role="status" in
+   the markup so it announces. Also the tenants in-table provisioning row
+   (#581), which polls in via the rows fragment until the job finishes. */
+.busy-status {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  margin: 0;
   font-size: 13px;
   color: var(--muted);
 }
@@ -4645,6 +4674,21 @@ textarea.field__input {
   align-items: center;
   gap: 8px;
   margin-top: 14px;
+}
+
+/* #679: one busy region serves both the parse and execute phases; sticky
+   keeps it in view when a large plan pushes the bottom footer past the
+   viewport (#675's scroll problem, again). */
+.batch-busy {
+  position: sticky;
+  bottom: 12px;
+  width: fit-content;
+  margin-top: 12px;
+  padding: 6px 12px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 9px;
+  box-shadow: var(--surface-shadow);
 }
 
 .batch-footer--top {

--- a/crates/ui/assets/batch.js
+++ b/crates/ui/assets/batch.js
@@ -8,8 +8,9 @@
   "use strict";
 
   var root = document.getElementById("batch");
-  if (!root || !window.fetch) return;
+  if (!root || !window.fetch || !window.hfsBusy) return;
   var messages = root.dataset;
+  var hfsBusy = window.hfsBusy;
 
   /* The effective tenant, stamped by the server (#344); FHIR calls carry it. */
   var TENANT = (document.querySelector('meta[name="hfs-tenant"]') || {}).content || "";
@@ -42,6 +43,12 @@
   var outcomes = document.getElementById("batch-outcomes");
   var overall = document.getElementById("batch-overall");
   var summary = document.getElementById("batch-summary");
+  var executeBtn = document.getElementById("batch-execute");
+  var executeTopBtn = document.getElementById("batch-execute-top");
+  var cancelBtn = document.getElementById("batch-cancel");
+  var cancelTopBtn = document.getElementById("batch-cancel-top");
+  var doneBtn = document.getElementById("batch-done");
+  var busyRegion = document.getElementById("batch-busy");
 
   var bundle = null;
   var bundleJsonRenderer = null;
@@ -130,26 +137,69 @@
     bundleJsonRenderer = null;
   }
 
+  /* Yield so the busy region paints before a heavy parse blocks the main
+     thread; rAF never fires in a hidden tab, hence the timeout lane. */
+  function afterPaint(fn) {
+    if (document.hidden) {
+      setTimeout(fn, 0);
+      return;
+    }
+    requestAnimationFrame(function () {
+      setTimeout(fn, 0);
+    });
+  }
+
   function readFile(file) {
     var generation = resetJsonRendering();
     bundle = null;
     clearPreflight();
     show("upload");
     uploadError.hidden = true;
+    /* Busy is up before the file is even read (#679): the region reveal is
+       synchronous, FileReader delivery is already async. */
+    var busy = hfsBusy.region(busyRegion, messages.msgReading);
     var reader = new FileReader();
+    /* A folder drop or a file that vanished between pick and read fires
+       error/abort, never load — the region must clear and say something. */
+    reader.onerror = reader.onabort = function () {
+      if (generation !== renderGeneration) return;
+      try {
+        fail(messages.msgReadFailed);
+      } finally {
+        busy.done();
+      }
+    };
     reader.onload = function () {
       if (generation !== renderGeneration) return;
-      var parsed;
-      try {
-        parsed = JSON.parse(reader.result);
-      } catch (e) {
-        return fail(messages.msgInvalidJson + " (" + e.message + ")");
-      }
-      if (!parsed || parsed.resourceType !== "Bundle") return fail(messages.msgNotABundle);
-      if (parsed.type !== "batch" && parsed.type !== "transaction") return fail(messages.msgBadType);
-      bundle = parsed;
-      renderPreflight(generation);
-      show("preflight");
+      afterPaint(function () {
+        /* Re-checked here, not just above: a second pick during this
+           deferred window owns the stage now. */
+        if (generation !== renderGeneration) return;
+        try {
+          var parsed;
+          try {
+            parsed = JSON.parse(reader.result);
+          } catch (e) {
+            return fail(messages.msgInvalidJson + " (" + e.message + ")");
+          }
+          if (!parsed || parsed.resourceType !== "Bundle") return fail(messages.msgNotABundle);
+          if (parsed.type !== "batch" && parsed.type !== "transaction") return fail(messages.msgBadType);
+          bundle = parsed;
+          renderPreflight(generation);
+          show("preflight");
+          /* The drop zone was hidden with its stage, stranding focus.
+             Checked by containment, not activeElement === body: the focus
+             fixup for a hidden element runs at the next render update, so
+             the hidden trigger can still read as active here. Land on the
+             revealed stage, not its primary action. */
+          var active = document.activeElement;
+          if (active === document.body || stages.upload.contains(active)) {
+            stages.preflight.focus();
+          }
+        } finally {
+          busy.done();
+        }
+      });
     };
     reader.readAsText(file);
   }
@@ -252,9 +302,20 @@
     fileInput.value = "";
     clearPreflight();
     show("upload");
+    /* Done/Cancel hid the stage that held focus; land on the one action
+       the upload stage offers (#679). Containment, not body: the focus
+       fixup for the hidden trigger runs at the next render update. */
+    var active = document.activeElement;
+    if (
+      active === document.body ||
+      stages.preflight.contains(active) ||
+      stages.response.contains(active)
+    ) {
+      drop.focus();
+    }
   }
-  document.getElementById("batch-cancel").addEventListener("click", reset);
-  document.getElementById("batch-cancel-top").addEventListener("click", reset);
+  cancelBtn.addEventListener("click", reset);
+  cancelTopBtn.addEventListener("click", reset);
 
   /* ---- stage 3: execute and report ------------------------------------ */
 
@@ -265,28 +326,38 @@
       show("upload");
       return;
     }
-    fetch("/", {
-      method: "POST",
-      headers: fhirHeaders({ "Content-Type": "application/fhir+json" }),
-      credentials: "same-origin",
-      body: JSON.stringify(bundle),
-    })
-      .then(function (response) {
-        return response
-          .json()
-          .catch(function () { return null; })
-          .then(function (body) { renderResponse(response, body); });
-      })
-      .catch(function (e) {
-        executeError.textContent = messages.msgRequestFailed + " (" + e.message + ")";
-        executeError.hidden = false;
-      });
+    /* The whole footer goes inert (#679): both Execute copies spin, and the
+       Cancels disable with them — a mid-flight Cancel nulled `bundle` and
+       crashed the settling renderResponse. Busy holds until the outcome is
+       rendered, not merely until response headers arrive. */
+    hfsBusy.during(
+      [executeBtn, executeTopBtn],
+      function () {
+        return fetch("/", {
+          method: "POST",
+          headers: fhirHeaders({ "Content-Type": "application/fhir+json" }),
+          credentials: "same-origin",
+          body: JSON.stringify(bundle),
+        })
+          .then(function (response) {
+            return response
+              .json()
+              .catch(function () { return null; })
+              .then(function (body) { renderResponse(response, body); });
+          })
+          .catch(function (e) {
+            executeError.textContent = messages.msgRequestFailed + " (" + e.message + ")";
+            executeError.hidden = false;
+          });
+      },
+      { alsoDisable: [cancelBtn, cancelTopBtn], region: busyRegion, label: messages.msgExecuting }
+    );
   }
-  document.getElementById("batch-execute").addEventListener("click", execute);
-  document.getElementById("batch-execute-top").addEventListener("click", execute);
+  executeBtn.addEventListener("click", execute);
+  executeTopBtn.addEventListener("click", execute);
   /* The run already happened: Done lands back on a clean upload stage
      rather than offering to re-run a mutation that succeeded (#675). */
-  document.getElementById("batch-done").addEventListener("click", reset);
+  doneBtn.addEventListener("click", reset);
 
   function renderResponse(response, body) {
     overall.textContent = String(response.status);
@@ -353,5 +424,8 @@
     summary.textContent = parts.join(" · ");
 
     show("response");
+    /* The disabled trigger was hidden with its stage; land on the one
+       action this stage offers (#679). */
+    doneBtn.focus();
   }
 })();

--- a/crates/ui/assets/busy.js
+++ b/crates/ui/assets/busy.js
@@ -1,0 +1,110 @@
+/*
+ * The shared busy/working states (#679): one convention for "this control is
+ * doing something". Buttons get `disabled` plus `aria-busy="true"` — the CSS
+ * ring in app.css keys off the ARIA attribute, so a script cannot get the
+ * visuals without the semantics. Regions are pre-rendered `.busy-status`
+ * `role="status"` elements the helper reveals and labels; revealing FIRST
+ * and writing the label a tick later is what makes the announcement
+ * reliable (a hidden live region is not in the accessibility tree, and text
+ * set before it enters is routinely skipped).
+ *
+ * Fetch-driven scripts call this; htmx controls use `hx-disabled-elt`
+ * instead (#581). `window.hfsBusy` is the crate's one exported global: this
+ * file loads from the layout, so page scripts (all `defer`, document order)
+ * can rely on it. batch.js's renderGeneration guards the same two-quick-picks
+ * race for its own rendering; the region generation here is the helper's
+ * own so it stands alone — don't wire a third counter.
+ */
+(function () {
+  "use strict";
+
+  /* Per-element call generation: a stale done() from a superseded region()
+     call must not clear the newer state. */
+  var generations = new WeakMap();
+
+  /* Reveal the region, then write `label` into its [data-busy-label]. */
+  function region(el, label) {
+    var generation = (generations.get(el) || 0) + 1;
+    generations.set(el, generation);
+    var labelEl = el.querySelector("[data-busy-label]");
+    el.hidden = false;
+    setTimeout(function () {
+      if (generations.get(el) === generation && labelEl) labelEl.textContent = label;
+    }, 0);
+    return {
+      done: function () {
+        if (generations.get(el) !== generation) return;
+        /* Invalidate this call's own pending label write too: a clear()
+           riding a microtask beats the label's macrotask timer, and the
+           stale write would relabel the hidden region. */
+        generations.set(el, generation + 1);
+        /* Hide first: clearing the text of a visible polite region would
+           queue an announcement of nothing. */
+        el.hidden = true;
+        if (labelEl) labelEl.textContent = "";
+      },
+    };
+  }
+
+  /*
+   * Run `work` — a FUNCTION returning a promise, never a promise: the
+   * re-entrancy guard must run before the request exists — with `buttons`
+   * in the busy state and `opts.alsoDisable` merely disabled. Clears on
+   * settle, restoring each control's prior disabled state, and hands focus
+   * back to the trigger if disabling ejected it to <body>. `opts.region` /
+   * `opts.label` tie a status region to the same lifetime. A work() that
+   * navigates away should return a promise that never settles, so its
+   * controls stay inert until the page unloads.
+   */
+  function during(buttons, work, opts) {
+    opts = opts || {};
+    var held = buttons.some(function (b) {
+      return b.getAttribute("aria-busy") === "true";
+    });
+    if (held) return null;
+
+    /* Read the trigger before the disable loop ejects focus from it. */
+    var trigger = document.activeElement;
+    var all = buttons.concat(opts.alsoDisable || []);
+    var prior = all.map(function (b) {
+      return b.disabled;
+    });
+    buttons.forEach(function (b) {
+      b.setAttribute("aria-busy", "true");
+    });
+    all.forEach(function (b) {
+      b.disabled = true;
+    });
+    var status = opts.region ? region(opts.region, opts.label || "") : null;
+
+    var promise;
+    try {
+      promise = Promise.resolve(work());
+    } catch (e) {
+      promise = Promise.reject(e);
+    }
+
+    function clear() {
+      buttons.forEach(function (b) {
+        b.removeAttribute("aria-busy");
+      });
+      all.forEach(function (b, i) {
+        b.disabled = prior[i];
+      });
+      if (status) status.done();
+      if (
+        document.activeElement === document.body &&
+        trigger &&
+        trigger !== document.body &&
+        trigger.isConnected &&
+        !trigger.disabled
+      ) {
+        trigger.focus();
+      }
+    }
+    promise.then(clear, clear);
+    return promise;
+  }
+
+  window.hfsBusy = { during: during, region: region };
+})();

--- a/crates/ui/assets/conformance-crud.js
+++ b/crates/ui/assets/conformance-crud.js
@@ -12,28 +12,35 @@
 
   document.addEventListener("click", function (event) {
     var btn = event.target.closest ? event.target.closest("[data-crud-delete]") : null;
-    if (!btn || !window.fetch) return;
+    if (!btn || !window.fetch || !window.hfsBusy) return;
     if (!window.confirm(btn.dataset.confirm)) return;
 
     var headers = { Accept: "application/fhir+json" };
     if (TENANT) headers["X-Tenant-ID"] = TENANT;
-    btn.disabled = true;
-    fetch("/" + btn.dataset.type + "/" + btn.dataset.id, { method: "DELETE", headers: headers })
-      .then(function (response) {
-        if (!response.ok) throw new Error("HTTP " + response.status);
-        window.location = btn.dataset.redirect;
-      })
-      .catch(function (error) {
-        btn.disabled = false;
-        /* The shared error treatment, next to the button that failed (#676) —
-           not a native alert dialog. Replaced on the next attempt. */
-        var existing = btn.parentNode.querySelector(".alert");
-        if (existing) existing.remove();
-        var note = document.createElement("span");
-        note.className = "alert alert--inline";
-        note.setAttribute("role", "alert");
-        note.textContent = btn.dataset.failed + " (" + error.message + ")";
-        btn.insertAdjacentElement("afterend", note);
-      });
+    /* The shared busy state (#679); the guard is per-button, so unrelated
+       rows stay independently deletable. */
+    window.hfsBusy.during([btn], function () {
+      return fetch("/" + btn.dataset.type + "/" + btn.dataset.id, { method: "DELETE", headers: headers })
+        .then(function (response) {
+          if (!response.ok) throw new Error("HTTP " + response.status);
+          window.location = btn.dataset.redirect;
+          /* Navigating away: never settle, so the button stays inert until
+             the page unloads instead of re-arming mid-navigation. */
+          return new Promise(function () {});
+        })
+        .catch(function (error) {
+          /* Settling here is what re-enables the button via the helper. The
+             shared error treatment goes next to the button that failed
+             (#676) — not a native alert dialog. Replaced on the next
+             attempt. */
+          var existing = btn.parentNode.querySelector(".alert");
+          if (existing) existing.remove();
+          var note = document.createElement("span");
+          note.className = "alert alert--inline";
+          note.setAttribute("role", "alert");
+          note.textContent = btn.dataset.failed + " (" + error.message + ")";
+          btn.insertAdjacentElement("afterend", note);
+        });
+    });
   });
 })();

--- a/crates/ui/assets/nl-search.js
+++ b/crates/ui/assets/nl-search.js
@@ -20,7 +20,8 @@
   var pane = document.getElementById("nl-pane");
   var form = document.getElementById("saved-query-form");
   var urlInput = form && form.elements.url;
-  if (!page || !pane || !urlInput || !window.fetch) return;
+  if (!page || !pane || !urlInput || !window.fetch || !window.hfsBusy) return;
+  var hfsBusy = window.hfsBusy;
 
   var text = document.getElementById("nl-text");
   var submit = document.getElementById("nl-submit");
@@ -125,47 +126,48 @@
       return;
     }
 
-    submit.disabled = true;
-    showMessage("nl-answer--working", messages.msgWorking);
+    /* The shared busy state (#679). The guard inside `during` is what gates
+       re-entry: Enter and the example chips reach translate() while the
+       submit button is disabled, so the button alone never could. */
+    hfsBusy.during([submit], function () {
+      showMessage("nl-answer--working", messages.msgWorking);
 
-    fetch("/$nl-search", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify({ text: value }),
-    })
-      .then(function (response) {
-        return response
-          .json()
-          .catch(function () {
-            return null;
-          })
-          .then(function (body) {
-            return { ok: response.ok, body: body };
-          });
+      return fetch("/$nl-search", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ text: value }),
       })
-      .then(function (result) {
-        if (!result.ok) {
-          showMessage("nl-answer--error", outcomeText(result.body));
-          return;
-        }
-        if (!result.body || !result.body.supported) {
-          showMessage(
-            "nl-answer--unsupported",
-            (result.body && result.body.reason) || messages.msgUnsupported
-          );
-          return;
-        }
-        showTranslation(result.body);
-      })
-      .catch(function () {
-        showMessage("nl-answer--error", messages.msgError);
-      })
-      .then(function () {
-        submit.disabled = false;
-      });
+        .then(function (response) {
+          return response
+            .json()
+            .catch(function () {
+              return null;
+            })
+            .then(function (body) {
+              return { ok: response.ok, body: body };
+            });
+        })
+        .then(function (result) {
+          if (!result.ok) {
+            showMessage("nl-answer--error", outcomeText(result.body));
+            return;
+          }
+          if (!result.body || !result.body.supported) {
+            showMessage(
+              "nl-answer--unsupported",
+              (result.body && result.body.reason) || messages.msgUnsupported
+            );
+            return;
+          }
+          showTranslation(result.body);
+        })
+        .catch(function () {
+          showMessage("nl-answer--error", messages.msgError);
+        });
+    });
   }
 
   submit.addEventListener("click", translate);

--- a/crates/ui/e2e/pages/axe.ts
+++ b/crates/ui/e2e/pages/axe.ts
@@ -1,0 +1,17 @@
+// Renders axe violations the way a11y.spec.ts reports them, so a red run
+// names the rule and the offending node instead of dumping raw result objects.
+type Violation = {
+  id: string;
+  help: string;
+  nodes: { target: unknown[]; failureSummary?: string }[];
+};
+
+export function axeSummary(violations: Violation[]): string {
+  return violations
+    .map(
+      (v) =>
+        `${v.id}: ${v.help}\n` +
+        v.nodes.map((n) => `  ${n.target.join(" ")} — ${n.failureSummary ?? ""}`).join("\n"),
+    )
+    .join("\n");
+}

--- a/crates/ui/e2e/tests/batch.spec.ts
+++ b/crates/ui/e2e/tests/batch.spec.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import AxeBuilder from "@axe-core/playwright";
+import { axeSummary } from "../pages/axe";
 
 // The Batch/Transaction workspace (#476): upload → preflight → execute →
 // response, entirely against the ordinary FHIR API.
@@ -83,10 +84,12 @@ test("a transaction bundle uploads, previews, executes, and reports", async ({ p
   await expect(page.locator("#batch-summary")).toContainText(/created/i);
   await expect(page.locator("#batch-overall")).toHaveClass(/--ok/);
 
-  // Done is the one way out (#675): back to a clean upload stage.
+  // Done is the one way out (#675): back to a clean upload stage. Done hid
+  // the stage that held focus, so focus lands on the drop zone (#679).
   await page.locator("#batch-done").click();
   await expect(page.locator("#batch-upload")).toBeVisible();
   await expect(page.locator("#batch-preflight")).toBeHidden();
+  await expect(page.locator("#batch-drop")).toBeFocused();
 });
 
 test("JSON previews are lazy, cached, compact, accessible, and isolated per view", async ({ page }) => {
@@ -204,6 +207,7 @@ test("an invalid replacement clears the old preview and cannot execute stale or 
   await expect(page.locator("#batch-upload")).toBeVisible();
   await expect(page.locator("#batch-upload-error")).toBeVisible();
   await expect(page.locator("#batch-preflight")).toBeHidden();
+  await expect(page.locator("#batch-busy")).toBeHidden();
   await expect(page.locator("#batch-rows")).toBeEmpty();
   await expect(page.locator("#batch-json")).toBeEmpty();
 
@@ -308,4 +312,229 @@ test("a non-bundle file is rejected with a message, not a crash", async ({ page 
   await page.locator("#batch-file").setInputFiles(file);
   await expect(page.locator("#batch-upload-error")).toBeVisible();
   await expect(page.locator("#batch-preflight")).toBeHidden();
+  // The parse-side busy region clears on the failure path too (#679).
+  await expect(page.locator("#batch-busy")).toBeHidden();
+});
+
+// ---- #679: the shared busy states -----------------------------------------
+// The transient states are made deterministically observable: FileReader
+// delivery and the execute POST are both parked behind manual releases.
+
+const FOOTER_CONTROLS = ["#batch-execute", "#batch-execute-top", "#batch-cancel", "#batch-cancel-top"];
+
+test("picking a file shows the busy region before any file bytes arrive", async ({ page }) => {
+  await page.goto("/ui/batch", { waitUntil: "networkidle" });
+  // Park the read behind a manual release: the region must be up before the
+  // file is even delivered, which is the "within one frame of the pick"
+  // criterion made testable. readAsText resolves through the prototype at
+  // call time, so patching it here works.
+  await page.evaluate(() => {
+    const orig = FileReader.prototype.readAsText;
+    (window as { __releaseRead?: () => void }).__releaseRead = undefined;
+    FileReader.prototype.readAsText = function (this: FileReader, ...args: [Blob]) {
+      (window as { __releaseRead?: () => void }).__releaseRead = () => orig.apply(this, args);
+    };
+  });
+  // Focus the drop zone first: the real flow clicks it, and the focus
+  // fixup for its hidden stage is asynchronous — the containment check in
+  // batch.js must still re-home focus.
+  await page.locator("#batch-drop").focus();
+  await page.locator("#batch-file").setInputFiles(bundleFile("batch"));
+  const busy = page.locator("#batch-busy");
+  await expect(busy).toBeVisible();
+  // The real copy, not the Fluent key: a missing key renders as the key
+  // itself and /reading/i would happily match "batch-reading".
+  await expect(busy).toContainText("Reading bundle");
+  await expect(busy).toHaveAttribute("role", "status");
+
+  await page.evaluate(() => (window as { __releaseRead?: () => void }).__releaseRead?.());
+  await expect(page.locator("#batch-preflight")).toBeVisible();
+  await expect(busy).toBeHidden();
+  // The picked file's drop zone was hidden with its stage; focus lands on
+  // the revealed stage (tabindex=-1), not its destructive primary action.
+  await expect(page.locator("#batch-preflight")).toBeFocused();
+});
+
+test("execute busies the whole footer, ignores re-entrant clicks, and lands focus on Done", async ({ page }) => {
+  // setInputFiles + preflight render + an axe scan + a real POST: the
+  // tightest budget in this file on the CI backend matrix.
+  test.slow();
+
+  let executeRequests = 0;
+  let release!: () => void;
+  const parked = new Promise<void>((resolve) => { release = resolve; });
+  await page.route((url) => url.pathname === "/", async (route) => {
+    if (route.request().method() !== "POST") return route.continue().catch(() => {});
+    executeRequests++;
+    await parked;
+    await route.continue().catch(() => {});
+  });
+
+  await page.goto("/ui/batch", { waitUntil: "networkidle" });
+  await page.locator("#batch-file").setInputFiles(bundleFile("batch"));
+  await expect(page.locator("#batch-preflight")).toBeVisible();
+  await page.locator("#batch-execute").click();
+
+  // Both Execute copies spin, and the Cancels go inert with them: a
+  // mid-flight Cancel raced the settling response and crashed on the nulled
+  // bundle before #679.
+  await expect(page.locator("#batch-execute")).toHaveAttribute("aria-busy", "true");
+  await expect(page.locator("#batch-execute-top")).toHaveAttribute("aria-busy", "true");
+  for (const control of FOOTER_CONTROLS) await expect(page.locator(control)).toBeDisabled();
+  await expect(page.locator("#batch-busy")).toBeVisible();
+  await expect(page.locator("#batch-busy")).toContainText("Executing");
+
+  // The default-motion busy button: the label yields to the animated ring,
+  // and the filled primary gets the explicit white ring (accent-on-accent
+  // vanishes in dark theme).
+  const busyStyle = await page.locator("#batch-execute").evaluate((button) => ({
+    color: getComputedStyle(button).color,
+    content: getComputedStyle(button, "::after").content,
+    animation: getComputedStyle(button, "::after").animationName,
+    ringTop: getComputedStyle(button, "::after").borderTopColor,
+  }));
+  expect(busyStyle.color).toBe("rgba(0, 0, 0, 0)");
+  expect(busyStyle.content).toBe('""');
+  expect(busyStyle.animation).toBe("spin");
+  expect(busyStyle.ringTop).toBe("rgb(255, 255, 255)");
+
+  // Re-entrant activation cannot double-POST: a real click on a disabled
+  // button dispatches nothing, and a synthetic event that does reach the
+  // handler is ignored by the busy guard.
+  await page.locator("#batch-execute").evaluate((button: HTMLButtonElement) => button.click());
+  await page
+    .locator("#batch-execute-top")
+    .evaluate((button) => button.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+  // The a11y gate scans routes at rest, so the held-open busy state is
+  // audited here or nowhere.
+  const { violations } = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+    .analyze();
+  expect(violations, axeSummary(violations)).toEqual([]);
+
+  release();
+  await expect(page.locator("#batch-response")).toBeVisible();
+  await expect(page.locator("#batch-busy")).toBeHidden();
+  // Only now is the count meaningful: every request the page could have
+  // issued has been intercepted (a sync read here raced the second click).
+  expect(executeRequests).toBe(1);
+  // The disabled trigger was hidden with its stage, so focus would die on
+  // <body>; it lands on the one action the response offers instead.
+  await expect(page.locator("#batch-done")).toBeFocused();
+});
+
+test("a whole-bundle failure clears the busy state and re-enables the footer", async ({ page }) => {
+  let release!: () => void;
+  const parked = new Promise<void>((resolve) => { release = resolve; });
+  await page.route((url) => url.pathname === "/", async (route) => {
+    if (route.request().method() !== "POST") return route.continue().catch(() => {});
+    await parked;
+    await route
+      .fulfill({
+        status: 400,
+        contentType: "application/fhir+json",
+        body: JSON.stringify({
+          resourceType: "OperationOutcome",
+          issue: [{ severity: "error", code: "processing", diagnostics: "boom" }],
+        }),
+      })
+      .catch(() => {});
+  });
+
+  await page.goto("/ui/batch", { waitUntil: "networkidle" });
+  await page.locator("#batch-file").setInputFiles(bundleFile("batch"));
+  await page.locator("#batch-execute").click();
+
+  // The busy state is genuinely entered before the failure lands…
+  await expect(page.locator("#batch-execute")).toHaveAttribute("aria-busy", "true");
+  await expect(page.locator("#batch-busy")).toBeVisible();
+  release();
+
+  // …and a rolled-back bundle clears every part of it: the early-return
+  // branch stays on the preflight with the inline error (#676).
+  await expect(page.locator("#batch-execute-error")).toBeVisible();
+  await expect(page.locator("#batch-preflight")).toBeVisible();
+  for (const control of FOOTER_CONTROLS) await expect(page.locator(control)).toBeEnabled();
+  await expect(page.locator("#batch-execute")).not.toHaveAttribute("aria-busy", "true");
+  await expect(page.locator("#batch-busy")).toBeHidden();
+  // Focus returns to the trigger, which sits next to the inline error (#676).
+  await expect(page.locator("#batch-execute")).toBeFocused();
+});
+
+test("reduced-motion users get a static ring, not an animated one", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  let release!: () => void;
+  const parked = new Promise<void>((resolve) => { release = resolve; });
+  await page.route((url) => url.pathname === "/", async (route) => {
+    if (route.request().method() !== "POST") return route.continue().catch(() => {});
+    await parked;
+    await route.continue().catch(() => {});
+  });
+
+  await page.goto("/ui/batch", { waitUntil: "networkidle" });
+  await page.locator("#batch-file").setInputFiles(bundleFile("batch"));
+  await page.locator("#batch-execute").click();
+  await expect(page.locator("#batch-execute")).toHaveAttribute("aria-busy", "true");
+
+  // The static form: the ring glyph is present but does not animate. A
+  // label-only dimmed button would read as "disabled", not "working".
+  const after = await page.locator("#batch-execute").evaluate((button) => ({
+    content: getComputedStyle(button, "::after").content,
+    animation: getComputedStyle(button, "::after").animationName,
+  }));
+  expect(after.content).toBe('""');
+  expect(after.animation).toBe("none");
+
+  release();
+  await expect(page.locator("#batch-response")).toBeVisible();
+});
+
+test("an unreadable file clears the busy region and reports the failure", async ({ page }) => {
+  await page.goto("/ui/batch", { waitUntil: "networkidle" });
+  // A folder drop or a file that vanished between pick and read fires
+  // `error`, never `load` — the busy region must not be left spinning.
+  await page.evaluate(() => {
+    FileReader.prototype.readAsText = function (this: FileReader) {
+      setTimeout(() => this.dispatchEvent(new ProgressEvent("error")), 0);
+    };
+  });
+  await page.locator("#batch-file").setInputFiles(bundleFile("batch"));
+  await expect(page.locator("#batch-upload-error")).toBeVisible();
+  await expect(page.locator("#batch-busy")).toBeHidden();
+  await expect(page.locator("#batch-preflight")).toBeHidden();
+});
+
+test("a synchronously-failing operation cannot leave a stale region label", async ({ page }) => {
+  await page.goto("/ui/batch", { waitUntil: "networkidle" });
+  // Drives the helper directly: clear() runs as a microtask and must also
+  // cancel the label write queued for the next macrotask, or the hidden
+  // region keeps the stale label and announces it on its next reveal.
+  const state = await page.evaluate(() => {
+    const region = document.getElementById("batch-busy") as HTMLElement;
+    const button = document.getElementById("batch-execute") as HTMLButtonElement;
+    const busyApi = (window as { hfsBusy?: { during: Function } }).hfsBusy!;
+    busyApi.during(
+      [button],
+      () => {
+        throw new Error("sync");
+      },
+      { region, label: "Stale label" },
+    );
+    return new Promise<{ hidden: boolean; label: string | null; busyAttr: string | null }>(
+      (resolve) =>
+        setTimeout(
+          () =>
+            resolve({
+              hidden: region.hidden,
+              label: region.querySelector("[data-busy-label]")!.textContent,
+              busyAttr: button.getAttribute("aria-busy"),
+            }),
+          30,
+        ),
+    );
+  });
+  expect(state.hidden).toBe(true);
+  expect(state.label).toBe("");
+  expect(state.busyAttr).toBeNull();
 });

--- a/crates/ui/e2e/tests/nl-search.spec.ts
+++ b/crates/ui/e2e/tests/nl-search.spec.ts
@@ -76,3 +76,45 @@ test("an example chip fills the box and translates", async ({ page, search }) =>
   await expect(search.nlText).not.toHaveValue("");
   await expect(search.nlAnswer).toBeVisible();
 });
+
+// #679: the shared busy state replaces the ad-hoc submit disable — and the
+// guard must gate the request itself, since Enter and the example chips can
+// re-enter translate() while the submit button is disabled.
+test("translating busies the submit button, and re-entry cannot double-POST", async ({
+  page,
+  search,
+}) => {
+  let posts = 0;
+  let release!: () => void;
+  const parked = new Promise<void>((resolve) => { release = resolve; });
+  await page.route(/\/\$nl-search$/, async (route) => {
+    posts++;
+    await parked;
+    await route
+      .fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          supported: true,
+          target: "Patient",
+          query: "name=smith",
+          explanation: "ok",
+        }),
+      })
+      .catch(() => {});
+  });
+
+  await search.goto();
+  await search.nlText.fill("patients named smith");
+  await search.nlSubmit.click();
+
+  await expect(search.nlSubmit).toHaveAttribute("aria-busy", "true");
+  await expect(search.nlSubmit).toBeDisabled();
+  // Enter in the textarea re-enters translate() around the disabled button.
+  await search.nlText.press("Enter");
+
+  release();
+  await expect(search.nlAnswer).toHaveClass(/nl-answer--ok/);
+  await expect(search.nlSubmit).not.toHaveAttribute("aria-busy", "true");
+  await expect(search.nlSubmit).toBeEnabled();
+  expect(posts, "re-entry while busy must not issue a second POST").toBe(1);
+});

--- a/crates/ui/e2e/tests/search-parameters.spec.ts
+++ b/crates/ui/e2e/tests/search-parameters.spec.ts
@@ -84,3 +84,54 @@ test("a stored parameter can be created, offers Edit, and deletes", async ({
   });
   expect([404, 410]).toContain(res.status());
 });
+
+// #679: the conformance delete rides the shared busy helper. A failed DELETE
+// must re-enable the button next to its inline error — the old ad-hoc code
+// did, and the helper must not regress it into a permanently dead control.
+test("a failed delete shows the busy state, then re-enables the button", async ({
+  page,
+  searchParameters,
+  request,
+}) => {
+  const stamp = Date.now();
+  const url = `http://example.org/e2e/SearchParameter/busy-${stamp}`;
+  const id = await createResource(request, "SearchParameter", {
+    url,
+    name: "e2eBusyDelete",
+    code: `e2e-busy-${stamp}`,
+    status: "active",
+    type: "token",
+    base: ["Patient"],
+    expression: "Patient.identifier",
+  });
+  await waitSearchable(request, "SearchParameter", id);
+  await searchParameters.goto(`?refresh=1&sel=${encodeURIComponent(url)}`);
+
+  let release!: () => void;
+  const parked = new Promise<void>((resolve) => { release = resolve; });
+  await page.route(new RegExp(`/SearchParameter/${id}$`), async (route) => {
+    if (route.request().method() !== "DELETE") return route.continue().catch(() => {});
+    await parked;
+    await route
+      .fulfill({
+        status: 500,
+        contentType: "application/fhir+json",
+        body: JSON.stringify({
+          resourceType: "OperationOutcome",
+          issue: [{ severity: "error", code: "exception", diagnostics: "boom" }],
+        }),
+      })
+      .catch(() => {});
+  });
+
+  page.once("dialog", (d) => d.accept());
+  const del = page.locator(".detail__actions [data-crud-delete]");
+  await del.click();
+  await expect(del).toHaveAttribute("aria-busy", "true");
+  await expect(del).toBeDisabled();
+
+  release();
+  await expect(page.locator(".detail__actions .alert")).toBeVisible();
+  await expect(del).toBeEnabled();
+  await expect(del).not.toHaveAttribute("aria-busy", "true");
+});

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -12,6 +12,9 @@
   <script src="/ui/assets/theme.js"></script>
   <!-- Vendored, pinned htmx (no runtime CDN). Served from the embedded asset store. -->
   <script src="/ui/assets/htmx.min.js" defer></script>
+  <!-- The shared busy states (#679); ahead of every page script by defer's
+       document order, because page scripts call into window.hfsBusy. -->
+  <script src="/ui/assets/busy.js" defer></script>
   <script src="/ui/assets/addbox.js" defer></script>
   <script src="/ui/assets/dashboard.js" defer></script>
   <script src="/ui/assets/editor-sync.js" defer></script>

--- a/crates/ui/templates/pages/batch.html
+++ b/crates/ui/templates/pages/batch.html
@@ -26,7 +26,10 @@
      data-msg-updated="{{ i18n.t("batch-sum-updated") }}"
      data-msg-other="{{ i18n.t("batch-sum-other") }}"
      data-msg-failed="{{ i18n.t("batch-sum-failed") }}"
-     data-msg-request-failed="{{ i18n.t("batch-request-failed") }}">
+     data-msg-request-failed="{{ i18n.t("batch-request-failed") }}"
+     data-msg-reading="{{ i18n.t("batch-reading") }}"
+     data-msg-executing="{{ i18n.t("batch-executing") }}"
+     data-msg-read-failed="{{ i18n.t("batch-read-failed") }}">
 
   <!-- ============ Stage 1: upload ============ -->
   <section class="card" id="batch-upload">
@@ -42,7 +45,11 @@
   </section>
 
   <!-- ============ Stage 2: preflight ============ -->
-  <section id="batch-preflight" hidden>
+  <!-- tabindex=-1: the stage receives focus when it appears — the picked
+       file's drop zone is hidden with its stage, which would strand focus
+       on <body> (#679). Not the Execute button: focusing the destructive
+       primary would arm it for a stray Enter. -->
+  <section id="batch-preflight" tabindex="-1" hidden>
     <!-- Cancel/Execute at the top as well as the bottom (#675): a large
          bundle must not push the only actions below the fold. Both copies
          drive the same handlers. -->
@@ -99,6 +106,11 @@
       <button type="button" class="btn btn--primary" id="batch-done">{{ i18n.t("batch-done") }}</button>
     </div>
   </section>
+
+  <!-- #679: the shared busy region, shipped in the shell so the live region
+       exists before it is ever labelled. One instance serves the parse and
+       execute phases; busy.js reveals it and writes [data-busy-label]. -->
+  <p class="busy-status batch-busy" id="batch-busy" role="status" hidden><span class="spinner" aria-hidden="true"></span><span data-busy-label></span></p>
 
   <!-- Cloned by batch.js into each row's disclosure control (#674). -->
   <template id="batch-chevron"><span class="icon">{% include "icons/chevron-down.svg" %}</span></template>

--- a/crates/ui/templates/partials/tenant_rows.html
+++ b/crates/ui/templates/partials/tenant_rows.html
@@ -41,7 +41,7 @@
       </td>
       {% if row.provisioning %}
       <td class="col-num">
-        <span class="provisioning" role="status">
+        <span class="busy-status" role="status">
           <span class="spinner" aria-hidden="true"></span>
           {{ i18n.t("tenants-row-provisioning") }}
         </span>

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -1422,6 +1422,57 @@ async fn batch_page_serves_the_workspace_shell() {
     assert!(html.contains(r#"src="/ui/assets/json-view.js""#));
 }
 
+/// #679: the shared busy convention. The helper is a global asset loaded from
+/// the layout before any page script, and the batch page pre-renders the
+/// status region — a live region injected at busy time is not reliably
+/// announced — with its labels riding on `data-msg-*` like the rest of the
+/// page copy.
+#[tokio::test]
+async fn batch_page_carries_the_shared_busy_affordances() {
+    let response = app()
+        .oneshot(
+            Request::get("/ui/assets/busy.js")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let js = body_text(response).await;
+    assert!(js.contains("hfsBusy"));
+
+    let response = app()
+        .oneshot(Request::get("/ui/batch").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    // The status region ships in the shell with its full shape pinned:
+    // hidden, empty, role="status", the shared region class, and the spinner
+    // + label pair the helper drives.
+    assert!(
+        html.contains(r#"<p class="busy-status batch-busy" id="batch-busy" role="status" hidden>"#)
+    );
+    assert!(html.contains(
+        r#"<span class="spinner" aria-hidden="true"></span><span data-busy-label></span>"#
+    ));
+    // The rendered copy, not just the attribute name: a missing Fluent key
+    // falls back to the key itself and would still carry the attribute.
+    assert!(html.contains(r#"data-msg-reading="Reading bundle…""#));
+    assert!(html.contains(r#"data-msg-executing="Executing…""#));
+    assert!(html.contains(r#"data-msg-read-failed="The file could not be read""#));
+    // The stage that receives focus when the preflight appears (#679).
+    assert!(html.contains(r#"<section id="batch-preflight" tabindex="-1" hidden>"#));
+    // The helper loads from the shared layout, before the page script (both
+    // defer, so document order is execution order).
+    let busy = html
+        .find(r#"src="/ui/assets/busy.js""#)
+        .expect("busy.js in the layout");
+    let batch = html
+        .find(r#"src="/ui/assets/batch.js""#)
+        .expect("batch.js in the page");
+    assert!(busy < batch);
+}
+
 /* #546: creating a resource with required elements must not dump duplicated,
  * unanchored error lines. */
 

--- a/crates/ui/tests/tenants_http.rs
+++ b/crates/ui/tests/tenants_http.rs
@@ -90,12 +90,12 @@ async fn post_form(router: &Router, form: &str) -> (StatusCode, String) {
 
 /// Polls the rows fragment until no provisioning row remains (every
 /// background job settled, one way or another), or panics after ~10s. The
-/// marker is the real in-flight row class (`class="provisioning"`), not an
-/// invented one.
+/// marker is the real in-flight row class (`class="busy-status"`, the
+/// shared busy region since #679), not an invented one.
 async fn wait_settled(router: &Router) -> String {
     for _ in 0..200 {
         let (_, html) = get(router, "/ui/tenants/rows").await;
-        if !html.contains(r#"class="provisioning""#) {
+        if !html.contains(r#"class="busy-status""#) {
             return html;
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -674,7 +674,7 @@ async fn create_signals_success_with_hx_trigger_and_failures_do_not() {
     );
     let ok_body = body_text(ok).await;
     assert!(
-        ok_body.contains(r#"class="provisioning""#),
+        ok_body.contains(r#"class="busy-status""#),
         "the accepted response already shows the in-flight row: {ok_body}"
     );
 
@@ -710,5 +710,5 @@ async fn a_provisioned_tenant_settles_into_a_normal_row() {
     let html = wait_settled(&router).await;
 
     assert!(html.contains(r#"hx-delete="/ui/tenants/acme""#));
-    assert!(!html.contains(r#"class="provisioning""#));
+    assert!(!html.contains(r#"class="busy-status""#));
 }

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -549,6 +549,9 @@ batch-sum-updated = aktualisiert
 batch-sum-other = gelesen/sonstige
 batch-sum-failed = fehlgeschlagen
 batch-request-failed = Die Anfrage ist fehlgeschlagen
+batch-reading = Bundle wird gelesen…
+batch-executing = Wird ausgeführt…
+batch-read-failed = Die Datei konnte nicht gelesen werden
 
 ## Bulk Import workspace (#527)
 

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -552,6 +552,9 @@ batch-sum-updated = updated
 batch-sum-other = read/other
 batch-sum-failed = failed
 batch-request-failed = The request failed
+batch-reading = Reading bundle…
+batch-executing = Executing…
+batch-read-failed = The file could not be read
 
 ## Bulk Import workspace (#527)
 

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -549,6 +549,9 @@ batch-sum-updated = actualizados
 batch-sum-other = lecturas/otros
 batch-sum-failed = fallidos
 batch-request-failed = La petición falló
+batch-reading = Leyendo el bundle…
+batch-executing = Ejecutando…
+batch-read-failed = No se pudo leer el archivo
 
 ## Bulk Import workspace (#527)
 


### PR DESCRIPTION

<img width="1100" height="800" alt="busy-execute-light" src="https://github.com/user-attachments/assets/0f08be7a-f61c-429c-9c69-f3ec788b0a0c" />
<img width="1100" height="800" alt="busy-execute-dark" src="https://github.com/user-attachments/assets/2dd00d7a-8ce9-448d-b8a6-00b9e736dfe3" />
## Summary

One busy/working convention for the whole UI, in two lanes, applied first to `/ui/batch`:

- **Fetch-driven scripts** call the new shared `assets/busy.js` (`window.hfsBusy` — the crate's one exported global). `during(buttons, work)` disables the controls and stamps `aria-busy="true"` for the life of the promise `work()` returns; `region(el, label)` reveals a pre-rendered `.busy-status` `role="status"` element. The CSS ring keys off `aria-busy`, so a script cannot get the visuals without the semantics.
- **htmx controls** keep `hx-disabled-elt` (#581) — documented in the README rather than adding indicator machinery no current adopter needs.

`work` is a thunk, not a promise, so the re-entrancy guard runs before the request exists; the thunk wraps the whole render chain, so busy clears when the outcome is on screen, not at response headers. Reduced-motion users get the ring as a static glyph; `.btn--primary` gets an explicit white ring (accent-on-accent vanishes in dark theme). `.provisioning` is renamed into the new `.busy-status` primitive (one region class per the vocabulary rule).

## On /ui/batch

- Picking or dropping a file shows the busy region **before any file bytes arrive**; parse + preflight render defer one paint so the region is actually visible for large bundles. FileReader `error`/`abort` (folder drops, vanished files) clear the region and report instead of spinning forever.
- Execute busies **both** button copies (#675 added a top copy) and disables the Cancels with them — which also fixes a real crash: Cancel mid-flight nulled `bundle` and the settling `renderResponse` threw on it.
- Focus is re-homed on every stage transition (preflight on upload, Done on response, drop zone on reset), using containment checks because the focus fixup for a hidden trigger is asynchronous.
- Labels are Fluent keys (`en`/`es`/`de`), riding the page's existing `data-msg-*` pattern.

## Adopters migrated

`nl-search.js` (whose Enter/chip handlers could double-POST around the disabled button — now gated by the helper's guard) and `conformance-crud.js` (stays inert through its success navigation via a never-settling promise; a failed DELETE re-enables next to its inline error).

## Screenshots

<img width="1100" height="800" alt="busy-execute-dark" src="https://github.com/user-attachments/assets/d90ecd12-781e-444f-bea3-82498780de65" />
<img width="1100" height="800" alt="busy-execute-light" src="https://github.com/user-attachments/assets/34307f1c-012e-4491-95b0-545cecb30151" />
## Testing

- `cargo test -p helios-ui` — 127 tests, including new shell-shape and rendered-copy assertions in `router_http.rs` and the `.busy-status` rename in `tenants_http.rs`.
- Playwright: 8 new busy tests — busy appears/clears on execute with a parked POST, no-double-fire (synthetic-event re-entry), the whole-bundle failure path, reduced motion, an axe WCAG 2.2 AA scan of the **held-open** busy state, unreadable-file cleanup, a stale-label race harness, and both adopter migrations. Design-system and no-CDN guards pass.

## Follow-ups (out of scope per the issue)

Remaining long operations to adopt the helper later: editor save, saved-query execution, history diff, bulk import/export polling.

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm3dCBykU67pvQAuMnwTNN