### PR TITLE
ui: unify data-table column alignment

### DIFF
--- a/crates/ui/README.md
+++ b/crates/ui/README.md
@@ -242,7 +242,7 @@ These are the shared primitives. Before styling anything, reach for one; add to
 | `.kv-grid` | Responsive two-column key/value layout; collapses to one column on compact viewports. |
 | `.page-head`, `.page-head__title`, `.page-head__lede`, `.page-head--row` | Page heading block; the only `<h1>` treatment; `--row` puts an action on the right. |
 | `.back-link` | In-page return link with theme-safe normal, visited, hover, and focus states. |
-| `.table-wrap` > `.data-table`, `.data-table__empty`, `.table-foot` | The table, always in its scroll wrapper; empty-state row; footer with pagination. |
+| `.table-wrap` > `.data-table`, `.col-num`, `.col-actions`, `.data-table__empty`, `.table-foot` | The table, always in its scroll wrapper: ordinary headers and data align left; `.col-num` uses tabular figures without changing alignment; `.col-actions` aligns right; empty-state rows stay centered; the footer hosts pagination. |
 | `.empty-state` | The same centered, muted empty treatment for non-table content. |
 | `.field`, `.field__label`, `.field__input`, `.field__hint`, `.field__hint--error` | A labelled form field. |
 | `.addbox`, `.addbox--modal`, `.addbox__panel`, `.addbox__head`, `.addbox__x`, `.addbox__actions` | The `<details>` disclosure for create/add flows; `--modal` centers it as a dialog. |

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1502,11 +1502,10 @@ select.field__input {
 }
 
 .col-num {
-  text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-.col-actions {
+.data-table .col-actions {
   text-align: right;
   width: 64px;
 }
@@ -2610,6 +2609,7 @@ details.json-fold[open] > summary .icon {
   padding: 9px 14px;
   border-bottom: 1px solid var(--surface-border);
   color: var(--text);
+  text-align: left;
   vertical-align: top;
 }
 
@@ -2617,7 +2617,7 @@ details.json-fold[open] > summary .icon {
   border-bottom: 0;
 }
 
-.data-table__empty td,
+.data-table .data-table__empty td,
 .empty-state {
   margin: 0;
   color: var(--muted);

--- a/crates/ui/e2e/tests/design-system.spec.ts
+++ b/crates/ui/e2e/tests/design-system.spec.ts
@@ -101,6 +101,66 @@ test("every page <h1> uses the canonical .page-head__title", async ({ page, requ
   expect(offenders, `page titles off the canonical class:\n${offenders.join("\n")}`).toEqual([]);
 });
 
+test("every rendered table uses the canonical .data-table", async ({ page, request }) => {
+  const offenders: string[] = [];
+  for (const route of [...ROUTES, await seedBulkImportDetail(request)]) {
+    await page.goto(route, { waitUntil: "networkidle" });
+    const tables = await page.$$eval("table:not(.data-table)", (nodes) =>
+      nodes.map((node) => {
+        const id = node.id ? `#${node.id}` : "";
+        const classes = Array.from(node.classList)
+          .map((name) => `.${name}`)
+          .join("");
+        return `${node.tagName.toLowerCase()}${id}${classes}`;
+      }),
+    );
+    for (const table of tables) offenders.push(`${route}: ${table}`);
+  }
+  expect(offenders, `tables off the canonical class:\n${offenders.join("\n")}`).toEqual([]);
+});
+
+test("data tables share one alignment contract", async ({ page }) => {
+  await page.goto("/ui");
+  await page.evaluate(() => {
+    const probe = document.createElement("table");
+    probe.id = "data-table-contract";
+    probe.className = "data-table";
+    probe.innerHTML = `
+      <thead>
+        <tr>
+          <th data-probe="ordinary-header">Name</th>
+          <th class="col-num" data-probe="numeric-header">Count</th>
+          <th class="col-actions" data-probe="actions-header">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td data-probe="ordinary-cell">Example</td>
+          <td class="col-num" data-probe="numeric-cell">123</td>
+          <td class="col-actions" data-probe="actions-cell"></td>
+        </tr>
+        <tr class="data-table__empty">
+          <td class="col-actions" colspan="3" data-probe="empty-cell">No results</td>
+        </tr>
+      </tbody>
+    `;
+    document.body.append(probe);
+  });
+
+  const probe = page.locator("#data-table-contract");
+  for (const name of ["ordinary-header", "ordinary-cell", "numeric-header", "numeric-cell"]) {
+    await expect(probe.locator(`[data-probe='${name}']`)).toHaveCSS("text-align", "left");
+  }
+  for (const name of ["numeric-header", "numeric-cell"]) {
+    await expect(probe.locator(`[data-probe='${name}']`)).toHaveCSS("font-variant-numeric", "tabular-nums");
+  }
+  for (const name of ["actions-header", "actions-cell"]) {
+    const action = probe.locator(`[data-probe='${name}']`);
+    await expect(action).toHaveCSS("text-align", "right");
+  }
+  await expect(probe.locator("[data-probe='empty-cell']")).toHaveCSS("text-align", "center");
+});
+
 test("ordinary actions resolve to the canonical button scale on every page", async ({ page, request }) => {
   const offenders: string[] = [];
   const primaryColors = new Map<string, string[]>();

--- a/crates/ui/e2e/tests/tenants.spec.ts
+++ b/crates/ui/e2e/tests/tenants.spec.ts
@@ -30,12 +30,19 @@ test.describe("tenants", () => {
     await expect(tenants.addForm).toBeHidden();
     // …and the table reports the in-flight job, surviving a reload.
     const row = tenants.row(id);
+    const resourcesHeader = tenants.page.locator(".data-table th.col-num");
+    const resourcesCell = row.locator("td.col-num");
+    await expect(resourcesHeader).toHaveCSS("text-align", "left");
     await expect(row.locator(".spinner")).toBeVisible();
+    await expect(resourcesCell).toHaveCSS("text-align", "left");
+    await expect(resourcesCell).toHaveCSS("font-variant-numeric", "tabular-nums");
     await tenants.page.reload();
     await expect(tenants.row(id).locator(".spinner")).toBeVisible();
     // Eventually the job settles into a normal row.
     await expect(tenants.row(id).locator("[hx-delete]")).toBeVisible({ timeout: 240_000 });
     await expect(tenants.row(id).locator(".spinner")).toHaveCount(0);
+    await expect(resourcesCell).toHaveCSS("text-align", "left");
+    await expect(resourcesCell).toHaveCSS("font-variant-numeric", "tabular-nums");
   });
 
   test("the search box filters the table (htmx)", async ({ page, tenants }) => {


### PR DESCRIPTION
Closes #758

## What changed

- Align ordinary and numeric data-table headers and cells to the left throughout the UI.
- Keep tabular figures for numeric columns.
- Keep action columns right-aligned, with matching header and cell alignment.
- Keep empty rows centered, including when an empty cell also has the action-column class.
- Document and test the shared alignment rules.

Tenant resource counts now line up with the `Resources` header. Capability tables, dashboard data, subscription metrics, and dynamic query results use the same rules without route-specific overrides. Diff and history grids are unchanged because they do not use the data-table component.

## Validation

- `cargo test -p helios-ui` with 230 passing tests
- `cargo build -p helios-hfs --features ui,subscriptions`
- Focused Chromium tests
- Full Playwright suite with 288 passing and 4 skipped tests
- Manual checks at desktop and compact sizes, plus dark theme and dynamic FHIR results

## Risk

The CSS changes only affect `.data-table` and its documented column classes. There are no backend, API, persistence, or dependency changes.
