### PR TITLE
fix(ui): define the ok/warn design tokens — green and amber states rendered transparent

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -102,6 +102,14 @@
   /* Destructive text clears 7:1 on the light card surface; the soft hover
      fill keeps 5.8:1 contrast with the same foreground. */
   --danger: #a61b12;
+  /* Positive / caution pairs, mirroring the danger pair: referenced by the
+     stored/member and warn tag variants and the progress track since the
+     SearchParameter viewer landed, but never defined - they rendered
+     transparent. */
+  --ok: #1e7d46;
+  --ok-soft: #e4f6ec;
+  --warn: #8a5a00;
+  --warn-soft: #fdf2dd;
   --danger-soft: #f0dfde;
   /* Menu panel input */
   --input-bg: #f5f5f5;
@@ -134,6 +142,10 @@
   --json-literal: #d2a8ff;
   /* Theme-specific destructive pair: 7.6:1 on the card and 5.6:1 on soft. */
   --danger: #ff9a90;
+  --ok: #7fd8a5;
+  --ok-soft: #14301f;
+  --warn: #e8c07a;
+  --warn-soft: #2f2410;
   --danger-soft: #453534;
   /* Same value as light for now (#681) — the point to adjust from if flat
      black at 45% is later found to read too heavy/light over the dark bg. */


### PR DESCRIPTION
Found while building the one-shot Bulk Submit mockups: `--ok`, `--ok-soft`, `--warn`, and `--warn-soft` have been **referenced but never defined** since the SearchParameter viewer landed — `.tag--stored`/`.tag--member`, the warn tag variants, and `.progress--complete`'s green fill all resolve to transparent, in both themes. (`--danger` was defined, which is why failed states looked right and nobody noticed.)

Both palettes now define the two pairs, mirroring the danger pair's shape: light `#1e7d46`/`#e4f6ec` and `#8a5a00`/`#fdf2dd`, dark `#7fd8a5`/`#14301f` and `#e8c07a`/`#2f2410`. The axe color-contrast gate passes light and dark on the pages that use them (search-parameters, bulk-export active).