### PR TITLE
feat(ui): View Definitions rail searches and pages server-side

### DIFF
--- a/crates/ui/e2e/tests/sql-view-definitions.spec.ts
+++ b/crates/ui/e2e/tests/sql-view-definitions.spec.ts
@@ -2,7 +2,9 @@
 // rail, its JSON lands in the editor, Run previews rows through $sql-run, and
 // Create New offers the starter document. Everything here is plain links and
 // forms, so it also holds with JavaScript disabled (the nojs sweep loads the
-// route; the flows are exercised in the chromium project only).
+// route; the flows are exercised in the chromium project only). The rail
+// itself is a server-side search — name filter, `_sort=name`, 50-item pages
+// with plain previous/next links (#741) — not a full-collection fetch.
 import { expect, test } from "../pages/fixtures";
 import { createResource, waitSearchable } from "../pages/api";
 
@@ -47,4 +49,105 @@ test("a stored ViewDefinition lists, edits, and previews rows", async ({ page, r
   // Create New swaps the editor to the starter document.
   await page.goto("/ui/sql/view-definitions?vd=new");
   await expect(page.locator("textarea[name='json']")).toContainText("new_view");
+});
+
+/** A minimal savable ViewDefinition, named for the rail. */
+function starter(name: string) {
+  return {
+    name,
+    status: "active",
+    resource: "Patient",
+    select: [{ column: [{ name: "id", path: "getResourceKey()" }] }],
+  };
+}
+
+// #741: the rail is now a server-side search (name filter, `_sort=name`,
+// 50-item pages) rather than a full-collection fetch filtered in memory.
+
+test("the search box filters the rail to exactly the matching names, case-insensitively", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now().toString(36);
+  // Both "patients" hits share the stamp so the filter below cannot pick up
+  // an unrelated ViewDefinition left over by another spec or worker.
+  const alphaId = await createResource(
+    request,
+    "ViewDefinition",
+    starter(`zpar_${stamp}_Patients_Alpha`),
+  );
+  const betaId = await createResource(
+    request,
+    "ViewDefinition",
+    starter(`zpar_${stamp}_PATIENTS_Beta`),
+  );
+  const gammaId = await createResource(
+    request,
+    "ViewDefinition",
+    starter(`zpar_${stamp}_Observations_Gamma`),
+  );
+  await Promise.all(
+    [alphaId, betaId, gammaId].map((id) => waitSearchable(request, "ViewDefinition", id)),
+  );
+
+  // Typed lowercase against stored mixed/upper case — a case-insensitive
+  // substring match either side, per the SQL-on-FHIR IG's `name:contains`.
+  await page.goto(`/ui/sql/view-definitions?filter=${stamp}_patients`);
+  const rail = page.locator("#vd-rail-list .filter-rail__item");
+  await expect(rail).toHaveCount(2);
+  await expect(page.locator(`#vd-rail-list [data-type='${alphaId}']`)).toBeVisible();
+  await expect(page.locator(`#vd-rail-list [data-type='${betaId}']`)).toBeVisible();
+  await expect(page.locator(`#vd-rail-list [data-type='${gammaId}']`)).toHaveCount(0);
+});
+
+test("paginates the rail past 50 views, preserving the filter across pages", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now().toString(36);
+  const names = Array.from(
+    { length: 55 },
+    (_, i) => `zpage_${stamp}_${String(i + 1).padStart(2, "0")}`,
+  );
+  const ids = await Promise.all(
+    names.map((name) => createResource(request, "ViewDefinition", starter(name))),
+  );
+  await Promise.all(ids.map((id) => waitSearchable(request, "ViewDefinition", id)));
+
+  await page.goto(`/ui/sql/view-definitions?filter=zpage_${stamp}`);
+  const rail = page.locator("#vd-rail-list .filter-rail__item");
+  await expect(rail).toHaveCount(50);
+  const pagination = page.locator("nav.pagination");
+  const next = pagination.locator("a", { hasText: "Next" });
+  await expect(next).toBeVisible();
+  await expect(pagination.locator("a", { hasText: "Previous" })).toHaveCount(0);
+
+  await next.click();
+  await expect(page).toHaveURL(/page=2/);
+  expect(new URL(page.url()).searchParams.get("filter")).toBe(`zpage_${stamp}`);
+  await expect(rail).toHaveCount(5);
+  await expect(pagination.locator("a", { hasText: "Previous" })).toBeVisible();
+  await expect(pagination.locator("a", { hasText: "Next" })).toHaveCount(0);
+});
+
+test("a selection the filter excludes from the rail still shows its own editor", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now().toString(36);
+  const keepId = await createResource(request, "ViewDefinition", starter(`zsel_${stamp}_keep`));
+  const otherId = await createResource(
+    request,
+    "ViewDefinition",
+    starter(`zsel_${stamp}_exclude`),
+  );
+  await Promise.all([keepId, otherId].map((id) => waitSearchable(request, "ViewDefinition", id)));
+
+  await page.goto(`/ui/sql/view-definitions?vd=${keepId}&filter=exclude`);
+  // The rail only shows what the filter matches...
+  await expect(page.locator(`#vd-rail-list [data-type='${otherId}']`)).toBeVisible();
+  await expect(page.locator(`#vd-rail-list [data-type='${keepId}']`)).toHaveCount(0);
+  // ...but the editor still holds the view the filter excluded, read
+  // directly by id rather than dropped as "not found" (#741).
+  await expect(page.locator("textarea[name='json']")).toContainText(`zsel_${stamp}_keep`);
 });

--- a/crates/ui/src/conformance.rs
+++ b/crates/ui/src/conformance.rs
@@ -103,6 +103,48 @@ pub trait ConformanceSource: Send + Sync {
         let _ = (job_id, tenant);
         Err("$sql-export is not available from this source".to_string())
     }
+
+    /// Runs `GET {type}?{params}&_count={count}&_offset={offset}` and returns
+    /// the resulting page plus whether the server advertised a `next` link.
+    /// Unlike [`fetch`](ConformanceSource::fetch), which pulls the whole
+    /// collection into memory, this issues exactly one request per page so a
+    /// page can filter and paginate server-side (#741).
+    async fn search_page(
+        &self,
+        resource_type: &str,
+        params: &[(String, String)],
+        count: usize,
+        offset: usize,
+        version: FhirVersion,
+        tenant: &str,
+    ) -> Result<SearchPage, String> {
+        let _ = (resource_type, params, count, offset, version, tenant);
+        Err("search is not available from this source".to_string())
+    }
+
+    /// `GET /{resource_type}/{id}`, or an `Err` message when it fails —
+    /// including a 404, surfaced as text rather than `Option` so the caller
+    /// can show the reason without a second request (#741).
+    async fn read_resource(
+        &self,
+        resource_type: &str,
+        id: &str,
+        version: FhirVersion,
+        tenant: &str,
+    ) -> Result<Value, String> {
+        let _ = (resource_type, id, version, tenant);
+        Err("reading a resource by id is not available from this source".to_string())
+    }
+}
+
+/// One page of a server-side search (#741): the resources that page holds,
+/// plus whether the server advertised a `next` link — the UI uses this to
+/// decide whether to render a "next" control without fetching an extra page
+/// just to find out.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchPage {
+    pub resources: Vec<Value>,
+    pub has_next: bool,
 }
 
 /// What a `$sql-export` status poll answered (#649).
@@ -375,6 +417,94 @@ impl ConformanceSource for HttpConformanceSource {
             .json::<Vec<Value>>()
             .await
             .map_err(|e| format!("parsing $sql-run rows failed: {e}"))
+    }
+
+    /// `GET {base}/{resource_type}?{params}&_count={count}&_offset={offset}`
+    /// on the loopback base, a single request per page. Storage holds the
+    /// seeded default version only, so a non-default version degrades the
+    /// same way `sql_run` does rather than answering from the spec bundles —
+    /// those bundles have no search index to page over, and ViewDefinitions
+    /// (the first caller of this method) only exist in storage anyway.
+    async fn search_page(
+        &self,
+        resource_type: &str,
+        params: &[(String, String)],
+        count: usize,
+        offset: usize,
+        version: FhirVersion,
+        tenant: &str,
+    ) -> Result<SearchPage, String> {
+        if version != self.default_version {
+            return Err(format!(
+                "search reads stored data, which holds the server default (FHIR {}); switch the sidebar back to search this type",
+                self.default_version.as_str(),
+            ));
+        }
+        let url = format!("{}/{resource_type}", self.base_url);
+        let mut query: Vec<(String, String)> = params.to_vec();
+        query.push(("_count".to_string(), count.to_string()));
+        query.push(("_offset".to_string(), offset.to_string()));
+        let request = self.client.get(&url).query(&query).header(
+            "Accept",
+            format!(
+                "application/fhir+json; fhirVersion={}",
+                version.as_mime_param()
+            ),
+        );
+        let request = self.authorized(request, tenant).await?;
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("request to {url} failed: {e}"))?;
+        if !response.status().is_success() {
+            return Err(format!("{url} returned {}", response.status()));
+        }
+        let bundle: Value = response
+            .json()
+            .await
+            .map_err(|e| format!("parsing {resource_type} search results failed: {e}"))?;
+        Ok(SearchPage {
+            resources: extract_bundle_resources(&bundle),
+            has_next: next_link(&bundle).is_some(),
+        })
+    }
+
+    /// `GET {base}/{resource_type}/{id}` on the loopback base. Same
+    /// non-default-version degradation as [`search_page`](Self::search_page):
+    /// storage only holds the server default.
+    async fn read_resource(
+        &self,
+        resource_type: &str,
+        id: &str,
+        version: FhirVersion,
+        tenant: &str,
+    ) -> Result<Value, String> {
+        if version != self.default_version {
+            return Err(format!(
+                "reading {resource_type}/{id} reads stored data, which holds the server default (FHIR {}); switch the sidebar back to read this resource",
+                self.default_version.as_str(),
+            ));
+        }
+        let url = format!("{}/{resource_type}/{id}", self.base_url);
+        let request = self.client.get(&url).header(
+            "Accept",
+            format!(
+                "application/fhir+json; fhirVersion={}",
+                version.as_mime_param()
+            ),
+        );
+        let request = self.authorized(request, tenant).await?;
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("request to {url} failed: {e}"))?;
+        if !response.status().is_success() {
+            return Err(format!("{url} returned {}", response.status()));
+        }
+        response
+            .json()
+            .await
+            .map_err(|e| format!("parsing {resource_type}/{id} failed: {e}"))
     }
 
     async fn save_resource(
@@ -761,6 +891,83 @@ impl ConformanceSource for StaticConformanceSource {
             .unwrap_or_else(|| Err("no manifest seeded".to_string()))
     }
 
+    /// Filters and paginates the seeded resources in memory. Implements the
+    /// subset of search semantics the View Definitions page actually sends
+    /// (#741): `name:contains` (case-insensitive substring on `name`) and
+    /// `_sort=name` (also the default with no `_sort` param, matching the
+    /// server's own default order). Other params are accepted but ignored —
+    /// this is a test double standing in for the real search engine, not a
+    /// reimplementation of it.
+    async fn search_page(
+        &self,
+        resource_type: &str,
+        params: &[(String, String)],
+        count: usize,
+        offset: usize,
+        version: FhirVersion,
+        _tenant: &str,
+    ) -> Result<SearchPage, String> {
+        let mut resources = self
+            .map
+            .get(&(resource_type.to_string(), version))
+            .cloned()
+            .unwrap_or_default();
+
+        if let Some((_, needle)) = params.iter().find(|(name, _)| name == "name:contains") {
+            let needle = needle.to_lowercase();
+            resources.retain(|r| {
+                r.get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|n| n.to_lowercase().contains(&needle))
+            });
+        }
+
+        let sort = params
+            .iter()
+            .find(|(name, _)| name == "_sort")
+            .map(|(_, value)| value.as_str())
+            .unwrap_or("name");
+        if sort == "name" {
+            resources.sort_by(|a, b| {
+                let name_of = |r: &Value| {
+                    r.get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string()
+                };
+                name_of(a).cmp(&name_of(b))
+            });
+        }
+
+        let total = resources.len();
+        let page: Vec<Value> = resources.into_iter().skip(offset).take(count).collect();
+        let has_next = offset + page.len() < total;
+        Ok(SearchPage {
+            resources: page,
+            has_next,
+        })
+    }
+
+    /// The seeded resource with matching `id`, or an `Err` when none exists —
+    /// the same failure the HTTP source reports for a 404 (#741).
+    async fn read_resource(
+        &self,
+        resource_type: &str,
+        id: &str,
+        version: FhirVersion,
+        _tenant: &str,
+    ) -> Result<Value, String> {
+        self.map
+            .get(&(resource_type.to_string(), version))
+            .and_then(|resources| {
+                resources
+                    .iter()
+                    .find(|r| r.get("id").and_then(Value::as_str) == Some(id))
+            })
+            .cloned()
+            .ok_or_else(|| format!("no {resource_type} with id {id}"))
+    }
+
     /// Echoes the resource back with an id, so the save handler's redirect
     /// (and a test's assertion on it) has something stable to point at.
     async fn save_resource(
@@ -923,5 +1130,301 @@ mod tests {
             .map(|r| r["id"].as_str().unwrap().to_string())
             .collect();
         assert_eq!(ids, vec!["sp-0", "sp-1"]);
+    }
+
+    /// #741: `search_page` issues one request with the given params plus
+    /// `_count`/`_offset`, and derives `has_next` from the response Bundle's
+    /// `next` link (present or absent).
+    #[tokio::test]
+    async fn http_search_page_sends_params_count_offset_and_reports_has_next() {
+        use axum::extract::Query;
+        use axum::{Router, routing::get};
+        use std::collections::HashMap;
+
+        async fn page(Query(q): Query<HashMap<String, String>>) -> axum::Json<Value> {
+            // Echo the received query back as the entry resource, so the
+            // test can assert on exactly what the client sent.
+            let mut echo = serde_json::json!({ "resourceType": "QueryEcho" });
+            if let Some(map) = echo.as_object_mut() {
+                for (k, v) in &q {
+                    map.insert(k.clone(), Value::String(v.clone()));
+                }
+            }
+            let mut bundle = serde_json::json!({
+                "resourceType": "Bundle",
+                "type": "searchset",
+                "entry": [{"resource": echo}]
+            });
+            // Only the first page (offset 0) advertises a next link.
+            if q.get("_offset").map(String::as_str) == Some("0") {
+                bundle["link"] = serde_json::json!([
+                    {"relation": "next", "url": "http://x/ViewDefinition?_offset=50"}
+                ]);
+            }
+            axum::Json(bundle)
+        }
+
+        let app = Router::new().route("/ViewDefinition", get(page));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let source = HttpConformanceSource::new(
+            format!("http://{addr}"),
+            std::sync::Arc::new(helios_auth::outbound::NoOpOutboundAuthProvider),
+            FhirVersion::R4,
+            None,
+        );
+
+        let first = source
+            .search_page(
+                "ViewDefinition",
+                &[("name:contains".to_string(), "pat".to_string())],
+                50,
+                0,
+                FhirVersion::R4,
+                "",
+            )
+            .await
+            .expect("search succeeds");
+        assert_eq!(first.resources[0]["name:contains"], "pat");
+        assert_eq!(first.resources[0]["_count"], "50");
+        assert_eq!(first.resources[0]["_offset"], "0");
+        assert!(first.has_next, "server advertised a next link");
+
+        let second = source
+            .search_page("ViewDefinition", &[], 50, 50, FhirVersion::R4, "")
+            .await
+            .expect("search succeeds");
+        assert!(!second.has_next, "no next link on the last page");
+    }
+
+    /// #741: the tenant header rides `search_page` and `read_resource` the
+    /// same way it does the other self-calls — sent when the tenant is not
+    /// empty, absent otherwise.
+    #[tokio::test]
+    async fn http_search_page_sends_the_tenant_header_only_when_present() {
+        use axum::extract::Path;
+        use axum::http::HeaderMap;
+        use axum::response::IntoResponse;
+        use axum::{Router, routing::get};
+
+        fn echo_tenant(headers: &HeaderMap) -> axum::Json<Value> {
+            let tenant = headers
+                .get("x-tenant-id")
+                .and_then(|v| v.to_str().ok())
+                .map(String::from);
+            let mut resource =
+                serde_json::json!({ "resourceType": "ViewDefinition", "id": "vd-1" });
+            if let Some(t) = tenant {
+                resource["tenant"] = Value::String(t);
+            }
+            axum::Json(resource)
+        }
+
+        async fn get_one(headers: HeaderMap, Path(_id): Path<String>) -> axum::response::Response {
+            echo_tenant(&headers).into_response()
+        }
+
+        let app = Router::new().route("/ViewDefinition/{id}", get(get_one));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let source = HttpConformanceSource::new(
+            format!("http://{addr}"),
+            std::sync::Arc::new(helios_auth::outbound::NoOpOutboundAuthProvider),
+            FhirVersion::R4,
+            None,
+        );
+
+        let with_tenant = source
+            .read_resource("ViewDefinition", "vd-1", FhirVersion::R4, "clinic-a")
+            .await
+            .expect("read succeeds");
+        assert_eq!(with_tenant["tenant"], "clinic-a");
+
+        let without_tenant = source
+            .read_resource("ViewDefinition", "vd-1", FhirVersion::R4, "")
+            .await
+            .expect("read succeeds");
+        assert!(
+            without_tenant.get("tenant").is_none(),
+            "no X-Tenant-ID sent for an empty tenant"
+        );
+    }
+
+    /// #741: a non-default FHIR version degrades with `Err` for both new
+    /// methods, the same as `sql_run` — storage only holds the server
+    /// default, and there is no search index or single-resource lookup over
+    /// the spec bundles to fall back to.
+    #[cfg(feature = "R4B")]
+    #[tokio::test]
+    async fn non_default_version_degrades_search_and_read() {
+        let source = HttpConformanceSource::new(
+            "http://127.0.0.1:1".to_string(),
+            std::sync::Arc::new(helios_auth::outbound::NoOpOutboundAuthProvider),
+            FhirVersion::R4,
+            None,
+        );
+
+        let err = source
+            .search_page("ViewDefinition", &[], 50, 0, FhirVersion::R4B, "")
+            .await
+            .expect_err("non-default version has no stored data to search");
+        assert!(err.contains(FhirVersion::R4.as_str()), "{err}");
+
+        let err = source
+            .read_resource("ViewDefinition", "vd-1", FhirVersion::R4B, "")
+            .await
+            .expect_err("non-default version has no stored data to read");
+        assert!(err.contains(FhirVersion::R4.as_str()), "{err}");
+    }
+
+    /// #741: `read_resource` surfaces both success and a 404 as the caller
+    /// expects — the same distinction the View Definitions detail view needs
+    /// to render "not found" rather than a generic error.
+    #[tokio::test]
+    async fn http_read_resource_succeeds_and_reports_404() {
+        use axum::extract::Path;
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::{Router, routing::get};
+
+        async fn get_one(Path(id): Path<String>) -> axum::response::Response {
+            if id == "vd-1" {
+                axum::Json(serde_json::json!({
+                    "resourceType": "ViewDefinition",
+                    "id": "vd-1",
+                    "name": "Patients"
+                }))
+                .into_response()
+            } else {
+                StatusCode::NOT_FOUND.into_response()
+            }
+        }
+
+        let app = Router::new().route("/ViewDefinition/{id}", get(get_one));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let source = HttpConformanceSource::new(
+            format!("http://{addr}"),
+            std::sync::Arc::new(helios_auth::outbound::NoOpOutboundAuthProvider),
+            FhirVersion::R4,
+            None,
+        );
+
+        let found = source
+            .read_resource("ViewDefinition", "vd-1", FhirVersion::R4, "")
+            .await
+            .expect("resource exists");
+        assert_eq!(found["name"], "Patients");
+
+        let missing = source
+            .read_resource("ViewDefinition", "missing", FhirVersion::R4, "")
+            .await
+            .expect_err("404 surfaces as an Err");
+        assert!(missing.contains("404"), "{missing}");
+    }
+
+    /// #741: the static double's `name:contains` filter is case-insensitive,
+    /// the default order is ascending by `name`, and `has_next` is correct on
+    /// the exact boundary (total is a multiple of the page size).
+    #[tokio::test]
+    async fn static_search_page_filters_sorts_and_paginates() {
+        fn vd(id: &str, name: &str) -> Value {
+            serde_json::json!({ "resourceType": "ViewDefinition", "id": id, "name": name })
+        }
+
+        let source = StaticConformanceSource::empty().with(
+            "ViewDefinition",
+            FhirVersion::default(),
+            vec![
+                vd("vd-3", "Charlie"),
+                vd("vd-1", "alpha-patients"),
+                vd("vd-2", "Bravo"),
+                vd("vd-4", "another-alpha"),
+            ],
+        );
+
+        // `name:contains` is case-insensitive on a substring.
+        let filtered = source
+            .search_page(
+                "ViewDefinition",
+                &[("name:contains".to_string(), "ALPHA".to_string())],
+                50,
+                0,
+                FhirVersion::default(),
+                "",
+            )
+            .await
+            .expect("search succeeds");
+        let names: Vec<_> = filtered
+            .resources
+            .iter()
+            .map(|r| r["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["alpha-patients", "another-alpha"]);
+        assert!(!filtered.has_next);
+
+        // Default order (no `_sort`) is ascending by name.
+        let sorted = source
+            .search_page("ViewDefinition", &[], 50, 0, FhirVersion::default(), "")
+            .await
+            .expect("search succeeds");
+        let names: Vec<_> = sorted
+            .resources
+            .iter()
+            .map(|r| r["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["Bravo", "Charlie", "alpha-patients", "another-alpha"]
+        );
+
+        // Pagination on the exact boundary: 4 resources, page size 2 — the
+        // first page has a next, the second does not.
+        let page1 = source
+            .search_page("ViewDefinition", &[], 2, 0, FhirVersion::default(), "")
+            .await
+            .expect("search succeeds");
+        assert_eq!(page1.resources.len(), 2);
+        assert!(page1.has_next, "two more resources remain");
+
+        let page2 = source
+            .search_page("ViewDefinition", &[], 2, 2, FhirVersion::default(), "")
+            .await
+            .expect("search succeeds");
+        assert_eq!(page2.resources.len(), 2);
+        assert!(!page2.has_next, "exactly consumed the total");
+    }
+
+    /// #741: the static double's `read_resource` finds the seeded resource by
+    /// id, or reports an `Err` when none matches.
+    #[tokio::test]
+    async fn static_read_resource_finds_by_id_or_errs() {
+        let source = StaticConformanceSource::empty().with(
+            "ViewDefinition",
+            FhirVersion::default(),
+            vec![serde_json::json!({
+                "resourceType": "ViewDefinition",
+                "id": "vd-1",
+                "name": "Patients"
+            })],
+        );
+
+        let found = source
+            .read_resource("ViewDefinition", "vd-1", FhirVersion::default(), "")
+            .await
+            .expect("resource exists");
+        assert_eq!(found["name"], "Patients");
+
+        let missing = source
+            .read_resource("ViewDefinition", "missing", FhirVersion::default(), "")
+            .await
+            .expect_err("no such id");
+        assert!(missing.contains("missing"), "{missing}");
     }
 }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1894,10 +1894,14 @@ struct SqlViewDefinitionsPage {
     rail: Vec<sql_views::VdSummary>,
     /// The rail's server-side name filter, echoed back into the search box.
     filter: String,
-    /// The list fetch failed — the page says so instead of showing an empty rail.
+    /// The rail's "previous" link, `None` on the first page (#741).
+    prev_href: Option<String>,
+    /// The rail's "next" link, `None` when the search reported no further page.
+    next_href: Option<String>,
+    /// The list search failed — the page says so instead of showing an empty rail.
     degraded: Option<String>,
-    /// `?vd=` (or the first entry): id, name, and pretty JSON. `None` only
-    /// when the store holds no views and none is being created.
+    /// `?vd=` (or the rail's first visible entry): id, name, and pretty JSON.
+    /// `None` only when the store holds no views and none is being created.
     selected: Option<SelectedVd>,
     /// `?vd=new`: the JSON below is the starter document, not a stored view.
     is_new: bool,
@@ -1919,8 +1923,20 @@ struct SqlVdQuery {
     filter: Option<String>,
     run: Option<String>,
     saved: Option<String>,
+    /// 1-based (#741). Kept as raw text rather than `Option<usize>` so a
+    /// non-numeric value fails the `parse` below instead of the whole
+    /// extractor — an invalid page falls back to 1, it never 400s.
+    page: Option<String>,
 }
 
+/// `GET /ui/sql/view-definitions`: the rail is one page of a server-side
+/// `ViewDefinition` search (#741) — `name:contains`, `_sort=name`,
+/// `_count`/`_offset` — never the full-collection fetch this page used
+/// before #741. The old in-memory filter also matched the resource-type
+/// column (`ViewDefinition.resource`); that match is dropped on purpose, not
+/// carried over into `name:contains` — it was never a documented part of
+/// #649 and has no standard FHIR search expression (see
+/// [`sql_views::rail_search_params`] for why).
 async fn sql_view_definitions_page(
     State(state): State<WebState>,
     locale: RequestLocale,
@@ -1929,28 +1945,44 @@ async fn sql_view_definitions_page(
     Query(query): Query<SqlVdQuery>,
 ) -> Response {
     let filter = query.filter.unwrap_or_default();
-    let (mut rail, degraded) = match state
+    // Absent or non-numeric falls back to page 1 rather than 400ing — a
+    // stale or hand-edited `?page=` is a navigation mistake, not an error.
+    let page = query
+        .page
+        .as_deref()
+        .and_then(|p| p.parse::<usize>().ok())
+        .filter(|&p| p >= 1)
+        .unwrap_or(1);
+    let offset = (page - 1) * sql_views::PAGE_SIZE;
+
+    // The rail is one page of a server-side search (#741): filtered by
+    // `name:contains`, ordered by `_sort=name`, sliced by `_count`/`_offset`.
+    // It never pulls the tenant's whole ViewDefinition collection into memory
+    // the way the page's other consumers of `ConformanceSource::fetch`
+    // (SearchParameters, Compartments, SQL Export) still do.
+    let params = sql_views::rail_search_params(&filter);
+    let (mut page_resources, has_next, degraded) = match state
         .conformance
-        .fetch("ViewDefinition", rv.0, &rt.id)
+        .search_page(
+            "ViewDefinition",
+            &params,
+            sql_views::PAGE_SIZE,
+            offset,
+            rv.0,
+            &rt.id,
+        )
         .await
     {
-        Ok(resources) => (resources, None),
+        Ok(page) => (page.resources, page.has_next, None),
         Err(error) => {
-            tracing::warn!("ViewDefinition self-fetch failed: {error}");
-            (Vec::new(), Some(error))
+            tracing::warn!("ViewDefinition search failed: {error}");
+            (Vec::new(), false, Some(error))
         }
     };
-    let summaries = {
-        let mut s = sql_views::summarize(&rail);
-        if !filter.is_empty() {
-            let needle = filter.to_lowercase();
-            s.retain(|e| {
-                e.name.to_lowercase().contains(&needle)
-                    || e.resource.to_lowercase().contains(&needle)
-            });
-        }
-        s
-    };
+    let summaries = sql_views::summarize(&page_resources);
+    let prev_href =
+        (page > 1).then(|| sql_views::page_href(&filter, query.vd.as_deref(), page - 1));
+    let next_href = has_next.then(|| sql_views::page_href(&filter, query.vd.as_deref(), page + 1));
 
     let is_new = query.vd.as_deref() == Some("new");
     let (selected, selected_value) = if is_new {
@@ -1963,17 +1995,44 @@ async fn sql_view_definitions_page(
             None,
         )
     } else {
-        // ?vd=<id>, defaulting to the first rail entry. The full resource is
-        // taken from the fetch — no second round trip.
+        // ?vd=<id>, defaulting to the rail's first visible entry. When the id
+        // is on the visible page the resource is taken from the search
+        // above — no second round trip; otherwise (a different page, or a
+        // filter that no longer matches it) it's read directly by id, so
+        // selection stays independent of what the rail currently shows
+        // (#741).
         let wanted = query
             .vd
             .clone()
             .or_else(|| summaries.first().map(|e| e.id.clone()));
-        let found = wanted.and_then(|id| {
-            rail.iter()
-                .position(|vd| vd.get("id").and_then(serde_json::Value::as_str) == Some(&id))
+        let on_page = wanted.as_deref().and_then(|id| {
+            page_resources
+                .iter()
+                .position(|vd| vd.get("id").and_then(serde_json::Value::as_str) == Some(id))
         });
-        match found.map(|i| rail.swap_remove(i)) {
+        let resource = match on_page {
+            Some(i) => Some(page_resources.swap_remove(i)),
+            None => match &wanted {
+                Some(id) => {
+                    match state
+                        .conformance
+                        .read_resource("ViewDefinition", id, rv.0, &rt.id)
+                        .await
+                    {
+                        Ok(vd) => Some(vd),
+                        Err(error) => {
+                            // A stale or mistyped id is ordinary navigation,
+                            // not an operator concern — the page just falls
+                            // back to its no-selection state below.
+                            tracing::debug!("ViewDefinition read failed for vd={id}: {error}");
+                            None
+                        }
+                    }
+                }
+                None => None,
+            },
+        };
+        match resource {
             Some(vd) => {
                 let id = vd
                     .get("id")
@@ -2008,6 +2067,8 @@ async fn sql_view_definitions_page(
         active_page: "sql-view-definitions",
         rail: summaries,
         filter,
+        prev_href,
+        next_href,
         degraded,
         selected,
         is_new,
@@ -2047,6 +2108,8 @@ async fn sql_view_definitions_save(
             active_page: "sql-view-definitions",
             rail: Vec::new(),
             filter: String::new(),
+            prev_href: None,
+            next_href: None,
             degraded: None,
             selected: Some(SelectedVd {
                 name: if is_new { String::new() } else { id.clone() },

--- a/crates/ui/src/sql_views.rs
+++ b/crates/ui/src/sql_views.rs
@@ -2,10 +2,19 @@
 //!
 //! The page lists the tenant's stored `ViewDefinition`s in a filter rail,
 //! shows the selected one as editable JSON, and previews its output through
-//! `$sql-run`. Everything here is a pure function over resource JSON; the
-//! fetching and running live behind [`crate::ConformanceSource`].
+//! `$sql-run`. Everything here is a pure function over resource JSON or over
+//! the page's query state; the fetching, searching, and running live behind
+//! [`crate::ConformanceSource`].
+//!
+//! The rail itself is filtered, sorted, and paginated server-side (#741) —
+//! this module only shapes what the server already narrowed down to one page,
+//! plus the plain-link pagination controls at its foot.
 
 use serde_json::Value;
+
+/// The rail's page size: how many ViewDefinitions `search_page` returns per
+/// request, and the stride between `?page=` values (#741).
+pub(crate) const PAGE_SIZE: usize = 50;
 
 /// One rail entry: a stored ViewDefinition summarized for the picker.
 pub(crate) struct VdSummary {
@@ -38,6 +47,57 @@ pub(crate) fn summarize(resources: &[Value]) -> Vec<VdSummary> {
         .collect();
     entries.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
     entries
+}
+
+/// The `search_page` params for the rail's current filter (#741): `_sort=name`
+/// always (the order the rail has always shown), plus `name:contains=<filter>`
+/// only when the search box is non-empty — an empty modifier value would
+/// search for the empty string rather than mean "no filter".
+///
+/// Deliberately narrower than the old in-memory filter it replaces, which
+/// also matched the resource type column (`ViewDefinition.resource`): that
+/// match was never a documented part of #649 (it fell out of filtering in
+/// memory over both fields) and has no standard FHIR search expression —
+/// `resource` is a `token` param, and `:contains` is a `string` modifier the
+/// server rejects on token params. Dropping it is a deliberate, spec-driven
+/// narrowing (#741), not a regression.
+pub(crate) fn rail_search_params(filter: &str) -> Vec<(String, String)> {
+    let mut params = vec![("_sort".to_string(), "name".to_string())];
+    if !filter.is_empty() {
+        params.push(("name:contains".to_string(), filter.to_string()));
+    }
+    params
+}
+
+/// Builds an `/ui/sql/view-definitions` href for a rail pagination link,
+/// preserving the rail's current `filter` and the URL's current `vd`
+/// selection alongside the target `page` (#741). `page` 1 is the implicit
+/// default and is omitted from the URL, matching the bare route the rail's
+/// search form itself submits.
+pub(crate) fn page_href(filter: &str, vd: Option<&str>, page: usize) -> String {
+    let mut params: Vec<String> = Vec::new();
+    if !filter.is_empty() {
+        params.push(format!("filter={}", urlencode(filter)));
+    }
+    if let Some(id) = vd {
+        params.push(format!("vd={}", urlencode(id)));
+    }
+    if page > 1 {
+        params.push(format!("page={page}"));
+    }
+    if params.is_empty() {
+        "/ui/sql/view-definitions".to_string()
+    } else {
+        format!("/ui/sql/view-definitions?{}", params.join("&"))
+    }
+}
+
+/// `application/x-www-form-urlencoded` percent-encoding — the same encoding
+/// a browser's own `<form method="get">` submission produces, so a
+/// pagination link round-trips through [`axum::extract::Query`] identically
+/// to a search-box submit.
+fn urlencode(value: &str) -> String {
+    form_urlencoded::byte_serialize(value.as_bytes()).collect()
 }
 
 /// The view's output column names, in declaration order: a depth-first walk of
@@ -177,5 +237,30 @@ mod tests {
         let vd: Value = serde_json::from_str(&starter_view_definition()).unwrap();
         assert_eq!(vd["resourceType"], "ViewDefinition");
         assert_eq!(column_names(&vd), ["id"]);
+    }
+
+    #[test]
+    fn rail_search_params_always_sorts_and_only_filters_when_non_empty() {
+        assert_eq!(
+            rail_search_params(""),
+            vec![("_sort".to_string(), "name".to_string())],
+        );
+        assert_eq!(
+            rail_search_params("Blood"),
+            vec![
+                ("_sort".to_string(), "name".to_string()),
+                ("name:contains".to_string(), "Blood".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn page_href_omits_empty_parts_and_page_one() {
+        assert_eq!(page_href("", None, 1), "/ui/sql/view-definitions");
+        assert_eq!(page_href("", None, 2), "/ui/sql/view-definitions?page=2");
+        assert_eq!(
+            page_href("blood pressure", Some("vd-1"), 3),
+            "/ui/sql/view-definitions?filter=blood+pressure&vd=vd-1&page=3"
+        );
     }
 }

--- a/crates/ui/templates/pages/sql-view-definitions.html
+++ b/crates/ui/templates/pages/sql-view-definitions.html
@@ -3,9 +3,12 @@
 {#
   View Definitions workspace (#649, Figma 420-2): rail of stored
   ViewDefinitions (name left, resource type right), the selected one in a
-  collapsible JSON fold, and a $sql-run Results preview. Save/Duplicate are
-  submit buttons of one plain form (POST back to this route); Run is a plain
-  link (?run=1); Delete rides conformance-crud.js like the other conformance
+  collapsible JSON fold, and a $sql-run Results preview. The rail is one page
+  of a server-side search (#741) — the search box filters by name, and plain
+  previous/next links at its foot page through the rest — so it never loads
+  the tenant's whole ViewDefinition collection. Save/Duplicate are submit
+  buttons of one plain form (POST back to this route); Run is a plain link
+  (?run=1); Delete rides conformance-crud.js like the other conformance
   viewers. Everything works without JavaScript.
 #}
 
@@ -51,6 +54,16 @@
       <p class="filter-rail__heading filter-rail__heading--group">{{ i18n.t("vd-none") }}</p>
       {% endif %}
     </div>
+    {% if prev_href.is_some() || next_href.is_some() %}
+    <nav class="pagination" aria-label="{{ i18n.t("vd-pagination-label") }}">
+      {% if let Some(href) = prev_href %}
+      <a class="btn" href="{{ href }}">{{ i18n.t("vd-page-prev") }}</a>
+      {% endif %}
+      {% if let Some(href) = next_href %}
+      <a class="btn" href="{{ href }}">{{ i18n.t("vd-page-next") }}</a>
+      {% endif %}
+    </nav>
+    {% endif %}
   </aside>
 
   <div class="filter-center">

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -2209,6 +2209,236 @@ async fn view_definitions_save_roundtrips_and_rejects_bad_json() {
     assert!(html.contains("{nope"));
 }
 
+fn view_definitions_app(source: helios_ui::StaticConformanceSource) -> Router {
+    helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        Some(std::path::PathBuf::from("../../data")),
+        nl(true, true),
+        None,
+        None,
+        "default".to_string(),
+        std::sync::Arc::new(source),
+        helios_fhir::FhirVersion::R4,
+        None,
+        "http://localhost:8080".to_string(),
+    )
+}
+
+/// #741: the rail is one page of a server-side search, not the whole
+/// tenant collection — with more than one page of stored views, page 1 holds
+/// the first 50 (name-sorted) with a "next" link, and page 2 holds the rest
+/// with a "previous" link and no "next". Both links preserve the (empty)
+/// filter.
+#[tokio::test]
+async fn view_definitions_rail_paginates_across_pages_of_fifty() {
+    let vds: Vec<Value> = (1..=52)
+        .map(|n| {
+            serde_json::json!({"resourceType": "ViewDefinition", "id": format!("vd{n:03}"),
+                "name": format!("vd_{n:03}"), "resource": "Patient"})
+        })
+        .collect();
+    let source = helios_ui::StaticConformanceSource::empty().with(
+        "ViewDefinition",
+        helios_fhir::FhirVersion::R4,
+        vds,
+    );
+    let app = view_definitions_app(source);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/ui/sql/view-definitions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    assert!(
+        html.contains(r#"data-type="vd001""#),
+        "first page holds vd001"
+    );
+    assert!(
+        html.contains(r#"data-type="vd050""#),
+        "first page holds vd050"
+    );
+    assert!(
+        !html.contains(r#"data-type="vd051""#),
+        "first page stops at 50"
+    );
+    assert!(
+        html.contains(r#"href="/ui/sql/view-definitions?page=2""#),
+        "a next link to page 2"
+    );
+
+    let response = app
+        .oneshot(
+            Request::get("/ui/sql/view-definitions?page=2")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    assert!(
+        !html.contains(r#"data-type="vd050""#),
+        "the second page does not repeat the first"
+    );
+    assert!(
+        html.contains(r#"data-type="vd051""#),
+        "second page holds vd051"
+    );
+    assert!(
+        html.contains(r#"data-type="vd052""#),
+        "second page holds vd052"
+    );
+    // Page 1 is the implicit default, so the "previous" link omits `?page=`
+    // entirely rather than spelling out `page=1`.
+    assert!(
+        html.contains(r#"class="pagination""#)
+            && html.contains(r#"href="/ui/sql/view-definitions""#),
+        "a previous link back to the bare route (page 1)"
+    );
+    assert!(!html.contains("page=3"), "no next link past the last page");
+}
+
+/// #741: the search box filters server-side by name only — a substring that
+/// matches none of the stored names (even one that matches a resource type
+/// column, the old in-memory filter's now-removed extra match) narrows the
+/// rail to nothing, case-insensitively.
+#[tokio::test]
+async fn view_definitions_rail_filters_by_name_case_insensitively() {
+    let vds = vec![
+        serde_json::json!({"resourceType": "ViewDefinition", "id": "vd1",
+            "name": "Active_Patients", "resource": "Patient"}),
+        serde_json::json!({"resourceType": "ViewDefinition", "id": "vd2",
+            "name": "blood_pressure", "resource": "Observation"}),
+    ];
+    let source = helios_ui::StaticConformanceSource::empty().with(
+        "ViewDefinition",
+        helios_fhir::FhirVersion::R4,
+        vds,
+    );
+    let app = view_definitions_app(source);
+
+    // A mixed-case substring of the name matches, case-insensitively.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/ui/sql/view-definitions?filter=PATIENT")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(html.contains(r#"data-type="vd1""#));
+    assert!(!html.contains(r#"data-type="vd2""#));
+
+    // "Observation" matches vd2's resource type but neither stored name —
+    // the retired in-memory filter used to match this, `name:contains` does
+    // not.
+    let response = app
+        .oneshot(
+            Request::get("/ui/sql/view-definitions?filter=Observation")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let html = body_text(response).await;
+    assert!(html.contains(r#"class="filter-rail__heading filter-rail__heading--group""#));
+    assert!(!html.contains(r#"data-type="vd1""#));
+    assert!(!html.contains(r#"data-type="vd2""#));
+}
+
+/// #741: a `?vd=` the current filter excludes from the rail still loads
+/// through the direct-by-id read (ticket 01) — selection is independent of
+/// what the rail happens to show.
+#[tokio::test]
+async fn view_definitions_selection_survives_a_filter_that_excludes_it() {
+    let vds = vec![
+        serde_json::json!({"resourceType": "ViewDefinition", "id": "keep",
+            "name": "keep_me", "resource": "Patient"}),
+        serde_json::json!({"resourceType": "ViewDefinition", "id": "other",
+            "name": "exclude_me", "resource": "Patient"}),
+    ];
+    let source = helios_ui::StaticConformanceSource::empty().with(
+        "ViewDefinition",
+        helios_fhir::FhirVersion::R4,
+        vds,
+    );
+    let app = view_definitions_app(source);
+
+    let response = app
+        .oneshot(
+            Request::get("/ui/sql/view-definitions?vd=keep&filter=exclude")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    // The rail shows only what the filter matches...
+    assert!(html.contains(r#"data-type="other""#));
+    assert!(!html.contains(r#"data-type="keep""#));
+    // ...but the editor still holds the selected view the filter excluded.
+    assert!(html.contains(r#"name="json""#));
+    assert!(html.contains("keep_me"));
+}
+
+/// #741: a failed rail search shows the same degradation notice the page has
+/// always shown for a failed fetch — never a 500, and never a stale
+/// full-collection fallback.
+#[tokio::test]
+async fn view_definitions_rail_degrades_when_search_fails() {
+    struct FailingSearchSource;
+
+    #[async_trait::async_trait]
+    impl helios_ui::ConformanceSource for FailingSearchSource {
+        async fn fetch(
+            &self,
+            _resource_type: &str,
+            _version: helios_fhir::FhirVersion,
+            _tenant: &str,
+        ) -> Result<Vec<Value>, String> {
+            Ok(Vec::new())
+        }
+        // `search_page` falls back to the trait's default `Err`.
+    }
+
+    let app = helios_ui::mount_with_conformance_source(
+        Router::new(),
+        "9.9.9",
+        Some(std::path::PathBuf::from("../../data")),
+        nl(true, true),
+        None,
+        None,
+        "default".to_string(),
+        std::sync::Arc::new(FailingSearchSource),
+        helios_fhir::FhirVersion::R4,
+        None,
+        "http://localhost:8080".to_string(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::get("/ui/sql/view-definitions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = body_text(response).await;
+    assert!(html.contains("The view definition list could not be loaded."));
+    assert!(html.contains("search is not available from this source"));
+}
+
 #[tokio::test]
 async fn user_menu_carries_language_and_the_signed_out_state() {
     // #725: the avatar is a <details> menu holding the language selector and

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -805,6 +805,9 @@ vd-delete-failed = Die View-Definition konnte nicht gelöscht werden.
 vd-json-heading = Definition (JSON)
 vd-results-heading = Ergebnisse
 vd-results-empty = Die View hat keine Zeilen erzeugt.
+vd-pagination-label = View-Definitionsseiten
+vd-page-prev = Zurück
+vd-page-next = Weiter
 
 ## SQL-Abfragen- / SQL-Views-Arbeitsbereiche (#649)
 

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -808,6 +808,9 @@ vd-delete-failed = Could not delete the view definition.
 vd-json-heading = Definition (JSON)
 vd-results-heading = Results
 vd-results-empty = The view produced no rows.
+vd-pagination-label = View definition pages
+vd-page-prev = Previous
+vd-page-next = Next
 
 ## SQL Queries / SQL Views workspaces (#649)
 

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -805,6 +805,9 @@ vd-delete-failed = No se pudo eliminar la definición de vista.
 vd-json-heading = Definición (JSON)
 vd-results-heading = Resultados
 vd-results-empty = La vista no produjo filas.
+vd-pagination-label = Páginas de definiciones de vistas
+vd-page-prev = Anterior
+vd-page-next = Siguiente
 
 ## Espacios de consultas y vistas SQL (#649)
 


### PR DESCRIPTION
Closes #741 (unblocked by #570 / #723).

## What changes

The `/ui/sql/view-definitions` page used to download the tenant's whole ViewDefinition collection (`_count=10000` + next links) on every load and filter/page the rail in memory. Since #723 the server knows the SQL-on-FHIR search parameters, so the rail now asks for exactly one page.

- **Filter server-side.** The rail's search box travels as `name:contains=<text>`. **Decision recorded:** free text maps to `name` only — the old in-memory filter also matched the resource type, and that match is retired on purpose (OR across different search params is not expressible in standard FHIR search, `_filter` is SQLite-only, and `resource` is a token that `:contains` does not apply to). Documented in the handler doc comment.
- **Sort + page server-side.** `_sort=name`, `_count=50`, `_offset=(page-1)*50`. New `?page=` (1-based; absent or invalid ⇒ 1).
- **Plain pagination links.** "Previous" / "Next" at the foot of the rail — real links with visible text, keyboard reachable, no JavaScript. They preserve `filter` and `vd`; a new search resets to page 1.
- **Selection independent of the page.** `?vd=<id>` is loaded with a direct `GET /ViewDefinition/{id}`, so the selected view renders in full even when it sits outside the visible 50 or is excluded by the filter. Without `?vd=` the first rail entry is selected from the page already fetched (no extra request). An unknown id degrades to the empty state, not a 500.
- Run, Save, Duplicate, Delete and `?vd=new` are unchanged; degradation for a non-default FHIR version is unchanged (storage only holds the default).

## Commits

1. `feat(ui): add paged search and read-by-id to ConformanceSource` — `search_page(type, params, count, offset) -> SearchPage { resources, has_next }` and `read_resource(type, id)` on the trait, HTTP implementation (one request per page, tenant header + outbound auth, version degradation) and the static test double (`name:contains`, `_sort=name`, `_count`/`_offset`). The existing full-collection `fetch` used by SearchParameters / Compartments / SQL Export is untouched.
2. `feat(ui): View Definitions rail searches and pages server-side` — handler, template, `en`/`es`/`de` strings, tests.

## Tests

- `cargo test -p helios-ui`: 250 green (5 new conformance tests incl. a `--features R4B` degradation test; 4 new router tests: filter, paging across 50, out-of-page selection, degradation; 2 unit tests for the search params / page href helpers).
- Playwright `sql-view-definitions.spec.ts` adds pagination past 50, filter parity and out-of-page selection; `a11y` (light/dark) and `nojs` rings green (65/65 locally).
- Manual pass on a release build with 61 seeded views: paging, filter (case-insensitive, no resource-type match), selection outside the page, Run/Save/Duplicate/Delete, `?vd=new`, es/de strings, keyboard navigation.

## Out of scope

- The SQL Export page still full-fetches the collection (same pattern, separate issue).
- No new filters (status, resource) — the issue asks to keep the UX.
