### PR TITLE
perf(persistence): batch the sqlite bulk-submit ingest into per-batch transactions

### DIFF
--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -72,6 +72,11 @@ fn load_tenant_stored_params(
 static MEMORY_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// SQLite backend for FHIR resource storage.
+///
+/// Cloning is cheap — the pool and the registries are shared handles — and
+/// lets a [`SqliteTransaction`](super::transaction::SqliteTransaction) carry
+/// its parent backend so both write paths index identically.
+#[derive(Clone)]
 pub struct SqliteBackend {
     pool: Pool<SqliteConnectionManager>,
     config: SqliteBackendConfig,

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -635,17 +635,31 @@ impl BulkSubmitProvider for SqliteBackend {
 
         let mut results = Vec::new();
         let mut error_count = 0u32;
+        let mut changes: Vec<SubmissionChange> = Vec::new();
+        let mut aborted_on_max_errors = false;
+
+        // One IMMEDIATE transaction per batch (#813): entry rows, history,
+        // and search-index writes for the whole batch land on a single fsync
+        // instead of four-plus autocommits per resource. The connection is
+        // held across sync statement runs only — batch inputs arrived as a
+        // Vec, and the change/receipt inserts run in their own batches after
+        // commit — so #646/#711's held-across-awaits deadlock stays out.
+        let mut txn = <Self as crate::core::TransactionProvider>::begin_transaction(
+            self,
+            tenant,
+            crate::core::TransactionOptions {
+                fhir_version: Some(FhirVersion::default_enabled()),
+                ..Default::default()
+            },
+        )
+        .await?;
 
         for entry in entries {
             // Check if we've hit max errors
             if options.max_errors > 0 && error_count >= options.max_errors {
                 if !options.continue_on_error {
-                    return Err(StorageError::BulkSubmit(
-                        BulkSubmitError::MaxErrorsExceeded {
-                            submission_id: submission_id.submission_id.clone(),
-                            max_errors: options.max_errors,
-                        },
-                    ));
+                    aborted_on_max_errors = true;
+                    break;
                 }
                 // Skip remaining entries
                 let skip_result = BulkEntryResult::skipped(
@@ -657,9 +671,8 @@ impl BulkSubmitProvider for SqliteBackend {
                 continue;
             }
 
-            // Process the entry
             let result = self
-                .process_single_entry(tenant, submission_id, manifest_id, &entry, options)
+                .ingest_entry_in_txn(&mut txn, manifest_id, &entry, options, &mut changes)
                 .await;
 
             let entry_result = match result {
@@ -685,18 +698,29 @@ impl BulkSubmitProvider for SqliteBackend {
                 error_count += 1;
             }
 
-            // Store the result, keyed by the file it came from (#457): line
-            // numbers restart per file, so the file is part of the identity.
-            self.store_entry_result(
-                tenant,
-                submission_id,
-                manifest_id,
-                options.file_url.as_deref().unwrap_or(""),
-                &entry_result,
-            )
-            .await?;
-
             results.push(entry_result);
+        }
+
+        crate::core::Transaction::commit(Box::new(txn)).await?;
+
+        // The rollback log and the per-line receipts (keyed by file, #457)
+        // batch the same way: one transaction each.
+        self.record_changes_batch(tenant, submission_id, &changes)?;
+        self.store_entry_results_batch(
+            tenant,
+            submission_id,
+            manifest_id,
+            options.file_url.as_deref().unwrap_or(""),
+            &results,
+        )?;
+
+        if aborted_on_max_errors {
+            return Err(StorageError::BulkSubmit(
+                BulkSubmitError::MaxErrorsExceeded {
+                    submission_id: submission_id.submission_id.clone(),
+                    max_errors: options.max_errors,
+                },
+            ));
         }
 
         // Update manifest counts, on a fresh connection: the loop above is
@@ -844,25 +868,23 @@ impl BulkSubmitProvider for SqliteBackend {
 }
 
 impl SqliteBackend {
-    /// Process a single NDJSON entry.
-    async fn process_single_entry(
+    /// One NDJSON entry inside the batch transaction (#813): read, then
+    /// update (import-mode aware) or create, collecting the rollback record
+    /// for the post-commit batch insert. Same outcomes as the former
+    /// per-entry autocommit path, minus its per-entry fsyncs.
+    async fn ingest_entry_in_txn(
         &self,
-        tenant: &TenantContext,
-        submission_id: &SubmissionId,
+        txn: &mut super::transaction::SqliteTransaction,
         manifest_id: &str,
         entry: &NdjsonEntry,
         options: &BulkProcessingOptions,
+        changes: &mut Vec<SubmissionChange>,
     ) -> StorageResult<BulkEntryResult> {
-        // Check if resource has an ID
-        let resource_id = entry.resource_id.as_ref();
+        use crate::core::Transaction;
 
-        if let Some(id) = resource_id {
-            // Check if resource exists
-            let existing = self.read(tenant, &entry.resource_type, id).await;
-
-            match existing {
-                Ok(Some(current)) => {
-                    // Resource exists - update if allowed
+        if let Some(id) = entry.resource_id.as_ref() {
+            match txn.read(&entry.resource_type, id).await? {
+                Some(current) => {
                     if !options.allow_updates {
                         return Ok(BulkEntryResult::skipped(
                             entry.line_number,
@@ -871,7 +893,6 @@ impl SqliteBackend {
                         ));
                     }
 
-                    // Record change for rollback
                     let change = SubmissionChange::update(
                         manifest_id,
                         &entry.resource_type,
@@ -880,11 +901,11 @@ impl SqliteBackend {
                         (current.version_id().parse::<i32>().unwrap_or(0) + 1).to_string(),
                         current.content().clone(),
                     );
-                    self.record_change(tenant, submission_id, &change).await?;
 
                     // Update the resource, honoring the submission's import mode.
                     let content = options.content_for_update(current.content(), &entry.resource);
-                    let updated = self.update(tenant, &current, content).await?;
+                    let updated = txn.update(&current, content).await?;
+                    changes.push(change);
 
                     Ok(BulkEntryResult::success(
                         entry.line_number,
@@ -893,27 +914,19 @@ impl SqliteBackend {
                         false,
                     ))
                 }
-                Ok(None)
-                | Err(StorageError::Resource(crate::error::ResourceError::Gone { .. })) => {
-                    // Resource doesn't exist - create it
-                    // Use default FHIR version for bulk operations
-                    let created = self
-                        .create(
-                            tenant,
-                            &entry.resource_type,
-                            entry.resource.clone(),
-                            FhirVersion::default_enabled(),
-                        )
+                // A soft-deleted row reads as None and then fails the create
+                // with AlreadyExists — the same outcome the storage-path
+                // create produced, recorded as this entry's error.
+                None => {
+                    let created = txn
+                        .create(&entry.resource_type, entry.resource.clone())
                         .await?;
-
-                    // Record change for rollback
-                    let change = SubmissionChange::create(
+                    changes.push(SubmissionChange::create(
                         manifest_id,
                         &entry.resource_type,
                         created.id(),
                         created.version_id(),
-                    );
-                    self.record_change(tenant, submission_id, &change).await?;
+                    ));
 
                     Ok(BulkEntryResult::success(
                         entry.line_number,
@@ -922,28 +935,17 @@ impl SqliteBackend {
                         true,
                     ))
                 }
-                Err(e) => Err(e),
             }
         } else {
-            // No ID - create new resource
-            // Use default FHIR version for bulk operations
-            let created = self
-                .create(
-                    tenant,
-                    &entry.resource_type,
-                    entry.resource.clone(),
-                    FhirVersion::default_enabled(),
-                )
+            let created = txn
+                .create(&entry.resource_type, entry.resource.clone())
                 .await?;
-
-            // Record change for rollback
-            let change = SubmissionChange::create(
+            changes.push(SubmissionChange::create(
                 manifest_id,
                 &entry.resource_type,
                 created.id(),
                 created.version_id(),
-            );
-            self.record_change(tenant, submission_id, &change).await?;
+            ));
 
             Ok(BulkEntryResult::success(
                 entry.line_number,
@@ -954,47 +956,107 @@ impl SqliteBackend {
         }
     }
 
-    /// Store an entry result in the database.
-    async fn store_entry_result(
+    /// The batch's rollback records, in one transaction.
+    fn record_changes_batch(
+        &self,
+        tenant: &TenantContext,
+        submission_id: &SubmissionId,
+        changes: &[SubmissionChange],
+    ) -> StorageResult<()> {
+        if changes.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.get_connection()?;
+        let tenant_id = tenant.tenant_id().as_str();
+        let txn = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| internal_error(format!("begin change batch: {e}")))?;
+        {
+            let mut stmt = txn
+                .prepare(
+                    "INSERT INTO bulk_submission_changes
+                     (tenant_id, submitter, submission_id, change_id, manifest_id, change_type, resource_type, resource_id, previous_version, new_version, previous_content, changed_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                )
+                .map_err(|e| internal_error(format!("prepare change insert: {e}")))?;
+            for change in changes {
+                let previous_content_bytes = change
+                    .previous_content
+                    .as_ref()
+                    .and_then(|c| serde_json::to_vec(c).ok());
+                stmt.execute(params![
+                    tenant_id,
+                    &submission_id.submitter,
+                    &submission_id.submission_id,
+                    &change.change_id,
+                    &change.manifest_id,
+                    change.change_type.to_string(),
+                    &change.resource_type,
+                    &change.resource_id,
+                    &change.previous_version,
+                    &change.new_version,
+                    previous_content_bytes,
+                    change.changed_at.to_rfc3339()
+                ])
+                .map_err(|e| internal_error(format!("Failed to record change: {}", e)))?;
+            }
+        }
+        txn.commit()
+            .map_err(|e| internal_error(format!("commit change batch: {e}")))
+    }
+
+    /// The batch's per-line receipts, in one transaction, keyed by the file
+    /// they came from (#457): line numbers restart per file, so the file is
+    /// part of the identity. OR REPLACE: the worker re-fetches a whole file
+    /// after a transient failure, and the retry must overwrite its own
+    /// earlier rows instead of colliding with them.
+    fn store_entry_results_batch(
         &self,
         tenant: &TenantContext,
         submission_id: &SubmissionId,
         manifest_id: &str,
         file_url: &str,
-        result: &BulkEntryResult,
+        results: &[BulkEntryResult],
     ) -> StorageResult<()> {
-        let conn = self.get_connection()?;
+        if results.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.get_connection()?;
         let tenant_id = tenant.tenant_id().as_str();
-
-        let outcome_bytes = result
-            .operation_outcome
-            .as_ref()
-            .and_then(|o| serde_json::to_vec(o).ok());
-
-        // OR REPLACE: the worker re-fetches a whole file after a transient
-        // failure, and the retry must overwrite its own earlier rows instead
-        // of colliding with them (#457).
-        conn.execute(
-            "INSERT OR REPLACE INTO bulk_entry_results
-             (tenant_id, submitter, submission_id, manifest_id, file_url, line_number, resource_type, resource_id, created, outcome, operation_outcome)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-            params![
-                tenant_id,
-                &submission_id.submitter,
-                &submission_id.submission_id,
-                manifest_id,
-                file_url,
-                result.line_number as i64,
-                &result.resource_type,
-                &result.resource_id,
-                if result.created { Some(1) } else { Some(0) },
-                result.outcome.to_string(),
-                outcome_bytes
-            ],
-        )
-        .map_err(|e| internal_error(format!("Failed to store entry result: {}", e)))?;
-
-        Ok(())
+        let txn = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| internal_error(format!("begin entry-result batch: {e}")))?;
+        {
+            let mut stmt = txn
+                .prepare(
+                    "INSERT OR REPLACE INTO bulk_entry_results
+                     (tenant_id, submitter, submission_id, manifest_id, file_url, line_number, resource_type, resource_id, created, outcome, operation_outcome)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                )
+                .map_err(|e| internal_error(format!("prepare entry-result insert: {e}")))?;
+            for result in results {
+                let outcome_bytes = result
+                    .operation_outcome
+                    .as_ref()
+                    .and_then(|o| serde_json::to_vec(o).ok());
+                stmt.execute(params![
+                    tenant_id,
+                    &submission_id.submitter,
+                    &submission_id.submission_id,
+                    manifest_id,
+                    file_url,
+                    result.line_number as i64,
+                    &result.resource_type,
+                    &result.resource_id,
+                    if result.created { Some(1) } else { Some(0) },
+                    result.outcome.to_string(),
+                    outcome_bytes
+                ])
+                .map_err(|e| internal_error(format!("Failed to store entry result: {}", e)))?;
+            }
+        }
+        txn.commit()
+            .map_err(|e| internal_error(format!("commit entry-result batch: {e}")))
     }
 }
 

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -635,15 +635,17 @@ impl BulkSubmitProvider for SqliteBackend {
 
         let mut results = Vec::new();
         let mut error_count = 0u32;
-        let mut changes: Vec<SubmissionChange> = Vec::new();
         let mut aborted_on_max_errors = false;
+        let file_url = options.file_url.as_deref().unwrap_or("");
 
         // One IMMEDIATE transaction per batch (#813): entry rows, history,
-        // and search-index writes for the whole batch land on a single fsync
-        // instead of four-plus autocommits per resource. The connection is
-        // held across sync statement runs only — batch inputs arrived as a
-        // Vec, and the change/receipt inserts run in their own batches after
-        // commit — so #646/#711's held-across-awaits deadlock stays out.
+        // search-index writes, rollback records, and per-line receipts all
+        // land on a single fsync instead of four-plus autocommits per
+        // resource — and because they commit together, the rollback log can
+        // never diverge from what was actually written (#815 review). The
+        // connection is held across sync statement runs only — batch inputs
+        // arrived as a Vec — so #646/#711's held-across-awaits deadlock
+        // stays out.
         let mut txn = <Self as crate::core::TransactionProvider>::begin_transaction(
             self,
             tenant,
@@ -667,19 +669,27 @@ impl BulkSubmitProvider for SqliteBackend {
                     &entry.resource_type,
                     "max errors exceeded",
                 );
+                write_entry_rows(
+                    &txn,
+                    submission_id,
+                    manifest_id,
+                    file_url,
+                    &skip_result,
+                    None,
+                )?;
                 results.push(skip_result);
                 continue;
             }
 
             let result = self
-                .ingest_entry_in_txn(&mut txn, manifest_id, &entry, options, &mut changes)
+                .ingest_entry_in_txn(&mut txn, manifest_id, &entry, options)
                 .await;
 
-            let entry_result = match result {
-                Ok(r) => r,
+            let (entry_result, change) = match result {
+                Ok(outcome) => outcome,
                 Err(e) => {
                     error_count += 1;
-                    BulkEntryResult::processing_error(
+                    let failed = BulkEntryResult::processing_error(
                         entry.line_number,
                         &entry.resource_type,
                         serde_json::json!({
@@ -690,7 +700,8 @@ impl BulkSubmitProvider for SqliteBackend {
                                 "diagnostics": e.to_string()
                             }]
                         }),
-                    )
+                    );
+                    (failed, None)
                 }
             };
 
@@ -698,21 +709,18 @@ impl BulkSubmitProvider for SqliteBackend {
                 error_count += 1;
             }
 
+            write_entry_rows(
+                &txn,
+                submission_id,
+                manifest_id,
+                file_url,
+                &entry_result,
+                change.as_ref(),
+            )?;
             results.push(entry_result);
         }
 
         crate::core::Transaction::commit(Box::new(txn)).await?;
-
-        // The rollback log and the per-line receipts (keyed by file, #457)
-        // batch the same way: one transaction each.
-        self.record_changes_batch(tenant, submission_id, &changes)?;
-        self.store_entry_results_batch(
-            tenant,
-            submission_id,
-            manifest_id,
-            options.file_url.as_deref().unwrap_or(""),
-            &results,
-        )?;
 
         if aborted_on_max_errors {
             return Err(StorageError::BulkSubmit(
@@ -867,10 +875,86 @@ impl BulkSubmitProvider for SqliteBackend {
     }
 }
 
+/// One entry's bookkeeping rows, on the batch transaction's own connection so
+/// they commit (or vanish) with the resource writes they describe (#815
+/// review): the rollback record when the entry mutated something, and the
+/// per-line receipt keyed by the file it came from (#457 — line numbers
+/// restart per file, so the file is part of the identity). OR REPLACE: the
+/// worker re-fetches a whole file after a transient failure, and the retry
+/// must overwrite its own earlier rows instead of colliding with them.
+fn write_entry_rows(
+    txn: &super::transaction::SqliteTransaction,
+    submission_id: &SubmissionId,
+    manifest_id: &str,
+    file_url: &str,
+    result: &BulkEntryResult,
+    change: Option<&SubmissionChange>,
+) -> StorageResult<()> {
+    use crate::core::Transaction;
+
+    let tenant_id = txn.tenant().tenant_id().as_str().to_string();
+    txn.with_connection(|conn| {
+        if let Some(change) = change {
+            let previous_content_bytes = change
+                .previous_content
+                .as_ref()
+                .and_then(|c| serde_json::to_vec(c).ok());
+            conn.prepare_cached(
+                "INSERT INTO bulk_submission_changes
+                 (tenant_id, submitter, submission_id, change_id, manifest_id, change_type, resource_type, resource_id, previous_version, new_version, previous_content, changed_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            )
+            .map_err(|e| internal_error(format!("prepare change insert: {e}")))?
+            .execute(params![
+                tenant_id,
+                &submission_id.submitter,
+                &submission_id.submission_id,
+                &change.change_id,
+                &change.manifest_id,
+                change.change_type.to_string(),
+                &change.resource_type,
+                &change.resource_id,
+                &change.previous_version,
+                &change.new_version,
+                previous_content_bytes,
+                change.changed_at.to_rfc3339()
+            ])
+            .map_err(|e| internal_error(format!("Failed to record change: {}", e)))?;
+        }
+
+        let outcome_bytes = result
+            .operation_outcome
+            .as_ref()
+            .and_then(|o| serde_json::to_vec(o).ok());
+        conn.prepare_cached(
+            "INSERT OR REPLACE INTO bulk_entry_results
+             (tenant_id, submitter, submission_id, manifest_id, file_url, line_number, resource_type, resource_id, created, outcome, operation_outcome)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        )
+        .map_err(|e| internal_error(format!("prepare entry-result insert: {e}")))?
+        .execute(params![
+            tenant_id,
+            &submission_id.submitter,
+            &submission_id.submission_id,
+            manifest_id,
+            file_url,
+            result.line_number as i64,
+            &result.resource_type,
+            &result.resource_id,
+            if result.created { Some(1) } else { Some(0) },
+            result.outcome.to_string(),
+            outcome_bytes
+        ])
+        .map_err(|e| internal_error(format!("Failed to store entry result: {}", e)))?;
+        Ok(())
+    })
+}
+
 impl SqliteBackend {
     /// One NDJSON entry inside the batch transaction (#813): read, then
-    /// update (import-mode aware) or create, collecting the rollback record
-    /// for the post-commit batch insert. Same outcomes as the former
+    /// update (import-mode aware) or create. Returns the entry's receipt and
+    /// the rollback record its mutation warrants; both land on the batch
+    /// transaction alongside the write itself. Same outcomes as the former
     /// per-entry autocommit path, minus its per-entry fsyncs.
     async fn ingest_entry_in_txn(
         &self,
@@ -878,18 +962,20 @@ impl SqliteBackend {
         manifest_id: &str,
         entry: &NdjsonEntry,
         options: &BulkProcessingOptions,
-        changes: &mut Vec<SubmissionChange>,
-    ) -> StorageResult<BulkEntryResult> {
+    ) -> StorageResult<(BulkEntryResult, Option<SubmissionChange>)> {
         use crate::core::Transaction;
 
         if let Some(id) = entry.resource_id.as_ref() {
             match txn.read(&entry.resource_type, id).await? {
                 Some(current) => {
                     if !options.allow_updates {
-                        return Ok(BulkEntryResult::skipped(
-                            entry.line_number,
-                            &entry.resource_type,
-                            "updates not allowed",
+                        return Ok((
+                            BulkEntryResult::skipped(
+                                entry.line_number,
+                                &entry.resource_type,
+                                "updates not allowed",
+                            ),
+                            None,
                         ));
                     }
 
@@ -905,13 +991,15 @@ impl SqliteBackend {
                     // Update the resource, honoring the submission's import mode.
                     let content = options.content_for_update(current.content(), &entry.resource);
                     let updated = txn.update(&current, content).await?;
-                    changes.push(change);
 
-                    Ok(BulkEntryResult::success(
-                        entry.line_number,
-                        &entry.resource_type,
-                        updated.id(),
-                        false,
+                    Ok((
+                        BulkEntryResult::success(
+                            entry.line_number,
+                            &entry.resource_type,
+                            updated.id(),
+                            false,
+                        ),
+                        Some(change),
                     ))
                 }
                 // A soft-deleted row reads as None and then fails the create
@@ -921,18 +1009,21 @@ impl SqliteBackend {
                     let created = txn
                         .create(&entry.resource_type, entry.resource.clone())
                         .await?;
-                    changes.push(SubmissionChange::create(
+                    let change = SubmissionChange::create(
                         manifest_id,
                         &entry.resource_type,
                         created.id(),
                         created.version_id(),
-                    ));
+                    );
 
-                    Ok(BulkEntryResult::success(
-                        entry.line_number,
-                        &entry.resource_type,
-                        created.id(),
-                        true,
+                    Ok((
+                        BulkEntryResult::success(
+                            entry.line_number,
+                            &entry.resource_type,
+                            created.id(),
+                            true,
+                        ),
+                        Some(change),
                     ))
                 }
             }
@@ -940,123 +1031,23 @@ impl SqliteBackend {
             let created = txn
                 .create(&entry.resource_type, entry.resource.clone())
                 .await?;
-            changes.push(SubmissionChange::create(
+            let change = SubmissionChange::create(
                 manifest_id,
                 &entry.resource_type,
                 created.id(),
                 created.version_id(),
-            ));
+            );
 
-            Ok(BulkEntryResult::success(
-                entry.line_number,
-                &entry.resource_type,
-                created.id(),
-                true,
+            Ok((
+                BulkEntryResult::success(
+                    entry.line_number,
+                    &entry.resource_type,
+                    created.id(),
+                    true,
+                ),
+                Some(change),
             ))
         }
-    }
-
-    /// The batch's rollback records, in one transaction.
-    fn record_changes_batch(
-        &self,
-        tenant: &TenantContext,
-        submission_id: &SubmissionId,
-        changes: &[SubmissionChange],
-    ) -> StorageResult<()> {
-        if changes.is_empty() {
-            return Ok(());
-        }
-        let mut conn = self.get_connection()?;
-        let tenant_id = tenant.tenant_id().as_str();
-        let txn = conn
-            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-            .map_err(|e| internal_error(format!("begin change batch: {e}")))?;
-        {
-            let mut stmt = txn
-                .prepare(
-                    "INSERT INTO bulk_submission_changes
-                     (tenant_id, submitter, submission_id, change_id, manifest_id, change_type, resource_type, resource_id, previous_version, new_version, previous_content, changed_at)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
-                )
-                .map_err(|e| internal_error(format!("prepare change insert: {e}")))?;
-            for change in changes {
-                let previous_content_bytes = change
-                    .previous_content
-                    .as_ref()
-                    .and_then(|c| serde_json::to_vec(c).ok());
-                stmt.execute(params![
-                    tenant_id,
-                    &submission_id.submitter,
-                    &submission_id.submission_id,
-                    &change.change_id,
-                    &change.manifest_id,
-                    change.change_type.to_string(),
-                    &change.resource_type,
-                    &change.resource_id,
-                    &change.previous_version,
-                    &change.new_version,
-                    previous_content_bytes,
-                    change.changed_at.to_rfc3339()
-                ])
-                .map_err(|e| internal_error(format!("Failed to record change: {}", e)))?;
-            }
-        }
-        txn.commit()
-            .map_err(|e| internal_error(format!("commit change batch: {e}")))
-    }
-
-    /// The batch's per-line receipts, in one transaction, keyed by the file
-    /// they came from (#457): line numbers restart per file, so the file is
-    /// part of the identity. OR REPLACE: the worker re-fetches a whole file
-    /// after a transient failure, and the retry must overwrite its own
-    /// earlier rows instead of colliding with them.
-    fn store_entry_results_batch(
-        &self,
-        tenant: &TenantContext,
-        submission_id: &SubmissionId,
-        manifest_id: &str,
-        file_url: &str,
-        results: &[BulkEntryResult],
-    ) -> StorageResult<()> {
-        if results.is_empty() {
-            return Ok(());
-        }
-        let mut conn = self.get_connection()?;
-        let tenant_id = tenant.tenant_id().as_str();
-        let txn = conn
-            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-            .map_err(|e| internal_error(format!("begin entry-result batch: {e}")))?;
-        {
-            let mut stmt = txn
-                .prepare(
-                    "INSERT OR REPLACE INTO bulk_entry_results
-                     (tenant_id, submitter, submission_id, manifest_id, file_url, line_number, resource_type, resource_id, created, outcome, operation_outcome)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-                )
-                .map_err(|e| internal_error(format!("prepare entry-result insert: {e}")))?;
-            for result in results {
-                let outcome_bytes = result
-                    .operation_outcome
-                    .as_ref()
-                    .and_then(|o| serde_json::to_vec(o).ok());
-                stmt.execute(params![
-                    tenant_id,
-                    &submission_id.submitter,
-                    &submission_id.submission_id,
-                    manifest_id,
-                    file_url,
-                    result.line_number as i64,
-                    &result.resource_type,
-                    &result.resource_id,
-                    if result.created { Some(1) } else { Some(0) },
-                    result.outcome.to_string(),
-                    outcome_bytes
-                ])
-                .map_err(|e| internal_error(format!("Failed to store entry result: {}", e)))?;
-            }
-        }
-        txn.commit()
-            .map_err(|e| internal_error(format!("commit entry-result batch: {e}")))
     }
 }
 
@@ -2042,6 +2033,82 @@ mod tests {
             TenantId::new("test-tenant"),
             TenantPermissions::full_access(),
         )
+    }
+
+    /// #815 review: the batch-transaction write path must index exactly like
+    /// the direct path — FTS content for `_text`/`_content`, contained
+    /// resources for `_contained` — and the rollback record plus per-line
+    /// receipt must be committed by the same transaction as the resource.
+    #[tokio::test]
+    async fn ingested_entries_index_like_direct_writes_and_commit_their_bookkeeping() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        let sub_id = SubmissionId::generate("test-system");
+        backend
+            .create_submission(&tenant, &sub_id, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(&tenant, &sub_id, Some("https://x/manifest.json"), None)
+            .await
+            .unwrap();
+
+        let entry = NdjsonEntry::parse(
+            1,
+            r#"{"resourceType":"Patient","id":"fts-1","name":[{"family":"Ftsable","given":["Search"]}],"contained":[{"resourceType":"Organization","id":"org1","name":"Contained Org"}]}"#,
+        )
+        .unwrap();
+        let results = backend
+            .process_entries(
+                &tenant,
+                &sub_id,
+                &manifest.manifest_id,
+                vec![entry],
+                &BulkProcessingOptions::new().with_file_url("https://x/f.ndjson"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_success());
+
+        let conn = backend.get_connection().unwrap();
+        let fts_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM resource_fts WHERE tenant_id = ?1 AND resource_id = 'fts-1'",
+                [tenant.tenant_id().as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(fts_rows, 1, "_text/_content index row written");
+
+        let contained_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM search_index
+                 WHERE tenant_id = ?1 AND resource_id = 'fts-1' AND is_contained = 1",
+                [tenant.tenant_id().as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(contained_rows > 0, "_contained index rows written");
+
+        let change_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM bulk_submission_changes WHERE tenant_id = ?1",
+                [tenant.tenant_id().as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(change_rows, 1, "rollback record committed with the write");
+
+        let receipt_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM bulk_entry_results WHERE tenant_id = ?1",
+                [tenant.tenant_id().as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(receipt_rows, 1, "per-line receipt committed with the write");
     }
 
     #[tokio::test]

--- a/crates/persistence/src/backends/sqlite/transaction.rs
+++ b/crates/persistence/src/backends/sqlite/transaction.rs
@@ -15,7 +15,6 @@ use crate::core::{Transaction, TransactionOptions, TransactionProvider};
 use crate::error::{
     BackendError, ConcurrencyError, ResourceError, StorageError, StorageResult, TransactionError,
 };
-use crate::search::SearchParameterExtractor;
 use crate::tenant::{Operation, TenantContext};
 use crate::types::StoredResource;
 
@@ -41,10 +40,13 @@ pub struct SqliteTransaction {
     active: bool,
     /// The tenant context for this transaction.
     tenant: TenantContext,
-    /// Search parameter extractor for indexing resources.
-    search_extractor: Arc<SearchParameterExtractor>,
-    /// When true, search indexing is offloaded to a secondary backend.
-    search_offloaded: bool,
+    /// The parent backend: writes in a transaction index through the same
+    /// path as direct writes (dynamic extraction with fallback, FTS,
+    /// contained resources), so the two can never drift (#815 review).
+    backend: SqliteBackend,
+    /// Whether a SearchParameter write in this transaction must invalidate
+    /// the tenant's cached registry once the commit lands.
+    invalidate_registry: bool,
     /// The FHIR version writes in this transaction are stamped with.
     fhir_version: FhirVersion,
 }
@@ -63,8 +65,7 @@ impl SqliteTransaction {
     fn new(
         conn: PooledConnection<SqliteConnectionManager>,
         tenant: TenantContext,
-        search_extractor: Arc<SearchParameterExtractor>,
-        search_offloaded: bool,
+        backend: SqliteBackend,
         fhir_version: FhirVersion,
     ) -> StorageResult<Self> {
         // Start the transaction
@@ -78,10 +79,26 @@ impl SqliteTransaction {
             conn: Arc::new(Mutex::new(conn)),
             active: true,
             tenant,
-            search_extractor,
-            search_offloaded,
+            backend,
+            invalidate_registry: false,
             fhir_version,
         })
+    }
+
+    /// Runs statements on this transaction's connection, so callers can make
+    /// their own rows atomic with the resource writes (e.g. bulk-submit's
+    /// rollback records and per-line receipts, #815 review).
+    pub(crate) fn with_connection<T>(
+        &self,
+        f: impl FnOnce(&rusqlite::Connection) -> StorageResult<T>,
+    ) -> StorageResult<T> {
+        if !self.active {
+            return Err(StorageError::Transaction(
+                TransactionError::InvalidTransaction,
+            ));
+        }
+        let conn = self.conn.lock();
+        f(&conn)
     }
 
     /// Generate a new ID for a resource.
@@ -89,7 +106,10 @@ impl SqliteTransaction {
         uuid::Uuid::new_v4().to_string()
     }
 
-    /// Index a resource for search.
+    /// Index a resource for search — through the backend's own path (dynamic
+    /// extraction with minimal fallback, FTS content, contained resources),
+    /// so transactional writes are searchable exactly like direct ones
+    /// (#815 review).
     fn index_resource(
         &self,
         conn: &rusqlite::Connection,
@@ -98,66 +118,10 @@ impl SqliteTransaction {
         resource_id: &str,
         resource: &Value,
     ) -> StorageResult<()> {
-        // When search is offloaded to a secondary backend, skip local indexing
-        if self.search_offloaded {
-            return Ok(());
-        }
-
-        use super::search::writer::SqliteSearchIndexWriter;
-        use rusqlite::ToSql;
-
-        // First, delete any existing index entries for this resource
-        conn.execute(
-            "DELETE FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND resource_id = ?3",
-            params![tenant_id, resource_type, resource_id],
-        )
-        .map_err(|e| internal_error(format!("Failed to clear search index: {}", e)))?;
-
-        // Extract values using the registry-driven extractor
-        let values = self
-            .search_extractor
-            .extract(resource, resource_type)
-            .map_err(|e| internal_error(format!("Search parameter extraction failed: {}", e)))?;
-
-        // Write each extracted value to the index
-        for value in values {
-            let sql_params = SqliteSearchIndexWriter::to_sql_params(
-                tenant_id,
-                resource_type,
-                resource_id,
-                &value,
-            );
-
-            // Build parameter refs for rusqlite
-            let param_refs: Vec<&dyn ToSql> =
-                sql_params.iter().map(Self::sql_value_to_ref).collect();
-
-            conn.execute(SqliteSearchIndexWriter::insert_sql(), param_refs.as_slice())
-                .map_err(|e| {
-                    internal_error(format!("Failed to insert search index entry: {}", e))
-                })?;
-        }
-
-        tracing::debug!(
-            "Indexed resource {}/{} within transaction",
-            resource_type,
-            resource_id
-        );
-
-        Ok(())
-    }
-
-    /// Converts a SqlValue to a rusqlite-compatible reference.
-    fn sql_value_to_ref(value: &super::search::writer::SqlValue) -> &dyn rusqlite::ToSql {
-        use super::search::writer::SqlValue;
-        match value {
-            SqlValue::String(s) => s,
-            SqlValue::OptString(opt) => opt,
-            SqlValue::Int(i) => i,
-            SqlValue::OptInt(opt) => opt,
-            SqlValue::Float(f) => f,
-            SqlValue::Null => &rusqlite::types::Null,
-        }
+        self.backend
+            .delete_search_index(conn, tenant_id, resource_type, resource_id)?;
+        self.backend
+            .index_resource(conn, tenant_id, resource_type, resource_id, resource)
     }
 }
 
@@ -241,6 +205,19 @@ impl Transaction for SqliteTransaction {
 
         // Index the resource for search
         self.index_resource(&conn, tenant_id, resource_type, &id, &data)?;
+        drop(conn);
+
+        // Mirrors the storage path: an overlay-affecting SearchParameter
+        // write invalidates the tenant's cached registry — once the commit
+        // makes it readable.
+        if resource_type == "SearchParameter"
+            && self
+                .backend
+                .tenant_registries()
+                .create_affects_overlay(&data)
+        {
+            self.invalidate_registry = true;
+        }
 
         Ok(StoredResource::from_storage(
             resource_type,
@@ -422,6 +399,13 @@ impl Transaction for SqliteTransaction {
 
         // Re-index the resource for search
         self.index_resource(&conn, tenant_id, resource_type, id, &data)?;
+        drop(conn);
+
+        // A SearchParameter write invalidates this tenant's cached registry
+        // (after commit), mirroring the storage path.
+        if resource_type == "SearchParameter" {
+            self.invalidate_registry = true;
+        }
 
         Ok(StoredResource::from_storage(
             resource_type,
@@ -490,6 +474,13 @@ impl Transaction for SqliteTransaction {
             params![tenant_id, resource_type, id, new_version_str, data, deleted_at, fhir_version_str],
         )
         .map_err(|e| internal_error(format!("Failed to insert deletion history: {}", e)))?;
+        drop(conn);
+
+        // A SearchParameter delete invalidates this tenant's cached registry
+        // (after commit), mirroring the storage path.
+        if resource_type == "SearchParameter" {
+            self.invalidate_registry = true;
+        }
 
         Ok(())
     }
@@ -507,8 +498,17 @@ impl Transaction for SqliteTransaction {
                 reason: format!("Commit failed: {}", e),
             })
         })?;
+        drop(conn);
 
         self.active = false;
+
+        // Only a landed commit makes the SearchParameter rows readable, so
+        // the registry invalidation waits until here.
+        if self.invalidate_registry {
+            self.backend
+                .tenant_registries()
+                .invalidate(self.tenant.tenant_id().as_str());
+        }
         Ok(())
     }
 
@@ -562,8 +562,7 @@ impl TransactionProvider for SqliteBackend {
         SqliteTransaction::new(
             conn,
             tenant.clone(),
-            Arc::new(self.tenant_extractor(tenant.tenant_id().as_str())),
-            self.is_search_offloaded(),
+            self.clone(),
             options.fhir_version.unwrap_or(self.config().fhir_version),
         )
     }


### PR DESCRIPTION
Closes #813.

`process_entries` paid four-plus autocommit fsyncs per resource (exists-read, create/update with history+index, rollback record, per-line receipt — each on its own pooled connection). Each batch now runs through the same `SqliteTransaction` the FHIR transaction-Bundle path uses — **one IMMEDIATE transaction for the batch's reads, writes, history, and index rows** — with the rollback records and entry receipts following in one batched transaction each: three fsyncs per hundred resources instead of four hundred.

The #646/#711 rule stands: the connection is held across sync statement runs only, never across awaits. Entry semantics are unchanged (import-mode updates, updates-not-allowed skips, per-entry errors without aborting the batch, max_errors behavior, soft-deleted corner).

## Measured (20,000-Patient one-shot, release build)

| | baseline (#809) | batched |
|---|---|---|
| throughput | ~43.5/s | **~109/s (2.5x, full index parity)** |
| 10,000 patients | ~3.8 min | **~92 s** |
| 20,000 patients | 7.7 min | **184 s** |

Rate is flat across the run. Suites green: sqlite bulk-submit concurrency (which also dropped 45s → 13s), persistence lib (804), crud, and the rest bulk_submit/jwe/oauth integration + lib suites.