### PR TITLE
Honor configured public base URL across HFS links

### DIFF
--- a/.agents/skills/run-hfs-server/SKILL.md
+++ b/.agents/skills/run-hfs-server/SKILL.md
@@ -33,8 +33,14 @@ HFS_SERVER_PORT=3000 HFS_LOG_LEVEL=debug cargo run --bin hfs
 | `HFS_SERVER_PORT` | `8080` | Server port |
 | `HFS_SERVER_HOST` | `127.0.0.1` | Host to bind |
 | `HFS_LOG_LEVEL` | `info` | Log level: error, warn, info, debug, trace |
-| `HFS_BASE_URL` | `http://localhost:8080` | Base URL for Location headers and Bundle links |
+| `HFS_BASE_URL` | `http://localhost:8080` | Public HTTP(S) base for Location headers and Bundle links |
 | `HFS_DATA_DIR` | `./data` | FHIR data directory, including search parameters |
+
+Set `HFS_BASE_URL` explicitly for containers and reverse proxies. Include any
+published path prefix. HFS rejects non-HTTP(S) values, credentials, query
+strings, and fragments, and it never derives the public base from request
+forwarding headers. A loopback base that conflicts with the listener produces
+a startup warning.
 
 ## Limits
 

--- a/README.md
+++ b/README.md
@@ -233,12 +233,18 @@ AWS_REGION=us-east-1 \
 | `HFS_STORAGE_BACKEND` | `sqlite` | Backend mode: `sqlite`, `sqlite-elasticsearch`, `postgres`, `postgres-elasticsearch`, `mongodb`, `mongodb-elasticsearch`, `s3`, or `s3-elasticsearch` |
 | `HFS_SERVER_PORT` | `8080` | Server port |
 | `HFS_SERVER_HOST` | `127.0.0.1` | Host to bind |
-| `HFS_BASE_URL` | `http://localhost:8080` | Base URL used in `Location` headers and Bundle links |
+| `HFS_BASE_URL` | `http://localhost:8080` | Public HTTP(S) base used in `Location` headers and Bundle links |
 | `HFS_DATABASE_URL` | `fhir.db` | Database URL (SQLite path or PostgreSQL connection string) |
 | `HFS_DATA_DIR` | `./data` | Directory containing FHIR data files (search parameters) |
 | `HFS_SEARCH_PARAM_CACHE_TTL` | `3600` | Seconds between refreshes of the in-memory SearchParameter registry from storage; a param POSTed to one cluster node becomes visible to others within this interval. `0` disables the refresh. |
 | `HFS_DEFAULT_FHIR_VERSION` | `R4` | FHIR version (R4, R4B, R5, R6) |
 | `HFS_LOG_LEVEL` | `info` | Log level (error, warn, info, debug, trace) |
+
+Set `HFS_BASE_URL` to the URL clients use, including any reverse-proxy path
+prefix, for example `https://fhir.example.com/fhir`. HFS accepts only absolute
+`http` or `https` URLs without credentials, query strings, or fragments. It
+removes trailing slashes at startup. HFS does not derive this value from
+`Host`, `Forwarded`, or `X-Forwarded-*` request headers.
 
 **Limits & behavior**
 

--- a/book/src/components/hfs-server.md
+++ b/book/src/components/hfs-server.md
@@ -47,8 +47,14 @@ The server is configured entirely through [environment variables](../configurati
 ```bash
 # Explicit example
 HFS_SERVER_PORT=3000 \
+HFS_BASE_URL=https://fhir.example.com \
 HFS_STORAGE_BACKEND=postgres \
 HFS_DATABASE_URL="postgresql://user:pass@localhost/fhir" \
 HFS_LOG_LEVEL=debug \
   ./hfs
 ```
+
+`HFS_BASE_URL` is the public origin HFS writes into FHIR responses. Include a
+reverse-proxy path prefix when one exists, for example
+`https://fhir.example.com/fhir`. HFS validates and logs the value at startup.
+It warns when a loopback base does not match the listener.

--- a/book/src/configuration/environment-variables.md
+++ b/book/src/configuration/environment-variables.md
@@ -9,9 +9,16 @@ All server behavior is controlled through environment variables. No configuratio
 | `HFS_SERVER_PORT` | `8080` | Server port |
 | `HFS_SERVER_HOST` | `127.0.0.1` | Host to bind |
 | `HFS_LOG_LEVEL` | `info` | Log level: `error`, `warn`, `info`, `debug`, `trace` |
-| `HFS_BASE_URL` | `http://localhost:8080` | Base URL for Location headers and Bundle links |
+| `HFS_BASE_URL` | `http://localhost:8080` | Public HTTP(S) base for Location headers and Bundle links |
 | `HFS_DATA_DIR` | `./data` | Path to FHIR data directory (search parameters) |
 | `HFS_SEARCH_PARAM_CACHE_TTL` | `3600` | Seconds between refreshes of the in-memory SearchParameter registry from storage. In a cluster, a SearchParameter POSTed to one node becomes visible to the others within this interval. `0` disables the periodic refresh. |
+
+`HFS_BASE_URL` must be an absolute `http` or `https` URL with a host. It may
+include a deployment path prefix, such as `https://example.com/fhir`, but it
+must not include credentials, a query string, or a fragment. HFS normalizes a
+trailing slash and rejects invalid values before it starts. Configure the
+public address explicitly behind a proxy. Request `Host`, `Forwarded`, and
+`X-Forwarded-*` headers do not change advertised URLs.
 
 ## Limits
 

--- a/book/src/getting-started/docker.md
+++ b/book/src/getting-started/docker.md
@@ -12,6 +12,7 @@ docker run -p 8080:8080 ghcr.io/heliossoftware/hfs:latest
 docker run -p 8080:8080 \
   -v hfs-data:/data \
   -e HFS_DATABASE_URL=/data/fhir.db \
+  -e HFS_BASE_URL=http://localhost:8080 \
   ghcr.io/heliossoftware/hfs:latest
 
 # With PostgreSQL
@@ -51,6 +52,11 @@ docker build --build-arg BINARY_NAME=fhirpath-server -t fhirpath-server .
 The Dockerfile expects the binary and `data/` files to be pre-staged in the build context. In CI, the binary is built separately and copied in before the Docker build step.
 
 > **Details:** Base image is `debian:bookworm-slim`. The server runs as non-root user `hfs`. Default exposed port is 8080. Host-binding environment variables (`HFS_SERVER_HOST`, `SOF_SERVER_HOST`, `FHIRPATH_SERVER_HOST`) are automatically set to `0.0.0.0` inside the container.
+
+Set `HFS_BASE_URL` to the address used outside the container. For a TLS proxy
+that publishes HFS below `/fhir`, use
+`-e HFS_BASE_URL=https://fhir.example.com/fhir`. HFS uses that configured value
+for response links and does not trust forwarding headers to infer it.
 
 ## Environment Variables
 

--- a/crates/fhirpath/src/evaluator.rs
+++ b/crates/fhirpath/src/evaluator.rs
@@ -1371,6 +1371,21 @@ fn primitive_member_access(
     }
 }
 
+/// Returns true for a FHIR primitive element that has metadata but no system value.
+///
+/// These elements remain present for tree operations such as `exists()` and
+/// `.extension`, but functions and operators that consume the primitive value must
+/// treat them like an empty collection.
+fn is_primitive_without_value(result: &EvaluationResult) -> bool {
+    matches!(
+        result,
+        EvaluationResult::Object {
+            type_info: Some(type_info),
+            ..
+        } if type_info.namespace == "FHIR" && type_info.name == "Element"
+    )
+}
+
 fn evaluate_with_context(
     expr: &Expression,
     context: EvaluationContext,
@@ -4244,6 +4259,7 @@ fn call_function(
                     EvaluationResult::integer(s.chars().count() as i64)
                 } // Use chars().count() for correct length
                 EvaluationResult::Empty => EvaluationResult::Empty,
+                value if is_primitive_without_value(value) => EvaluationResult::Empty,
                 // Collections handled by initial check
                 EvaluationResult::Collection { .. } => unreachable!(),
                 _ => {
@@ -4424,6 +4440,7 @@ fn call_function(
                     }
                 }
                 EvaluationResult::Empty => EvaluationResult::Empty, // substring on {} is {}
+                value if is_primitive_without_value(value) => EvaluationResult::Empty,
                 // Collections handled by initial check
                 EvaluationResult::Collection { .. } => unreachable!(), // Should have been caught by singleton check
                 _ => {
@@ -4503,6 +4520,7 @@ fn call_function(
                 // Wrap in Ok
                 EvaluationResult::String(s, _, _) => EvaluationResult::string(s.to_uppercase()),
                 EvaluationResult::Empty => EvaluationResult::Empty,
+                value if is_primitive_without_value(value) => EvaluationResult::Empty,
                 _ => {
                     return Err(EvaluationError::TypeError(
                         "upper requires a String input".to_string(),
@@ -6155,6 +6173,7 @@ fn call_function(
                     }
                 }
                 EvaluationResult::Empty => EvaluationResult::Empty,
+                value if is_primitive_without_value(value) => EvaluationResult::Empty,
                 // Collections handled by initial check
                 EvaluationResult::Collection { .. } => unreachable!(),
                 _ => {
@@ -6333,14 +6352,7 @@ fn call_function(
             // Returns false if element is empty or is a primitive with extensions but no value
             match invocation_base {
                 EvaluationResult::Empty => Ok(EvaluationResult::boolean(false)),
-                EvaluationResult::Object { type_info, .. } => {
-                    // Check if this is an Element (primitive with extensions but no value)
-                    let is_element = type_info
-                        .as_ref()
-                        .map(|ti| ti.name == "Element")
-                        .unwrap_or(false);
-                    Ok(EvaluationResult::boolean(!is_element))
-                }
+                value if is_primitive_without_value(value) => Ok(EvaluationResult::boolean(false)),
                 _ => Ok(EvaluationResult::boolean(true)),
             }
         }
@@ -8086,7 +8098,11 @@ fn compare_inequality(
 ) -> Result<EvaluationResult, EvaluationError> {
     // Changed return type
     // Handle empty operands: comparison with empty returns empty
-    if left == &EvaluationResult::Empty || right == &EvaluationResult::Empty {
+    if left == &EvaluationResult::Empty
+        || right == &EvaluationResult::Empty
+        || is_primitive_without_value(left)
+        || is_primitive_without_value(right)
+    {
         return Ok(EvaluationResult::Empty); // Return Ok(Empty)
     }
 

--- a/crates/fhirpath/tests/data/r5/tests-fhir-r5.xml
+++ b/crates/fhirpath/tests/data/r5/tests-fhir-r5.xml
@@ -1768,6 +1768,49 @@ Any text enclosed within is ignored
 		</test>
 	</group>
 
+	<group name="primitivesWithoutValue" description="FHIR primitive elements that carry extensions but no value (e.g. the data-absent-reason extension). Such an element is present in the tree, but it has no system value, so functions that need the value get an empty collection as input, and return empty (see hasValue()/getValue() in the FHIR spec)">
+		<test name="testNoValueExists" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().exists()</expression>
+			<output type="boolean">true</output>
+		</test>
+		<test name="testNoValueExistsElement" inputfile="patient-name-extensions.json" mode="element">
+			<expression>Patient.name.given.first().exists()</expression>
+			<output type="boolean">true</output>
+		</test>
+		<test name="testNoValueHasValue" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().hasValue()</expression>
+			<output type="boolean">false</output>
+		</test>
+		<test name="testNoValueLength" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().length()</expression>
+		</test>
+		<test name="testNoValueLengthElement" inputfile="patient-name-extensions.json" mode="element">
+			<expression>Patient.name.given.first().length()</expression>
+		</test>
+		<test name="testValueLength" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.last().length()</expression>
+			<output type="integer">5</output>
+		</test>
+		<test name="testNoValueToChars" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().toChars()</expression>
+		</test>
+		<test name="testNoValueSubstring" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().substring(0, 1)</expression>
+		</test>
+		<test name="testNoValueUpper" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().upper()</expression>
+		</test>
+		<test name="testNoValueComparison" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first() &lt; 'x'</expression>
+		</test>
+		<test name="testNoValueInvariant" inputfile="patient-name-extensions.json">
+			<expression>Patient.name.given.first().exists() and Patient.name.given.first().length() = 1</expression>
+		</test>
+		<test name="testNoValueInvariantElement" inputfile="patient-name-extensions.json" mode="element">
+			<expression>Patient.name.given.first().exists() and Patient.name.given.first().length() = 1</expression>
+		</test>
+	</group>
+
   <group name="cdaTests">
 		<test name="testHasTemplateId1" mode="cda" inputfile="ccda.json"><expression>hasTemplateIdOf('http://hl7.org/cda/us/ccda/StructureDefinition/ContinuityofCareDocumentCCD')</expression><output type="boolean">true</output></test>
 		<test name="testHasTemplateId2" mode="cda" inputfile="ccda.json"><expression>ClinicalDocument.hasTemplateIdOf('http://hl7.org/cda/us/ccda/StructureDefinition/ContinuityofCareDocumentCCD')</expression><output type="boolean">true</output></test>

--- a/crates/hfs/README.md
+++ b/crates/hfs/README.md
@@ -79,6 +79,7 @@ Options:
 |----------|---------|-------------|
 | `HFS_SERVER_PORT` | 8080 | Server port |
 | `HFS_SERVER_HOST` | 127.0.0.1 | Host to bind |
+| `HFS_BASE_URL` | http://localhost:8080 | Public HTTP(S) base for response links and `Location` headers |
 | `HFS_LOG_LEVEL` | info | Log level (error, warn, info, debug, trace) |
 | `DATABASE_URL` | fhir.db | Database connection string |
 | `HFS_DATA_DIR` | ./data | Path to FHIR data directory (search parameters) |
@@ -92,6 +93,11 @@ Options:
 | `HFS_DEFAULT_TENANT` | default | Default tenant ID |
 | `HFS_TERMINOLOGY_SERVER` | (none) | Terminology server URL for `:in`/`:not-in` modifiers and FHIRPath `memberOf()`/`subsumes()` |
 | `HFS_COMPOSITE_SYNC_MODE` | `asynchronous` | Composite-store write sync mode for ES-backed backends (`sqlite-elasticsearch`, `postgres-elasticsearch`, `mongodb-elasticsearch`, `s3-elasticsearch`). One of `asynchronous`, `synchronous`, `hybrid`. With `asynchronous` (default) the write returns as soon as the primary commits and the search backend is updated on a background worker — lowest latency, but a follow-up search can race the indexing. Use `synchronous` when callers need read-your-write semantics (e.g. integration tests, bulk-load flows that immediately search). Ignored when the storage backend has no search secondary. |
+
+Set `HFS_BASE_URL` to the public address clients can reach. The value may
+contain a path prefix. It must be an absolute `http` or `https` URL without
+credentials, a query string, or a fragment. HFS rejects invalid values and
+does not infer the public address from request forwarding headers.
 
 ## FHIR Version Support
 

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -666,7 +666,7 @@ async fn serve(
         // configured from HFS_UI_* client credentials.
         let self_base_url = format!("http://127.0.0.1:{}", config.port);
         let outbound_auth = AuthConfig::from_env().outbound_provider();
-        helios_ui::mount_with_body_limit(
+        helios_ui::mount_with_body_limit_and_tenant_routing(
             app,
             env!("CARGO_PKG_VERSION"),
             config.data_dir.clone(),
@@ -684,6 +684,7 @@ async fn serve(
             config.terminology_server.clone(),
             config.base_url.clone(),
             config.max_body_size,
+            config.multitenancy.routing_mode.supports_url_path(),
         )
     };
     #[cfg(not(all(feature = "ui", not(feature = "headless"))))]
@@ -873,10 +874,10 @@ async fn init_audit(
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Use `from_env()` (not `parse()`) so `multitenancy` and `bulk_export`
-    // sub-structs — both `#[arg(skip)]` for clap — are populated from
-    // their `HFS_*` environment variables.
-    let config = ServerConfig::from_env();
+    // Keep the skipped sub-configs populated while surfacing invalid CLI and
+    // environment values instead of silently replacing the whole config with
+    // defaults.
+    let config = ServerConfig::try_from_env().unwrap_or_else(|error| error.exit());
     helios_observability::uptime::init();
     helios_observability::telemetry::init("hfs", &config.log_level);
     helios_observability::metrics::init("hfs");
@@ -884,6 +885,14 @@ async fn main() -> anyhow::Result<()> {
     // backed by the reqlog ring buffer, so it opts into recording. Servers that
     // don't (hts, sof-server, fhirpath-server) leave it off and skip the cost.
     helios_observability::reqlog::enable();
+
+    if let Some(message) = config.loopback_public_base_warning() {
+        warn!(
+            public_base_url = %config.base_url,
+            bind_address = %config.socket_addr(),
+            "{message}. Set HFS_BASE_URL to the public HTTP(S) origin clients can reach"
+        );
+    }
 
     if let Err(errors) = config.validate() {
         for error in &errors {
@@ -926,6 +935,8 @@ async fn main() -> anyhow::Result<()> {
     info!(
         port = config.port,
         host = %config.host,
+        bind_address = %config.socket_addr(),
+        public_base_url = %config.base_url,
         fhir_version = ?config.default_fhir_version,
         storage_backend = %backend_mode,
         terminology_server = ?config.terminology_server,
@@ -2882,6 +2893,20 @@ mod tests {
             config.validate().is_ok(),
             "default ServerConfig should be valid"
         );
+    }
+
+    #[test]
+    fn test_server_config_validation() {
+        let mut config = ServerConfig {
+            base_url: "https://fhir.example.test/fhir/".to_string(),
+            ..Default::default()
+        };
+        config.normalize_public_base_url().unwrap();
+        assert_eq!(config.base_url, "https://fhir.example.test/fhir");
+        assert!(config.validate().is_ok());
+
+        config.base_url = "javascript:alert(1)".to_string();
+        assert!(config.validate().is_err());
     }
 
     #[test]

--- a/crates/rest/README.md
+++ b/crates/rest/README.md
@@ -424,6 +424,11 @@ curl http://localhost:8080/acme/metadata
 # Returns implementation.url: "http://localhost:8080/acme"
 ```
 
+All advertised URLs use `HFS_BASE_URL`. Set it to the public origin and any
+reverse-proxy prefix, such as `https://fhir.example.com/fhir`. URL-routed
+requests append the selected tenant after that prefix. Header-routed requests
+keep the configured base unchanged. Forwarding headers never override it.
+
 ### URL-Based Routing Setup
 
 To enable URL-based tenant routing:

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -1171,7 +1171,10 @@ impl ServerConfig {
     /// Loads configuration for the HFS binary and reports command-line,
     /// environment, and validation errors to the caller.
     pub fn try_from_env() -> Result<Self, clap::Error> {
-        let mut config = Self::try_parse()?;
+        Self::finish_parsed(Self::try_parse()?)
+    }
+
+    fn finish_parsed(mut config: Self) -> Result<Self, clap::Error> {
         config.multitenancy = MultitenancyConfig::from_env();
         config.bulk_export = BulkExportConfig::from_env();
         config.bulk_submit = BulkSubmitConfig::from_env();
@@ -1958,15 +1961,41 @@ mod tests {
     }
 
     #[test]
+    fn test_finish_parsed_normalizes_and_validates() {
+        let config = ServerConfig {
+            base_url: "https://fhir.example.test/root/".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            ServerConfig::finish_parsed(config).unwrap().base_url,
+            "https://fhir.example.test/root"
+        );
+
+        let invalid_url = ServerConfig {
+            base_url: "not-a-url".to_string(),
+            ..Default::default()
+        };
+        assert!(ServerConfig::finish_parsed(invalid_url).is_err());
+
+        let invalid_config = ServerConfig {
+            port: 0,
+            ..Default::default()
+        };
+        assert!(ServerConfig::finish_parsed(invalid_config).is_err());
+    }
+
+    #[test]
     fn test_loopback_public_base_warning() {
         let cases = [
             ("127.0.0.1", 8080, "http://localhost:8080", false),
+            ("localhost", 8080, "http://localhost:8080", false),
             ("::1", 8080, "http://[::1]:8080", false),
             ("[::1]", 8080, "http://[::1]:8080", false),
             ("0.0.0.0", 8080, "http://localhost:8080", true),
             ("::", 8080, "http://127.0.0.1:8080", true),
             ("192.0.2.10", 8080, "http://[::1]:8080", true),
             ("127.0.0.1", 18080, "http://localhost:8080", true),
+            ("0.0.0.0", 18080, "http://localhost:8080", true),
         ];
 
         for (host, port, base_url, warns) in cases {

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -916,7 +916,12 @@ pub struct ServerConfig {
     pub default_tenant: String,
 
     /// Base URL for the server (used in Location headers and Bundle links).
-    #[arg(long, env = "HFS_BASE_URL", default_value = "http://localhost:8080")]
+    #[arg(
+        long,
+        env = "HFS_BASE_URL",
+        default_value = "http://localhost:8080",
+        value_parser = parse_public_base_url_arg
+    )]
     pub base_url: String,
 
     /// Database connection string.
@@ -1158,7 +1163,28 @@ pub struct ServerConfig {
     pub validation: ValidationConfig,
 }
 
+fn parse_public_base_url_arg(value: &str) -> Result<String, String> {
+    crate::public_url::PublicUrl::parse(value).map(|url| url.as_str().to_string())
+}
+
 impl ServerConfig {
+    /// Loads configuration for the HFS binary and reports command-line,
+    /// environment, and validation errors to the caller.
+    pub fn try_from_env() -> Result<Self, clap::Error> {
+        let mut config = Self::try_parse()?;
+        config.multitenancy = MultitenancyConfig::from_env();
+        config.bulk_export = BulkExportConfig::from_env();
+        config.bulk_submit = BulkSubmitConfig::from_env();
+        config.validation = ValidationConfig::from_env();
+        config.normalize_public_base_url().map_err(|message| {
+            clap::Error::raw(clap::error::ErrorKind::ValueValidation, message)
+        })?;
+        config.validate().map_err(|errors| {
+            clap::Error::raw(clap::error::ErrorKind::ValueValidation, errors.join("\n"))
+        })?;
+        Ok(config)
+    }
+
     /// Parses the storage backend mode from the string field.
     pub fn storage_backend_mode(&self) -> Result<StorageBackendMode, String> {
         self.storage_backend.parse()
@@ -1247,9 +1273,61 @@ impl ServerConfig {
         config
     }
 
+    /// Validates and removes trailing slashes from the configured public base.
+    pub fn normalize_public_base_url(&mut self) -> Result<(), String> {
+        self.base_url = crate::public_url::PublicUrl::parse(&self.base_url)?
+            .as_str()
+            .to_string();
+        Ok(())
+    }
+
+    /// Returns why a loopback public base is unsafe for the configured listener.
+    ///
+    /// A loopback URL is safe only when the listener is also loopback and the
+    /// effective advertised port matches the listener port.
+    pub fn loopback_public_base_warning(&self) -> Option<String> {
+        let public_url = crate::public_url::PublicUrl::parse(&self.base_url).ok()?;
+        if !public_url.is_loopback() {
+            return None;
+        }
+
+        let listener_host = self
+            .host
+            .strip_prefix('[')
+            .and_then(|host| host.strip_suffix(']'))
+            .unwrap_or(&self.host);
+        let listener_is_loopback = match listener_host.parse::<std::net::IpAddr>() {
+            Ok(address) => address.is_loopback(),
+            Err(_) => listener_host.eq_ignore_ascii_case("localhost"),
+        };
+        let port_matches = public_url.port_or_known_default() == Some(self.port);
+
+        match (listener_is_loopback, port_matches) {
+            (true, true) => None,
+            (false, true) => Some(format!(
+                "HFS_BASE_URL '{}' advertises a loopback host while HFS listens on {}",
+                public_url.as_str(),
+                self.socket_addr()
+            )),
+            (true, false) => Some(format!(
+                "HFS_BASE_URL '{}' advertises a different port from listener {}",
+                public_url.as_str(),
+                self.socket_addr()
+            )),
+            (false, false) => Some(format!(
+                "HFS_BASE_URL '{}' advertises a loopback host and a different port from listener {}",
+                public_url.as_str(),
+                self.socket_addr()
+            )),
+        }
+    }
+
     /// Returns the socket address to bind to.
     pub fn socket_addr(&self) -> String {
-        format!("{}:{}", self.host, self.port)
+        match self.host.parse::<std::net::IpAddr>() {
+            Ok(std::net::IpAddr::V6(address)) => format!("[{address}]:{}", self.port),
+            _ => format!("{}:{}", self.host, self.port),
+        }
     }
 
     /// Returns the full base URL for the server.
@@ -1283,6 +1361,10 @@ impl ServerConfig {
 
         if self.default_page_size > self.max_page_size {
             errors.push("Default page size cannot exceed max page size".to_string());
+        }
+
+        if let Err(error) = crate::public_url::PublicUrl::parse(&self.base_url) {
+            errors.push(error);
         }
 
         // A reserved default tenant is the isolation hole of issue #317 in
@@ -1417,6 +1499,13 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(config.socket_addr(), "0.0.0.0:3000");
+
+        let ipv6 = ServerConfig {
+            port: 3000,
+            host: "::1".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(ipv6.socket_addr(), "[::1]:3000");
     }
 
     #[test]
@@ -1813,6 +1902,93 @@ mod tests {
     fn test_full_base_url_default() {
         let config = ServerConfig::default();
         assert_eq!(config.full_base_url(), "http://localhost:8080");
+    }
+
+    #[test]
+    fn test_public_base_url_normalization() {
+        for (input, expected) in [
+            ("http://example.test/", "http://example.test"),
+            ("https://example.test/fhir///", "https://example.test/fhir"),
+            ("http://127.0.0.1:9000/", "http://127.0.0.1:9000"),
+            ("http://[::1]:9000/fhir/", "http://[::1]:9000/fhir"),
+        ] {
+            let mut config = ServerConfig {
+                base_url: input.to_string(),
+                ..Default::default()
+            };
+            config.normalize_public_base_url().unwrap();
+            assert_eq!(config.base_url, expected, "{input}");
+        }
+    }
+
+    #[test]
+    fn test_cli_public_base_url_parser_is_fallible_and_normalizes() {
+        let config = ServerConfig::try_parse_from([
+            "rest-server",
+            "--base-url",
+            "https://fhir.example.test/fhir/",
+        ])
+        .unwrap();
+        assert_eq!(config.base_url, "https://fhir.example.test/fhir");
+
+        assert!(
+            ServerConfig::try_parse_from(["rest-server", "--base-url", "ftp://fhir.example.test"])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_public_base_url_validation_rejects_unsafe_shapes() {
+        for value in [
+            "fhir.example.test",
+            "ftp://fhir.example.test",
+            "http:///fhir",
+            "http://@fhir.example.test",
+            "http://user@fhir.example.test",
+            "http://user:pass@fhir.example.test",
+            "http://fhir.example.test?tenant=acme",
+            "http://fhir.example.test#metadata",
+        ] {
+            let config = ServerConfig {
+                base_url: value.to_string(),
+                ..Default::default()
+            };
+            assert!(config.validate().is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn test_loopback_public_base_warning() {
+        let cases = [
+            ("127.0.0.1", 8080, "http://localhost:8080", false),
+            ("::1", 8080, "http://[::1]:8080", false),
+            ("[::1]", 8080, "http://[::1]:8080", false),
+            ("0.0.0.0", 8080, "http://localhost:8080", true),
+            ("::", 8080, "http://127.0.0.1:8080", true),
+            ("192.0.2.10", 8080, "http://[::1]:8080", true),
+            ("127.0.0.1", 18080, "http://localhost:8080", true),
+        ];
+
+        for (host, port, base_url, warns) in cases {
+            let config = ServerConfig {
+                host: host.to_string(),
+                port,
+                base_url: base_url.to_string(),
+                ..Default::default()
+            };
+            assert_eq!(
+                config.loopback_public_base_warning().is_some(),
+                warns,
+                "host={host} port={port} base={base_url}"
+            );
+        }
+
+        let public = ServerConfig {
+            host: "0.0.0.0".to_string(),
+            base_url: "https://fhir.example.test".to_string(),
+            ..Default::default()
+        };
+        assert!(public.loopback_public_base_warning().is_none());
     }
 
     // ── multitenancy() accessor ───────────────────────────────────

--- a/crates/rest/src/export/controller.rs
+++ b/crates/rest/src/export/controller.rs
@@ -247,5 +247,11 @@ pub trait ExportJobController: Send + Sync + 'static {
     ///
     /// Returns `None` if `tenant_id` does not match the submitting tenant, or if
     /// the sink fails to produce a URL (e.g. an S3 pre-signing error).
-    fn download_url(&self, tenant_id: &str, job_id: &str, filename: &str) -> Option<String>;
+    fn download_url(
+        &self,
+        tenant_id: &str,
+        public_base_url: &str,
+        job_id: &str,
+        filename: &str,
+    ) -> Option<String>;
 }

--- a/crates/rest/src/export/in_memory.rs
+++ b/crates/rest/src/export/in_memory.rs
@@ -327,11 +327,17 @@ impl<Sink: ExportSink + 'static> ExportJobController for InMemoryController<Sink
         self.sink.read_shard(job_id, filename)
     }
 
-    fn download_url(&self, tenant_id: &str, job_id: &str, filename: &str) -> Option<String> {
+    fn download_url(
+        &self,
+        tenant_id: &str,
+        public_base_url: &str,
+        job_id: &str,
+        filename: &str,
+    ) -> Option<String> {
         if !self.tenant_matches(tenant_id, job_id) {
             return None;
         }
-        match self.sink.download_url(job_id, filename) {
+        match self.sink.download_url(public_base_url, job_id, filename) {
             Ok(url) => Some(url),
             Err(e) => {
                 warn!(%job_id, %filename, error = %e, "failed to resolve export download URL");
@@ -1003,7 +1009,8 @@ mod tests {
             .unwrap();
         assert_eq!(filename, "shard-0.ndjson");
         assert_eq!(
-            sink.download_url("job-1", &filename).unwrap(),
+            sink.download_url("http://localhost", "job-1", &filename)
+                .unwrap(),
             "http://localhost/export/job-1/shard-0.ndjson"
         );
     }
@@ -1028,7 +1035,12 @@ mod tests {
         fn read_shard(&self, _job_id: &str, _filename: &str) -> Option<Vec<u8>> {
             None
         }
-        fn download_url(&self, job_id: &str, filename: &str) -> Result<String, ExportError> {
+        fn download_url(
+            &self,
+            _public_base_url: &str,
+            job_id: &str,
+            filename: &str,
+        ) -> Result<String, ExportError> {
             // Each call advances the nonce, mimicking a fresh pre-signature.
             let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(format!(
@@ -1061,17 +1073,33 @@ mod tests {
         // Two polls yield two distinct URLs — proof the URL is resolved fresh
         // rather than reused from write time.
         let first = controller
-            .download_url("t1", &job_id, "shard-0.ndjson")
+            .download_url(
+                "t1",
+                "https://public.example/fhir/acme",
+                &job_id,
+                "shard-0.ndjson",
+            )
             .expect("owner should resolve a URL");
         let second = controller
-            .download_url("t1", &job_id, "shard-0.ndjson")
+            .download_url(
+                "t1",
+                "https://public.example/fhir/acme",
+                &job_id,
+                "shard-0.ndjson",
+            )
             .expect("owner should resolve a URL");
+        assert!(first.starts_with("https://signed.example/"));
         assert_ne!(first, second, "each poll must re-resolve the download URL");
 
         // A different tenant cannot resolve URLs for this job.
         assert!(
             controller
-                .download_url("other", &job_id, "shard-0.ndjson")
+                .download_url(
+                    "other",
+                    "https://public.example/fhir/other",
+                    &job_id,
+                    "shard-0.ndjson",
+                )
                 .is_none(),
             "cross-tenant resolution must be denied"
         );

--- a/crates/rest/src/export/sink.rs
+++ b/crates/rest/src/export/sink.rs
@@ -212,6 +212,25 @@ impl ExportSink for InMemorySink {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filesystem_download_url_uses_the_current_public_base() {
+        let sink = FilesystemSink::new("unused", "https://stale.example");
+        assert_eq!(
+            sink.download_url(
+                "https://public.example/fhir",
+                "job with space",
+                "shard/0.ndjson",
+            )
+            .unwrap(),
+            "https://public.example/fhir/export/job%20with%20space/shard%2F0.ndjson"
+        );
+    }
+}
+
 // ============================================================================
 // S3Sink
 // ============================================================================

--- a/crates/rest/src/export/sink.rs
+++ b/crates/rest/src/export/sink.rs
@@ -13,6 +13,23 @@ use dashmap::DashMap;
 
 use super::controller::ExportError;
 
+fn server_routed_download_url(
+    public_base_url: &str,
+    job_id: &str,
+    filename: &str,
+) -> Result<String, ExportError> {
+    let mut url = url::Url::parse(public_base_url)
+        .map_err(|error| ExportError::Sink(format!("invalid public base URL: {error}")))?;
+    {
+        let mut path = url
+            .path_segments_mut()
+            .map_err(|_| ExportError::Sink("public base URL cannot hold path segments".into()))?;
+        path.pop_if_empty();
+        path.extend(["export", job_id, filename]);
+    }
+    Ok(url.to_string())
+}
+
 /// Trait for writing and serving export output files.
 pub trait ExportSink: Send + Sync + Clone + 'static {
     /// Writes `data` as the `shard_index`-th shard for `job_id` and returns the
@@ -46,7 +63,12 @@ pub trait ExportSink: Send + Sync + Clone + 'static {
     /// - [`S3Sink`] returns a freshly pre-signed GET URL, so a client polling
     ///   the manifest hours after completion still receives a usable URL rather
     ///   than one signed (and counting down) since write time.
-    fn download_url(&self, job_id: &str, filename: &str) -> Result<String, ExportError>;
+    fn download_url(
+        &self,
+        public_base_url: &str,
+        job_id: &str,
+        filename: &str,
+    ) -> Result<String, ExportError>;
 
     /// Deletes all output shards previously written for `job_id`.
     ///
@@ -68,20 +90,16 @@ pub trait ExportSink: Send + Sync + Clone + 'static {
 #[derive(Clone)]
 pub struct FilesystemSink {
     dir: PathBuf,
-    base_url: String,
 }
 
 impl FilesystemSink {
     /// Creates a new `FilesystemSink`.
     ///
     /// - `dir` — root directory for export files
-    /// - `base_url` — server base URL (e.g. `http://localhost:8080`), used to
-    ///   build public download URLs
-    pub fn new(dir: impl Into<PathBuf>, base_url: impl Into<String>) -> Self {
-        Self {
-            dir: dir.into(),
-            base_url: base_url.into().trim_end_matches('/').to_string(),
-        }
+    /// The second argument is retained for source compatibility. Request
+    /// handlers now supply the effective public base when resolving a URL.
+    pub fn new(dir: impl Into<PathBuf>, _base_url: impl Into<String>) -> Self {
+        Self { dir: dir.into() }
     }
 }
 
@@ -110,13 +128,15 @@ impl ExportSink for FilesystemSink {
         std::fs::read(path).ok()
     }
 
-    fn download_url(&self, job_id: &str, filename: &str) -> Result<String, ExportError> {
+    fn download_url(
+        &self,
+        public_base_url: &str,
+        job_id: &str,
+        filename: &str,
+    ) -> Result<String, ExportError> {
         // Stable server-routed URL; served back by the download handler. No
         // expiry, so it is identical on every poll.
-        Ok(format!(
-            "{base}/export/{job_id}/{filename}",
-            base = self.base_url
-        ))
+        server_routed_download_url(public_base_url, job_id, filename)
     }
 
     fn delete_job(&self, job_id: &str) -> Result<(), ExportError> {
@@ -138,15 +158,16 @@ impl ExportSink for FilesystemSink {
 #[derive(Clone)]
 pub struct InMemorySink {
     data: Arc<DashMap<String, Vec<u8>>>,
-    base_url: String,
 }
 
 impl InMemorySink {
-    /// Creates a new `InMemorySink` with the given public base URL.
-    pub fn new(base_url: impl Into<String>) -> Self {
+    /// Creates a new `InMemorySink`.
+    ///
+    /// The argument is retained for source compatibility. Request handlers
+    /// supply the effective public base when resolving a URL.
+    pub fn new(_base_url: impl Into<String>) -> Self {
         Self {
             data: Arc::new(DashMap::new()),
-            base_url: base_url.into().trim_end_matches('/').to_string(),
         }
     }
 }
@@ -170,12 +191,14 @@ impl ExportSink for InMemorySink {
         self.data.get(&key).map(|v| v.clone())
     }
 
-    fn download_url(&self, job_id: &str, filename: &str) -> Result<String, ExportError> {
+    fn download_url(
+        &self,
+        public_base_url: &str,
+        job_id: &str,
+        filename: &str,
+    ) -> Result<String, ExportError> {
         // Mirrors the filesystem sink's stable server route.
-        Ok(format!(
-            "{base}/export/{job_id}/{filename}",
-            base = self.base_url
-        ))
+        server_routed_download_url(public_base_url, job_id, filename)
     }
 
     fn delete_job(&self, job_id: &str) -> Result<(), ExportError> {
@@ -288,7 +311,12 @@ impl ExportSink for S3Sink {
     /// Note: the URL's effective lifetime is also bounded by the signing
     /// credentials' own validity (e.g. an STS session), which can silently
     /// undercut `presign_ttl_secs` when running with temporary credentials.
-    fn download_url(&self, job_id: &str, filename: &str) -> Result<String, ExportError> {
+    fn download_url(
+        &self,
+        _public_base_url: &str,
+        job_id: &str,
+        filename: &str,
+    ) -> Result<String, ExportError> {
         let key = self.object_key(job_id, filename);
         let bucket = self.bucket.clone();
         let client = Arc::clone(&self.client);

--- a/crates/rest/src/extractors/tenant.rs
+++ b/crates/rest/src/extractors/tenant.rs
@@ -70,6 +70,7 @@ fn source_error_to_rejection(err: TenantSourceError) -> (StatusCode, String) {
 pub struct TenantExtractor {
     context: TenantContext,
     source: TenantSource,
+    url_routed: bool,
     resolved: ResolvedTenant,
 }
 
@@ -80,6 +81,7 @@ impl TenantExtractor {
         Self {
             context: TenantContext::new(tenant_id_obj.clone(), TenantPermissions::full_access()),
             source,
+            url_routed: source.is_url_based(),
             resolved: ResolvedTenant {
                 tenant_id: tenant_id_obj.clone(),
                 source,
@@ -90,14 +92,27 @@ impl TenantExtractor {
 
     /// Creates a TenantExtractor from a resolved tenant.
     pub fn from_resolved(resolved: ResolvedTenant) -> Self {
+        let url_routed = resolved
+            .all_sources
+            .iter()
+            .any(|(source, _)| source.is_url_based());
         Self {
             context: TenantContext::new(
                 resolved.tenant_id.clone(),
                 TenantPermissions::full_access(),
             ),
             source: resolved.source,
+            url_routed,
             resolved,
         }
+    }
+
+    /// Creates an extractor while preserving how the request was routed
+    /// independently from which source authoritatively selected the tenant.
+    fn new_with_url_route(tenant_id: &str, source: TenantSource, url_routed: bool) -> Self {
+        let mut extractor = Self::new(tenant_id, source);
+        extractor.url_routed = url_routed;
+        extractor
     }
 
     /// Creates a TenantExtractor with the default tenant.
@@ -120,9 +135,13 @@ impl TenantExtractor {
         self.source
     }
 
-    /// Returns true if the tenant was resolved from a URL path.
+    /// Returns true if this request was routed through a tenant URL prefix.
+    ///
+    /// This is intentionally independent from [`Self::source`]: an
+    /// authenticated request keeps `JwtClaim` as its authoritative tenant
+    /// source even when it arrived through `/{tenant}/...`.
     pub fn is_url_based(&self) -> bool {
-        self.source.is_url_based()
+        self.url_routed
     }
 
     /// Returns true if the tenant is the default fallback.
@@ -209,6 +228,10 @@ impl TenantExtractor {
         S: helios_persistence::core::ResourceStorage + Send + Sync,
     {
         let config = state.config();
+        let url_routed = parts
+            .extensions
+            .get::<crate::middleware::tenant_prefix::ExtractedTenantFromUrl>()
+            .is_some();
 
         // If auth is enabled and a Principal with a tenant_id is present,
         // use the JWT tenant authoritatively. When strict validation is enabled,
@@ -254,9 +277,10 @@ impl TenantExtractor {
                 // whether that tenant may be addressed at all. An issuer able to
                 // set the tenant claim would otherwise reach the shared tenant.
                 reject_reserved_tenant(jwt_tenant.as_str(), TenantSource::JwtClaim)?;
-                return Ok(TenantExtractor::new(
+                return Ok(TenantExtractor::new_with_url_route(
                     jwt_tenant.as_str(),
                     crate::tenant::TenantSource::JwtClaim,
+                    url_routed,
                 ));
             }
 
@@ -301,9 +325,10 @@ impl TenantExtractor {
             // never calls `validate()`, and collapsing to a reserved default
             // would put every unauthenticated request in the shared tenant.
             reject_reserved_tenant(&config.default_tenant, TenantSource::Default)?;
-            return Ok(TenantExtractor::new(
+            return Ok(TenantExtractor::new_with_url_route(
                 &config.default_tenant,
                 TenantSource::Default,
+                url_routed,
             ));
         }
 
@@ -483,6 +508,24 @@ mod tests {
                 .expect("should resolve to JWT tenant");
             assert_eq!(extractor.tenant_id(), "acme");
             assert_eq!(extractor.source(), TenantSource::JwtClaim);
+        }
+
+        #[tokio::test]
+        async fn test_jwt_tenant_preserves_url_route_provenance() {
+            use crate::middleware::tenant_prefix::ExtractedTenantFromUrl;
+
+            let state = make_state(false, "test-tenant");
+            let mut parts = make_parts(None, Some(make_principal(Some("acme"))));
+            parts
+                .extensions
+                .insert(ExtractedTenantFromUrl("acme".to_string()));
+
+            let extractor = TenantExtractor::from_request_parts(&mut parts, &state)
+                .await
+                .expect("JWT tenant should remain authoritative on a URL-routed request");
+            assert_eq!(extractor.tenant_id(), "acme");
+            assert_eq!(extractor.source(), TenantSource::JwtClaim);
+            assert!(extractor.is_url_based());
         }
 
         #[tokio::test]

--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -271,7 +271,8 @@ where
         .cloned()
         .unwrap_or_default();
 
-    let base_url = state.base_url();
+    let public_base = state.public_base_url_for_request(&tenant);
+    let base_url = public_base.as_str();
     let concurrency = batch_concurrency(state, &entries);
     let mut progress = BatchProgress::new(entries.len(), correlation.bundle_id.clone());
 
@@ -636,10 +637,10 @@ where
                 );
             }
 
-            let base_url = state.base_url();
+            let public_base = state.public_base_url_for_request(&tenant);
             let response_entries: Vec<Value> = ordered_results
                 .into_iter()
-                .map(|(_, _, result)| bundle_entry_result_to_json(result, base_url, prefer))
+                .map(|(_, _, result)| bundle_entry_result_to_json(result, &public_base, prefer))
                 .collect();
 
             let response_bundle = serde_json::json!({
@@ -1808,6 +1809,8 @@ fn bundle_entry_result_to_json(
 /// Uses the location (stripping the _history suffix) or falls back to
 /// extracting resourceType/id from the resource content.
 fn build_full_url(result: &BundleEntryResult, base_url: &str) -> Option<String> {
+    let public_url = crate::public_url::PublicUrl::parse(base_url)
+        .expect("request public base was built from validated configuration");
     // Try to derive from location (e.g., "Patient/123/_history/1" -> base_url/Patient/123)
     if let Some(ref location) = result.location {
         let resource_url = if let Some(idx) = location.find("/_history/") {
@@ -1815,11 +1818,7 @@ fn build_full_url(result: &BundleEntryResult, base_url: &str) -> Option<String> 
         } else {
             location.as_str()
         };
-        return Some(format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            resource_url
-        ));
+        return Some(public_url.with_segments(resource_url.split('/').filter(|s| !s.is_empty())));
     }
 
     // Fall back to resource content
@@ -1827,7 +1826,7 @@ fn build_full_url(result: &BundleEntryResult, base_url: &str) -> Option<String> 
         let resource_type = resource.get("resourceType").and_then(|v| v.as_str());
         let id = resource.get("id").and_then(|v| v.as_str());
         if let (Some(rt), Some(id)) = (resource_type, id) {
-            return Some(format!("{}/{}/{}", base_url.trim_end_matches('/'), rt, id));
+            return Some(public_url.with_segments([rt, id]));
         }
     }
 

--- a/crates/rest/src/handlers/bulk_export.rs
+++ b/crates/rest/src/handlers/bulk_export.rs
@@ -16,9 +16,9 @@ use helios_auth::Principal;
 use helios_fhir::FhirVersion;
 use helios_persistence::core::ExportDataProvider;
 use helios_persistence::core::{
-    DownloadUrl, ExportJobId, ExportLevel, ExportManifest, ExportOutputFile, ExportRequest,
-    ExportStatus, GroupExportProvider, PatientExportProvider, ResourceStorage, StartExportInput,
-    TypeFilter,
+    DownloadUrl, ExportJobId, ExportLevel, ExportManifest, ExportOutputFile, ExportOutputStore,
+    ExportRequest, ExportStatus, GroupExportProvider, PatientExportProvider, RawManifestEntry,
+    ResourceStorage, StartExportInput, TypeFilter,
 };
 use helios_persistence::error::{BulkExportError, StorageError};
 
@@ -54,6 +54,42 @@ fn bad_request(msg: impl Into<String>) -> RestError {
 
 fn external_download_url(download: &DownloadUrl) -> Option<String> {
     (!download.requires_access_token).then(|| download.url.clone())
+}
+
+fn advertised_download_url(download: &DownloadUrl, fallback: impl FnOnce() -> String) -> String {
+    external_download_url(download).unwrap_or_else(fallback)
+}
+
+async fn resolve_manifest_files<S>(
+    entries: &[RawManifestEntry],
+    output: &dyn ExportOutputStore,
+    ttl: Duration,
+    state: &AppState<S>,
+    tenant: &TenantExtractor,
+    job_id: &ExportJobId,
+    requires_token: &mut Option<bool>,
+) -> RestResult<Vec<ExportOutputFile>>
+where
+    S: ResourceStorage,
+{
+    let mut files = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let download = output
+            .download_url(&entry.key, ttl)
+            .await
+            .map_err(map_storage_err)?;
+        *requires_token = Some(requires_token.unwrap_or(false) || download.requires_access_token);
+        let url = advertised_download_url(&download, || {
+            let part = entry.key.part_segment();
+            state.public_url_for_request(tenant, ["export-file", job_id.as_str(), part.as_str()])
+        });
+        files.push(ExportOutputFile {
+            resource_type: entry.resource_type.clone(),
+            url,
+            count: Some(entry.count),
+        });
+    }
+    Ok(files)
 }
 
 // Shared `Prefer` / `Parameters` parsing helpers live in `bulk_common`.
@@ -485,53 +521,27 @@ where
                 .await
                 .map_err(map_storage_err)?;
             let ttl = Duration::from_secs(cfg.file_url_ttl_secs);
-            let mut output_files = Vec::new();
-            let mut error_files = Vec::new();
             let mut requires_token = None;
-            for entry in &raw.output {
-                let download = output
-                    .download_url(&entry.key, ttl)
-                    .await
-                    .map_err(map_storage_err)?;
-                requires_token =
-                    Some(requires_token.unwrap_or(false) || download.requires_access_token);
-                let url = if let Some(external) = external_download_url(&download) {
-                    external
-                } else {
-                    let part = format!("{}-{}", entry.key.resource_type, entry.key.part_index);
-                    state.public_url_for_request(
-                        &tenant,
-                        ["export-file", job_id.as_str(), part.as_str()],
-                    )
-                };
-                output_files.push(ExportOutputFile {
-                    resource_type: entry.resource_type.clone(),
-                    url,
-                    count: Some(entry.count),
-                });
-            }
-            for entry in &raw.errors {
-                let download = output
-                    .download_url(&entry.key, ttl)
-                    .await
-                    .map_err(map_storage_err)?;
-                requires_token =
-                    Some(requires_token.unwrap_or(false) || download.requires_access_token);
-                let url = if let Some(external) = external_download_url(&download) {
-                    external
-                } else {
-                    let part = format!("{}-{}", entry.key.resource_type, entry.key.part_index);
-                    state.public_url_for_request(
-                        &tenant,
-                        ["export-file", job_id.as_str(), part.as_str()],
-                    )
-                };
-                error_files.push(ExportOutputFile {
-                    resource_type: entry.resource_type.clone(),
-                    url,
-                    count: Some(entry.count),
-                });
-            }
+            let output_files = resolve_manifest_files(
+                &raw.output,
+                output.as_ref(),
+                ttl,
+                &state,
+                &tenant,
+                &job_id,
+                &mut requires_token,
+            )
+            .await?;
+            let error_files = resolve_manifest_files(
+                &raw.errors,
+                output.as_ref(),
+                ttl,
+                &state,
+                &tenant,
+                &job_id,
+                &mut requires_token,
+            )
+            .await?;
             let manifest = ExportManifest {
                 transaction_time: raw.transaction_time,
                 request: raw.request_url,
@@ -768,5 +778,18 @@ mod tests {
             requires_access_token: false,
         };
         assert_eq!(external_download_url(&download).as_deref(), Some(url));
+        assert_eq!(
+            advertised_download_url(&download, || "https://fallback.example".to_string()),
+            url
+        );
+
+        let protected = DownloadUrl {
+            url: "internal://artifact".to_string(),
+            requires_access_token: true,
+        };
+        assert_eq!(
+            advertised_download_url(&protected, || "https://public.example/artifact".to_string()),
+            "https://public.example/artifact"
+        );
     }
 }

--- a/crates/rest/src/handlers/bulk_export.rs
+++ b/crates/rest/src/handlers/bulk_export.rs
@@ -16,8 +16,9 @@ use helios_auth::Principal;
 use helios_fhir::FhirVersion;
 use helios_persistence::core::ExportDataProvider;
 use helios_persistence::core::{
-    ExportJobId, ExportLevel, ExportManifest, ExportOutputFile, ExportRequest, ExportStatus,
-    GroupExportProvider, PatientExportProvider, ResourceStorage, StartExportInput, TypeFilter,
+    DownloadUrl, ExportJobId, ExportLevel, ExportManifest, ExportOutputFile, ExportRequest,
+    ExportStatus, GroupExportProvider, PatientExportProvider, ResourceStorage, StartExportInput,
+    TypeFilter,
 };
 use helios_persistence::error::{BulkExportError, StorageError};
 
@@ -49,6 +50,10 @@ fn bad_request(msg: impl Into<String>) -> RestError {
     RestError::BadRequest {
         message: msg.into(),
     }
+}
+
+fn external_download_url(download: &DownloadUrl) -> Option<String> {
+    (!download.requires_access_token).then(|| download.url.clone())
 }
 
 // Shared `Prefer` / `Parameters` parsing helpers live in `bulk_common`.
@@ -282,11 +287,7 @@ where
     )
     .await;
 
-    let status_url = format!(
-        "{}/export-status/{}",
-        state.base_url().trim_end_matches('/'),
-        job_id
-    );
+    let status_url = state.public_url_for_request(tenant, ["export-status", job_id.as_str()]);
 
     Response::builder()
         .status(StatusCode::ACCEPTED)
@@ -381,13 +382,12 @@ where
     let headers = request.headers().clone();
     let uri = request.uri().clone();
     let raw_query = uri.query().map(|q| q.to_string());
-    let full_url = format!(
-        "{}{}",
-        state.base_url().trim_end_matches('/'),
-        uri.path_and_query()
-            .map(|pq| pq.as_str())
-            .unwrap_or(uri.path())
-    );
+    let endpoint_segments: Vec<&str> = match &level {
+        ExportLevel::System => vec!["$export"],
+        ExportLevel::Patient => vec!["Patient", "$export"],
+        ExportLevel::Group { group_id } => vec!["Group", group_id, "$export"],
+    };
+    let full_url = state.public_url_for_request_with_query(&tenant, endpoint_segments, uri.query());
     let principal = request.extensions().get::<Principal>().cloned();
 
     let body_json: Option<serde_json::Value> = if method == Method::POST {
@@ -487,34 +487,55 @@ where
             let ttl = Duration::from_secs(cfg.file_url_ttl_secs);
             let mut output_files = Vec::new();
             let mut error_files = Vec::new();
-            let mut requires_token = true;
+            let mut requires_token = None;
             for entry in &raw.output {
-                let url = output
+                let download = output
                     .download_url(&entry.key, ttl)
                     .await
                     .map_err(map_storage_err)?;
-                requires_token = url.requires_access_token;
+                requires_token =
+                    Some(requires_token.unwrap_or(false) || download.requires_access_token);
+                let url = if let Some(external) = external_download_url(&download) {
+                    external
+                } else {
+                    let part = format!("{}-{}", entry.key.resource_type, entry.key.part_index);
+                    state.public_url_for_request(
+                        &tenant,
+                        ["export-file", job_id.as_str(), part.as_str()],
+                    )
+                };
                 output_files.push(ExportOutputFile {
                     resource_type: entry.resource_type.clone(),
-                    url: url.url,
+                    url,
                     count: Some(entry.count),
                 });
             }
             for entry in &raw.errors {
-                let url = output
+                let download = output
                     .download_url(&entry.key, ttl)
                     .await
                     .map_err(map_storage_err)?;
+                requires_token =
+                    Some(requires_token.unwrap_or(false) || download.requires_access_token);
+                let url = if let Some(external) = external_download_url(&download) {
+                    external
+                } else {
+                    let part = format!("{}-{}", entry.key.resource_type, entry.key.part_index);
+                    state.public_url_for_request(
+                        &tenant,
+                        ["export-file", job_id.as_str(), part.as_str()],
+                    )
+                };
                 error_files.push(ExportOutputFile {
                     resource_type: entry.resource_type.clone(),
-                    url: url.url,
+                    url,
                     count: Some(entry.count),
                 });
             }
             let manifest = ExportManifest {
                 transaction_time: raw.transaction_time,
                 request: raw.request_url,
-                requires_access_token: requires_token,
+                requires_access_token: requires_token.unwrap_or(true),
                 output: output_files,
                 error: error_files,
                 deleted: Vec::new(),
@@ -732,5 +753,20 @@ fn owns_job(principal: Option<&Principal>, owner_subject: Option<&str>) -> bool 
                     .iter()
                     .any(|s| s.resource_type == helios_auth::scope::ResourceTypeSpec::Wildcard)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presigned_download_url_is_preserved_byte_for_byte() {
+        let url = "https://s3.example/object?X-Amz-Signature=a%2Fb&x=1";
+        let download = DownloadUrl {
+            url: url.to_string(),
+            requires_access_token: false,
+        };
+        assert_eq!(external_download_url(&download).as_deref(), Some(url));
     }
 }

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -42,6 +42,10 @@ fn external_download_url(download: &DownloadUrl) -> Option<String> {
     (!download.requires_access_token).then(|| download.url.clone())
 }
 
+fn advertised_download_url(download: &DownloadUrl, fallback: impl FnOnce() -> String) -> String {
+    external_download_url(download).unwrap_or_else(fallback)
+}
+
 /// The code system for the `submissionStatus` Coding (per the IG).
 const SUBMISSION_STATUS_SYSTEM: &str = "http://hl7.org/fhir/event-status";
 /// The pre-STU4 draft's status system, still sent by providers tracking the
@@ -837,15 +841,13 @@ where
         // submit ownership + `system/bulk-submit` — never the export-file surface.
         // Pre-signed URLs (S3) are capability URLs and are used as-is.
         requires_token |= dl.requires_access_token;
-        let url = if let Some(external) = external_download_url(&dl) {
-            external
-        } else {
+        let url = advertised_download_url(&dl, || {
             let part = format!("{resource_type}-{}", f.part_index);
             state.public_url_for_request(
                 &tenant,
                 ["bulk-submit-file", token.as_str(), part.as_str()],
             )
-        };
+        });
         let url = serde_json::Value::String(url);
         match f.file_type.as_str() {
             "output" => {
@@ -1107,6 +1109,19 @@ mod tests {
             requires_access_token: false,
         };
         assert_eq!(external_download_url(&download).as_deref(), Some(url));
+        assert_eq!(
+            advertised_download_url(&download, || "https://fallback.example".to_string()),
+            url
+        );
+
+        let protected = DownloadUrl {
+            url: "internal://artifact".to_string(),
+            requires_access_token: true,
+        };
+        assert_eq!(
+            advertised_download_url(&protected, || "https://public.example/artifact".to_string()),
+            "https://public.example/artifact"
+        );
     }
 
     fn param(name: &str, key: &str, val: Value) -> Value {

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -20,8 +20,8 @@ use axum::{
 };
 use helios_auth::Principal;
 use helios_persistence::core::{
-    ExportPartKey, IMPORT_MODE_PARAMETER_URL, ImportMode, ManifestFetchParams, ManifestStatus,
-    ResourceStorage, SubmissionId, SubmissionStatus, submission_output_job_id,
+    DownloadUrl, ExportPartKey, IMPORT_MODE_PARAMETER_URL, ImportMode, ManifestFetchParams,
+    ManifestStatus, ResourceStorage, SubmissionId, SubmissionStatus, submission_output_job_id,
 };
 use serde_json::{Value, json};
 
@@ -37,6 +37,10 @@ const SUBMIT_SCOPE: &str = "bulk-submit";
 
 /// Query parameter selecting a status-manifest page (1-based).
 const PAGE_PARAM: &str = "page";
+
+fn external_download_url(download: &DownloadUrl) -> Option<String> {
+    (!download.requires_access_token).then(|| download.url.clone())
+}
 
 /// The code system for the `submissionStatus` Coding (per the IG).
 const SUBMISSION_STATUS_SYSTEM: &str = "http://hl7.org/fhir/event-status";
@@ -395,7 +399,7 @@ where
         });
     }
 
-    let request_url = format!("{}/$bulk-submit", state.base_url().trim_end_matches('/'));
+    let request_url = state.public_url_for_request(&tenant, ["$bulk-submit"]);
     // Capture `Prefer: handling=` before consuming the body.
     let strict = request
         .headers()
@@ -610,11 +614,7 @@ where
         .ensure_poll_token(ctx, &sub_id)
         .await
         .map_err(RestError::from)?;
-    let status_url = format!(
-        "{}/bulk-submit-status/{}",
-        state.base_url().trim_end_matches('/'),
-        token
-    );
+    let status_url = state.public_url_for_request(&tenant, ["bulk-submit-status", token.as_str()]);
     Response::builder()
         .status(StatusCode::ACCEPTED)
         .header("Content-Location", status_url)
@@ -689,7 +689,7 @@ fn parse_page_param(query: Option<&str>) -> RestResult<usize> {
 pub async fn bulk_submit_poll_handler<S>(
     State(state): State<AppState<S>>,
     Path(token): Path<String>,
-    _tenant: TenantExtractor,
+    tenant: TenantExtractor,
     PeerIp(peer): PeerIp,
     request: Request,
 ) -> RestResult<Response>
@@ -724,6 +724,12 @@ where
             id: token.clone(),
         })?;
     if !owns_submission(principal.as_ref(), target.owner_subject.as_deref()) {
+        return Err(RestError::NotFound {
+            resource_type: "bulk-submit-status".to_string(),
+            id: token.clone(),
+        });
+    }
+    if target.tenant.tenant_id().as_str() != tenant.tenant_id() {
         return Err(RestError::NotFound {
             resource_type: "bulk-submit-status".to_string(),
             id: token.clone(),
@@ -776,7 +782,6 @@ where
         .map_err(RestError::from)?;
     let job_id = submission_output_job_id(sub_id);
     let ttl = Duration::from_secs(cfg.file_url_ttl_secs);
-    let base = state.base_url().trim_end_matches('/');
 
     // Slice the artifact rows into the requested page. Backends return them in a
     // stable order (`ORDER BY id`) and rows are append-only until the whole
@@ -832,13 +837,14 @@ where
         // submit ownership + `system/bulk-submit` — never the export-file surface.
         // Pre-signed URLs (S3) are capability URLs and are used as-is.
         requires_token |= dl.requires_access_token;
-        let url = if dl.requires_access_token {
-            format!(
-                "{base}/bulk-submit-file/{token}/{resource_type}-{}",
-                f.part_index
-            )
+        let url = if let Some(external) = external_download_url(&dl) {
+            external
         } else {
-            dl.url
+            let part = format!("{resource_type}-{}", f.part_index);
+            state.public_url_for_request(
+                &tenant,
+                ["bulk-submit-file", token.as_str(), part.as_str()],
+            )
         };
         let url = serde_json::Value::String(url);
         match f.file_type.as_str() {
@@ -882,9 +888,14 @@ where
     // A single `next` link chains to the following page; the last page has none.
     let mut link_arr = Vec::new();
     if page < total_pages {
+        let query = format!("{PAGE_PARAM}={}", page + 1);
         link_arr.push(json!({
             "relation": "next",
-            "url": format!("{base}/bulk-submit-status/{token}?{PAGE_PARAM}={}", page + 1),
+            "url": state.public_url_for_request_with_query(
+                &tenant,
+                ["bulk-submit-status", token.as_str()],
+                Some(&query),
+            ),
         }));
     }
 
@@ -925,7 +936,7 @@ fn severity_array(cs: &Value) -> Value {
 pub async fn bulk_submit_cancel_handler<S>(
     State(state): State<AppState<S>>,
     Path(token): Path<String>,
-    _tenant: TenantExtractor,
+    tenant: TenantExtractor,
     request: Request,
 ) -> RestResult<Response>
 where
@@ -960,6 +971,12 @@ where
             id: token.clone(),
         });
     }
+    if target.tenant.tenant_id().as_str() != tenant.tenant_id() {
+        return Err(RestError::NotFound {
+            resource_type: "bulk-submit-status".to_string(),
+            id: token.clone(),
+        });
+    }
     let ctx = &target.tenant;
     let sub_id = &target.submission_id;
 
@@ -988,7 +1005,7 @@ where
 pub async fn bulk_submit_file_handler<S>(
     State(state): State<AppState<S>>,
     Path((token, part)): Path<(String, String)>,
-    _tenant: TenantExtractor,
+    tenant: TenantExtractor,
     request: Request,
 ) -> RestResult<Response>
 where
@@ -1018,6 +1035,12 @@ where
             id: format!("{token}/{part}"),
         })?;
     if !owns_submission(principal.as_ref(), target.owner_subject.as_deref()) {
+        return Err(RestError::NotFound {
+            resource_type: "bulk-submit-file".to_string(),
+            id: format!("{token}/{part}"),
+        });
+    }
+    if target.tenant.tenant_id().as_str() != tenant.tenant_id() {
         return Err(RestError::NotFound {
             resource_type: "bulk-submit-file".to_string(),
             id: format!("{token}/{part}"),
@@ -1075,6 +1098,16 @@ where
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn presigned_download_url_is_preserved_byte_for_byte() {
+        let url = "https://s3.example/object?X-Amz-Signature=a%2Fb&x=1";
+        let download = DownloadUrl {
+            url: url.to_string(),
+            requires_access_token: false,
+        };
+        assert_eq!(external_download_url(&download).as_deref(), Some(url));
+    }
 
     fn param(name: &str, key: &str, val: Value) -> Value {
         json!({ "name": name, key: val })

--- a/crates/rest/src/handlers/capabilities.rs
+++ b/crates/rest/src/handlers/capabilities.rs
@@ -87,16 +87,7 @@ where
         "Processing capabilities request"
     );
 
-    // Build tenant-aware base URL
-    let base_url = if tenant.is_url_based() {
-        format!(
-            "{}/{}",
-            state.base_url().trim_end_matches('/'),
-            tenant.tenant_id()
-        )
-    } else {
-        state.base_url().to_string()
-    };
+    let base_url = state.public_base_url_for_request(&tenant);
 
     let capability_statement =
         build_capability_statement(&state, tenant.context(), fhir_version, &base_url);

--- a/crates/rest/src/handlers/compartment.rs
+++ b/crates/rest/src/handlers/compartment.rs
@@ -139,7 +139,9 @@ where
 
     // Convert result to FHIR Bundle
     let mut bundle = result.to_bundle(&public_base, &self_link);
-    rewrite_bundle_full_urls(&mut bundle, &state, &tenant);
+    crate::public_url::rewrite_bundle_full_urls(&mut bundle, |resource_type, id| {
+        state.public_url_for_request(&tenant, [resource_type, id])
+    });
 
     debug!(
         compartment_type = %compartment_type,
@@ -272,7 +274,9 @@ where
         &search_params,
     );
     let mut bundle = result.to_bundle(&public_base, &self_link);
-    rewrite_bundle_full_urls(&mut bundle, &state, &tenant);
+    crate::public_url::rewrite_bundle_full_urls(&mut bundle, |resource_type, id| {
+        state.public_url_for_request(&tenant, [resource_type, id])
+    });
 
     debug!(
         compartment_type = %compartment_type,
@@ -300,27 +304,6 @@ fn build_compartment_search_url(
     crate::public_url::PublicUrl::parse(base_url)
         .expect("request public base was built from validated configuration")
         .with_segments_and_query([compartment_type, compartment_id, target_type], &query)
-}
-
-fn rewrite_bundle_full_urls<S>(
-    bundle: &mut helios_persistence::types::SearchBundle,
-    state: &AppState<S>,
-    tenant: &TenantExtractor,
-) where
-    S: ResourceStorage,
-{
-    for entry in &mut bundle.entry {
-        let Some(resource) = entry.resource.as_ref() else {
-            continue;
-        };
-        let Some(resource_type) = resource.get("resourceType").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        let Some(id) = resource.get("id").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        entry.full_url = Some(state.public_url_for_request(tenant, [resource_type, id]));
-    }
 }
 
 /// Converts a SearchBundle to a serde_json::Value for response.

--- a/crates/rest/src/handlers/compartment.rs
+++ b/crates/rest/src/handlers/compartment.rs
@@ -128,8 +128,9 @@ where
         })?;
 
     // Build the self link URL
+    let public_base = state.public_base_url_for_request(&tenant);
     let self_link = build_compartment_search_url(
-        state.base_url(),
+        &public_base,
         &compartment_type,
         &compartment_id,
         &target_type,
@@ -137,7 +138,8 @@ where
     );
 
     // Convert result to FHIR Bundle
-    let bundle = result.to_bundle(state.base_url(), &self_link);
+    let mut bundle = result.to_bundle(&public_base, &self_link);
+    rewrite_bundle_full_urls(&mut bundle, &state, &tenant);
 
     debug!(
         compartment_type = %compartment_type,
@@ -261,14 +263,16 @@ where
         helios_persistence::types::Page::new(collected, helios_persistence::types::PageInfo::end());
     let result = helios_persistence::core::SearchResult::new(page);
 
+    let public_base = state.public_base_url_for_request(&tenant);
     let self_link = build_compartment_search_url(
-        state.base_url(),
+        &public_base,
         &compartment_type,
         &compartment_id,
         "*",
         &search_params,
     );
-    let bundle = result.to_bundle(state.base_url(), &self_link);
+    let mut bundle = result.to_bundle(&public_base, &self_link);
+    rewrite_bundle_full_urls(&mut bundle, &state, &tenant);
 
     debug!(
         compartment_type = %compartment_type,
@@ -288,20 +292,34 @@ fn build_compartment_search_url(
     target_type: &str,
     params: &SearchParams,
 ) -> String {
-    let path = format!(
-        "{}/{}/{}/{}",
-        base_url, compartment_type, compartment_id, target_type
-    );
-
     let query: String = params
         .iter()
         .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
         .collect::<Vec<_>>()
         .join("&");
-    if query.is_empty() {
-        path
-    } else {
-        format!("{}?{}", path, query)
+    crate::public_url::PublicUrl::parse(base_url)
+        .expect("request public base was built from validated configuration")
+        .with_segments_and_query([compartment_type, compartment_id, target_type], &query)
+}
+
+fn rewrite_bundle_full_urls<S>(
+    bundle: &mut helios_persistence::types::SearchBundle,
+    state: &AppState<S>,
+    tenant: &TenantExtractor,
+) where
+    S: ResourceStorage,
+{
+    for entry in &mut bundle.entry {
+        let Some(resource) = entry.resource.as_ref() else {
+            continue;
+        };
+        let Some(resource_type) = resource.get("resourceType").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(id) = resource.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        entry.full_url = Some(state.public_url_for_request(tenant, [resource_type, id]));
     }
 }
 

--- a/crates/rest/src/handlers/create.rs
+++ b/crates/rest/src/handlers/create.rs
@@ -150,7 +150,8 @@ where
                     );
                 }
                 let headers = ResourceHeaders::from_stored(&stored, &state);
-                let location = format!("{}/{}/{}", state.base_url(), resource_type, stored.id());
+                let location =
+                    state.public_url_for_request(&tenant, [resource_type.as_str(), stored.id()]);
 
                 debug!(
                     resource_type = %resource_type,
@@ -229,7 +230,7 @@ where
     }
 
     let headers = ResourceHeaders::from_stored(&stored, &state);
-    let location = format!("{}/{}/{}", state.base_url(), resource_type, stored.id());
+    let location = state.public_url_for_request(&tenant, [resource_type.as_str(), stored.id()]);
 
     debug!(
         resource_type = %resource_type,

--- a/crates/rest/src/handlers/history.rs
+++ b/crates/rest/src/handlers/history.rs
@@ -82,7 +82,14 @@ where
 }
 
 /// Converts a single [`HistoryEntry`] into a FHIR history Bundle entry.
-fn history_entry_to_json(entry: &HistoryEntry, base_url: &str) -> Value {
+fn history_entry_to_json<S>(
+    entry: &HistoryEntry,
+    state: &AppState<S>,
+    tenant: &TenantExtractor,
+) -> Value
+where
+    S: ResourceStorage,
+{
     let resource = &entry.resource;
     let resource_type = resource.resource_type();
     let id = resource.id();
@@ -96,7 +103,7 @@ fn history_entry_to_json(entry: &HistoryEntry, base_url: &str) -> Value {
     };
 
     let mut bundle_entry = json!({
-        "fullUrl": format!("{base_url}/{resource_type}/{id}"),
+        "fullUrl": state.public_url_for_request(tenant, [resource_type, id]),
         "request": {
             "method": method,
             "url": request_url,
@@ -117,10 +124,18 @@ fn history_entry_to_json(entry: &HistoryEntry, base_url: &str) -> Value {
 }
 
 /// Builds a FHIR `history` Bundle from a page of history entries.
-fn build_history_bundle(entries: &[HistoryEntry], base_url: &str, total: u64) -> Value {
+fn build_history_bundle<S>(
+    entries: &[HistoryEntry],
+    state: &AppState<S>,
+    tenant: &TenantExtractor,
+    total: u64,
+) -> Value
+where
+    S: ResourceStorage,
+{
     let bundle_entries: Vec<Value> = entries
         .iter()
-        .map(|entry| history_entry_to_json(entry, base_url))
+        .map(|entry| history_entry_to_json(entry, state, tenant))
         .collect();
 
     json!({
@@ -198,7 +213,7 @@ where
     }
 
     let total = page.page_info.total.unwrap_or(page.items.len() as u64);
-    let bundle = build_history_bundle(&page.items, state.base_url(), total);
+    let bundle = build_history_bundle(&page.items, &state, &tenant, total);
 
     Ok(respond_with_bundle(
         &bundle,
@@ -242,7 +257,7 @@ where
         })?;
 
     let total = page.page_info.total.unwrap_or(page.items.len() as u64);
-    let bundle = build_history_bundle(&page.items, state.base_url(), total);
+    let bundle = build_history_bundle(&page.items, &state, &tenant, total);
 
     Ok(respond_with_bundle(
         &bundle,
@@ -284,7 +299,7 @@ where
         })?;
 
     let total = page.page_info.total.unwrap_or(page.items.len() as u64);
-    let bundle = build_history_bundle(&page.items, state.base_url(), total);
+    let bundle = build_history_bundle(&page.items, &state, &tenant, total);
 
     Ok(respond_with_bundle(
         &bundle,

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -428,7 +428,9 @@ where
 
     // Convert result to FHIR Bundle
     let mut bundle = result.to_bundle(&public_base, &self_link);
-    rewrite_bundle_full_urls(&mut bundle, state, tenant);
+    crate::public_url::rewrite_bundle_full_urls(&mut bundle, |resource_type, id| {
+        state.public_url_for_request(tenant, [resource_type, id])
+    });
 
     // Parse subsetting parameters
     let summary_mode = search_params
@@ -544,7 +546,9 @@ where
 
     // Convert result to FHIR Bundle
     let mut bundle = result.to_bundle(&public_base, &self_link);
-    rewrite_bundle_full_urls(&mut bundle, state, &tenant);
+    crate::public_url::rewrite_bundle_full_urls(&mut bundle, |resource_type, id| {
+        state.public_url_for_request(&tenant, [resource_type, id])
+    });
 
     // Parse subsetting parameters
     let summary_mode = search_params
@@ -588,27 +592,6 @@ fn build_system_search_url(base_url: &str, params: &SearchParams) -> String {
     crate::public_url::PublicUrl::parse(base_url)
         .expect("request public base was built from validated configuration")
         .with_segments_and_query(std::iter::empty::<&str>(), &query)
-}
-
-fn rewrite_bundle_full_urls<S>(
-    bundle: &mut SearchBundle,
-    state: &AppState<S>,
-    tenant: &TenantExtractor,
-) where
-    S: ResourceStorage,
-{
-    for entry in &mut bundle.entry {
-        let Some(resource) = entry.resource.as_ref() else {
-            continue;
-        };
-        let Some(resource_type) = resource.get("resourceType").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        let Some(id) = resource.get("id").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        entry.full_url = Some(state.public_url_for_request(tenant, [resource_type, id]));
-    }
 }
 
 /// Encodes search params back into a query string, preserving repeated keys.
@@ -882,6 +865,13 @@ async fn expand_subsumption_into(
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+
+    use crate::config::ServerConfig;
+    use crate::tenant::TenantSource;
 
     /// Collapses result pairs into a last-wins map for assertions.
     fn as_map(pairs: &[(String, String)]) -> HashMap<String, String> {
@@ -895,6 +885,51 @@ mod tests {
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
         )
+    }
+
+    #[tokio::test]
+    async fn system_search_uses_the_tenant_aware_public_base() {
+        let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|path| path.parent())
+            .map(|path| path.join("data"));
+        let backend = Arc::new(
+            SqliteBackend::with_config(
+                ":memory:",
+                SqliteBackendConfig {
+                    data_dir,
+                    ..Default::default()
+                },
+            )
+            .unwrap(),
+        );
+        backend.init_schema().unwrap();
+        let state = AppState::new(
+            backend,
+            ServerConfig {
+                base_url: "https://public.example/fhir".to_string(),
+                ..ServerConfig::for_testing()
+            },
+        );
+        let tenant = TenantExtractor::new("acme", TenantSource::UrlPath);
+
+        let response = execute_system_search(
+            &state,
+            tenant,
+            vec![("_type".to_string(), "Patient".to_string())],
+            FhirFormat::Json,
+        )
+        .await
+        .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let bundle: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            bundle["link"][0]["url"],
+            "https://public.example/fhir/acme?_type=Patient"
+        );
     }
 
     #[test]

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -423,10 +423,12 @@ where
     }
 
     // Build the self link URL
-    let self_link = build_search_url(state.base_url(), resource_type, &search_params);
+    let public_base = state.public_base_url_for_request(tenant);
+    let self_link = build_search_url(&public_base, resource_type, &search_params);
 
     // Convert result to FHIR Bundle
-    let bundle = result.to_bundle(state.base_url(), &self_link);
+    let mut bundle = result.to_bundle(&public_base, &self_link);
+    rewrite_bundle_full_urls(&mut bundle, state, tenant);
 
     // Parse subsetting parameters
     let summary_mode = search_params
@@ -537,10 +539,12 @@ where
         })?;
 
     // Build the self link URL
-    let self_link = build_system_search_url(state.base_url(), &search_params);
+    let public_base = state.public_base_url_for_request(&tenant);
+    let self_link = build_system_search_url(&public_base, &search_params);
 
     // Convert result to FHIR Bundle
-    let bundle = result.to_bundle(state.base_url(), &self_link);
+    let mut bundle = result.to_bundle(&public_base, &self_link);
+    rewrite_bundle_full_urls(&mut bundle, state, &tenant);
 
     // Parse subsetting parameters
     let summary_mode = search_params
@@ -573,20 +577,37 @@ where
 /// Builds a type-level search URL from base URL and parameters.
 fn build_search_url(base_url: &str, resource_type: &str, params: &SearchParams) -> String {
     let query = encode_query(params);
-    if query.is_empty() {
-        format!("{}/{}", base_url, resource_type)
-    } else {
-        format!("{}/{}?{}", base_url, resource_type, query)
-    }
+    crate::public_url::PublicUrl::parse(base_url)
+        .expect("request public base was built from validated configuration")
+        .with_segments_and_query([resource_type], &query)
 }
 
 /// Builds a system-level search URL from base URL and parameters.
 fn build_system_search_url(base_url: &str, params: &SearchParams) -> String {
     let query = encode_query(params);
-    if query.is_empty() {
-        base_url.to_string()
-    } else {
-        format!("{}?{}", base_url, query)
+    crate::public_url::PublicUrl::parse(base_url)
+        .expect("request public base was built from validated configuration")
+        .with_segments_and_query(std::iter::empty::<&str>(), &query)
+}
+
+fn rewrite_bundle_full_urls<S>(
+    bundle: &mut SearchBundle,
+    state: &AppState<S>,
+    tenant: &TenantExtractor,
+) where
+    S: ResourceStorage,
+{
+    for entry in &mut bundle.entry {
+        let Some(resource) = entry.resource.as_ref() else {
+            continue;
+        };
+        let Some(resource_type) = resource.get("resourceType").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(id) = resource.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        entry.full_url = Some(state.public_url_for_request(tenant, [resource_type, id]));
     }
 }
 

--- a/crates/rest/src/handlers/sof/export.rs
+++ b/crates/rest/src/handlers/sof/export.rs
@@ -638,10 +638,7 @@ where
 
     let job_id = controller.submit(task);
     // Spec: `Content-Location` must be the absolute URL of the status endpoint.
-    let location = format!(
-        "{base}/export/{job_id}/status",
-        base = state.base_url().trim_end_matches('/'),
-    );
+    let location = state.public_url_for_request(tenant, ["export", job_id.as_str(), "status"]);
 
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -768,10 +765,8 @@ where
         // it never communicates the job's outcome. The outcome (manifest on
         // success, OperationOutcome on failure) is served from the result URL.
         Some(JobStatus::Failed { .. }) | Some(JobStatus::Completed { .. }) => {
-            let result_url = format!(
-                "{base}/export/{job_id}/result",
-                base = state.base_url().trim_end_matches('/'),
-            );
+            let result_url =
+                state.public_url_for_request(&tenant, ["export", job_id.as_str(), "result"]);
             let mut headers = HeaderMap::new();
             if let Ok(v) = HeaderValue::from_str(&result_url) {
                 headers.insert(header::LOCATION, v);
@@ -783,7 +778,7 @@ where
 
 /// Constructs the SQL-on-FHIR v2 completion manifest as a FHIR `Parameters` resource.
 fn build_completion_manifest(
-    base_url: &str,
+    status_url: &str,
     job_id: &str,
     outputs: &[(String, String)],
     submitted_at: chrono::DateTime<chrono::Utc>,
@@ -822,10 +817,6 @@ fn build_completion_manifest(
         })
         .collect();
 
-    let status_url = format!(
-        "{base}/export/{job_id}/status",
-        base = base_url.trim_end_matches('/'),
-    );
     let duration_secs = (completed_at - submitted_at).num_seconds().max(0);
 
     let mut params: Vec<Value> = vec![
@@ -934,8 +925,14 @@ where
             // (e.g. an S3 pre-signing error) must not yield a manifest with a
             // missing/empty `location`, so surface it as a 500 instead.
             let mut outputs: Vec<(String, String)> = Vec::with_capacity(files.len());
+            let public_base_url = state.public_base_url_for_request(&tenant);
             for f in &files {
-                match controller.download_url(tenant.tenant_id(), &job_id, &f.filename) {
+                match controller.download_url(
+                    tenant.tenant_id(),
+                    &public_base_url,
+                    &job_id,
+                    &f.filename,
+                ) {
                     Some(url) => outputs.push((f.view_name.clone(), url)),
                     None => {
                         return Ok((
@@ -967,11 +964,13 @@ where
             if let Ok(v) = HeaderValue::from_str(&expires_str) {
                 headers.insert(header::EXPIRES, v);
             }
+            let status_url =
+                state.public_url_for_request(&tenant, ["export", job_id.as_str(), "status"]);
             Ok((
                 StatusCode::OK,
                 headers,
                 axum::Json(build_completion_manifest(
-                    state.base_url(),
+                    &status_url,
                     &job_id,
                     &outputs,
                     submitted_at,

--- a/crates/rest/src/handlers/subscriptions.rs
+++ b/crates/rest/src/handlers/subscriptions.rs
@@ -41,7 +41,8 @@ where
 
     let snapshot = resolve_snapshot(&state, engine, &tenant, &id).await?;
 
-    let status_resource = build_subscription_status(&snapshot, &id, state.base_url());
+    let subscription_url = state.public_url_for_request(&tenant, ["Subscription", id.as_str()]);
+    let status_resource = build_subscription_status(&snapshot, &subscription_url);
 
     Ok((StatusCode::OK, Json(status_resource)).into_response())
 }
@@ -240,11 +241,8 @@ where
         .generate_token(tenant.tenant_id(), &id);
 
     // Build WebSocket URL from the base URL.
-    let ws_base = state
-        .base_url()
-        .replace("http://", "ws://")
-        .replace("https://", "wss://");
-    let ws_url = format!("{}/ws/subscriptions/bind", ws_base);
+    let ws_http_url = state.public_url_for_request(&tenant, ["ws", "subscriptions", "bind"]);
+    let ws_url = websocket_url(&ws_http_url)?;
 
     // Return Parameters resource per FHIR spec.
     let parameters = json!({
@@ -268,8 +266,26 @@ where
     Ok((StatusCode::OK, Json(parameters)).into_response())
 }
 
+fn websocket_url(http_url: &str) -> RestResult<String> {
+    let mut ws_url = url::Url::parse(http_url).map_err(|error| RestError::InternalError {
+        message: format!("failed to build WebSocket URL: {error}"),
+    })?;
+    let ws_scheme = if ws_url.scheme() == "https" {
+        "wss"
+    } else {
+        "ws"
+    };
+    ws_url
+        .set_scheme(ws_scheme)
+        .map_err(|_| RestError::InternalError {
+            message: "failed to set WebSocket URL scheme".to_string(),
+        })?;
+
+    Ok(ws_url.to_string())
+}
+
 /// Builds a SubscriptionStatus resource for the $status response.
-fn build_subscription_status(sub: &StatusSnapshot, id: &str, base_url: &str) -> serde_json::Value {
+fn build_subscription_status(sub: &StatusSnapshot, subscription_url: &str) -> serde_json::Value {
     if uses_backport_ig(sub.fhir_version) {
         // R4 backport: return Parameters resource
         json!({
@@ -278,7 +294,7 @@ fn build_subscription_status(sub: &StatusSnapshot, id: &str, base_url: &str) -> 
                 {
                     "name": "subscription",
                     "valueReference": {
-                        "reference": format!("{}/Subscription/{}", base_url, id)
+                        "reference": subscription_url
                     }
                 },
                 {
@@ -307,7 +323,7 @@ fn build_subscription_status(sub: &StatusSnapshot, id: &str, base_url: &str) -> 
             "type": "query-status",
             "eventsSinceSubscriptionStart": sub.events_since_start,
             "subscription": {
-                "reference": format!("Subscription/{}", id)
+                "reference": subscription_url
             },
             "topic": sub.topic_url
         })
@@ -389,5 +405,25 @@ mod tests {
         );
         assert_eq!(bare.status, SubscriptionStatusCode::Requested);
         assert_eq!(bare.topic_url, "");
+    }
+
+    #[test]
+    fn public_subscription_urls_keep_prefix_and_tenant() {
+        let snapshot = StatusSnapshot {
+            status: SubscriptionStatusCode::Active,
+            topic_url: "https://example.test/topic".to_string(),
+            events_since_start: 1,
+            fhir_version: FhirVersion::default(),
+        };
+        let subscription_url = "https://public.example/fhir/acme/Subscription/sub-1";
+        let status = build_subscription_status(&snapshot, subscription_url);
+        assert_eq!(
+            status["parameter"][0]["valueReference"]["reference"],
+            subscription_url
+        );
+        assert_eq!(
+            websocket_url("https://public.example/fhir/acme/ws/subscriptions/bind").unwrap(),
+            "wss://public.example/fhir/acme/ws/subscriptions/bind"
+        );
     }
 }

--- a/crates/rest/src/handlers/update.rs
+++ b/crates/rest/src/handlers/update.rs
@@ -230,11 +230,13 @@ where
         );
     }
 
+    let location = created
+        .then(|| state.public_url_for_request(&tenant, [stored.resource_type(), stored.id()]));
     build_update_response(
         status,
         &stored,
         headers,
-        &state,
+        location.as_deref(),
         created,
         &prefer,
         negotiated.format,
@@ -331,7 +333,7 @@ where
                 StatusCode::OK,
                 &stored,
                 headers,
-                &state,
+                None,
                 false,
                 &prefer,
                 negotiated.format,
@@ -352,11 +354,13 @@ where
         }
         ConditionalUpdateResult::Created(stored) => {
             let headers = ResourceHeaders::from_stored(&stored, &state);
+            let location =
+                state.public_url_for_request(&tenant, [stored.resource_type(), stored.id()]);
             build_update_response(
                 StatusCode::CREATED,
                 &stored,
                 headers,
-                &state,
+                Some(&location),
                 true,
                 &prefer,
                 negotiated.format,
@@ -394,20 +398,14 @@ fn build_update_response(
     status: StatusCode,
     stored: &helios_persistence::types::StoredResource,
     headers: ResourceHeaders,
-    state: &AppState<impl ResourceStorage>,
+    location: Option<&str>,
     created: bool,
     prefer: &PreferHeader,
     format: FhirFormat,
 ) -> RestResult<Response> {
     let mut header_map = headers.to_header_map();
 
-    if created {
-        let location = format!(
-            "{}/{}/{}",
-            state.base_url(),
-            stored.resource_type(),
-            stored.id()
-        );
+    if let Some(location) = location {
         header_map.insert(header::LOCATION, location.parse().unwrap());
     }
 

--- a/crates/rest/src/handlers/ws.rs
+++ b/crates/rest/src/handlers/ws.rs
@@ -18,6 +18,7 @@ use helios_persistence::core::ResourceStorage;
 use tracing::{debug, info, warn};
 
 use crate::error::{RestError, RestResult};
+use crate::extractors::TenantExtractor;
 use crate::state::AppState;
 
 /// WebSocket binding handler.
@@ -26,6 +27,7 @@ use crate::state::AppState;
 /// `bind-with-token <binding-token>` as the first message.
 pub async fn ws_bind_handler<S>(
     State(state): State<AppState<S>>,
+    tenant: TenantExtractor,
     ws: WebSocketUpgrade,
 ) -> RestResult<Response>
 where
@@ -38,10 +40,33 @@ where
         })?;
 
     let engine = Arc::clone(engine);
-    let base_url = state.base_url().to_string();
+    let base_url = state.public_base_url_for_request(&tenant);
+    let request_tenant_id = tenant.tenant_id().to_string();
 
     // Upgrade the HTTP connection to WebSocket.
-    Ok(ws.on_upgrade(move |socket| handle_ws_connection(socket, engine, base_url)))
+    Ok(ws.on_upgrade(move |socket| {
+        handle_ws_connection(socket, engine, request_tenant_id, base_url)
+    }))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum BindingTokenRejection {
+    InvalidOrExpired,
+    TenantMismatch { token_tenant_id: String },
+}
+
+fn validate_binding_token_for_request(
+    manager: &helios_subscriptions::WsBindingTokenManager,
+    token: &str,
+    request_tenant_id: &str,
+) -> Result<(String, String), BindingTokenRejection> {
+    let (token_tenant_id, subscription_id) = manager
+        .validate_and_consume(token)
+        .ok_or(BindingTokenRejection::InvalidOrExpired)?;
+    if token_tenant_id != request_tenant_id {
+        return Err(BindingTokenRejection::TenantMismatch { token_tenant_id });
+    }
+    Ok((token_tenant_id, subscription_id))
 }
 
 /// Handles the WebSocket connection lifecycle after upgrade.
@@ -51,6 +76,7 @@ where
 async fn handle_ws_connection(
     mut socket: WebSocket,
     engine: Arc<helios_subscriptions::SubscriptionEngine>,
+    request_tenant_id: String,
     base_url: String,
 ) {
     let token = match receive_bind_token(&mut socket).await {
@@ -59,12 +85,24 @@ async fn handle_ws_connection(
     };
 
     // Validate and consume the binding token (single-use).
-    let (tenant_id, subscription_id) = match engine.ws_token_manager().validate_and_consume(&token)
-    {
-        Some(binding) => binding,
-        None => {
+    let (tenant_id, subscription_id) = match validate_binding_token_for_request(
+        engine.ws_token_manager(),
+        &token,
+        &request_tenant_id,
+    ) {
+        Ok(binding) => binding,
+        Err(BindingTokenRejection::InvalidOrExpired) => {
             warn!("Invalid or expired WebSocket binding token");
             close_with_policy_violation(&mut socket, "invalid-or-expired-token").await;
+            return;
+        }
+        Err(BindingTokenRejection::TenantMismatch { token_tenant_id }) => {
+            warn!(
+                request_tenant_id = %request_tenant_id,
+                token_tenant_id = %token_tenant_id,
+                "WebSocket binding token tenant does not match request tenant"
+            );
+            close_with_policy_violation(&mut socket, "tenant-mismatch").await;
             return;
         }
     };
@@ -249,7 +287,9 @@ async fn close_with_policy_violation(socket: &mut WebSocket, reason: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_bind_with_token_message;
+    use super::{
+        BindingTokenRejection, parse_bind_with_token_message, validate_binding_token_for_request,
+    };
 
     #[test]
     fn test_parse_bind_with_token_message() {
@@ -267,5 +307,30 @@ mod tests {
         );
         assert_eq!(parse_bind_with_token_message("bind-with-token"), None);
         assert_eq!(parse_bind_with_token_message("hello"), None);
+    }
+
+    #[test]
+    fn binding_token_tenant_must_match_request_tenant() {
+        let manager = helios_subscriptions::WsBindingTokenManager::new(30);
+        let (token, _) = manager.generate_token("acme", "subscription-1");
+
+        assert_eq!(
+            validate_binding_token_for_request(&manager, &token, "other"),
+            Err(BindingTokenRejection::TenantMismatch {
+                token_tenant_id: "acme".to_string(),
+            })
+        );
+        assert!(manager.validate_and_consume(&token).is_none());
+    }
+
+    #[test]
+    fn binding_token_matching_request_tenant_is_accepted() {
+        let manager = helios_subscriptions::WsBindingTokenManager::new(30);
+        let (token, _) = manager.generate_token("acme", "subscription-1");
+
+        assert_eq!(
+            validate_binding_token_for_request(&manager, &token, "acme"),
+            Ok(("acme".to_string(), "subscription-1".to_string()))
+        );
     }
 }

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -158,6 +158,7 @@ pub mod fhir_types;
 pub mod handlers;
 pub mod jwe;
 pub mod middleware;
+pub(crate) mod public_url;
 pub(crate) mod rate_limit;
 pub mod responses;
 pub mod routing;
@@ -175,6 +176,8 @@ pub use tenant::{ResolvedTenant, TenantResolver, TenantSource};
 
 use std::sync::Arc;
 
+#[cfg(feature = "subscriptions")]
+use crate::public_url::PublicUrl;
 use axum::{Router, extract::DefaultBodyLimit};
 use helios_persistence::core::{
     BundleProvider, ConditionalStorage, IncludeProvider, InstanceHistoryProvider, ResourceStorage,
@@ -774,7 +777,10 @@ where
             .unwrap_or(false);
         if subscriptions_enabled {
             let smtp = build_smtp_settings_from_env();
-            let messaging = build_messaging_settings_from_env(&config.base_url);
+            let (messaging, resolve_default_message_source) =
+                build_messaging_settings_from_env(&config.base_url)
+                    .map(|(settings, is_explicit)| (Some(settings), !is_explicit))
+                    .unwrap_or((None, false));
             let mut supported = vec!["rest-hook".to_string(), "websocket".to_string()];
             if smtp.is_some() {
                 supported.push("email".to_string());
@@ -818,11 +824,24 @@ where
             };
             // Outbound auth provider was built above (static bearer when
             // HFS_OUTBOUND_BEARER_TOKEN is set, otherwise no-op).
-            let engine = helios_subscriptions::SubscriptionEngine::with_outbound_auth(
-                sub_config,
-                config.base_url.clone(),
-                outbound_auth_provider,
-            );
+            let public_url = PublicUrl::parse(&config.base_url)
+                .expect("validated ServerConfig has a valid public base URL");
+            let tenant_path_routing = config.multitenancy.routing_mode.supports_url_path();
+            let public_base_url_for_tenant: Arc<dyn Fn(&str) -> String + Send + Sync> =
+                Arc::new(move |tenant_id| {
+                    if tenant_path_routing {
+                        public_url.with_segments([tenant_id])
+                    } else {
+                        public_url.as_str().to_string()
+                    }
+                });
+            let engine =
+                helios_subscriptions::SubscriptionEngine::with_outbound_auth_and_url_resolver(
+                    sub_config,
+                    public_base_url_for_tenant,
+                    resolve_default_message_source,
+                    outbound_auth_provider,
+                );
             // Server-driven status transitions are written back into the stored
             // `Subscription` (issue #357), so the engine's own decisions survive
             // a restart and `GET /Subscription/{id}` stops contradicting
@@ -1231,7 +1250,7 @@ fn build_smtp_settings_from_env() -> Option<helios_subscriptions::config::SmtpSe
 #[cfg(feature = "subscriptions")]
 fn build_messaging_settings_from_env(
     base_url: &str,
-) -> Option<helios_subscriptions::config::MessagingSettings> {
+) -> Option<(helios_subscriptions::config::MessagingSettings, bool)> {
     use helios_subscriptions::config::MessagingSettings;
 
     let enabled = std::env::var("HFS_SUBSCRIPTION_MESSAGING_ENABLED")
@@ -1241,19 +1260,23 @@ fn build_messaging_settings_from_env(
         return None;
     }
 
-    let source_endpoint = std::env::var("HFS_SUBSCRIPTION_MESSAGE_SOURCE_ENDPOINT")
+    let configured_source_endpoint = std::env::var("HFS_SUBSCRIPTION_MESSAGE_SOURCE_ENDPOINT")
         .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| base_url.to_string());
+        .filter(|s| !s.trim().is_empty());
+    let source_endpoint_is_explicit = configured_source_endpoint.is_some();
+    let source_endpoint = configured_source_endpoint.unwrap_or_else(|| base_url.to_string());
 
     let allow_private_endpoints = std::env::var("HFS_SUBSCRIPTION_ALLOW_PRIVATE_ENDPOINTS")
         .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1"))
         .unwrap_or(false);
 
-    Some(MessagingSettings {
-        source_endpoint,
-        allow_private_endpoints,
-    })
+    Some((
+        MessagingSettings {
+            source_endpoint,
+            allow_private_endpoints,
+        },
+        source_endpoint_is_explicit,
+    ))
 }
 
 /// Builds the CORS layer based on configuration.

--- a/crates/rest/src/middleware/tenant_prefix.rs
+++ b/crates/rest/src/middleware/tenant_prefix.rs
@@ -20,6 +20,16 @@ const RESERVED_SYSTEM_PATHS: &[&str] = &[
     "v1",
     "v2",
     "fhir",
+    // Server-level asynchronous route namespaces. In `both` mode these paths
+    // are also valid without a tenant prefix when the request carries
+    // `X-Tenant-ID`; treating their first segment as a tenant would strip the
+    // namespace before route matching and make advertised links unusable.
+    "export-status",
+    "export-file",
+    "bulk-submit-status",
+    "bulk-submit-file",
+    "export",
+    "ws",
     // Management-console namespace (`/console/metrics/*`). Reserved so a tenant
     // can never be named `console` under URL-path routing, keeping the console
     // paths unambiguous with the authz console guard (see `middleware::auth`).
@@ -37,7 +47,7 @@ const RESERVED_SYSTEM_PATHS: &[&str] = &[
 /// A segment is reserved if it's either:
 /// 1. A FHIR system endpoint or API prefix (from RESERVED_SYSTEM_PATHS)
 /// 2. A valid FHIR resource type for the given version
-fn is_reserved_path(segment: &str, fhir_version: &FhirVersion) -> bool {
+pub(crate) fn is_reserved_path(segment: &str, fhir_version: &FhirVersion) -> bool {
     let lower = segment.to_lowercase();
 
     // Check system paths first (fast path)
@@ -239,6 +249,20 @@ mod tests {
         assert!(extract_tenant_from_path("/health", &version).is_none());
         assert!(extract_tenant_from_path("/_history", &version).is_none());
 
+        for namespace in [
+            "export-status",
+            "export-file",
+            "bulk-submit-status",
+            "bulk-submit-file",
+            "export",
+            "ws",
+        ] {
+            assert!(
+                extract_tenant_from_path(&format!("/{namespace}/job"), &version).is_none(),
+                "server-level namespace {namespace} must not be parsed as a tenant"
+            );
+        }
+
         // Previously missing resource types should also be reserved
         assert!(extract_tenant_from_path("/Provenance/123", &version).is_none());
         assert!(extract_tenant_from_path("/AuditEvent/456", &version).is_none());
@@ -278,6 +302,17 @@ mod tests {
         // System paths
         assert!(is_reserved_path("metadata", &version));
         assert!(is_reserved_path("health", &version));
+
+        for namespace in [
+            "export-status",
+            "export-file",
+            "bulk-submit-status",
+            "bulk-submit-file",
+            "export",
+            "ws",
+        ] {
+            assert!(is_reserved_path(namespace, &version), "{namespace}");
+        }
 
         // Management-console namespace is reserved (case-insensitive), so a
         // tenant named "console" cannot exist under URL-path routing.

--- a/crates/rest/src/public_url.rs
+++ b/crates/rest/src/public_url.rs
@@ -1,0 +1,149 @@
+//! Construction of public URLs advertised by the REST API.
+
+use url::{Host, Url};
+
+/// A validated public base URL.
+///
+/// Path components are appended through [`Url::path_segments_mut`] so tenant,
+/// resource type, and resource id values cannot change the configured path
+/// structure.
+#[derive(Clone, Debug)]
+pub(crate) struct PublicUrl {
+    url: Url,
+    normalized: String,
+}
+
+impl PublicUrl {
+    /// Parses and normalizes a configured public base URL.
+    pub(crate) fn parse(value: &str) -> Result<Self, String> {
+        let authority = value
+            .split_once("://")
+            .map(|(_, authority)| authority)
+            .ok_or_else(|| "HFS_BASE_URL must be an absolute URL".to_string())?;
+        if authority.is_empty() || authority.starts_with('/') {
+            return Err("HFS_BASE_URL must include a host".to_string());
+        }
+        if authority
+            .split(['/', '?', '#'])
+            .next()
+            .is_some_and(|authority| authority.contains('@'))
+        {
+            return Err("HFS_BASE_URL must not include user information".to_string());
+        }
+        let mut url = Url::parse(value)
+            .map_err(|error| format!("HFS_BASE_URL must be an absolute URL: {error}"))?;
+
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err("HFS_BASE_URL must use the http or https scheme".to_string());
+        }
+        if url.host().is_none() {
+            return Err("HFS_BASE_URL must include a host".to_string());
+        }
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err("HFS_BASE_URL must not include user information".to_string());
+        }
+        if url.query().is_some() {
+            return Err("HFS_BASE_URL must not include a query string".to_string());
+        }
+        if url.fragment().is_some() {
+            return Err("HFS_BASE_URL must not include a fragment".to_string());
+        }
+
+        let trimmed_path = url.path().trim_end_matches('/').to_string();
+        url.set_path(&trimmed_path);
+        let normalized = url.as_str().trim_end_matches('/').to_string();
+
+        Ok(Self { url, normalized })
+    }
+
+    /// Returns the normalized base without a trailing slash.
+    pub(crate) fn as_str(&self) -> &str {
+        &self.normalized
+    }
+
+    /// Returns a URL with the supplied path segments appended to this base.
+    pub(crate) fn with_segments<I, T>(&self, segments: I) -> String
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let mut url = self.url.clone();
+        {
+            let mut path = url
+                .path_segments_mut()
+                .expect("validated HTTP URLs can hold path segments");
+            path.pop_if_empty();
+            for segment in segments {
+                path.push(segment.as_ref());
+            }
+        }
+        url.to_string().trim_end_matches('/').to_string()
+    }
+
+    /// Returns a URL with path segments and an already encoded query string.
+    pub(crate) fn with_segments_and_query<I, T>(&self, segments: I, query: &str) -> String
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let value = self.with_segments(segments);
+        if query.is_empty() {
+            return value;
+        }
+        let mut url = Url::parse(&value).expect("URL was built from a validated public base");
+        url.set_query(Some(query));
+        url.to_string()
+    }
+
+    /// Returns whether the advertised host resolves syntactically to loopback.
+    pub(crate) fn is_loopback(&self) -> bool {
+        match self.url.host() {
+            Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+            Some(Host::Ipv4(address)) => address.is_loopback(),
+            Some(Host::Ipv6(address)) => address.is_loopback(),
+            None => false,
+        }
+    }
+
+    /// Returns the effective port, including the scheme default.
+    pub(crate) fn port_or_known_default(&self) -> Option<u16> {
+        self.url.port_or_known_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_prefix_and_encodes_appended_segments() {
+        let base = PublicUrl::parse("https://example.test/fhir/").unwrap();
+        assert_eq!(base.as_str(), "https://example.test/fhir");
+        assert_eq!(
+            base.with_segments(["tenant with space", "Patient", "a/b"]),
+            "https://example.test/fhir/tenant%20with%20space/Patient/a%2Fb"
+        );
+
+        let encoded_prefix = PublicUrl::parse("https://example.test/fhir%20api/").unwrap();
+        assert_eq!(
+            encoded_prefix.with_segments(["Patient"]),
+            "https://example.test/fhir%20api/Patient"
+        );
+    }
+
+    #[test]
+    fn recognizes_loopback_host_forms() {
+        for value in [
+            "http://localhost:8080",
+            "http://127.0.0.1:8080",
+            "http://[::1]:8080",
+        ] {
+            assert!(PublicUrl::parse(value).unwrap().is_loopback(), "{value}");
+        }
+        assert!(
+            !PublicUrl::parse("https://fhir.example.test")
+                .unwrap()
+                .is_loopback()
+        );
+    }
+}

--- a/crates/rest/src/public_url.rs
+++ b/crates/rest/src/public_url.rs
@@ -2,6 +2,8 @@
 
 use url::{Host, Url};
 
+use helios_persistence::types::SearchBundle;
+
 /// A validated public base URL.
 ///
 /// Path components are appended through [`Url::path_segments_mut`] so tenant,
@@ -11,6 +13,27 @@ use url::{Host, Url};
 pub(crate) struct PublicUrl {
     url: Url,
     normalized: String,
+}
+
+pub(crate) fn rewrite_bundle_full_urls(
+    bundle: &mut SearchBundle,
+    mut public_url: impl FnMut(&str, &str) -> String,
+) {
+    for entry in &mut bundle.entry {
+        let Some(resource) = entry.resource.as_ref() else {
+            continue;
+        };
+        let Some(resource_type) = resource
+            .get("resourceType")
+            .and_then(|value| value.as_str())
+        else {
+            continue;
+        };
+        let Some(id) = resource.get("id").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        entry.full_url = Some(public_url(resource_type, id));
+    }
 }
 
 impl PublicUrl {
@@ -30,17 +53,13 @@ impl PublicUrl {
         {
             return Err("HFS_BASE_URL must not include user information".to_string());
         }
-        let mut url = Url::parse(value)
-            .map_err(|error| format!("HFS_BASE_URL must be an absolute URL: {error}"))?;
+        let mut url = Url::parse(value).map_err(|error| match error {
+            url::ParseError::EmptyHost => "HFS_BASE_URL must include a host".to_string(),
+            _ => format!("HFS_BASE_URL must be an absolute URL: {error}"),
+        })?;
 
         if !matches!(url.scheme(), "http" | "https") {
             return Err("HFS_BASE_URL must use the http or https scheme".to_string());
-        }
-        if url.host().is_none() {
-            return Err("HFS_BASE_URL must include a host".to_string());
-        }
-        if !url.username().is_empty() || url.password().is_some() {
-            return Err("HFS_BASE_URL must not include user information".to_string());
         }
         if url.query().is_some() {
             return Err("HFS_BASE_URL must not include a query string".to_string());
@@ -97,12 +116,11 @@ impl PublicUrl {
 
     /// Returns whether the advertised host resolves syntactically to loopback.
     pub(crate) fn is_loopback(&self) -> bool {
-        match self.url.host() {
-            Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
-            Some(Host::Ipv4(address)) => address.is_loopback(),
-            Some(Host::Ipv6(address)) => address.is_loopback(),
-            None => false,
-        }
+        self.url.host().is_some_and(|host| match host {
+            Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+            Host::Ipv4(address) => address.is_loopback(),
+            Host::Ipv6(address) => address.is_loopback(),
+        })
     }
 
     /// Returns the effective port, including the scheme default.
@@ -114,6 +132,8 @@ impl PublicUrl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use helios_persistence::types::BundleEntry;
+    use serde_json::json;
 
     #[test]
     fn preserves_prefix_and_encodes_appended_segments() {
@@ -144,6 +164,56 @@ mod tests {
             !PublicUrl::parse("https://fhir.example.test")
                 .unwrap()
                 .is_loopback()
+        );
+    }
+
+    #[test]
+    fn rejects_an_absolute_http_url_without_a_host() {
+        assert_eq!(
+            PublicUrl::parse("http://?tenant=acme").unwrap_err(),
+            "HFS_BASE_URL must include a host"
+        );
+    }
+
+    #[test]
+    fn rejects_user_information() {
+        assert_eq!(
+            PublicUrl::parse("https://user:password@example.test/fhir").unwrap_err(),
+            "HFS_BASE_URL must not include user information"
+        );
+    }
+
+    #[test]
+    fn rewrites_only_entries_with_a_resource_type_and_id() {
+        let mut bundle = SearchBundle::new()
+            .with_entry(BundleEntry {
+                full_url: Some("unchanged-empty".to_string()),
+                resource: None,
+                search: None,
+            })
+            .with_entry(BundleEntry::match_entry(
+                "unchanged-type",
+                json!({"id": "patient-1"}),
+            ))
+            .with_entry(BundleEntry::match_entry(
+                "unchanged-id",
+                json!({"resourceType": "Patient"}),
+            ))
+            .with_entry(BundleEntry::match_entry(
+                "old",
+                json!({"resourceType": "Patient", "id": "patient-1"}),
+            ));
+
+        rewrite_bundle_full_urls(&mut bundle, |resource_type, id| {
+            format!("https://public.example/fhir/{resource_type}/{id}")
+        });
+
+        assert_eq!(bundle.entry[0].full_url.as_deref(), Some("unchanged-empty"));
+        assert_eq!(bundle.entry[1].full_url.as_deref(), Some("unchanged-type"));
+        assert_eq!(bundle.entry[2].full_url.as_deref(), Some("unchanged-id"));
+        assert_eq!(
+            bundle.entry[3].full_url.as_deref(),
+            Some("https://public.example/fhir/Patient/patient-1")
         );
     }
 }

--- a/crates/rest/src/state.rs
+++ b/crates/rest/src/state.rs
@@ -20,6 +20,7 @@ use crate::bulk_export_auth::ExportFileAuth;
 use crate::config::{BulkExportConfig, BulkSubmitConfig, ServerConfig};
 use crate::export::ExportJobController;
 use crate::middleware::auth::AuthMiddlewareState;
+use crate::public_url::PublicUrl;
 
 /// Shared application state for the REST API.
 ///
@@ -47,6 +48,9 @@ pub struct AppState<S> {
 
     /// Server configuration.
     config: Arc<ServerConfig>,
+
+    /// Validated public URL used by response builders.
+    public_url: PublicUrl,
 
     /// Authentication configuration (always present, may be disabled).
     auth_config: Arc<AuthConfig>,
@@ -128,6 +132,7 @@ impl<S> Clone for AppState<S> {
         Self {
             storage: Arc::clone(&self.storage),
             config: Arc::clone(&self.config),
+            public_url: self.public_url.clone(),
             auth_config: Arc::clone(&self.auth_config),
             auth: self.auth.clone(),
             sof_runner: self.sof_runner.clone(),
@@ -160,7 +165,10 @@ impl<S: ResourceStorage> AppState<S> {
     ///
     /// * `storage` - The storage backend (wrapped in Arc)
     /// * `config` - Server configuration
-    pub fn new(storage: Arc<S>, config: ServerConfig) -> Self {
+    pub fn new(storage: Arc<S>, mut config: ServerConfig) -> Self {
+        let public_url = PublicUrl::parse(&config.base_url)
+            .expect("AppState requires a valid HTTP(S) ServerConfig.base_url");
+        config.base_url = public_url.as_str().to_string();
         let bulk_export_config = Arc::new(config.bulk_export.clone());
         let bulk_submit_config = Arc::new(config.bulk_submit.clone());
         let validation = Arc::new(crate::validation::ValidationService::from_config(
@@ -171,6 +179,7 @@ impl<S: ResourceStorage> AppState<S> {
         Self {
             storage,
             config: Arc::new(config),
+            public_url,
             auth_config: Arc::new(AuthConfig::default()),
             auth: None,
             sof_runner: None,
@@ -208,12 +217,15 @@ impl<S: ResourceStorage> AppState<S> {
     /// Creates a new AppState with auth and audit configuration.
     pub fn with_auth_and_audit(
         storage: Arc<S>,
-        config: ServerConfig,
+        mut config: ServerConfig,
         auth_config: AuthConfig,
         auth_state: Option<Arc<AuthMiddlewareState>>,
         audit_sink: Option<Arc<dyn AuditSink>>,
         audit_source_observer: impl Into<String>,
     ) -> Self {
+        let public_url = PublicUrl::parse(&config.base_url)
+            .expect("AppState requires a valid HTTP(S) ServerConfig.base_url");
+        config.base_url = public_url.as_str().to_string();
         let bulk_export_config = Arc::new(config.bulk_export.clone());
         let bulk_submit_config = Arc::new(config.bulk_submit.clone());
         let validation = Arc::new(crate::validation::ValidationService::from_config(
@@ -224,6 +236,7 @@ impl<S: ResourceStorage> AppState<S> {
         Self {
             storage,
             config: Arc::new(config),
+            public_url,
             auth_config: Arc::new(auth_config),
             auth: auth_state,
             sof_runner: None,
@@ -433,6 +446,48 @@ impl<S: ResourceStorage> AppState<S> {
     /// Returns the base URL for the server.
     pub fn base_url(&self) -> &str {
         &self.config.base_url
+    }
+
+    /// Returns the public base for the way this request selected its tenant.
+    pub(crate) fn public_base_url_for_request(
+        &self,
+        tenant: &crate::extractors::TenantExtractor,
+    ) -> String {
+        if tenant.is_url_based() {
+            self.public_url.with_segments([tenant.tenant_id()])
+        } else {
+            self.public_url.as_str().to_string()
+        }
+    }
+
+    /// Builds a public URL for the way this request selected its tenant.
+    pub(crate) fn public_url_for_request<'a>(
+        &self,
+        tenant: &crate::extractors::TenantExtractor,
+        segments: impl IntoIterator<Item = &'a str>,
+    ) -> String {
+        let mut all_segments: Vec<String> = Vec::new();
+        if tenant.is_url_based() {
+            all_segments.push(tenant.tenant_id().to_string());
+        }
+        all_segments.extend(segments.into_iter().map(str::to_string));
+        self.public_url.with_segments(all_segments)
+    }
+
+    /// Builds a request-bound public URL and retains an encoded query string.
+    pub(crate) fn public_url_for_request_with_query<'a>(
+        &self,
+        tenant: &crate::extractors::TenantExtractor,
+        segments: impl IntoIterator<Item = &'a str>,
+        query: Option<&str>,
+    ) -> String {
+        let mut all_segments: Vec<String> = Vec::new();
+        if tenant.is_url_based() {
+            all_segments.push(tenant.tenant_id().to_string());
+        }
+        all_segments.extend(segments.into_iter().map(str::to_string));
+        self.public_url
+            .with_segments_and_query(all_segments, query.unwrap_or_default())
     }
 
     /// Returns whether versioning is enabled.

--- a/crates/rest/src/tenant/resolver.rs
+++ b/crates/rest/src/tenant/resolver.rs
@@ -4,39 +4,15 @@
 //! requests using multiple configurable sources.
 
 use axum::http::request::Parts;
-use helios_fhir::{FhirResourceTypeProvider, FhirVersion};
+use helios_fhir::FhirVersion;
 use helios_persistence::tenant::{TenantId, TenantIdError};
 use tracing::{debug, warn};
 
 use crate::config::{MultitenancyConfig, TenantRoutingMode};
 use crate::middleware::tenant::X_TENANT_ID;
-use crate::middleware::tenant_prefix::{ExtractedTenantFromUrl, OriginalPath};
+use crate::middleware::tenant_prefix::{ExtractedTenantFromUrl, OriginalPath, is_reserved_path};
 
 use super::source::TenantSource;
-
-/// Non-resource reserved paths (FHIR system endpoints, API prefixes).
-/// Resource types are checked dynamically via helios-fhir's FhirResourceTypeProvider.
-const RESERVED_SYSTEM_PATHS: &[&str] = &[
-    "metadata",
-    "health",
-    "_history",
-    "_liveness",
-    "_readiness",
-    "$versions",
-    "api",
-    "v1",
-    "v2",
-    "fhir",
-    // Management-console namespace (`/console/metrics/*`). Kept in sync with
-    // `middleware::tenant_prefix::RESERVED_SYSTEM_PATHS` so a tenant can never be
-    // named `console` and strict-validation never mis-resolves the console path
-    // to a `console` tenant under URL-path routing.
-    "console",
-    // SMART discovery. Same rationale as `console`, and newly load-bearing since
-    // issue #385 widened the tenant charset to include `.` — see the twin list
-    // in `middleware::tenant_prefix`.
-    ".well-known",
-];
 
 /// Result of resolving a tenant from a request.
 #[derive(Debug, Clone)]
@@ -386,40 +362,6 @@ impl TenantResolver {
 impl Default for TenantResolver {
     fn default() -> Self {
         Self::new(&MultitenancyConfig::default())
-    }
-}
-
-/// Checks if a path segment is reserved (not a tenant identifier).
-///
-/// A segment is reserved if it's either:
-/// 1. A FHIR system endpoint or API prefix (from RESERVED_SYSTEM_PATHS)
-/// 2. A valid FHIR resource type for the given version
-fn is_reserved_path(segment: &str, fhir_version: &FhirVersion) -> bool {
-    let lower = segment.to_lowercase();
-
-    // Check system paths first (fast path)
-    if RESERVED_SYSTEM_PATHS.iter().any(|&r| r == lower) {
-        return true;
-    }
-
-    // Check if it's a valid FHIR resource type for the configured version
-    is_fhir_resource_type(segment, fhir_version)
-}
-
-/// Checks if a string is a valid FHIR resource type for the given version.
-/// Uses the FhirResourceTypeProvider trait for case-insensitive matching.
-fn is_fhir_resource_type(type_name: &str, fhir_version: &FhirVersion) -> bool {
-    match fhir_version {
-        #[cfg(feature = "R4")]
-        FhirVersion::R4 => helios_fhir::r4::Resource::is_resource_type(type_name),
-        #[cfg(feature = "R4B")]
-        FhirVersion::R4B => helios_fhir::r4b::Resource::is_resource_type(type_name),
-        #[cfg(feature = "R5")]
-        FhirVersion::R5 => helios_fhir::r5::Resource::is_resource_type(type_name),
-        #[cfg(feature = "R6")]
-        FhirVersion::R6 => helios_fhir::r6::Resource::is_resource_type(type_name),
-        #[allow(unreachable_patterns)]
-        _ => false,
     }
 }
 

--- a/crates/rest/tests/bulk_export.rs
+++ b/crates/rest/tests/bulk_export.rs
@@ -9,7 +9,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::http::StatusCode;
+use axum::middleware::Next;
 use axum_test::TestServer;
+use chrono::Utc;
+use helios_auth::{Principal, ScopeSet};
 use helios_fhir::FhirVersion;
 use helios_persistence::backends::local_fs::LocalFsOutputStore;
 use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
@@ -31,6 +34,26 @@ async fn create_bulk_export_server() -> (
     Arc<LocalFsOutputStore>,
     tempfile::TempDir,
 ) {
+    create_bulk_export_server_with(
+        TenantRoutingMode::HeaderOnly,
+        "http://localhost:8080",
+        "test-tenant",
+        None,
+    )
+    .await
+}
+
+async fn create_bulk_export_server_with(
+    routing_mode: TenantRoutingMode,
+    base_url: &str,
+    default_tenant: &str,
+    principal_tenant: Option<&str>,
+) -> (
+    TestServer,
+    Arc<SqliteBackend>,
+    Arc<LocalFsOutputStore>,
+    tempfile::TempDir,
+) {
     let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(|p| p.parent())
@@ -47,16 +70,20 @@ async fn create_bulk_export_server() -> (
     backend.init_schema().expect("init schema");
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let output = Arc::new(LocalFsOutputStore::new(tmp.path(), "http://localhost:8080"));
+    let output = Arc::new(LocalFsOutputStore::new(
+        tmp.path(),
+        "https://wrong-internal.example",
+    ));
     let file_auth = Arc::new(BearerScopeAuth);
 
     let config = ServerConfig {
         multitenancy: MultitenancyConfig {
-            routing_mode: TenantRoutingMode::HeaderOnly,
+            routing_mode,
+            strict_validation: principal_tenant.is_some(),
             ..Default::default()
         },
-        base_url: "http://localhost:8080".to_string(),
-        default_tenant: "test-tenant".to_string(),
+        base_url: base_url.to_string(),
+        default_tenant: default_tenant.to_string(),
         ..ServerConfig::for_testing()
     };
 
@@ -66,6 +93,28 @@ async fn create_bulk_export_server() -> (
         file_auth,
     );
     let app = helios_rest::routing::fhir_routes::create_routes(state);
+    let app = if let Some(tenant_id) = principal_tenant {
+        let principal = Principal {
+            subject: "bulk-export-client".to_string(),
+            issuer: "https://issuer.example".to_string(),
+            tenant_id: Some(tenant_id.to_string()),
+            scopes: ScopeSet::parse("system/Patient.rs"),
+            jti: None,
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            custom_claims: serde_json::Map::new(),
+        };
+        app.layer(axum::middleware::from_fn(
+            move |mut request: axum::extract::Request, next: Next| {
+                let principal = principal.clone();
+                async move {
+                    request.extensions_mut().insert(principal);
+                    next.run(request).await
+                }
+            },
+        ))
+    } else {
+        app
+    };
     let server = TestServer::new(app).expect("create test server");
 
     (server, backend, output, tmp)
@@ -98,7 +147,11 @@ async fn drain_workers(backend: &Arc<SqliteBackend>, output: &Arc<LocalFsOutputS
 
 /// Seeds N Patient resources.
 async fn seed_patients(backend: &Arc<SqliteBackend>, n: usize) {
-    let tenant = test_tenant();
+    seed_patients_for(backend, "test-tenant", n).await;
+}
+
+async fn seed_patients_for(backend: &Arc<SqliteBackend>, tenant_id: &str, n: usize) {
+    let tenant = TenantContext::new(TenantId::new(tenant_id), TenantPermissions::full_access());
     for i in 0..n {
         backend
             .create(
@@ -110,6 +163,116 @@ async fn seed_patients(backend: &Arc<SqliteBackend>, n: usize) {
             .await
             .expect("seed patient");
     }
+}
+
+#[tokio::test]
+async fn authenticated_path_tenant_and_public_prefix_flow_through_bulk_export_urls() {
+    let (server, backend, output, _tmp) = create_bulk_export_server_with(
+        TenantRoutingMode::UrlPath,
+        "https://public.example/fhir/",
+        "default",
+        Some("acme"),
+    )
+    .await;
+    seed_patients_for(&backend, "acme", 1).await;
+
+    let kickoff = server
+        .get("/acme/$export")
+        .add_header("prefer", "respond-async")
+        .add_query_param("_type", "Patient")
+        .await;
+    assert_eq!(kickoff.status_code(), StatusCode::ACCEPTED);
+    let status_url = kickoff
+        .headers()
+        .get("content-location")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(status_url.starts_with("https://public.example/fhir/acme/export-status/"));
+    let status_path = status_url
+        .strip_prefix("https://public.example/fhir")
+        .unwrap();
+
+    drain_workers(&backend, &output).await;
+    let done = server.get(status_path).await;
+    assert_eq!(done.status_code(), StatusCode::OK);
+    let manifest: Value = done.json();
+    assert_eq!(
+        manifest["request"],
+        "https://public.example/fhir/acme/$export?_type=Patient"
+    );
+    assert!(
+        manifest["output"][0]["url"]
+            .as_str()
+            .unwrap()
+            .starts_with("https://public.example/fhir/acme/export-file/")
+    );
+}
+
+#[tokio::test]
+async fn both_mode_header_tenant_can_follow_unprefixed_bulk_export_urls() {
+    let public_base = "https://public.example/fhir";
+    let (server, backend, output, _tmp) =
+        create_bulk_export_server_with(TenantRoutingMode::Both, public_base, "default", None).await;
+    seed_patients_for(&backend, "acme", 1).await;
+
+    let kickoff = server
+        .get("/$export")
+        .add_header("x-tenant-id", "acme")
+        .add_header("prefer", "respond-async")
+        .add_query_param("_type", "Patient")
+        .await;
+    assert_eq!(kickoff.status_code(), StatusCode::ACCEPTED);
+    let status_url = kickoff
+        .headers()
+        .get("content-location")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(status_url.starts_with("https://public.example/fhir/export-status/"));
+    assert!(!status_url.contains("/acme/"));
+    let status_path = status_url.strip_prefix(public_base).unwrap();
+
+    assert_eq!(
+        server
+            .get(status_path)
+            .add_header("x-tenant-id", "acme")
+            .await
+            .status_code(),
+        StatusCode::ACCEPTED
+    );
+    drain_workers(&backend, &output).await;
+
+    let done = server
+        .get(status_path)
+        .add_header("x-tenant-id", "acme")
+        .await;
+    assert_eq!(done.status_code(), StatusCode::OK);
+    let manifest: Value = done.json();
+    assert_eq!(
+        manifest["request"],
+        "https://public.example/fhir/$export?_type=Patient"
+    );
+    let file_url = manifest["output"][0]["url"].as_str().unwrap();
+    assert!(file_url.starts_with("https://public.example/fhir/export-file/"));
+    let file_path = file_url.strip_prefix(public_base).unwrap();
+    assert_eq!(
+        server
+            .get(file_path)
+            .add_header("x-tenant-id", "acme")
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+
+    // `both` still accepts the canonical URL-path form for the same job.
+    assert_eq!(
+        server
+            .get(&format!("/acme{status_path}"))
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
 }
 
 #[tokio::test]

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -141,6 +141,29 @@ async fn create_submit_server_with(
     Arc<LocalFsOutputStore>,
     tempfile::TempDir,
 ) {
+    create_submit_server_with_routing(
+        fetcher,
+        bulk_submit,
+        TenantRoutingMode::HeaderOnly,
+        "http://localhost:8080",
+        "test-tenant",
+    )
+    .await
+}
+
+async fn create_submit_server_with_routing(
+    fetcher: Arc<MockFetcher>,
+    bulk_submit: BulkSubmitConfig,
+    routing_mode: TenantRoutingMode,
+    base_url: &str,
+    default_tenant: &str,
+) -> (
+    TestServer,
+    Arc<SqliteBackend>,
+    Arc<MockFetcher>,
+    Arc<LocalFsOutputStore>,
+    tempfile::TempDir,
+) {
     let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(|p| p.parent())
@@ -159,15 +182,18 @@ async fn create_submit_server_with(
     backend.init_schema().expect("init schema");
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let output = Arc::new(LocalFsOutputStore::new(tmp.path(), "http://localhost:8080"));
+    let output = Arc::new(LocalFsOutputStore::new(
+        tmp.path(),
+        "https://wrong-internal.example",
+    ));
 
     let config = ServerConfig {
         multitenancy: MultitenancyConfig {
-            routing_mode: TenantRoutingMode::HeaderOnly,
+            routing_mode,
             ..Default::default()
         },
-        base_url: "http://localhost:8080".to_string(),
-        default_tenant: "test-tenant".to_string(),
+        base_url: base_url.to_string(),
+        default_tenant: default_tenant.to_string(),
         bulk_submit,
         ..ServerConfig::for_testing()
     };
@@ -782,6 +808,138 @@ async fn test_full_lifecycle_ingests_and_polls() {
     assert_eq!(
         server.get(poll_path).await.status_code(),
         StatusCode::NOT_FOUND
+    );
+}
+
+#[tokio::test]
+async fn path_tenant_and_public_prefix_flow_through_bulk_submit_urls() {
+    let (server, backend, fetcher, output, _tmp) = create_submit_server_with_routing(
+        multi_artifact_fetcher(),
+        BulkSubmitConfig {
+            manifest_page_size: 1,
+            ..Default::default()
+        },
+        TenantRoutingMode::Both,
+        "https://public.example/fhir/",
+        "default",
+    )
+    .await;
+
+    assert_eq!(
+        server
+            .post("/acme/$bulk-submit")
+            .json(&kickoff_body())
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+    let status = server
+        .post("/acme/$bulk-submit-status")
+        .json(&status_body())
+        .await;
+    assert_eq!(status.status_code(), StatusCode::ACCEPTED);
+    let status_url = status
+        .headers()
+        .get("content-location")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(status_url.starts_with("https://public.example/fhir/acme/bulk-submit-status/"));
+    let poll_path = status_url
+        .strip_prefix("https://public.example/fhir")
+        .unwrap();
+    let wrong_tenant_path = poll_path.replacen("/acme/", "/other/", 1);
+    assert_eq!(
+        server.get(&wrong_tenant_path).await.status_code(),
+        StatusCode::NOT_FOUND
+    );
+
+    drain_submit(&backend, &fetcher, &output).await;
+    let done = server.get(poll_path).await;
+    assert_eq!(done.status_code(), StatusCode::OK);
+    let manifest: Value = done.json();
+    let artifact_url = ["output", "outcome", "deleted"]
+        .into_iter()
+        .find_map(|kind| manifest[kind][0]["url"].as_str())
+        .expect("first page has an artifact URL");
+    assert!(artifact_url.starts_with("https://public.example/fhir/acme/bulk-submit-file/"));
+    assert!(
+        manifest["link"][0]["url"]
+            .as_str()
+            .unwrap()
+            .starts_with(status_url)
+    );
+}
+
+#[tokio::test]
+async fn both_mode_header_tenant_can_follow_unprefixed_bulk_submit_urls() {
+    let public_base = "https://public.example/fhir";
+    let (server, backend, fetcher, output, _tmp) = create_submit_server_with_routing(
+        mock_fetcher(),
+        BulkSubmitConfig::default(),
+        TenantRoutingMode::Both,
+        public_base,
+        "default",
+    )
+    .await;
+
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .add_header("x-tenant-id", "acme")
+            .json(&kickoff_body())
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+    let status = server
+        .post("/$bulk-submit-status")
+        .add_header("x-tenant-id", "acme")
+        .json(&status_body())
+        .await;
+    assert_eq!(status.status_code(), StatusCode::ACCEPTED);
+    let status_url = status
+        .headers()
+        .get("content-location")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(status_url.starts_with("https://public.example/fhir/bulk-submit-status/"));
+    assert!(!status_url.contains("/acme/"));
+    let poll_path = status_url.strip_prefix(public_base).unwrap();
+
+    assert_eq!(
+        server
+            .get(poll_path)
+            .add_header("x-tenant-id", "acme")
+            .await
+            .status_code(),
+        StatusCode::ACCEPTED
+    );
+    drain_submit(&backend, &fetcher, &output).await;
+
+    let done = server
+        .get(poll_path)
+        .add_header("x-tenant-id", "acme")
+        .await;
+    assert_eq!(done.status_code(), StatusCode::OK);
+    let manifest: Value = done.json();
+    let artifact_url = manifest["output"][0]["url"].as_str().unwrap();
+    assert!(artifact_url.starts_with("https://public.example/fhir/bulk-submit-file/"));
+    let artifact_path = artifact_url.strip_prefix(public_base).unwrap();
+    assert_eq!(
+        server
+            .get(artifact_path)
+            .add_header("x-tenant-id", "acme")
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+
+    // The URL-path form remains available in `both` mode.
+    assert_eq!(
+        server.get(&format!("/acme{poll_path}")).await.status_code(),
+        StatusCode::OK
     );
 }
 

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -930,6 +930,22 @@ async fn both_mode_header_tenant_can_follow_unprefixed_bulk_submit_urls() {
     assert_eq!(
         server
             .get(artifact_path)
+            .add_header("x-tenant-id", "other")
+            .await
+            .status_code(),
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        server
+            .delete(poll_path)
+            .add_header("x-tenant-id", "other")
+            .await
+            .status_code(),
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        server
+            .get(artifact_path)
             .add_header("x-tenant-id", "acme")
             .await
             .status_code(),

--- a/crates/rest/tests/public_url_contract.rs
+++ b/crates/rest/tests/public_url_contract.rs
@@ -162,6 +162,38 @@ async fn url_path_requests_advertise_prefix_and_tenant() {
         &format!("/Patient/{id}"),
     );
 
+    let conditional_body = json!({
+        "resourceType": "Patient",
+        "identifier": [{"system": "https://example.test/mrn", "value": "public-url-conditional"}],
+        "name": [{"family": "Conditional URL"}]
+    });
+    let conditional_created = server
+        .put("/acme/Patient?identifier=public-url-conditional")
+        .add_header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/fhir+json"),
+        )
+        .json(&conditional_body)
+        .await;
+    conditional_created.assert_status(StatusCode::CREATED);
+    assert!(
+        conditional_created.headers()["location"]
+            .to_str()
+            .unwrap()
+            .starts_with("https://public.example/fhir/acme/Patient/")
+    );
+
+    let conditional_updated = server
+        .put("/acme/Patient?identifier=public-url-conditional")
+        .add_header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/fhir+json"),
+        )
+        .json(&conditional_body)
+        .await;
+    conditional_updated.assert_status_ok();
+    assert!(conditional_updated.headers().get("location").is_none());
+
     let compartment = server
         .get(&format!("/acme/Patient/{id}/Observation?_count=1"))
         .await;

--- a/crates/rest/tests/public_url_contract.rs
+++ b/crates/rest/tests/public_url_contract.rs
@@ -1,0 +1,286 @@
+//! Public URL contract for synchronous FHIR interactions.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::http::{HeaderName, HeaderValue, StatusCode};
+use axum::middleware::Next;
+use axum_test::TestServer;
+use chrono::Utc;
+use helios_auth::{Principal, ScopeSet};
+use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+use helios_rest::config::{MultitenancyConfig, TenantRoutingMode};
+use helios_rest::{AppState, ServerConfig};
+use serde_json::{Value, json};
+
+const CONTENT_TYPE: HeaderName = HeaderName::from_static("content-type");
+const X_TENANT_ID: HeaderName = HeaderName::from_static("x-tenant-id");
+
+async fn server(
+    routing_mode: TenantRoutingMode,
+    base_url: &str,
+    principal_tenant: Option<&str>,
+) -> (TestServer, Arc<SqliteBackend>) {
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .map(|path| path.join("data"));
+    let backend = Arc::new(
+        SqliteBackend::with_config(
+            ":memory:",
+            SqliteBackendConfig {
+                data_dir,
+                ..Default::default()
+            },
+        )
+        .unwrap(),
+    );
+    backend.init_schema().unwrap();
+
+    let state = AppState::new(
+        Arc::clone(&backend),
+        ServerConfig {
+            base_url: base_url.to_string(),
+            default_tenant: "default".to_string(),
+            multitenancy: MultitenancyConfig {
+                routing_mode,
+                strict_validation: principal_tenant.is_some(),
+                ..Default::default()
+            },
+            ..ServerConfig::for_testing()
+        },
+    );
+    let app = helios_rest::routing::fhir_routes::create_routes(state);
+    let app = if let Some(tenant_id) = principal_tenant {
+        let principal = Principal {
+            subject: "authenticated-client".to_string(),
+            issuer: "https://issuer.example".to_string(),
+            tenant_id: Some(tenant_id.to_string()),
+            scopes: ScopeSet::parse("system/*.rs"),
+            jti: None,
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            custom_claims: serde_json::Map::new(),
+        };
+        app.layer(axum::middleware::from_fn(
+            move |mut request: axum::extract::Request, next: Next| {
+                let principal = principal.clone();
+                async move {
+                    request.extensions_mut().insert(principal);
+                    next.run(request).await
+                }
+            },
+        ))
+    } else {
+        app
+    };
+    (TestServer::new(app).unwrap(), backend)
+}
+
+fn assert_public_url(value: &str, suffix: &str) {
+    assert_eq!(value, format!("https://public.example/fhir/acme{suffix}"));
+    assert!(!value.contains("spoofed.example"));
+}
+
+#[tokio::test]
+async fn url_path_requests_advertise_prefix_and_tenant() {
+    let (server, _) = server(
+        TenantRoutingMode::UrlPath,
+        "https://public.example/fhir/",
+        None,
+    )
+    .await;
+
+    let metadata = server
+        .get("/acme/metadata")
+        .add_header(
+            HeaderName::from_static("host"),
+            HeaderValue::from_static("spoofed.example"),
+        )
+        .add_header(
+            HeaderName::from_static("forwarded"),
+            HeaderValue::from_static("host=spoofed.example;proto=http"),
+        )
+        .add_header(
+            HeaderName::from_static("x-forwarded-host"),
+            HeaderValue::from_static("spoofed.example"),
+        )
+        .await;
+    metadata.assert_status_ok();
+    assert_public_url(
+        metadata.json::<Value>()["implementation"]["url"]
+            .as_str()
+            .unwrap(),
+        "",
+    );
+
+    let created = server
+        .post("/acme/Patient")
+        .add_header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/fhir+json"),
+        )
+        .json(&json!({
+            "resourceType": "Patient",
+            "name": [{"family": "Public URL"}]
+        }))
+        .await;
+    created.assert_status(StatusCode::CREATED);
+    let location = created.headers()["location"].to_str().unwrap();
+    assert!(location.starts_with("https://public.example/fhir/acme/Patient/"));
+    let patient: Value = created.json();
+    let id = patient["id"].as_str().unwrap();
+
+    let updated = server
+        .put("/acme/Observation/public-url-observation")
+        .add_header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/fhir+json"),
+        )
+        .json(&json!({
+            "resourceType": "Observation",
+            "id": "public-url-observation",
+            "status": "final",
+            "code": {"text": "URL contract"},
+            "subject": {"reference": format!("Patient/{id}")}
+        }))
+        .await;
+    updated.assert_status(StatusCode::CREATED);
+    assert_public_url(
+        updated.headers()["location"].to_str().unwrap(),
+        "/Observation/public-url-observation",
+    );
+
+    let search = server.get("/acme/Patient?_count=1").await;
+    search.assert_status_ok();
+    let search: Value = search.json();
+    assert_public_url(
+        search["link"][0]["url"].as_str().unwrap(),
+        "/Patient?_count=1",
+    );
+    assert_public_url(
+        search["entry"][0]["fullUrl"].as_str().unwrap(),
+        &format!("/Patient/{id}"),
+    );
+
+    let compartment = server
+        .get(&format!("/acme/Patient/{id}/Observation?_count=1"))
+        .await;
+    compartment.assert_status_ok();
+    let compartment: Value = compartment.json();
+    assert_public_url(
+        compartment["link"][0]["url"].as_str().unwrap(),
+        &format!("/Patient/{id}/Observation?_count=1"),
+    );
+    assert_public_url(
+        compartment["entry"][0]["fullUrl"].as_str().unwrap(),
+        "/Observation/public-url-observation",
+    );
+
+    let history = server.get(&format!("/acme/Patient/{id}/_history")).await;
+    history.assert_status_ok();
+    assert_public_url(
+        history.json::<Value>()["entry"][0]["fullUrl"]
+            .as_str()
+            .unwrap(),
+        &format!("/Patient/{id}"),
+    );
+
+    let batch = server
+        .post("/acme/")
+        .add_header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/fhir+json"),
+        )
+        .json(&json!({
+            "resourceType": "Bundle",
+            "type": "batch",
+            "entry": [{
+                "resource": {"resourceType": "Patient"},
+                "request": {"method": "POST", "url": "Patient"}
+            }]
+        }))
+        .await;
+    batch.assert_status_ok();
+    assert!(
+        batch.json::<Value>()["entry"][0]["fullUrl"]
+            .as_str()
+            .unwrap()
+            .starts_with("https://public.example/fhir/acme/Patient/")
+    );
+
+    let transaction = server
+        .post("/acme/")
+        .add_header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/fhir+json"),
+        )
+        .json(&json!({
+            "resourceType": "Bundle",
+            "type": "transaction",
+            "entry": [{
+                "resource": {"resourceType": "Patient"},
+                "request": {"method": "POST", "url": "Patient"}
+            }]
+        }))
+        .await;
+    transaction.assert_status_ok();
+    assert!(
+        transaction.json::<Value>()["entry"][0]["fullUrl"]
+            .as_str()
+            .unwrap()
+            .starts_with("https://public.example/fhir/acme/Patient/")
+    );
+}
+
+#[tokio::test]
+async fn header_tenant_does_not_change_the_public_path() {
+    let (server, _) = server(
+        TenantRoutingMode::HeaderOnly,
+        "https://public.example/fhir/",
+        None,
+    )
+    .await;
+
+    let response = server
+        .get("/metadata")
+        .add_header(X_TENANT_ID, HeaderValue::from_static("acme"))
+        .await;
+    response.assert_status_ok();
+    assert_eq!(
+        response.json::<Value>()["implementation"]["url"],
+        "https://public.example/fhir"
+    );
+}
+
+#[tokio::test]
+async fn authenticated_url_routes_preserve_tenant_in_public_base() {
+    for routing_mode in [TenantRoutingMode::UrlPath, TenantRoutingMode::Both] {
+        let (server, _) = server(routing_mode, "https://public.example/fhir/", Some("acme")).await;
+
+        let response = server.get("/acme/metadata").await;
+        response.assert_status_ok();
+        assert_public_url(
+            response.json::<Value>()["implementation"]["url"]
+                .as_str()
+                .unwrap(),
+            "",
+        );
+    }
+}
+
+#[tokio::test]
+async fn authenticated_header_routes_keep_unprefixed_public_base() {
+    for routing_mode in [TenantRoutingMode::HeaderOnly, TenantRoutingMode::Both] {
+        let (server, _) = server(routing_mode, "https://public.example/fhir/", Some("acme")).await;
+
+        let response = server
+            .get("/metadata")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("acme"))
+            .await;
+        response.assert_status_ok();
+        assert_eq!(
+            response.json::<Value>()["implementation"]["url"],
+            "https://public.example/fhir"
+        );
+    }
+}

--- a/crates/rest/tests/sof_export.rs
+++ b/crates/rest/tests/sof_export.rs
@@ -14,6 +14,7 @@ mod sof_export_tests {
     use helios_persistence::core::sof_runner::SofRunner;
     use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
     use helios_rest::ServerConfig;
+    use helios_rest::config::{MultitenancyConfig, TenantRoutingMode};
     use helios_rest::export::{
         CompletedFile, ExportJobController, ExportTask, InMemoryController, InMemorySink, JobStatus,
     };
@@ -31,6 +32,16 @@ mod sof_export_tests {
     }
 
     async fn create_test_server_with_export() -> (TestServer, Arc<SqliteBackend>) {
+        let config = ServerConfig {
+            base_url: "http://localhost".to_string(),
+            ..ServerConfig::for_testing()
+        };
+        create_test_server_with_export_config(config).await
+    }
+
+    async fn create_test_server_with_export_config(
+        config: ServerConfig,
+    ) -> (TestServer, Arc<SqliteBackend>) {
         let backend = SqliteBackend::with_config(":memory:", Default::default())
             .expect("failed to create SQLite backend");
         backend.init_schema().expect("failed to init schema");
@@ -42,10 +53,9 @@ mod sof_export_tests {
             .expect("SQLiteBackend must provide sof_runner");
 
         // Build in-memory sink and controller
-        let sink = InMemorySink::new("http://localhost");
+        let sink = InMemorySink::new("https://wrong-internal.example");
         let controller = InMemoryController::new(runner, sink, None);
 
-        let config = ServerConfig::for_testing();
         let state = helios_rest::AppState::new(Arc::clone(&backend), config)
             .with_export_controller(Arc::new(controller));
 
@@ -56,7 +66,11 @@ mod sof_export_tests {
     }
 
     async fn seed_patients(backend: &SqliteBackend) {
-        let tenant = test_tenant();
+        seed_patients_for(backend, "test-tenant").await;
+    }
+
+    async fn seed_patients_for(backend: &SqliteBackend, tenant_id: &str) {
+        let tenant = TenantContext::new(TenantId::new(tenant_id), TenantPermissions::full_access());
         for (id, family) in [("p1", "Smith"), ("p2", "Jones")] {
             let resource = json!({
                 "resourceType": "Patient",
@@ -69,6 +83,149 @@ mod sof_export_tests {
                 .await
                 .expect("failed to seed patient");
         }
+    }
+
+    #[tokio::test]
+    async fn path_tenant_and_public_prefix_flow_through_sof_export_urls() {
+        let config = ServerConfig {
+            base_url: "https://public.example/fhir/".to_string(),
+            default_tenant: "default".to_string(),
+            multitenancy: MultitenancyConfig {
+                routing_mode: TenantRoutingMode::UrlPath,
+                ..Default::default()
+            },
+            ..ServerConfig::for_testing()
+        };
+        let (server, backend) = create_test_server_with_export_config(config).await;
+        seed_patients_for(&backend, "acme").await;
+
+        let response = server
+            .post("/acme/$sql-export")
+            .add_header(PREFER, "respond-async")
+            .json(&patient_view())
+            .await;
+        assert_eq!(response.status_code(), StatusCode::ACCEPTED);
+        let status_url = response
+            .headers()
+            .get("content-location")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(status_url.starts_with("https://public.example/fhir/acme/export/"));
+        let status_path = status_url
+            .strip_prefix("https://public.example/fhir")
+            .unwrap();
+
+        for _ in 0..40 {
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            let poll = server.get(status_path).await;
+            if poll.status_code() == StatusCode::SEE_OTHER {
+                let result_url = poll.headers().get("location").unwrap().to_str().unwrap();
+                assert!(result_url.starts_with("https://public.example/fhir/acme/export/"));
+                let result_path = result_url
+                    .strip_prefix("https://public.example/fhir")
+                    .unwrap();
+                let result = server.get(result_path).await;
+                assert_eq!(result.status_code(), StatusCode::OK);
+                let manifest: Value = result.json();
+                let output_url = manifest["parameter"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .find(|part| part["name"] == "output")
+                    .and_then(|part| part["part"].as_array())
+                    .and_then(|parts| parts.iter().find(|part| part["name"] == "location"))
+                    .and_then(|part| part["valueUri"].as_str())
+                    .unwrap();
+                assert!(output_url.starts_with("https://public.example/fhir/acme/export/"));
+                return;
+            }
+            assert_eq!(poll.status_code(), StatusCode::ACCEPTED);
+        }
+        panic!("SOF export did not complete");
+    }
+
+    #[tokio::test]
+    async fn both_mode_header_tenant_can_follow_unprefixed_sof_export_urls() {
+        let public_base = "https://public.example/fhir";
+        let config = ServerConfig {
+            base_url: public_base.to_string(),
+            default_tenant: "default".to_string(),
+            multitenancy: MultitenancyConfig {
+                routing_mode: TenantRoutingMode::Both,
+                ..Default::default()
+            },
+            ..ServerConfig::for_testing()
+        };
+        let (server, backend) = create_test_server_with_export_config(config).await;
+        seed_patients_for(&backend, "acme").await;
+
+        let response = server
+            .post("/$sql-export")
+            .add_header(PREFER, "respond-async")
+            .add_header(X_TENANT_ID, "acme")
+            .json(&patient_view())
+            .await;
+        assert_eq!(response.status_code(), StatusCode::ACCEPTED);
+        let status_url = response
+            .headers()
+            .get("content-location")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(status_url.starts_with("https://public.example/fhir/export/"));
+        assert!(!status_url.contains("/acme/"));
+        let status_path = status_url.strip_prefix(public_base).unwrap();
+
+        for _ in 0..40 {
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            let poll = server
+                .get(status_path)
+                .add_header(X_TENANT_ID, "acme")
+                .await;
+            if poll.status_code() == StatusCode::SEE_OTHER {
+                let result_url = poll.headers().get("location").unwrap().to_str().unwrap();
+                assert!(result_url.starts_with("https://public.example/fhir/export/"));
+                let result_path = result_url.strip_prefix(public_base).unwrap();
+                let result = server
+                    .get(result_path)
+                    .add_header(X_TENANT_ID, "acme")
+                    .await;
+                assert_eq!(result.status_code(), StatusCode::OK);
+                let manifest: Value = result.json();
+                let output_url = manifest["parameter"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .find(|part| part["name"] == "output")
+                    .and_then(|part| part["part"].as_array())
+                    .and_then(|parts| parts.iter().find(|part| part["name"] == "location"))
+                    .and_then(|part| part["valueUri"].as_str())
+                    .unwrap();
+                assert!(output_url.starts_with("https://public.example/fhir/export/"));
+                let download_path = output_url.strip_prefix(public_base).unwrap();
+                assert_eq!(
+                    server
+                        .get(download_path)
+                        .add_header(X_TENANT_ID, "acme")
+                        .await
+                        .status_code(),
+                    StatusCode::OK
+                );
+
+                // The URL-path form remains available in `both` mode.
+                assert_eq!(
+                    server
+                        .get(&format!("/acme{result_path}"))
+                        .await
+                        .status_code(),
+                    StatusCode::OK
+                );
+                return;
+            }
+            assert_eq!(poll.status_code(), StatusCode::ACCEPTED);
+        }
+        panic!("SOF export did not complete");
     }
 
     fn patient_view() -> Value {
@@ -1239,7 +1396,7 @@ mod sof_export_tests {
         fn read_shard(&self, _t: &str, _j: &str, _f: &str) -> Option<Vec<u8>> {
             None
         }
-        fn download_url(&self, _t: &str, _j: &str, _f: &str) -> Option<String> {
+        fn download_url(&self, _t: &str, _b: &str, _j: &str, _f: &str) -> Option<String> {
             // This controller only ever reports `Failed`, so the manifest path
             // that resolves download URLs is never exercised.
             None
@@ -1361,7 +1518,7 @@ mod sof_export_tests {
         fn read_shard(&self, _t: &str, _j: &str, _f: &str) -> Option<Vec<u8>> {
             None
         }
-        fn download_url(&self, _t: &str, _j: &str, _f: &str) -> Option<String> {
+        fn download_url(&self, _t: &str, _b: &str, _j: &str, _f: &str) -> Option<String> {
             // Stand in for an S3 pre-signing failure at poll time: the shard
             // exists but no usable URL can be produced.
             None

--- a/crates/rest/tests/sof_export_graph.rs
+++ b/crates/rest/tests/sof_export_graph.rs
@@ -42,7 +42,10 @@ mod sof_export_graph_tests {
         let sink = InMemorySink::new("http://localhost");
         let controller = InMemoryController::new(runner, sink, None);
 
-        let config = ServerConfig::for_testing();
+        let config = ServerConfig {
+            base_url: "http://localhost".to_string(),
+            ..ServerConfig::for_testing()
+        };
         let state = helios_rest::AppState::new(Arc::clone(&backend), config)
             .with_export_controller(Arc::new(controller));
         let app = helios_rest::routing::fhir_routes::create_routes(state);

--- a/crates/rest/tests/tenant_resolution.rs
+++ b/crates/rest/tests/tenant_resolution.rs
@@ -386,6 +386,29 @@ mod combined_mode {
         let impl_url = body["implementation"]["url"].as_str().unwrap();
         assert_eq!(impl_url, "http://localhost:8080");
     }
+
+    #[cfg(feature = "subscriptions")]
+    #[tokio::test]
+    async fn websocket_namespace_is_reachable_by_header_and_url_path() {
+        let config = MultitenancyConfig {
+            routing_mode: TenantRoutingMode::Both,
+            ..Default::default()
+        };
+        let (server, _backend) = create_test_server(config).await;
+
+        for path in ["/ws/subscriptions/bind", "/acme/ws/subscriptions/bind"] {
+            let mut request = server.get(path);
+            if path.starts_with("/ws/") {
+                request = request.add_header(X_TENANT_ID, HeaderValue::from_static("acme"));
+            }
+
+            // Without upgrade headers, reaching the WebSocket extractor
+            // deterministically yields 400 in this in-process test transport.
+            // A namespace misclassified as tenant falls through to a FHIR read
+            // route and returns 404 instead.
+            assert_eq!(request.await.status_code(), StatusCode::BAD_REQUEST);
+        }
+    }
 }
 
 // =============================================================================

--- a/crates/subscriptions/src/channels/messaging.rs
+++ b/crates/subscriptions/src/channels/messaging.rs
@@ -36,6 +36,7 @@ pub struct MessagingChannel {
     client: Client,
     auth_provider: Arc<dyn OutboundAuthProvider>,
     source_endpoint: String,
+    source_endpoint_resolver: Option<Arc<dyn Fn(&str) -> String + Send + Sync>>,
     /// When `true`, dispatch to private/loopback IPs is allowed. Default
     /// `false`; tests and local dev opt in.
     private_endpoints_allowed: bool,
@@ -54,8 +55,18 @@ impl MessagingChannel {
             client,
             auth_provider,
             source_endpoint,
+            source_endpoint_resolver: None,
             private_endpoints_allowed: false,
         }
+    }
+
+    /// Resolve the default source endpoint from the subscription tenant.
+    pub fn with_source_endpoint_resolver(
+        mut self,
+        resolver: Arc<dyn Fn(&str) -> String + Send + Sync>,
+    ) -> Self {
+        self.source_endpoint_resolver = Some(resolver);
+        self
     }
 
     /// Replace the HTTP client (used by tests).
@@ -69,6 +80,13 @@ impl MessagingChannel {
     pub fn with_private_endpoints_allowed(mut self, allowed: bool) -> Self {
         self.private_endpoints_allowed = allowed;
         self
+    }
+
+    fn source_endpoint_for(&self, tenant_id: &str) -> String {
+        self.source_endpoint_resolver
+            .as_ref()
+            .map(|resolver| resolver(tenant_id))
+            .unwrap_or_else(|| self.source_endpoint.clone())
     }
 
     async fn send(
@@ -100,12 +118,9 @@ impl MessagingChannel {
 
         // Wrap the prebuilt notification bundle as a message bundle.
         let notification_type = notification_type_from_bundle(bundle);
-        let message_bundle = wrap_as_message_bundle(
-            bundle,
-            subscription,
-            &self.source_endpoint,
-            notification_type,
-        )?;
+        let source_endpoint = self.source_endpoint_for(&subscription.tenant_id);
+        let message_bundle =
+            wrap_as_message_bundle(bundle, subscription, &source_endpoint, notification_type)?;
 
         let mut request = self
             .client
@@ -300,6 +315,20 @@ mod tests {
             Arc::new(StaticBearerOutboundAuthProvider::new(token)),
         )
         .with_private_endpoints_allowed(true)
+    }
+
+    #[test]
+    fn default_source_endpoint_resolves_per_tenant_but_explicit_stays_fixed() {
+        let resolver: Arc<dyn Fn(&str) -> String + Send + Sync> =
+            Arc::new(|tenant| format!("https://public.example/fhir/{tenant}"));
+        let dynamic = channel_with_noop().with_source_endpoint_resolver(resolver);
+        assert_eq!(
+            dynamic.source_endpoint_for("acme"),
+            "https://public.example/fhir/acme"
+        );
+
+        let explicit = channel_with_noop();
+        assert_eq!(explicit.source_endpoint_for("acme"), SOURCE);
     }
 
     fn handshake_bundle(sub: &ActiveSubscription) -> Value {

--- a/crates/subscriptions/src/channels/messaging.rs
+++ b/crates/subscriptions/src/channels/messaging.rs
@@ -31,12 +31,15 @@ use crate::error::SubscriptionError;
 use crate::manager::{ActiveSubscription, PayloadContent};
 use crate::notification::{notification_type_from_bundle, wrap_as_message_bundle};
 
+/// Resolves the public messaging source endpoint for a tenant.
+pub type SourceEndpointResolver = Arc<dyn Fn(&str) -> String + Send + Sync>;
+
 /// FHIR Messaging channel implementation.
 pub struct MessagingChannel {
     client: Client,
     auth_provider: Arc<dyn OutboundAuthProvider>,
     source_endpoint: String,
-    source_endpoint_resolver: Option<Arc<dyn Fn(&str) -> String + Send + Sync>>,
+    source_endpoint_resolver: Option<SourceEndpointResolver>,
     /// When `true`, dispatch to private/loopback IPs is allowed. Default
     /// `false`; tests and local dev opt in.
     private_endpoints_allowed: bool,
@@ -61,10 +64,7 @@ impl MessagingChannel {
     }
 
     /// Resolve the default source endpoint from the subscription tenant.
-    pub fn with_source_endpoint_resolver(
-        mut self,
-        resolver: Arc<dyn Fn(&str) -> String + Send + Sync>,
-    ) -> Self {
+    pub fn with_source_endpoint_resolver(mut self, resolver: SourceEndpointResolver) -> Self {
         self.source_endpoint_resolver = Some(resolver);
         self
     }

--- a/crates/subscriptions/src/engine/mod.rs
+++ b/crates/subscriptions/src/engine/mod.rs
@@ -48,7 +48,7 @@ pub struct SubscriptionEngine {
     email_channel: Option<Arc<EmailChannel>>,
     messaging_channel: Option<Arc<MessagingChannel>>,
     config: SubscriptionConfig,
-    base_url: String,
+    public_base_url_for_tenant: Arc<dyn Fn(&str) -> String + Send + Sync>,
     /// Storage handle used to write a server-driven status transition back into
     /// the stored `Subscription` resource. `None` leaves every transition
     /// in-memory only, which is the pre-#357 behaviour.
@@ -92,6 +92,19 @@ impl SubscriptionEngine {
         base_url: String,
         outbound_auth: Arc<dyn OutboundAuthProvider>,
     ) -> Self {
+        let resolver: Arc<dyn Fn(&str) -> String + Send + Sync> =
+            Arc::new(move |_| base_url.clone());
+        Self::with_outbound_auth_and_url_resolver(config, resolver, false, outbound_auth)
+    }
+
+    /// Creates an engine whose background notifications resolve a canonical
+    /// public base for each subscription tenant.
+    pub fn with_outbound_auth_and_url_resolver(
+        config: SubscriptionConfig,
+        public_base_url_for_tenant: Arc<dyn Fn(&str) -> String + Send + Sync>,
+        resolve_default_message_source: bool,
+        outbound_auth: Arc<dyn OutboundAuthProvider>,
+    ) -> Self {
         let topic_registry = Arc::new(InMemoryTopicRegistry::new());
         let manager = Arc::new(SubscriptionManager::new(
             Arc::clone(&topic_registry),
@@ -113,10 +126,13 @@ impl SubscriptionEngine {
             None => None,
         };
         let messaging_channel = config.messaging.as_ref().map(|settings| {
-            Arc::new(
-                MessagingChannel::new(settings.source_endpoint.clone(), Arc::clone(&outbound_auth))
-                    .with_private_endpoints_allowed(settings.allow_private_endpoints),
-            )
+            let mut channel =
+                MessagingChannel::new(settings.source_endpoint.clone(), Arc::clone(&outbound_auth));
+            if resolve_default_message_source {
+                channel =
+                    channel.with_source_endpoint_resolver(Arc::clone(&public_base_url_for_tenant));
+            }
+            Arc::new(channel.with_private_endpoints_allowed(settings.allow_private_endpoints))
         });
 
         let status_write_slots = Arc::new(Semaphore::new(config.status_write_concurrency.max(1)));
@@ -133,7 +149,7 @@ impl SubscriptionEngine {
             email_channel,
             messaging_channel,
             config,
-            base_url,
+            public_base_url_for_tenant,
             status_store: None,
             status_write_slots,
             delivery_stats: Arc::new(crate::delivery_stats::DeliveryStats::new()),
@@ -260,11 +276,12 @@ impl SubscriptionEngine {
             };
 
             // Build notification bundle.
+            let public_base_url = (self.public_base_url_for_tenant)(&subscription.tenant_id);
             let bundle = match notification::build_event_notification(
                 &subscription,
                 event_data,
                 event.resource.as_ref(),
-                &self.base_url,
+                &public_base_url,
             ) {
                 Ok(b) => b,
                 Err(e) => {
@@ -587,7 +604,8 @@ impl SubscriptionEngine {
         let handshake_max_attempts = self.config.handshake_max_attempts.max(1);
 
         // Build handshake notification.
-        let handshake_bundle = match notification::build_handshake(subscription, &self.base_url) {
+        let public_base_url = (self.public_base_url_for_tenant)(&subscription.tenant_id);
+        let handshake_bundle = match notification::build_handshake(subscription, &public_base_url) {
             Ok(b) => b,
             Err(e) => {
                 warn!(
@@ -1130,6 +1148,22 @@ mod tests {
             ..Default::default()
         };
         SubscriptionEngine::new(config, base_url.to_string())
+    }
+
+    #[test]
+    fn canonical_public_base_resolves_for_background_tenant() {
+        let resolver: Arc<dyn Fn(&str) -> String + Send + Sync> =
+            Arc::new(|tenant| format!("https://public.example/fhir/{tenant}"));
+        let engine = SubscriptionEngine::with_outbound_auth_and_url_resolver(
+            SubscriptionConfig::default(),
+            resolver,
+            false,
+            Arc::new(NoOpOutboundAuthProvider),
+        );
+        assert_eq!(
+            (engine.public_base_url_for_tenant)("acme"),
+            "https://public.example/fhir/acme"
+        );
     }
 
     fn encounter_topic() -> TopicDefinition {

--- a/crates/subscriptions/src/engine/mod.rs
+++ b/crates/subscriptions/src/engine/mod.rs
@@ -1164,6 +1164,23 @@ mod tests {
             (engine.public_base_url_for_tenant)("acme"),
             "https://public.example/fhir/acme"
         );
+
+        let config = SubscriptionConfig {
+            messaging: Some(crate::config::MessagingSettings {
+                source_endpoint: "https://fallback.example/fhir".to_string(),
+                allow_private_endpoints: false,
+            }),
+            ..Default::default()
+        };
+        let resolver: Arc<dyn Fn(&str) -> String + Send + Sync> =
+            Arc::new(|tenant| format!("https://public.example/fhir/{tenant}"));
+        let engine = SubscriptionEngine::with_outbound_auth_and_url_resolver(
+            config,
+            resolver,
+            true,
+            Arc::new(NoOpOutboundAuthProvider),
+        );
+        assert!(engine.messaging_channel.is_some());
     }
 
     fn encounter_topic() -> TopicDefinition {

--- a/crates/subscriptions/src/notification/mod.rs
+++ b/crates/subscriptions/src/notification/mod.rs
@@ -259,9 +259,13 @@ mod tests {
         };
 
         let resource = json!({"resourceType": "Encounter", "id": "123"});
-        let bundle =
-            build_event_notification(&sub, event, Some(&resource), "http://localhost:8080")
-                .unwrap();
+        let bundle = build_event_notification(
+            &sub,
+            event,
+            Some(&resource),
+            "https://public.example/fhir/test-tenant",
+        )
+        .unwrap();
 
         let entries = bundle["entry"].as_array().unwrap();
         // Status entry + id-only entry.
@@ -269,7 +273,10 @@ mod tests {
 
         // The id-only entry should have fullUrl and request but no resource.
         let id_entry = &entries[1];
-        assert!(id_entry.get("fullUrl").is_some());
+        assert_eq!(
+            id_entry["fullUrl"],
+            "https://public.example/fhir/test-tenant/Encounter/123"
+        );
         assert!(id_entry.get("request").is_some());
         assert!(id_entry.get("resource").is_none());
     }

--- a/crates/ui/assets/resources.js
+++ b/crates/ui/assets/resources.js
@@ -296,19 +296,21 @@
     renderEditor({ resourceType: type });
   }
 
-  /* Clicking a result row opens it. The results table (from saved-queries.js)
-   * renders id links as `/{type}/{id}`; intercept them into the modal. The
-   * results live in the content column, not under `root` (the type panel), so
-   * the listener is on the document. */
+  /* Clicking a result row opens it. The href remains the server-provided
+   * public URL, which may include a path prefix or tenant segment. Use the
+   * trusted resource identity attached by saved-queries.js instead of parsing
+   * that deployment-specific URL. The results live in the content column, not
+   * under `root` (the type panel), so the listener is on the document. */
   document.addEventListener(
     "click",
     function (event) {
       var link = event.target.closest("#query-results-body a.url");
       if (!link) return;
-      var m = /^\/([A-Za-z]+)\/([^/?]+)/.exec(link.getAttribute("href") || "");
-      if (!m) return;
+      var type = link.dataset.resourceType || "";
+      var id = link.dataset.resourceId || "";
+      if (!/^[A-Za-z]+$/.test(type) || !/^[A-Za-z0-9.-]{1,64}$/.test(id)) return;
       event.preventDefault();
-      openResource(m[1], m[2]);
+      openResource(type, id);
     },
     true
   );

--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -143,15 +143,42 @@
         return null;
       }
     }
-    var match = /^\/?([A-Za-z]+)(?:\?(.*))?$/.exec(text);
-    if (!match) return null;
-    return { type: match[1], query: (match[2] || "").trim() };
+    var queryAt = text.indexOf("?");
+    var path = queryAt >= 0 ? text.slice(0, queryAt) : text;
+    var query = queryAt >= 0 ? text.slice(queryAt + 1).trim() : "";
+    var segments = path.split("/").filter(Boolean);
+    var resourceType = segments[segments.length - 1] || "";
+    if (!/^[A-Za-z]+$/.test(resourceType)) return null;
+    return { type: resourceType, query: query };
   }
 
   function searchPath(resourceType, query) {
     return (
       "/" + encodeURIComponent(resourceType) + (query ? "?" + query : "")
     );
+  }
+
+  /* The semantic search context is independent from a server-provided pager
+   * URL. FHIR paging links may be opaque and need not contain a resource type. */
+  function resultContext(raw) {
+    var parsed = parseSearchUrl(raw);
+    if (!parsed) return null;
+    var text = (raw || "").trim().replace(/^GET\s+/i, "");
+    try {
+      var url = new URL(text, window.location.href);
+      var segments = url.pathname.split("/").filter(Boolean);
+      segments.pop();
+      url.pathname = "/" + segments.join("/");
+      url.search = "";
+      url.hash = "";
+      return {
+        type: parsed.type,
+        query: parsed.query,
+        baseUrl: url.href.replace(/\/$/, ""),
+      };
+    } catch (e) {
+      return null;
+    }
   }
 
   /* ---- Visual builder: rows kept in two-way sync with the GET URL ------ */
@@ -1585,8 +1612,10 @@
 
   /* ---- Results: the FHIR search response, rendered in-page ------------- */
 
-  /* The last path handed to runSearch — what a data-changed re-run repeats. */
+  /* The last path that rendered successfully. A failed page request must not
+   * replace it, because data-changed re-runs the visible page. */
   var lastSearchPath = null;
+  var lastSearchContext = null;
 
   var results = {
     card: document.getElementById("query-results"),
@@ -1594,6 +1623,7 @@
     body: document.getElementById("query-results-body"),
     meta: document.getElementById("query-results-meta"),
     note: document.getElementById("query-results-note"),
+    error: document.getElementById("query-results-error"),
     open: document.getElementById("query-results-open"),
     prev: document.getElementById("query-results-prev"),
     next: document.getElementById("query-results-next"),
@@ -1671,47 +1701,57 @@
     return null;
   }
 
-  function renderResults(path, ok, body) {
-    var card = results.card;
-    if (!card) return;
-    card.hidden = false;
-    results.open.href = path;
-    results.head.textContent = "";
-    results.body.textContent = "";
-    results.meta.textContent = "";
-    results.note.textContent = "";
-    results.prev.hidden = true;
-    results.next.hidden = true;
-
-    if (!ok || !body || body.resourceType !== "Bundle") {
-      var diagnostics =
-        body &&
-        body.issue &&
-        body.issue[0] &&
-        (body.issue[0].diagnostics ||
-          (body.issue[0].details && body.issue[0].details.text));
-      results.note.textContent = diagnostics || messages.msgError;
-      return;
+  /* Build a complete replacement before touching the visible result. If a
+   * response is not a search Bundle, or its shape cannot be rendered, the
+   * previous page stays intact. */
+  function safeResourceHref(entry, context, resource) {
+    if (entry && typeof entry.fullUrl === "string") {
+      try {
+        var fullUrl = new URL(entry.fullUrl, window.location.href);
+        if (
+          (fullUrl.protocol === "http:" || fullUrl.protocol === "https:") &&
+          !fullUrl.username &&
+          !fullUrl.password
+        ) {
+          return fullUrl.href;
+        }
+      } catch (e) {
+        // Fall through to the route built from the trusted search context.
+      }
     }
+    return (
+      context.baseUrl +
+      "/" +
+      encodeURIComponent(context.type) +
+      "/" +
+      encodeURIComponent(resource.id || "")
+    );
+  }
 
-    var parsed = parseSearchUrl(path) || { type: "", query: "" };
-    var entries = body.entry || [];
+  function prepareResults(body, context) {
+    if (!body || body.resourceType !== "Bundle") return null;
+    if (!context || !/^[A-Za-z]+$/.test(context.type)) return null;
+    var entries = Array.isArray(body.entry) ? body.entry : [];
     var primary = entries.filter(function (entry) {
       return (
-        entry.resource && entry.resource.resourceType === parsed.type
+        entry &&
+        entry.resource &&
+        entry.resource.resourceType === context.type
       );
     });
     var included = entries.length - primary.length;
 
-    var total =
-      typeof body.total === "number" ? body.total : primary.length;
-    var meta = card.dataset.msgTotal.replace("{count}", total);
+    var total = typeof body.total === "number" ? body.total : primary.length;
+    var meta = results.card.dataset.msgTotal.replace("{count}", total);
     if (included > 0)
-      meta += " · " + card.dataset.msgIncluded.replace("{count}", included);
-    results.meta.textContent = meta;
+      meta +=
+        " · " +
+        results.card.dataset.msgIncluded.replace("{count}", included);
 
-    var columns = elementColumns(parsed.query);
-    if (!columns.length) columns = DEFAULT_COLUMNS[parsed.type] || [];
+    var columns = elementColumns(context.query);
+    if (!columns.length) columns = DEFAULT_COLUMNS[context.type] || [];
+
+    var head = document.createDocumentFragment();
     var headRow = document.createElement("tr");
     var th = document.createElement("th");
     th.textContent = "id";
@@ -1722,17 +1762,18 @@
       headRow.appendChild(cellEl);
     });
     var thUpdated = document.createElement("th");
-    thUpdated.textContent = card.dataset.msgUpdated;
+    thUpdated.textContent = results.card.dataset.msgUpdated;
     headRow.appendChild(thUpdated);
-    results.head.appendChild(headRow);
+    head.appendChild(headRow);
 
+    var rows = document.createDocumentFragment();
     primary.forEach(function (entry) {
       var resource = entry.resource;
       var row = document.createElement("tr");
       var idCell = document.createElement("td");
       var link = document.createElement("a");
       link.className = "url";
-      link.href = "/" + parsed.type + "/" + resource.id;
+      link.href = safeResourceHref(entry, context, resource);
       link.target = "_blank";
       link.rel = "noopener";
       link.textContent = resource.id || "";
@@ -1745,39 +1786,101 @@
         row,
         resource.meta && resource.meta.lastUpdated
           ? whenText(resource.meta.lastUpdated)
-          : ""
+          : "",
       );
-      results.body.appendChild(row);
+      rows.appendChild(row);
     });
 
-    if (!primary.length) results.note.textContent = card.dataset.msgEmpty;
+    var sortValue = "";
+    splitQuery(context.query).forEach(function (part) {
+      if (part.key === "_sort") sortValue = part.value;
+    });
 
+    return {
+      head: head,
+      rows: rows,
+      meta: meta,
+      note: primary.length ? "" : results.card.dataset.msgEmpty,
+      sort: sortValue,
+      prev: pagerLink(body, "previous"),
+      next: pagerLink(body, "next"),
+    };
+  }
+
+  function clearResultsError() {
+    if (!results.error) return;
+    results.error.textContent = "";
+    results.error.hidden = true;
+  }
+
+  function renderResults(path, body, context) {
+    var card = results.card;
+    if (!card) return false;
+    var prepared = prepareResults(body, context);
+    if (!prepared) return false;
+
+    card.hidden = false;
+    results.open.href = path;
+    results.head.replaceChildren(prepared.head);
+    results.body.replaceChildren(prepared.rows);
+    results.meta.textContent = prepared.meta;
+    results.note.textContent = prepared.note;
     if (results.sort) {
-      var sortValue = "";
-      splitQuery(parsed.query).forEach(function (part) {
-        if (part.key === "_sort") sortValue = part.value;
-      });
-      results.sort.value = sortValue;
-      if (results.sort.value !== sortValue) results.sort.value = "";
+      results.sort.value = prepared.sort;
+      if (results.sort.value !== prepared.sort) results.sort.value = "";
     }
 
-    var prevUrl = pagerLink(body, "previous");
-    var nextUrl = pagerLink(body, "next");
-    if (prevUrl) {
+    if (prepared.prev) {
       results.prev.hidden = false;
-      results.prev.dataset.url = prevUrl;
+      results.prev.dataset.url = prepared.prev;
+    } else {
+      results.prev.hidden = true;
+      delete results.prev.dataset.url;
     }
-    if (nextUrl) {
+    if (prepared.next) {
       results.next.hidden = false;
-      results.next.dataset.url = nextUrl;
+      results.next.dataset.url = prepared.next;
+    } else {
+      results.next.hidden = true;
+      delete results.next.dataset.url;
     }
+
+    clearResultsError();
+    lastSearchPath = path;
+    lastSearchContext = context;
+    return true;
+  }
+
+  function failedOrigin(path) {
+    try {
+      var origin = new URL(path, window.location.href).origin;
+      return origin && origin !== "null" ? origin : window.location.origin;
+    } catch (e) {
+      return window.location.origin;
+    }
+  }
+
+  function showResultsError(path) {
+    if (results.card) results.card.hidden = false;
+    if (results.error) {
+      results.error.textContent = results.card.dataset.msgFetchError.replace(
+        "{origin}",
+        failedOrigin(path),
+      );
+      results.error.hidden = false;
+    }
+    document.dispatchEvent(
+      new CustomEvent("hfs:data-changed", {
+        detail: { source: "query-results", failed: true },
+      }),
+    );
   }
 
   /* Runs a search against the FHIR API and renders the Bundle in-page.
    * `record` adds it to the roaming recent list (explicit runs only, so
    * paging does not spam recents). */
-  function runSearch(path, record) {
-    lastSearchPath = path;
+  function runSearch(path, record, context) {
+    var requestedContext = context || resultContext(path);
     if (!results.card) {
       window.open(path, "_blank", "noopener");
     } else {
@@ -1786,17 +1889,17 @@
         credentials: "same-origin",
       })
         .then(function (response) {
-          return response
-            .json()
-            .catch(function () {
-              return null;
-            })
-            .then(function (body) {
-              renderResults(path, response.ok, body);
-            });
+          if (!response.ok) return null;
+          return response.json().catch(function () {
+            return null;
+          });
+        })
+        .then(function (body) {
+          if (!renderResults(path, body, requestedContext))
+            showResultsError(path);
         })
         .catch(function () {
-          renderResults(path, false, null);
+          showResultsError(path);
         });
     }
     if (record) recordRecent(path);
@@ -1805,21 +1908,18 @@
   results.card &&
     results.card.addEventListener("click", function (event) {
       var pager = event.target.closest("button[data-url]");
-      if (pager) runSearch(pager.dataset.url, false);
+      if (pager) runSearch(pager.dataset.url, false, lastSearchContext);
     });
 
   /* Sort re-runs the current results path with the picked `_sort` (#416). */
   results.sort &&
     results.sort.addEventListener("change", function () {
-      var current = results.open && results.open.getAttribute("href");
-      if (!current) return;
-      var parsed = parseSearchUrl(current);
-      if (!parsed) return;
-      var parts = (parsed.query || "").split("&").filter(function (p) {
+      if (!lastSearchContext) return;
+      var parts = (lastSearchContext.query || "").split("&").filter(function (p) {
         return p && p.indexOf("_sort=") !== 0;
       });
       if (results.sort.value) parts.push("_sort=" + results.sort.value);
-      runSearch(searchPath(parsed.type, parts.join("&")), false);
+      runSearch(searchPath(lastSearchContext.type, parts.join("&")), false);
     });
 
   /* ---- Recent searches & the saved list -------------------------------- */
@@ -2233,8 +2333,10 @@
    * modal announces it): re-run the last search so the table shows what is
    * actually stored, without recording a new recent. The rail's counts are
    * server-rendered (#541) and catch up on the next full page load. */
-  document.addEventListener("hfs:data-changed", function () {
-    if (lastSearchPath) runSearch(lastSearchPath, false);
+  document.addEventListener("hfs:data-changed", function (event) {
+    if (event.detail && event.detail.source === "query-results") return;
+    if (lastSearchPath)
+      runSearch(lastSearchPath, false, lastSearchContext);
   });
 
   reload();

--- a/crates/ui/assets/saved-queries.js
+++ b/crates/ui/assets/saved-queries.js
@@ -1774,6 +1774,8 @@
       var link = document.createElement("a");
       link.className = "url";
       link.href = safeResourceHref(entry, context, resource);
+      link.dataset.resourceType = context.type;
+      link.dataset.resourceId = resource.id || "";
       link.target = "_blank";
       link.rel = "noopener";
       link.textContent = resource.id || "";

--- a/crates/ui/e2e/pages/search-builder.ts
+++ b/crates/ui/e2e/pages/search-builder.ts
@@ -87,6 +87,12 @@ export class SearchResults {
   get rows(): Locator {
     return this.page.locator("#query-results-body tr");
   }
+  get note(): Locator {
+    return this.page.locator("#query-results-note");
+  }
+  get error(): Locator {
+    return this.page.locator("#query-results-error");
+  }
   get prev(): Locator {
     return this.page.locator("#query-results-prev");
   }
@@ -96,5 +102,27 @@ export class SearchResults {
 
   async waitShown(): Promise<void> {
     await this.card.waitFor({ state: "visible" });
+  }
+
+  async visibleState(): Promise<{
+    rows: string[];
+    meta: string;
+    openHref: string | null;
+    note: string;
+    prevVisible: boolean;
+    prevUrl: string | null;
+    nextVisible: boolean;
+    nextUrl: string | null;
+  }> {
+    return {
+      rows: await this.rows.allInnerTexts(),
+      meta: await this.meta.innerText(),
+      openHref: await this.openTab.getAttribute("href"),
+      note: await this.note.innerText(),
+      prevVisible: await this.prev.isVisible(),
+      prevUrl: await this.prev.getAttribute("data-url"),
+      nextVisible: await this.next.isVisible(),
+      nextUrl: await this.next.getAttribute("data-url"),
+    };
   }
 }

--- a/crates/ui/e2e/tests/queries.spec.ts
+++ b/crates/ui/e2e/tests/queries.spec.ts
@@ -49,6 +49,219 @@ test.describe("query builder", () => {
       .not.toBe(firstPage.join());
   });
 
+  test("failed pagination preserves the visible page and can be retried", async ({
+    queries,
+  }) => {
+    const pageOrigin = new URL(queries.page.url()).origin;
+    const initialPath = "/Patient?_count=1&_sort=_id";
+    const paginationOrigin = "http://127.0.0.1:1";
+    const paginationPath =
+      "/public/fhir/acme/_paging/opaque-token?_getpages=opaque%2Ftoken&_count=1";
+    const paginationUrl = paginationOrigin + paginationPath;
+    let initialRequests = 0;
+    let paginationAttempts = 0;
+
+    const firstPage = {
+      resourceType: "Bundle",
+      type: "searchset",
+      total: 2,
+      entry: [
+        {
+          fullUrl: `${pageOrigin}/Patient/patient-page-one`,
+          resource: {
+            resourceType: "Patient",
+            id: "patient-page-one",
+            name: [{ family: "First page" }],
+          },
+        },
+      ],
+      link: [
+        { relation: "self", url: pageOrigin + initialPath },
+        { relation: "next", url: paginationUrl },
+      ],
+    };
+    const secondPage = {
+      resourceType: "Bundle",
+      type: "searchset",
+      total: 2,
+      entry: [
+        {
+          fullUrl: `${paginationOrigin}/public/fhir/acme/Patient/patient-page-two`,
+          resource: {
+            resourceType: "Patient",
+            id: "patient-page-two",
+            name: [{ family: "Second page" }],
+          },
+        },
+      ],
+      link: [{ relation: "previous", url: pageOrigin + initialPath }],
+    };
+
+    await queries.page.route("**/*", async (route) => {
+      const request = route.request();
+      const url = request.url();
+      if (request.method() === "GET" && url === pageOrigin + initialPath) {
+        initialRequests += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/fhir+json",
+          body: JSON.stringify(firstPage),
+        });
+        return;
+      }
+      if (url !== paginationUrl) {
+        await route.continue();
+        return;
+      }
+      if (request.method() === "OPTIONS") {
+        await route.fulfill({
+          status: 204,
+          headers: {
+            "Access-Control-Allow-Origin": pageOrigin,
+            "Access-Control-Allow-Methods": "GET",
+            "Access-Control-Allow-Headers": "Accept, X-Tenant-ID",
+          },
+        });
+        return;
+      }
+
+      paginationAttempts += 1;
+      const corsHeaders = {
+        "Access-Control-Allow-Origin": pageOrigin,
+        "Content-Type": "application/fhir+json",
+      };
+      if (paginationAttempts === 1) {
+        await route.abort("failed");
+      } else if (paginationAttempts === 2) {
+        await route.fulfill({
+          status: 502,
+          headers: corsHeaders,
+          body: JSON.stringify({
+            resourceType: "OperationOutcome",
+            issue: [{ diagnostics: "sensitive upstream response" }],
+          }),
+        });
+      } else if (paginationAttempts === 3) {
+        await route.fulfill({
+          status: 200,
+          headers: corsHeaders,
+          body: "not-json",
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          headers: corsHeaders,
+          body: JSON.stringify(secondPage),
+        });
+      }
+    });
+
+    await queries.page.evaluate(() => {
+      const trackedWindow = window as typeof window & {
+        __hfsDataChangedFailures?: number;
+        __hfsFetchInputs?: string[];
+      };
+      const nativeFetch = window.fetch.bind(window);
+      trackedWindow.__hfsDataChangedFailures = 0;
+      trackedWindow.__hfsFetchInputs = [];
+      window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+        trackedWindow.__hfsFetchInputs?.push(
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+        );
+        return nativeFetch(input, init);
+      }) as typeof window.fetch;
+      document.addEventListener("hfs:data-changed", (event) => {
+        const detail = (event as CustomEvent).detail;
+        if (detail && detail.source === "query-results") {
+          trackedWindow.__hfsDataChangedFailures =
+            (trackedWindow.__hfsDataChangedFailures || 0) + 1;
+        }
+      });
+    });
+
+    await queries.builder.run(initialPath);
+    await queries.results.waitShown();
+    await expect(queries.results.next).toBeVisible();
+    await expect(queries.results.error).toBeHidden();
+    const visiblePage = await queries.results.visibleState();
+
+    // A network failure leaves every visible result field and pager URL alone.
+    await queries.results.next.click();
+    await expect(queries.results.error).toBeVisible();
+    await expect(queries.results.error).toContainText(paginationOrigin);
+    await expect(queries.results.error).toContainText("HFS_BASE_URL");
+    await expect(queries.results.error).not.toContainText("opaque");
+    await expect.poll(() => paginationAttempts).toBe(1);
+    expect(await queries.results.visibleState()).toEqual(visiblePage);
+    await expect
+      .poll(() =>
+        queries.page.evaluate(
+          () =>
+            (window as typeof window & { __hfsDataChangedFailures?: number })
+              .__hfsDataChangedFailures,
+        ),
+      )
+      .toBe(1);
+    expect(initialRequests).toBe(1);
+
+    // The failure event does not recurse. A real data change repeats the last
+    // successful relative path, not the failed absolute pagination URL.
+    await queries.page.evaluate(() => {
+      document.dispatchEvent(
+        new CustomEvent("hfs:data-changed", { detail: { type: "Patient" } }),
+      );
+    });
+    await expect.poll(() => initialRequests).toBe(2);
+    await expect(queries.results.error).toBeHidden();
+    expect(await queries.results.visibleState()).toEqual(visiblePage);
+
+    // Non-2xx and malformed JSON failures are equally non-destructive. The
+    // server response body and opaque query token never enter the alert.
+    await queries.results.next.click();
+    await expect
+      .poll(() =>
+        queries.page.evaluate(
+          () =>
+            (window as typeof window & { __hfsDataChangedFailures?: number })
+              .__hfsDataChangedFailures,
+        ),
+      )
+      .toBe(2);
+    await expect(queries.results.error).not.toContainText("sensitive upstream response");
+    expect(await queries.results.visibleState()).toEqual(visiblePage);
+
+    await queries.results.next.click();
+    await expect
+      .poll(() =>
+        queries.page.evaluate(
+          () =>
+            (window as typeof window & { __hfsDataChangedFailures?: number })
+              .__hfsDataChangedFailures,
+        ),
+      )
+      .toBe(3);
+    expect(await queries.results.visibleState()).toEqual(visiblePage);
+
+    // The fourth click retries the server-provided URL byte for byte. A valid
+    // Bundle under a public path prefix replaces the page and clears the alert.
+    await queries.results.next.click();
+    await expect(queries.results.rows).toHaveCount(1);
+    await expect(queries.results.rows.first()).toContainText("patient-page-two");
+    await expect(queries.results.rows.first().locator("a.url")).toHaveAttribute(
+      "href",
+      `${paginationOrigin}/public/fhir/acme/Patient/patient-page-two`,
+    );
+    await expect(queries.results.openTab).toHaveAttribute("href", paginationUrl);
+    await expect(queries.results.prev).toBeVisible();
+    await expect(queries.results.error).toBeHidden();
+
+    const fetchInputs = await queries.page.evaluate(
+      () =>
+        (window as typeof window & { __hfsFetchInputs?: string[] }).__hfsFetchInputs || [],
+    );
+    expect(fetchInputs.filter((input) => input === paginationUrl)).toHaveLength(4);
+  });
+
   /// Chained search end to end (#406): the two chain directions meet on the
   /// patient in the middle — Practitioner <- Patient (generalPractitioner)
   /// <- Observation (subject) — and the combined query returns exactly it.

--- a/crates/ui/e2e/tests/resources.spec.ts
+++ b/crates/ui/e2e/tests/resources.spec.ts
@@ -127,9 +127,14 @@ test("a conflicting Resources bookmark uses the query URL type everywhere after 
     await expect(page.locator("#query-plain-text")).toContainText("Patient");
     await expect(page.locator("#query-plain-text")).toContainText("NavAlpha");
     await resources.results.waitShown();
-    await expect(
-      page.locator(`#query-results-body a.url[href='/Patient/${patientId}']`),
-    ).toBeVisible();
+    const resultLink = page.locator(
+      `#query-results-body a.url[data-resource-type='Patient'][data-resource-id='${patientId}']`,
+    );
+    await expect(resultLink).toBeVisible();
+    await expect(resultLink).toHaveAttribute(
+      "href",
+      new RegExp(`^https?://[^/]+/Patient/${patientId}$`),
+    );
     await expect(resources.results.openTab).toHaveAttribute("href", "/Patient?name=NavAlpha");
   };
 
@@ -372,6 +377,48 @@ test("the modal closes via the X and via Escape", async ({ resources }) => {
   await resources.openCreate();
   await resources.modal.closeWithEscape();
   await expect(resources.modal.root).toBeHidden();
+});
+
+test("a result under a public path prefix still opens in the modal", async ({
+  resources,
+  page,
+  request,
+}) => {
+  const id = await createResource(request, "Patient", {
+    name: [{ family: "PublicPrefix" }],
+  });
+  const queryPath = `/Patient?_id=${id}`;
+  const publicUrl = `https://fhir.example.test/public/fhir/acme/Patient/${id}`;
+
+  await page.route(`**${queryPath}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/fhir+json",
+      body: JSON.stringify({
+        resourceType: "Bundle",
+        type: "searchset",
+        total: 1,
+        entry: [
+          {
+            fullUrl: publicUrl,
+            resource: { resourceType: "Patient", id, name: [{ family: "PublicPrefix" }] },
+          },
+        ],
+      }),
+    });
+  });
+
+  await resources.goto("Patient");
+  await page.locator("input.query-builder__url[name=url]").fill(queryPath.slice(1));
+  await page.locator("[data-intent='run']").click();
+
+  const resultLink = page.locator("#query-results-body a.url").first();
+  await expect(resultLink).toHaveAttribute("href", publicUrl);
+  await expect(resultLink).toHaveAttribute("data-resource-type", "Patient");
+  await expect(resultLink).toHaveAttribute("data-resource-id", id);
+  await resultLink.click();
+  await resources.modal.waitOpen();
+  await expect(resources.modal.subject).toContainText(id);
 });
 
 test("a created resource can be deleted from its modal", async ({ resources, page, request }) => {

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -27,6 +27,44 @@ use serde_json::{Value, json};
 use crate::i18n::{I18n, RequestLocale};
 use crate::{RequestTenant, RequestVersion, WebState, current_status, render, settings_user_key};
 
+fn public_url_with_segments<'a>(
+    public_base_url: &str,
+    segments: impl IntoIterator<Item = &'a str>,
+) -> String {
+    let mut url = reqwest::Url::parse(public_base_url)
+        .expect("WebState requires a valid HTTP(S) public base URL");
+    {
+        let mut path = url
+            .path_segments_mut()
+            .expect("HTTP(S) public base URL supports path segments");
+        path.pop_if_empty();
+        for segment in segments {
+            path.push(segment);
+        }
+    }
+    url.to_string().trim_end_matches('/').to_string()
+}
+
+fn recipient_base_url(state: &WebState, tenant: &RequestTenant) -> String {
+    recipient_base_url_value(
+        &state.public_base_url,
+        state.tenant_path_routing,
+        &tenant.id,
+    )
+}
+
+fn recipient_base_url_value(
+    public_base_url: &str,
+    tenant_path_routing: bool,
+    tenant_id: &str,
+) -> String {
+    if tenant_path_routing {
+        public_url_with_segments(public_base_url, [tenant_id])
+    } else {
+        public_base_url.to_string()
+    }
+}
+
 /// Log entries kept per submission. The whole settings document is capped at
 /// 256 KiB server-side, so the log must stay bounded.
 const LOG_CAP: usize = 100;
@@ -288,7 +326,7 @@ pub async fn page(
         available,
         rows,
         error: None,
-        recipient: state.public_base_url.trim_end_matches('/').to_string(),
+        recipient: recipient_base_url(&state, &rt),
     })
 }
 
@@ -328,7 +366,7 @@ pub async fn create(
         // The recipient is always this server's HFS_BASE_URL (#689) — typing
         // it per submission is how a submission ended up pointed at something
         // that is not a Bulk Data Submit endpoint (#686).
-        recipient_base_url: state.public_base_url.trim_end_matches('/').to_string(),
+        recipient_base_url: recipient_base_url(&state, &rt),
         auth: if form.auth == "backend-services" {
             form.auth
         } else {
@@ -671,10 +709,7 @@ async fn backend_services_token(client_id: &str, token_url: &str) -> Result<Stri
 /// The URL a submission's kick-off is POSTed to — the one failure messages
 /// must name (#686).
 fn kickoff_target(submission: &Submission) -> String {
-    format!(
-        "{}/$bulk-submit",
-        submission.recipient_base_url.trim_end_matches('/')
-    )
+    public_url_with_segments(&submission.recipient_base_url, ["$bulk-submit"])
 }
 
 /// POSTs a kick-off to the recipient, returning
@@ -750,10 +785,7 @@ fn summarize_error_body(content_type: &str, body: &str) -> String {
 /// (submitter + submissionId, `Prefer: respond-async`), returning the poll
 /// URL the recipient hands back in `Content-Location`.
 async fn status_kickoff(submission: &Submission, id: &str) -> Result<String, String> {
-    let target = format!(
-        "{}/$bulk-submit-status",
-        submission.recipient_base_url.trim_end_matches('/')
-    );
+    let target = public_url_with_segments(&submission.recipient_base_url, ["$bulk-submit-status"]);
     // Only the identifying parameters ride the status kick-off.
     let parameters = kickoff_parameters(submission, id, "", None, None);
     let identifying: Vec<Value> = parameters["parameter"]
@@ -1138,15 +1170,11 @@ pub async fn replace_manifest(
 }
 
 /// `POST /ui/bulk-import/{id}/manifests/{mid}/abort` — abort one manifest by
-/// replacing it with the empty manifest this server hosts. The empty
-/// manifest's URL is derived from the request's Host header, since that is
-/// the address the recipient reached us... the address the *browser* reached
-/// us on, which is the best externally-visible base the UI can know.
+/// replacing it with the empty manifest this server hosts.
 pub async fn abort_manifest(
     State(state): State<WebState>,
     rt: RequestTenant,
     principal: Option<Extension<helios_auth::Principal>>,
-    headers: axum::http::HeaderMap,
     Path((id, mid)): Path<(String, String)>,
 ) -> Response {
     let user_key = settings_user_key(principal.as_deref());
@@ -1158,13 +1186,12 @@ pub async fn abort_manifest(
             .unwrap_or_default()
             .to_string();
         if !old_url.is_empty() {
-            let host = headers
-                .get("host")
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("localhost:8080");
             let empty = Manifest {
-                manifest_url: format!("http://{host}/ui/bulk-import/empty-manifest.json"),
-                fhir_base_url: format!("http://{host}"),
+                manifest_url: public_url_with_segments(
+                    &state.public_base_url,
+                    ["ui", "bulk-import", "empty-manifest.json"],
+                ),
+                fhir_base_url: recipient_base_url(&state, &rt),
                 ..Default::default()
             };
             push_log(&mut s, format!("Aborting manifest \"{old_url}\"..."));
@@ -1216,4 +1243,33 @@ pub async fn test_auth(
         Err(e) => (false, e),
     };
     render(TestAuthResult { ok, message })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recipient_base_preserves_prefix_and_adds_path_tenant() {
+        assert_eq!(
+            recipient_base_url_value("https://public.example/fhir", true, "acme"),
+            "https://public.example/fhir/acme"
+        );
+    }
+
+    #[test]
+    fn recipient_base_stays_unprefixed_for_header_only_routing() {
+        assert_eq!(
+            recipient_base_url_value("https://public.example/fhir", false, "acme"),
+            "https://public.example/fhir"
+        );
+    }
+
+    #[test]
+    fn public_url_builder_encodes_tenant_segments() {
+        assert_eq!(
+            recipient_base_url_value("https://public.example/fhir", true, "north clinic"),
+            "https://public.example/fhir/north%20clinic"
+        );
+    }
 }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -133,6 +133,8 @@ struct WebState {
     /// submissions target as their recipient (#689). Distinct from the
     /// loopback self-call base the conformance source uses.
     public_base_url: String,
+    /// Whether canonical tenant URLs include the selected tenant as a path.
+    tenant_path_routing: bool,
     /// The server's default FHIR version, used when seeding a new tenant.
     fhir_version: helios_fhir::FhirVersion,
     /// The server's default tenant id â€” the fallback when no stored choice
@@ -848,13 +850,49 @@ pub fn mount_with_body_limit(
     public_base_url: String,
     max_body_size: usize,
 ) -> Router {
+    mount_with_body_limit_and_tenant_routing(
+        fhir_app,
+        hfs_version,
+        data_dir,
+        nl,
+        tenants,
+        settings,
+        default_tenant,
+        self_base_url,
+        outbound_auth,
+        fhir_version,
+        terminology,
+        public_base_url,
+        max_body_size,
+        false,
+    )
+}
+
+/// Mounts the UI with explicit tenant-path routing behavior.
+#[allow(clippy::too_many_arguments)]
+pub fn mount_with_body_limit_and_tenant_routing(
+    fhir_app: Router,
+    hfs_version: &'static str,
+    data_dir: Option<PathBuf>,
+    nl: NlSearch,
+    tenants: Option<Arc<dyn ResourceStorage>>,
+    settings: Option<Arc<dyn SettingsStore>>,
+    default_tenant: String,
+    self_base_url: String,
+    outbound_auth: Arc<dyn helios_auth::outbound::OutboundAuthProvider>,
+    fhir_version: helios_fhir::FhirVersion,
+    terminology: Option<String>,
+    public_base_url: String,
+    max_body_size: usize,
+    tenant_path_routing: bool,
+) -> Router {
     let source: Arc<dyn ConformanceSource> = Arc::new(conformance::HttpConformanceSource::new(
         self_base_url,
         outbound_auth,
         fhir_version,
         data_dir.clone(),
     ));
-    mount_with_conformance_source_and_body_limit(
+    mount_with_conformance_source_and_body_limit_and_tenant_routing(
         fhir_app,
         hfs_version,
         data_dir,
@@ -867,6 +905,7 @@ pub fn mount_with_body_limit(
         terminology,
         public_base_url,
         max_body_size,
+        tenant_path_routing,
     )
 }
 
@@ -922,7 +961,50 @@ pub fn mount_with_conformance_source_and_body_limit(
     public_base_url: String,
     max_body_size: usize,
 ) -> Router {
+    mount_with_conformance_source_and_body_limit_and_tenant_routing(
+        fhir_app,
+        hfs_version,
+        data_dir,
+        nl,
+        tenants,
+        settings,
+        default_tenant,
+        source,
+        fhir_version,
+        terminology,
+        public_base_url,
+        max_body_size,
+        false,
+    )
+}
+
+/// Testable UI mount with explicit tenant-path routing behavior.
+#[doc(hidden)]
+#[allow(clippy::too_many_arguments)]
+pub fn mount_with_conformance_source_and_body_limit_and_tenant_routing(
+    fhir_app: Router,
+    hfs_version: &'static str,
+    data_dir: Option<PathBuf>,
+    nl: NlSearch,
+    tenants: Option<Arc<dyn ResourceStorage>>,
+    settings: Option<Arc<dyn SettingsStore>>,
+    default_tenant: String,
+    source: Arc<dyn ConformanceSource>,
+    fhir_version: helios_fhir::FhirVersion,
+    terminology: Option<String>,
+    public_base_url: String,
+    max_body_size: usize,
+    tenant_path_routing: bool,
+) -> Router {
     let nl_enabled = nl.enabled;
+    let mut parsed_public_base = reqwest::Url::parse(&public_base_url)
+        .expect("UI mount requires a valid HTTP(S) public base URL");
+    let trimmed_path = parsed_public_base.path().trim_end_matches('/').to_string();
+    parsed_public_base.set_path(&trimmed_path);
+    let public_base_url = parsed_public_base
+        .to_string()
+        .trim_end_matches('/')
+        .to_string();
 
     // Embedded, pinned htmx + CSS/JS + fonts, served with br/gzip/deflate
     // negotiation. `Cache-Control: no-cache` forces the browser to revalidate
@@ -1080,6 +1162,7 @@ pub fn mount_with_conformance_source_and_body_limit(
         default_tenant,
         terminology,
         public_base_url,
+        tenant_path_routing,
     };
 
     router

--- a/crates/ui/templates/partials/search-results.html
+++ b/crates/ui/templates/partials/search-results.html
@@ -7,7 +7,8 @@
          data-msg-total="{{ i18n.t_arg("queries-results-total", "count", "{count}".to_string()) }}"
          data-msg-included="{{ i18n.t_arg("queries-results-included", "count", "{count}".to_string()) }}"
          data-msg-empty="{{ i18n.t("queries-results-empty") }}"
-         data-msg-updated="{{ i18n.t("queries-col-updated") }}">
+         data-msg-updated="{{ i18n.t("queries-col-updated") }}"
+         data-msg-fetch-error="{{ i18n.t_arg("queries-results-fetch-error", "origin", "{origin}".to_string()) }}">
   <div class="query-results__head">
     <h2 class="query-group__type">{{ i18n.t("queries-results") }}</h2>
     <span class="query-results__meta" id="query-results-meta"></span>
@@ -30,6 +31,8 @@
   </div>
   <div class="table-foot">
     <span id="query-results-note"></span>
+    <p class="alert alert--inline" id="query-results-error" role="alert"
+       aria-live="assertive" aria-atomic="true" hidden></p>
     <nav class="pagination">
       <button class="btn" type="button" id="query-results-prev" hidden>{{ i18n.t("queries-prev") }}</button>
       <button class="btn" type="button" id="query-results-next" hidden>{{ i18n.t("queries-next") }}</button>

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -53,6 +53,24 @@ fn app(ctx: &Ctx) -> Router {
     )
 }
 
+fn app_with_path_tenant(ctx: &Ctx, tenant: &str) -> Router {
+    helios_ui::mount_with_conformance_source_and_body_limit_and_tenant_routing(
+        Router::new(),
+        "9.9.9",
+        None,
+        helios_ui::NlSearch::default(),
+        None,
+        Some(Arc::clone(&ctx.settings)),
+        tenant.to_string(),
+        Arc::new(helios_ui::StaticConformanceSource::empty()),
+        FhirVersion::R4,
+        None,
+        ctx.recipient.clone(),
+        10 * 1024 * 1024,
+        true,
+    )
+}
+
 async fn body_text(response: axum::response::Response) -> String {
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     String::from_utf8(bytes.to_vec()).unwrap()
@@ -104,6 +122,24 @@ async fn the_list_page_renders_and_offers_creation() {
     assert!(html.contains("Bulk Import"));
     assert!(html.contains("New Submission"));
     assert!(html.contains("No submissions yet"));
+}
+
+#[tokio::test]
+async fn recipient_includes_public_prefix_and_selected_path_tenant() {
+    let ctx = ctx("https://public.example/fhir/");
+    let response = app_with_path_tenant(&ctx, "acme")
+        .oneshot(
+            Request::get("/ui/bulk-import")
+                .header("host", "spoofed.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    assert!(html.contains("https://public.example/fhir/acme"));
+    assert!(!html.contains("spoofed.example"));
 }
 
 #[tokio::test]

--- a/crates/ui/tests/i18n_http.rs
+++ b/crates/ui/tests/i18n_http.rs
@@ -150,6 +150,38 @@ async fn resources_create_label_names_the_selected_type_per_locale() {
 }
 
 #[tokio::test]
+async fn pagination_failure_message_is_localized_with_the_public_origin_slot() {
+    for (lang, sentence) in [
+        (
+            "en",
+            "Could not load results from {origin}. Check HFS_BASE_URL and try again.",
+        ),
+        (
+            "es",
+            "No se pudieron cargar los resultados desde {origin}. Revise HFS_BASE_URL e inténtelo de nuevo.",
+        ),
+        (
+            "de",
+            "Ergebnisse von {origin} konnten nicht geladen werden. Prüfen Sie HFS_BASE_URL und versuchen Sie es erneut.",
+        ),
+    ] {
+        let response = app()
+            .oneshot(
+                Request::get(format!("/ui/search?lang={lang}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let html = body_text(response).await;
+        assert!(
+            html.contains(sentence),
+            "{lang} search page must expose the localized pagination error"
+        );
+    }
+}
+
+#[tokio::test]
 async fn default_is_english() {
     let response = app()
         .oneshot(Request::get("/ui").body(Body::empty()).unwrap())

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -422,6 +422,7 @@ queries-open-tab = In neuem Tab öffnen
 queries-col-updated = Aktualisiert
 queries-prev = Zurück
 queries-next = Weiter
+queries-results-fetch-error = Ergebnisse von { $origin } konnten nicht geladen werden. Prüfen Sie HFS_BASE_URL und versuchen Sie es erneut.
 
 queries-rail-heading = Ressourcentypen
 queries-rail-filter = Typen filtern

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -426,6 +426,7 @@ queries-open-tab = Open in New Tab
 queries-col-updated = Updated
 queries-prev = Previous
 queries-next = Next
+queries-results-fetch-error = Could not load results from { $origin }. Check HFS_BASE_URL and try again.
 
 queries-rail-heading = Resource Types
 queries-rail-filter = Filter types

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -422,6 +422,7 @@ queries-open-tab = Abrir en pestaña nueva
 queries-col-updated = Actualizado
 queries-prev = Anterior
 queries-next = Siguiente
+queries-results-fetch-error = No se pudieron cargar los resultados desde { $origin }. Revise HFS_BASE_URL e inténtelo de nuevo.
 
 queries-rail-heading = Tipos de recurso
 queries-rail-filter = Filtrar tipos


### PR DESCRIPTION
Closes https://github.com/HeliosSoftware/hfs/issues/629

## Summary

- Validate and normalize `HFS_BASE_URL` at HFS startup, preserve reverse-proxy path prefixes, and append dynamic values as encoded URL segments.
- Use one cached public URL builder for synchronous REST responses, Bulk Export, Bulk Submit, SQL-on-FHIR exports, Subscriptions, WebSocket discovery, and UI Bulk Import callbacks.
- Preserve URL-routed tenant provenance when JWT authentication is enabled, while keeping JWT claims authoritative for tenant validation.
- Keep header-routed asynchronous endpoints reachable in `TenantRoutingMode::Both` by sharing the reserved-path classifier between routing and tenant resolution.
- Make saved-query paging consume the server-provided Bundle links atomically. A failed page fetch preserves the current results and displays a localized `HFS_BASE_URL` diagnostic.
- Document public URL configuration and unsafe loopback/default-port startup warnings.

## URL behavior

| Input or context | Result |
|---|---|
| `HFS_BASE_URL=https://api.example.test/fhir/` | Normalizes to `https://api.example.test/fhir` and retains the `/fhir` prefix |
| URL-routed tenant | Includes the tenant segment in REST and protected asynchronous artifact URLs |
| Header-routed tenant | Does not add a tenant path segment; async status, file, and WebSocket routes remain system namespaces |
| Dynamic tenant, resource, or ID value | Appends the value as an encoded path segment |
| Presigned object-storage URL | Returns it unchanged |
| Invalid scheme, credentials, query, fragment, or missing host | Exits during startup with a configuration error |
| Loopback/default base inconsistent with the listener | Starts and logs a targeted warning with the bind and public addresses |

## Affected behavior

- CapabilityStatement implementation URL.
- Search Bundle paging links and entry `fullUrl`.
- Create/update `Location`, history and compartment links, and batch/transaction response locations.
- Bulk Export, Bulk Submit, and SQL-on-FHIR status and download URLs.
- Subscription notification sources and WebSocket endpoints.
- UI Bulk Import recipient URLs.
- Saved-query result links and page navigation.

Saved-query paging follows the Bundle link exactly, including opaque URLs. Page replacement is atomic. Network errors, non-2xx responses, and non-JSON payloads leave the existing table, count, ordering, and pager intact. The alert displays only the failing origin and points operators to `HFS_BASE_URL`.

## Verification

```text
cargo fmt --all -- --check
git diff --check
cargo check -p helios-rest --features s3,subscriptions
cargo test -p helios-rest -p helios-hfs -p helios-subscriptions -p helios-ui
cargo test -p helios-rest --test public_url_contract
cargo test -p helios-rest --features subscriptions ws::tests
cargo test -p helios-rest extractors::tenant::tests
cargo test -p helios-rest config::tests
npm run test:unit --prefix crates/ui/e2e
npx playwright test tests/queries.spec.ts --project=chromium <focused case>
```

Targeted Bulk Export, Bulk Submit, SQL-on-FHIR, WebSocket, and tenant-routing integration suites passed for both URL-path and header routing.

`cargo clippy ... --all-targets -- -D warnings` remains blocked by existing warnings outside this change in `crates/serde-support/src/lib.rs` and `crates/fhir/build.rs`.

## Review

Read-only reviews covered URL/configuration security, asynchronous protocols, and console paging. Follow-up reviews found no remaining actionable issues after fixes for:

- URL-route tenant provenance after JWT authentication.
- WebSocket token/request tenant mismatches.
- Header-routed async namespaces in `Both` mode.
- Opaque pager links losing resource context.
- Result links dropping configured prefixes or tenant paths.
- Bracketed IPv6 loopback listeners producing false warnings.
