### PR TITLE
ui: make Capability Statement capabilities navigable and filterable

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -42,6 +42,41 @@
 }
 }
 
+@layer pages {
+/* CapabilityStatement-only presentation: keep the backend note subordinate to
+   its interaction tags, and let the resource filter fit a phone-width card. */
+.cap-transaction-note {
+  margin: 8px 0 0 16px;
+  padding-left: 10px;
+  border-left: 2px solid var(--surface-border);
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.cap-resource-filter {
+  flex: 0 1 280px;
+  min-width: 0;
+}
+
+.cap-resource-filter input {
+  width: 100%;
+  min-width: 0;
+}
+
+@media (max-width: 520px) {
+  .cap-resource-card > .card-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cap-resource-filter {
+    flex-basis: auto;
+    width: 100%;
+  }
+}
+}
+
 @layer tokens {
 :root {
   color-scheme: light;

--- a/crates/ui/e2e/pages/capability-statement.ts
+++ b/crates/ui/e2e/pages/capability-statement.ts
@@ -1,0 +1,25 @@
+// Live CapabilityStatement viewer (/ui/capability-statement): system and
+// resource capabilities, the progressively enhanced type filter, and raw JSON.
+import type { Locator, Page } from "@playwright/test";
+
+export class CapabilityStatementPage {
+  constructor(readonly page: Page) {}
+
+  async goto(query = ""): Promise<void> {
+    await this.page.goto(`/ui/capability-statement${query}`, { waitUntil: "networkidle" });
+  }
+
+  get filter(): Locator {
+    return this.page.locator('input[name="filter"]');
+  }
+
+  get resourceTable(): Locator {
+    return this.page.locator("#cap-resource-table");
+  }
+
+  resourceRow(resourceType: string): Locator {
+    return this.resourceTable.locator("tbody tr", {
+      has: this.page.getByRole("link", { name: resourceType, exact: true }),
+    });
+  }
+}

--- a/crates/ui/e2e/pages/fixtures.ts
+++ b/crates/ui/e2e/pages/fixtures.ts
@@ -12,6 +12,7 @@ import { SearchPage } from "./search";
 import { SearchParametersPage } from "./search-parameters";
 import { TenantsPage } from "./tenants";
 import { BulkImportPage } from "./bulk-import";
+import { CapabilityStatementPage } from "./capability-statement";
 
 type Fixtures = {
   chrome: AppChrome;
@@ -24,6 +25,7 @@ type Fixtures = {
   searchParameters: SearchParametersPage;
   tenants: TenantsPage;
   bulkImport: BulkImportPage;
+  capabilityStatement: CapabilityStatementPage;
 };
 
 export const test = base.extend<Fixtures>({
@@ -50,6 +52,7 @@ export const test = base.extend<Fixtures>({
   searchParameters: async ({ page }, use) => use(new SearchParametersPage(page)),
   tenants: async ({ page }, use) => use(new TenantsPage(page)),
   bulkImport: async ({ page }, use) => use(new BulkImportPage(page)),
+  capabilityStatement: async ({ page }, use) => use(new CapabilityStatementPage(page)),
 });
 
 export { expect };

--- a/crates/ui/e2e/tests/capability-statement.spec.ts
+++ b/crates/ui/e2e/tests/capability-statement.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "../pages/fixtures";
+
+test("typing filters resource capabilities live", async ({ capabilityStatement }) => {
+  await capabilityStatement.goto();
+  await expect(capabilityStatement.resourceRow("Patient")).toBeVisible();
+  await expect(capabilityStatement.resourceRow("Observation")).toBeVisible();
+
+  await capabilityStatement.filter.fill("Patient");
+
+  await expect(capabilityStatement.resourceRow("Patient")).toBeVisible();
+  await expect(capabilityStatement.resourceRow("Observation")).toHaveCount(0);
+});
+
+test("the resource filter stacks inside the card at phone width", async ({
+  page,
+  capabilityStatement,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await capabilityStatement.goto();
+
+  const header = page.locator(".cap-resource-card > .card-head");
+  const filter = page.locator(".cap-resource-filter");
+  await expect(header).toHaveCSS("flex-direction", "column");
+  await expect(filter).toBeVisible();
+
+  const headerBox = await header.boundingBox();
+  const filterBox = await filter.boundingBox();
+  expect(headerBox).not.toBeNull();
+  expect(filterBox).not.toBeNull();
+  expect(filterBox!.x).toBeGreaterThanOrEqual(headerBox!.x);
+  expect(filterBox!.x + filterBox!.width).toBeLessThanOrEqual(
+    headerBox!.x + headerBox!.width + 1,
+  );
+});

--- a/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
+++ b/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
@@ -89,6 +89,19 @@ test("the Resources type rail navigates via plain links with no JavaScript", asy
   await expect(item).toHaveAttribute("aria-current", "true");
 });
 
+test("the CapabilityStatement filter submits a GET form with no JavaScript", async ({
+  page,
+  capabilityStatement,
+}) => {
+  await capabilityStatement.goto();
+  await capabilityStatement.filter.fill("Patient");
+  await capabilityStatement.filter.press("Enter");
+
+  await expect(page).toHaveURL(/\/ui\/capability-statement\?filter=Patient$/);
+  await expect(capabilityStatement.resourceRow("Patient")).toBeVisible();
+  await expect(capabilityStatement.resourceRow("Observation")).toHaveCount(0);
+});
+
 test("a hard navigation returns the full page, not an htmx fragment", async ({ page, chrome }) => {
   // /ui/status is fragment-or-full depending on HX-Request; a plain load (no JS,
   // no htmx header) must get the whole document.

--- a/crates/ui/src/capability.rs
+++ b/crates/ui/src/capability.rs
@@ -127,29 +127,35 @@ pub(crate) struct CapabilitySummary {
     pub formats: Vec<String>,
 }
 
-/// One system-level interaction (`rest[0].interaction`). `transaction` is
-/// advertised only when the backend supports atomicity while `batch` is
-/// unconditional — the flag lets the template say so instead of rendering an
-/// undifferentiated list.
+/// One system-level interaction (`rest[0].interaction`).
 pub(crate) struct SystemInteraction {
     pub code: String,
-    pub conditional: bool,
+    pub href: String,
+    pub tag_class: &'static str,
 }
 
-/// One server operation (`rest[0].operation`), with its OperationDefinition
-/// link when the definition points at this server.
+/// One server operation (`rest[0].operation`).
 pub(crate) struct OperationRow {
     pub name: String,
-    /// A same-server `/OperationDefinition/{id}` path, when the canonical
-    /// resolves locally; external canonicals render as plain text.
-    pub definition_path: String,
+    /// An absolute HTTP(S) canonical, without its optional `|version` suffix.
+    /// Empty when the advertised definition is not safe to navigate to.
+    pub definition_href: String,
     pub definition: String,
+}
+
+/// An interaction code and the semantic tag style used across UI tables.
+pub(crate) struct InteractionTag {
+    pub code: String,
+    pub tag_class: &'static str,
 }
 
 /// One per-resource row (`rest[0].resource[]`).
 pub(crate) struct ResourceRow {
     pub resource_type: String,
-    pub interactions: Vec<String>,
+    /// A safe advertised profile, or the version's official core resource
+    /// page. Empty only when neither is safe to construct.
+    pub resource_href: String,
+    pub interactions: Vec<InteractionTag>,
     pub search_param_count: usize,
     pub include_count: usize,
     pub revinclude_count: usize,
@@ -160,6 +166,9 @@ pub(crate) struct CapabilityView {
     pub interactions: Vec<SystemInteraction>,
     pub operations: Vec<OperationRow>,
     pub resources: Vec<ResourceRow>,
+    /// The explanatory backend-role note is rendered once, even if malformed
+    /// metadata advertises the transaction interaction more than once.
+    pub has_conditional_transaction: bool,
 }
 
 fn str_at<'a>(value: &'a Value, path: &[&str]) -> &'a str {
@@ -184,7 +193,7 @@ fn arr<'a>(value: &'a Value, key: &str) -> &'a [Value] {
 /// Projects the raw CapabilityStatement into the page's view. Defensive over
 /// the JSON: absent fields render empty, never panic — the statement shape
 /// varies with enabled features and FHIR version.
-pub(crate) fn build_view(statement: &Value) -> CapabilityView {
+pub(crate) fn build_view(statement: &Value, version: FhirVersion) -> CapabilityView {
     let rest = arr(statement, "rest")
         .first()
         .cloned()
@@ -204,48 +213,61 @@ pub(crate) fn build_view(statement: &Value) -> CapabilityView {
             .collect(),
     };
 
-    let interactions = arr(&rest, "interaction")
+    let interactions: Vec<SystemInteraction> = arr(&rest, "interaction")
         .iter()
         .map(|i| {
             let code = str_at(i, &["code"]).to_string();
             SystemInteraction {
-                // `transaction` only appears when the backend is atomic;
-                // `batch` always does. Mark the conditional one.
-                conditional: code == "transaction",
+                href: system_interaction_href(version, &code).unwrap_or_default(),
+                tag_class: interaction_tag_class(&code),
                 code,
             }
         })
         .collect();
+    let has_conditional_transaction = interactions.iter().any(|i| i.code == "transaction");
 
     let operations = arr(&rest, "operation")
         .iter()
         .map(|o| {
             let definition = str_at(o, &["definition"]).to_string();
-            // A canonical of this server's own OperationDefinition gets a
-            // relative, clickable path; foreign canonicals stay text.
-            let definition_path = definition
-                .find("/OperationDefinition/")
-                .map(|i| definition[i..].to_string())
-                .unwrap_or_default();
             OperationRow {
                 name: str_at(o, &["name"]).to_string(),
-                definition_path,
+                definition_href: safe_canonical_href(&definition).unwrap_or_default(),
                 definition,
             }
         })
         .collect();
 
+    let registry = packs::core_registry(version);
     let resources = arr(&rest, "resource")
         .iter()
-        .map(|r| ResourceRow {
-            resource_type: str_at(r, &["type"]).to_string(),
-            interactions: arr(r, "interaction")
-                .iter()
-                .map(|i| str_at(i, &["code"]).to_string())
-                .collect(),
-            search_param_count: arr(r, "searchParam").len(),
-            include_count: arr(r, "searchInclude").len(),
-            revinclude_count: arr(r, "searchRevInclude").len(),
+        .map(|r| {
+            let resource_type = str_at(r, &["type"]).to_string();
+            let advertised_profile = str_at(r, &["profile"]);
+            let resource_href = safe_canonical_href(advertised_profile).unwrap_or_else(|| {
+                registry
+                    .resolve(&resource_type)
+                    .is_some_and(|schema| editor::is_resource(&schema))
+                    .then(|| resource_definition_href(version, &resource_type))
+                    .unwrap_or_default()
+            });
+            ResourceRow {
+                resource_type,
+                resource_href,
+                interactions: arr(r, "interaction")
+                    .iter()
+                    .map(|i| {
+                        let code = str_at(i, &["code"]).to_string();
+                        InteractionTag {
+                            tag_class: interaction_tag_class(&code),
+                            code,
+                        }
+                    })
+                    .collect(),
+                search_param_count: arr(r, "searchParam").len(),
+                include_count: arr(r, "searchInclude").len(),
+                revinclude_count: arr(r, "searchRevInclude").len(),
+            }
         })
         .collect();
 
@@ -254,6 +276,68 @@ pub(crate) fn build_view(statement: &Value) -> CapabilityView {
         interactions,
         operations,
         resources,
+        has_conditional_transaction,
+    }
+}
+
+fn fhir_docs_root(version: FhirVersion) -> &'static str {
+    match version {
+        #[cfg(feature = "R4")]
+        FhirVersion::R4 => "https://hl7.org/fhir/R4/",
+        #[cfg(feature = "R4B")]
+        FhirVersion::R4B => "https://hl7.org/fhir/R4B/",
+        #[cfg(feature = "R5")]
+        FhirVersion::R5 => "https://hl7.org/fhir/R5/",
+        #[cfg(feature = "R6")]
+        FhirVersion::R6 => "https://build.fhir.org/",
+    }
+}
+
+fn system_interaction_href(version: FhirVersion, code: &str) -> Option<String> {
+    let fragment = match code {
+        "transaction" => "http.html#transaction",
+        "batch" => "http.html#batch",
+        "search-system" => "http.html#search",
+        "history-system" => "http.html#history",
+        _ => return None,
+    };
+    Some(format!("{}{fragment}", fhir_docs_root(version)))
+}
+
+fn resource_definition_href(version: FhirVersion, resource_type: &str) -> String {
+    // Callers validate the type against the version's schema registry before
+    // deriving a path. Core resource pages use lowercase ASCII slugs.
+    format!(
+        "{}{resource_slug}.html",
+        fhir_docs_root(version),
+        resource_slug = resource_type.to_ascii_lowercase()
+    )
+}
+
+/// Returns an absolute HTTP(S) canonical stripped of its optional FHIR
+/// `|version` qualifier. Everything else stays visible as plain text.
+fn safe_canonical_href(canonical: &str) -> Option<String> {
+    let fragment_start = canonical.find('#').unwrap_or(canonical.len());
+    let before_fragment = &canonical[..fragment_start];
+    let fragment = &canonical[fragment_start..];
+    let base = before_fragment
+        .split_once('|')
+        .map_or(before_fragment, |(url, _)| url);
+    let raw = format!("{base}{fragment}");
+    let parsed = reqwest::Url::parse(&raw).ok()?;
+    matches!(parsed.scheme(), "http" | "https")
+        .then(|| parsed.has_host())
+        .filter(|has_host| *has_host)
+        .map(|_| raw)
+}
+
+fn interaction_tag_class(code: &str) -> &'static str {
+    match code {
+        "read" | "vread" | "search-type" | "search-system" | "history-instance"
+        | "history-type" | "history-system" => "tag--member",
+        "create" | "update" | "patch" | "batch" | "transaction" => "tag--config",
+        "delete" => "tag--excluded",
+        _ => "tag--muted",
     }
 }
 
@@ -263,6 +347,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    #[cfg(feature = "R4")]
     fn projects_the_statement_defensively() {
         let statement = json!({
             "resourceType": "CapabilityStatement",
@@ -285,38 +370,236 @@ mod tests {
                 }]
             }]
         });
-        let view = build_view(&statement);
+        let view = build_view(&statement, FhirVersion::R4);
         assert_eq!(view.summary.fhir_version, "4.0.1");
         assert_eq!(view.summary.formats.len(), 1);
         assert!(
             view.interactions
                 .iter()
-                .any(|i| i.code == "transaction" && i.conditional)
+                .any(|i| i.code == "transaction" && i.tag_class == "tag--config")
         );
         assert!(
             view.interactions
                 .iter()
-                .any(|i| i.code == "batch" && !i.conditional)
-        );
-        // Any /OperationDefinition/{id} canonical links relatively: the
-        // statement this server emits advertises its own definitions, and
-        // GET /OperationDefinition/{id} is routed.
-        assert_eq!(
-            view.operations[0].definition_path,
-            "/OperationDefinition/export"
+                .any(|i| i.code == "batch" && i.tag_class == "tag--config")
         );
         assert_eq!(
-            view.operations[1].definition_path,
-            "/OperationDefinition/run"
+            view.operations[0].definition_href,
+            "http://x/OperationDefinition/export"
+        );
+        assert_eq!(
+            view.operations[1].definition_href,
+            "http://sql-on-fhir.org/OperationDefinition/run"
+        );
+        assert!(view.has_conditional_transaction);
+        assert_eq!(
+            view.resources[0].resource_href,
+            "https://hl7.org/fhir/R4/patient.html"
         );
         assert_eq!(view.resources[0].search_param_count, 2);
         assert_eq!(view.resources[0].include_count, 1);
         assert_eq!(view.resources[0].revinclude_count, 0);
 
         // An empty statement renders empty, never panics.
-        let empty = build_view(&json!({}));
+        let empty = build_view(&json!({}), FhirVersion::R4);
         assert!(empty.resources.is_empty());
         assert!(empty.summary.fhir_version.is_empty());
+    }
+
+    #[test]
+    fn fhir_documentation_roots_are_version_aware() {
+        #[cfg(feature = "R4")]
+        assert_eq!(fhir_docs_root(FhirVersion::R4), "https://hl7.org/fhir/R4/");
+        #[cfg(feature = "R4B")]
+        assert_eq!(
+            fhir_docs_root(FhirVersion::R4B),
+            "https://hl7.org/fhir/R4B/"
+        );
+        #[cfg(feature = "R5")]
+        assert_eq!(fhir_docs_root(FhirVersion::R5), "https://hl7.org/fhir/R5/");
+        #[cfg(feature = "R6")]
+        assert_eq!(fhir_docs_root(FhirVersion::R6), "https://build.fhir.org/");
+    }
+
+    #[test]
+    fn core_resource_fallbacks_follow_each_enabled_version_root() {
+        fn assert_fallback(version: FhirVersion, expected: &str) {
+            let statement = json!({"rest": [{"resource": [{"type": "Patient"}]}]});
+            let view = build_view(&statement, version);
+            assert_eq!(view.resources[0].resource_href, expected);
+        }
+
+        #[cfg(feature = "R4")]
+        assert_fallback(FhirVersion::R4, "https://hl7.org/fhir/R4/patient.html");
+        #[cfg(feature = "R4B")]
+        assert_fallback(FhirVersion::R4B, "https://hl7.org/fhir/R4B/patient.html");
+        #[cfg(feature = "R5")]
+        assert_fallback(FhirVersion::R5, "https://hl7.org/fhir/R5/patient.html");
+        #[cfg(feature = "R6")]
+        assert_fallback(FhirVersion::R6, "https://build.fhir.org/patient.html");
+    }
+
+    #[test]
+    #[cfg(feature = "R4")]
+    fn system_interactions_have_exact_links_and_semantic_classes() {
+        let statement = json!({"rest": [{"interaction": [
+            {"code": "transaction"}, {"code": "batch"},
+            {"code": "search-system"}, {"code": "history-system"},
+            {"code": "read"}, {"code": "delete"}, {"code": "future-code"}
+        ]}]});
+        let view = build_view(&statement, FhirVersion::R4);
+
+        let link = |code: &str| {
+            view.interactions
+                .iter()
+                .find(|interaction| interaction.code == code)
+                .map(|interaction| interaction.href.as_str())
+                .unwrap()
+        };
+        assert_eq!(
+            link("transaction"),
+            "https://hl7.org/fhir/R4/http.html#transaction"
+        );
+        assert_eq!(link("batch"), "https://hl7.org/fhir/R4/http.html#batch");
+        assert_eq!(
+            link("search-system"),
+            "https://hl7.org/fhir/R4/http.html#search"
+        );
+        assert_eq!(
+            link("history-system"),
+            "https://hl7.org/fhir/R4/http.html#history"
+        );
+        assert_eq!(link("read"), "");
+        assert_eq!(link("future-code"), "");
+
+        let class = |code: &str| {
+            view.interactions
+                .iter()
+                .find(|interaction| interaction.code == code)
+                .map(|interaction| interaction.tag_class)
+                .unwrap()
+        };
+        assert_eq!(class("transaction"), "tag--config");
+        assert_eq!(class("read"), "tag--member");
+        assert_eq!(class("delete"), "tag--excluded");
+        assert_eq!(class("future-code"), "tag--muted");
+    }
+
+    #[test]
+    fn system_interaction_links_follow_each_enabled_version_root() {
+        fn assert_links(version: FhirVersion, root: &str) {
+            for (code, fragment) in [
+                ("transaction", "http.html#transaction"),
+                ("batch", "http.html#batch"),
+                ("search-system", "http.html#search"),
+                ("history-system", "http.html#history"),
+            ] {
+                assert_eq!(
+                    system_interaction_href(version, code),
+                    Some(format!("{root}{fragment}"))
+                );
+            }
+            assert_eq!(system_interaction_href(version, "unknown"), None);
+        }
+
+        #[cfg(feature = "R4")]
+        assert_links(FhirVersion::R4, "https://hl7.org/fhir/R4/");
+        #[cfg(feature = "R4B")]
+        assert_links(FhirVersion::R4B, "https://hl7.org/fhir/R4B/");
+        #[cfg(feature = "R5")]
+        assert_links(FhirVersion::R5, "https://hl7.org/fhir/R5/");
+        #[cfg(feature = "R6")]
+        assert_links(FhirVersion::R6, "https://build.fhir.org/");
+    }
+
+    #[test]
+    fn interaction_codes_use_the_semantic_tag_palette() {
+        for code in [
+            "read",
+            "vread",
+            "search-type",
+            "search-system",
+            "history-instance",
+            "history-type",
+            "history-system",
+        ] {
+            assert_eq!(interaction_tag_class(code), "tag--member", "{code}");
+        }
+        for code in ["create", "update", "patch", "batch", "transaction"] {
+            assert_eq!(interaction_tag_class(code), "tag--config", "{code}");
+        }
+        assert_eq!(interaction_tag_class("delete"), "tag--excluded");
+        assert_eq!(interaction_tag_class("future-code"), "tag--muted");
+    }
+
+    #[test]
+    fn canonicals_are_safe_and_strip_the_fhir_version_qualifier() {
+        assert_eq!(
+            safe_canonical_href("https://example.org/OperationDefinition/export|1.2.3"),
+            Some("https://example.org/OperationDefinition/export".to_string())
+        );
+        assert_eq!(
+            safe_canonical_href("http://example.org/StructureDefinition/Patient"),
+            Some("http://example.org/StructureDefinition/Patient".to_string())
+        );
+        assert_eq!(
+            safe_canonical_href("https://example.org/Profile|1.0#details"),
+            Some("https://example.org/Profile#details".to_string())
+        );
+        assert_eq!(
+            safe_canonical_href("https://example.org/Profile#details|part"),
+            Some("https://example.org/Profile#details|part".to_string())
+        );
+        for unsafe_value in [
+            "OperationDefinition/export",
+            "/OperationDefinition/export",
+            "javascript:alert(1)",
+            "urn:oid:1.2.3",
+            "https://",
+            "not a URL",
+        ] {
+            assert_eq!(safe_canonical_href(unsafe_value), None, "{unsafe_value}");
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "R4")]
+    fn safe_profiles_precede_known_fallbacks_and_unknown_unsafe_types_stay_plain() {
+        let statement = json!({"rest": [{"resource": [
+            {"type": "Patient", "profile": "https://example.org/Patient|2.0"},
+            {"type": "Observation", "profile": "javascript:alert(1)"},
+            {"type": "NotARealResource", "profile": "https://example.org/custom"},
+            {"type": "UnknownUnsafe", "profile": "javascript:alert(2)"},
+            {"type": "UnknownMissing"},
+            {"type": "<script>"}
+        ]}]});
+        let view = build_view(&statement, FhirVersion::R4);
+
+        assert_eq!(
+            view.resources[0].resource_href,
+            "https://example.org/Patient"
+        );
+        assert_eq!(
+            view.resources[1].resource_href,
+            "https://hl7.org/fhir/R4/observation.html"
+        );
+        assert_eq!(
+            view.resources[2].resource_href,
+            "https://example.org/custom"
+        );
+        assert!(view.resources[3].resource_href.is_empty());
+        assert!(view.resources[4].resource_href.is_empty());
+        assert!(view.resources[5].resource_href.is_empty());
+    }
+
+    #[test]
+    #[cfg(feature = "R4")]
+    fn duplicate_transactions_produce_one_note_state() {
+        let statement = json!({"rest": [{"interaction": [
+            {"code": "transaction"}, {"code": "transaction"}
+        ]}]});
+        let view = build_view(&statement, FhirVersion::R4);
+        assert!(view.has_conditional_transaction);
     }
 
     #[test]

--- a/crates/ui/src/capability.rs
+++ b/crates/ui/src/capability.rs
@@ -245,11 +245,14 @@ pub(crate) fn build_view(statement: &Value, version: FhirVersion) -> CapabilityV
             let resource_type = str_at(r, &["type"]).to_string();
             let advertised_profile = str_at(r, &["profile"]);
             let resource_href = safe_canonical_href(advertised_profile).unwrap_or_else(|| {
-                registry
+                if registry
                     .resolve(&resource_type)
                     .is_some_and(|schema| editor::is_resource(&schema))
-                    .then(|| resource_definition_href(version, &resource_type))
-                    .unwrap_or_default()
+                {
+                    resource_definition_href(version, &resource_type)
+                } else {
+                    String::new()
+                }
             });
             ResourceRow {
                 resource_type,

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -2695,8 +2695,14 @@ struct CapabilityPage {
     active_page: &'static str,
     /// `None` when the self-fetch failed — the page degrades to a warning.
     view: Option<capability::CapabilityView>,
-    /// Pretty-printed raw statement for the foldable block.
+    /// Highlighted, foldable JSON when the statement fits the render budget.
+    json_lines: Vec<json_view::JsonLine>,
+    json_view_id: String,
+    json_view_paths: bool,
+    /// Pretty-printed raw statement when highlighted rendering exceeds its
+    /// budget. Askama escapes it inside the fallback `<pre>`.
     raw: String,
+    raw_fallback: bool,
     /// The server-side resource-type filter, echoed back into the form.
     filter: String,
 }
@@ -2715,20 +2721,38 @@ async fn capability_page(
 ) -> Response {
     let filter = query.filter.unwrap_or_default();
     let fetched = state.conformance.metadata(rv.0, &rt.id).await;
-    let (view, raw) = match fetched {
+    let (view, json_lines, raw, raw_fallback) = match fetched {
         Ok(statement) => {
-            let mut view = capability::build_view(&statement);
+            let mut view = capability::build_view(&statement, rv.0);
             if !filter.is_empty() {
                 let needle = filter.to_lowercase();
                 view.resources
                     .retain(|r| r.resource_type.to_lowercase().contains(&needle));
             }
-            let raw = serde_json::to_string_pretty(&statement).unwrap_or_default();
-            (Some(view), raw)
+            const MAX_LINES: usize = 4_000;
+            const MAX_ESTIMATED_HTML_BYTES: usize = 2 * 1024 * 1024;
+            match json_view::try_lines(
+                &statement,
+                json_view::RenderOptions {
+                    include_paths: false,
+                    budget: Some(json_view::RenderBudget {
+                        max_lines: MAX_LINES,
+                        max_estimated_html_bytes: MAX_ESTIMATED_HTML_BYTES,
+                    }),
+                },
+            ) {
+                Ok(lines) => (Some(view), lines, String::new(), false),
+                Err(_) => (
+                    Some(view),
+                    Vec::new(),
+                    serde_json::to_string_pretty(&statement).unwrap_or_default(),
+                    true,
+                ),
+            }
         }
         Err(error) => {
             tracing::warn!("CapabilityStatement self-fetch failed: {error}");
-            (None, String::new())
+            (None, Vec::new(), String::new(), false)
         }
     };
     render(CapabilityPage {
@@ -2736,7 +2760,11 @@ async fn capability_page(
         i18n: I18n::new(locale),
         active_page: "capability-statement",
         view,
+        json_lines,
+        json_view_id: "capability-json".to_string(),
+        json_view_paths: false,
         raw,
+        raw_fallback,
         filter,
     })
 }

--- a/crates/ui/templates/pages/capability-statement.html
+++ b/crates/ui/templates/pages/capability-statement.html
@@ -31,12 +31,20 @@
   <div class="card__body">
     <p>
       {% for i in view.interactions %}
-      <span class="tag">{{ i.code }}</span>
+      {% if !i.href.is_empty() %}
+      <a class="tag {{ i.tag_class }}" href="{{ i.href }}" target="_blank" rel="noopener">{{ i.code }}</a>
+      {% else %}
+      <span class="tag {{ i.tag_class }}">{{ i.code }}</span>
+      {% endif %}
       {% endfor %}
     </p>
-    {% for i in view.interactions %}{% if i.conditional %}
-    <p class="page-head__lede">{{ i18n.t("cap-transaction-note") }}</p>
-    {% endif %}{% endfor %}
+    {% if view.has_conditional_transaction %}
+    <p class="cap-transaction-note">
+      {{ i18n.t("cap-transaction-note") }}
+      <a href="https://github.com/HeliosSoftware/hfs/blob/main/crates/persistence/README.md#primarysecondary-role-matrix"
+         target="_blank" rel="noopener">{{ i18n.t("cap-role-matrix") }}</a>
+    </p>
+    {% endif %}
   </div>
 </section>
 
@@ -54,8 +62,8 @@
         <tr>
           <td>${{ op.name }}</td>
           <td>
-            {% if !op.definition_path.is_empty() %}
-            <a class="url" href="{{ op.definition_path }}">{{ op.definition }}</a>
+            {% if !op.definition_href.is_empty() %}
+            <a class="url" href="{{ op.definition_href }}" target="_blank" rel="noopener">{{ op.definition }}</a>
             {% else %}
             <span class="url">{{ op.definition }}</span>
             {% endif %}
@@ -67,17 +75,21 @@
   </div>
 </section>
 
-<section class="card table-card">
+<section class="card table-card cap-resource-card">
   <div class="card-head">
     <h3>{{ i18n.t("cap-resources-heading") }}</h3>
     <!-- Server-side narrowing: a plain GET form, so it works without JS. -->
-    <form class="filter-rail__search" method="get" action="/ui/capability-statement" role="search">
+    <form class="filter-rail__search cap-resource-filter" method="get" action="/ui/capability-statement" role="search">
       <input type="search" name="filter" value="{{ filter }}"
              placeholder="{{ i18n.t("cap-filter-placeholder") }}"
-             aria-label="{{ i18n.t("cap-filter-placeholder") }}">
+             aria-label="{{ i18n.t("cap-filter-placeholder") }}"
+             hx-get="/ui/capability-statement" hx-include="closest form"
+             hx-trigger="input changed delay:300ms, search"
+             hx-target="#cap-resource-table" hx-select="#cap-resource-table"
+             hx-swap="outerHTML">
     </form>
   </div>
-  <div class="table-wrap">
+  <div class="table-wrap" id="cap-resource-table">
     <table class="data-table">
       <thead>
         <tr>
@@ -91,8 +103,14 @@
       <tbody>
         {% for r in view.resources %}
         <tr>
-          <td>{{ r.resource_type }}</td>
-          <td>{% for i in r.interactions %}<span class="tag">{{ i }}</span> {% endfor %}</td>
+          <td>
+            {% if !r.resource_href.is_empty() %}
+            <a href="{{ r.resource_href }}" target="_blank" rel="noopener">{{ r.resource_type }}</a>
+            {% else %}
+            <span>{{ r.resource_type }}</span>
+            {% endif %}
+          </td>
+          <td>{% for i in r.interactions %}<span class="tag {{ i.tag_class }}">{{ i.code }}</span> {% endfor %}</td>
           <td class="col-num">{{ r.search_param_count }}</td>
           <td class="col-num">{{ r.include_count }}</td>
           <td class="col-num">{{ r.revinclude_count }}</td>
@@ -112,7 +130,11 @@
     <span class="icon">{% include "icons/chevron-down.svg" %}</span>
   </summary>
   <div class="card__body">
+    {% if raw_fallback %}
     <pre class="detail__code">{{ raw }}</pre>
+    {% else %}
+    {% include "partials/json-view.html" %}
+    {% endif %}
   </div>
 </details>
 {% else %}

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -373,8 +373,8 @@ async fn non_ui_paths_fall_through_to_the_fhir_app() {
 }
 
 /// #653: the CapabilityStatement page renders the live /metadata answer —
-/// summary, the batch/transaction distinction, linkified local operation
-/// definitions, the filterable per-resource table, and the raw fold. Without
+/// summary, safe external documentation links, semantic interaction tags, the
+/// progressively enhanced resource filter, and highlighted raw JSON. Without
 /// a fetchable statement it degrades to the warning, never fabricates.
 #[tokio::test]
 async fn capability_statement_page_renders_summary_and_degrades() {
@@ -403,12 +403,25 @@ async fn capability_statement_page_renders_summary_and_degrades() {
         "implementation": {"description": "Helios FHIR Server", "url": "http://t/"},
         "rest": [{
             "mode": "server",
-            "interaction": [{"code": "batch"}, {"code": "transaction"}],
-            "operation": [{"name": "export", "definition": "http://t/OperationDefinition/export"}],
+            "interaction": [
+                {"code": "batch"}, {"code": "transaction"}, {"code": "transaction"},
+                {"code": "search-system"}, {"code": "history-system"},
+                {"code": "future-code"}
+            ],
+            "operation": [
+                {"name": "export", "definition": "https://example.org/OperationDefinition/export|1.2.3"},
+                {"name": "unsafe", "definition": "javascript:alert(1)"}
+            ],
             "resource": [
-                {"type": "Patient", "interaction": [{"code": "read"}],
+                {"type": "Patient", "profile": "https://example.org/StructureDefinition/Patient|2.0",
+                 "interaction": [{"code": "read"}, {"code": "delete"}],
                  "searchParam": [{"name": "name"}]},
-                {"type": "Observation", "interaction": [{"code": "read"}]}
+                {"type": "Observation", "profile": "urn:oid:1.2.3",
+                 "interaction": [{"code": "create"}, {"code": "future-code"}]},
+                {"type": "NotARealResource", "profile": "https://example.org/custom|1.0",
+                 "interaction": [{"code": "read"}]},
+                {"type": "UnknownUnsafe", "profile": "javascript:alert(2)",
+                 "interaction": [{"code": "read"}]}
             ]
         }]
     }));
@@ -437,13 +450,56 @@ async fn capability_statement_page_renders_summary_and_degrades() {
         .unwrap();
     let html = body_text(response).await;
     assert!(html.contains("4.0.1"));
-    assert!(html.contains(">batch<"));
-    assert!(html.contains(">transaction<"));
-    // The transaction-is-conditional note renders alongside the chips.
-    assert!(html.contains("atomic transactions"));
-    // Local operation definitions are clickable, at their local path.
-    assert!(html.contains(r#"href="/OperationDefinition/export""#));
+    assert!(html.contains(
+        r#"href="https://hl7.org/fhir/R4/http.html#batch" target="_blank" rel="noopener">batch</a>"#
+    ));
+    assert!(html.contains(
+        r#"href="https://hl7.org/fhir/R4/http.html#transaction" target="_blank" rel="noopener">transaction</a>"#
+    ));
+    assert!(html.contains(r#"href="https://hl7.org/fhir/R4/http.html#search""#));
+    assert!(html.contains(r#"href="https://hl7.org/fhir/R4/http.html#history""#));
+    assert!(html.contains(r#"class="tag tag--muted">future-code</span>"#));
+    // Duplicate transaction declarations still produce one subordinate note.
+    assert_eq!(html.matches("atomic transactions").count(), 1);
+    assert!(html.contains(r#"<p class="cap-transaction-note">"#));
+    assert!(!html.contains(r#"<p class="page-head__lede">atomic transactions"#));
+    assert!(html.contains("#primarysecondary-role-matrix"));
+    // Absolute HTTP(S) canonicals are clickable and their FHIR `|version`
+    // qualifier is omitted from href while remaining visible as link text.
+    assert!(html.contains(
+        r#"href="https://example.org/OperationDefinition/export" target="_blank" rel="noopener">https://example.org/OperationDefinition/export|1.2.3</a>"#
+    ));
+    assert!(html.contains("javascript:alert(1)"));
+    assert!(!html.contains(r#"href="javascript:"#));
     assert!(html.contains("$export"));
+    // Resource profiles take precedence, unsafe profiles fall back to the
+    // versioned core definition, and unknown types remain plain text.
+    assert!(html.contains(
+        r#"href="https://example.org/StructureDefinition/Patient" target="_blank" rel="noopener">Patient</a>"#
+    ));
+    assert!(html.contains(
+        r#"href="https://hl7.org/fhir/R4/observation.html" target="_blank" rel="noopener">Observation</a>"#
+    ));
+    assert!(html.contains(
+        r#"href="https://example.org/custom" target="_blank" rel="noopener">NotARealResource</a>"#
+    ));
+    assert!(html.contains("<span>UnknownUnsafe</span>"));
+    assert!(!html.contains(r#"href="javascript:alert(2)""#));
+    assert!(html.contains(r#"class="tag tag--member">read</span>"#));
+    assert!(html.contains(r#"class="tag tag--config">create</span>"#));
+    assert!(html.contains(r#"class="tag tag--excluded">delete</span>"#));
+    // The raw statement uses the shared foldable, highlighted JSON renderer.
+    assert!(html.contains(r#"class="json-view" id="capability-json""#));
+    assert!(html.contains(r#"class="jt--key""#));
+    assert!(html.contains("data-fold="));
+    assert!(!html.contains(r#"<pre class="detail__code">"#));
+    // The real GET form remains the fallback while htmx enhances live input.
+    assert!(html.contains(r#"method="get" action="/ui/capability-statement""#));
+    assert!(html.contains(r#"hx-get="/ui/capability-statement" hx-include="closest form""#));
+    assert!(html.contains(r#"hx-trigger="input changed delay:300ms, search""#));
+    assert!(html.contains(r##"hx-target="#cap-resource-table" hx-select="#cap-resource-table""##));
+    assert!(html.contains(r#"class="card table-card cap-resource-card""#));
+    assert!(html.contains(r#"class="filter-rail__search cap-resource-filter""#));
     // Both resource rows, then the server-side filter narrows to one.
     assert!(html.contains(">Patient<") && html.contains(">Observation<"));
     let response = app
@@ -456,8 +512,46 @@ async fn capability_statement_page_renders_summary_and_degrades() {
         .unwrap();
     let html = body_text(response).await;
     assert!(!html.contains(">Patient<") && html.contains(">Observation<"));
-    // The raw statement rides in the fold.
+}
+
+#[tokio::test]
+async fn capability_statement_raw_json_falls_back_with_http_200_over_budget() {
+    let oversized = Value::Array((0..4_001).map(|index| Value::from(index as u64)).collect());
+    let source =
+        helios_ui::StaticConformanceSource::from_data_dir(std::path::Path::new("../../data"))
+            .with_metadata(serde_json::json!({
+                "resourceType": "CapabilityStatement",
+                "fhirVersion": "4.0.1",
+                "extension": oversized,
+                "rest": [{"mode": "server"}]
+            }));
+    let app = helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        Some(std::path::PathBuf::from("../../data")),
+        nl(true, true),
+        None,
+        None,
+        "default".to_string(),
+        Arc::new(source),
+        helios_fhir::FhirVersion::R4,
+        None,
+        "http://localhost:8080".to_string(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::get("/ui/capability-statement")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    assert!(html.contains(r#"<pre class="detail__code">"#));
     assert!(html.contains("CapabilityStatement"));
+    assert!(!html.contains(r#"id="capability-json""#));
 }
 
 #[tokio::test]

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -750,6 +750,7 @@ cap-summary-date = Datum
 cap-summary-formats = Formate
 cap-interactions-heading = System-Interaktionen
 cap-transaction-note = transaction wird angeboten, weil das aktive Backend atomare Transaktionen unterstützt; batch ist immer verfügbar.
+cap-role-matrix = Backend-Rollenmatrix anzeigen.
 cap-operations-heading = Operationen
 cap-col-operation = Operation
 cap-col-definition = Definition

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -753,6 +753,7 @@ cap-summary-date = Date
 cap-summary-formats = Formats
 cap-interactions-heading = System Interactions
 cap-transaction-note = transaction is advertised because the active backend supports atomic transactions; batch is always available.
+cap-role-matrix = View the backend role matrix.
 cap-operations-heading = Operations
 cap-col-operation = Operation
 cap-col-definition = Definition

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -750,6 +750,7 @@ cap-summary-date = Fecha
 cap-summary-formats = Formatos
 cap-interactions-heading = Interacciones de sistema
 cap-transaction-note = transaction se anuncia porque el backend activo soporta transacciones atómicas; batch está siempre disponible.
+cap-role-matrix = Ver la matriz de roles de backend.
 cap-operations-heading = Operaciones
 cap-col-operation = Operación
 cap-col-definition = Definición


### PR DESCRIPTION
Closes #760.

## Summary

Make `/ui/capability-statement` a navigable conformance view instead of a dead-end metadata dump. Capability links now use the effective FHIR version, interaction tags are semantically grouped, filtering updates live while retaining its no-JavaScript fallback, and raw JSON reuses the shared bounded renderer.

## Changes

- Link system interactions to their version-specific FHIR REST anchors.
- Link operation definitions to safe absolute HTTP(S) canonicals and leave unsafe or relative values as text.
- Link resource types through an advertised HTTP(S) profile when available, otherwise through the version-specific core resource page.
- Preserve FHIR canonical fragments while removing only the optional `|version` qualifier from link targets.
- Open external links with native anchors using `target="_blank"` and `rel="noopener"`.
- Group read/search/history, write/configuration, destructive, and unknown interactions with the existing semantic tag palette.
- Render the transaction/backend-role explanation once, as an indented footnote linked to the persistence role matrix.
- Reuse the shared highlighted and foldable JSON view within a 4,000-line / 2 MiB budget, with an escaped HTTP-200 fallback for larger statements.
- Enhance the resource filter with HTMX while preserving the normal GET form for JavaScript-disabled clients.
- Keep the resource header/filter contained at phone widths.
- Add matching English, Spanish, and German copy.
- Add Rust HTTP/unit coverage plus focused Playwright page-object, live-filter, mobile, and no-JavaScript coverage.

The count-column alignment is supplied by merged PR #777 on the target branch; this change does not add a competing override.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p helios-ui`
- `cargo test -p helios-ui capability -- --nocapture`
- `cargo test -p helios-ui --all-features capability -- --nocapture`
- `cargo build -p helios-hfs --no-default-features --features ui,sqlite,R4,R4B,R5,R6`
- `npm run test:unit` — 8 passed
- Focused Capability Statement Playwright tests — live filtering and 390×844 layout passed
- Focused no-JavaScript GET/Enter test — passed
- Chromium accessibility, design-system, and no-CDN guards — 63 passed across light/dark coverage
- Two independent read-only code reviews followed by remediation and clean re-review

## Notes

Large CapabilityStatements intentionally fall back to escaped raw JSON rather than creating an unbounded highlighted DOM. The route remains HTTP 200 in both bounded and fallback paths.
