### PR TITLE
fix(ui): unify the button size scale app-wide

### DIFF
--- a/crates/ui/README.md
+++ b/crates/ui/README.md
@@ -202,7 +202,7 @@ These are the shared primitives. Before styling anything, reach for one; add to
 
 | Class | What it is |
 |---|---|
-| `.btn`, `.btn--primary`, `.btn--danger`, `.btn--current` | The button. Secondary by default; primary is the one blue action on a page. |
+| `.btn`, `.btn--primary`, `.btn--danger`, `.btn--current`, `.btn--icon` | The action button: 30px high, 12px horizontal padding, 12px type, and a 9px radius. Primary, danger, and current change emphasis only; `--icon` makes the control a 30px square with no horizontal padding. |
 | `.card`, `.card-head`, `.table-card` | Raised surface; its header row; the padding variant that hosts a table. |
 | `.panel` | Padding for a full-width card that hosts detail fields without rail behavior. |
 | `.kv-grid` | Responsive two-column key/value layout; collapses to one column on compact viewports. |
@@ -220,11 +220,20 @@ These are the shared primitives. Before styling anything, reach for one; add to
 | `.toolbar`, `.toolbar__title`, `.toolbar__search`, `.toolbar__count` | In-card section header with optional search. |
 | `.tabs`, `.tab`, `.tab--on` | Tab strip. |
 | `.filter-rail`, `.nav-panel` | Left rails: the filter list inside a page; the type panel flush against the sidebar. |
-| `.icon-button`, `.icon-button--danger` | Bare icon action (table rows). |
+| `.icon-button`, `.icon-button--danger` | Bare 30px-square icon action (table rows), with the action-button 9px radius. |
 | `.busy-status` > `.spinner` | Inline working state: the ring plus a short label, `role="status"` in the markup so it announces. |
 
 Starting a new page: copy `templates/pages/_scaffold.html` (or crib
 `tenants.html`, the smallest real page). Both compose only this vocabulary.
+
+Button emphasis never changes geometry: pair `.btn` with `--primary`,
+`--danger`, or `--current` for color and state, and add `--icon` only for a
+square icon-only action. Inputs keep their own field scale and do not dictate
+button height. The sole fixed-height exception is the open
+`.addbox--modal > summary.btn`: while its native `<details>` is open, that
+summary becomes the full-viewport backdrop (`height: auto`, zero padding and
+radius); its closed state and the actions inside the dialog use the canonical
+button scale.
 
 ### Busy states
 

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1338,13 +1338,6 @@ select.field__input {
   justify-content: flex-end;
 }
 
-/* Dialog feet pair a plain button with the primary; both sit on the primary's
-   metrics so the row lines up. */
-.addbox__actions .btn {
-  height: 36px;
-  padding: 0 18px;
-}
-
 .spinner,
 .btn[aria-busy="true"]::after {
   width: 14px;
@@ -1403,7 +1396,7 @@ select.field__input {
    same no-JS <details> mechanics, presented as a modal. While open, the
    summary itself stretches over the viewport as the backdrop, so clicking
    outside the panel closes the dialog without any script. */
-.addbox--modal[open] > summary {
+.addbox--modal[open] > summary.btn {
   position: fixed;
   inset: 0;
   z-index: 40;
@@ -1510,10 +1503,11 @@ select.field__input {
 .icon-button {
   display: inline-grid;
   place-items: center;
-  width: 32px;
-  height: 32px;
+  width: 30px;
+  height: 30px;
+  padding: 0;
   border: 0;
-  border-radius: 8px;
+  border-radius: 9px;
   background: transparent;
   color: var(--muted);
   cursor: pointer;
@@ -1851,8 +1845,6 @@ select.field__input {
 }
 
 .btn--primary {
-  height: 36px;
-  padding: 0 18px;
   color: #ffffff;
   background: var(--accent-strong);
   border-color: var(--accent-strong);
@@ -1863,18 +1855,10 @@ select.field__input {
   filter: brightness(1.08);
 }
 
-/* Accent-filled at the standard .btn metrics: for buttons that sit in a row
-   with plain siblings, where the taller primary would break the line-up. */
-.btn--accent {
-  color: #ffffff;
-  background: var(--accent-strong);
-  border-color: var(--accent-strong);
-}
-
-.btn--accent:hover {
-  background: var(--accent-strong);
-  border-color: var(--accent-strong);
-  filter: brightness(1.08);
+.btn--icon {
+  width: 30px;
+  padding: 0;
+  justify-content: center;
 }
 
 .btn:disabled {
@@ -2020,8 +2004,6 @@ select.field__input {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 38px;
-  padding: 0 14px;
   white-space: nowrap;
 }
 
@@ -2151,10 +2133,6 @@ select.field__input {
 
 .query-builder__name {
   flex: 0 1 280px;
-}
-
-.query-builder__save .btn {
-  height: 36px;
 }
 
 .query-builder__hint {
@@ -3452,10 +3430,8 @@ details.json-fold[open] > summary .icon {
   color: var(--muted);
 }
 
-/* The Ask button keeps the shared primary metrics (36px — design-system.spec
-   holds every page to one primary button); only its icon gap is local. */
-.nl-input .btn--primary {
-  gap: 8px;
+/* The Ask button keeps the shared action-button scale. */
+.nl-input .btn {
   white-space: nowrap;
 }
 
@@ -3596,12 +3572,6 @@ details.json-fold[open] > summary .icon {
 }
 
 .query-builder__copy {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 38px;
-  height: 38px;
-  padding: 0;
   color: var(--muted);
 }
 

--- a/crates/ui/e2e/pages/button-geometry.ts
+++ b/crates/ui/e2e/pages/button-geometry.ts
@@ -1,0 +1,42 @@
+import type { Locator } from "@playwright/test";
+
+export interface ButtonGeometry {
+  height: string;
+  paddingLeft: string;
+  paddingRight: string;
+  fontSize: string;
+  radius: string;
+}
+
+export const CANONICAL_BUTTON_GEOMETRY: ButtonGeometry = {
+  height: "30px",
+  paddingLeft: "12px",
+  paddingRight: "12px",
+  fontSize: "12px",
+  radius: "9px",
+};
+
+export async function readButtonGeometry(button: Locator): Promise<ButtonGeometry> {
+  const geometries = await readButtonGeometries(button);
+  if (geometries.length !== 1) {
+    throw new Error(
+      `readButtonGeometry expected exactly one matched element, got ${geometries.length}: ${button}`,
+    );
+  }
+  return geometries[0];
+}
+
+export async function readButtonGeometries(buttons: Locator): Promise<ButtonGeometry[]> {
+  return buttons.evaluateAll((elements) =>
+    elements.map((element) => {
+      const style = getComputedStyle(element);
+      return {
+        height: style.height,
+        paddingLeft: style.paddingLeft,
+        paddingRight: style.paddingRight,
+        fontSize: style.fontSize,
+        radius: style.borderRadius,
+      };
+    }),
+  );
+}

--- a/crates/ui/e2e/tests/a11y.spec.ts
+++ b/crates/ui/e2e/tests/a11y.spec.ts
@@ -3,10 +3,11 @@ import AxeBuilder from "@axe-core/playwright";
 import { ROUTES, seedBulkImportDetail } from "../pages/routes";
 
 // Tier 1 of the strategy (issue #249): WCAG 2.2 AA is the spec, axe-core the
-// harness. Contrast and target-size verdicts differ per theme, so every route
-// is scanned in both light and dark. The route list is shared with the other
-// cross-page guards (#543); the bulk-import detail page has no static URL, so
-// it is seeded and scanned as its own named test below.
+// harness. Contrast differs per theme, so every route is scanned in both light
+// and dark. axe-core does not currently execute its disabled target-size rule;
+// design-system.spec.ts carries an explicit >=24px action-target guard. The
+// route list is shared with the other cross-page guards (#543); the bulk-import
+// detail page has no static URL, so it is seeded and scanned separately below.
 const WCAG = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"];
 const THEMES = ["light", "dark"] as const;
 

--- a/crates/ui/e2e/tests/batch.spec.ts
+++ b/crates/ui/e2e/tests/batch.spec.ts
@@ -4,6 +4,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import AxeBuilder from "@axe-core/playwright";
 import { axeSummary } from "../pages/axe";
+import {
+  CANONICAL_BUTTON_GEOMETRY,
+  readButtonGeometry,
+} from "../pages/button-geometry";
 
 // The Batch/Transaction workspace (#476): upload → preflight → execute →
 // response, entirely against the ordinary FHIR API.
@@ -94,6 +98,25 @@ test("a transaction bundle uploads, previews, executes, and reports", async ({ p
   await expect(page.locator("#batch-preflight")).toBeHidden();
   await expect(page.locator("#batch-drop")).toBeFocused();
 });
+
+for (const type of ["batch", "transaction"] as const) {
+  test(`${type} preflight keeps Cancel/Execute on the canonical scale`, async ({ page }) => {
+    test.skip(
+      type === "transaction" && process.env.HFS_E2E_NO_TRANSACTIONS === "1",
+      "transactions refused on this backend",
+    );
+    await page.goto("/ui/batch", { waitUntil: "networkidle" });
+    await page.locator("#batch-file").setInputFiles(bundleFile(type));
+    await expect(page.locator("#batch-preflight")).toBeVisible();
+
+    const controls = ["#batch-cancel-top", "#batch-execute-top"];
+    const geometries = await Promise.all(
+      controls.map((selector) => readButtonGeometry(page.locator(selector))),
+    );
+    expect(new Set(geometries.map((geometry) => JSON.stringify(geometry))).size).toBe(1);
+    expect(geometries[0]).toEqual(CANONICAL_BUTTON_GEOMETRY);
+  });
+}
 
 test("JSON previews are lazy, cached, compact, accessible, and isolated per view", async ({ page }) => {
   const previews: { contentType: string | undefined; body: string | null }[] = [];
@@ -376,14 +399,16 @@ test("execute busies the whole footer, ignores re-entrant clicks, and lands focu
   await page.goto("/ui/batch", { waitUntil: "networkidle" });
   await page.locator("#batch-file").setInputFiles(bundleFile("batch"));
   await expect(page.locator("#batch-preflight")).toBeVisible();
+  const geometryBefore = await readButtonGeometry(page.locator("#batch-execute-top"));
   await page.locator("#batch-execute-top").click();
 
-  // Both Execute copies spin, and the Cancels go inert with them: a
+  // Execute spins and Cancel goes inert with it: a
   // mid-flight Cancel raced the settling response and crashed on the nulled
   // bundle before #679.
   await expect(page.locator("#batch-execute-top")).toHaveAttribute("aria-busy", "true");
-  await expect(page.locator("#batch-execute-top")).toHaveAttribute("aria-busy", "true");
   for (const control of FOOTER_CONTROLS) await expect(page.locator(control)).toBeDisabled();
+  expect(await readButtonGeometry(page.locator("#batch-execute-top"))).toEqual(geometryBefore);
+  expect(await readButtonGeometry(page.locator("#batch-cancel-top"))).toEqual(geometryBefore);
   await expect(page.locator("#batch-busy")).toBeVisible();
   await expect(page.locator("#batch-busy")).toContainText("Executing");
 

--- a/crates/ui/e2e/tests/bulk-import.spec.ts
+++ b/crates/ui/e2e/tests/bulk-import.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from "../pages/fixtures";
 import type { Locator } from "@playwright/test";
 import { seedBulkImportDetail } from "../pages/routes";
+import {
+  CANONICAL_BUTTON_GEOMETRY,
+  readButtonGeometries,
+} from "../pages/button-geometry";
 
 function contrastRatio(foreground: string, background: string): number {
   const luminance = (cssColor: string): number => {
@@ -211,6 +215,29 @@ test("the Add Manifest dialog labels Format and sizes its textarea", async ({
   expect(styles.resize).toBe("vertical");
   expect(styles.boxSizing).toBe("border-box");
   expect(styles.fontFamily.toLowerCase()).not.toContain("monospace");
+});
+
+test("manifest-row actions use the canonical scale across emphasis variants", async ({
+  page,
+  request,
+  bulkImport,
+}) => {
+  const detail = await bulkImport.seedAndGoto(request, `button-scale-${Date.now()}`);
+  const response = await request.post(`${detail}/manifests`, {
+    form: {
+      manifest_url: "https://example.test/manifest.json",
+      fhir_base_url: "https://example.test/fhir",
+      output_format: "application/fhir+ndjson",
+    },
+    maxRedirects: 0,
+  });
+  expect(response.status()).toBeGreaterThanOrEqual(300);
+  expect(response.status()).toBeLessThan(400);
+  await page.goto(detail, { waitUntil: "networkidle" });
+
+  const metrics = await readButtonGeometries(bulkImport.manifestsCard.locator("tbody .btn"));
+  expect(metrics.length).toBeGreaterThanOrEqual(3);
+  for (const geometry of metrics) expect(geometry).toEqual(CANONICAL_BUTTON_GEOMETRY);
 });
 
 // #721: the New Submission summary doubles as the modal backdrop; the

--- a/crates/ui/e2e/tests/design-system.spec.ts
+++ b/crates/ui/e2e/tests/design-system.spec.ts
@@ -9,8 +9,7 @@ import postcss from "postcss";
 //   - a class that matches no rule is a typo or a second vocabulary starting
 //     (class="table" shipped that way and styled nothing);
 //   - a page <h1> off the canonical class is a second heading scale;
-//   - primary buttons that resolve to different metrics on different pages
-//     are two button designs;
+//   - ordinary actions use one exact size scale, regardless of emphasis;
 //   - a selector defined twice renders as the cascade-merge of two authors'
 //     blocks, which nobody wrote.
 
@@ -102,25 +101,152 @@ test("every page <h1> uses the canonical .page-head__title", async ({ page, requ
   expect(offenders, `page titles off the canonical class:\n${offenders.join("\n")}`).toEqual([]);
 });
 
-test("primary buttons resolve to the same metrics on every page", async ({ page, request }) => {
-  // Computed, not declared: a page-layer override that restyles the shared
-  // control shows up here no matter how it was written.
-  const byRoute = new Map<string, string[]>();
+test("ordinary actions resolve to the canonical button scale on every page", async ({ page, request }) => {
+  const offenders: string[] = [];
+  const primaryColors = new Map<string, string[]>();
   for (const route of [...ROUTES, await seedBulkImportDetail(request)]) {
     await page.goto(route, { waitUntil: "networkidle" });
-    const signatures = await page.$$eval(".btn--primary", (nodes) =>
+    const actions = await page.$$eval(".btn, .icon-button", (nodes) =>
       nodes
         .filter((n) => n instanceof HTMLElement && n.offsetParent !== null)
         .map((n) => {
           const s = getComputedStyle(n);
-          return `height=${s.height} radius=${s.borderRadius} bg=${s.backgroundColor} color=${s.color}`;
+          const box = n.getBoundingClientRect();
+          return {
+            label: `${n.tagName.toLowerCase()}.${Array.from(n.classList).join(".")} “${(n.textContent ?? "").trim().slice(0, 30)}”`,
+            isButton: n.classList.contains("btn"),
+            isIconButton: n.classList.contains("icon-button"),
+            isIconShape: n.classList.contains("btn--icon"),
+            isPrimary: n.classList.contains("btn--primary"),
+            height: s.height,
+            width: s.width,
+            radius: s.borderRadius,
+            fontSize: s.fontSize,
+            paddingLeft: s.paddingLeft,
+            paddingRight: s.paddingRight,
+            background: s.backgroundColor,
+            color: s.color,
+            targetWidth: box.width,
+            targetHeight: box.height,
+          };
         }),
     );
-    if (signatures.length) byRoute.set(route, Array.from(new Set(signatures)));
+    const routePrimaryColors: string[] = [];
+    for (const action of actions) {
+      if (action.targetWidth < 24 || action.targetHeight < 24) {
+        offenders.push(`${route}: ${action.label} target=${action.targetWidth}x${action.targetHeight}`);
+      }
+      if (action.isIconButton) {
+        if (action.width !== "30px" || action.height !== "30px" || action.radius !== "9px") {
+          offenders.push(`${route}: ${action.label} icon geometry=${action.width}x${action.height} radius=${action.radius}`);
+        }
+        continue;
+      }
+      if (!action.isButton) continue;
+      if (action.height !== "30px" || action.radius !== "9px" || action.fontSize !== "12px") {
+        offenders.push(`${route}: ${action.label} height=${action.height} radius=${action.radius} font=${action.fontSize}`);
+      }
+      const expectedPadding = action.isIconShape ? "0px" : "12px";
+      if (action.paddingLeft !== expectedPadding || action.paddingRight !== expectedPadding) {
+        offenders.push(`${route}: ${action.label} padding=${action.paddingLeft}/${action.paddingRight}`);
+      }
+      if (action.isIconShape && action.width !== "30px") {
+        offenders.push(`${route}: ${action.label} icon width=${action.width}`);
+      }
+      if (action.isPrimary) routePrimaryColors.push(`${action.background}/${action.color}`);
+    }
+    if (routePrimaryColors.length) primaryColors.set(route, Array.from(new Set(routePrimaryColors)));
   }
-  const distinct = new Set(Array.from(byRoute.values()).flat());
-  const listing = Array.from(byRoute, ([r, sigs]) => `${r}: ${sigs.join(" | ")}`).join("\n");
-  expect(distinct.size, `primary buttons diverge across pages:\n${listing}`).toBeLessThanOrEqual(1);
+  expect(offenders, `actions off the canonical scale or below 24px:\n${offenders.join("\n")}`).toEqual([]);
+
+  const distinctPrimaryColors = new Set(Array.from(primaryColors.values()).flat());
+  const listing = Array.from(primaryColors, ([r, colors]) => `${r}: ${colors.join(" | ")}`).join("\n");
+  expect(distinctPrimaryColors.size, `primary emphasis diverges across pages:\n${listing}`).toBeLessThanOrEqual(1);
+});
+
+test("emphasis variants cannot declare geometry and the retired accent variant stays absent", async ({ request }) => {
+  const css = await stylesheet(request);
+  const root = postcss.parse(css);
+  const geometry = /^(?:width|min-width|max-width|height|min-height|max-height|padding(?:-.+)?|font(?:-.+)?|line-height|border-radius|gap)$/;
+  const offenders: string[] = [];
+  const contextual: string[] = [];
+  root.walkRules((rule) => {
+    const emphasis = rule.selectors.filter((selector) => /\.btn--(?:primary|danger|current)(?![-\w])/.test(selector));
+    rule.walkDecls((decl) => {
+      if (!geometry.test(decl.prop)) return;
+      if (emphasis.length) offenders.push(`${emphasis.join(", ")}: ${decl.prop}: ${decl.value}`);
+      for (const selector of rule.selectors) {
+        const target = selector.trim();
+        if (!/\.btn(?:--[\w-]+)?(?:\[[^\]]+\]|:[\w()-]+)*$/.test(target)) continue;
+        if (target === ".btn" || target === ".btn--icon" || target === ".addbox--modal[open] > summary.btn") continue;
+        contextual.push(`${target}: ${decl.prop}: ${decl.value}`);
+      }
+    });
+  });
+  expect(offenders, `emphasis variants declaring geometry:\n${offenders.join("\n")}`).toEqual([]);
+  expect(contextual, `contextual button geometry outside the icon/backdrop exceptions:\n${contextual.join("\n")}`).toEqual([]);
+  expect(css).not.toContain(".btn--accent");
+});
+
+test("shared query-builder actions stay 30px while their inputs keep the field scale", async ({ page }) => {
+  for (const route of ["/ui/resources", "/ui/search", "/ui/queries"]) {
+    await page.goto(route, { waitUntil: "networkidle" });
+    const form = page.locator("#saved-query-form");
+    await expect(form, `${route} should render the shared query builder`).toBeVisible();
+    for (const control of ["#query-copy", ".query-recent__toggle", "[data-intent='run']"]) {
+      await expect(form.locator(control)).toHaveCSS("height", "30px");
+    }
+    await expect(form.locator("#query-copy")).toHaveCSS("width", "30px");
+    await expect(form.locator("#query-copy")).toHaveCSS("padding-left", "0px");
+    await expect(form.locator(".query-builder__url")).toHaveCSS("height", "38px");
+
+    if (route === "/ui/queries") {
+      await expect(form.locator("[data-intent='save']")).toHaveCSS("height", "30px");
+      await expect(form.locator("input[name='name']")).toHaveCSS("height", "36px");
+    }
+  }
+
+  for (const theme of ["light", "dark"] as const) {
+    for (const width of [1280, 390]) {
+      await page.setViewportSize({ width, height: 800 });
+      await page.goto("/ui");
+      await page.evaluate((selected) => localStorage.setItem("hfs-theme", selected), theme);
+      await page.goto("/ui/queries", { waitUntil: "networkidle" });
+      await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+      for (const control of ["#query-copy", ".query-recent__toggle", "[data-intent='run']", "[data-intent='save']"]) {
+        await expect(page.locator(`#saved-query-form ${control}`)).toHaveCSS("height", "30px");
+      }
+    }
+  }
+});
+
+test("icon-only action shapes compute to the shared 30px square", async ({ page }) => {
+  await page.goto("/ui");
+  const metrics = await page.evaluate(() => {
+    const classes = ["btn btn--icon", "icon-button"];
+    return classes.map((className) => {
+      const probe = document.createElement("button");
+      probe.className = className;
+      probe.type = "button";
+      probe.textContent = "x";
+      document.body.append(probe);
+      const style = getComputedStyle(probe);
+      const result = {
+        className,
+        width: style.width,
+        height: style.height,
+        radius: style.borderRadius,
+        paddingLeft: style.paddingLeft,
+        paddingRight: style.paddingRight,
+      };
+      probe.remove();
+      return result;
+    });
+  });
+  expect(metrics).toEqual([
+    { className: "btn btn--icon", width: "30px", height: "30px", radius: "9px", paddingLeft: "0px", paddingRight: "0px" },
+    { className: "icon-button", width: "30px", height: "30px", radius: "9px", paddingLeft: "0px", paddingRight: "0px" },
+  ]);
 });
 
 test("no selector is defined twice in app.css", async ({ request }) => {

--- a/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
+++ b/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "../../pages/fixtures";
+import {
+  CANONICAL_BUTTON_GEOMETRY,
+  readButtonGeometries,
+} from "../../pages/button-geometry";
 
 // This whole file runs in the `nojs` project (javaScriptEnabled: false), which
 // exercises the README's core promise: the UI works with JavaScript off. htmx,
@@ -91,4 +95,25 @@ test("a hard navigation returns the full page, not an htmx fragment", async ({ p
   await page.goto("/ui/status");
   await expect(chrome.sidebar).toBeVisible();
   await expect(page.locator("html")).toHaveAttribute("lang", /.+/);
+});
+
+test("native Addbox dialogs keep canonical actions and the open-summary backdrop", async ({ page }) => {
+  await page.goto("/ui/bulk-import");
+  const details = page.locator("details.addbox--modal");
+  const summary = details.locator("summary.btn");
+  await expect(summary).toHaveCSS("height", "30px");
+  await expect(summary).toHaveCSS("padding-left", "12px");
+  await expect(summary).toHaveCSS("border-radius", "9px");
+
+  await summary.click();
+  await expect(details).toHaveAttribute("open", "");
+  const backdrop = await summary.boundingBox();
+  const viewport = page.viewportSize()!;
+  expect(backdrop!.height).toBeGreaterThan(viewport.height * 0.9);
+  await expect(summary).toHaveCSS("padding-left", "0px");
+  await expect(summary).toHaveCSS("border-radius", "0px");
+
+  const actionMetrics = await readButtonGeometries(details.locator(".addbox__actions .btn"));
+  expect(actionMetrics).toHaveLength(2);
+  for (const geometry of actionMetrics) expect(geometry).toEqual(CANONICAL_BUTTON_GEOMETRY);
 });

--- a/crates/ui/e2e/tests/queries.spec.ts
+++ b/crates/ui/e2e/tests/queries.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "../pages/fixtures";
 import { createResource, waitSearchable } from "../pages/api";
+import {
+  CANONICAL_BUTTON_GEOMETRY,
+  readButtonGeometries,
+} from "../pages/button-geometry";
 
 function catalogHtml(
   params: Array<{ code: string; type: string; targets?: string[] }>,
@@ -2242,6 +2246,11 @@ test.describe("query builder", () => {
     await queries.builder.nameInput.fill(name);
     await queries.builder.saveButton.click();
     await expect(queries.savedList).toContainText(name);
+    const savedActionMetrics = await readButtonGeometries(queries.savedList.locator(".btn"));
+    expect(savedActionMetrics.length).toBeGreaterThan(0);
+    for (const geometry of savedActionMetrics) {
+      expect(geometry).toEqual(CANONICAL_BUTTON_GEOMETRY);
+    }
 
     await page.reload({ waitUntil: "networkidle" });
     await queries.builder.recentToggle.click();

--- a/crates/ui/e2e/tests/resources-editor.spec.ts
+++ b/crates/ui/e2e/tests/resources-editor.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "../pages/fixtures";
+import {
+  CANONICAL_BUTTON_GEOMETRY,
+  readButtonGeometry,
+} from "../pages/button-geometry";
 
 // Regression cover for the Resources workspace edit flows — each of these was a
 // real bug fixed by hand; the browser is the only place they're observable.
@@ -13,6 +17,14 @@ test("Create new targets the resource type picked in the rail, not always Patien
   expect((await resources.modal.editor.currentDoc()).resourceType).toBe("Observation");
   // The editor projects the picked type's schema: Observation requires status + code.
   await expect(resources.modal.editor.form).toHaveAttribute("data-error-count", /[1-9]/);
+
+  const actionMetrics = await Promise.all(
+    [resources.modal.deleteButton, resources.modal.saveButton].map((button) =>
+      readButtonGeometry(button),
+    ),
+  );
+  expect(actionMetrics[0]).toEqual(actionMetrics[1]);
+  expect(actionMetrics[0]).toEqual(CANONICAL_BUTTON_GEOMETRY);
 });
 
 test("an encoded HTML-like type stays text and cannot open a draft", async ({ resources, page }) => {

--- a/crates/ui/e2e/tests/sql-libraries.spec.ts
+++ b/crates/ui/e2e/tests/sql-libraries.spec.ts
@@ -40,6 +40,12 @@ test("a stored SQLQuery lists, decodes its SQL, and previews rows", async ({ pag
   // The SQL pane holds the decoded query, not base64.
   await expect(page.locator("textarea[name='sql']")).toContainText("SELECT COUNT(*)");
 
+  const createNew = page.locator("a[href$='?lib=new']");
+  await expect(createNew).toHaveClass(/\bbtn--primary\b/);
+  await expect(createNew).not.toHaveClass(/\bbtn--accent\b/);
+  await expect(createNew).toHaveCSS("height", "30px");
+  await expect(createNew).toHaveCSS("padding-left", "12px");
+
   await page.locator("a[href*='run=1']").click();
   await expect(page.locator(".data-table")).toBeVisible();
   await expect(page.locator(".data-table th", { hasText: "n" }).first()).toBeVisible();

--- a/crates/ui/e2e/tests/sql-view-definitions.spec.ts
+++ b/crates/ui/e2e/tests/sql-view-definitions.spec.ts
@@ -25,6 +25,12 @@ test("a stored ViewDefinition lists, edits, and previews rows", async ({ page, r
   );
   await expect(page.locator("textarea[name='json']")).toContainText("e2e_patients");
 
+  const createNew = page.locator("a[href$='?vd=new']");
+  await expect(createNew).toHaveClass(/\bbtn--primary\b/);
+  await expect(createNew).not.toHaveClass(/\bbtn--accent\b/);
+  await expect(createNew).toHaveCSS("height", "30px");
+  await expect(createNew).toHaveCSS("padding-left", "12px");
+
   // Run previews the output; the seeded patient's key is among the rows.
   await page.locator("a[href*='run=1']").click();
   await expect(page.locator(".data-table")).toBeVisible();

--- a/crates/ui/e2e/tests/tenants.spec.ts
+++ b/crates/ui/e2e/tests/tenants.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "../pages/fixtures";
+import {
+  CANONICAL_BUTTON_GEOMETRY,
+  readButtonGeometries,
+} from "../pages/button-geometry";
 
 // Tenant maintenance (/ui/tenants): the htmx add-tenant slide-over, the live
 // search filter, and per-row delete (hx-confirm). Skips itself if this backend
@@ -71,6 +75,11 @@ test.describe("tenants", () => {
 
   test("typing a display name mirrors a slug into the tenant id", async ({ tenants }) => {
     await tenants.addToggle.click();
+    const actionMetrics = await readButtonGeometries(
+      tenants.addForm.locator(".addbox__actions .btn"),
+    );
+    expect(actionMetrics).toHaveLength(2);
+    for (const geometry of actionMetrics) expect(geometry).toEqual(CANONICAL_BUTTON_GEOMETRY);
     await tenants.addForm.locator("input[name=display_name]").fill("Acme Health");
     await expect(tenants.addForm.locator("input[name=id]")).toHaveValue("acme-health");
     await tenants.addForm.locator("input[name=display_name]").fill("  Ünïcode & Co.  ");

--- a/crates/ui/templates/pages/sql-library.html
+++ b/crates/ui/templates/pages/sql-library.html
@@ -69,7 +69,7 @@
                 data-redirect="{{ base_href }}">
           <span class="icon">{% include "icons/trash.svg" %}</span> {{ i18n.t("vd-delete") }}
         </button>
-        <a class="btn btn--accent" href="{{ base_href }}?lib=new">
+        <a class="btn btn--primary" href="{{ base_href }}?lib=new">
           <span class="icon">{% include "icons/plus.svg" %}</span> {{ i18n.t("vd-new") }}
         </a>
         {% endif %}

--- a/crates/ui/templates/pages/sql-view-definitions.html
+++ b/crates/ui/templates/pages/sql-view-definitions.html
@@ -73,7 +73,7 @@
                 data-redirect="/ui/sql/view-definitions">
           <span class="icon">{% include "icons/trash.svg" %}</span> {{ i18n.t("vd-delete") }}
         </button>
-        <a class="btn btn--accent" href="/ui/sql/view-definitions?vd=new">
+        <a class="btn btn--primary" href="/ui/sql/view-definitions?vd=new">
           <span class="icon">{% include "icons/plus.svg" %}</span> {{ i18n.t("vd-new") }}
         </a>
         {% endif %}

--- a/crates/ui/templates/partials/search-builder.html
+++ b/crates/ui/templates/partials/search-builder.html
@@ -22,7 +22,7 @@
            placeholder="{{ i18n.t("queries-url-placeholder") }}"
            aria-label="{{ i18n.t("queries-url-label") }}"
            {% if let Some(v) = builder_url %}value="GET {{ v }}"{% endif %}>
-    <button class="btn query-builder__copy" type="button" id="query-copy"
+    <button class="btn btn--icon query-builder__copy" type="button" id="query-copy"
             aria-label="{{ i18n.t("search-copy") }}" title="{{ i18n.t("search-copy") }}">
       <span class="icon">{% include "icons/copy.svg" %}</span>
     </button>


### PR DESCRIPTION
Closes #728.

## Summary

- Establish one canonical ordinary-action scale across the UI: `30px` height, `12px` horizontal padding, `12px` type, and `9px` radius.
- Keep primary, danger, and current variants geometry-neutral; retire the duplicate accent variant.
- Normalize icon actions to a `30px` square and remove page-specific button geometry from the query builder, resource editor, Batch, Bulk Import, tenants, and SQL workspaces.
- Document the component contract and make it executable through app-wide, dynamic-state, responsive, accessibility, and no-JavaScript coverage.

## Reconciliation with main

- Reconciled onto `main` at `92c3762bf56caeed08715560be63eafd12a3d40b`.
- Preserved the single Batch footer introduced by #736: the geometry and busy-state coverage now targets the surviving top Cancel/Execute pair instead of restoring the removed footer.
- Retained the current Query Builder behavior from main while applying the shared scale.

## Evidence

Both captures are from the final reconciled binary. Every visible `.btn` in these surfaces measured `30px` high with `9px` radius and `12px` type. Emphasis changes color only.

| Query Builder — icon, secondary, primary, and save actions | View Definitions — secondary, danger, primary, and save actions |
|---|---|
| ![Query Builder button scale in dark theme](https://raw.githubusercontent.com/HeliosSoftware/hfs/assets/255-nl-search-screenshots/728-button-size-scale/query-builder-dark.png) | ![SQL View Definitions button scale in dark theme](https://raw.githubusercontent.com/HeliosSoftware/hfs/assets/255-nl-search-screenshots/728-button-size-scale/sql-actions-dark.png) |

Measured examples:

- Query Builder: Copy `30×30`; Recent, Run, and Save all `30px` high.
- View Definitions: Run, Duplicate, Delete, Create New, and Save all `30px` high across neutral, danger, and primary variants.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p helios-ui`
- `npm run test:unit` — 8 passed
- `cargo build -p helios-hfs --features ui`
- `CI=1 HFS_E2E_BASE_URL=http://127.0.0.1:63528 npx playwright test` — 270 passed, 7 expected configuration skips
- `git diff --check`