### PR TITLE
fix(sof-server): malformed inline ViewDefinition answers the documented 422

### DIFF
--- a/crates/sof/src/handlers.rs
+++ b/crates/sof/src/handlers.rs
@@ -22,6 +22,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use chrono::{DateTime, Utc};
+use serde::Deserialize;
 use tracing::{debug, info};
 
 use super::{
@@ -803,6 +804,37 @@ fn parse_view_definition_for_version(
     sof_parse_view_definition_for_version(json, version).map_err(ServerError::from)
 }
 
+/// Maps a strict `Parameters` deserialization failure to the right status.
+///
+/// The whole wrapper deserializes in one pass, so a type mismatch *inside an
+/// inline ViewDefinition* also fails there — but that case is documented as
+/// `422 Unprocessable Entity` (audit item #9), not the wrapper's 400 (#670).
+/// Probe the raw JSON for inline ViewDefinitions and let the first one that
+/// fails its own parse speak, with the 422-mapped error; a wrapper that is
+/// malformed anywhere else keeps the 400.
+fn invalid_parameters_error(
+    json: &serde_json::Value,
+    version: helios_fhir::FhirVersion,
+    message: String,
+) -> ServerError {
+    for param in json
+        .get("parameter")
+        .and_then(|p| p.as_array())
+        .into_iter()
+        .flatten()
+    {
+        let Some(resource) = param.get("resource") else {
+            continue;
+        };
+        if resource.get("resourceType").and_then(|t| t.as_str()) == Some("ViewDefinition")
+            && let Err(error) = parse_view_definition_for_version(resource.clone(), version)
+        {
+            return error;
+        }
+    }
+    ServerError::BadRequest(message)
+}
+
 /// Parse a Parameters resource from JSON
 fn parse_parameters(json: serde_json::Value) -> ServerResult<RunParameters> {
     // Validate that it's a Parameters resource
@@ -823,26 +855,46 @@ fn parse_parameters(json: serde_json::Value) -> ServerResult<RunParameters> {
     match newest_version {
         #[cfg(feature = "R4")]
         helios_fhir::FhirVersion::R4 => {
-            let params: helios_fhir::r4::Parameters = serde_json::from_value(json)
-                .map_err(|e| ServerError::BadRequest(format!("Invalid R4 Parameters: {}", e)))?;
+            let params = helios_fhir::r4::Parameters::deserialize(&json).map_err(|e| {
+                invalid_parameters_error(
+                    &json,
+                    newest_version,
+                    format!("Invalid R4 Parameters: {}", e),
+                )
+            })?;
             Ok(RunParameters::R4(params))
         }
         #[cfg(feature = "R4B")]
         helios_fhir::FhirVersion::R4B => {
-            let params: helios_fhir::r4b::Parameters = serde_json::from_value(json)
-                .map_err(|e| ServerError::BadRequest(format!("Invalid R4B Parameters: {}", e)))?;
+            let params = helios_fhir::r4b::Parameters::deserialize(&json).map_err(|e| {
+                invalid_parameters_error(
+                    &json,
+                    newest_version,
+                    format!("Invalid R4B Parameters: {}", e),
+                )
+            })?;
             Ok(RunParameters::R4B(params))
         }
         #[cfg(feature = "R5")]
         helios_fhir::FhirVersion::R5 => {
-            let params: helios_fhir::r5::Parameters = serde_json::from_value(json)
-                .map_err(|e| ServerError::BadRequest(format!("Invalid R5 Parameters: {}", e)))?;
+            let params = helios_fhir::r5::Parameters::deserialize(&json).map_err(|e| {
+                invalid_parameters_error(
+                    &json,
+                    newest_version,
+                    format!("Invalid R5 Parameters: {}", e),
+                )
+            })?;
             Ok(RunParameters::R5(params))
         }
         #[cfg(feature = "R6")]
         helios_fhir::FhirVersion::R6 => {
-            let params: helios_fhir::r6::Parameters = serde_json::from_value(json)
-                .map_err(|e| ServerError::BadRequest(format!("Invalid R6 Parameters: {}", e)))?;
+            let params = helios_fhir::r6::Parameters::deserialize(&json).map_err(|e| {
+                invalid_parameters_error(
+                    &json,
+                    newest_version,
+                    format!("Invalid R6 Parameters: {}", e),
+                )
+            })?;
             Ok(RunParameters::R6(params))
         }
         // A `FhirVersion` variant can exist without helios-sof enabling the

--- a/crates/sof/tests/server_tests.rs
+++ b/crates/sof/tests/server_tests.rs
@@ -1070,7 +1070,6 @@ async fn test_parquet_response_uses_native_parquet_content_type() {
 /// wrapper, but the inner ViewDefinition has a type mismatch serde can't
 /// parse) must surface as `422 Unprocessable Entity`, not `400 Bad Request`.
 #[tokio::test]
-#[ignore = "production returns 400: strict Parameters deserialization short-circuits the 422 path, tracked in #670"]
 async fn test_invalid_view_definition_returns_422() {
     let server = common::test_server().await;
 


### PR DESCRIPTION
Closes #670.

`parse_parameters` strictly deserializes the whole `Parameters` wrapper in one pass, so a type mismatch inside an **inline ViewDefinition** (`select: "not-an-array"`) failed at the wrapper stage and answered the wrapper's `400` — the documented `422` path (audit item #9) only ever fired for the bare-ViewDefinition body shortcut.

Exactly the fix direction the issue sketched: on a wrapper deserialization failure, the handler probes the raw JSON for inline ViewDefinitions (`parameter[].resource.resourceType == "ViewDefinition"`) and lets the first one that fails its own parse speak, with the 422-mapped `InvalidViewDefinition` error. A wrapper that is malformed anywhere else keeps its 400 untouched. The four version arms now deserialize from a borrowed `Value` (`Parameters::deserialize(&json)`), so the happy path pays no clone for the probe's sake.

`test_invalid_view_definition_returns_422` comes out of `#[ignore]` quarantine and passes against the real router; the full `helios-sof` suite is green.