### PR TITLE
feat(ui): subscriptions nav always present; page built out to the frame

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2846,12 +2846,12 @@ details.json-fold[open] > summary .icon {
 
 /* FHIR publication-status tags (HTS browsers + resource detail headers).
    Distinct from the .tag--stored/config/conflict family: those describe
-   configuration/lint outcomes, these describe a resource's own status.
+   configuration/lint outcomes, these describe a resource's own status. */
+.tag--active {
+  background: var(--ok-soft);
+  color: var(--ok);
+}
 
-   `active` is deliberately absent here: the subscription-state block below
-   already defines `.tag--active` with the identical treatment, and defining
-   it twice is what `design-system.spec.ts` forbids. FHIR's `active` status
-   and a live subscription happen to want the same pill. */
 .tag--draft {
   background: var(--warn-soft);
   color: var(--warn);
@@ -2868,22 +2868,38 @@ details.json-fold[open] > summary .icon {
   border: 1px solid var(--surface-border);
   color: var(--muted);
 }
-/* Subscription states (#580): the cards and the STATUS column share this
-   vocabulary — active delivers, idle has no listeners, error needs attention. */
-.tag--active {
-  background: var(--ok-soft);
-  color: var(--ok);
+
+/* Subscription states (#580, reshaped to the frame in #767): the cards and
+   the STATUS column share a dot vocabulary — green delivers, amber has no
+   listeners, red needs attention. */
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-right: 7px;
+  border-radius: 50%;
+  vertical-align: baseline;
 }
 
-.tag--idle,
-.tag--requested {
-  background: var(--warn-soft);
-  color: var(--warn);
+.status-dot--ok {
+  background: var(--ok);
 }
 
-.tag--error {
-  background: var(--danger-soft);
-  color: var(--danger);
+.status-dot--danger {
+  background: var(--danger);
+}
+
+.status-dot--warn {
+  background: var(--warn);
+}
+
+.status-dot--muted {
+  background: var(--muted);
+}
+
+/* A failing row carries the frame's red left edge. */
+.data-table tr.row--alert > td:first-child {
+  box-shadow: inset 3px 0 0 var(--danger);
 }
 
 /* Bulk Export job states (#537) — the same status-pill vocabulary. */
@@ -2913,6 +2929,21 @@ details.json-fold[open] > summary .icon {
 
 .subs-sort summary.btn::-webkit-details-marker {
   display: none;
+}
+
+.subs-sort__label {
+  color: var(--muted);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.subs-sort__chevron {
+  transition: transform 120ms ease;
+}
+
+.subs-sort[open] .subs-sort__chevron {
+  transform: rotate(180deg);
 }
 }
 

--- a/crates/ui/e2e/tests/subscriptions.spec.ts
+++ b/crates/ui/e2e/tests/subscriptions.spec.ts
@@ -7,30 +7,39 @@ import { test, expect } from "../pages/fixtures";
 // with an injected provider (crates/ui/tests/subscriptions_http.rs).
 //
 // CI builds hfs with the `subscriptions` feature; a local binary built with
-// plain defaults compiles the engine out, so these skip on the unavailable
-// state rather than failing the local run.
+// plain defaults compiles the engine out, so the live-state tests skip on the
+// unavailable state rather than failing the local run. The nav entry and the
+// explained off state are engine-independent (#767) and never skip.
 test.beforeEach(async ({ page }) => {
   await page.goto("/ui/subscriptions", { waitUntil: "networkidle" });
-  const unavailable = await page.locator(".card.notice").count();
-  test.skip(unavailable > 0, "hfs built without the subscriptions feature");
 });
 
-test("the page renders its cards and empty table when the engine is on", async ({ page }) => {
-
-  await expect(page.locator("h1.page-head__title")).toHaveText(/subscriptions/i);
-  await expect(page.locator(".card.stat")).toHaveCount(4);
-  await expect(page.locator(".card.stat .stat__value").first()).toHaveText("0");
-  await expect(page.locator(".data-table__empty")).toBeVisible();
-});
-
-test("the sidebar advertises the page while the engine is enabled", async ({ page, chrome }) => {
+test("the sidebar always links the page, engine or no engine", async ({ chrome }) => {
   await chrome.sidebar.hover();
   const link = chrome.navLink("/ui/subscriptions");
   await expect(link).toBeVisible();
   await expect(link).toHaveAttribute("aria-current", "page");
 });
 
+test("with the engine off, the page names the switch and build feature", async ({ page }) => {
+  const unavailable = await page.locator(".card.notice").count();
+  test.skip(unavailable === 0, "engine enabled on this server");
+  await expect(page.locator(".card.notice")).toContainText("HFS_SUBSCRIPTIONS_ENABLED=true");
+  await expect(page.locator(".card.notice")).toContainText("--features subscriptions");
+});
+
+test("the page renders its cards and empty table when the engine is on", async ({ page }) => {
+  const unavailable = await page.locator(".card.notice").count();
+  test.skip(unavailable > 0, "hfs built without the subscriptions feature");
+  await expect(page.locator("h1.page-head__title")).toHaveText(/subscriptions/i);
+  await expect(page.locator(".card.stat")).toHaveCount(4);
+  await expect(page.locator(".card.stat .stat__value").first()).toHaveText("0");
+  await expect(page.locator(".data-table__empty")).toBeVisible();
+});
+
 test("the sort control works as plain links", async ({ page }) => {
+  const unavailable = await page.locator(".card.notice").count();
+  test.skip(unavailable > 0, "hfs built without the subscriptions feature");
   await page.locator(".subs-sort summary").click();
   await page.locator('.subs-sort a[href*="sort=sent"]').click();
   await expect(page).toHaveURL(/sort=sent/);

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -320,9 +320,6 @@ pub(crate) struct Status {
     tenant_display: Option<String>,
     /// Whether the sidebar renders the tenant picker (#544).
     show_tenant_picker: bool,
-    /// Whether the subscriptions engine is advertised â€” the sidebar entry and
-    /// the operator page only appear when it is (#580).
-    subscriptions_enabled: bool,
     /// The safe navigation state derived from `HFS_TERMINOLOGY_SERVER` (#611).
     /// The raw value is never exposed to templates unless it is a valid HTTP(S)
     /// base URL.
@@ -385,11 +382,6 @@ impl Status {
     /// Whether the sidebar renders the tenant picker (#544).
     pub(crate) fn show_tenant_picker(&self) -> bool {
         self.show_tenant_picker
-    }
-
-    /// Whether the subscriptions engine is advertised (#580).
-    pub(crate) fn subscriptions_enabled(&self) -> bool {
-        self.subscriptions_enabled
     }
 
     /// The topbar avatar menu's identity (#725). `/ui` sits outside the auth
@@ -3456,7 +3448,6 @@ pub(crate) fn current_status(
         tenant_id: tenant.id.clone(),
         tenant_display: tenant.display.clone(),
         show_tenant_picker: tenant.multi,
-        subscriptions_enabled: helios_observability::subscriptions::enabled(),
         terminology: TerminologyNavigation::from_config(state.terminology.as_deref()),
     }
 }
@@ -3503,7 +3494,6 @@ mod tests {
                 tenant_id: "default".to_string(),
                 tenant_display: None,
                 show_tenant_picker: true,
-                subscriptions_enabled: false,
                 terminology: TerminologyNavigation::Unconfigured,
             },
             metrics: dash.metrics,
@@ -3675,7 +3665,6 @@ mod tests {
                 tenant_id: "default".to_string(),
                 tenant_display: None,
                 show_tenant_picker: true,
-                subscriptions_enabled: false,
                 terminology: TerminologyNavigation::Unconfigured,
             },
             i18n: i18n("en"),
@@ -3735,7 +3724,6 @@ mod tests {
                 tenant_id: "default".to_string(),
                 tenant_display: None,
                 show_tenant_picker: true,
-                subscriptions_enabled: false,
                 terminology: TerminologyNavigation::Unconfigured,
             },
             i18n: i18n("en"),
@@ -3797,7 +3785,6 @@ mod tests {
                 tenant_id: "default".to_string(),
                 tenant_display: None,
                 show_tenant_picker: true,
-                subscriptions_enabled: false,
                 terminology: TerminologyNavigation::Unconfigured,
             },
             i18n: i18n("es"),

--- a/crates/ui/src/subscriptions.rs
+++ b/crates/ui/src/subscriptions.rs
@@ -1,18 +1,18 @@
 //! Subscriptions operator page (#580) — read-only, per Brett's design.
 //!
-//! One screen over the engine's live inventory: four status cards (failing /
-//! idle / active / notifications since start) and a table of every
-//! subscription with its channel, status chip, event counter, and consecutive
-//! failure streak. The data arrives through the process-global
+//! One screen over the engine's live inventory: four status cards (active /
+//! failing / idle / delivered in 24 h) and a table of every subscription with
+//! its channel, status, 24-hour delivery count, event counter, and
+//! consecutive failure streak. The data arrives through the process-global
 //! [`helios_observability::subscriptions`] provider the server registers when
 //! the engine is enabled — the page renders an explained unavailable state
-//! when it is not, and the sidebar hides the entry entirely (the feature is
-//! only *advertised* when the engine runs).
+//! (naming `HFS_SUBSCRIPTIONS_ENABLED` and the `subscriptions` build feature)
+//! when it is not; the sidebar entry is always present (#767).
 //!
-//! Deliberately absent: per-window delivery counts and success rates. The
-//! engine does not persist delivery history yet, and this page shows real
-//! figures or none (#555's rule) — the 24-hour column of the design lands
-//! with the engine instrumentation, not before.
+//! The design's 24-hour sparkline needs a per-window time series the
+//! [`SubscriptionsSnapshot`](helios_observability::subscriptions::SubscriptionsSnapshot)
+//! does not carry; the column shows the real count until the engine grows
+//! that series (#555's rule: real figures or none).
 
 use askama::Template;
 use axum::{extract::RawQuery, extract::State, response::Response};

--- a/crates/ui/templates/layouts/base.html
+++ b/crates/ui/templates/layouts/base.html
@@ -153,13 +153,12 @@
         <span class="nav-item__label">{{ i18n.t("nav-terminology") }}</span>
       </a>
       {% endif %}
-      <!-- Visible only when the subscriptions engine is advertised (#580). -->
-      {% if status.subscriptions_enabled() %}
+      <!-- Always present, like the other feature pages: with the engine off
+           the page explains how to enable it (#767). -->
       <a class="nav-item" href="/ui/subscriptions"{% if active_page == "subscriptions" %} aria-current="page"{% endif %} title="{{ i18n.t("nav-subscriptions") }}">
         <span class="icon">{% include "icons/sync.svg" %}</span>
         <span class="nav-item__label">{{ i18n.t("nav-subscriptions") }}</span>
       </a>
-      {% endif %}
     </nav>
 
     <!--

--- a/crates/ui/templates/pages/subscriptions.html
+++ b/crates/ui/templates/pages/subscriptions.html
@@ -9,26 +9,27 @@
 </section>
 
 {% if !available %}
-<div class="card notice">{{ i18n.t("subs-unavailable") }}</div>
+<div class="card notice">
+  <p>{{ i18n.t("subs-unavailable") }}</p>
+  <p>{{ i18n.t("subs-unavailable-how") }} <code>HFS_SUBSCRIPTIONS_ENABLED=true</code> · <code>--features subscriptions</code></p>
+</div>
 {% else %}
 
-<!-- The four headline cards from Brett's design. The delivery-window card
-     waits for engine instrumentation (#580): figures here are real or absent. -->
 <section class="stat-grid">
   <article class="card stat">
-    <span class="stat__label">{{ i18n.t("subs-card-failing") }}</span>
+    <span class="stat__label"><span class="status-dot status-dot--ok" aria-hidden="true"></span>{{ i18n.t("subs-card-active") }}</span>
+    <span class="stat__value">{{ cards.active }}</span>
+    <span class="stat__sub">{{ i18n.t("subs-card-active-sub") }}</span>
+  </article>
+  <article class="card stat">
+    <span class="stat__label"><span class="status-dot status-dot--danger" aria-hidden="true"></span>{{ i18n.t("subs-card-failing") }}</span>
     <span class="stat__value">{{ cards.failing }}</span>
     <span class="stat__sub">{{ i18n.t("subs-card-failing-sub") }}</span>
   </article>
   <article class="card stat">
-    <span class="stat__label">{{ i18n.t("subs-card-idle") }}</span>
+    <span class="stat__label"><span class="status-dot status-dot--warn" aria-hidden="true"></span>{{ i18n.t("subs-card-idle") }}</span>
     <span class="stat__value">{{ cards.idle }}</span>
     <span class="stat__sub">{{ i18n.t("subs-card-idle-sub") }}</span>
-  </article>
-  <article class="card stat">
-    <span class="stat__label">{{ i18n.t("subs-card-active") }}</span>
-    <span class="stat__value">{{ cards.active }}</span>
-    <span class="stat__sub">{{ i18n.t("subs-card-active-sub") }}</span>
   </article>
   <article class="card stat">
     <span class="stat__label">{{ i18n.t("subs-card-delivered") }}</span>
@@ -46,10 +47,11 @@
     <!-- Sort is a plain-links menu, so it works without JavaScript. -->
     <details class="menu subs-sort">
       <summary class="btn">
-        {{ i18n.t("subs-sort") }}:
-        {% if sort == "sent" %}{{ i18n.t("subs-sort-sent") }}{% else if sort == "fails" %}{{ i18n.t("subs-sort-fails") }}{% else %}{{ i18n.t("subs-sort-status") }}{% endif %}
+        <span class="subs-sort__label">{{ i18n.t("subs-sort") }}</span>
+        <span>{% if sort == "sent" %}{{ i18n.t("subs-sort-sent") }}{% else if sort == "fails" %}{{ i18n.t("subs-sort-fails") }}{% else %}{{ i18n.t("subs-sort-status") }}{% endif %}</span>
+        <span class="icon subs-sort__chevron" aria-hidden="true">{% include "icons/chevron-down.svg" %}</span>
       </summary>
-      <div class="menu__panel menu__panel--right">
+      <div class="menu__panel menu__panel--right menu__panel--compact">
         <a class="menu__option" href="/ui/subscriptions?sort=status"{% if sort == "status" %} aria-current="true"{% endif %}>{{ i18n.t("subs-sort-status") }}</a>
         <a class="menu__option" href="/ui/subscriptions?sort=sent"{% if sort == "sent" %} aria-current="true"{% endif %}>{{ i18n.t("subs-sort-sent") }}</a>
         <a class="menu__option" href="/ui/subscriptions?sort=fails"{% if sort == "fails" %} aria-current="true"{% endif %}>{{ i18n.t("subs-sort-fails") }}</a>
@@ -71,7 +73,7 @@
       </thead>
       <tbody>
         {% for row in rows %}
-        <tr>
+        <tr{% if row.state == "error" %} class="row--alert"{% endif %}>
           <td>
             <span class="code">{{ row.id }}</span>
             <span class="url" title="{{ row.topic_url }}">{{ row.topic }}</span>
@@ -84,15 +86,15 @@
           </td>
           <td>
             {% if row.state == "active" %}
-            <span class="tag tag--active">{{ i18n.t("subs-state-active") }}</span>
+            <span class="status-dot status-dot--ok" aria-hidden="true"></span>{{ i18n.t("subs-state-active") }}
             {% else if row.state == "error" %}
-            <span class="tag tag--error">{{ i18n.t("subs-state-error") }}</span>
+            <span class="status-dot status-dot--danger" aria-hidden="true"></span>{{ i18n.t("subs-state-error") }}
             {% else if row.state == "idle" %}
-            <span class="tag tag--idle">{{ i18n.t("subs-state-idle") }}</span>
+            <span class="status-dot status-dot--warn" aria-hidden="true"></span>{{ i18n.t("subs-state-idle") }}
             {% else if row.state == "requested" %}
-            <span class="tag tag--requested">{{ i18n.t("subs-state-requested") }}</span>
+            <span class="status-dot status-dot--muted" aria-hidden="true"></span>{{ i18n.t("subs-state-requested") }}
             {% else %}
-            <span class="tag tag--muted">{{ i18n.t("subs-state-off") }}</span>
+            <span class="status-dot status-dot--muted" aria-hidden="true"></span>{{ i18n.t("subs-state-off") }}
             {% endif %}
           </td>
           <td class="col-num">{{ row.last24 }}</td>

--- a/crates/ui/tests/subscriptions_http.rs
+++ b/crates/ui/tests/subscriptions_http.rs
@@ -104,21 +104,29 @@ impl SubscriptionsProvider for Fixed {
 
 #[tokio::test]
 async fn the_page_goes_from_unavailable_to_the_live_dashboard() {
-    // Phase 1 — no provider registered: the page explains itself and the
-    // sidebar hides the entry (the feature is not advertised).
+    // Phase 1 — no provider registered: the nav entry is present anyway
+    // (#767) and the page explains what to do, naming the switch and the
+    // build feature rather than a bare "unavailable".
     let (status, html) = get("/ui/subscriptions").await;
     assert_eq!(status, StatusCode::OK);
-    assert!(html.contains("subs") || !html.is_empty());
     assert!(
         html.contains("not enabled on this server"),
         "unavailable state renders"
     );
     assert!(
-        !html.contains(r#"href="/ui/subscriptions""#),
-        "nav entry hidden while not advertised"
+        html.contains("HFS_SUBSCRIPTIONS_ENABLED"),
+        "the off state names the switch"
+    );
+    assert!(
+        html.contains("--features subscriptions"),
+        "the off state names the build feature"
+    );
+    assert!(
+        html.contains(r#"href="/ui/subscriptions""#),
+        "nav entry present with the engine off"
     );
 
-    // Phase 2 — provider registered: cards, rows, chips, and the nav entry.
+    // Phase 2 — provider registered: cards, rows, dots, and the nav entry.
     set_provider(Arc::new(Fixed));
     let (status, html) = get("/ui/subscriptions").await;
     assert_eq!(status, StatusCode::OK);
@@ -134,13 +142,17 @@ async fn the_page_goes_from_unavailable_to_the_live_dashboard() {
     );
     assert!(html.contains("96.2"), "first-try rate renders");
 
-    // Rows: the failing subscription leads (worst first), the idle websocket
+    // Rows: the failing subscription leads (worst first) and carries the red
+    // edge, statuses render as dots with plain labels, the idle websocket
     // shows the 0-clients state with no streak, and the streak prints.
     let error_at = html.find("obs-critical").expect("error row");
     let active_at = html.find("encounter-start").expect("active row");
     assert!(error_at < active_at, "errors sort first");
-    assert!(html.contains(r#"tag--error"#));
-    assert!(html.contains(r#"tag--idle"#));
+    assert!(html.contains(r#"class="row--alert""#), "failing row edge");
+    assert!(html.contains(r#"status-dot--danger"#));
+    assert!(html.contains(r#"status-dot--ok"#));
+    assert!(html.contains(r#"status-dot--warn"#));
+    assert!(!html.contains(r#"tag--error"#), "pills gave way to dots");
     assert!(html.contains("0 clients"));
     assert!(html.contains(">7<"), "fail streak renders");
     assert!(html.contains("4,182"));

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -660,11 +660,12 @@ editor-hint-instant = FHIR instant: vollständiger Zeitstempel mit Zeitzone, z. 
 subs-title = Abonnements
 subs-lede = Schreibgeschützte Sicht auf die Abonnement-Engine: jedes registrierte Abonnement, sein Kanal, Live-Status und Zustellzähler.
 subs-unavailable = Die Abonnement-Engine ist auf diesem Server nicht aktiviert.
+subs-unavailable-how = Zum Aktivieren HFS starten mit:
 subs-empty = Für diesen Mandanten sind keine Abonnements registriert.
 subs-card-failing = Fehlgeschlagen
-subs-card-failing-sub = braucht Aufmerksamkeit
+subs-card-failing-sub = Braucht Aufmerksamkeit
 subs-card-idle = Inaktiv
-subs-card-idle-sub = keine Clients
+subs-card-idle-sub = Keine Clients
 subs-card-active = Aktiv
 subs-card-active-sub = wird zugestellt
 subs-card-delivered = Zugestellt in 24 h
@@ -681,11 +682,11 @@ subs-col-status = Status
 subs-col-last24 = Letzte 24 h
 subs-col-sent = Gesendet
 subs-col-fails = Fehlerserie
-subs-state-active = aktiv
+subs-state-active = Aktiv
 subs-state-error = Fehler
 subs-state-idle = 0 Clients
-subs-state-requested = angefragt
-subs-state-off = aus
+subs-state-requested = Angefragt
+subs-state-off = Aus
 
 ## Bulk Export workspace (#537)
 

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -663,11 +663,12 @@ editor-hint-instant = FHIR instant: full timestamp with timezone, e.g. 2024-05-1
 subs-title = Subscriptions
 subs-lede = Read-only view of the subscriptions engine: every registered subscription, its channel, live status, and delivery counters.
 subs-unavailable = The subscriptions engine is not enabled on this server.
+subs-unavailable-how = Turn it on by starting HFS with:
 subs-empty = No subscriptions are registered for this tenant.
 subs-card-failing = Failing
-subs-card-failing-sub = needs attention
+subs-card-failing-sub = Needs attention
 subs-card-idle = Idle
-subs-card-idle-sub = no clients
+subs-card-idle-sub = No clients
 subs-card-active = Active
 subs-card-active-sub = delivering
 subs-card-delivered = Delivered in 24 h
@@ -684,11 +685,11 @@ subs-col-status = Status
 subs-col-last24 = Last 24 hrs
 subs-col-sent = Sent
 subs-col-fails = Fail streak
-subs-state-active = active
-subs-state-error = error
+subs-state-active = Active
+subs-state-error = Error
 subs-state-idle = 0 clients
-subs-state-requested = requested
-subs-state-off = off
+subs-state-requested = Requested
+subs-state-off = Off
 
 ## Bulk Export workspace (#537)
 

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -660,11 +660,12 @@ editor-hint-instant = FHIR instant: timestamp completo con zona horaria, p. ej. 
 subs-title = Suscripciones
 subs-lede = Vista de solo lectura del motor de suscripciones: cada suscripción registrada, su canal, estado en vivo y contadores de entrega.
 subs-unavailable = El motor de suscripciones no está habilitado en este servidor.
+subs-unavailable-how = Actívalo arrancando HFS con:
 subs-empty = No hay suscripciones registradas para este tenant.
 subs-card-failing = Fallando
-subs-card-failing-sub = requiere atención
+subs-card-failing-sub = Requiere atención
 subs-card-idle = Inactivas
-subs-card-idle-sub = sin clientes
+subs-card-idle-sub = Sin clientes
 subs-card-active = Activas
 subs-card-active-sub = entregando
 subs-card-delivered = Entregadas en 24 h
@@ -681,11 +682,11 @@ subs-col-status = Estado
 subs-col-last24 = Últimas 24 h
 subs-col-sent = Enviadas
 subs-col-fails = Racha de fallos
-subs-state-active = activa
-subs-state-error = error
+subs-state-active = Activa
+subs-state-error = Error
 subs-state-idle = 0 clientes
-subs-state-requested = solicitada
-subs-state-off = apagada
+subs-state-requested = Solicitada
+subs-state-off = Apagada
 
 ## Bulk Export workspace (#537)
 


### PR DESCRIPTION
Closes #767.

## Nav entry

Always present in Tools, like Bulk Import / Bulk Export / Tenants — the conditional `subscriptions_enabled()` gate and its `Status` plumbing are removed. **Decision recorded:** the entry stays a live link with the engine off rather than rendering disabled — that matches how every other feature page degrades, and the frame shows no disabled nav treatment. With the engine off, the page now names `HFS_SUBSCRIPTIONS_ENABLED=true` and `--features subscriptions` instead of a bare "unavailable".

## Page vs the frame (405:2)

- Cards reordered to **Active / Failing / Idle / Delivered in 24 h**, with status dots on the first three labels and the frame's sub-lines (`delivering`, `Needs attention`, `No clients`, `{rate}% first try`).
- The STATUS column renders **dots with plain labels** (Active / Error / 0 clients / Requested / Off) instead of pill tags; the publication-status block reclaims `.tag--active` now that the subscription pills are gone.
- A failing row carries the frame's **red left edge** (`row--alert`).
- The sort control gets the SORT label / value / chevron treatment; options stay the honest three (Status / Most sent / Fail streak) since the snapshot has no recency field.
- Numeric columns inherit #758's left alignment via the shared `col-num`.
- The two stale "deliberately absent" comments are removed — #586 landed the 24-hour instrumentation and the cards/columns show it.

**Not faked:** the frame's per-row 24-hour sparkline needs a per-subscription time series `SubscriptionsSnapshot` does not carry. Filed as #782; the column shows the real count until the engine grows the series.

## Tests

- `subscriptions_http.rs` reworked: the off state asserts the switch and build feature are named and the nav entry is present either way; the live phase asserts dots, the red row edge, and that the pills are gone.
- Playwright `subscriptions.spec.ts` restructured: the nav test never skips; a new off-state test covers the explained copy (runs on default local builds); the live-state tests keep their engine-on skip for CI.
- New strings landed in `en`/`es`/`de` (parity enforced); a11y, design-system, no-cdn, and nojs rings green.