### PR TITLE
fix: validate create targets against the effective FHIR version

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -140,8 +140,9 @@ jobs:
           reap "$RUN_CONTAINER"
 
   # Build once with every FHIR version, then boot that binary once per default
-  # version for the complete escaped-value contract. This is intentionally the
-  # version axis of an orthogonal matrix: ui-tests-matrix.yml covers all seven
+  # version for the escaped-value and Resources create-target contracts. These
+  # jobs are the version axis of an orthogonal matrix: ui-tests-matrix.yml
+  # covers all seven
   # search-capable storage modes on R4, because the codec and REST alternative
   # boundary run before backend dispatch. The R6 leg also retains #600's
   # dedicated selector coverage. Split into build + test jobs,
@@ -178,7 +179,7 @@ jobs:
           retention-days: 1
 
   ui-multiversion-tests:
-    name: escaped-comma smoke (${{ matrix.fhir_version }})
+    name: search + Resources (${{ matrix.fhir_version }})
     needs: ui-multiversion-build
     runs-on: [self-hosted, Linux]
     strategy:
@@ -205,7 +206,7 @@ jobs:
       - name: Make HFS binary executable
         run: chmod +x target/debug/hfs
 
-      - name: Run escaped-comma smoke for the selected FHIR version
+      - name: Run search and Resources checks for the selected FHIR version
         run: |
           set -euo pipefail
           docker rm -fv "$RUN_CONTAINER" 2>/dev/null || true
@@ -246,8 +247,8 @@ jobs:
                 exit 1
               fi
               HFS_E2E_BASE_URL=http://127.0.0.1:8080 \
-                npx playwright test tests/queries.spec.ts \
-                  --grep "escaped commas|literal commas|malformed FHIR|empty alternatives|drilling preserves"
+                npx playwright test tests/queries.spec.ts tests/resources.spec.ts \
+                  --grep "escaped commas|literal commas|malformed FHIR|empty alternatives|drilling preserves|create eligibility follows"
               if [ "$HFS_DEFAULT_FHIR_VERSION" = R6 ]; then
                 HFS_E2E_BASE_URL=http://127.0.0.1:8080 \
                   npx playwright test tests/dashboard-multiversion.spec.ts

--- a/crates/rest/src/fhir_types.rs
+++ b/crates/rest/src/fhir_types.rs
@@ -7,6 +7,8 @@
 //! the cached `&'static [&'static str]`.
 
 use helios_fhir::{FhirResourceTypeProvider, FhirVersion};
+use serde_json::Value;
+use std::fmt;
 use std::sync::OnceLock;
 
 #[cfg(feature = "R4")]
@@ -127,6 +129,34 @@ pub fn is_valid_resource_type(type_name: &str) -> bool {
     false
 }
 
+/// Checks whether a path segment names a resource type in any FHIR version
+/// compiled into this server.
+///
+/// Route reservation is deliberately broader than request admission. It is
+/// case-insensitive so a misspelled resource path such as `/patient` reaches
+/// the FHIR router and gets a client error instead of being reinterpreted as a
+/// tenant prefix. Write handlers still require the exact, case-sensitive name
+/// for the request's effective FHIR version through [`admit_resource_type`].
+pub fn is_reserved_resource_path(type_name: &str) -> bool {
+    #[cfg(feature = "R4")]
+    if helios_fhir::r4::Resource::is_resource_type(type_name) {
+        return true;
+    }
+    #[cfg(feature = "R4B")]
+    if helios_fhir::r4b::Resource::is_resource_type(type_name) {
+        return true;
+    }
+    #[cfg(feature = "R5")]
+    if helios_fhir::r5::Resource::is_resource_type(type_name) {
+        return true;
+    }
+    #[cfg(feature = "R6")]
+    if helios_fhir::r6::Resource::is_resource_type(type_name) {
+        return true;
+    }
+    false
+}
+
 /// Returns the FHIR version string for the enabled version.
 ///
 /// This is useful for including in CapabilityStatements and other metadata.
@@ -182,6 +212,82 @@ pub fn is_valid_resource_type_for_version(type_name: &str, version: FhirVersion)
     get_resource_type_names_for_version(version).contains(&type_name)
 }
 
+/// A failure at the resource-type admission gate for a create or update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResourceTypeAdmissionError {
+    /// The URL type is not an exact core resource name in the effective version.
+    UnsupportedForVersion {
+        /// Resource type taken from the request URL.
+        resource_type: String,
+        /// Effective FHIR version for this write.
+        version: FhirVersion,
+    },
+    /// The request body has no string-valued `resourceType`.
+    MissingBodyType,
+    /// The body names a different resource type than the request URL.
+    UrlBodyMismatch {
+        /// Resource type taken from the request URL.
+        url_type: String,
+        /// Resource type declared in the request body.
+        body_type: String,
+    },
+}
+
+impl fmt::Display for ResourceTypeAdmissionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedForVersion {
+                resource_type,
+                version,
+            } => write!(
+                f,
+                "Resource type '{}' is not supported for FHIR {}",
+                resource_type, version
+            ),
+            Self::MissingBodyType => write!(f, "Resource must contain resourceType"),
+            Self::UrlBodyMismatch {
+                url_type,
+                body_type,
+            } => write!(
+                f,
+                "Resource type in body ({}) does not match URL ({})",
+                body_type, url_type
+            ),
+        }
+    }
+}
+
+/// Admits a resource to a create or update path.
+///
+/// This check is independent of configurable profile validation. It prevents
+/// unknown, wrong-case, and wrong-version types, then requires the body type to
+/// match the URL exactly. Callers must run it before persistence.
+pub fn admit_resource_type(
+    url_type: &str,
+    resource: &Value,
+    version: FhirVersion,
+) -> Result<(), ResourceTypeAdmissionError> {
+    if !is_valid_resource_type_for_version(url_type, version) {
+        return Err(ResourceTypeAdmissionError::UnsupportedForVersion {
+            resource_type: url_type.to_string(),
+            version,
+        });
+    }
+
+    let body_type = resource
+        .get("resourceType")
+        .and_then(Value::as_str)
+        .ok_or(ResourceTypeAdmissionError::MissingBodyType)?;
+    if body_type != url_type {
+        return Err(ResourceTypeAdmissionError::UrlBodyMismatch {
+            url_type: url_type.to_string(),
+            body_type: body_type.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,6 +317,120 @@ mod tests {
         assert!(!is_valid_resource_type("InvalidType"));
         assert!(!is_valid_resource_type(""));
         assert!(!is_valid_resource_type("patient")); // Case-sensitive
+    }
+
+    #[test]
+    fn route_reservation_spans_enabled_versions_and_is_case_insensitive() {
+        assert!(is_reserved_resource_path("Patient"));
+        assert!(is_reserved_resource_path("patient"));
+        assert!(!is_reserved_resource_path("NoSuchResource"));
+
+        #[cfg(any(feature = "R5", feature = "R6"))]
+        assert!(is_reserved_resource_path("ActorDefinition"));
+    }
+
+    #[test]
+    fn admission_requires_exact_type_and_matching_body() {
+        let patient = serde_json::json!({ "resourceType": "Patient" });
+        assert!(admit_resource_type("Patient", &patient, FhirVersion::default_enabled()).is_ok());
+        assert!(matches!(
+            admit_resource_type("patient", &patient, FhirVersion::default_enabled()),
+            Err(ResourceTypeAdmissionError::UnsupportedForVersion { .. })
+        ));
+        assert!(matches!(
+            admit_resource_type(
+                "Patient",
+                &serde_json::json!({ "resourceType": "Observation" }),
+                FhirVersion::default_enabled()
+            ),
+            Err(ResourceTypeAdmissionError::UrlBodyMismatch { .. })
+        ));
+        assert!(matches!(
+            admit_resource_type(
+                "Patient",
+                &serde_json::json!({}),
+                FhirVersion::default_enabled()
+            ),
+            Err(ResourceTypeAdmissionError::MissingBodyType)
+        ));
+    }
+
+    #[test]
+    fn patient_is_admitted_in_every_enabled_version() {
+        let patient = serde_json::json!({ "resourceType": "Patient" });
+        #[cfg(feature = "R4")]
+        assert!(admit_resource_type("Patient", &patient, FhirVersion::R4).is_ok());
+        #[cfg(feature = "R4B")]
+        assert!(admit_resource_type("Patient", &patient, FhirVersion::R4B).is_ok());
+        #[cfg(feature = "R5")]
+        assert!(admit_resource_type("Patient", &patient, FhirVersion::R5).is_ok());
+        #[cfg(feature = "R6")]
+        assert!(admit_resource_type("Patient", &patient, FhirVersion::R6).is_ok());
+    }
+
+    #[cfg(feature = "R4")]
+    #[test]
+    fn r4_admits_document_manifest_but_not_subscription_topic() {
+        let manifest = serde_json::json!({ "resourceType": "DocumentManifest" });
+        assert!(admit_resource_type("DocumentManifest", &manifest, FhirVersion::R4).is_ok());
+        let topic = serde_json::json!({ "resourceType": "SubscriptionTopic" });
+        assert!(matches!(
+            admit_resource_type("SubscriptionTopic", &topic, FhirVersion::R4),
+            Err(ResourceTypeAdmissionError::UnsupportedForVersion { .. })
+        ));
+    }
+
+    #[cfg(feature = "R4B")]
+    #[test]
+    fn r4b_admits_subscription_topic_and_document_manifest() {
+        let topic = serde_json::json!({ "resourceType": "SubscriptionTopic" });
+        let manifest = serde_json::json!({ "resourceType": "DocumentManifest" });
+        assert!(admit_resource_type("SubscriptionTopic", &topic, FhirVersion::R4B).is_ok());
+        assert!(admit_resource_type("DocumentManifest", &manifest, FhirVersion::R4B).is_ok());
+    }
+
+    #[cfg(all(feature = "R4", any(feature = "R5", feature = "R6")))]
+    #[test]
+    fn admission_rejects_version_specific_type_under_r4() {
+        let actor = serde_json::json!({ "resourceType": "ActorDefinition" });
+        assert!(is_reserved_resource_path("ActorDefinition"));
+        assert!(matches!(
+            admit_resource_type("ActorDefinition", &actor, FhirVersion::R4),
+            Err(ResourceTypeAdmissionError::UnsupportedForVersion { .. })
+        ));
+    }
+
+    #[cfg(feature = "R5")]
+    #[test]
+    fn r5_admits_actor_definition_but_not_document_manifest() {
+        let actor = serde_json::json!({ "resourceType": "ActorDefinition" });
+        assert!(admit_resource_type("ActorDefinition", &actor, FhirVersion::R5).is_ok());
+        let topic = serde_json::json!({ "resourceType": "SubscriptionTopic" });
+        assert!(admit_resource_type("SubscriptionTopic", &topic, FhirVersion::R5).is_ok());
+        let manifest = serde_json::json!({ "resourceType": "DocumentManifest" });
+        assert!(matches!(
+            admit_resource_type("DocumentManifest", &manifest, FhirVersion::R5),
+            Err(ResourceTypeAdmissionError::UnsupportedForVersion { .. })
+        ));
+    }
+
+    #[cfg(feature = "R6")]
+    #[test]
+    fn r6_admits_actor_definition_and_rejects_removed_types() {
+        let actor = serde_json::json!({ "resourceType": "ActorDefinition" });
+        assert!(admit_resource_type("ActorDefinition", &actor, FhirVersion::R6).is_ok());
+        let topic = serde_json::json!({ "resourceType": "SubscriptionTopic" });
+        assert!(admit_resource_type("SubscriptionTopic", &topic, FhirVersion::R6).is_ok());
+        let media = serde_json::json!({ "resourceType": "Media" });
+        let manifest = serde_json::json!({ "resourceType": "DocumentManifest" });
+        assert!(matches!(
+            admit_resource_type("Media", &media, FhirVersion::R6),
+            Err(ResourceTypeAdmissionError::UnsupportedForVersion { .. })
+        ));
+        assert!(matches!(
+            admit_resource_type("DocumentManifest", &manifest, FhirVersion::R6),
+            Err(ResourceTypeAdmissionError::UnsupportedForVersion { .. })
+        ));
     }
 
     #[test]

--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -26,6 +26,7 @@ use tracing::{debug, error, warn};
 
 use crate::error::{RestError, RestResult};
 use crate::extractors::{FhirVersionExtractor, TenantExtractor};
+use crate::fhir_types::{admit_resource_type, is_valid_resource_type};
 use crate::handlers::extract_patient_from_resource;
 use crate::middleware::prefer::PreferHeader;
 use crate::state::AppState;
@@ -186,9 +187,11 @@ where
     let writes_conformance = entries.iter().any(|entry| {
         entry
             .get("request")
-            .and_then(|request| request.get("url"))
-            .and_then(Value::as_str)
-            .and_then(|url| parse_request_url(url).ok())
+            .and_then(|request| {
+                let method = parse_entry_method(request).ok()?;
+                let url = request.get("url").and_then(Value::as_str)?;
+                parse_bundle_request_url(&method, url).ok()
+            })
             .is_some_and(|(resource_type, _)| resource_type == "StructureDefinition")
     });
     if writes_conformance {
@@ -486,6 +489,34 @@ where
         }
     }
 
+    // Admit every mutation before reference resolution, configurable
+    // validation, or storage. A transaction with one invalid write is declined
+    // whole, so none of its otherwise valid siblings can commit or delete.
+    for (index, entry, _) in &indexed_entries {
+        if !matches!(
+            entry.method,
+            BundleMethod::Post | BundleMethod::Put | BundleMethod::Delete
+        ) {
+            continue;
+        }
+        let (resource_type, _) =
+            parse_request_url(&entry.url).map_err(|error| RestError::BadRequest {
+                message: format!("Entry {index}: {error}"),
+            })?;
+        admit_bundle_mutation(
+            &entry.method,
+            &resource_type,
+            entry.resource.as_ref(),
+            fhir_version,
+        )
+        .map_err(|error| match error {
+            RestError::BadRequest { message } => RestError::BadRequest {
+                message: format!("Entry {index}: {message}"),
+            },
+            other => other,
+        })?;
+    }
+
     // GET search entries (`Patient?name=x`, bare `Patient`) cannot run inside
     // the storage transaction; the spec orders GETs after all writes, so they
     // execute against the just-committed state instead (#478). Their queries
@@ -770,7 +801,7 @@ where
     let if_match = request.get("ifMatch").and_then(|v| v.as_str());
 
     // Parse the URL to extract resource type and ID
-    let (resource_type, id) = match parse_request_url(url) {
+    let (resource_type, id) = match parse_bundle_request_url(&method, url) {
         Ok(parsed) => parsed,
         Err(e) => {
             return create_error_result(400, &e);
@@ -874,6 +905,12 @@ where
                 }
             };
 
+            if let Err(error) =
+                admit_bundle_mutation(&method, &resource_type, Some(&resource), fhir_version)
+            {
+                return entry_failure(error);
+            }
+
             // Write-path validation (per-entry outcome in batch semantics).
             if let Err(e) = state
                 .validation()
@@ -912,6 +949,12 @@ where
                     return create_error_result(400, "PUT entry missing resource");
                 }
             };
+
+            if let Err(error) =
+                admit_bundle_mutation(&method, &resource_type, Some(&resource), fhir_version)
+            {
+                return entry_failure(error);
+            }
 
             // `PUT Patient` names no instance to update. Left to fall through it
             // reaches `create_or_update` with an empty id, and that writes a row
@@ -979,6 +1022,10 @@ where
             }
         }
         BundleMethod::Delete => {
+            if let Err(error) = admit_bundle_mutation(&method, &resource_type, None, fhir_version) {
+                return entry_failure(error);
+            }
+
             // Mirror of the PUT guard above. FHIR defines no unconditional
             // type-level delete, and an empty id would otherwise target the
             // empty-id row a pre-#503 conditional PUT could have written.
@@ -1029,6 +1076,42 @@ where
         // outside the value set never reach this point — `parse_entry_method`
         // refuses them at the top of this function.
     }
+}
+
+/// Applies the type and immutability gates shared by batch and transaction
+/// mutations. The caller decides whether the error belongs to one batch entry
+/// or rejects the whole transaction.
+fn admit_bundle_mutation(
+    method: &BundleMethod,
+    resource_type: &str,
+    resource: Option<&Value>,
+    fhir_version: FhirVersion,
+) -> RestResult<()> {
+    if matches!(method, BundleMethod::Post | BundleMethod::Put) {
+        let resource = resource.ok_or_else(|| RestError::BadRequest {
+            message: format!("{method} entry missing resource"),
+        })?;
+
+        admit_resource_type(resource_type, resource, fhir_version).map_err(|error| {
+            RestError::BadRequest {
+                message: error.to_string(),
+            }
+        })?;
+    }
+
+    if resource_type == "AuditEvent"
+        && matches!(
+            method,
+            BundleMethod::Post | BundleMethod::Put | BundleMethod::Delete
+        )
+    {
+        return Err(RestError::MethodNotAllowed {
+            method: bundle_method_to_http_method(method).to_string(),
+            resource_type: resource_type.to_string(),
+        });
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -1262,6 +1345,83 @@ fn parse_request_url(url: &str) -> Result<(String, String), String> {
         resource_type.to_string(),
         segments.next().unwrap_or_default().to_string(),
     ))
+}
+
+/// Parses the target of a Bundle request using the method's URL shape.
+///
+/// Mutation URLs may be absolute or carry a server path prefix. POST targets
+/// the final path segment as a resource type, while PUT, PATCH, and DELETE
+/// target the final two segments as `[type]/[id]`. This matches the transaction
+/// backends. GET keeps the existing type, instance, and history interpretation.
+fn parse_bundle_request_url(
+    method: &BundleMethod,
+    request_url: &str,
+) -> Result<(String, String), String> {
+    if matches!(method, BundleMethod::Get) {
+        return parse_request_url(request_url);
+    }
+
+    let path = match url::Url::parse(request_url) {
+        Ok(parsed) if matches!(parsed.scheme(), "http" | "https") => parsed.path().to_string(),
+        Ok(_) => return Err("Entry request.url uses an unsupported absolute scheme".to_string()),
+        Err(_) => request_url
+            .split_once('?')
+            .map_or(request_url, |(path, _)| path)
+            .to_string(),
+    };
+    let segments: Vec<&str> = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+
+    match method {
+        BundleMethod::Post => segments
+            .last()
+            .map(|resource_type| ((*resource_type).to_string(), String::new()))
+            .ok_or_else(|| "Entry request.url is empty".to_string()),
+        BundleMethod::Put | BundleMethod::Patch | BundleMethod::Delete => {
+            if request_url
+                .split_once('?')
+                .is_some_and(|(_, query)| !query.is_empty())
+                && segments
+                    .last()
+                    .is_some_and(|segment| is_valid_resource_type(segment))
+            {
+                return Ok((
+                    segments.last().expect("checked above").to_string(),
+                    String::new(),
+                ));
+            }
+            if segments.len() < 2 {
+                return Err(format!(
+                    "{method} entry request.url must address an instance ('[type]/[id]')"
+                ));
+            }
+            let len = segments.len();
+            Ok((segments[len - 2].to_string(), segments[len - 1].to_string()))
+        }
+        BundleMethod::Get => unreachable!("GET returned above"),
+    }
+}
+
+/// Rewrites a mutation URL to the relative form every transaction backend
+/// parses identically. The query is retained so existing refusal and
+/// conditional-interaction checks still see it before storage.
+fn canonical_bundle_mutation_url(
+    method: &BundleMethod,
+    request_url: &str,
+) -> Result<String, String> {
+    let (resource_type, id) = parse_bundle_request_url(method, request_url)?;
+    let mut canonical = if id.is_empty() {
+        resource_type
+    } else {
+        format!("{resource_type}/{id}")
+    };
+    if let Some((_, query)) = request_url.split_once('?') {
+        canonical.push('?');
+        canonical.push_str(query);
+    }
+    Ok(canonical)
 }
 
 /// Returns the conditional criteria an entry URL carries, if any.
@@ -1662,11 +1822,19 @@ fn parse_bundle_entry(entry: &Value) -> Result<(BundleEntry, Option<String>), En
     // agrees with the per-entry result the batch arm would produce.
     let method = parse_entry_method(request).map_err(EntryParseError::Method)?;
 
-    let url = request
+    let raw_url = request
         .get("url")
         .and_then(|v| v.as_str())
         .ok_or_else(|| EntryParseError::Malformed("Entry request missing 'url'".to_string()))?
         .to_string();
+    let url = if matches!(
+        method,
+        BundleMethod::Post | BundleMethod::Put | BundleMethod::Patch | BundleMethod::Delete
+    ) {
+        canonical_bundle_mutation_url(&method, &raw_url).map_err(EntryParseError::Malformed)?
+    } else {
+        raw_url
+    };
 
     let mut resource = entry.get("resource").cloned();
     // Per http.html#create the server ignores an id supplied on a POST — the
@@ -2779,6 +2947,43 @@ mod tests {
                 "url: {url}"
             );
         }
+    }
+
+    #[test]
+    fn mutation_url_parser_handles_absolute_prefixed_and_type_level_targets() {
+        assert_eq!(
+            parse_bundle_request_url(&BundleMethod::Post, "https://example.test/fhir/Patient")
+                .unwrap(),
+            ("Patient".to_string(), String::new())
+        );
+        assert_eq!(
+            parse_bundle_request_url(
+                &BundleMethod::Put,
+                "https://example.test/fhir/Patient/p1?_format=json"
+            )
+            .unwrap(),
+            ("Patient".to_string(), "p1".to_string())
+        );
+        assert_eq!(
+            parse_bundle_request_url(&BundleMethod::Delete, "fhir/AuditEvent/audit-1").unwrap(),
+            ("AuditEvent".to_string(), "audit-1".to_string())
+        );
+        assert_eq!(
+            canonical_bundle_mutation_url(
+                &BundleMethod::Delete,
+                "https://example.test/fhir/AuditEvent/audit-1"
+            )
+            .unwrap(),
+            "AuditEvent/audit-1"
+        );
+        assert_eq!(
+            canonical_bundle_mutation_url(
+                &BundleMethod::Post,
+                "https://example.test/fhir/Patient?ignored=value"
+            )
+            .unwrap(),
+            "Patient?ignored=value"
+        );
     }
 
     /// The empty-URL arm used to be unreachable — `str::split` always yields at

--- a/crates/rest/src/handlers/capabilities.rs
+++ b/crates/rest/src/handlers/capabilities.rs
@@ -320,10 +320,16 @@ fn build_resource_capability(
     modifier_map: &std::collections::HashMap<SearchParamType, Vec<&'static str>>,
     revinclude_by_target: &std::collections::HashMap<String, std::collections::BTreeSet<String>>,
 ) -> serde_json::Value {
-    let mut entry = serde_json::json!({
-        "type": resource_type,
-        "profile": format!("http://hl7.org/fhir/StructureDefinition/{}", resource_type),
-        "interaction": [
+    let interactions = if resource_type == "AuditEvent" {
+        serde_json::json!([
+            { "code": "read" },
+            { "code": "vread" },
+            { "code": "history-instance" },
+            { "code": "history-type" },
+            { "code": "search-type" }
+        ])
+    } else {
+        serde_json::json!([
             { "code": "read" },
             { "code": "vread" },
             { "code": "update" },
@@ -333,16 +339,25 @@ fn build_resource_capability(
             { "code": "history-type" },
             { "code": "create" },
             { "code": "search-type" }
-        ],
+        ])
+    };
+
+    let mut entry = serde_json::json!({
+        "type": resource_type,
+        "profile": format!("http://hl7.org/fhir/StructureDefinition/{}", resource_type),
+        "interaction": interactions,
         "versioning": "versioned",
         "readHistory": true,
-        "updateCreate": true,
-        "conditionalCreate": true,
         "conditionalRead": "full-support",
-        "conditionalUpdate": true,
-        "conditionalDelete": "single",
         "searchParam": build_search_params(resource_type, registry, supports_contained, modifier_map)
     });
+
+    if resource_type != "AuditEvent" {
+        entry["updateCreate"] = serde_json::Value::Bool(true);
+        entry["conditionalCreate"] = serde_json::Value::Bool(true);
+        entry["conditionalUpdate"] = serde_json::Value::Bool(true);
+        entry["conditionalDelete"] = serde_json::Value::String("single".to_string());
+    }
 
     // Advertise real `_include` targets: one "Type:code" per reference param on
     // this type. Omitted entirely when the type has no reference params.

--- a/crates/rest/src/handlers/create.rs
+++ b/crates/rest/src/handlers/create.rs
@@ -13,6 +13,7 @@ use tracing::debug;
 
 use crate::error::{RestError, RestResult};
 use crate::extractors::{FhirResource, FhirVersionExtractor, TenantExtractor};
+use crate::fhir_types::admit_resource_type;
 use crate::handlers::extract_patient_from_resource;
 use crate::middleware::conditional::ConditionalHeaders;
 use crate::middleware::content_type::{FhirFormat, negotiate_format};
@@ -66,6 +67,15 @@ pub async fn create_handler<S>(
 where
     S: ResourceStorage + ConditionalStorage + Send + Sync,
 {
+    // Determine FHIR version from header or use server default
+    let fhir_version = version.storage_version_or(state.config().default_fhir_version);
+
+    admit_resource_type(&resource_type, &resource, fhir_version).map_err(|error| {
+        RestError::BadRequest {
+            message: error.to_string(),
+        }
+    })?;
+
     // AuditEvent resources are immutable — block write operations
     if resource_type == "AuditEvent" {
         return Err(RestError::MethodNotAllowed {
@@ -73,9 +83,6 @@ where
             resource_type: resource_type.to_string(),
         });
     }
-
-    // Determine FHIR version from header or use server default
-    let fhir_version = version.storage_version_or(state.config().default_fhir_version);
 
     // Negotiate response format from Accept header
     let negotiated = negotiate_format(&req_headers, None);
@@ -87,22 +94,6 @@ where
         conditional = ?conditional.if_none_exist(),
         "Processing create request"
     );
-
-    // Validate resourceType in body matches URL
-    if let Some(body_type) = resource.get("resourceType").and_then(|v| v.as_str()) {
-        if body_type != resource_type {
-            return Err(RestError::BadRequest {
-                message: format!(
-                    "Resource type in body ({}) does not match URL ({})",
-                    body_type, resource_type
-                ),
-            });
-        }
-    } else {
-        return Err(RestError::BadRequest {
-            message: "Resource must contain resourceType".to_string(),
-        });
-    }
 
     // Per http.html#create "the server ignores the id provided in the
     // resource" — a create always assigns a fresh server id. Honoring a

--- a/crates/rest/src/handlers/delete.rs
+++ b/crates/rest/src/handlers/delete.rs
@@ -245,6 +245,13 @@ pub async fn conditional_delete_handler<S>(
 where
     S: ResourceStorage + ConditionalStorage + Send + Sync,
 {
+    if resource_type == "AuditEvent" {
+        return Err(RestError::MethodNotAllowed {
+            method: "DELETE".to_string(),
+            resource_type,
+        });
+    }
+
     // Build search params string
     let search_params: String = query
         .iter()

--- a/crates/rest/src/handlers/update.rs
+++ b/crates/rest/src/handlers/update.rs
@@ -14,6 +14,7 @@ use tracing::debug;
 
 use crate::error::{RestError, RestResult};
 use crate::extractors::{FhirResource, FhirVersionExtractor, TenantExtractor};
+use crate::fhir_types::admit_resource_type;
 use crate::handlers::extract_patient_from_resource;
 use crate::middleware::conditional::ConditionalHeaders;
 use crate::middleware::content_type::{FhirFormat, negotiate_format};
@@ -68,6 +69,15 @@ pub async fn update_handler<S>(
 where
     S: ResourceStorage + ConditionalStorage + Send + Sync,
 {
+    // Determine FHIR version from header or use server default
+    let fhir_version = version.storage_version_or(state.config().default_fhir_version);
+
+    admit_resource_type(&resource_type, &resource, fhir_version).map_err(|error| {
+        RestError::BadRequest {
+            message: error.to_string(),
+        }
+    })?;
+
     // AuditEvent resources are immutable — block write operations
     if resource_type == "AuditEvent" {
         return Err(RestError::MethodNotAllowed {
@@ -75,9 +85,6 @@ where
             resource_type: resource_type.to_string(),
         });
     }
-
-    // Determine FHIR version from header or use server default
-    let fhir_version = version.storage_version_or(state.config().default_fhir_version);
 
     // Negotiate response format from Accept header
     let negotiated = negotiate_format(&req_headers, None);
@@ -90,22 +97,6 @@ where
         if_match = ?conditional.if_match_tags(),
         "Processing update request"
     );
-
-    // Validate resourceType in body matches URL
-    if let Some(body_type) = resource.get("resourceType").and_then(|v| v.as_str()) {
-        if body_type != resource_type {
-            return Err(RestError::BadRequest {
-                message: format!(
-                    "Resource type in body ({}) does not match URL ({})",
-                    body_type, resource_type
-                ),
-            });
-        }
-    } else {
-        return Err(RestError::BadRequest {
-            message: "Resource must contain resourceType".to_string(),
-        });
-    }
 
     // Validate ID in body matches URL (if present)
     if let Some(body_id) = resource.get("id").and_then(|v| v.as_str()) {
@@ -275,6 +266,19 @@ where
     // Determine FHIR version from header or use server default
     let fhir_version = version.storage_version_or(state.config().default_fhir_version);
 
+    admit_resource_type(&resource_type, &resource, fhir_version).map_err(|error| {
+        RestError::BadRequest {
+            message: error.to_string(),
+        }
+    })?;
+
+    if resource_type == "AuditEvent" {
+        return Err(RestError::MethodNotAllowed {
+            method: "PUT".to_string(),
+            resource_type: resource_type.to_string(),
+        });
+    }
+
     // Negotiate response format from Accept header
     let negotiated = negotiate_format(&req_headers, None);
 
@@ -292,18 +296,6 @@ where
         fhir_version = %fhir_version,
         "Processing conditional update request"
     );
-
-    // Validate resourceType
-    if let Some(body_type) = resource.get("resourceType").and_then(|v| v.as_str()) {
-        if body_type != resource_type {
-            return Err(RestError::BadRequest {
-                message: format!(
-                    "Resource type in body ({}) does not match URL ({})",
-                    body_type, resource_type
-                ),
-            });
-        }
-    }
 
     // Write-path validation (HFS_VALIDATION_MODE: off | log | enforce).
     state

--- a/crates/rest/src/middleware/tenant_prefix.rs
+++ b/crates/rest/src/middleware/tenant_prefix.rs
@@ -4,8 +4,10 @@
 //! when using URL-based tenant routing.
 
 use axum::{extract::Request, http::Uri, middleware::Next, response::Response};
-use helios_fhir::{FhirResourceTypeProvider, FhirVersion};
+use helios_fhir::FhirVersion;
 use helios_persistence::tenant::TenantId;
+
+use crate::fhir_types::is_reserved_resource_path;
 
 /// Non-resource reserved paths (FHIR system endpoints, API prefixes).
 /// Resource types are checked dynamically via helios-fhir's FhirResourceTypeProvider.
@@ -36,8 +38,8 @@ const RESERVED_SYSTEM_PATHS: &[&str] = &[
 ///
 /// A segment is reserved if it's either:
 /// 1. A FHIR system endpoint or API prefix (from RESERVED_SYSTEM_PATHS)
-/// 2. A valid FHIR resource type for the given version
-fn is_reserved_path(segment: &str, fhir_version: &FhirVersion) -> bool {
+/// 2. A FHIR resource type in any version compiled into the server
+fn is_reserved_path(segment: &str, _fhir_version: &FhirVersion) -> bool {
     let lower = segment.to_lowercase();
 
     // Check system paths first (fast path)
@@ -45,25 +47,9 @@ fn is_reserved_path(segment: &str, fhir_version: &FhirVersion) -> bool {
         return true;
     }
 
-    // Check if it's a valid FHIR resource type for the configured version
-    is_fhir_resource_type(segment, fhir_version)
-}
-
-/// Checks if a string is a valid FHIR resource type for the given version.
-/// Uses the FhirResourceTypeProvider trait for case-insensitive matching.
-fn is_fhir_resource_type(type_name: &str, fhir_version: &FhirVersion) -> bool {
-    match fhir_version {
-        #[cfg(feature = "R4")]
-        FhirVersion::R4 => helios_fhir::r4::Resource::is_resource_type(type_name),
-        #[cfg(feature = "R4B")]
-        FhirVersion::R4B => helios_fhir::r4b::Resource::is_resource_type(type_name),
-        #[cfg(feature = "R5")]
-        FhirVersion::R5 => helios_fhir::r5::Resource::is_resource_type(type_name),
-        #[cfg(feature = "R6")]
-        FhirVersion::R6 => helios_fhir::r6::Resource::is_resource_type(type_name),
-        #[allow(unreachable_patterns)]
-        _ => false,
-    }
+    // Reserve resource paths from every version compiled into this server.
+    // The handler later applies exact admission for the negotiated version.
+    is_reserved_resource_path(segment)
 }
 
 /// Validates that a path segment could be a tenant ID.
@@ -104,7 +90,8 @@ fn is_valid_tenant_id(s: &str) -> bool {
 /// Returns `Some((tenant_id, remaining_path))` if a tenant prefix was found,
 /// or `None` if the path doesn't start with a tenant prefix.
 ///
-/// Uses the provided FHIR version for resource type detection.
+/// The version argument remains part of the public helper contract. Resource
+/// path reservation itself spans every version compiled into the server.
 pub fn extract_tenant_from_path(
     path: &str,
     fhir_version: &FhirVersion,
@@ -151,7 +138,7 @@ pub async fn strip_tenant_prefix_middleware(mut request: Request, next: Next) ->
     let original_uri = request.uri().clone();
     let path = original_uri.path();
 
-    // Use the default FHIR version for resource type checking
+    // Keep the existing helper contract; reservation spans all compiled versions.
     let fhir_version = FhirVersion::default_enabled();
 
     // Try to extract tenant from path
@@ -248,6 +235,13 @@ mod tests {
         // `console` cannot shadow / be confused with a tenant literally named
         // "console" under URL-path routing.
         assert!(extract_tenant_from_path("/console/metrics/uptime", &version).is_none());
+    }
+
+    #[cfg(all(feature = "R4", any(feature = "R5", feature = "R6")))]
+    #[test]
+    fn resource_from_later_compiled_version_is_not_a_tenant_under_r4() {
+        assert!(extract_tenant_from_path("/ActorDefinition", &FhirVersion::R4).is_none());
+        assert!(extract_tenant_from_path("/actordefinition", &FhirVersion::R4).is_none());
     }
 
     /// Regression for a break this change would otherwise have introduced.

--- a/crates/rest/src/tenant/resolver.rs
+++ b/crates/rest/src/tenant/resolver.rs
@@ -4,11 +4,12 @@
 //! requests using multiple configurable sources.
 
 use axum::http::request::Parts;
-use helios_fhir::{FhirResourceTypeProvider, FhirVersion};
+use helios_fhir::FhirVersion;
 use helios_persistence::tenant::{TenantId, TenantIdError};
 use tracing::{debug, warn};
 
 use crate::config::{MultitenancyConfig, TenantRoutingMode};
+use crate::fhir_types::is_reserved_resource_path;
 use crate::middleware::tenant::X_TENANT_ID;
 use crate::middleware::tenant_prefix::{ExtractedTenantFromUrl, OriginalPath};
 
@@ -393,8 +394,8 @@ impl Default for TenantResolver {
 ///
 /// A segment is reserved if it's either:
 /// 1. A FHIR system endpoint or API prefix (from RESERVED_SYSTEM_PATHS)
-/// 2. A valid FHIR resource type for the given version
-fn is_reserved_path(segment: &str, fhir_version: &FhirVersion) -> bool {
+/// 2. A FHIR resource type in any version compiled into the server
+fn is_reserved_path(segment: &str, _fhir_version: &FhirVersion) -> bool {
     let lower = segment.to_lowercase();
 
     // Check system paths first (fast path)
@@ -402,25 +403,7 @@ fn is_reserved_path(segment: &str, fhir_version: &FhirVersion) -> bool {
         return true;
     }
 
-    // Check if it's a valid FHIR resource type for the configured version
-    is_fhir_resource_type(segment, fhir_version)
-}
-
-/// Checks if a string is a valid FHIR resource type for the given version.
-/// Uses the FhirResourceTypeProvider trait for case-insensitive matching.
-fn is_fhir_resource_type(type_name: &str, fhir_version: &FhirVersion) -> bool {
-    match fhir_version {
-        #[cfg(feature = "R4")]
-        FhirVersion::R4 => helios_fhir::r4::Resource::is_resource_type(type_name),
-        #[cfg(feature = "R4B")]
-        FhirVersion::R4B => helios_fhir::r4b::Resource::is_resource_type(type_name),
-        #[cfg(feature = "R5")]
-        FhirVersion::R5 => helios_fhir::r5::Resource::is_resource_type(type_name),
-        #[cfg(feature = "R6")]
-        FhirVersion::R6 => helios_fhir::r6::Resource::is_resource_type(type_name),
-        #[allow(unreachable_patterns)]
-        _ => false,
-    }
+    is_reserved_resource_path(segment)
 }
 
 // The local `is_valid_tenant_id` that used to live here is gone: it was one of
@@ -442,6 +425,13 @@ mod tests {
 
         let request = builder.body(()).unwrap();
         request.into_parts().0
+    }
+
+    #[cfg(all(feature = "R4", any(feature = "R5", feature = "R6")))]
+    #[test]
+    fn later_version_resource_paths_are_reserved_under_r4() {
+        assert!(is_reserved_path("ActorDefinition", &FhirVersion::R4));
+        assert!(is_reserved_path("actordefinition", &FhirVersion::R4));
     }
 
     /// `Ok(Some(id))` unwrapped, for the many assertions that only care about

--- a/crates/rest/tests/batch_conformance.rs
+++ b/crates/rest/tests/batch_conformance.rs
@@ -82,6 +82,18 @@ async fn seed_patient(backend: &SqliteBackend, id: &str, family: &str) {
         .expect("Failed to seed patient");
 }
 
+async fn seed_audit_event(backend: &SqliteBackend, id: &str) {
+    backend
+        .create(
+            &test_tenant(),
+            "AuditEvent",
+            json!({ "resourceType": "AuditEvent", "id": id }),
+            FhirVersion::R4,
+        )
+        .await
+        .expect("Failed to seed AuditEvent");
+}
+
 /// Helper: post a batch bundle and return the parsed response body.
 async fn post_batch(server: &TestServer, bundle: Value) -> Value {
     let response = server
@@ -807,6 +819,304 @@ mod transaction_errors {
             .await;
 
         response.assert_status(StatusCode::BAD_REQUEST);
+    }
+}
+
+mod resource_type_admission {
+    use super::*;
+
+    #[tokio::test]
+    async fn batch_keeps_valid_siblings_and_rejects_invalid_write_types() {
+        let (server, backend) = create_test_server().await;
+        let body = post_batch(
+            &server,
+            json!({
+                "resourceType": "Bundle",
+                "type": "batch",
+                "entry": [
+                    {
+                        "request": { "method": "PUT", "url": "Patient/good" },
+                        "resource": { "resourceType": "Patient", "id": "good" }
+                    },
+                    {
+                        "request": { "method": "PUT", "url": "NoLongerValid/bad" },
+                        "resource": { "resourceType": "NoLongerValid", "id": "bad" }
+                    }
+                ]
+            }),
+        )
+        .await;
+
+        assert_eq!(body["entry"][0]["response"]["status"], "201 Created");
+        assert_eq!(body["entry"][1]["response"]["status"], "400 Bad Request");
+        assert!(
+            backend
+                .read(&test_tenant(), "Patient", "good")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            backend
+                .read(&test_tenant(), "NoLongerValid", "bad")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_rejects_missing_mismatched_and_audit_event_bodies() {
+        let (server, backend) = create_test_server().await;
+        let body = post_batch(
+            &server,
+            json!({
+                "resourceType": "Bundle",
+                "type": "batch",
+                "entry": [
+                    {
+                        "request": { "method": "PUT", "url": "Patient/missing" },
+                        "resource": { "id": "missing" }
+                    },
+                    {
+                        "request": { "method": "PUT", "url": "Patient/mismatch" },
+                        "resource": { "resourceType": "Observation", "id": "mismatch" }
+                    },
+                    {
+                        "request": { "method": "POST", "url": "AuditEvent" },
+                        "resource": { "resourceType": "AuditEvent" }
+                    }
+                ]
+            }),
+        )
+        .await;
+
+        assert_eq!(body["entry"][0]["response"]["status"], "400 Bad Request");
+        assert_eq!(body["entry"][1]["response"]["status"], "400 Bad Request");
+        assert_eq!(
+            body["entry"][2]["response"]["status"],
+            "405 Method Not Allowed"
+        );
+        assert!(
+            backend
+                .read(&test_tenant(), "Patient", "missing")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            backend
+                .read(&test_tenant(), "Patient", "mismatch")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_type_failure_prevents_every_sibling_write() {
+        let (server, backend) = create_test_server().await;
+        let response = server
+            .post("/")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .add_header(
+                CONTENT_TYPE,
+                HeaderValue::from_static("application/fhir+json"),
+            )
+            .json(&json!({
+                "resourceType": "Bundle",
+                "type": "transaction",
+                "entry": [
+                    {
+                        "request": { "method": "PUT", "url": "Patient/sibling" },
+                        "resource": { "resourceType": "Patient", "id": "sibling" }
+                    },
+                    {
+                        "request": { "method": "PUT", "url": "NoLongerValid/bad" },
+                        "resource": { "resourceType": "NoLongerValid", "id": "bad" }
+                    }
+                ]
+            }))
+            .await;
+
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let outcome: Value = response.json();
+        assert_eq!(outcome["resourceType"], "OperationOutcome");
+        assert!(
+            backend
+                .read(&test_tenant(), "Patient", "sibling")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            backend
+                .read(&test_tenant(), "NoLongerValid", "bad")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_audit_event_failure_prevents_sibling_write() {
+        let (server, backend) = create_test_server().await;
+        let response = server
+            .post("/")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .add_header(
+                CONTENT_TYPE,
+                HeaderValue::from_static("application/fhir+json"),
+            )
+            .json(&json!({
+                "resourceType": "Bundle",
+                "type": "transaction",
+                "entry": [
+                    {
+                        "request": { "method": "PUT", "url": "Patient/sibling" },
+                        "resource": { "resourceType": "Patient", "id": "sibling" }
+                    },
+                    {
+                        "request": { "method": "POST", "url": "AuditEvent" },
+                        "resource": { "resourceType": "AuditEvent" }
+                    }
+                ]
+            }))
+            .await;
+
+        response.assert_status(StatusCode::METHOD_NOT_ALLOWED);
+        assert!(
+            backend
+                .read(&test_tenant(), "Patient", "sibling")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_audit_event_delete_is_405_without_blocking_valid_siblings() {
+        let (server, backend) = create_test_server().await;
+        seed_audit_event(&backend, "audit-1").await;
+        seed_audit_event(&backend, "audit-2").await;
+
+        let body = post_batch(
+            &server,
+            json!({
+                "resourceType": "Bundle",
+                "type": "batch",
+                "entry": [
+                    {
+                        "request": {
+                            "method": "DELETE",
+                            "url": "https://example.test/fhir/AuditEvent/audit-1"
+                        }
+                    },
+                    {
+                        "request": { "method": "DELETE", "url": "fhir/AuditEvent/audit-2" }
+                    },
+                    {
+                        "request": { "method": "PUT", "url": "Patient/good" },
+                        "resource": { "resourceType": "Patient", "id": "good" }
+                    }
+                ]
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            body["entry"][0]["response"]["status"],
+            "405 Method Not Allowed"
+        );
+        assert_eq!(
+            body["entry"][1]["response"]["status"],
+            "405 Method Not Allowed"
+        );
+        assert_eq!(body["entry"][2]["response"]["status"], "201 Created");
+        assert!(
+            backend
+                .read(&test_tenant(), "AuditEvent", "audit-1")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            backend
+                .read(&test_tenant(), "Patient", "good")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            backend
+                .read(&test_tenant(), "AuditEvent", "audit-2")
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_audit_event_delete_preflight_prevents_all_mutations() {
+        for audit_url in [
+            "https://example.test/fhir/AuditEvent/audit-1",
+            "fhir/AuditEvent/audit-1",
+        ] {
+            let (server, backend) = create_test_server().await;
+            seed_audit_event(&backend, "audit-1").await;
+            seed_patient(&backend, "existing", "Keep").await;
+
+            let response = server
+                .post("/")
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .add_header(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/fhir+json"),
+                )
+                .json(&json!({
+                    "resourceType": "Bundle",
+                    "type": "transaction",
+                    "entry": [
+                        {
+                            "request": { "method": "DELETE", "url": "Patient/existing" }
+                        },
+                        {
+                            "request": { "method": "PUT", "url": "Patient/new" },
+                            "resource": { "resourceType": "Patient", "id": "new" }
+                        },
+                        {
+                            "request": { "method": "DELETE", "url": audit_url }
+                        }
+                    ]
+                }))
+                .await;
+
+            response.assert_status(StatusCode::METHOD_NOT_ALLOWED);
+            assert!(
+                backend
+                    .read(&test_tenant(), "AuditEvent", "audit-1")
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "AuditEvent must survive {audit_url}"
+            );
+            assert!(
+                backend
+                    .read(&test_tenant(), "Patient", "existing")
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "sibling delete must not run for {audit_url}"
+            );
+            assert!(
+                backend
+                    .read(&test_tenant(), "Patient", "new")
+                    .await
+                    .unwrap()
+                    .is_none(),
+                "sibling write must not run for {audit_url}"
+            );
+        }
     }
 }
 

--- a/crates/rest/tests/resource_type_validation.rs
+++ b/crates/rest/tests/resource_type_validation.rs
@@ -1,0 +1,260 @@
+//! Resource-type admission tests for REST write paths.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::http::{HeaderName, HeaderValue, StatusCode};
+use axum_test::TestServer;
+use helios_fhir::FhirVersion;
+use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+use helios_persistence::core::ResourceStorage;
+use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
+use helios_rest::ServerConfig;
+use helios_rest::config::{MultitenancyConfig, TenantRoutingMode, ValidationConfig};
+use serde_json::{Value, json};
+
+const X_TENANT_ID: HeaderName = HeaderName::from_static("x-tenant-id");
+const CONTENT_TYPE: HeaderName = HeaderName::from_static("content-type");
+
+async fn create_test_server(
+    validation_mode: &str,
+    default_fhir_version: FhirVersion,
+) -> (TestServer, Arc<SqliteBackend>) {
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .map(|path| path.join("data"))
+        .unwrap_or_else(|| PathBuf::from("data"));
+    let backend = SqliteBackend::with_config(
+        ":memory:",
+        SqliteBackendConfig {
+            data_dir: Some(data_dir),
+            ..Default::default()
+        },
+    )
+    .expect("create SQLite backend");
+    backend.init_schema().expect("initialize SQLite schema");
+    let backend = Arc::new(backend);
+
+    let config = ServerConfig {
+        multitenancy: MultitenancyConfig {
+            routing_mode: TenantRoutingMode::HeaderOnly,
+            ..Default::default()
+        },
+        base_url: "http://localhost:8080".to_string(),
+        default_tenant: "test-tenant".to_string(),
+        default_fhir_version,
+        validation: ValidationConfig {
+            mode: validation_mode.to_string(),
+            ..Default::default()
+        },
+        ..ServerConfig::for_testing()
+    };
+    let state = helios_rest::AppState::new(Arc::clone(&backend), config);
+    let app = helios_rest::routing::fhir_routes::create_routes(state);
+    (TestServer::new(app).expect("create test server"), backend)
+}
+
+fn tenant() -> TenantContext {
+    TenantContext::new(
+        TenantId::new("test-tenant"),
+        TenantPermissions::full_access(),
+    )
+}
+
+async fn put(server: &TestServer, path: &str, body: Value) -> axum_test::TestResponse {
+    server
+        .put(path)
+        .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+        .add_header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/fhir+json"),
+        )
+        .json(&body)
+        .await
+}
+
+#[tokio::test]
+async fn direct_updates_reject_unknown_wrong_case_missing_and_mismatched_types() {
+    let (server, backend) = create_test_server("off", FhirVersion::default_enabled()).await;
+
+    put(
+        &server,
+        "/NoLongerValid/unknown",
+        json!({ "resourceType": "NoLongerValid", "id": "unknown" }),
+    )
+    .await
+    .assert_status(StatusCode::BAD_REQUEST);
+    put(
+        &server,
+        "/patient/lowercase",
+        json!({ "resourceType": "patient", "id": "lowercase" }),
+    )
+    .await
+    .assert_status(StatusCode::BAD_REQUEST);
+    put(&server, "/Patient/missing", json!({ "id": "missing" }))
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+    put(
+        &server,
+        "/Patient/mismatch",
+        json!({ "resourceType": "Observation", "id": "mismatch" }),
+    )
+    .await
+    .assert_status(StatusCode::BAD_REQUEST);
+
+    for (resource_type, id) in [
+        ("NoLongerValid", "unknown"),
+        ("patient", "lowercase"),
+        ("Patient", "missing"),
+        ("Patient", "mismatch"),
+    ] {
+        assert!(
+            backend
+                .read(&tenant(), resource_type, id)
+                .await
+                .unwrap()
+                .is_none(),
+            "{resource_type}/{id} must not be stored"
+        );
+    }
+}
+
+#[tokio::test]
+async fn type_admission_is_independent_of_validation_mode() {
+    for mode in ["off", "enforce"] {
+        let (server, backend) = create_test_server(mode, FhirVersion::default_enabled()).await;
+        put(
+            &server,
+            "/NoLongerValid/rejected",
+            json!({ "resourceType": "NoLongerValid", "id": "rejected" }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+        assert!(
+            backend
+                .read(&tenant(), "NoLongerValid", "rejected")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+}
+
+#[tokio::test]
+async fn conditional_update_keeps_audit_event_immutable() {
+    let (server, backend) = create_test_server("off", FhirVersion::default_enabled()).await;
+    put(
+        &server,
+        "/AuditEvent?entity=Patient%2Fexample",
+        json!({ "resourceType": "AuditEvent" }),
+    )
+    .await
+    .assert_status(StatusCode::METHOD_NOT_ALLOWED);
+    assert!(
+        backend
+            .read(&tenant(), "AuditEvent", "example")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn conditional_delete_keeps_audit_event_immutable() {
+    let (server, backend) = create_test_server("off", FhirVersion::default_enabled()).await;
+    backend
+        .create(
+            &tenant(),
+            "AuditEvent",
+            json!({ "resourceType": "AuditEvent", "id": "audit-1" }),
+            FhirVersion::default_enabled(),
+        )
+        .await
+        .expect("seed AuditEvent");
+
+    let response = server
+        .delete("/AuditEvent?_id=audit-1")
+        .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+        .await;
+    response.assert_status(StatusCode::METHOD_NOT_ALLOWED);
+    assert!(
+        backend
+            .read(&tenant(), "AuditEvent", "audit-1")
+            .await
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn capability_statement_does_not_advertise_audit_event_mutation() {
+    let (server, _) = create_test_server("off", FhirVersion::default_enabled()).await;
+    let response = server.get("/metadata").await;
+    response.assert_status_ok();
+    let body: Value = response.json();
+    let audit = body["rest"][0]["resource"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["type"] == "AuditEvent")
+        .expect("AuditEvent capability");
+    let interactions: Vec<&str> = audit["interaction"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|interaction| interaction["code"].as_str())
+        .collect();
+
+    for mutation in ["create", "update", "patch", "delete"] {
+        assert!(!interactions.contains(&mutation));
+    }
+    for flag in [
+        "updateCreate",
+        "conditionalCreate",
+        "conditionalUpdate",
+        "conditionalDelete",
+    ] {
+        assert!(audit.get(flag).is_none(), "{flag} must be omitted");
+    }
+}
+
+#[cfg(all(feature = "R4", any(feature = "R5", feature = "R6")))]
+#[tokio::test]
+async fn direct_update_rejects_a_type_from_another_compiled_version() {
+    let (server, backend) = create_test_server("off", FhirVersion::R4).await;
+    put(
+        &server,
+        "/ActorDefinition/r5-only",
+        json!({ "resourceType": "ActorDefinition", "id": "r5-only" }),
+    )
+    .await
+    .assert_status(StatusCode::BAD_REQUEST);
+    assert!(
+        backend
+            .read(&tenant(), "ActorDefinition", "r5-only")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[cfg(all(feature = "R4", feature = "R6"))]
+#[tokio::test]
+async fn r6_rejects_a_resource_removed_after_r4() {
+    let (server, backend) = create_test_server("off", FhirVersion::R6).await;
+    put(
+        &server,
+        "/Media/r4-only",
+        json!({ "resourceType": "Media", "id": "r4-only" }),
+    )
+    .await
+    .assert_status(StatusCode::BAD_REQUEST);
+    assert!(
+        backend
+            .read(&tenant(), "Media", "r4-only")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -4152,10 +4152,16 @@ textarea.field__input {
    The label names the selected type ("Create new Patient") and can grow long
    (#605) — the button caps its width and truncates the label rather than
    pushing the header row wider than the page. */
-.resources-create {
+.resources-create-wrap {
   flex: 0 1 auto;
   min-width: 0;
   max-width: 320px;
+}
+
+.resources-create {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .resources-create__label {

--- a/crates/ui/assets/resources.js
+++ b/crates/ui/assets/resources.js
@@ -289,6 +289,11 @@
   }
 
   function openNew(type) {
+    if (
+      !type ||
+      root.dataset.createEligible !== "true" ||
+      root.dataset.createTarget !== type
+    ) return;
     current = { type: type, id: "" };
     subject.textContent = type + " · " + "new";
     openModal();
@@ -319,7 +324,7 @@
       // `panel.dataset.selectedType` (the rail's `<aside>`) is the single
       // source of truth for the selected type (#605) — the button carries no
       // type of its own any more.
-      openNew(root.dataset.selectedType || "Patient");
+      openNew(root.dataset.selectedType);
     });
   }
 

--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -1058,6 +1058,10 @@
       });
   }
 
+  function csvHas(csv, value) {
+    return !!value && (csv || "").split(",").indexOf(value) >= 0;
+  }
+
   /* Keeps every type-dependent Resources control on the type parsed from the
    * query URL. Search and Saved Queries share this script and the rail, but do
    * not render the Resources panel or Create button, so those updates are
@@ -1066,11 +1070,35 @@
     markRailType(type);
     var panel = document.getElementById("resources");
     if (!panel) return;
-    panel.dataset.selectedType = type;
+    panel.dataset.selectedType = type || "";
     var createBtn = document.getElementById("resource-create");
-    if (createBtn && createBtn.dataset.msgCreate) {
+    if (createBtn) {
       var label = createBtn.querySelector(".resources-create__label");
-      if (label) label.textContent = createBtn.dataset.msgCreate.replace("{type}", type);
+      if (label) {
+        label.textContent = type
+          ? createBtn.dataset.msgCreate.replace("{type}", type)
+          : createBtn.dataset.msgCreateGeneric;
+      }
+
+      var reason = "";
+      if (panel.dataset.createMetadata !== "available") {
+        reason = panel.dataset.msgCreateMetadataUnavailable;
+      } else if (!csvHas(panel.dataset.createResourceTypes, type)) {
+        reason = panel.dataset.msgCreateInvalid;
+      } else if (!csvHas(panel.dataset.createAdvertisedTypes, type)) {
+        reason = panel.dataset.msgCreateNotAdvertised;
+      } else if (!csvHas(panel.dataset.createSchemaTypes, type)) {
+        reason = panel.dataset.msgCreateSchemaUnavailable;
+      }
+
+      createBtn.disabled = !!reason;
+      panel.dataset.createEligible = reason ? "false" : "true";
+      panel.dataset.createTarget = reason ? "" : type;
+      var reasonEl = document.getElementById("resource-create-reason");
+      if (reasonEl) {
+        reasonEl.textContent = reason;
+        reasonEl.hidden = !reason;
+      }
     }
   }
 
@@ -1111,7 +1139,7 @@
     var parsed = parseSearchUrl(urlInput.value);
     if (!parsed) {
       sections.hidden = true;
-      markRailType(null);
+      syncTypeContext("");
       return;
     }
     // Context sync must precede the echo guard: even a URL whose rows are
@@ -1407,6 +1435,23 @@
       window.history.pushState({}, "", item.getAttribute("href"));
     });
   }
+
+  function locationSearchValue() {
+    var params = new URLSearchParams(window.location.search);
+    if (params.has("url")) return params.get("url") || "";
+    var type = params.get("type");
+    return "/" + (type || "Patient");
+  }
+
+  function restoreLocationContext() {
+    if (!urlInput || !document.getElementById("resources")) return;
+    urlInput.value = "GET " + locationSearchValue().replace(/^GET\s+/i, "");
+    renderBuilder();
+    var parsed = parseSearchUrl(urlInput.value);
+    if (parsed) runSearch(searchPath(parsed.type, parsed.query), false);
+  }
+
+  window.addEventListener("popstate", restoreLocationContext);
   if (railFilter && railList) {
     railFilter.addEventListener("input", function () {
       var needle = railFilter.value.trim().toLowerCase();
@@ -2241,8 +2286,9 @@
 
   /* Deep link: /ui/queries?url=/Patient?name=smith loads the builder and
    * runs immediately — also what saved/recent entries could link to. */
-  var deepLink = new URLSearchParams(window.location.search).get("url");
-  if (deepLink && urlInput) {
+  var locationParams = new URLSearchParams(window.location.search);
+  var deepLink = locationParams.get("url");
+  if (locationParams.has("url") && urlInput) {
     loadIntoBuilder(deepLink.replace(/^GET\s+/i, ""));
     var parsedDeep = parseSearchUrl(urlInput.value);
     if (parsedDeep)
@@ -2254,7 +2300,10 @@
     // since that only fires on an actual rail click (resource-filter.js).
     var initialPanel = document.getElementById("resources");
     if (initialPanel && urlInput) {
-      selectType(initialPanel.dataset.selectedType || "Patient");
+      renderBuilder();
+      var parsedInitial = parseSearchUrl(urlInput.value);
+      if (parsedInitial)
+        runSearch(searchPath(parsedInitial.type, parsedInitial.query), false);
     } else {
       renderBuilder();
     }

--- a/crates/ui/e2e/tests/a11y.spec.ts
+++ b/crates/ui/e2e/tests/a11y.spec.ts
@@ -42,4 +42,19 @@ for (const theme of THEMES) {
       ).toEqual([]);
     });
   }
+
+
+  test(`invalid Resources create state is accessible — ${theme}`, async ({ page, chrome }) => {
+    await chrome.seedTheme(theme);
+    await page.goto("/ui/resources?type=patient", { waitUntil: "networkidle" });
+
+    const create = page.locator("#resource-create");
+    const reason = page.locator("#resource-create-reason");
+    await expect(create).toBeDisabled();
+    await expect(create).toHaveAttribute("aria-describedby", "resource-create-reason");
+    await expect(reason).toBeVisible();
+
+    const { violations } = await new AxeBuilder({ page }).withTags(WCAG).analyze();
+    expect(violations).toEqual([]);
+  });
 }

--- a/crates/ui/e2e/tests/resources-editor.spec.ts
+++ b/crates/ui/e2e/tests/resources-editor.spec.ts
@@ -15,6 +15,18 @@ test("Create new targets the resource type picked in the rail, not always Patien
   await expect(resources.modal.editor.form).toHaveAttribute("data-error-count", /[1-9]/);
 });
 
+test("an encoded HTML-like type stays text and cannot open a draft", async ({ resources, page }) => {
+  const value = "/<img src=x onerror=alert(1)>";
+  await page.goto("/ui/resources?url=" + encodeURIComponent(value), {
+    waitUntil: "networkidle",
+  });
+
+  await expect(resources.builder.url).toHaveValue("GET " + value);
+  await expect(resources.createButton).toBeDisabled();
+  await expect(page.locator("img[src='x']")).toHaveCount(0);
+  await expect(resources.modal.root).toBeHidden();
+});
+
 test("an out-of-value-set code shows a red issue inline in the editor", async ({ resources }) => {
   await resources.goto("Patient");
   await resources.openCreate();

--- a/crates/ui/e2e/tests/resources.spec.ts
+++ b/crates/ui/e2e/tests/resources.spec.ts
@@ -36,6 +36,9 @@ test("picking a rail type updates the URL and back navigates", async ({ resource
 
   await page.goBack();
   await expect(page).toHaveURL(/\/ui\/resources\?type=Patient/);
+  await expect(resources.railItem("Patient")).toHaveAttribute("aria-current", "true");
+  await expect(resources.builder.url).toHaveValue("GET /Patient");
+  await expect(resources.createLabel).toHaveText("Create new Patient");
 });
 
 // Opening in Patient context (#605): the client takes the same path as a
@@ -102,6 +105,64 @@ test("a ?url= deep link still wins over the default Patient context", async ({ r
   await expect(resources.railItem("Observation")).toHaveAttribute("aria-current", "true");
   await expect(resources.createLabel).toHaveText("Create new Observation");
   await resources.results.waitShown();
+});
+
+test("invalid, wrong-case, and empty inputs fail closed without losing the typed query", async ({
+  resources,
+  page,
+}) => {
+  for (const [target, expected] of [
+    ["?type=NoLongerValid", "GET /NoLongerValid"],
+    ["?type=patient", "GET /patient"],
+    ["?url=" + encodeURIComponent("/NoLongerValid?name=kept"), "GET /NoLongerValid?name=kept"],
+    ["?type=Patient&url=" + encodeURIComponent("/NoLongerValid"), "GET /NoLongerValid"],
+  ] as const) {
+    await page.goto("/ui/resources" + target, { waitUntil: "networkidle" });
+    await expect(resources.builder.url).toHaveValue(expected);
+    await expect(resources.createButton).toBeDisabled();
+    await expect(page.locator("#resource-create-reason")).toBeVisible();
+    await expect(page.locator("#type-rail-list [aria-current='true']")).toHaveCount(0);
+  }
+
+  await page.goto("/ui/resources?type=", { waitUntil: "networkidle" });
+  await expect(resources.builder.url).toHaveValue("GET /Patient");
+  await expect(resources.createButton).toBeEnabled();
+});
+
+test("manual URL edits and popstate keep Create on the effective query type", async ({
+  resources,
+  page,
+}) => {
+  await resources.goto("Patient");
+  await resources.builder.url.fill("GET /patient");
+  await resources.builder.url.dispatchEvent("change");
+  await expect(resources.createButton).toBeDisabled();
+  await expect(page.locator("#resources")).toHaveAttribute("data-selected-type", "patient");
+
+  await resources.builder.url.fill("GET /Observation?status=final");
+  await resources.builder.url.dispatchEvent("change");
+  await expect(resources.createButton).toBeEnabled();
+  await expect(resources.railItem("Observation")).toHaveAttribute("aria-current", "true");
+
+  await resources.pickType("Encounter");
+  await page.goBack();
+  await expect(resources.builder.url).toHaveValue("GET /Patient");
+  await expect(resources.createButton).toBeEnabled();
+  await expect(resources.railItem("Patient")).toHaveAttribute("aria-current", "true");
+});
+
+test("openNew refuses a disabled target even if script removes the native disabled flag", async ({
+  resources,
+  page,
+}) => {
+  await page.goto("/ui/resources?type=patient", { waitUntil: "networkidle" });
+  await expect(resources.createButton).toBeDisabled();
+  await resources.createButton.evaluate((button: HTMLButtonElement) => {
+    button.disabled = false;
+    button.click();
+  });
+  await expect(resources.modal.root).toBeHidden();
+  await expect(page.locator("#resource-editor-body")).toBeEmpty();
 });
 
 test("a conflicting Resources bookmark uses the query URL type everywhere after reload", async ({
@@ -210,12 +271,17 @@ test("counts render next to each type from the dashboard snapshot", async ({
     .not.toBe("");
 });
 
-test("every resource type is reachable — Create targets each one", async ({ resources }) => {
+test("every rail type is searchable, while Create opens only eligible targets", async ({ resources }) => {
   await resources.goto("Patient");
   const types = await resources.railTypes();
 
   for (const type of types) {
     await resources.pickType(type);
+    if (await resources.createButton.isDisabled()) {
+      await expect(resources.modal.root).toBeHidden();
+      await expect(resources.page.locator("#resource-create-reason")).toBeVisible();
+      continue;
+    }
     await resources.createButton.click();
     await resources.modal.waitOpen();
     expect(
@@ -224,6 +290,30 @@ test("every resource type is reachable — Create targets each one", async ({ re
     ).toBe(type);
     await resources.modal.closeWithEscape();
   }
+});
+
+test("create eligibility follows the effective FHIR version", async ({ resources }) => {
+  const version = process.env.HFS_DEFAULT_FHIR_VERSION || "R4";
+  const boundary = {
+    R4: { accepted: "Media", rejected: "ActorDefinition" },
+    R4B: { accepted: "SubscriptionTopic", rejected: "ActorDefinition" },
+    R5: { accepted: "ActorDefinition", rejected: "DocumentManifest" },
+    R6: { accepted: "ActorDefinition", rejected: "Media" },
+  }[version];
+  expect(boundary, `No Resources boundary is defined for ${version}`).toBeTruthy();
+
+  await resources.goto(boundary!.accepted);
+  await expect(resources.railItem(boundary!.accepted)).toHaveAttribute("aria-current", "true");
+  await expect(resources.createButton).toBeEnabled();
+  await resources.openCreate();
+  expect((await resources.modal.editor.currentDoc()).resourceType).toBe(boundary!.accepted);
+  await resources.modal.close();
+
+  await resources.goto(boundary!.rejected);
+  await expect(resources.builder.url).toHaveValue(`GET /${boundary!.rejected}`);
+  await expect(resources.createButton).toBeDisabled();
+  await expect(resources.page.locator("#resource-create-reason")).toBeVisible();
+  await expect(resources.page.locator("#type-rail-list [aria-current='true']")).toHaveCount(0);
 });
 
 // "Recently used" group (#603): a per-browser convenience, populated by

--- a/crates/ui/src/capability.rs
+++ b/crates/ui/src/capability.rs
@@ -8,7 +8,113 @@
 //! conformance viewers ([`crate::conformance`]); a failed fetch degrades to a
 //! warning, never to fabricated capabilities.
 
+use helios_fhir::FhirVersion;
+use helios_fhir_validator::{SchemaResolver, editor, packs};
 use serde_json::Value;
+use std::collections::HashSet;
+
+/// Why the Resources workspace cannot create its current resource type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CreateTargetBlock {
+    InvalidType,
+    CreateNotAdvertised,
+    SchemaUnavailable,
+    MetadataUnavailable,
+}
+
+/// The three exact sets that make a Resources create target safe.
+///
+/// Search and the type rail deliberately use the broader `resource_types`
+/// catalog. Creation is narrower: the type must also have a live `create`
+/// interaction and an editor resource schema for the effective FHIR version.
+pub(crate) struct CreateTargets {
+    resource_types: HashSet<String>,
+    advertised_create: HashSet<String>,
+    schema_resources: HashSet<String>,
+}
+
+impl CreateTargets {
+    pub(crate) fn from_statement(
+        resource_types: &[String],
+        statement: &Value,
+        version: FhirVersion,
+    ) -> Result<Self, &'static str> {
+        if str_at(statement, &["resourceType"]) != "CapabilityStatement" {
+            return Err("metadata is not a CapabilityStatement");
+        }
+        if str_at(statement, &["fhirVersion"]) != version.full_version() {
+            return Err("metadata describes a different FHIR version");
+        }
+
+        let server_rest: Vec<&Value> = arr(statement, "rest")
+            .iter()
+            .filter(|rest| str_at(rest, &["mode"]) == "server")
+            .collect();
+        if server_rest.is_empty() {
+            return Err("metadata has no server REST component");
+        }
+
+        let advertised_create = server_rest
+            .into_iter()
+            .flat_map(|rest| arr(rest, "resource"))
+            .filter(|resource| {
+                arr(resource, "interaction")
+                    .iter()
+                    .any(|interaction| str_at(interaction, &["code"]) == "create")
+            })
+            .filter_map(|resource| resource.get("type").and_then(Value::as_str))
+            .map(str::to_string)
+            .collect();
+
+        let registry = packs::core_registry(version);
+        let schema_resources = resource_types
+            .iter()
+            .filter(|resource_type| {
+                registry
+                    .resolve(resource_type)
+                    .is_some_and(|schema| editor::is_resource(&schema))
+            })
+            .cloned()
+            .collect();
+
+        Ok(Self {
+            resource_types: resource_types.iter().cloned().collect(),
+            advertised_create,
+            schema_resources,
+        })
+    }
+
+    pub(crate) fn classify(&self, resource_type: &str) -> Result<(), CreateTargetBlock> {
+        if !self.resource_types.contains(resource_type) {
+            return Err(CreateTargetBlock::InvalidType);
+        }
+        if !self.advertised_create.contains(resource_type) {
+            return Err(CreateTargetBlock::CreateNotAdvertised);
+        }
+        if !self.schema_resources.contains(resource_type) {
+            return Err(CreateTargetBlock::SchemaUnavailable);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn resource_types_csv(&self) -> String {
+        sorted_csv(&self.resource_types)
+    }
+
+    pub(crate) fn advertised_create_csv(&self) -> String {
+        sorted_csv(&self.advertised_create)
+    }
+
+    pub(crate) fn schema_resources_csv(&self) -> String {
+        sorted_csv(&self.schema_resources)
+    }
+}
+
+fn sorted_csv(values: &HashSet<String>) -> String {
+    let mut values: Vec<&str> = values.iter().map(String::as_str).collect();
+    values.sort_unstable();
+    values.join(",")
+}
 
 /// The server-summary block: identity fields lifted off the statement root.
 pub(crate) struct CapabilitySummary {
@@ -165,6 +271,7 @@ mod tests {
             "format": ["application/fhir+json"],
             "implementation": {"description": "Helios FHIR Server", "url": "http://x/"},
             "rest": [{
+                "mode": "server",
                 "interaction": [{"code": "batch"}, {"code": "transaction"}],
                 "operation": [
                     {"name": "export", "definition": "http://x/OperationDefinition/export"},
@@ -210,5 +317,148 @@ mod tests {
         let empty = build_view(&json!({}));
         assert!(empty.resources.is_empty());
         assert!(empty.summary.fhir_version.is_empty());
+    }
+
+    #[test]
+    #[cfg(feature = "R4")]
+    fn create_targets_require_catalog_capability_and_resource_schema() {
+        let types = vec!["Patient".to_string(), "Observation".to_string()];
+        let statement = json!({
+            "resourceType": "CapabilityStatement",
+            "fhirVersion": "4.0.1",
+            "rest": [{"mode": "server", "resource": [
+                {"type": "Patient", "interaction": [{"code": "create"}]},
+                {"type": "Observation", "interaction": [{"code": "read"}]},
+                {"type": "HumanName", "interaction": [{"code": "create"}]}
+            ]}]
+        });
+        let targets = CreateTargets::from_statement(&types, &statement, FhirVersion::R4).unwrap();
+
+        assert_eq!(targets.classify("Patient"), Ok(()));
+        assert_eq!(
+            targets.classify("Observation"),
+            Err(CreateTargetBlock::CreateNotAdvertised)
+        );
+        assert_eq!(
+            targets.classify("patient"),
+            Err(CreateTargetBlock::InvalidType)
+        );
+        assert_eq!(
+            targets.classify("HumanName"),
+            Err(CreateTargetBlock::InvalidType)
+        );
+    }
+
+    #[test]
+    fn classifies_an_advertised_type_without_an_editor_schema() {
+        let targets = CreateTargets {
+            resource_types: HashSet::from(["CustomResource".to_string()]),
+            advertised_create: HashSet::from(["CustomResource".to_string()]),
+            schema_resources: HashSet::new(),
+        };
+        assert_eq!(
+            targets.classify("CustomResource"),
+            Err(CreateTargetBlock::SchemaUnavailable)
+        );
+    }
+
+    fn assert_core_target(version: FhirVersion, resource_type: &str) {
+        let types = vec![resource_type.to_string()];
+        let statement = json!({
+            "resourceType": "CapabilityStatement",
+            "fhirVersion": version.full_version(),
+            "rest": [{"mode": "server", "resource": [{
+                "type": resource_type,
+                "interaction": [{"code": "create"}]
+            }]}]
+        });
+        assert_eq!(
+            CreateTargets::from_statement(&types, &statement, version)
+                .unwrap()
+                .classify(resource_type),
+            Ok(())
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "R4")]
+    fn rejects_malformed_wrong_version_and_non_server_metadata() {
+        let types = vec!["Patient".to_string()];
+        for statement in [
+            json!({}),
+            json!({
+                "resourceType": "Bundle",
+                "fhirVersion": "4.0.1",
+                "rest": [{"mode": "server"}]
+            }),
+            json!({
+                "resourceType": "CapabilityStatement",
+                "rest": [{"mode": "server"}]
+            }),
+            json!({
+                "resourceType": "CapabilityStatement",
+                "fhirVersion": "5.0.0",
+                "rest": [{"mode": "server"}]
+            }),
+            json!({
+                "resourceType": "CapabilityStatement",
+                "fhirVersion": "4.0.1",
+                "rest": [{"resource": []}]
+            }),
+            json!({
+                "resourceType": "CapabilityStatement",
+                "fhirVersion": "4.0.1",
+                "rest": [{"mode": "", "resource": []}]
+            }),
+            json!({
+                "resourceType": "CapabilityStatement",
+                "fhirVersion": "4.0.1",
+                "rest": [{"mode": "client", "resource": [{
+                    "type": "Patient", "interaction": [{"code": "create"}]
+                }]}]
+            }),
+        ] {
+            assert!(
+                CreateTargets::from_statement(&types, &statement, FhirVersion::R4).is_err(),
+                "metadata should be rejected: {statement}"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "R4")]
+    fn ignores_create_interactions_from_client_rest_components() {
+        let types = vec!["Patient".to_string(), "Observation".to_string()];
+        let statement = json!({
+            "resourceType": "CapabilityStatement",
+            "fhirVersion": "4.0.1",
+            "rest": [
+                {"mode": "client", "resource": [{
+                    "type": "Observation", "interaction": [{"code": "create"}]
+                }]},
+                {"mode": "server", "resource": [{
+                    "type": "Patient", "interaction": [{"code": "create"}]},
+                    {"type": "Observation", "interaction": [{"code": "read"}]}
+                ]}
+            ]
+        });
+        let targets = CreateTargets::from_statement(&types, &statement, FhirVersion::R4).unwrap();
+        assert_eq!(targets.classify("Patient"), Ok(()));
+        assert_eq!(
+            targets.classify("Observation"),
+            Err(CreateTargetBlock::CreateNotAdvertised)
+        );
+    }
+
+    #[test]
+    fn representative_version_specific_resources_resolve_in_their_pack() {
+        #[cfg(feature = "R4")]
+        assert_core_target(FhirVersion::R4, "Media");
+        #[cfg(feature = "R4B")]
+        assert_core_target(FhirVersion::R4B, "Media");
+        #[cfg(feature = "R5")]
+        assert_core_target(FhirVersion::R5, "ActorDefinition");
+        #[cfg(feature = "R6")]
+        assert_core_target(FhirVersion::R6, "ActorDefinition");
     }
 }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -632,6 +632,13 @@ struct ResourcesPage {
     docs_url: &'static str,
     resource_types: Vec<String>,
     selected_type: String,
+    create_label: String,
+    create_disabled: bool,
+    create_reason: String,
+    create_resource_types: String,
+    create_advertised_types: String,
+    create_schema_types: String,
+    create_metadata_available: bool,
     /// The search-builder partial's save controls are the Saved Queries page's
     /// job, not this one's.
     show_save: bool,
@@ -1461,8 +1468,41 @@ async fn resources(
     Query(query): Query<ResourcesQuery>,
 ) -> Response {
     let resource_types = state.compartments.resource_type_names(&rt.id, rv.0).await;
-    // The type the rail opens focused on (from the nav submenu deep link).
-    let selected_type = query.resource_type.unwrap_or_else(|| "Patient".to_string());
+    // `url` is the builder's actual query, so it wins over the convenience
+    // `type` bookmark. Parse it here too: Create must be safe before the
+    // deferred client script hydrates the page.
+    let (selected_type, builder_url) = resources_query_context(&query);
+    let targets = match state.conformance.metadata(rv.0, &rt.id).await {
+        Ok(statement) => {
+            match capability::CreateTargets::from_statement(&resource_types, &statement, rv.0) {
+                Ok(targets) => Some(targets),
+                Err(error) => {
+                    tracing::warn!("Resources create-target metadata rejected: {error}");
+                    None
+                }
+            }
+        }
+        Err(error) => {
+            tracing::warn!("Resources create-target metadata fetch failed: {error}");
+            None
+        }
+    };
+    let block = targets
+        .as_ref()
+        .map_or(
+            Err(capability::CreateTargetBlock::MetadataUnavailable),
+            |targets| targets.classify(&selected_type),
+        )
+        .err();
+    let i18n = I18n::new(locale);
+    let create_reason = block
+        .map(|block| create_target_reason(&i18n, block))
+        .unwrap_or_default();
+    let create_label = if selected_type.is_empty() {
+        i18n.t("resources-create")
+    } else {
+        i18n.t_arg("resources-create-typed", "type", selected_type.clone())
+    };
     let live =
         helios_observability::dashboard::snapshot(DashboardWindow::default(), &rt.id, &[], false)
             .await;
@@ -1472,15 +1512,30 @@ async fn resources(
         live.as_ref().map(|s| s.available.as_slice()),
         Some(selected_type.as_str()),
     );
-    let builder_url = Some(format!("/{selected_type}"));
     render(ResourcesPage {
         status: current_status(&state, rv.0, &rt),
-        i18n: I18n::new(locale),
+        i18n,
         active_page: "resources",
         nl: (*state.nl).clone(),
         docs_url: NL_SEARCH_DOCS,
         resource_types,
         selected_type,
+        create_label,
+        create_disabled: block.is_some(),
+        create_reason,
+        create_resource_types: targets
+            .as_ref()
+            .map(capability::CreateTargets::resource_types_csv)
+            .unwrap_or_default(),
+        create_advertised_types: targets
+            .as_ref()
+            .map(capability::CreateTargets::advertised_create_csv)
+            .unwrap_or_default(),
+        create_schema_types: targets
+            .as_ref()
+            .map(capability::CreateTargets::schema_resources_csv)
+            .unwrap_or_default(),
+        create_metadata_available: targets.is_some(),
         show_save: false,
         rail_entries,
         builder_url,
@@ -1508,6 +1563,61 @@ async fn terminology_page(
 struct ResourcesQuery {
     #[serde(rename = "type")]
     resource_type: Option<String>,
+    url: Option<String>,
+}
+
+fn resources_query_context(query: &ResourcesQuery) -> (String, Option<String>) {
+    if let Some(raw_url) = &query.url {
+        let visible = raw_url
+            .trim()
+            .strip_prefix("GET ")
+            .or_else(|| raw_url.trim().strip_prefix("get "))
+            .unwrap_or(raw_url.trim())
+            .to_string();
+        return (
+            resource_type_from_search_url(&visible).unwrap_or_default(),
+            Some(visible),
+        );
+    }
+
+    let selected = query
+        .resource_type
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("Patient")
+        .to_string();
+    (selected.clone(), Some(format!("/{selected}")))
+}
+
+fn resource_type_from_search_url(raw: &str) -> Option<String> {
+    let mut value = raw.trim();
+    if let Some(after_scheme) = value
+        .strip_prefix("http://")
+        .or_else(|| value.strip_prefix("https://"))
+    {
+        value = after_scheme.find('/').map(|index| &after_scheme[index..])?;
+    }
+    let path = value.split_once('?').map_or(value, |(path, _)| path);
+    let resource_type = path.strip_prefix('/').unwrap_or(path);
+    if resource_type.is_empty()
+        || resource_type.contains('/')
+        || !resource_type.chars().all(|c| c.is_ascii_alphabetic())
+    {
+        return None;
+    }
+    Some(resource_type.to_string())
+}
+
+fn create_target_reason(i18n: &I18n, block: capability::CreateTargetBlock) -> String {
+    let key = match block {
+        capability::CreateTargetBlock::InvalidType => "resources-create-invalid-type",
+        capability::CreateTargetBlock::CreateNotAdvertised => "resources-create-not-advertised",
+        capability::CreateTargetBlock::SchemaUnavailable => "resources-create-schema-unavailable",
+        capability::CreateTargetBlock::MetadataUnavailable => {
+            "resources-create-metadata-unavailable"
+        }
+    };
+    i18n.t(key)
 }
 
 #[derive(Deserialize, Default)]

--- a/crates/ui/templates/pages/resources.html
+++ b/crates/ui/templates/pages/resources.html
@@ -19,16 +19,32 @@
     <h1 class="page-head__title">{{ i18n.t("resources-heading") }}</h1>
     <p class="page-head__lede" id="resources-subtitle">{{ i18n.t("resources-lede") }}</p>
   </div>
-  <button type="button" class="btn btn--primary resources-create" id="resource-create"
-          data-msg-create="{{ i18n.t_arg("resources-create-typed", "type", "{type}".to_string()) }}">
-    <span class="icon">{% include "icons/plus.svg" %}</span>
-    <span class="resources-create__label">{{ i18n.t_arg("resources-create-typed", "type", selected_type.clone()) }}</span>
-  </button>
+  <div class="resources-create-wrap">
+    <button type="button" class="btn btn--primary resources-create" id="resource-create"
+            aria-describedby="resource-create-reason"
+            data-msg-create="{{ i18n.t_arg("resources-create-typed", "type", "{type}".to_string()) }}"
+            data-msg-create-generic="{{ i18n.t("resources-create") }}"
+            {% if create_disabled %}disabled{% endif %}>
+      <span class="icon">{% include "icons/plus.svg" %}</span>
+      <span class="resources-create__label">{{ create_label }}</span>
+    </button>
+    <p class="field__hint" id="resource-create-reason" {% if create_reason.is_empty() %}hidden{% endif %}>{{ create_reason }}</p>
+  </div>
 </section>
 
 <div class="queries-layout search-page" data-mode="{% if nl.configured %}nl{% else %}builder{% endif %}">
   <aside class="filter-rail" id="resources" aria-label="{{ i18n.t("queries-rail-heading") }}"
-         data-selected-type="{{ selected_type }}">
+         data-selected-type="{{ selected_type }}"
+         data-create-eligible="{% if create_disabled %}false{% else %}true{% endif %}"
+         data-create-target="{% if create_disabled %}{% else %}{{ selected_type }}{% endif %}"
+         data-create-metadata="{% if create_metadata_available %}available{% else %}unavailable{% endif %}"
+         data-create-resource-types="{{ create_resource_types }}"
+         data-create-advertised-types="{{ create_advertised_types }}"
+         data-create-schema-types="{{ create_schema_types }}"
+         data-msg-create-invalid="{{ i18n.t("resources-create-invalid-type") }}"
+         data-msg-create-not-advertised="{{ i18n.t("resources-create-not-advertised") }}"
+         data-msg-create-schema-unavailable="{{ i18n.t("resources-create-schema-unavailable") }}"
+         data-msg-create-metadata-unavailable="{{ i18n.t("resources-create-metadata-unavailable") }}">
     <div class="filter-rail__heading">{{ i18n.t("resources-types-heading") }}</div>
     <div class="filter-rail__search">
       <span class="icon">{% include "icons/search.svg" %}</span>

--- a/crates/ui/tests/i18n_http.rs
+++ b/crates/ui/tests/i18n_http.rs
@@ -30,6 +30,34 @@ fn app() -> Router {
     )
 }
 
+fn resources_app() -> Router {
+    let source = helios_ui::StaticConformanceSource::empty().with_metadata(serde_json::json!({
+        "resourceType": "CapabilityStatement",
+        "fhirVersion": "4.0.1",
+        "rest": [{"mode": "server", "resource": [{
+            "type": "Patient",
+            "interaction": [{"code": "create"}]
+        }]}]
+    }));
+    helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        None,
+        helios_ui::NlSearch {
+            enabled: true,
+            configured: true,
+            model: "test-model".to_string(),
+        },
+        None,
+        None,
+        "default".to_string(),
+        std::sync::Arc::new(source),
+        helios_fhir::FhirVersion::R4,
+        None,
+        "http://localhost:8080".to_string(),
+    )
+}
+
 async fn body_text(response: axum::response::Response) -> String {
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     String::from_utf8(bytes.to_vec()).unwrap()
@@ -133,7 +161,7 @@ async fn resources_create_label_names_the_selected_type_per_locale() {
         ("es", "Crear Patient"),
         ("de", "Patient erstellen"),
     ] {
-        let response = app()
+        let response = resources_app()
             .oneshot(
                 Request::get(format!("/ui/resources?lang={lang}"))
                     .body(Body::empty())
@@ -146,6 +174,27 @@ async fn resources_create_label_names_the_selected_type_per_locale() {
             html.contains(sentence),
             "{lang} resources page must contain {sentence:?}, got: {html}"
         );
+    }
+}
+
+#[tokio::test]
+async fn resources_create_block_reason_is_localized() {
+    for (lang, sentence) in [
+        ("en", "not available in the selected FHIR version"),
+        ("es", "no está disponible en la versión FHIR seleccionada"),
+        ("de", "ist in der ausgewählten FHIR-Version nicht verfügbar"),
+    ] {
+        let response = resources_app()
+            .oneshot(
+                Request::get(format!("/ui/resources?lang={lang}&type=patient"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = body_text(response).await;
+        assert!(html.contains(sentence), "missing {lang} reason: {html}");
+        assert!(html.contains(r#"data-create-eligible="false""#));
     }
 }
 

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -86,6 +86,46 @@ fn app_with(nl: helios_ui::NlSearch) -> Router {
     )
 }
 
+fn resources_app_with_metadata(resources: &[(&str, bool)]) -> Router {
+    let rows: Vec<Value> = resources
+        .iter()
+        .map(|(resource_type, create)| {
+            serde_json::json!({
+                "type": resource_type,
+                "interaction": if *create {
+                    serde_json::json!([{"code": "read"}, {"code": "create"}])
+                } else {
+                    serde_json::json!([{"code": "read"}])
+                }
+            })
+        })
+        .collect();
+    resources_app_with_statement(serde_json::json!({
+        "resourceType": "CapabilityStatement",
+        "fhirVersion": "4.0.1",
+        "rest": [{"mode": "server", "resource": rows}]
+    }))
+}
+
+fn resources_app_with_statement(statement: Value) -> Router {
+    let source =
+        helios_ui::StaticConformanceSource::from_data_dir(std::path::Path::new("../../data"))
+            .with_metadata(statement);
+    helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        Some(std::path::PathBuf::from("../../data")),
+        nl(true, true),
+        None,
+        None,
+        "default".to_string(),
+        Arc::new(source),
+        helios_fhir::FhirVersion::R4,
+        None,
+        "http://localhost:8080".to_string(),
+    )
+}
+
 fn app_with_body_limit(max_body_size: usize) -> Router {
     helios_ui::mount_with_conformance_source_and_body_limit(
         Router::new(),
@@ -362,6 +402,7 @@ async fn capability_statement_page_renders_summary_and_degrades() {
         "format": ["application/fhir+json"],
         "implementation": {"description": "Helios FHIR Server", "url": "http://t/"},
         "rest": [{
+            "mode": "server",
             "interaction": [{"code": "batch"}, {"code": "transaction"}],
             "operation": [{"name": "export", "definition": "http://t/OperationDefinition/export"}],
             "resource": [
@@ -1072,7 +1113,7 @@ async fn unparseable_versions_report_an_error_not_an_empty_diff() {
 
 #[tokio::test]
 async fn resources_page_has_the_filter_search_and_create_button() {
-    let response = app()
+    let response = resources_app_with_metadata(&[("Patient", true), ("Observation", true)])
         .oneshot(Request::get("/ui/resources").body(Body::empty()).unwrap())
         .await
         .unwrap();
@@ -1083,6 +1124,7 @@ async fn resources_page_has_the_filter_search_and_create_button() {
     assert!(html.contains(r#"id="type-rail-list""#));
     assert!(html.contains(r#"id="saved-query-form""#));
     assert!(html.contains(r#"id="resource-create""#));
+    assert!(html.contains(r#"data-create-eligible="true""#));
     // The Create button names the selected type (#605), defaulting to
     // Patient, and the builder's URL is pre-filled so the no-JS form already
     // shows the query the client also runs on load.
@@ -1119,7 +1161,7 @@ async fn resources_page_has_the_filter_search_and_create_button() {
 
 #[tokio::test]
 async fn resources_deep_links_focus_the_selected_type() {
-    let response = app()
+    let response = resources_app_with_metadata(&[("Patient", true), ("Observation", true)])
         .oneshot(
             Request::get("/ui/resources?type=Observation")
                 .body(Body::empty())
@@ -1149,6 +1191,110 @@ async fn resources_deep_links_focus_the_selected_type() {
     // Create and the builder prefill both follow the deep-linked type.
     assert!(html.contains("Create new Observation"));
     assert!(html.contains(r#"value="GET /Observation""#));
+}
+
+#[tokio::test]
+async fn resources_fail_closed_for_metadata_and_non_create_capabilities() {
+    let response = app()
+        .oneshot(Request::get("/ui/resources").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(html.contains(r#"id="resource-create""#));
+    assert!(html.contains("Server capabilities are unavailable"));
+    assert!(html.contains(r#"data-create-metadata="unavailable""#));
+    assert!(html.contains(r#"data-create-eligible="false""#));
+
+    let response = resources_app_with_metadata(&[("Patient", false)])
+        .oneshot(Request::get("/ui/resources").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(html.contains("does not allow creating this resource type"));
+    assert!(html.contains(r#"data-create-eligible="false""#));
+
+    for statement in [
+        serde_json::json!({"resourceType": "CapabilityStatement"}),
+        serde_json::json!({
+            "resourceType": "CapabilityStatement",
+            "fhirVersion": "5.0.0",
+            "rest": [{"mode": "server", "resource": [{
+                "type": "Patient", "interaction": [{"code": "create"}]
+            }]}]
+        }),
+        serde_json::json!({
+            "resourceType": "CapabilityStatement",
+            "fhirVersion": "4.0.1",
+            "rest": [{"mode": "client", "resource": [{
+                "type": "Patient", "interaction": [{"code": "create"}]
+            }]}]
+        }),
+    ] {
+        let response = resources_app_with_statement(statement)
+            .oneshot(Request::get("/ui/resources").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let html = body_text(response).await;
+        assert!(html.contains("Server capabilities are unavailable"));
+        assert!(html.contains(r#"data-create-metadata="unavailable""#));
+        assert!(html.contains(r#"data-create-eligible="false""#));
+    }
+}
+
+#[tokio::test]
+async fn resources_preserve_invalid_inputs_and_url_wins_over_type() {
+    let app = resources_app_with_metadata(&[("Patient", true), ("Observation", true)]);
+
+    for path in [
+        "/ui/resources?type=patient",
+        "/ui/resources?type=NoLongerValid",
+        "/ui/resources?type=",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let html = body_text(response).await;
+        if path.ends_with("type=") {
+            assert!(html.contains(r#"data-selected-type="Patient""#));
+            assert!(html.contains(r#"data-create-eligible="true""#));
+        } else {
+            assert!(html.contains("not available in the selected FHIR version"));
+            assert!(html.contains(r#"data-create-eligible="false""#));
+        }
+    }
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/ui/resources?type=Observation&url=%2FPatient%3Fname%3DSmith")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(html.contains(r#"data-selected-type="Patient""#));
+    assert!(html.contains(r#"value="GET /Patient?name=Smith""#));
+    assert!(html.contains(r#"data-create-target="Patient""#));
+
+    let response = app
+        .oneshot(
+            Request::get("/ui/resources?url=%2F%3Cimg%20src%3Dx%20onerror%3Dalert%281%29%3E")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(
+        html.contains("onerror"),
+        "the editable value must remain visible"
+    );
+    assert!(!html.contains("<img src=x"), "the value must stay escaped");
+    assert!(html.contains(r#"data-selected-type="""#));
+    assert!(html.contains(r#"data-create-eligible="false""#));
 }
 
 #[tokio::test]

--- a/docs/resources-create-targets.md
+++ b/docs/resources-create-targets.md
@@ -1,0 +1,47 @@
+# Resources create targets
+
+The Resources workspace keeps search and creation separate. A type can remain
+in the rail and query builder even when the UI cannot create it.
+
+Create is enabled only when the type passes all three checks for the request's
+effective FHIR version:
+
+1. The compiled resource catalog contains the exact, case-sensitive type.
+2. The live, tenant-scoped `CapabilityStatement` advertises a `create`
+   interaction for that type.
+3. The editor's core schema registry resolves the type to a resource schema.
+
+The UI fetches `/metadata` through its authenticated loopback client. If that
+request fails, creation stays disabled. Unknown types, types from another FHIR
+version, read-only resources, and types without an editor schema also stay
+disabled. The page keeps the typed query visible so the user can correct it.
+The `url` query parameter supplies the effective type when both `url` and
+`type` are present.
+
+This rule uses the compiled core schema pack on purpose. HFS can include
+built-in extensions such as `ViewDefinition` in its compiled resource catalog;
+they are eligible when the same binary also has their editor schema and
+advertises `create`. Tenant-defined additional resources are different. FHIR
+R6 allows a server to advertise them through
+`CapabilityStatement.rest.resource.definition` and a `StructureDefinition`,
+but the current editor does not load tenant-defined resource schemas. Those
+resources may be searchable, but the Resources workspace will not create them
+until it can resolve the matching runtime schema.
+
+## Resource names and path-based tenants
+
+HFS reserves every resource name from every FHIR version compiled into the
+binary, using a case-insensitive comparison for the first URL path segment.
+This keeps a resource path from being mistaken for a tenant when the selected
+FHIR version does not contain that resource. It also means a path-based tenant
+whose id matches any compiled resource name can no longer be addressed through
+`/{tenant}/...`.
+
+Operators with such a tenant can select it through the `X-Tenant-ID` header and
+use ordinary FHIR resource paths, or migrate its data to a tenant id that does
+not collide with a compiled resource name. HFS does not rename tenant data
+automatically.
+
+`ViewDefinition` remains HFS's compiled extension to the resource set.
+Its advertised definition and version alignment need a separate decision if
+HFS moves it to the same runtime-definition model as R6 additional resources.

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -511,7 +511,12 @@ editor-versions-none = Keine früheren Versionen.
 
 resources-heading = Ressourcen
 resources-lede = FHIR-Ressourcen durchsuchen, suchen, erstellen und bearbeiten. In natürlicher Sprache suchen oder die Abfrage selbst bauen, dann ein Ergebnis zum Bearbeiten öffnen.
+resources-create = Ressource erstellen
 resources-create-typed = { $type } erstellen
+resources-create-invalid-type = Dieser Ressourcentyp ist in der ausgewählten FHIR-Version nicht verfügbar. Korrigieren Sie die Abfrage oder wählen Sie einen Typ aus der Liste.
+resources-create-not-advertised = Dieser Server erlaubt das Erstellen dieses Ressourcentyps nicht. Sie können ihn weiterhin durchsuchen.
+resources-create-schema-unavailable = Für diesen Ressourcentyp gibt es in der ausgewählten FHIR-Version kein Editorschema. Die UI kann ihn deshalb nicht sicher erstellen.
+resources-create-metadata-unavailable = Die Serverfähigkeiten sind nicht verfügbar. Das Erstellen bleibt deaktiviert, bis die UI sie prüfen kann.
 resources-save-blocked = Beheben Sie die Validierungsprobleme vor dem Speichern.
 resources-save-invalid = Das JSON ist ungültig — beheben Sie es vor dem Speichern.
 resources-edit-title = Ressource bearbeiten

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -514,7 +514,12 @@ editor-versions-none = No prior versions.
 
 resources-heading = Resources
 resources-lede = Browse, search, create, and edit FHIR resources. Search in natural language or build the query by hand, then open any result to edit it.
+resources-create = Create new resource
 resources-create-typed = Create new { $type }
+resources-create-invalid-type = This resource type is not available in the selected FHIR version. Correct the query or choose a type from the list.
+resources-create-not-advertised = This server does not allow creating this resource type. You can still search it.
+resources-create-schema-unavailable = This resource type has no editor schema in the selected FHIR version, so the UI cannot create it safely.
+resources-create-metadata-unavailable = Server capabilities are unavailable. Creation stays disabled until the UI can verify them.
 resources-save-blocked = Fix the validation issues before saving.
 resources-save-invalid = The JSON is not valid — fix it before saving.
 resources-edit-title = Edit Resource

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -511,7 +511,12 @@ editor-versions-none = Sin versiones anteriores.
 
 resources-heading = Recursos
 resources-lede = Explora, busca, crea y edita recursos FHIR. Busca en lenguaje natural o arma la consulta a mano, y abre cualquier resultado para editarlo.
+resources-create = Crear recurso
 resources-create-typed = Crear { $type }
+resources-create-invalid-type = Este tipo de recurso no está disponible en la versión FHIR seleccionada. Corrige la consulta o elige un tipo de la lista.
+resources-create-not-advertised = Este servidor no permite crear este tipo de recurso. Aún puedes buscarlo.
+resources-create-schema-unavailable = Este tipo de recurso no tiene un esquema de edición en la versión FHIR seleccionada, por lo que la UI no puede crearlo de forma segura.
+resources-create-metadata-unavailable = Las capacidades del servidor no están disponibles. La creación seguirá desactivada hasta que la UI pueda verificarlas.
 resources-save-blocked = Corrige los problemas de validación antes de guardar.
 resources-save-invalid = El JSON no es válido — corrígelo antes de guardar.
 resources-edit-title = Editar recurso


### PR DESCRIPTION
## Summary

- Reject unknown, wrong-case, wrong-version, missing, and mismatched resource types before validation or persistence.
- Apply the same admission rules to direct writes, batch entries, and transaction preflight while preserving batch independence and transaction atomicity.
- Keep `AuditEvent` immutable across direct, conditional, batch, and transaction mutation paths, and stop advertising unsupported mutations.
- Make the Resources UI enable Create only when the effective-version catalog, live server capability, and editor schema all agree.
- Preserve invalid query values visibly, make `url` authoritative over `type`, and keep rail, builder, Create label, and browser history synchronized.
- Add version-specific CI coverage and document compiled extensions, R6 additional resources, and resource-name collisions with path-based tenant ids.

## Verification

- `cargo test -p helios-rest --test resource_type_validation`
- `cargo test -p helios-rest --test batch_conformance`
- `cargo test -p helios-rest`
- `cargo test -p helios-ui`
- `cargo test -p helios-rest --lib fhir_types::tests --features R4,R4B,R5,R6,sqlite`
- Resources/editor/accessibility browser suites
- R4, R4B, R5, and R6 create-eligibility browser matrix
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #636.
