### PR TITLE
fix(ui): edit-dialog parity via shared auth fieldset, page ledes, anonymous identity

### DIFF
--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -250,7 +250,7 @@
                 {% if let Some(initials) = status.user_initials() %}{{ initials }}{% else %}<span class="icon">{% include "icons/user.svg" %}</span>{% endif %}
                 {% endif %}
               </span>
-              <div class="user-menu__name">{% if let Some(name) = status.user_display() %}{{ name }}{% else %}{{ i18n.t("user-local") }}{% endif %}</div>
+              <div class="user-menu__name">{% if let Some(name) = status.user_display() %}{{ name }}{% else %}{{ i18n.t("user-anonymous") }}{% endif %}</div>
               <div class="user-menu__hint">{% if let Some(secondary) = status.user_secondary() %}{{ secondary }}{% else %}{{ i18n.t("user-local-hint") }}{% endif %}</div>
             </div>
             <div class="menu__heading">{{ i18n.t("language-label") }}</div>

--- a/crates/ui/templates/pages/bulk-export.html
+++ b/crates/ui/templates/pages/bulk-export.html
@@ -7,6 +7,7 @@
 {% block content %}
 <header class="page-head">
   <h1 class="page-head__title">{{ i18n.t("bulk-export-title") }}</h1>
+  <p class="page-head__lede">{{ i18n.t("bulk-export-lede") }}</p>
 </header>
 
 {% if !available %}

--- a/crates/ui/templates/pages/bulk-import-detail.html
+++ b/crates/ui/templates/pages/bulk-import-detail.html
@@ -8,6 +8,7 @@
   <div>
     <a class="back-link" href="/ui/bulk-import">‹ {{ i18n.t("bulk-import-all") }}</a>
     <h1 class="page-head__title">{{ name }}</h1>
+    <p class="page-head__lede">{{ i18n.t("bulk-import-detail-lede") }}</p>
   </div>
 
   {% if terminal %}
@@ -44,40 +45,24 @@
     <div class="detail__field"><span>{{ i18n.t("bulk-import-detail-auth") }}</span><div>{{ auth }}</div></div>
   </div>
   <div class="detail__actions bulk-import-summary__actions">
-    <details class="addbox addbox--modal"{% if edit_open %} open{% endif %}>
-      <summary class="btn">{% include "icons/pencil.svg" %}{{ i18n.t("bulk-import-edit") }}</summary>
-      <div class="addbox__panel" role="dialog" aria-labelledby="bulk-import-edit-title">
-        <div class="addbox__head">
-          <div class="addbox__title" id="bulk-import-edit-title">{{ i18n.t("bulk-import-edit-title") }}</div>
-          <button type="button" class="addbox__x" data-addbox-close aria-label="{{ i18n.t("ui-close") }}">×</button>
-        </div>
+    {% call dialog::modal(i18n.t("bulk-import-edit"), "bulk-import-edit-title", i18n.t("bulk-import-edit-title"), icon="pencil", primary=false, open=edit_open) %}
         {% match error %}{% when Some(message) %}<div class="alert" role="alert">{{ message }}</div>{% when None %}{% endmatch %}
         <form method="post" action="/ui/bulk-import/{{ id }}/edit">
-          <label class="field">
-            <span class="field__label">{{ i18n.t("bulk-import-field-name") }}</span>
-            <input class="field__input" type="text" name="name" value="{{ name }}" required autocomplete="off" data-addbox-initial-focus>
-          </label>
-          <fieldset class="field">
-            <legend class="field__label">{{ i18n.t("bulk-import-auth") }}</legend>
-            <span class="field__hint">{{ i18n.t("bulk-import-auth-hint") }}</span>
-            <label class="field"><input type="radio" name="auth" value="none"{% if auth == "none" %} checked{% endif %}> {{ i18n.t("bulk-import-auth-none") }}</label>
-            <label class="field"><input type="radio" name="auth" value="backend-services"{% if auth == "backend-services" %} checked{% endif %}> {{ i18n.t("bulk-import-auth-backend") }}</label>
-            <label class="field">
-              <span class="field__label">{{ i18n.t("bulk-import-field-client-id") }}</span>
-              <input class="field__input" type="text" name="client_id" autocomplete="off" value="{{ client_id }}">
-            </label>
-            <label class="field">
-              <span class="field__label">{{ i18n.t("bulk-import-field-token-url") }}</span>
-              <input class="field__input" type="url" name="token_url" autocomplete="off" value="{{ token_url }}">
-            </label>
-          </fieldset>
+          {# `value=name` would resolve to the macro's own `name` parameter
+             (macro args shadow the caller's scope), so bind it first. #}
+          {% let submission_name = name.as_str() %}
+          {% call dialog::field(i18n.t("bulk-import-field-name"), "name", "text", required=true, initial_focus=true, value=submission_name) %}{% endcall %}
+          {% let auth_value = auth.as_str() %}
+          {% let client_id_value = client_id.as_str() %}
+          {% let token_url_value = token_url.as_str() %}
+          {% let test_auth_result_id = "edit-test-auth-result" %}
+          {% include "partials/bulk_import_auth_fieldset.html" %}
           <div class="addbox__actions">
             <button type="button" class="btn" data-addbox-close>{{ i18n.t("ui-cancel") }}</button>
             <button type="submit" class="btn btn--primary">{{ i18n.t("bulk-import-edit-submit") }}</button>
           </div>
         </form>
-      </div>
-    </details>
+    {% endcall %}
     <form method="post" action="/ui/bulk-import/{{ id }}/delete">
       <button type="submit" class="btn btn--danger">{% include "icons/trash.svg" %}{{ i18n.t("bulk-import-delete") }}</button>
     </form>

--- a/crates/ui/templates/pages/bulk-import.html
+++ b/crates/ui/templates/pages/bulk-import.html
@@ -7,7 +7,10 @@
 
 {% block content %}
 <header class="page-head page-head--row">
-  <h1 class="page-head__title">{{ i18n.t("bulk-import-title") }}</h1>
+  <div>
+    <h1 class="page-head__title">{{ i18n.t("bulk-import-title") }}</h1>
+    <p class="page-head__lede">{{ i18n.t("bulk-import-lede") }}</p>
+  </div>
 
   {% if available %}
   {% call dialog::modal(i18n.t("bulk-import-new"), "bulk-import-create-dialog-title", i18n.t("bulk-import-create-title")) %}
@@ -17,44 +20,11 @@
         {% call dialog::field(i18n.t("bulk-import-field-submitter-value"), "submitter_value", "text", hint=i18n.t("bulk-import-field-submitter-hint")) %}{% endcall %}
         {% call dialog::field(i18n.t("bulk-import-field-submission-id"), "submission_id", "text", hint=i18n.t("bulk-import-field-submission-id-hint")) %}{% endcall %}
 
-        <fieldset class="field">
-          <legend class="field__label">{{ i18n.t("bulk-import-auth") }}</legend>
-          <span class="field__hint">{{ i18n.t("bulk-import-auth-hint") }}</span>
-          <label class="field">
-            <input type="radio" name="auth" value="none" checked>
-            {{ i18n.t("bulk-import-auth-none") }}
-            <span class="field__hint">{{ i18n.t("bulk-import-auth-none-hint") }}</span>
-          </label>
-          <label class="field">
-            <input type="radio" name="auth" value="backend-services">
-            {{ i18n.t("bulk-import-auth-backend") }}
-            <span class="field__hint">{{ i18n.t("bulk-import-auth-backend-hint") }}</span>
-          </label>
-          <label class="field">
-            <span class="field__label">{{ i18n.t("bulk-import-field-client-id") }}</span>
-            <input class="field__input" type="text" name="client_id" autocomplete="off">
-            <span class="field__hint">{{ i18n.t("bulk-import-field-client-id-hint") }}</span>
-          </label>
-          <label class="field">
-            <span class="field__label">{{ i18n.t("bulk-import-field-token-url") }}</span>
-            <input class="field__input" type="url" name="token_url" autocomplete="off">
-            <span class="field__hint">{{ i18n.t("bulk-import-field-token-url-hint") }}</span>
-          </label>
-          <p class="field__hint">
-            {{ i18n.t("bulk-import-jwks-hint") }}
-            <a href="/.well-known/bulk-submit-jwks.json" target="_blank" rel="noopener">
-              /.well-known/bulk-submit-jwks.json
-            </a>
-          </p>
-          <button type="submit" class="btn"
-                  formaction="/ui/bulk-import/test-auth"
-                  hx-post="/ui/bulk-import/test-auth"
-                  hx-target="#test-auth-result"
-                  hx-swap="innerHTML">
-            {{ i18n.t("bulk-import-test-auth") }}
-          </button>
-          <div id="test-auth-result" role="status"></div>
-        </fieldset>
+        {% let auth_value = "none" %}
+        {% let client_id_value = "" %}
+        {% let token_url_value = "" %}
+        {% let test_auth_result_id = "test-auth-result" %}
+        {% include "partials/bulk_import_auth_fieldset.html" %}
 
         <div class="addbox__actions">
           <button type="button" class="btn" data-addbox-close>{{ i18n.t("ui-cancel") }}</button>

--- a/crates/ui/templates/pages/tenants.html
+++ b/crates/ui/templates/pages/tenants.html
@@ -8,6 +8,7 @@
 {% block content %}
 <header class="page-head">
   <h1 class="page-head__title">{{ i18n.t("tenants-title") }}</h1>
+  <p class="page-head__lede">{{ i18n.t("tenants-lede") }}</p>
 </header>
 
 {% if !available %}

--- a/crates/ui/templates/partials/bulk_import_auth_fieldset.html
+++ b/crates/ui/templates/partials/bulk_import_auth_fieldset.html
@@ -1,0 +1,48 @@
+{#
+  The authentication section shared by the New Submission and Edit Submission
+  dialogs (#761): the scope radios with their hints, Client ID / Token URL
+  with theirs, the JWKS registration pointer, and the Test authentication
+  round trip. Including pages bind, with {% let %}:
+    auth_value           — "none" | "backend-services", selects the radio
+    client_id_value      — prefill for Client ID ("" on create)
+    token_url_value      — prefill for Token URL ("" on create)
+    test_auth_result_id  — unique id for the htmx outcome target
+#}
+<fieldset class="field">
+  <legend class="field__label">{{ i18n.t("bulk-import-auth") }}</legend>
+  <span class="field__hint">{{ i18n.t("bulk-import-auth-hint") }}</span>
+  <label class="field">
+    <input type="radio" name="auth" value="none"{% if auth_value == "none" %} checked{% endif %}>
+    {{ i18n.t("bulk-import-auth-none") }}
+    <span class="field__hint">{{ i18n.t("bulk-import-auth-none-hint") }}</span>
+  </label>
+  <label class="field">
+    <input type="radio" name="auth" value="backend-services"{% if auth_value == "backend-services" %} checked{% endif %}>
+    {{ i18n.t("bulk-import-auth-backend") }}
+    <span class="field__hint">{{ i18n.t("bulk-import-auth-backend-hint") }}</span>
+  </label>
+  <label class="field">
+    <span class="field__label">{{ i18n.t("bulk-import-field-client-id") }}</span>
+    <input class="field__input" type="text" name="client_id" autocomplete="off"{% if !client_id_value.is_empty() %} value="{{ client_id_value }}"{% endif %}>
+    <span class="field__hint">{{ i18n.t("bulk-import-field-client-id-hint") }}</span>
+  </label>
+  <label class="field">
+    <span class="field__label">{{ i18n.t("bulk-import-field-token-url") }}</span>
+    <input class="field__input" type="url" name="token_url" autocomplete="off"{% if !token_url_value.is_empty() %} value="{{ token_url_value }}"{% endif %}>
+    <span class="field__hint">{{ i18n.t("bulk-import-field-token-url-hint") }}</span>
+  </label>
+  <p class="field__hint">
+    {{ i18n.t("bulk-import-jwks-hint") }}
+    <a href="/.well-known/bulk-submit-jwks.json" target="_blank" rel="noopener">
+      /.well-known/bulk-submit-jwks.json
+    </a>
+  </p>
+  <button type="submit" class="btn"
+          formaction="/ui/bulk-import/test-auth"
+          hx-post="/ui/bulk-import/test-auth"
+          hx-target="#{{ test_auth_result_id }}"
+          hx-swap="innerHTML">
+    {{ i18n.t("bulk-import-test-auth") }}
+  </button>
+  <div id="{{ test_auth_result_id }}" role="status"></div>
+</fieldset>

--- a/crates/ui/templates/partials/dialog.html
+++ b/crates/ui/templates/partials/dialog.html
@@ -26,10 +26,10 @@
                     address one specific dialog (e.g. Add Manifest's
                     data-bulk-import-add-manifest).
 -->
-{% macro modal(trigger_label, title_id, title_text, marker="") %}
-<details class="addbox addbox--modal"{% if !marker.is_empty() %} {{ marker }}{% endif %}>
-  <summary class="btn btn--primary">
-    {% include "icons/plus.svg" %}
+{% macro modal(trigger_label, title_id, title_text, marker="", icon="plus", primary=true, open=false) %}
+<details class="addbox addbox--modal"{% if !marker.is_empty() %} {{ marker }}{% endif %}{% if open %} open{% endif %}>
+  <summary class="{% if primary %}btn btn--primary{% else %}btn{% endif %}">
+    {% if icon == "pencil" %}{% include "icons/pencil.svg" %}{% else %}{% include "icons/plus.svg" %}{% endif %}
     {{ trigger_label }}
   </summary>
   <div class="addbox__panel" role="dialog" aria-modal="true" aria-labelledby="{{ title_id }}">
@@ -55,10 +55,11 @@
   initial_focus marks the field addbox.js moves focus to when the dialog
   opens (data-addbox-initial-focus) — set it on a dialog's first field.
 -->
-{% macro field(label, name, kind, required=false, placeholder="", hint="", initial_focus=false) %}
+{% macro field(label, name, kind, required=false, placeholder="", hint="", initial_focus=false, value="") %}
 <label class="field">
   <span class="field__label">{{ label }}</span>
   <input class="field__input" type="{{ kind }}" name="{{ name }}"
+         {% if !value.is_empty() %}value="{{ value }}"{% endif %}
          {% if required %}required{% endif %}
          {% if !placeholder.is_empty() %}placeholder="{{ placeholder }}"{% endif %}
          autocomplete="off"{% if initial_focus %} data-addbox-initial-focus{% endif %}>

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -401,8 +401,10 @@ async fn editing_a_submission_changes_only_local_display_and_auth_fields() {
     assert!(!html.contains("evil.example"));
     assert!(html.contains(r#"value="After""#));
     assert!(html.contains(r#"value="none" checked"#));
-    assert!(html.contains(r#"name="client_id" autocomplete="off" value="""#));
-    assert!(html.contains(r#"name="token_url" autocomplete="off" value="""#));
+    // A cleared credential renders with no value attribute at all - the
+    // shared fieldset omits it when empty rather than emitting value="".
+    assert!(html.contains(r#"name="client_id" autocomplete="off">"#));
+    assert!(html.contains(r#"name="token_url" autocomplete="off">"#));
 }
 
 #[tokio::test]

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -2117,7 +2117,7 @@ async fn user_menu_carries_language_and_the_signed_out_state() {
     // English is the negotiated default: its option is current, once.
     assert!(html.contains(r#"href="?lang=en" aria-current="true""#));
     assert!(!html.contains(r#"href="?lang=es" aria-current="true""#));
-    assert!(html.contains("Local user"));
+    assert!(html.contains("Anonymous user"));
     assert!(html.contains("Authentication is disabled"));
     assert!(!html.contains("/ui/logout"));
 }

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -29,7 +29,7 @@ language-en = Englisch
 language-es = Spanisch
 language-de = Deutsch
 user-menu-label = Kontomenü
-user-local = Lokaler Benutzer
+user-anonymous = Anonymer Benutzer
 user-local-hint = Authentifizierung ist deaktiviert
 user-logout = Abmelden
 
@@ -113,6 +113,7 @@ nav-tenants = Mandanten
 ## Mandantenverwaltung (/ui/tenants)
 
 tenants-title = Mandantenverwaltung
+tenants-lede = Tenants anlegen, prüfen und löschen, zwischen denen dieser Server Daten isoliert.
 tenants-unavailable = Die Mandantenregistrierung ist auf diesem Speicher-Backend nicht verfügbar.
 tenants-stat-total = Mandanten gesamt
 tenants-stat-total-sub = { $count ->
@@ -566,6 +567,8 @@ batch-read-failed = Die Datei konnte nicht gelesen werden.
 ## Bulk Import workspace (#527)
 
 bulk-import-title = Massenimport
+bulk-import-lede = Vorkoordinierte FHIR-Datensätze mit der Bulk-Data-Operation $bulk-submit an einen Data Recipient senden.
+bulk-import-detail-lede = Manifeste, Status und Ausführungsprotokoll dieser Übermittlung.
 bulk-import-new = Neue Submission
 bulk-import-create-title = Bulk Submission anlegen
 bulk-import-field-name = Name der Submission
@@ -687,6 +690,7 @@ subs-state-off = aus
 ## Bulk Export workspace (#537)
 
 bulk-export-title = Massenexport
+bulk-export-lede = Daten mit der FHIR-Bulk-Data-Operation $export als NDJSON-Dateien aus diesem Server exportieren.
 bulk-export-active-title = Aktive Exporte
 bulk-export-active-link = Aktive Exporte
 bulk-export-new = Neuer Export

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -31,7 +31,7 @@ language-en = English
 language-es = Spanish
 language-de = German
 user-menu-label = Account menu
-user-local = Local user
+user-anonymous = Anonymous user
 user-local-hint = Authentication is disabled
 user-logout = Sign out
 
@@ -117,6 +117,7 @@ nav-tenants = Tenants
 ## Tenant maintenance (/ui/tenants)
 
 tenants-title = Tenant Maintenance
+tenants-lede = Provision, inspect, and delete the tenants this server isolates data between.
 tenants-unavailable = The tenant registry is not available on this storage backend.
 tenants-stat-total = Total tenants
 tenants-stat-total-sub = { $count ->
@@ -569,6 +570,8 @@ batch-read-failed = The file could not be read.
 ## Bulk Import workspace (#527)
 
 bulk-import-title = Bulk Import
+bulk-import-lede = Send precoordinated FHIR data sets to a Data Recipient with the Bulk Data $bulk-submit operation.
+bulk-import-detail-lede = The manifests, status, and run log of this submission.
 bulk-import-new = New Submission
 bulk-import-create-title = Create Bulk Submission
 bulk-import-field-name = Submission name
@@ -690,6 +693,7 @@ subs-state-off = off
 ## Bulk Export workspace (#537)
 
 bulk-export-title = Bulk Export
+bulk-export-lede = Pull data out of this server as NDJSON files with the FHIR Bulk Data $export operation.
 bulk-export-active-title = Active Exports
 bulk-export-active-link = Active exports
 bulk-export-new = New Export

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -29,7 +29,7 @@ language-en = Inglés
 language-es = Español
 language-de = Alemán
 user-menu-label = Menú de la cuenta
-user-local = Usuario local
+user-anonymous = Usuario anónimo
 user-local-hint = La autenticación está deshabilitada
 user-logout = Cerrar sesión
 
@@ -113,6 +113,7 @@ nav-tenants = Tenants
 ## Mantenimiento de tenants (/ui/tenants)
 
 tenants-title = Mantenimiento de tenants
+tenants-lede = Aprovisiona, inspecciona y elimina los tenants entre los que este servidor aísla los datos.
 tenants-unavailable = El registro de tenants no está disponible en este backend de almacenamiento.
 tenants-stat-total = Tenants totales
 tenants-stat-total-sub = { $count ->
@@ -566,6 +567,8 @@ batch-read-failed = No se pudo leer el archivo.
 ## Bulk Import workspace (#527)
 
 bulk-import-title = Importación masiva
+bulk-import-lede = Envía conjuntos de datos FHIR precoordinados a un Data Recipient con la operación $bulk-submit de Bulk Data.
+bulk-import-detail-lede = Los manifests, el estado y el registro de ejecución de este envío.
 bulk-import-new = Nueva submission
 bulk-import-create-title = Crear Bulk Submission
 bulk-import-field-name = Nombre de la submission
@@ -687,6 +690,7 @@ subs-state-off = apagada
 ## Bulk Export workspace (#537)
 
 bulk-export-title = Exportación masiva
+bulk-export-lede = Extrae datos de este servidor como archivos NDJSON con la operación $export de FHIR Bulk Data.
 bulk-export-active-title = Exportaciones activas
 bulk-export-active-link = Exportaciones activas
 bulk-export-new = Nueva exportación


### PR DESCRIPTION
Closes #757. Closes #761. Closes #762.

## #761 — one dialog, twice

Edit Submission joins `dialog::modal` (gaining `aria-modal` and the standard head/close chrome) and stops carrying a stripped-down copy of the auth section: the **entire fieldset** — scope radios with their hints, Client ID / Token URL with theirs, the JWKS registration pointer, and the Test authentication round trip — moves to a shared partial (`partials/bulk_import_auth_fieldset.html`) that both dialogs include, prefilled via `{% let %}`-bound values, with a per-dialog result-target id. Future drift between the two dialogs is now structurally impossible.

Two small macro extensions carry Edit's needs: `modal` takes `icon`/`primary`/`open` (pencil trigger, plain button, validation-reopen), `field` takes `value`. One subtlety worth a reviewer's eye: **macro parameters shadow the caller's scope in Askama**, so `value=name` resolved to the field's own `name` argument — call sites bind through a `let` first (commented in the template).

## #762 — ledes

Bulk Import, Bulk Import detail, Bulk Export, and Tenant Maintenance gain the house `page-head__lede` under their titles, in en/es/de.

## #757 — Anonymous user

`user-anonymous` replaces `user-local` (key and copy) in the avatar menu's signed-out identity, all three locales; router test updated.

## Checks

Full `helios-ui` ring green (the two edit-dialog tests now assert the shared fieldset's markup: a cleared credential renders with no `value` attribute rather than `value=""`); bulk-import + design-system + a11y (light/dark) + nojs Playwright projects green — 82 tests.