### PR TITLE
fix(bulk-submit): lease heartbeats through files, renewed by the claimed duration

### DIFF
--- a/crates/persistence/src/backends/mongodb/bulk_submit.rs
+++ b/crates/persistence/src/backends/mongodb/bulk_submit.rs
@@ -1264,9 +1264,7 @@ impl SubmitClaimStrategy for MongoBackend {
     }
 
     async fn heartbeat(&self, lease: &ManifestLease) -> Result<DateTime<Utc>, LeaseError> {
-        let new_expiry = now_at_bson_precision()
-            + chrono::Duration::from_std(lease.lease_duration)
-                .unwrap_or_else(|_| chrono::Duration::seconds(60));
+        let new_expiry = from_bson_time(&to_bson_time(lease.renewed_expiry()));
         self.fenced_update(
             lease,
             doc! { "$set": { "lease_expiry": to_bson_time(new_expiry) } },

--- a/crates/persistence/src/backends/mongodb/bulk_submit.rs
+++ b/crates/persistence/src/backends/mongodb/bulk_submit.rs
@@ -1255,6 +1255,7 @@ impl SubmitClaimStrategy for MongoBackend {
                 manifest_id: manifest_id.to_string(),
                 worker_id: worker_id.clone(),
                 lease_expiry,
+                lease_duration,
                 fencing_token: claimed.get_i64("fencing_token").unwrap_or(token + 1).max(0) as u64,
             }));
         }
@@ -1263,7 +1264,9 @@ impl SubmitClaimStrategy for MongoBackend {
     }
 
     async fn heartbeat(&self, lease: &ManifestLease) -> Result<DateTime<Utc>, LeaseError> {
-        let new_expiry = now_at_bson_precision() + chrono::Duration::seconds(60);
+        let new_expiry = now_at_bson_precision()
+            + chrono::Duration::from_std(lease.lease_duration)
+                .unwrap_or_else(|_| chrono::Duration::seconds(60));
         self.fenced_update(
             lease,
             doc! { "$set": { "lease_expiry": to_bson_time(new_expiry) } },

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -1351,10 +1351,7 @@ impl SubmitClaimStrategy for PostgresBackend {
 
     async fn heartbeat(&self, lease: &ManifestLease) -> Result<DateTime<Utc>, LeaseError> {
         let client = self.get_client().await.map_err(LeaseError::Storage)?;
-        let now = Utc::now();
-        let new_expiry = now
-            + chrono::Duration::from_std(lease.lease_duration)
-                .unwrap_or_else(|_| chrono::Duration::seconds(60));
+        let new_expiry = lease.renewed_expiry();
         let affected = client
             .execute(
                 "UPDATE bulk_manifests SET lease_expiry = $1

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -1344,6 +1344,7 @@ impl SubmitClaimStrategy for PostgresBackend {
             manifest_id,
             worker_id: worker_id.clone(),
             lease_expiry,
+            lease_duration,
             fencing_token: new_token as u64,
         }))
     }
@@ -1351,7 +1352,9 @@ impl SubmitClaimStrategy for PostgresBackend {
     async fn heartbeat(&self, lease: &ManifestLease) -> Result<DateTime<Utc>, LeaseError> {
         let client = self.get_client().await.map_err(LeaseError::Storage)?;
         let now = Utc::now();
-        let new_expiry = now + chrono::Duration::seconds(60);
+        let new_expiry = now
+            + chrono::Duration::from_std(lease.lease_duration)
+                .unwrap_or_else(|_| chrono::Duration::seconds(60));
         let affected = client
             .execute(
                 "UPDATE bulk_manifests SET lease_expiry = $1

--- a/crates/persistence/src/backends/s3/submit_worker.rs
+++ b/crates/persistence/src/backends/s3/submit_worker.rs
@@ -591,9 +591,7 @@ impl SubmitClaimStrategy for S3Backend {
     }
 
     async fn heartbeat(&self, lease: &ManifestLease) -> Result<DateTime<Utc>, LeaseError> {
-        let new_expiry = Utc::now()
-            + chrono::Duration::from_std(lease.lease_duration)
-                .unwrap_or_else(|_| chrono::Duration::seconds(60));
+        let new_expiry = lease.renewed_expiry();
         self.fenced_mutate(lease, |state| {
             state.lease_expiry = Some(new_expiry);
         })

--- a/crates/persistence/src/backends/s3/submit_worker.rs
+++ b/crates/persistence/src/backends/s3/submit_worker.rs
@@ -582,6 +582,7 @@ impl SubmitClaimStrategy for S3Backend {
                 manifest_id,
                 worker_id: worker_id.clone(),
                 lease_expiry,
+                lease_duration,
                 fencing_token: new_token,
             }));
         }
@@ -590,7 +591,9 @@ impl SubmitClaimStrategy for S3Backend {
     }
 
     async fn heartbeat(&self, lease: &ManifestLease) -> Result<DateTime<Utc>, LeaseError> {
-        let new_expiry = Utc::now() + chrono::Duration::seconds(60);
+        let new_expiry = Utc::now()
+            + chrono::Duration::from_std(lease.lease_duration)
+                .unwrap_or_else(|_| chrono::Duration::seconds(60));
         self.fenced_mutate(lease, |state| {
             state.lease_expiry = Some(new_expiry);
         })

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -1351,10 +1351,7 @@ impl SubmitClaimStrategy for SqliteBackend {
 
     async fn heartbeat(&self, lease: &ManifestLease) -> Result<DateTime<Utc>, LeaseError> {
         let conn = self.get_connection().map_err(LeaseError::Storage)?;
-        let now = Utc::now();
-        let new_expiry = now
-            + chrono::Duration::from_std(lease.lease_duration)
-                .unwrap_or_else(|_| chrono::Duration::seconds(60));
+        let new_expiry = lease.renewed_expiry();
         let affected = conn
             .execute(
                 "UPDATE bulk_manifests SET lease_expiry = ?1

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -1344,6 +1344,7 @@ impl SubmitClaimStrategy for SqliteBackend {
             manifest_id,
             worker_id: worker_id.clone(),
             lease_expiry,
+            lease_duration,
             fencing_token: new_token as u64,
         }))
     }
@@ -1351,7 +1352,9 @@ impl SubmitClaimStrategy for SqliteBackend {
     async fn heartbeat(&self, lease: &ManifestLease) -> Result<DateTime<Utc>, LeaseError> {
         let conn = self.get_connection().map_err(LeaseError::Storage)?;
         let now = Utc::now();
-        let new_expiry = now + chrono::Duration::seconds(60);
+        let new_expiry = now
+            + chrono::Duration::from_std(lease.lease_duration)
+                .unwrap_or_else(|_| chrono::Duration::seconds(60));
         let affected = conn
             .execute(
                 "UPDATE bulk_manifests SET lease_expiry = ?1

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -44,6 +44,10 @@ pub struct ManifestLease {
     pub worker_id: WorkerId,
     /// When the lease expires if not renewed.
     pub lease_expiry: DateTime<Utc>,
+    /// The duration the lease was claimed for; each heartbeat renews by this
+    /// much, so short test leases stay short instead of jumping to a
+    /// constant.
+    pub lease_duration: Duration,
     /// Monotonically increasing token, bumped on every claim.
     pub fencing_token: u64,
 }
@@ -434,11 +438,14 @@ where
         let opts = BulkProcessingOptions::new().with_import_mode(import_mode);
         let mut processed: u64 = 0;
         let mut failed: u64 = 0;
+        let mut lease_expiry = lease.lease_expiry;
 
         // 2. Ingest each output file via the existing streaming engine.
         for file in &manifest.output {
-            if let Err(LeaseError::LeaseLost { .. }) = self.jobs.heartbeat(&lease).await {
-                return Ok(());
+            match self.jobs.heartbeat(&lease).await {
+                Ok(expiry) => lease_expiry = expiry,
+                Err(LeaseError::LeaseLost { .. }) => return Ok(()),
+                Err(LeaseError::Storage(_)) => {}
             }
             let resource_type = file
                 .resource_type
@@ -471,18 +478,38 @@ where
             // Per-file options: the file url is part of every entry result's
             // identity, since line numbers restart in each file (#457).
             let file_opts = opts.clone().with_file_url(&file.url);
-            match self
-                .jobs
-                .process_ndjson_stream(
-                    &lease.tenant,
-                    &lease.submission_id,
-                    &lease.manifest_id,
-                    &resource_type,
-                    stream,
-                    &file_opts,
-                )
-                .await
-            {
+            // The lease must stay heartbeated *through* a file, not only
+            // between files: a single file whose ingest outlives the lease
+            // would otherwise expire mid-stream, get reclaimed, and restart
+            // the manifest from its first file — an unbounded silent loop,
+            // since the re-ingested entries upsert idempotently and no error
+            // is ever recorded.
+            let ingest = self.jobs.process_ndjson_stream(
+                &lease.tenant,
+                &lease.submission_id,
+                &lease.manifest_id,
+                &resource_type,
+                stream,
+                &file_opts,
+            );
+            tokio::pin!(ingest);
+            let outcome = loop {
+                let remaining = (lease_expiry - Utc::now())
+                    .to_std()
+                    .unwrap_or(Duration::from_secs(1));
+                let wait = (remaining / 3).clamp(Duration::from_secs(1), Duration::from_secs(60));
+                tokio::select! {
+                    r = &mut ingest => break r,
+                    _ = tokio::time::sleep(wait) => {
+                        match self.jobs.heartbeat(&lease).await {
+                            Ok(expiry) => lease_expiry = expiry,
+                            Err(LeaseError::LeaseLost { .. }) => return Ok(()),
+                            Err(LeaseError::Storage(_)) => {}
+                        }
+                    }
+                }
+            };
+            match outcome {
                 Ok(result) => {
                     processed += result.counts.success + result.counts.skipped;
                     failed += result.counts.error_count();

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -52,6 +52,16 @@ pub struct ManifestLease {
     pub fencing_token: u64,
 }
 
+impl ManifestLease {
+    /// The expiry a successful heartbeat renews to: now plus the duration the
+    /// lease was claimed with. Shared by every backend's `heartbeat`.
+    pub fn renewed_expiry(&self) -> DateTime<Utc> {
+        Utc::now()
+            + chrono::Duration::from_std(self.lease_duration)
+                .unwrap_or_else(|_| chrono::Duration::seconds(60))
+    }
+}
+
 /// The worker's view of a claimed manifest: everything needed to fetch + ingest it.
 #[derive(Debug, Clone)]
 pub struct ManifestWorkerView {

--- a/crates/persistence/tests/sqlite_bulk_submit_concurrency.rs
+++ b/crates/persistence/tests/sqlite_bulk_submit_concurrency.rs
@@ -242,3 +242,120 @@ async fn two_workers_run_whole_manifests_to_completion() {
     let total = backend.count(&tenant(), Some("Patient")).await.unwrap();
     assert_eq!(total as usize, 2 * FILES * LINES);
 }
+
+/// #448's Synthea pass surfaced this: one output file whose ingestion takes
+/// longer than the lease. The worker heartbeated only *between* files, so the
+/// lease lapsed mid-stream, a rival claim succeeded, and the manifest
+/// restarted from its first file — an unbounded silent loop, invisible in the
+/// counts because the re-ingested entries upsert idempotently.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_file_slower_than_the_lease_stays_leased_to_completion() {
+    use helios_persistence::backends::local_fs::LocalFsOutputStore;
+    use helios_persistence::core::{
+        BulkSubmitJobStore, DefaultSubmitWorker, ExportOutputStore, RemoteFile, RemoteManifest,
+        SubmitInputFetcher, WorkerId,
+    };
+    use helios_persistence::error::StorageResult;
+
+    const LINES: usize = 40;
+
+    struct SlowFetcher {
+        manifest: RemoteManifest,
+        lines: Vec<u8>,
+    }
+
+    #[async_trait::async_trait]
+    impl SubmitInputFetcher for SlowFetcher {
+        async fn fetch_manifest(
+            &self,
+            _url: &str,
+            _headers: &[(String, String)],
+            _oauth: &[String],
+            _key: Option<&serde_json::Value>,
+        ) -> StorageResult<RemoteManifest> {
+            Ok(self.manifest.clone())
+        }
+
+        async fn open_file_stream(
+            &self,
+            _url: &str,
+            _headers: &[(String, String)],
+            _requires_access_token: bool,
+            _oauth: &[String],
+            _key: Option<&serde_json::Value>,
+        ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
+            // Trickle the file over ~6 seconds — three times the lease.
+            let (reader, mut writer) = tokio::io::duplex(1024);
+            let lines = self.lines.clone();
+            tokio::spawn(async move {
+                use tokio::io::AsyncWriteExt;
+                for line in lines.split_inclusive(|b| *b == b'\n') {
+                    if writer.write_all(line).await.is_err() {
+                        return;
+                    }
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                }
+            });
+            Ok(Box::new(tokio::io::BufReader::new(reader)))
+        }
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = SqliteBackend::with_config(
+        tmp.path().join("submit-slow.db").to_str().unwrap(),
+        SqliteBackendConfig::default(),
+    )
+    .unwrap();
+    backend.init_schema().unwrap();
+    let backend = Arc::new(backend);
+    let _ = seed(&backend, "slow").await;
+
+    let url = "https://provider.example/slow/file-0.ndjson".to_string();
+    let fetcher: Arc<dyn SubmitInputFetcher> = Arc::new(SlowFetcher {
+        manifest: RemoteManifest {
+            output: vec![RemoteFile {
+                resource_type: Some("Patient".to_string()),
+                url,
+                count: None,
+            }],
+            ..Default::default()
+        },
+        lines: ndjson("slow-0", LINES),
+    });
+    let jobs: Arc<dyn BulkSubmitJobStore> = backend.clone();
+    let output: Arc<dyn ExportOutputStore> = Arc::new(LocalFsOutputStore::new(
+        tmp.path().join("out"),
+        "http://localhost:8080",
+    ));
+
+    let lease = Duration::from_secs(2);
+    let worker_id = WorkerId::new("slow-worker");
+    let claimed = jobs
+        .claim_next_manifest(&worker_id, lease)
+        .await
+        .unwrap()
+        .expect("a pending manifest to claim");
+    let worker = DefaultSubmitWorker::new(jobs.clone(), fetcher, output, worker_id);
+    let run = tokio::spawn(async move { worker.run_job(claimed).await.unwrap() });
+
+    // Well past the original expiry, mid-file: the manifest must not be
+    // reclaimable, or the ingestion restarts from the first file.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let rival = WorkerId::new("rival-worker");
+    assert!(
+        jobs.claim_next_manifest(&rival, lease)
+            .await
+            .unwrap()
+            .is_none(),
+        "the lease lapsed mid-file and a rival reclaimed the manifest"
+    );
+
+    tokio::time::timeout(Duration::from_secs(120), run)
+        .await
+        .expect("slow-file ingestion did not finish")
+        .unwrap();
+
+    use helios_persistence::core::ResourceStorage;
+    let total = backend.count(&tenant(), Some("Patient")).await.unwrap();
+    assert_eq!(total as usize, LINES);
+}

--- a/crates/persistence/tests/sqlite_bulk_submit_concurrency.rs
+++ b/crates/persistence/tests/sqlite_bulk_submit_concurrency.rs
@@ -359,3 +359,114 @@ async fn a_file_slower_than_the_lease_stays_leased_to_completion() {
     let total = backend.count(&tenant(), Some("Patient")).await.unwrap();
     assert_eq!(total as usize, LINES);
 }
+
+/// The abort half of the mid-file heartbeat: a worker whose lease was
+/// genuinely taken over must notice at its next beat and stop quietly,
+/// ingesting nothing further under the stale fencing token.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_lost_lease_aborts_the_run_quietly() {
+    use helios_persistence::backends::local_fs::LocalFsOutputStore;
+    use helios_persistence::core::{
+        BulkSubmitJobStore, DefaultSubmitWorker, ExportOutputStore, RemoteFile, RemoteManifest,
+        SubmitInputFetcher, WorkerId,
+    };
+    use helios_persistence::error::StorageResult;
+
+    struct SlowFetcher {
+        manifest: RemoteManifest,
+        lines: Vec<u8>,
+    }
+
+    #[async_trait::async_trait]
+    impl SubmitInputFetcher for SlowFetcher {
+        async fn fetch_manifest(
+            &self,
+            _url: &str,
+            _headers: &[(String, String)],
+            _oauth: &[String],
+            _key: Option<&serde_json::Value>,
+        ) -> StorageResult<RemoteManifest> {
+            Ok(self.manifest.clone())
+        }
+
+        async fn open_file_stream(
+            &self,
+            _url: &str,
+            _headers: &[(String, String)],
+            _requires_access_token: bool,
+            _oauth: &[String],
+            _key: Option<&serde_json::Value>,
+        ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
+            let (reader, mut writer) = tokio::io::duplex(1024);
+            let lines = self.lines.clone();
+            tokio::spawn(async move {
+                use tokio::io::AsyncWriteExt;
+                for line in lines.split_inclusive(|b| *b == b'\n') {
+                    if writer.write_all(line).await.is_err() {
+                        return;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                }
+            });
+            Ok(Box::new(tokio::io::BufReader::new(reader)))
+        }
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = SqliteBackend::with_config(
+        tmp.path().join("submit-lost.db").to_str().unwrap(),
+        SqliteBackendConfig::default(),
+    )
+    .unwrap();
+    backend.init_schema().unwrap();
+    let backend = Arc::new(backend);
+    let _ = seed(&backend, "lost").await;
+
+    let fetcher: Arc<dyn SubmitInputFetcher> = Arc::new(SlowFetcher {
+        manifest: RemoteManifest {
+            output: vec![RemoteFile {
+                resource_type: Some("Patient".to_string()),
+                url: "https://provider.example/lost/file-0.ndjson".to_string(),
+                count: None,
+            }],
+            ..Default::default()
+        },
+        lines: ndjson("lost-0", 40),
+    });
+    let jobs: Arc<dyn BulkSubmitJobStore> = backend.clone();
+    let output: Arc<dyn ExportOutputStore> = Arc::new(LocalFsOutputStore::new(
+        tmp.path().join("out"),
+        "http://localhost:8080",
+    ));
+
+    // Claim, then sit on the lease until it expires so a rival can take it
+    // over legitimately - the crash-recovery scenario the fencing token is for.
+    let stale_worker = WorkerId::new("stale-worker");
+    let stale = jobs
+        .claim_next_manifest(&stale_worker, Duration::from_secs(1))
+        .await
+        .unwrap()
+        .expect("a pending manifest to claim");
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let rival = jobs
+        .claim_next_manifest(&WorkerId::new("rival-worker"), Duration::from_secs(60))
+        .await
+        .unwrap()
+        .expect("the expired lease must be reclaimable");
+    assert!(rival.fencing_token > stale.fencing_token);
+
+    // The stale worker wakes up and tries to run its old claim: the first
+    // heartbeat answers LeaseLost and run_job returns Ok without ingesting.
+    let worker = DefaultSubmitWorker::new(jobs.clone(), fetcher, output, stale_worker);
+    tokio::time::timeout(Duration::from_secs(30), worker.run_job(stale))
+        .await
+        .expect("a lost lease must abort promptly")
+        .unwrap();
+
+    use helios_persistence::core::ResourceStorage;
+    let total = backend.count(&tenant(), Some("Patient")).await.unwrap();
+    assert_eq!(
+        total, 0,
+        "the stale worker must not ingest under a lost lease"
+    );
+}


### PR DESCRIPTION
Closes #739. Found live during #448's Synthea sanity pass — writeup on the issue.

## The livelock

`run_job` heartbeated the lease only **between** files. A single output file whose ingestion outlives the lease expires mid-stream; `claim_next_manifest` sees an abandoned `processing` manifest and hands it to a rival worker, which restarts **from the first file**. Entries upsert idempotently, so counts freeze while CPU burns; every re-claim refreshes `lease_expiry`, so the #646/#711 stall detection sees a healthy lease forever. Observed: all 896 Encounters of a 20-file submission re-indexed 7× in 7 minutes, poll stuck at `processing 0%`.

Compounding it, all four backends' `heartbeat()` renewed by a **hardcoded 60 s**, ignoring the claimed `lease_duration` — so no configuration could buy a slow file more time.

## The fix

- `run_job` drives each file's ingest (and the deleted-files pass untouched — it heartbeats per file and those files are refs, not bulk data) under a `tokio::select!` with a periodic heartbeat at **a third of the remaining lease** (clamped 1–60 s), aborting cleanly on `LeaseLost`.
- `ManifestLease` now carries `lease_duration`; sqlite/postgres/mongodb/s3 `heartbeat()` renew by it.

## Regression test

`a_file_slower_than_the_lease_stays_leased_to_completion`: one file trickled over ~6 s under a 2 s lease. Mid-file, a rival `claim_next_manifest` must return `None`; the run must complete with every line ingested exactly once. Verified both ways — with the periodic heartbeat neutralized the test fails at the rival-claim assert with the exact production symptom.