### PR TITLE
fix(ui): show the HFS favicon in browser tabs

### DIFF
--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -3619,6 +3619,7 @@ mod tests {
 
         assert!(html.contains("Helios FHIR Server"));
         assert!(html.contains("1.2.3"));
+        assert!(html.contains(r#"<link rel="icon" type="image/png" href="/ui/assets/logo.png">"#));
         assert!(html.contains("/ui/assets/htmx.min.js"));
         // No runtime CDN dependency.
         assert!(!html.contains("unpkg.com"));

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}{{ i18n.t("app-title") }}{% endblock %}</title>
+  <link rel="icon" type="image/png" href="/ui/assets/logo.png">
   <link rel="stylesheet" href="/ui/assets/app.css">
   <!-- The effective tenant for browser-issued FHIR calls (#344). -->
   <meta name="hfs-tenant" content="{{ status.tenant_id() }}">


### PR DESCRIPTION
Closes #745.

## Summary

- Declare the existing HFS brand mark as the favicon in the shared UI layout.
- Reuse the embedded `/ui/assets/logo.png`; no new route, manifest, or image asset is needed.
- Assert the favicon link when rendering the index page.

## Evidence

Chrome now shows the HFS mark in the browser tab instead of its generic site icon.

<img width="250" height="40" alt="HFS favicon shown in the Chrome tab" src="https://github.com/user-attachments/assets/f91ece80-2b6d-4f9f-b1ff-266c26d95ed2" />

## Testing

- `cargo fmt --check`
- `cargo test -p helios-ui` — 225 tests passed.
- `git diff --check`
- Live server check: `/ui` renders the favicon link and `/ui/assets/logo.png` returns `200 OK` as `image/png` with an ETag and `Cache-Control: no-cache`.
