### PR TITLE
fix(ui): bulk import dialog backdrop, recipient row, test-auth e2e

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1266,6 +1266,12 @@ textarea.field__input {
   position: fixed;
   inset: 0;
   z-index: 40;
+  /* The summary doubles as the button (.btn/.btn--primary), whose fixed
+     height would beat the inset stretch and shrink the backdrop to a bar
+     across the top of the viewport. */
+  height: auto;
+  padding: 0;
+  border: 0;
   background: rgb(10 14 20 / 45%);
   border-radius: 0;
   cursor: default;

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1233,6 +1233,13 @@ textarea.field__input {
   justify-content: flex-end;
 }
 
+/* Dialog feet pair a plain button with the primary; both sit on the primary's
+   metrics so the row lines up. */
+.addbox__actions .btn {
+  height: 36px;
+  padding: 0 18px;
+}
+
 .spinner {
   width: 14px;
   height: 14px;

--- a/crates/ui/e2e/tests/bulk-import.spec.ts
+++ b/crates/ui/e2e/tests/bulk-import.spec.ts
@@ -212,3 +212,37 @@ test("the Add Manifest dialog labels Format and sizes its textarea", async ({
   expect(styles.boxSizing).toBe("border-box");
   expect(styles.fontFamily.toLowerCase()).not.toContain("monospace");
 });
+
+// #721: the New Submission summary doubles as the modal backdrop; the
+// button's fixed height used to beat the inset stretch and shrink it to a
+// bar across the top of the viewport, so clicking anywhere lower neither
+// closed the dialog nor dimmed the page. The dialog also repeated the
+// server-fixed recipient URL as a read-only row.
+test("the open New Submission dialog backdrop covers the viewport", async ({ page }) => {
+  await page.goto("/ui/bulk-import");
+  const toggle = page.locator("summary.btn", { hasText: "New Submission" });
+  await toggle.click();
+  const backdrop = await toggle.boundingBox();
+  const viewport = page.viewportSize()!;
+  expect(backdrop!.height).toBeGreaterThan(viewport.height * 0.9);
+  await expect(
+    page.locator(".addbox__panel .field__label", { hasText: "Recipient base URL" }),
+  ).toHaveCount(0);
+  // Clicking the backdrop low on the screen closes the dialog.
+  await page.mouse.click(viewport.width / 2, viewport.height - 10);
+  await expect(page.locator(".addbox__panel")).not.toBeVisible();
+});
+
+// The Test authentication button wires an htmx post to a fragment target
+// inside the dialog. The handler's outcome states are covered by the Rust
+// ring; this asserts the round trip lands in #test-auth-result.
+test("Test authentication reports its outcome inside the dialog", async ({ page }) => {
+  await page.goto("/ui/bulk-import");
+  await page.locator("summary.btn", { hasText: "New Submission" }).click();
+  await page.locator("input[name='client_id']").fill("e2e-client");
+  await page
+    .locator("input[name='token_url']")
+    .fill(new URL("/health", page.url()).toString());
+  await page.locator("button[formaction='/ui/bulk-import/test-auth']").click();
+  await expect(page.locator("#test-auth-result .field__hint")).toBeVisible();
+});

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -211,9 +211,6 @@ struct BulkImportPage {
     available: bool,
     rows: Vec<SubmissionRow>,
     error: Option<String>,
-    /// Where every new submission goes (`HFS_BASE_URL`, #689) — shown in the
-    /// dialog so the fixed recipient is visible, not invisible.
-    recipient: String,
 }
 
 #[derive(Template)]
@@ -288,7 +285,6 @@ pub async fn page(
         available,
         rows,
         error: None,
-        recipient: state.public_base_url.trim_end_matches('/').to_string(),
     })
 }
 

--- a/crates/ui/templates/pages/bulk-import.html
+++ b/crates/ui/templates/pages/bulk-import.html
@@ -25,13 +25,6 @@
           <span class="field__label">{{ i18n.t("bulk-import-field-name") }}</span>
           <input class="field__input" type="text" name="name" required autocomplete="off">
         </label>
-        <!-- The recipient is fixed to this server's HFS_BASE_URL (#689);
-             shown so the target is visible, not typed. -->
-        <label class="field">
-          <span class="field__label">{{ i18n.t("bulk-import-field-recipient") }}</span>
-          <span class="field__hint">{{ recipient }}</span>
-        </label>
-
         <label class="field">
           <span class="field__label">{{ i18n.t("bulk-import-field-submitter-system") }}</span>
           <input class="field__input" type="text" name="submitter_system" autocomplete="off"

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -556,7 +556,6 @@ bulk-import-title = Massenimport
 bulk-import-new = Neue Submission
 bulk-import-create-title = Bulk Submission anlegen
 bulk-import-field-name = Name der Submission
-bulk-import-field-recipient = Basis-URL des Empfängers
 bulk-import-auth = Authentifizierung
 bulk-import-auth-hint = Wie gegenüber dem Empfängerserver authentifiziert wird.
 bulk-import-auth-none = Keine

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -559,7 +559,6 @@ bulk-import-title = Bulk Import
 bulk-import-new = New Submission
 bulk-import-create-title = Create Bulk Submission
 bulk-import-field-name = Submission name
-bulk-import-field-recipient = Recipient base URL
 bulk-import-auth = Authentication
 bulk-import-auth-hint = How to authenticate to the recipient server.
 bulk-import-auth-none = None

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -556,7 +556,6 @@ bulk-import-title = Importación masiva
 bulk-import-new = Nueva submission
 bulk-import-create-title = Crear Bulk Submission
 bulk-import-field-name = Nombre de la submission
-bulk-import-field-recipient = URL base del receptor
 bulk-import-auth = Autenticación
 bulk-import-auth-hint = Cómo autenticarse ante el servidor receptor.
 bulk-import-auth-none = Ninguna


### PR DESCRIPTION
Closes #721.

## The backdrop bar

`.addbox--modal[open] > summary` turns the New Submission summary into the full-viewport backdrop (`position: fixed; inset: 0`), but the summary also carries `btn btn--primary`, whose fixed `height: 36px` beats the `bottom: 0` stretch. The "backdrop" collapsed to a 36px strip across the top of the viewport that still painted as the button, and clicking anywhere lower neither dimmed the page nor closed the dialog. The open state now clears the button metrics (`height: auto; padding: 0; border: 0`) — same fix inherited by the Add Manifest dialog on the detail page, which shares the pattern.

## Recipient base URL row

Removed from the create dialog: the recipient is fixed to this server's `HFS_BASE_URL` (#689), so the read-only row (e.g. `http://localhost:8080`) was noise. The detail page keeps its Data Recipient field, and the `bulk-import-field-recipient` key leaves all three locales.

## Test authentication

The handler already had five outcome states covered by the Rust ring (`backend_services_auth_mints_and_attaches_tokens`). What was missing was e2e coverage of the UI wiring, so the spec gains two tests: the backdrop now covers the viewport / the recipient row is gone / clicking low on the backdrop closes the dialog, and the Test authentication button round-trips its htmx post into `#test-auth-result`.

Note: the design-system h1 spec can fail on this branch for an unrelated pre-existing reason — the SQL pages' double `<h1>` when a ViewDefinition exists, fixed in #712.