### PR TITLE
fix(hts): implement FHIR string search for terminology names and titles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3472,6 +3472,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "uuid",
  "zip 0.6.6",
 ]

--- a/crates/hts-ui/e2e/tests/code-systems.spec.ts
+++ b/crates/hts-ui/e2e/tests/code-systems.spec.ts
@@ -43,6 +43,32 @@ test.describe("HTS CodeSystem browser (§7.2)", () => {
     ).toBeVisible();
   });
 
+  test("Title substring keeps the browser URL bare and selects ExampleCodeSystem", async ({
+    page,
+  }) => {
+    await page.goto("/ui/hts/code-systems?title=Anatomy%20Code");
+
+    const browserUrl = new URL(page.url());
+    expect(browserUrl.searchParams.get("title")).toBe("Anatomy Code");
+    expect(browserUrl.searchParams.has("title:contains")).toBe(false);
+    await expect(page.locator("#filter-title")).toHaveValue("Anatomy Code");
+    await expect(
+      page.getByText("No CodeSystems match these filters."),
+    ).toHaveCount(0);
+
+    const rows = page.locator("table tbody tr");
+    await expect(rows).toHaveCount(1);
+    await expect(
+      rows.getByRole("link", { name: "ExampleCodeSystem", exact: true }),
+    ).toBeVisible();
+    await expect(
+      rows.getByRole("cell", {
+        name: "Example Anatomy Code System",
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+
   test("load-more appends the next page beforeend without replacing rows", async ({ page }) => {
     // The seed loader injects 34 CodeSystems total (ex-cs-1 + ex-cs-2..
     // ex-cs-31 + ex-cs-source + ex-cs-target + ex-cs-limbs). The default

--- a/crates/hts-ui/e2e/tests/concept-maps.spec.ts
+++ b/crates/hts-ui/e2e/tests/concept-maps.spec.ts
@@ -85,6 +85,32 @@ test.describe("HTS ConceptMap browser (§7.5)", () => {
     await expect(page.locator("#hts-cm-rows tbody > tr").first()).toBeVisible();
   });
 
+  test("Title substring keeps the browser URL bare and selects ExampleCM", async ({
+    page,
+  }) => {
+    await page.goto("/ui/hts/concept-maps?title=Source-to-Target");
+
+    const browserUrl = new URL(page.url());
+    expect(browserUrl.searchParams.get("title")).toBe("Source-to-Target");
+    expect(browserUrl.searchParams.has("title:contains")).toBe(false);
+    await expect(page.locator("#filter-title")).toHaveValue("Source-to-Target");
+    await expect(
+      page.getByText("No ConceptMaps match these filters."),
+    ).toHaveCount(0);
+
+    const rows = page.locator("table tbody tr");
+    await expect(rows).toHaveCount(1);
+    await expect(
+      rows.getByRole("link", { name: "ExampleCM", exact: true }),
+    ).toBeVisible();
+    await expect(
+      rows.getByRole("cell", {
+        name: "Example Source-to-Target Mapping",
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+
   test("Source system filter routes to the `source` FHIR param without narrowing the table", async ({
     page,
   }) => {

--- a/crates/hts-ui/e2e/tests/value-sets.spec.ts
+++ b/crates/hts-ui/e2e/tests/value-sets.spec.ts
@@ -57,6 +57,32 @@ test.describe("HTS ValueSet browser (Â§7.4)", () => {
       page.getByRole("cell", { name: "http://example.org/vs/limbs" }),
     ).toBeVisible();
   });
+
+  test("Title substring keeps the browser URL bare and selects ExampleLimbsVS", async ({
+    page,
+  }) => {
+    await page.goto("/ui/hts/value-sets?title=Limbs%20Value");
+
+    const browserUrl = new URL(page.url());
+    expect(browserUrl.searchParams.get("title")).toBe("Limbs Value");
+    expect(browserUrl.searchParams.has("title:contains")).toBe(false);
+    await expect(page.locator("#filter-title")).toHaveValue("Limbs Value");
+    await expect(
+      page.getByText("No ValueSets match these filters."),
+    ).toHaveCount(0);
+
+    const rows = page.locator("table tbody tr");
+    await expect(rows).toHaveCount(1);
+    await expect(
+      rows.getByRole("link", { name: "ExampleLimbsVS", exact: true }),
+    ).toBeVisible();
+    await expect(
+      rows.getByRole("cell", {
+        name: "Example Limbs Value Set",
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
 });
 
 test.describe("HTS ValueSet detail + $expand workbench (Â§7.4)", () => {

--- a/crates/hts-ui/src/upstream.rs
+++ b/crates/hts-ui/src/upstream.rs
@@ -430,6 +430,33 @@ impl OutcomeView {
     }
 }
 
+/// Build the FHIR query used by the three terminology browsers.
+///
+/// The UI's public query language stays stable (`name` and `title`), but its
+/// loopback FHIR request uses `:contains` so the filter rail keeps the
+/// substring behavior operators already expect.
+fn build_upstream_browser_query<const N: usize>(
+    filters: [(&str, &Option<String>); N],
+    count: u32,
+    offset: u32,
+) -> Vec<(String, String)> {
+    let mut query = Vec::new();
+    for (field, value) in filters {
+        let Some(value) = value.as_ref().filter(|value| !value.is_empty()) else {
+            continue;
+        };
+        let upstream_field = match field {
+            "name" => "name:contains",
+            "title" => "title:contains",
+            _ => field,
+        };
+        query.push((upstream_field.to_owned(), value.clone()));
+    }
+    query.push(("_count".to_owned(), count.to_string()));
+    query.push(("_offset".to_owned(), offset.to_string()));
+    query
+}
+
 /// Filters accepted by the CS browser page and its rows fragment.
 ///
 /// `_count` and `_offset` are parsed from strings so a malformed query
@@ -468,6 +495,23 @@ impl CsBrowserFilters {
     /// rejects the request when this is true (design doc §7.2 states matrix).
     pub fn count_exceeds_cap(&self) -> bool {
         self.count > Self::MAX_COUNT
+    }
+
+    /// Query sent from the UI process to HTS. The public browser URL keeps
+    /// the bare `name` / `title` keys, while the FHIR request asks HTS for
+    /// substring matching explicitly.
+    fn upstream_query(&self) -> Vec<(String, String)> {
+        build_upstream_browser_query(
+            [
+                ("url", &self.url),
+                ("version", &self.version),
+                ("name", &self.name),
+                ("title", &self.title),
+                ("status", &self.status),
+            ],
+            self.effective_count(),
+            self.offset,
+        )
     }
 
     /// URL for the Load-more button that preserves every active filter
@@ -843,22 +887,7 @@ impl UpstreamClient {
         &self,
         filters: &CsBrowserFilters,
     ) -> Result<CsBrowserPage, UpstreamError> {
-        let mut query: Vec<(String, String)> = Vec::new();
-        for (field, value) in [
-            ("url", &filters.url),
-            ("version", &filters.version),
-            ("name", &filters.name),
-            ("title", &filters.title),
-            ("status", &filters.status),
-        ] {
-            if let Some(v) = value {
-                if !v.is_empty() {
-                    query.push((field.to_owned(), v.clone()));
-                }
-            }
-        }
-        query.push(("_count".to_owned(), filters.effective_count().to_string()));
-        query.push(("_offset".to_owned(), filters.offset.to_string()));
+        let query = filters.upstream_query();
 
         let url = format!("{}/CodeSystem", self.base_url);
         let response = self
@@ -1579,6 +1608,22 @@ impl VsBrowserFilters {
         self.count > Self::MAX_COUNT
     }
 
+    /// Query sent from the UI process to HTS. See
+    /// [`CsBrowserFilters::upstream_query`].
+    fn upstream_query(&self) -> Vec<(String, String)> {
+        build_upstream_browser_query(
+            [
+                ("url", &self.url),
+                ("version", &self.version),
+                ("name", &self.name),
+                ("title", &self.title),
+                ("status", &self.status),
+            ],
+            self.effective_count(),
+            self.offset,
+        )
+    }
+
     /// See [`CsBrowserFilters::load_more_url`].
     pub fn load_more_url(&self, next_offset: &u32) -> String {
         let mut ser = form_urlencoded::Serializer::new(String::new());
@@ -1936,22 +1981,7 @@ impl UpstreamClient {
         &self,
         filters: &VsBrowserFilters,
     ) -> Result<VsBrowserPage, UpstreamError> {
-        let mut query: Vec<(String, String)> = Vec::new();
-        for (field, value) in [
-            ("url", &filters.url),
-            ("version", &filters.version),
-            ("name", &filters.name),
-            ("title", &filters.title),
-            ("status", &filters.status),
-        ] {
-            if let Some(v) = value {
-                if !v.is_empty() {
-                    query.push((field.to_owned(), v.clone()));
-                }
-            }
-        }
-        query.push(("_count".to_owned(), filters.effective_count().to_string()));
-        query.push(("_offset".to_owned(), filters.offset.to_string()));
+        let query = filters.upstream_query();
 
         let url = format!("{}/ValueSet", self.base_url);
         let response = self
@@ -2518,6 +2548,23 @@ impl CmBrowserFilters {
         self.count > Self::MAX_COUNT
     }
 
+    /// Query sent from the UI process to HTS. See
+    /// [`CsBrowserFilters::upstream_query`].
+    fn upstream_query(&self) -> Vec<(String, String)> {
+        build_upstream_browser_query(
+            [
+                ("url", &self.url),
+                ("name", &self.name),
+                ("title", &self.title),
+                ("source-uri", &self.source),
+                ("target-uri", &self.target),
+                ("status", &self.status),
+            ],
+            self.effective_count(),
+            self.offset,
+        )
+    }
+
     /// See [`CsBrowserFilters::load_more_url`]. CM omits `version` from
     /// the filter strip (design doc §7.5: HTS ignores CM version on
     /// `$translate`) and adds `source-uri` / `target-uri`.
@@ -2856,23 +2903,7 @@ impl UpstreamClient {
         &self,
         filters: &CmBrowserFilters,
     ) -> Result<CmBrowserPage, UpstreamError> {
-        let mut query: Vec<(String, String)> = Vec::new();
-        for (field, value) in [
-            ("url", &filters.url),
-            ("name", &filters.name),
-            ("title", &filters.title),
-            ("source-uri", &filters.source),
-            ("target-uri", &filters.target),
-            ("status", &filters.status),
-        ] {
-            if let Some(v) = value {
-                if !v.is_empty() {
-                    query.push((field.to_owned(), v.clone()));
-                }
-            }
-        }
-        query.push(("_count".to_owned(), filters.effective_count().to_string()));
-        query.push(("_offset".to_owned(), filters.offset.to_string()));
+        let query = filters.upstream_query();
 
         let url = format!("{}/ConceptMap", self.base_url);
         let response = self
@@ -4467,6 +4498,82 @@ mod tests {
         };
         assert!(!f.count_exceeds_cap());
         assert_eq!(f.effective_count(), CsBrowserFilters::DEFAULT_COUNT);
+    }
+
+    #[test]
+    fn browser_queries_add_fhir_contains_only_on_the_upstream_hop() {
+        let cs = CsBrowserFilters {
+            url: Some("http://example.org/cs".into()),
+            version: Some("1.0.0".into()),
+            name: Some("ExampleCodeSystem".into()),
+            title: Some("Anatomy Code".into()),
+            status: Some("active".into()),
+            count: 50,
+            offset: 25,
+        };
+        assert_eq!(
+            cs.upstream_query(),
+            vec![
+                ("url".into(), "http://example.org/cs".into()),
+                ("version".into(), "1.0.0".into()),
+                ("name:contains".into(), "ExampleCodeSystem".into()),
+                ("title:contains".into(), "Anatomy Code".into()),
+                ("status".into(), "active".into()),
+                ("_count".into(), "50".into()),
+                ("_offset".into(), "25".into()),
+            ]
+        );
+        let cs_load_more = cs.load_more_url(&75);
+        assert!(cs_load_more.contains("name=ExampleCodeSystem"));
+        assert!(cs_load_more.contains("title=Anatomy+Code"));
+        assert!(!cs_load_more.contains("%3Acontains"));
+
+        let vs = VsBrowserFilters {
+            name: Some("ExampleLimbsVS".into()),
+            title: Some("Limbs Value".into()),
+            ..VsBrowserFilters::default()
+        };
+        assert_eq!(
+            vs.upstream_query(),
+            vec![
+                ("name:contains".into(), "ExampleLimbsVS".into()),
+                ("title:contains".into(), "Limbs Value".into()),
+                ("_count".into(), "25".into()),
+                ("_offset".into(), "0".into()),
+            ]
+        );
+        let vs_load_more = vs.load_more_url(&25);
+        assert!(vs_load_more.contains("name=ExampleLimbsVS"));
+        assert!(vs_load_more.contains("title=Limbs+Value"));
+        assert!(!vs_load_more.contains("%3Acontains"));
+
+        let cm = CmBrowserFilters {
+            url: Some("http://example.org/cm/example".into()),
+            name: Some("ExampleCM".into()),
+            title: Some("Source-to-Target".into()),
+            source: Some("http://example.org/cs/source".into()),
+            target: Some("http://example.org/cs/target".into()),
+            status: Some("active".into()),
+            count: 100,
+            offset: 50,
+        };
+        assert_eq!(
+            cm.upstream_query(),
+            vec![
+                ("url".into(), "http://example.org/cm/example".into()),
+                ("name:contains".into(), "ExampleCM".into()),
+                ("title:contains".into(), "Source-to-Target".into()),
+                ("source-uri".into(), "http://example.org/cs/source".into()),
+                ("target-uri".into(), "http://example.org/cs/target".into()),
+                ("status".into(), "active".into()),
+                ("_count".into(), "100".into()),
+                ("_offset".into(), "50".into()),
+            ]
+        );
+        let cm_load_more = cm.load_more_url(&75);
+        assert!(cm_load_more.contains("name=ExampleCM"));
+        assert!(cm_load_more.contains("title=Source-to-Target"));
+        assert!(!cm_load_more.contains("%3Acontains"));
     }
 
     #[test]

--- a/crates/hts/Cargo.toml
+++ b/crates/hts/Cargo.toml
@@ -71,6 +71,7 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1"
 sha2 = "0.10"
 octofhir-ucum = "0.5"
+unicode-normalization = "0.1"
 
 # SQLite (default)
 rusqlite = { version = "0.33", features = ["bundled"], optional = true }

--- a/crates/hts/src/backends/postgres/code_system.rs
+++ b/crates/hts/src/backends/postgres/code_system.rs
@@ -995,16 +995,37 @@ impl CodeSystemOperations for PostgresTerminologyBackend {
         Ok(out)
     }
 
+    /// Search CodeSystem resources by query parameters.
+    ///
+    /// `url`, `version`, and `status` use exact matching. `name` and `title`
+    /// use normalized FHIR prefix matching by default and support `:contains`
+    /// and `:exact`. Multiple populated fields are ANDed.
     async fn search(
         &self,
         _ctx: &TenantContext,
-        query: ResourceSearchQuery,
+        mut query: ResourceSearchQuery,
     ) -> Result<Vec<serde_json::Value>, HtsError> {
-        let client = self
+        let string_search = crate::string_search::ResourceStringSearch::new(&query);
+        if string_search.is_empty() {
+            query.name = None;
+            query.title = None;
+        }
+        let mut client = self
             .pool
             .get()
             .await
             .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+
+        if !string_search.is_empty() {
+            return super::search_resources(
+                &mut client,
+                "code_systems",
+                "CodeSystem",
+                query,
+                string_search,
+            )
+            .await;
+        }
 
         let limit = i64::from(query.count.unwrap_or(20));
         let offset = i64::from(query.offset.unwrap_or(0));

--- a/crates/hts/src/backends/postgres/concept_map.rs
+++ b/crates/hts/src/backends/postgres/concept_map.rs
@@ -213,16 +213,37 @@ impl ConceptMapOperations for PostgresTerminologyBackend {
         })
     }
 
+    /// Search ConceptMap resources by query parameters.
+    ///
+    /// `url`, `version`, and `status` use exact matching. `name` and `title`
+    /// use normalized FHIR prefix matching by default and support `:contains`
+    /// and `:exact`. Multiple populated fields are ANDed.
     async fn search(
         &self,
         _ctx: &TenantContext,
-        query: ResourceSearchQuery,
+        mut query: ResourceSearchQuery,
     ) -> Result<Vec<serde_json::Value>, HtsError> {
-        let client = self
+        let string_search = crate::string_search::ResourceStringSearch::new(&query);
+        if string_search.is_empty() {
+            query.name = None;
+            query.title = None;
+        }
+        let mut client = self
             .pool
             .get()
             .await
             .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+
+        if !string_search.is_empty() {
+            return super::search_resources(
+                &mut client,
+                "concept_maps",
+                "ConceptMap",
+                query,
+                string_search,
+            )
+            .await;
+        }
 
         let limit = i64::from(query.count.unwrap_or(20));
         let offset = i64::from(query.offset.unwrap_or(0));

--- a/crates/hts/src/backends/postgres/mod.rs
+++ b/crates/hts/src/backends/postgres/mod.rs
@@ -19,8 +19,11 @@ use tracing::info;
 use crate::error::HtsError;
 use crate::import::bundle_parser::{self, ParsedCodeSystem, ParsedConceptMap, ParsedValueSet};
 use crate::import::{BundleImportBackend, ImportStats};
+use crate::string_search::{ResourceSearchRow, ResourceStringSearch, filter_rows};
 use crate::traits::{TerminologyCaches, TerminologyMetadata};
-use crate::types::{ExpansionContains, LookupResponse, SubsumesResponse, TranslateResponse};
+use crate::types::{
+    ExpansionContains, LookupResponse, ResourceSearchQuery, SubsumesResponse, TranslateResponse,
+};
 use helios_persistence::tenant::TenantContext;
 
 /// Per-compose in-memory expansion index. Mirrors SQLite's
@@ -82,6 +85,126 @@ pub const PG_SUBSUMES_RESPONSE_CACHE_MAX: usize = 16384;
 
 /// Soft cap on `translate_response_cache` entries.
 pub const PG_TRANSLATE_RESPONSE_CACHE_MAX: usize = 16384;
+
+/// Search metadata using backend-neutral FHIR string matching, then hydrate
+/// only the selected page. PostgreSQL search historically returns full
+/// resources even for `_summary=true`, which this path preserves.
+async fn search_resources(
+    client: &mut deadpool_postgres::Object,
+    table: &str,
+    resource_type: &str,
+    query: ResourceSearchQuery,
+    search: ResourceStringSearch,
+) -> Result<Vec<serde_json::Value>, HtsError> {
+    // PostgreSQL's default READ COMMITTED level takes a fresh snapshot per
+    // statement, so use REPEATABLE READ to keep metadata selection and JSON
+    // hydration on one read snapshot without taking write locks.
+    let transaction = client
+        .build_transaction()
+        .isolation_level(tokio_postgres::IsolationLevel::RepeatableRead)
+        .start()
+        .await
+        .map_err(|error| HtsError::StorageError(error.to_string()))?;
+    let result =
+        search_resources_in_transaction(&transaction, table, resource_type, query, search).await;
+    match result {
+        Ok(resources) => {
+            transaction
+                .commit()
+                .await
+                .map_err(|error| HtsError::StorageError(error.to_string()))?;
+            Ok(resources)
+        }
+        Err(search_error) => match transaction.rollback().await {
+            Ok(()) => Err(search_error),
+            Err(rollback_error) => Err(HtsError::StorageError(format!(
+                "{search_error}; failed to roll back search snapshot: {rollback_error}"
+            ))),
+        },
+    }
+}
+
+async fn search_resources_in_transaction<C>(
+    client: &C,
+    table: &str,
+    resource_type: &str,
+    query: ResourceSearchQuery,
+    search: ResourceStringSearch,
+) -> Result<Vec<serde_json::Value>, HtsError>
+where
+    C: GenericClient + Sync,
+{
+    let metadata_sql = format!(
+        "SELECT id, url, version, name, title, status
+         FROM {table}
+         WHERE ($1::text IS NULL OR url = $1)
+           AND ($2::text IS NULL OR version = $2)
+           AND ($3::text IS NULL OR status = $3)
+         ORDER BY created_at"
+    );
+    let rows = client
+        .query(&metadata_sql, &[&query.url, &query.version, &query.status])
+        .await
+        .map_err(|error| HtsError::StorageError(error.to_string()))?
+        .into_iter()
+        .map(|row| ResourceSearchRow {
+            id: row.get(0),
+            url: row.get(1),
+            version: row.get(2),
+            name: row.get(3),
+            title: row.get(4),
+            status: row.get(5),
+        })
+        .collect::<Vec<_>>();
+    let selected = filter_rows(rows, &query, &search);
+
+    let stored_resources = if selected.is_empty() {
+        HashMap::new()
+    } else {
+        let ids = selected
+            .iter()
+            .map(|row| row.id.clone())
+            .collect::<Vec<_>>();
+        let resource_sql = format!("SELECT id, resource_json FROM {table} WHERE id = ANY($1)");
+        client
+            .query(&resource_sql, &[&ids])
+            .await
+            .map_err(|error| HtsError::StorageError(error.to_string()))?
+            .into_iter()
+            .map(|row| {
+                (
+                    row.get::<_, String>(0),
+                    row.get::<_, Option<serde_json::Value>>(1),
+                )
+            })
+            .collect::<HashMap<_, _>>()
+    };
+
+    let mut results = Vec::with_capacity(selected.len());
+    for row in selected {
+        let mut resource = stored_resources
+            .get(&row.id)
+            .cloned()
+            .flatten()
+            .unwrap_or_else(|| {
+                code_system::build_synthetic_resource(
+                    resource_type,
+                    &row.id,
+                    &row.url,
+                    row.version.as_deref(),
+                    row.name.as_deref(),
+                    row.title.as_deref(),
+                    &row.status,
+                )
+            });
+        // The table id is authoritative after URL-conflict upserts.
+        if let Some(object) = resource.as_object_mut() {
+            object.insert("id".to_owned(), serde_json::Value::String(row.id));
+        }
+        results.push(resource);
+    }
+    Ok(results)
+}
 
 /// PostgreSQL-backed terminology service backend.
 ///

--- a/crates/hts/src/backends/postgres/value_set.rs
+++ b/crates/hts/src/backends/postgres/value_set.rs
@@ -1748,16 +1748,37 @@ impl ValueSetOperations for PostgresTerminologyBackend {
         )
     }
 
+    /// Search ValueSet resources by query parameters.
+    ///
+    /// `url`, `version`, and `status` use exact matching. `name` and `title`
+    /// use normalized FHIR prefix matching by default and support `:contains`
+    /// and `:exact`. Multiple populated fields are ANDed.
     async fn search(
         &self,
         _ctx: &TenantContext,
-        query: ResourceSearchQuery,
+        mut query: ResourceSearchQuery,
     ) -> Result<Vec<serde_json::Value>, HtsError> {
-        let client = self
+        let string_search = crate::string_search::ResourceStringSearch::new(&query);
+        if string_search.is_empty() {
+            query.name = None;
+            query.title = None;
+        }
+        let mut client = self
             .pool
             .get()
             .await
             .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+
+        if !string_search.is_empty() {
+            return super::search_resources(
+                &mut client,
+                "value_sets",
+                "ValueSet",
+                query,
+                string_search,
+            )
+            .await;
+        }
 
         let limit = i64::from(query.count.unwrap_or(20));
         let offset = i64::from(query.offset.unwrap_or(0));

--- a/crates/hts/src/backends/sqlite/code_system.rs
+++ b/crates/hts/src/backends/sqlite/code_system.rs
@@ -1132,20 +1132,36 @@ impl CodeSystemOperations for SqliteTerminologyBackend {
 
     /// Search CodeSystem resources by query parameters.
     ///
-    /// Filters are applied as exact matches against stored columns. Omitting a
-    /// field means "no filter". Returns up to `count` results starting at
-    /// `offset`, defaulting to 20 results from the beginning.
+    /// `url`, `version`, and `status` use exact matching. `name` and `title`
+    /// use normalized FHIR prefix matching by default and support `:contains`
+    /// and `:exact`. Multiple populated fields are ANDed.
     async fn search(
         &self,
         _ctx: &TenantContext,
-        query: ResourceSearchQuery,
+        mut query: ResourceSearchQuery,
     ) -> Result<Vec<serde_json::Value>, HtsError> {
+        let string_search = crate::string_search::ResourceStringSearch::new(&query);
+        if string_search.is_empty() {
+            query.name = None;
+            query.title = None;
+        }
         let pool = self.pool().clone();
 
         tokio::task::spawn_blocking(move || {
-            let conn = pool
+            let mut conn = pool
                 .get()
                 .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+
+            if !string_search.is_empty() {
+                return super::search_resources(
+                    &mut conn,
+                    "code_systems",
+                    "CodeSystem",
+                    query,
+                    string_search,
+                    true,
+                );
+            }
 
             let limit = i64::from(query.count.unwrap_or(20));
             let offset = i64::from(query.offset.unwrap_or(0));

--- a/crates/hts/src/backends/sqlite/concept_map.rs
+++ b/crates/hts/src/backends/sqlite/concept_map.rs
@@ -63,17 +63,37 @@ impl ConceptMapOperations for SqliteTerminologyBackend {
     }
 
     /// Search ConceptMap resources by query parameters.
+    ///
+    /// `url`, `version`, and `status` use exact matching. `name` and `title`
+    /// use normalized FHIR prefix matching by default and support `:contains`
+    /// and `:exact`. Multiple populated fields are ANDed.
     async fn search(
         &self,
         _ctx: &TenantContext,
-        query: ResourceSearchQuery,
+        mut query: ResourceSearchQuery,
     ) -> Result<Vec<serde_json::Value>, HtsError> {
+        let string_search = crate::string_search::ResourceStringSearch::new(&query);
+        if string_search.is_empty() {
+            query.name = None;
+            query.title = None;
+        }
         let pool = self.pool().clone();
 
         tokio::task::spawn_blocking(move || {
-            let conn = pool
+            let mut conn = pool
                 .get()
                 .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+
+            if !string_search.is_empty() {
+                return super::search_resources(
+                    &mut conn,
+                    "concept_maps",
+                    "ConceptMap",
+                    query,
+                    string_search,
+                    false,
+                );
+            }
 
             let limit = i64::from(query.count.unwrap_or(20));
             let offset = i64::from(query.offset.unwrap_or(0));

--- a/crates/hts/src/backends/sqlite/mod.rs
+++ b/crates/hts/src/backends/sqlite/mod.rs
@@ -30,8 +30,9 @@ use tracing::info;
 
 use crate::error::HtsError;
 use crate::import::{BundleImportBackend, ImportStats};
+use crate::string_search::{ResourceSearchRow, ResourceStringSearch, filter_rows};
 use crate::traits::{TerminologyCaches, TerminologyMetadata};
-use crate::types::{LookupResponse, ValidateCodeResponse};
+use crate::types::{LookupResponse, ResourceSearchQuery, ValidateCodeResponse};
 use helios_persistence::tenant::TenantContext;
 
 // ─── Per-instance cache type aliases (see field docs on SqliteTerminologyBackend) ──
@@ -43,6 +44,138 @@ pub(crate) type StringOptionMap = HashMap<String, Option<String>>;
 pub(crate) type BoolMap = HashMap<String, bool>;
 pub(crate) type LookupResponseMap = HashMap<String, Arc<LookupResponse>>;
 pub(crate) type ValidateCodeResponseMap = HashMap<String, Arc<ValidateCodeResponse>>;
+
+/// Search metadata using backend-neutral FHIR string matching, then hydrate
+/// only the selected page. Exact URL/version/status predicates stay in SQL.
+fn search_resources(
+    conn: &mut rusqlite::Connection,
+    table: &str,
+    resource_type: &str,
+    query: ResourceSearchQuery,
+    search: ResourceStringSearch,
+    synthetic_summary: bool,
+) -> Result<Vec<serde_json::Value>, HtsError> {
+    // A deferred transaction acquires no write lock. It pins the read snapshot
+    // so metadata selection and subsequent JSON hydration cannot observe
+    // different resource revisions.
+    let transaction = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Deferred)
+        .map_err(|error| HtsError::StorageError(error.to_string()))?;
+    let result = search_resources_in_transaction(
+        &transaction,
+        table,
+        resource_type,
+        query,
+        search,
+        synthetic_summary,
+    );
+    match result {
+        Ok(resources) => {
+            transaction
+                .commit()
+                .map_err(|error| HtsError::StorageError(error.to_string()))?;
+            Ok(resources)
+        }
+        Err(search_error) => match transaction.rollback() {
+            Ok(()) => Err(search_error),
+            Err(rollback_error) => Err(HtsError::StorageError(format!(
+                "{search_error}; failed to roll back search snapshot: {rollback_error}"
+            ))),
+        },
+    }
+}
+
+fn search_resources_in_transaction(
+    conn: &rusqlite::Connection,
+    table: &str,
+    resource_type: &str,
+    query: ResourceSearchQuery,
+    search: ResourceStringSearch,
+    synthetic_summary: bool,
+) -> Result<Vec<serde_json::Value>, HtsError> {
+    let metadata_sql = format!(
+        "SELECT id, url, version, name, title, status
+         FROM {table}
+         WHERE (?1 IS NULL OR url = ?1)
+           AND (?2 IS NULL OR version = ?2)
+           AND (?3 IS NULL OR status = ?3)
+         ORDER BY created_at"
+    );
+    let mut statement = conn
+        .prepare(&metadata_sql)
+        .map_err(|error| HtsError::StorageError(error.to_string()))?;
+    let rows = statement
+        .query_map(
+            rusqlite::params![
+                query.url.as_deref(),
+                query.version.as_deref(),
+                query.status.as_deref()
+            ],
+            |row| {
+                Ok(ResourceSearchRow {
+                    id: row.get(0)?,
+                    url: row.get(1)?,
+                    version: row.get(2)?,
+                    name: row.get(3)?,
+                    title: row.get(4)?,
+                    status: row.get(5)?,
+                })
+            },
+        )
+        .map_err(|error| HtsError::StorageError(error.to_string()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| HtsError::StorageError(error.to_string()))?;
+    let selected = filter_rows(rows, &query, &search);
+
+    let use_synthetic = synthetic_summary && query.summary.as_deref() == Some("true");
+    let mut stored_resources = HashMap::<String, Option<String>>::new();
+    if !use_synthetic {
+        // Stay below SQLite's common 999-variable ceiling regardless of an
+        // arbitrary u32 `_count`. Chunking also avoids loading unselected JSON.
+        for chunk in selected.chunks(900) {
+            let placeholders = std::iter::repeat_n("?", chunk.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let resource_sql =
+                format!("SELECT id, resource_json FROM {table} WHERE id IN ({placeholders})");
+            let mut resource_statement = conn
+                .prepare(&resource_sql)
+                .map_err(|error| HtsError::StorageError(error.to_string()))?;
+            let resource_rows = resource_statement
+                .query_map(
+                    rusqlite::params_from_iter(chunk.iter().map(|row| row.id.as_str())),
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+                )
+                .map_err(|error| HtsError::StorageError(error.to_string()))?;
+            for resource in resource_rows {
+                let (id, json) =
+                    resource.map_err(|error| HtsError::StorageError(error.to_string()))?;
+                stored_resources.insert(id, json);
+            }
+        }
+    }
+
+    let mut results = Vec::with_capacity(selected.len());
+    for row in selected {
+        let resource = stored_resources
+            .remove(&row.id)
+            .flatten()
+            .and_then(|json| serde_json::from_str(&json).ok())
+            .unwrap_or_else(|| {
+                code_system::build_synthetic_resource(
+                    resource_type,
+                    &row.id,
+                    &row.url,
+                    row.version.as_deref(),
+                    row.name.as_deref(),
+                    row.title.as_deref(),
+                    &row.status,
+                )
+            });
+        results.push(resource);
+    }
+    Ok(results)
+}
 
 /// Insert `(key, value)` into a bounded cache, evicting one existing entry when
 /// the map is already at `max` capacity.

--- a/crates/hts/src/backends/sqlite/mod.rs
+++ b/crates/hts/src/backends/sqlite/mod.rs
@@ -1008,6 +1008,29 @@ mod tests {
     }
 
     #[test]
+    fn string_search_rolls_back_after_query_error() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        let query = ResourceSearchQuery::default();
+        let search = ResourceStringSearch::new(&query);
+
+        let error = search_resources(
+            &mut conn,
+            "missing_search_table",
+            "CodeSystem",
+            query,
+            search,
+            false,
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, HtsError::StorageError(_)));
+        assert!(
+            conn.is_autocommit(),
+            "failed search must close its transaction"
+        );
+    }
+
+    #[test]
     fn supported_systems_empty_initially() {
         let b = backend();
         assert!(

--- a/crates/hts/src/backends/sqlite/value_set.rs
+++ b/crates/hts/src/backends/sqlite/value_set.rs
@@ -2081,17 +2081,37 @@ impl ValueSetOperations for SqliteTerminologyBackend {
     }
 
     /// Search ValueSet resources by query parameters.
+    ///
+    /// `url`, `version`, and `status` use exact matching. `name` and `title`
+    /// use normalized FHIR prefix matching by default and support `:contains`
+    /// and `:exact`. Multiple populated fields are ANDed.
     async fn search(
         &self,
         _ctx: &TenantContext,
-        query: ResourceSearchQuery,
+        mut query: ResourceSearchQuery,
     ) -> Result<Vec<serde_json::Value>, HtsError> {
+        let string_search = crate::string_search::ResourceStringSearch::new(&query);
+        if string_search.is_empty() {
+            query.name = None;
+            query.title = None;
+        }
         let pool = self.pool().clone();
 
         tokio::task::spawn_blocking(move || {
-            let conn = pool
+            let mut conn = pool
                 .get()
                 .map_err(|e| HtsError::StorageError(format!("Pool error: {e}")))?;
+
+            if !string_search.is_empty() {
+                return super::search_resources(
+                    &mut conn,
+                    "value_sets",
+                    "ValueSet",
+                    query,
+                    string_search,
+                    true,
+                );
+            }
 
             let limit = i64::from(query.count.unwrap_or(20));
             let offset = i64::from(query.offset.unwrap_or(0));

--- a/crates/hts/src/lib.rs
+++ b/crates/hts/src/lib.rs
@@ -46,6 +46,7 @@ pub(crate) mod language;
 pub mod operations;
 pub mod server;
 pub mod state;
+pub mod string_search;
 pub mod traits;
 pub mod types;
 pub(crate) mod ucum_validate;

--- a/crates/hts/src/operations/search.rs
+++ b/crates/hts/src/operations/search.rs
@@ -13,15 +13,17 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{RawQuery, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use helios_persistence::tenant::TenantContext;
 use serde_json::{Value, json};
 
+use crate::error::HtsError;
 use crate::import::BundleImportBackend;
 use crate::state::AppState;
+use crate::string_search::FhirStringSearchMode;
 use crate::traits::{
     CodeSystemOperations, ConceptMapOperations, TerminologyBackend, ValueSetOperations,
 };
@@ -29,6 +31,124 @@ use crate::types::ResourceSearchQuery;
 
 fn ctx() -> TenantContext {
     TenantContext::system()
+}
+
+fn parse_search_query(raw: Option<&str>) -> Result<ResourceSearchQuery, HtsError> {
+    let mut query = ResourceSearchQuery::default();
+
+    for (key, value) in form_urlencoded::parse(raw.unwrap_or_default().as_bytes()) {
+        // FHIR requires empty search parameters to be ignored. This check must
+        // precede modifier and control validation (for example `url:not=` and
+        // `_count=` are both no-ops).
+        if value.is_empty() {
+            continue;
+        }
+
+        let value = value.into_owned();
+        let (parameter, modifier) = key
+            .split_once(':')
+            .map_or((key.as_ref(), None), |(base, modifier)| {
+                (base, Some(modifier))
+            });
+
+        match parameter {
+            "url" => {
+                reject_modifier("url", modifier)?;
+                set_once(&mut query.url, value, "url")?;
+            }
+            "version" => {
+                reject_modifier("version", modifier)?;
+                set_once(&mut query.version, value, "version")?;
+            }
+            "name" => {
+                let mode = string_mode("name", modifier)?;
+                set_string_filter(&mut query.name, &mut query.name_mode, value, mode, "name")?;
+            }
+            "title" => {
+                let mode = string_mode("title", modifier)?;
+                set_string_filter(
+                    &mut query.title,
+                    &mut query.title_mode,
+                    value,
+                    mode,
+                    "title",
+                )?;
+            }
+            "status" => {
+                reject_modifier("status", modifier)?;
+                set_once(&mut query.status, value, "status")?;
+            }
+            "_count" if modifier.is_none() => {
+                let count = parse_u32("_count", &value)?;
+                set_once(&mut query.count, count, "_count")?;
+            }
+            "_offset" if modifier.is_none() => {
+                let offset = parse_u32("_offset", &value)?;
+                set_once(&mut query.offset, offset, "_offset")?;
+            }
+            "_summary" if modifier.is_none() => {
+                set_once(&mut query.summary, value, "_summary")?;
+            }
+            // Unknown parameters remain lenient, matching the existing HTS
+            // behavior. Only modifiers on the five announced parameters above
+            // are rejected.
+            _ => {}
+        }
+    }
+
+    Ok(query)
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T, parameter: &str) -> Result<(), HtsError> {
+    if slot.is_some() {
+        return Err(HtsError::InvalidRequest(format!(
+            "Search parameter `{parameter}` was supplied more than once"
+        )));
+    }
+    *slot = Some(value);
+    Ok(())
+}
+
+fn set_string_filter(
+    slot: &mut Option<String>,
+    mode_slot: &mut FhirStringSearchMode,
+    value: String,
+    mode: FhirStringSearchMode,
+    parameter: &str,
+) -> Result<(), HtsError> {
+    set_once(slot, value, parameter)?;
+    *mode_slot = mode;
+    Ok(())
+}
+
+fn string_mode(parameter: &str, modifier: Option<&str>) -> Result<FhirStringSearchMode, HtsError> {
+    match modifier {
+        None => Ok(FhirStringSearchMode::Prefix),
+        Some("contains") => Ok(FhirStringSearchMode::Contains),
+        Some("exact") => Ok(FhirStringSearchMode::Exact),
+        Some(modifier) => Err(unsupported_modifier(parameter, modifier)),
+    }
+}
+
+fn reject_modifier(parameter: &str, modifier: Option<&str>) -> Result<(), HtsError> {
+    match modifier {
+        Some(modifier) => Err(unsupported_modifier(parameter, modifier)),
+        None => Ok(()),
+    }
+}
+
+fn unsupported_modifier(parameter: &str, modifier: &str) -> HtsError {
+    HtsError::InvalidRequest(format!(
+        "Unsupported modifier `:{modifier}` for search parameter `{parameter}`"
+    ))
+}
+
+fn parse_u32(parameter: &str, value: &str) -> Result<u32, HtsError> {
+    value.parse().map_err(|_| {
+        HtsError::InvalidRequest(format!(
+            "Search parameter `{parameter}` must be an unsigned integer"
+        ))
+    })
 }
 
 /// Build a FHIR `Bundle` of type `searchset` from a list of resource values.
@@ -52,11 +172,15 @@ fn build_searchset_bundle(resources: Vec<Value>) -> Value {
 /// Returns a `searchset` Bundle containing matching CodeSystem resources.
 pub async fn search_code_systems<B>(
     State(state): State<AppState<B>>,
-    Query(query): Query<ResourceSearchQuery>,
+    RawQuery(raw): RawQuery,
 ) -> impl IntoResponse
 where
     B: TerminologyBackend + BundleImportBackend,
 {
+    let query = match parse_search_query(raw.as_deref()) {
+        Ok(query) => query,
+        Err(error) => return error.into_response(),
+    };
     match CodeSystemOperations::search(state.backend(), &ctx(), query).await {
         Ok(resources) => (StatusCode::OK, Json(build_searchset_bundle(resources))).into_response(),
         Err(e) => e.into_response(),
@@ -68,11 +192,15 @@ where
 /// Returns a `searchset` Bundle containing matching ValueSet resources.
 pub async fn search_value_sets<B>(
     State(state): State<AppState<B>>,
-    Query(query): Query<ResourceSearchQuery>,
+    RawQuery(raw): RawQuery,
 ) -> impl IntoResponse
 where
     B: TerminologyBackend + BundleImportBackend,
 {
+    let query = match parse_search_query(raw.as_deref()) {
+        Ok(query) => query,
+        Err(error) => return error.into_response(),
+    };
     match ValueSetOperations::search(state.backend(), &ctx(), query).await {
         Ok(resources) => (StatusCode::OK, Json(build_searchset_bundle(resources))).into_response(),
         Err(e) => e.into_response(),
@@ -84,11 +212,15 @@ where
 /// Returns a `searchset` Bundle containing matching ConceptMap resources.
 pub async fn search_concept_maps<B>(
     State(state): State<AppState<B>>,
-    Query(query): Query<ResourceSearchQuery>,
+    RawQuery(raw): RawQuery,
 ) -> impl IntoResponse
 where
     B: TerminologyBackend + BundleImportBackend,
 {
+    let query = match parse_search_query(raw.as_deref()) {
+        Ok(query) => query,
+        Err(error) => return error.into_response(),
+    };
     match ConceptMapOperations::search(state.backend(), &ctx(), query).await {
         Ok(resources) => (StatusCode::OK, Json(build_searchset_bundle(resources))).into_response(),
         Err(e) => e.into_response(),

--- a/crates/hts/src/string_search.rs
+++ b/crates/hts/src/string_search.rs
@@ -52,15 +52,10 @@ impl FhirStringSearch {
 
     /// Whether a present candidate satisfies this search value.
     pub(crate) fn matches(&self, candidate: &str) -> bool {
-        if self.mode == FhirStringSearchMode::Exact {
-            return candidate == self.value;
-        }
-
-        let candidate = normalize(candidate);
         match self.mode {
-            FhirStringSearchMode::Prefix => candidate.starts_with(&self.normalized),
-            FhirStringSearchMode::Contains => candidate.contains(&self.normalized),
-            FhirStringSearchMode::Exact => unreachable!("handled above"),
+            FhirStringSearchMode::Prefix => normalize(candidate).starts_with(&self.normalized),
+            FhirStringSearchMode::Contains => normalize(candidate).contains(&self.normalized),
+            FhirStringSearchMode::Exact => candidate == self.value,
         }
     }
 }

--- a/crates/hts/src/string_search.rs
+++ b/crates/hts/src/string_search.rs
@@ -1,0 +1,203 @@
+//! Backend-neutral matching for the FHIR `string` search parameter type.
+//!
+//! SQLite and PostgreSQL do not provide identical Unicode case and accent
+//! handling. HTS therefore normalizes metadata in Rust and applies pagination
+//! after matching. This module intentionally does not normalize punctuation or
+//! non-significant whitespace, which FHIR describes as recommended behavior.
+
+use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
+
+use crate::types::ResourceSearchQuery;
+
+/// FHIR `string` matching modes supported by HTS.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum FhirStringSearchMode {
+    /// Case- and accent-insensitive prefix matching.
+    #[default]
+    Prefix,
+    /// Case- and accent-insensitive substring matching.
+    Contains,
+    /// Equality of the decoded Unicode scalar-value sequence.
+    Exact,
+}
+
+/// A compiled search value. The normalized query is computed only once.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct FhirStringSearch {
+    value: String,
+    normalized: String,
+    mode: FhirStringSearchMode,
+}
+
+impl FhirStringSearch {
+    /// Compile a non-empty effective search value.
+    ///
+    /// Values that are empty before or after normalization are ignored. In
+    /// particular, a value containing only combining marks must not turn a
+    /// `contains` search into a predicate that matches every resource.
+    pub(crate) fn new(value: &str, mode: FhirStringSearchMode) -> Option<Self> {
+        if value.is_empty() {
+            return None;
+        }
+        let normalized = normalize(value);
+        if normalized.is_empty() {
+            return None;
+        }
+        Some(Self {
+            value: value.to_owned(),
+            normalized,
+            mode,
+        })
+    }
+
+    /// Whether a present candidate satisfies this search value.
+    pub(crate) fn matches(&self, candidate: &str) -> bool {
+        if self.mode == FhirStringSearchMode::Exact {
+            return candidate == self.value;
+        }
+
+        let candidate = normalize(candidate);
+        match self.mode {
+            FhirStringSearchMode::Prefix => candidate.starts_with(&self.normalized),
+            FhirStringSearchMode::Contains => candidate.contains(&self.normalized),
+            FhirStringSearchMode::Exact => unreachable!("handled above"),
+        }
+    }
+}
+
+/// The compiled name/title predicates for one resource search.
+pub(crate) struct ResourceStringSearch {
+    name: Option<FhirStringSearch>,
+    title: Option<FhirStringSearch>,
+}
+
+impl ResourceStringSearch {
+    /// Compile each query value exactly once.
+    pub(crate) fn new(query: &ResourceSearchQuery) -> Self {
+        Self {
+            name: query
+                .name
+                .as_deref()
+                .and_then(|value| FhirStringSearch::new(value, query.name_mode)),
+            title: query
+                .title
+                .as_deref()
+                .and_then(|value| FhirStringSearch::new(value, query.title_mode)),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.name.is_none() && self.title.is_none()
+    }
+}
+
+/// Metadata needed to apply name/title filters before pagination.
+#[derive(Clone, Debug)]
+pub(crate) struct ResourceSearchRow {
+    pub id: String,
+    pub url: String,
+    pub version: Option<String>,
+    pub name: Option<String>,
+    pub title: Option<String>,
+    pub status: String,
+}
+
+/// Apply FHIR string filters and then `_offset`/`_count`.
+pub(crate) fn filter_rows(
+    rows: impl IntoIterator<Item = ResourceSearchRow>,
+    query: &ResourceSearchQuery,
+    search: &ResourceStringSearch,
+) -> Vec<ResourceSearchRow> {
+    let offset = query.offset.unwrap_or(0) as usize;
+    let count = query.count.unwrap_or(20) as usize;
+
+    rows.into_iter()
+        .filter(|row| {
+            search.name.as_ref().is_none_or(|search| {
+                row.name
+                    .as_deref()
+                    .is_some_and(|candidate| search.matches(candidate))
+            }) && search.title.as_ref().is_none_or(|search| {
+                row.title
+                    .as_deref()
+                    .is_some_and(|candidate| search.matches(candidate))
+            })
+        })
+        .skip(offset)
+        .take(count)
+        .collect()
+}
+
+/// Normalize case and combining marks consistently across storage backends.
+fn normalize(value: &str) -> String {
+    value
+        .nfd()
+        .flat_map(char::to_uppercase)
+        .flat_map(char::to_lowercase)
+        .nfd()
+        .filter(|character| !is_combining_mark(*character))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_and_contains_are_case_and_accent_insensitive() {
+        let prefix = FhirStringSearch::new("cafe", FhirStringSearchMode::Prefix).unwrap();
+        assert!(prefix.matches("Café terminology"));
+        assert!(prefix.matches("Cafe\u{301} terminology"));
+        assert!(!prefix.matches("Terminology café"));
+
+        let contains = FhirStringSearch::new("CAFE", FhirStringSearchMode::Contains).unwrap();
+        assert!(contains.matches("Terminology café"));
+    }
+
+    #[test]
+    fn normalization_handles_non_ascii_case_expansion() {
+        let search = FhirStringSearch::new("STRASSE", FhirStringSearchMode::Prefix).unwrap();
+        assert!(search.matches("Straße terminology"));
+    }
+
+    #[test]
+    fn exact_preserves_case_accents_and_unicode_sequence() {
+        let search = FhirStringSearch::new("Café", FhirStringSearchMode::Exact).unwrap();
+        assert!(search.matches("Café"));
+        assert!(!search.matches("café"));
+        assert!(!search.matches("Cafe\u{301}"));
+        assert!(!search.matches("Cafe"));
+    }
+
+    #[test]
+    fn empty_and_normalization_empty_values_are_ignored() {
+        assert!(FhirStringSearch::new("", FhirStringSearchMode::Prefix).is_none());
+        assert!(FhirStringSearch::new("\u{301}", FhirStringSearchMode::Contains).is_none());
+    }
+
+    #[test]
+    fn missing_fields_do_not_match_and_pagination_follows_filtering() {
+        let query = ResourceSearchQuery {
+            name: Some("match".to_owned()),
+            count: Some(1),
+            offset: Some(1),
+            ..ResourceSearchQuery::default()
+        };
+        let rows = [None, Some("MatchOne"), Some("other"), Some("matchTwo")]
+            .into_iter()
+            .enumerate()
+            .map(|(index, name)| ResourceSearchRow {
+                id: index.to_string(),
+                url: format!("http://example.org/{index}"),
+                version: None,
+                name: name.map(str::to_owned),
+                title: None,
+                status: "active".to_owned(),
+            });
+
+        let search = ResourceStringSearch::new(&query);
+        let selected = filter_rows(rows, &query, &search);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].name.as_deref(), Some("matchTwo"));
+    }
+}

--- a/crates/hts/src/types.rs
+++ b/crates/hts/src/types.rs
@@ -500,10 +500,18 @@ pub struct ResourceSearchQuery {
     pub url: Option<String>,
     /// Filter by version string (exact match).
     pub version: Option<String>,
-    /// Filter by computer-friendly name (exact match).
+    /// Filter by computer-friendly name using FHIR `string` search semantics.
     pub name: Option<String>,
-    /// Filter by human-friendly title (exact match).
+    /// Matching mode for [`Self::name`].
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub name_mode: crate::string_search::FhirStringSearchMode,
+    /// Filter by human-friendly title using FHIR `string` search semantics.
     pub title: Option<String>,
+    /// Matching mode for [`Self::title`].
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub title_mode: crate::string_search::FhirStringSearchMode,
     /// Filter by status: `draft`, `active`, `retired`, or `unknown`.
     pub status: Option<String>,
     /// Maximum number of results to return (default: 20).

--- a/crates/hts/tests/string_search.rs
+++ b/crates/hts/tests/string_search.rs
@@ -1,0 +1,279 @@
+//! Regression coverage for FHIR `string` search on terminology resources.
+
+mod common;
+
+use axum::http::StatusCode;
+#[cfg(feature = "sqlite")]
+use common::TestApp;
+#[cfg(feature = "postgres")]
+use common::TestAppPg;
+use serde_json::Value;
+
+const SEARCH_BUNDLE: &str = r#"{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {"resource": {
+      "resourceType": "CodeSystem", "id": "cafe-cs",
+      "url": "http://hts.test/719/cs/cafe", "version": "1.0",
+      "name": "CafeCodeSystem", "title": "Café terminology", "status": "active",
+      "content": "complete", "concept": [{"code": "one", "display": "One"}]
+    }},
+    {"resource": {
+      "resourceType": "CodeSystem", "id": "literal-cs",
+      "url": "http://hts.test/719/cs/literal", "version": "1.0",
+      "name": "LiteralCodeSystem", "title": "Rate_100% terminology", "status": "active",
+      "content": "complete", "concept": [{"code": "one", "display": "One"}]
+    }},
+    {"resource": {
+      "resourceType": "CodeSystem", "id": "wildcard-decoy-cs",
+      "url": "http://hts.test/719/cs/decoy", "version": "1.0",
+      "name": "WildcardDecoy", "title": "RateX100Y terminology", "status": "active",
+      "content": "complete", "concept": [{"code": "one", "display": "One"}]
+    }},
+    {"resource": {
+      "resourceType": "CodeSystem", "id": "page-one-cs",
+      "url": "http://hts.test/719/cs/page-one", "version": "1.0",
+      "name": "PageOne", "title": "First page candidate", "status": "active",
+      "content": "complete", "concept": [{"code": "one", "display": "One"}]
+    }},
+    {"resource": {
+      "resourceType": "CodeSystem", "id": "page-two-cs",
+      "url": "http://hts.test/719/cs/page-two", "version": "1.0",
+      "name": "PageTwo", "title": "Second page candidate", "status": "active",
+      "content": "complete", "concept": [{"code": "one", "display": "One"}]
+    }},
+    {"resource": {
+      "resourceType": "CodeSystem", "id": "nameless-cs",
+      "url": "http://hts.test/719/cs/nameless", "version": "1.0",
+      "title": "Nameless candidate", "status": "active",
+      "content": "complete", "concept": [{"code": "one", "display": "One"}]
+    }},
+    {"resource": {
+      "resourceType": "ValueSet", "id": "cafe-vs",
+      "url": "http://hts.test/719/vs/cafe", "version": "1.0",
+      "name": "CafeValueSet", "title": "Cafe\u0301 value set", "status": "active",
+      "compose": {"include": [{"system": "http://hts.test/719/cs/cafe"}]}
+    }},
+    {"resource": {
+      "resourceType": "ConceptMap", "id": "cafe-cm",
+      "url": "http://hts.test/719/cm/cafe", "version": "1.0",
+      "name": "CafeConceptMap", "title": "CAFÉ concept map", "status": "active",
+      "sourceUri": "http://hts.test/719/cs/cafe", "targetUri": "http://example.org/target",
+      "group": []
+    }}
+  ]
+}"#;
+
+fn entries(body: &Value) -> &[Value] {
+    body["entry"].as_array().expect("searchset entry array")
+}
+
+fn resource_id(resource: &Value) -> &str {
+    resource["id"].as_str().expect("resource id")
+}
+
+fn assert_id(resource: &Value, expected: &str) {
+    let actual = resource_id(resource);
+    assert!(
+        actual == expected
+            || actual
+                .strip_prefix(expected)
+                .is_some_and(|suffix| suffix.starts_with('|')),
+        "expected {expected} (optionally version-qualified), got {actual}"
+    );
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn sqlite_supports_prefix_contains_exact_and_decoded_modifier_keys() {
+    let app = TestApp::new();
+    app.import_bundle_ok(SEARCH_BUNDLE).await;
+
+    for (path, expected_type, expected_id) in [
+        ("/CodeSystem?title=cafe", "CodeSystem", "cafe-cs"),
+        ("/ValueSet?name%3Acontains=fevalue", "ValueSet", "cafe-vs"),
+        (
+            "/ConceptMap?title:contains=FE%20concept",
+            "ConceptMap",
+            "cafe-cm",
+        ),
+    ] {
+        let (status, body) = app.get_fhir(path).await;
+        assert_eq!(status, StatusCode::OK, "{path}: {body}");
+        assert_eq!(entries(&body).len(), 1, "{path}: {body}");
+        assert_eq!(entries(&body)[0]["resource"]["resourceType"], expected_type);
+        assert_id(&entries(&body)[0]["resource"], expected_id);
+    }
+
+    let (status, exact) = app
+        .get_fhir("/CodeSystem?title:exact=Caf%C3%A9%20terminology")
+        .await;
+    assert_eq!(status, StatusCode::OK, "{exact}");
+    assert_eq!(entries(&exact).len(), 1, "{exact}");
+
+    for path in [
+        "/CodeSystem?title:exact=caf%C3%A9%20terminology",
+        "/CodeSystem?title:exact=Cafe%CC%81%20terminology",
+        "/CodeSystem?title=terminology",
+    ] {
+        let (status, body) = app.get_fhir(path).await;
+        assert_eq!(status, StatusCode::OK, "{path}: {body}");
+        assert!(entries(&body).is_empty(), "{path}: {body}");
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn sqlite_applies_and_semantics_literal_matching_and_filter_before_pagination() {
+    let app = TestApp::new();
+    app.import_bundle_ok(SEARCH_BUNDLE).await;
+
+    let (status, combined) = app
+        .get_fhir(
+            "/CodeSystem?name=cafe&title:contains=terminology&url=http%3A%2F%2Fhts.test%2F719%2Fcs%2Fcafe&status=active",
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{combined}");
+    assert_eq!(entries(&combined).len(), 1, "{combined}");
+
+    let (_, wrong_status) = app.get_fhir("/CodeSystem?name=cafe&status=retired").await;
+    assert!(entries(&wrong_status).is_empty(), "{wrong_status}");
+    let (_, missing_name) = app.get_fhir("/CodeSystem?name=nameless").await;
+    assert!(entries(&missing_name).is_empty(), "{missing_name}");
+
+    let (_, literal) = app.get_fhir("/CodeSystem?title=rate_100%25").await;
+    assert_eq!(entries(&literal).len(), 1, "{literal}");
+    assert_id(&entries(&literal)[0]["resource"], "literal-cs");
+
+    let (_, all_matches) = app.get_fhir("/CodeSystem?name=page").await;
+    assert_eq!(entries(&all_matches).len(), 2, "{all_matches}");
+    let (_, page) = app
+        .get_fhir("/CodeSystem?name=page&_offset=1&_count=1")
+        .await;
+    assert_eq!(entries(&page).len(), 1, "{page}");
+    assert_eq!(
+        resource_id(&entries(&page)[0]["resource"]),
+        resource_id(&entries(&all_matches)[1]["resource"])
+    );
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn empty_and_normalization_empty_parameters_are_ignored_first() {
+    let app = TestApp::new();
+    app.import_bundle_ok(SEARCH_BUNDLE).await;
+
+    let (_, baseline) = app.get_fhir("/CodeSystem").await;
+    let baseline_ids = entries(&baseline)
+        .iter()
+        .map(|entry| resource_id(&entry["resource"]))
+        .collect::<Vec<_>>();
+
+    for path in [
+        "/CodeSystem?name=",
+        "/CodeSystem?url=",
+        "/CodeSystem?version=",
+        "/CodeSystem?title=",
+        "/CodeSystem?status=",
+        "/CodeSystem?name:not=",
+        "/CodeSystem?url:not=",
+        "/CodeSystem?_count=",
+        "/CodeSystem?_offset=",
+        "/CodeSystem?_summary=",
+        "/CodeSystem?name:contains=%CC%81",
+        "/CodeSystem?unknown=value",
+    ] {
+        let (status, body) = app.get_fhir(path).await;
+        assert_eq!(status, StatusCode::OK, "{path}: {body}");
+        let ids = entries(&body)
+            .iter()
+            .map(|entry| resource_id(&entry["resource"]))
+            .collect::<Vec<_>>();
+        assert_eq!(ids, baseline_ids, "{path}: {body}");
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn unsupported_modifiers_on_announced_parameters_return_operation_outcome() {
+    let app = TestApp::new();
+
+    for parameter in ["url", "version", "name", "title", "status"] {
+        let path = format!("/CodeSystem?{parameter}:not=value");
+        let (status, body) = app.get_fhir(&path).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{path}: {body}");
+        assert_eq!(body["resourceType"], "OperationOutcome", "{path}: {body}");
+        assert_eq!(body["issue"][0]["code"], "invalid", "{path}: {body}");
+    }
+
+    let (status, body) = app.get_fhir("/CodeSystem?_count=not-a-number").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["resourceType"], "OperationOutcome", "{body}");
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn sqlite_preserves_resource_specific_hydration_behavior() {
+    let app = TestApp::new();
+    app.import_bundle_ok(SEARCH_BUNDLE).await;
+
+    let (_, code_system) = app.get_fhir("/CodeSystem?name=cafe").await;
+    assert!(entries(&code_system)[0]["resource"]["concept"].is_array());
+    let (_, code_system_summary) = app.get_fhir("/CodeSystem?name=cafe&_summary=true").await;
+    assert!(entries(&code_system_summary)[0]["resource"]["concept"].is_null());
+
+    let (_, value_set) = app.get_fhir("/ValueSet?name=cafe").await;
+    assert!(entries(&value_set)[0]["resource"]["compose"].is_object());
+    let (_, value_set_summary) = app.get_fhir("/ValueSet?name=cafe&_summary=true").await;
+    assert!(entries(&value_set_summary)[0]["resource"]["compose"].is_null());
+
+    let (_, concept_map_summary) = app.get_fhir("/ConceptMap?name=cafe&_summary=true").await;
+    assert!(entries(&concept_map_summary)[0]["resource"]["group"].is_array());
+
+    let (_, unfiltered_code_systems) = app.get_fhir("/CodeSystem").await;
+    assert!(
+        entries(&unfiltered_code_systems)
+            .iter()
+            .all(|entry| entry["resource"]["concept"].is_null())
+    );
+    let (_, unfiltered_concept_maps) = app.get_fhir("/ConceptMap").await;
+    assert!(entries(&unfiltered_concept_maps)[0]["resource"]["group"].is_array());
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test(flavor = "multi_thread")]
+async fn postgres_matches_string_and_full_hydration_contract() {
+    let app = TestAppPg::new().await;
+    app.import_bundle_ok(SEARCH_BUNDLE).await;
+
+    for (path, full_field, expected_id) in [
+        ("/CodeSystem?title=cafe&_summary=true", "concept", "cafe-cs"),
+        (
+            "/ValueSet?name:contains=fevalue&_summary=true",
+            "compose",
+            "cafe-vs",
+        ),
+        (
+            "/ConceptMap?title:contains=fe%20concept&_summary=true",
+            "group",
+            "cafe-cm",
+        ),
+    ] {
+        let (status, body) = app.get_fhir(path).await;
+        assert_eq!(status, StatusCode::OK, "{path}: {body}");
+        assert_eq!(entries(&body).len(), 1, "{path}: {body}");
+        let resource = &entries(&body)[0]["resource"];
+        assert!(!resource[full_field].is_null(), "{path}: {body}");
+        assert_id(resource, expected_id);
+    }
+
+    let (_, exact_miss) = app
+        .get_fhir("/ConceptMap?title:exact=caf%C3%A9%20concept%20map")
+        .await;
+    assert!(entries(&exact_miss).is_empty(), "{exact_miss}");
+
+    let (status, outcome) = app.get_fhir("/ConceptMap?status:not=active").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{outcome}");
+    assert_eq!(outcome["resourceType"], "OperationOutcome", "{outcome}");
+}

--- a/crates/hts/tests/string_search.rs
+++ b/crates/hts/tests/string_search.rs
@@ -131,7 +131,7 @@ async fn sqlite_applies_and_semantics_literal_matching_and_filter_before_paginat
 
     let (status, combined) = app
         .get_fhir(
-            "/CodeSystem?name=cafe&title:contains=terminology&url=http%3A%2F%2Fhts.test%2F719%2Fcs%2Fcafe&status=active",
+            "/CodeSystem?name=cafe&title:contains=terminology&url=http%3A%2F%2Fhts.test%2F719%2Fcs%2Fcafe&version=1.0&status=active",
         )
         .await;
     assert_eq!(status, StatusCode::OK, "{combined}");
@@ -199,17 +199,24 @@ async fn empty_and_normalization_empty_parameters_are_ignored_first() {
 async fn unsupported_modifiers_on_announced_parameters_return_operation_outcome() {
     let app = TestApp::new();
 
-    for parameter in ["url", "version", "name", "title", "status"] {
-        let path = format!("/CodeSystem?{parameter}:not=value");
-        let (status, body) = app.get_fhir(&path).await;
-        assert_eq!(status, StatusCode::BAD_REQUEST, "{path}: {body}");
-        assert_eq!(body["resourceType"], "OperationOutcome", "{path}: {body}");
-        assert_eq!(body["issue"][0]["code"], "invalid", "{path}: {body}");
+    for resource_type in ["CodeSystem", "ValueSet", "ConceptMap"] {
+        for parameter in ["url", "version", "name", "title", "status"] {
+            let path = format!("/{resource_type}?{parameter}:not=value");
+            let (status, body) = app.get_fhir(&path).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{path}: {body}");
+            assert_eq!(body["resourceType"], "OperationOutcome", "{path}: {body}");
+            assert_eq!(body["issue"][0]["code"], "invalid", "{path}: {body}");
+        }
     }
 
     let (status, body) = app.get_fhir("/CodeSystem?_count=not-a-number").await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
     assert_eq!(body["resourceType"], "OperationOutcome", "{body}");
+
+    let (status, body) = app.get_fhir("/CodeSystem?title=first&title=second").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["resourceType"], "OperationOutcome", "{body}");
+    assert_eq!(body["issue"][0]["code"], "invalid", "{body}");
 }
 
 #[cfg(feature = "sqlite")]
@@ -247,6 +254,30 @@ async fn postgres_matches_string_and_full_hydration_contract() {
     let app = TestAppPg::new().await;
     app.import_bundle_ok(SEARCH_BUNDLE).await;
 
+    let (client, connection) =
+        tokio_postgres::connect(common::pg_http_url().await, tokio_postgres::NoTls)
+            .await
+            .expect("connect to PostgreSQL test database");
+    tokio::spawn(async move {
+        connection.await.expect("PostgreSQL test connection");
+    });
+    client
+        .execute(
+            "INSERT INTO code_systems
+             (id, url, version, name, title, status, content, resource_json, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, 'active', 'complete', NULL, $6, $6)",
+            &[
+                &"synthetic-search-cs",
+                &"http://hts.test/719/cs/synthetic",
+                &"1.0",
+                &"SyntheticSearchCodeSystem",
+                &"Synthetic search fallback",
+                &"2026-08-29T00:00:00Z",
+            ],
+        )
+        .await
+        .expect("insert legacy CodeSystem metadata without resource_json");
+
     for (path, full_field, expected_id) in [
         ("/CodeSystem?title=cafe&_summary=true", "concept", "cafe-cs"),
         (
@@ -272,6 +303,17 @@ async fn postgres_matches_string_and_full_hydration_contract() {
         .get_fhir("/ConceptMap?title:exact=caf%C3%A9%20concept%20map")
         .await;
     assert!(entries(&exact_miss).is_empty(), "{exact_miss}");
+
+    let (status, synthetic) = app.get_fhir("/CodeSystem?name=syntheticsearch").await;
+    assert_eq!(status, StatusCode::OK, "{synthetic}");
+    assert_eq!(entries(&synthetic).len(), 1, "{synthetic}");
+    let synthetic_resource = &entries(&synthetic)[0]["resource"];
+    assert_eq!(synthetic_resource["resourceType"], "CodeSystem");
+    assert_eq!(synthetic_resource["id"], "synthetic-search-cs");
+    assert_eq!(
+        synthetic_resource["url"],
+        "http://hts.test/719/cs/synthetic"
+    );
 
     let (status, outcome) = app.get_fhir("/ConceptMap?status:not=active").await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{outcome}");


### PR DESCRIPTION
Closes #719.

### Summary

- implement case- and accent-insensitive FHIR prefix matching for bare `name` and `title` searches;
- support `:contains` and case-/accent-sensitive `:exact` modifiers;
- return `400 OperationOutcome` for unsupported modifiers on advertised terminology search parameters;
- ignore empty parameters before modifier/control validation, while preventing normalization-empty values from becoming match-all predicates;
- apply string filtering before pagination in SQLite and PostgreSQL, then hydrate only the selected resources in a consistent read snapshot;
- preserve exact matching and existing fast paths for `url`, `version`, and `status`;
- keep public HTS UI URLs on bare `name`/`title`, while sending `name:contains`/`title:contains` only on the internal FHIR request.

### Implementation notes

- Matching is centralized in a backend-neutral Rust module using Unicode decomposition, combining-mark removal, and Unicode case folding.
- `:exact` compares the decoded Unicode string without case or accent normalization.
- SQLite uses a deferred read transaction and chunks selected-ID hydration in batches of 900.
- PostgreSQL uses a repeatable-read transaction and preserves the authoritative table ID when hydrating JSON.
- Existing resource-shape behavior is unchanged: SQLite CodeSystem/ValueSet summary and unfiltered synthesis, SQLite ConceptMap full hydration, and PostgreSQL full hydration are preserved.
- FHIR's recommended punctuation and non-significant-whitespace normalization remains out of scope for this issue.

### Validation

- `cargo fmt --all --check`
- `cargo check -p helios-hts --no-default-features --features sqlite,R4`
- feature checks for SQLite with R4B, R5, and R6
- combined SQLite/PostgreSQL R4 check
- new SQLite HTTP/storage contract: 5/5
- existing SQLite CodeSystem/ValueSet/ConceptMap search tests: 16/16
- new PostgreSQL contract: 1/1
- existing PostgreSQL search tests: 9/9
- `cargo test -p helios-hts-ui --lib`: 74/74
- new Playwright title-substring cases: 3/3
- manual API and UI before/after QA on seeded SQLite

### Manual QA result

- bare prefix `name=example` now returns the four expected seeded CodeSystems;
- `title:contains=Anatomy Code` returns only `ExampleCodeSystem`;
- percent-encoded `name%3Acontains` is decoded and matched;
- unsupported `name:not` returns HTTP 400 with an `OperationOutcome`;
- an empty `name=` is ignored;
- exact `url + status` behavior remains unchanged;
- CodeSystem, ValueSet, and ConceptMap UI title substrings each return exactly the expected row while the browser URL retains the bare `title` key.
