### PR TITLE
fix(ui): equal spacing above both type-rail group headings

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2459,6 +2459,13 @@ select.field__input {
   font-weight: 700;
 }
 
+/* The Recently used heading sits inside its group, so the group's 2px item
+   gap is all that separates it from the first entry; the All Types heading
+   is a rail child and gets the rail's 10px. Top up to the same 10px (#785). */
+.filter-rail__group > .filter-rail__heading--group {
+  margin-bottom: 8px;
+}
+
 /* Between the Recently used group and the general list. Hidden by default —
    shown only when it directly follows a *populated* (non-`hidden`) recent
    group, so there is nothing to divide from before resource-filter.js has

--- a/crates/ui/e2e/tests/design-system.spec.ts
+++ b/crates/ui/e2e/tests/design-system.spec.ts
@@ -330,9 +330,11 @@ test("shared back links match the Figma geometry on both consumers", async ({
   expect(headerRule?.["grid-template-areas"]).toContain('"back-link ."');
   expect(headerRule?.["grid-template-areas"]).toContain('"copy action"');
 
+  // One-shot bulk import (#781) dropped the detail page's action slot; its
+  // copy column simply spans. The shared link geometry still binds both.
   const consumers = [
-    { name: "bulk import detail", route: await seedBulkImportDetail(request) },
-    { name: "active bulk exports", route: "/ui/bulk-export/active" },
+    { name: "bulk import detail", route: await seedBulkImportDetail(request), hasAction: false },
+    { name: "active bulk exports", route: "/ui/bulk-export/active", hasAction: true },
   ];
   for (const theme of ["light", "dark"] as const) {
     await page.goto("/ui");
@@ -357,9 +359,13 @@ test("shared back links match the Figma geometry on both consumers", async ({
         const actionControl = action.locator(
           ":scope > a.btn, :scope > details > summary.btn",
         );
-        await expect(action).toHaveCount(1);
-        await expect(actionControl).toHaveCount(1);
-        await expect(actionControl).toBeVisible();
+        if (consumer.hasAction) {
+          await expect(action).toHaveCount(1);
+          await expect(actionControl).toHaveCount(1);
+          await expect(actionControl).toBeVisible();
+        } else {
+          await expect(action).toHaveCount(0);
+        }
         // Grid items are blockified, so the authored inline-flex computes to
         // flex here. The source-rule assertion above guards the shared value.
         await expect(link).toHaveCSS("display", "flex");
@@ -369,22 +375,24 @@ test("shared back links match the Figma geometry on both consumers", async ({
         await expect(icon).toHaveAttribute("width", "5");
         await expect(icon).toHaveAttribute("height", "8");
 
-        const [linkBox, iconBox, labelBox, titleBox, actionBox] = await Promise.all([
+        const [linkBox, iconBox, labelBox, titleBox] = await Promise.all([
           link.boundingBox(),
           icon.boundingBox(),
           label.boundingBox(),
           title.boundingBox(),
-          action.boundingBox(),
         ]);
+        const actionBox = consumer.hasAction ? await action.boundingBox() : null;
         expect(linkBox).not.toBeNull();
         expect(iconBox).not.toBeNull();
         expect(labelBox).not.toBeNull();
         expect(titleBox).not.toBeNull();
-        expect(actionBox).not.toBeNull();
         expect(Math.abs(labelBox!.x - (iconBox!.x + iconBox!.width) - 7)).toBeLessThanOrEqual(1);
         expect(Math.abs(titleBox!.y - (linkBox!.y + linkBox!.height) - 24)).toBeLessThanOrEqual(1);
-        expect(actionBox!.y).toBeGreaterThan(linkBox!.y + linkBox!.height);
-        expect(Math.abs(actionBox!.y - titleBox!.y)).toBeLessThanOrEqual(1);
+        if (consumer.hasAction) {
+          expect(actionBox).not.toBeNull();
+          expect(actionBox!.y).toBeGreaterThan(linkBox!.y + linkBox!.height);
+          expect(Math.abs(actionBox!.y - titleBox!.y)).toBeLessThanOrEqual(1);
+        }
 
         const normal = await link.evaluate((element) => {
           const style = getComputedStyle(element);

--- a/crates/ui/e2e/tests/resources.spec.ts
+++ b/crates/ui/e2e/tests/resources.spec.ts
@@ -325,6 +325,7 @@ test("create eligibility follows the effective FHIR version", async ({ resources
 // resource-filter.js from explicit rail picks and re-rendered on load.
 test("the recently-used group caps at five, keeps MRU order, deduplicates, and preserves counts", async ({
   resources,
+  page,
 }) => {
   await resources.goto("Patient");
   await resources.pickType("Account");
@@ -360,6 +361,27 @@ test("the recently-used group caps at five, keeps MRU order, deduplicates, and p
     const recentCount = await resources.recentItem(type).locator(".count").textContent();
     expect(recentCount).toBe(listCount);
   }
+
+  // #785: both group headings sit the same distance above their first item.
+  // The list scrolls the selected type into view, so measure from the top.
+  await page.evaluate(() => {
+    document.querySelector("#type-rail-list")!.scrollTop = 0;
+    document.querySelector(".filter-rail")!.scrollTop = 0;
+  });
+  const gapBelow = async (heading: import("@playwright/test").Locator, item: import("@playwright/test").Locator) => {
+    const h = await heading.boundingBox();
+    const i = await item.boundingBox();
+    return i!.y - (h!.y + h!.height);
+  };
+  const recentGap = await gapBelow(
+    resources.recentGroup.locator(".filter-rail__heading--group"),
+    resources.recentGroup.locator("a.filter-rail__item").first(),
+  );
+  const allGap = await gapBelow(
+    resources.generalHeading,
+    page.locator("#type-rail-list a.filter-rail__item").first(),
+  );
+  expect(Math.abs(recentGap - allGap)).toBeLessThanOrEqual(1);
 });
 
 test("the type rails keep recents and the All Types heading fixed while type items scroll", async ({


### PR DESCRIPTION
Closes #785.

The Recently used heading lives inside `.filter-rail__group` (2px item gap); the All Types heading is a rail child (10px rail gap). The in-group heading now carries an 8px bottom margin so both headings sit **10px** above their first item, and the recents spec asserts the two gaps match within 1px (scroll-normalized — the rail scrolls the selected type into view).

Also repairs a spec left red on main by a merge crossing: the back-link geometry test required a `page-head__action` slot on the bulk-import detail, which one-shot (#781) removed. Consumers now declare whether they carry an action — bulk import asserts the slot is absent, active bulk exports keeps the full checks.

Suites: resources (all green incl. the new gap assertion) and design-system 14/14.