### PR TITLE
feat(subscriptions,ui): the Last 24 hrs column draws the frame's sparkline

### DIFF
--- a/crates/observability/src/subscriptions.rs
+++ b/crates/observability/src/subscriptions.rs
@@ -45,6 +45,10 @@ pub struct SubscriptionRow {
     /// Deliveries abandoned in the last 24 hours (permanent errors and
     /// exhausted retries).
     pub failed_24h: u64,
+    /// `delivered_24h` as a chronological series — one count per half-hour
+    /// bucket, oldest first (#782). Empty when the engine carries no series;
+    /// the UI then renders no sparkline rather than a fabricated flat line.
+    pub delivered_series: Vec<u64>,
 }
 
 /// The engine's current inventory for one tenant.
@@ -104,6 +108,7 @@ mod tests {
                     delivered_24h: 12,
                     first_try_24h: 11,
                     failed_24h: 1,
+                    delivered_series: vec![0, 4, 8],
                 }],
             }
         }

--- a/crates/rest/src/lib.rs
+++ b/crates/rest/src/lib.rs
@@ -1061,6 +1061,11 @@ impl helios_observability::subscriptions::SubscriptionsProvider for EngineSubscr
                     .engine
                     .delivery_stats()
                     .window(&s.tenant_id, &s.id, now);
+                let series = self
+                    .engine
+                    .delivery_stats()
+                    .series(&s.tenant_id, &s.id, now)
+                    .to_vec();
                 SubscriptionRow {
                     id: s.id,
                     topic_url: s.topic_url,
@@ -1073,6 +1078,7 @@ impl helios_observability::subscriptions::SubscriptionsProvider for EngineSubscr
                     delivered_24h: window.delivered,
                     first_try_24h: window.first_try,
                     failed_24h: window.failed,
+                    delivered_series: series,
                 }
             })
             .collect();

--- a/crates/subscriptions/src/delivery_stats.rs
+++ b/crates/subscriptions/src/delivery_stats.rs
@@ -87,6 +87,27 @@ impl DeliveryStats {
         out
     }
 
+    /// The last 24 hours of deliveries as a chronological series — one count
+    /// per half-hour bucket, oldest first, zeros where nothing was recorded.
+    /// This is the operator page's sparkline (#782): the same ring the
+    /// [`window`](Self::window) totals read, just not summed.
+    pub fn series(&self, tenant: &str, id: &str, now_epoch: i64) -> [u64; BUCKET_COUNT] {
+        let mut out = [0u64; BUCKET_COUNT];
+        let Some(ring) = self.rings.get(&(tenant.to_string(), id.to_string())) else {
+            return out;
+        };
+        let newest = bucket_start(now_epoch);
+        let horizon = newest - BUCKET_SECONDS * (BUCKET_COUNT as i64 - 1);
+        let ring = ring.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        for bucket in ring.iter() {
+            if bucket.start >= horizon && bucket.start <= now_epoch {
+                let offset = ((bucket.start - horizon) / BUCKET_SECONDS) as usize;
+                out[offset] = bucket.delivered;
+            }
+        }
+        out
+    }
+
     /// Drops a subscription's counters (deregistration).
     pub fn remove(&self, tenant: &str, id: &str) {
         self.rings.remove(&(tenant.to_string(), id.to_string()));
@@ -174,6 +195,25 @@ mod tests {
                 failed: 1
             }
         );
+    }
+
+    #[test]
+    fn the_series_is_chronological_with_zeros_between() {
+        let stats = DeliveryStats::new();
+        // Three buckets ago, one delivery; latest bucket, two.
+        stats.record_success("t", "s", true, T0);
+        stats.record_success("t", "s", true, T0 + BUCKET_SECONDS * 3);
+        stats.record_success("t", "s", false, T0 + BUCKET_SECONDS * 3 + 5);
+
+        let series = stats.series("t", "s", T0 + BUCKET_SECONDS * 3 + 10);
+        assert_eq!(series[BUCKET_COUNT - 4], 1, "oldest recorded bucket");
+        assert_eq!(series[BUCKET_COUNT - 3], 0);
+        assert_eq!(series[BUCKET_COUNT - 2], 0);
+        assert_eq!(series[BUCKET_COUNT - 1], 2, "newest bucket");
+        assert_eq!(series.iter().sum::<u64>(), 3);
+
+        // Unknown subscription: all zeros.
+        assert_eq!(stats.series("t", "other", T0).iter().sum::<u64>(), 0);
     }
 
     #[test]

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2962,6 +2962,41 @@ details.json-fold[open] > summary .icon {
   box-shadow: inset 3px 0 0 var(--danger);
 }
 
+/* The Last 24 hrs sparkline (#782): the engine's half-hour delivery series,
+   scaled server-side; color follows the row's state — the frame's dotted
+   amber marks a listener-less websocket. */
+.spark {
+  display: block;
+  width: 120px;
+  height: 24px;
+}
+
+.spark__line {
+  fill: none;
+  stroke: var(--muted);
+  stroke-width: 1.5;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.spark--active .spark__line {
+  stroke: var(--ok);
+}
+
+.spark--error .spark__line {
+  stroke: var(--danger);
+}
+
+.spark--idle .spark__line {
+  stroke: var(--warn);
+  stroke-dasharray: 2 3;
+}
+
+.spark--requested .spark__line,
+.spark--off .spark__line {
+  stroke: var(--muted);
+}
+
 /* Bulk Export job states (#537) — the same status-pill vocabulary. */
 .tag--in-progress {
   background: var(--warn-soft);

--- a/crates/ui/e2e/tests/design-system.spec.ts
+++ b/crates/ui/e2e/tests/design-system.spec.ts
@@ -330,9 +330,11 @@ test("shared back links match the Figma geometry on both consumers", async ({
   expect(headerRule?.["grid-template-areas"]).toContain('"back-link ."');
   expect(headerRule?.["grid-template-areas"]).toContain('"copy action"');
 
+  // One-shot bulk import (#781) dropped the detail page's action slot; its
+  // copy column simply spans. The shared link geometry still binds both.
   const consumers = [
-    { name: "bulk import detail", route: await seedBulkImportDetail(request) },
-    { name: "active bulk exports", route: "/ui/bulk-export/active" },
+    { name: "bulk import detail", route: await seedBulkImportDetail(request), hasAction: false },
+    { name: "active bulk exports", route: "/ui/bulk-export/active", hasAction: true },
   ];
   for (const theme of ["light", "dark"] as const) {
     await page.goto("/ui");
@@ -357,9 +359,13 @@ test("shared back links match the Figma geometry on both consumers", async ({
         const actionControl = action.locator(
           ":scope > a.btn, :scope > details > summary.btn",
         );
-        await expect(action).toHaveCount(1);
-        await expect(actionControl).toHaveCount(1);
-        await expect(actionControl).toBeVisible();
+        if (consumer.hasAction) {
+          await expect(action).toHaveCount(1);
+          await expect(actionControl).toHaveCount(1);
+          await expect(actionControl).toBeVisible();
+        } else {
+          await expect(action).toHaveCount(0);
+        }
         // Grid items are blockified, so the authored inline-flex computes to
         // flex here. The source-rule assertion above guards the shared value.
         await expect(link).toHaveCSS("display", "flex");
@@ -369,22 +375,24 @@ test("shared back links match the Figma geometry on both consumers", async ({
         await expect(icon).toHaveAttribute("width", "5");
         await expect(icon).toHaveAttribute("height", "8");
 
-        const [linkBox, iconBox, labelBox, titleBox, actionBox] = await Promise.all([
+        const [linkBox, iconBox, labelBox, titleBox] = await Promise.all([
           link.boundingBox(),
           icon.boundingBox(),
           label.boundingBox(),
           title.boundingBox(),
-          action.boundingBox(),
         ]);
+        const actionBox = consumer.hasAction ? await action.boundingBox() : null;
         expect(linkBox).not.toBeNull();
         expect(iconBox).not.toBeNull();
         expect(labelBox).not.toBeNull();
         expect(titleBox).not.toBeNull();
-        expect(actionBox).not.toBeNull();
         expect(Math.abs(labelBox!.x - (iconBox!.x + iconBox!.width) - 7)).toBeLessThanOrEqual(1);
         expect(Math.abs(titleBox!.y - (linkBox!.y + linkBox!.height) - 24)).toBeLessThanOrEqual(1);
-        expect(actionBox!.y).toBeGreaterThan(linkBox!.y + linkBox!.height);
-        expect(Math.abs(actionBox!.y - titleBox!.y)).toBeLessThanOrEqual(1);
+        if (consumer.hasAction) {
+          expect(actionBox).not.toBeNull();
+          expect(actionBox!.y).toBeGreaterThan(linkBox!.y + linkBox!.height);
+          expect(Math.abs(actionBox!.y - titleBox!.y)).toBeLessThanOrEqual(1);
+        }
 
         const normal = await link.evaluate((element) => {
           const style = getComputedStyle(element);

--- a/crates/ui/src/subscriptions.rs
+++ b/crates/ui/src/subscriptions.rs
@@ -9,10 +9,10 @@
 //! (naming `HFS_SUBSCRIPTIONS_ENABLED` and the `subscriptions` build feature)
 //! when it is not; the sidebar entry is always present (#767).
 //!
-//! The design's 24-hour sparkline needs a per-window time series the
-//! [`SubscriptionsSnapshot`](helios_observability::subscriptions::SubscriptionsSnapshot)
-//! does not carry; the column shows the real count until the engine grows
-//! that series (#555's rule: real figures or none).
+//! The Last 24 hrs column draws the design's sparkline from the engine's
+//! half-hour delivery series (#782), scaled server-side into SVG polyline
+//! points — no client script involved. A snapshot without a series renders
+//! the plain count (#555's rule: real figures or none).
 
 use askama::Template;
 use axum::{extract::RawQuery, extract::State, response::Response};
@@ -36,9 +36,45 @@ pub struct SubscriptionRowView {
     pub sent: String,
     /// Notifications delivered in the last 24 hours (#586).
     pub last24: String,
+    /// The 24-hour delivery series as SVG polyline points (#782), pre-scaled
+    /// to the sparkline's viewBox. Empty when the engine carries no series —
+    /// the cell then shows the count alone rather than a fabricated line.
+    pub spark_points: String,
     /// Consecutive delivery failures; `—` when the channel has no delivery
     /// (an idle websocket).
     pub streak: String,
+}
+
+/// The sparkline's viewBox, shared by the point scaling and the template.
+pub const SPARK_WIDTH: f64 = 120.0;
+pub const SPARK_HEIGHT: f64 = 24.0;
+
+/// Scales a delivery series into `x,y` polyline points for the sparkline's
+/// viewBox — normalized to the series' own peak, with a 2px inset so the
+/// stroke never clips. An empty series yields no points.
+fn spark_points(series: &[u64]) -> String {
+    if series.is_empty() {
+        return String::new();
+    }
+    let peak = series.iter().copied().max().unwrap_or(0).max(1) as f64;
+    let inset = 2.0;
+    let span_x = SPARK_WIDTH - inset * 2.0;
+    let span_y = SPARK_HEIGHT - inset * 2.0;
+    let step = if series.len() > 1 {
+        span_x / (series.len() as f64 - 1.0)
+    } else {
+        0.0
+    };
+    series
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            let x = inset + step * i as f64;
+            let y = inset + span_y * (1.0 - (*v as f64 / peak));
+            format!("{x:.1},{y:.1}")
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// The four headline cards.
@@ -127,6 +163,7 @@ pub async fn page(
                 state,
                 sent: grouped(row.events_since_start),
                 last24: grouped(row.delivered_24h),
+                spark_points: spark_points(&row.delivered_series),
                 streak: if idle {
                     "—".to_string()
                 } else {

--- a/crates/ui/templates/pages/subscriptions.html
+++ b/crates/ui/templates/pages/subscriptions.html
@@ -97,7 +97,16 @@
             <span class="status-dot status-dot--muted" aria-hidden="true"></span>{{ i18n.t("subs-state-off") }}
             {% endif %}
           </td>
-          <td class="col-num">{{ row.last24 }}</td>
+          <td class="col-num">
+            {% if !row.spark_points.is_empty() %}
+            <svg class="spark spark--{{ row.state }}" viewBox="0 0 120 24" role="img" aria-label="{{ row.last24 }}">
+              <title>{{ row.last24 }}</title>
+              <polyline class="spark__line" points="{{ row.spark_points }}"></polyline>
+            </svg>
+            {% else %}
+            {{ row.last24 }}
+            {% endif %}
+          </td>
           <td class="col-num">{{ row.sent }}</td>
           <td class="col-num">{{ row.streak }}</td>
         </tr>

--- a/crates/ui/tests/subscriptions_http.rs
+++ b/crates/ui/tests/subscriptions_http.rs
@@ -71,6 +71,7 @@ impl SubscriptionsProvider for Fixed {
                     delivered_24h: 4182,
                     first_try_24h: 4031,
                     failed_24h: 0,
+                    delivered_series: vec![80, 95, 90, 110, 120, 100, 115],
                 },
                 SubscriptionRow {
                     id: "obs-critical".into(),
@@ -84,6 +85,7 @@ impl SubscriptionsProvider for Fixed {
                     delivered_24h: 311,
                     first_try_24h: 290,
                     failed_24h: 7,
+                    delivered_series: vec![40, 35, 20, 8, 0, 0, 0],
                 },
                 SubscriptionRow {
                     id: "admit-feed".into(),
@@ -97,6 +99,7 @@ impl SubscriptionsProvider for Fixed {
                     delivered_24h: 0,
                     first_try_24h: 0,
                     failed_24h: 0,
+                    delivered_series: Vec::new(),
                 },
             ],
         }
@@ -157,6 +160,18 @@ async fn the_page_goes_from_unavailable_to_the_live_dashboard() {
     assert!(html.contains("0 clients"));
     assert!(html.contains(">7<"), "fail streak renders");
     assert!(html.contains("4,182"));
+
+    // The Last 24 hrs sparkline (#782): rows with a series draw a state-tinted
+    // polyline (with the count as its accessible name); the idle websocket has
+    // no series and keeps the plain count.
+    assert!(html.contains(r#"class="spark spark--active""#), "{html}");
+    assert!(html.contains(r#"class="spark spark--error""#));
+    assert!(
+        !html.contains(r#"class="spark spark--idle""#),
+        "no series, no line"
+    );
+    assert!(html.contains(r#"<polyline class="spark__line""#));
+    assert!(html.contains(r#"aria-label="4,182""#));
 
     // Phase 3 — the sort control re-orders: most sent leads with the biggest
     // counter.


### PR DESCRIPTION
Closes #782.

The half-hour delivery ring from #586 already held the series the frame's sparkline needs — it was only ever summed. `DeliveryStats::series` now exposes it chronologically (48 buckets, zeros where nothing was recorded), `SubscriptionRow` carries it as `delivered_series`, and the operator page scales it **server-side into SVG polyline points** — an inline `<svg>`, no client script, per the crate's no-JS rules.

Per the frame (405:2): **green** for active, **red** for failing, **dotted amber** for a listener-less websocket. The delivered count stays as the SVG's accessible name and tooltip. A snapshot without a series renders the plain count — no fabricated flat line (#555).

Tests: a chronological-series unit test on the ring; the subscriptions page test asserts the state-tinted polylines, the accessible name, and that a series-less row keeps the count. Full ui/observability/subscriptions suites green; e2e subscriptions + a11y + design-system green except the pre-existing back-link spec red on main, whose fix is already in #817.