### PR TITLE
fix(fhirpath): valueless primitives are empty input to value functions and comparisons

### DIFF
--- a/crates/fhirpath/src/evaluator.rs
+++ b/crates/fhirpath/src/evaluator.rs
@@ -3306,6 +3306,20 @@ fn apply_regex_flags(builder: &mut RegexBuilder, flags: &str) {
     }
 }
 
+/// A FHIR primitive element that carries extensions but no value (e.g. a
+/// data-absent-reason extension). The element exists in the tree, but it has
+/// no system value, so functions that consume the value must see an empty
+/// collection as their input (tests-fhir-r5.xml `primitivesWithoutValue`).
+fn is_valueless_element(value: &EvaluationResult) -> bool {
+    matches!(
+        value,
+        EvaluationResult::Object {
+            type_info: Some(ti),
+            ..
+        } if ti.name == "Element"
+    )
+}
+
 /// Calls a standard FHIRPath function (that doesn't take a lambda).
 fn call_function(
     name: &str,
@@ -3314,6 +3328,16 @@ fn call_function(
     // Add context parameter here, as call_function is called from evaluate_invocation which has context
     context: &EvaluationContext,
 ) -> Result<EvaluationResult, EvaluationError> {
+    let invocation_base = match name {
+        "length" | "toChars" | "substring" | "upper" | "lower" | "indexOf" | "contains"
+        | "startsWith" | "endsWith" | "matches" | "matchesFull" | "replace" | "replaceMatches"
+        | "trim" | "split" | "encode" | "decode"
+            if is_valueless_element(invocation_base) =>
+        {
+            &EvaluationResult::Empty
+        }
+        _ => invocation_base,
+    };
     match name {
         "is" | "as" => {
             if args.len() != 1 {
@@ -8088,6 +8112,11 @@ fn compare_inequality(
     // Handle empty operands: comparison with empty returns empty
     if left == &EvaluationResult::Empty || right == &EvaluationResult::Empty {
         return Ok(EvaluationResult::Empty); // Return Ok(Empty)
+    }
+    // A primitive element with extensions but no value has no system value to
+    // compare: treat it as empty
+    if is_valueless_element(left) || is_valueless_element(right) {
+        return Ok(EvaluationResult::Empty);
     }
 
     // Check for collection vs singleton comparison (error)

--- a/crates/fhirpath/tests/data/r5/tests-fhir-r5.xml
+++ b/crates/fhirpath/tests/data/r5/tests-fhir-r5.xml
@@ -1768,6 +1768,53 @@ Any text enclosed within is ignored
 		</test>
 	</group>
 
+	<group name="primitivesWithoutValue" description="FHIR primitive elements that carry extensions but no value (e.g. the data-absent-reason extension). Such an element is present in the tree, but it has no system value, so functions that need the value get an empty collection as input, and return empty (see hasValue()/getValue() in the FHIR spec)">
+		<test name="testNoValueExists" testing="exists" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().exists()</expression>
+			<output type="boolean">true</output>
+		</test>
+		<test name="testNoValueExistsElement" testing="exists" inputfile="patient-name-extensions.json" mode="element">
+			<expression>Patient.name.given.first().exists()</expression>
+			<output type="boolean">true</output>
+		</test>
+		<test name="testNoValueHasValue" testing="hasValue" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().hasValue()</expression>
+			<output type="boolean">false</output>
+		</test>
+		<test name="testNoValueLength" testing="length" inputfile="patient-name-extensions.json">
+			<!-- no value means no string to take the length of: empty in, empty out -->
+			<expression>Patient.name.given.first().length()</expression>
+		</test>
+		<test name="testNoValueLengthElement" testing="length" inputfile="patient-name-extensions.json" mode="element">
+			<expression>Patient.name.given.first().length()</expression>
+		</test>
+		<test name="testValueLength" testing="length" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.last().length()</expression>
+			<output type="integer">5</output>
+		</test>
+		<test name="testNoValueToChars" testing="toChars" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().toChars()</expression>
+		</test>
+		<test name="testNoValueSubstring" testing="substring" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().substring(0, 1)</expression>
+		</test>
+		<test name="testNoValueUpper" testing="upper" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().upper()</expression>
+		</test>
+		<test name="testNoValueComparison" testing="comparison" inputfile="patient-name-extensions.json">
+			<!-- comparing with something that has no value is comparing with empty -->
+			<expression>Patient.name.given.first() &lt; 'x'</expression>
+		</test>
+		<test name="testNoValueInvariant" testing="length" inputfile="patient-name-extensions.json">
+			<!-- the pattern used by invariants that check the length of a name part: exists() is true, but
+			     length() is empty, so the whole expression is empty (and therefore not true) -->
+			<expression>Patient.name.given.first().exists() and Patient.name.given.first().length() = 1</expression>
+		</test>
+		<test name="testNoValueInvariantElement" testing="length" inputfile="patient-name-extensions.json" mode="element">
+			<expression>Patient.name.given.first().exists() and Patient.name.given.first().length() = 1</expression>
+		</test>
+	</group>
+
   <group name="cdaTests">
 		<test name="testHasTemplateId1" mode="cda" inputfile="ccda.json"><expression>hasTemplateIdOf('http://hl7.org/cda/us/ccda/StructureDefinition/ContinuityofCareDocumentCCD')</expression><output type="boolean">true</output></test>
 		<test name="testHasTemplateId2" mode="cda" inputfile="ccda.json"><expression>ClinicalDocument.hasTemplateIdOf('http://hl7.org/cda/us/ccda/StructureDefinition/ContinuityofCareDocumentCCD')</expression><output type="boolean">true</output></test>

--- a/crates/fhirpath/tests/valueless_primitive_tests.rs
+++ b/crates/fhirpath/tests/valueless_primitive_tests.rs
@@ -1,0 +1,118 @@
+// A FHIR primitive element that carries extensions but no value exists in the
+// tree, but has no system value: value-consuming functions receive an empty
+// collection and return empty, and ordering comparisons yield empty
+// (tests-fhir-r5.xml `primitivesWithoutValue`).
+
+use helios_fhir::FhirResource;
+use helios_fhir::r4::Patient;
+use helios_fhirpath::{EvaluationContext, evaluate_expression};
+use helios_fhirpath_support::EvaluationResult;
+use serde_json::json;
+
+fn valueless_given_context() -> EvaluationContext {
+    let patient_json = json!({
+        "resourceType": "Patient",
+        "id": "example",
+        "name": [
+            {
+                "use": "maiden",
+                "family": "Windsor",
+                "given": [null, "James"],
+                "_given": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://example.org/syllable-count",
+                                "valueString": "five"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    });
+
+    let patient: Patient = serde_json::from_value(patient_json).unwrap();
+    let resource = FhirResource::R4(Box::new(helios_fhir::r4::Resource::Patient(Box::new(
+        patient,
+    ))));
+    EvaluationContext::new(vec![resource])
+}
+
+#[test]
+fn valueless_element_is_present_but_has_no_value() {
+    let ctx = valueless_given_context();
+    assert_eq!(
+        evaluate_expression("Patient.name.given.first().exists()", &ctx).unwrap(),
+        EvaluationResult::boolean(true)
+    );
+    assert_eq!(
+        evaluate_expression("Patient.name.given.first().hasValue()", &ctx).unwrap(),
+        EvaluationResult::boolean(false)
+    );
+    assert_eq!(
+        evaluate_expression("Patient.name.given.last().length()", &ctx).unwrap(),
+        EvaluationResult::integer(5)
+    );
+}
+
+#[test]
+fn value_consuming_functions_return_empty_for_valueless_element() {
+    let ctx = valueless_given_context();
+    let base = "Patient.name.given.first()";
+    for call in [
+        "length()",
+        "toChars()",
+        "substring(0, 1)",
+        "upper()",
+        "lower()",
+        "indexOf('a')",
+        "contains('a')",
+        "startsWith('a')",
+        "endsWith('a')",
+        "matches('a')",
+        "matchesFull('a')",
+        "replace('a', 'b')",
+        "replaceMatches('a', 'b')",
+        "trim()",
+        "split(',')",
+        "encode('base64')",
+        "decode('base64')",
+    ] {
+        let expr = format!("{base}.{call}");
+        assert_eq!(
+            evaluate_expression(&expr, &ctx).unwrap(),
+            EvaluationResult::Empty,
+            "{expr} must be empty"
+        );
+    }
+}
+
+#[test]
+fn ordering_comparisons_with_valueless_element_return_empty() {
+    let ctx = valueless_given_context();
+    for expr in [
+        "Patient.name.given.first() < 'x'",
+        "Patient.name.given.first() <= 'x'",
+        "Patient.name.given.first() > 'x'",
+        "Patient.name.given.first() >= 'x'",
+        "'x' < Patient.name.given.first()",
+        "'x' >= Patient.name.given.first()",
+    ] {
+        assert_eq!(
+            evaluate_expression(expr, &ctx).unwrap(),
+            EvaluationResult::Empty,
+            "{expr} must be empty"
+        );
+    }
+}
+
+#[test]
+fn invariant_pattern_over_valueless_element_is_not_true() {
+    let ctx = valueless_given_context();
+    let expr = "Patient.name.given.first().exists() and Patient.name.given.first().length() = 1";
+    assert_eq!(
+        evaluate_expression(expr, &ctx).unwrap(),
+        EvaluationResult::Empty
+    );
+}


### PR DESCRIPTION
Unblocks every open PR: the FHIRPath conformance job checks out `FHIR/fhir-test-cases@master` unpinned, and on Aug 21 upstream added the `primitivesWithoutValue` group (commit 9ed6ca0) — 8 of its tests fail against our evaluator, so the COVERAGE-LOST gate now rejects any PR regardless of its diff (first seen on #712, a CSS/template-only change).

## The defect

A FHIR primitive element that carries extensions but no value (`"given": [null, "James"]` with `_given[0].extension`) exists in the tree — `exists()` is true, `hasValue()` is false — but it has **no system value**, so per the spec the functions that consume the value get an empty collection as input and return empty. Our evaluator raised type errors instead:

```
Patient.name.given.first().length()   → Type Error: length() requires a String input
Patient.name.given.first() < 'x'      → Type Error: Cannot compare Object and String
```

## The fix

The evaluator already represents these elements as `Object` with type `Element` — the exact test `hasValue()` relies on. A new `is_valueless_element` helper applies that same test in two places:

- `call_function`: the string-value functions (`length`, `toChars`, `substring`, `upper`, `lower`, `indexOf`, `contains`, `startsWith`, `endsWith`, `matches`, `matchesFull`, `replace`, `replaceMatches`, `trim`, `split`, `encode`, `decode`) see the base as empty and propagate empty.
- `compare_inequality`: a valueless element compares as empty, like the existing empty-operand rule.

`exists()`, `hasValue()`, `extension()`, `children()` etc. still see the element node — only value-consuming call sites are normalized.

## Test coverage

The vendored `tests/data/r5/tests-fhir-r5.xml` gains the upstream group verbatim (the `patient-name-extensions.json` fixture was already vendored), so `r5_tests` covers it locally: all 12 tests in the group pass, suite green, no regressions in the rest of the crate.

No CI change: the unpinned `master` checkout is what surfaced this within days of the upstream commit, which seems to be the gate working as intended.