### PR TITLE
hts-ui: give the CM translate group wrappers the .field class (#807)

### DIFF
--- a/crates/hts-ui/templates/partials/hts-cm-translate-input.html
+++ b/crates/hts-ui/templates/partials/hts-cm-translate-input.html
@@ -125,27 +125,27 @@
     </div>
 
     {% if direction == TranslateDirection::Forward %}
-    <div role="group" aria-labelledby="translate-source-label">
+    <div class="field" role="group" aria-labelledby="translate-source-label">
       <span class="field__label" id="translate-source-label">{{ chrome.i18n.t("hts-cm-translate-source-legend") }}</span>
-    <div class="builder-grid">
-      <div class="field">
-        <label class="field__label" for="translate-system">{{ chrome.i18n.t("hts-cm-translate-source-system") }}</label>
-        <input class="field__input" id="translate-system" name="system" type="text" autocomplete="off" spellcheck="false"
-               placeholder="{{ chrome.i18n.t("hts-cm-translate-source-system-placeholder") }}">
+      <div class="builder-grid">
+        <div class="field">
+          <label class="field__label" for="translate-system">{{ chrome.i18n.t("hts-cm-translate-source-system") }}</label>
+          <input class="field__input" id="translate-system" name="system" type="text" autocomplete="off" spellcheck="false"
+                 placeholder="{{ chrome.i18n.t("hts-cm-translate-source-system-placeholder") }}">
+        </div>
+        <div class="field">
+          <label class="field__label" for="translate-code">{{ chrome.i18n.t("hts-cm-translate-source-code") }}</label>
+          <input class="field__input" id="translate-code" name="code" type="text" autocomplete="off" spellcheck="false">
+        </div>
       </div>
       <div class="field">
-        <label class="field__label" for="translate-code">{{ chrome.i18n.t("hts-cm-translate-source-code") }}</label>
-        <input class="field__input" id="translate-code" name="code" type="text" autocomplete="off" spellcheck="false">
+        <label class="field__label" for="translate-display">{{ chrome.i18n.t("hts-cm-translate-source-display") }}</label>
+        <input class="field__input" id="translate-display" name="display" type="text" autocomplete="off" spellcheck="false"
+               placeholder="{{ chrome.i18n.t("hts-cm-translate-source-display-placeholder") }}">
       </div>
-    </div>
-    <div class="field">
-      <label class="field__label" for="translate-display">{{ chrome.i18n.t("hts-cm-translate-source-display") }}</label>
-      <input class="field__input" id="translate-display" name="display" type="text" autocomplete="off" spellcheck="false"
-             placeholder="{{ chrome.i18n.t("hts-cm-translate-source-display-placeholder") }}">
-    </div>
     </div>
     {% else %}
-    <div role="group" aria-labelledby="translate-reverse-label">
+    <div class="field" role="group" aria-labelledby="translate-reverse-label">
       <span class="field__label" id="translate-reverse-label">{{ chrome.i18n.t("hts-cm-translate-reverse-legend") }}</span>
       <div class="field">
         <label class="field__label" for="translate-target-code">{{ chrome.i18n.t("hts-cm-translate-target-code") }}</label>

--- a/crates/hts-ui/tests/chrome_parity.rs
+++ b/crates/hts-ui/tests/chrome_parity.rs
@@ -690,3 +690,59 @@ async fn favicon_link_resolves_under_the_hts_mount() {
          /ui/hts/assets/ — a mount-prefix typo shows up here, not in the markup",
     );
 }
+
+#[test]
+fn workbench_input_group_wrappers_all_carry_the_field_class() {
+    // `.field` (`display: block; margin-bottom: 14px` in the shared app.css)
+    // is what gives a form group its trailing gap. A `role="group"` wrapper
+    // without it contributes no margin of its own and inherits whatever its
+    // last child happens to leave behind — in the case this pins (#807) that
+    // was a `.field` whose own bottom margin collapsed out through the
+    // unstyled wrapper, so the rendered geometry happened to match. That is a
+    // coincidence of margin collapsing, not a design: give such a group a
+    // non-`.field` last child (a `.facets--bare` row, say, as the Direction
+    // group above it has) or put padding on the wrapper, and its spacing
+    // silently drops to zero.
+    //
+    // Source check across all three workbench forms rather than one rendered
+    // page: the omission was in the Forward *and* Reverse branches of the
+    // translate form, and only one of those is in the DOM at a time.
+    let templates = [
+        (
+            "crates/hts-ui/templates/partials/hts-cs-validate-input.html",
+            include_str!("../templates/partials/hts-cs-validate-input.html"),
+        ),
+        (
+            "crates/hts-ui/templates/partials/hts-cm-translate-input.html",
+            include_str!("../templates/partials/hts-cm-translate-input.html"),
+        ),
+        (
+            "crates/hts-ui/templates/partials/hts-vs-expand-input.html",
+            include_str!("../templates/partials/hts-vs-expand-input.html"),
+        ),
+    ];
+
+    let mut groups = 0usize;
+    for (path, template) in templates {
+        // `role="group"` is also discussed in these files' prose.
+        let body = strip_askama_comments(template);
+        for chunk in body.split('<').skip(1) {
+            let Some(tag) = chunk.split('>').next() else {
+                continue;
+            };
+            if !tag.contains(r#"role="group""#) {
+                continue;
+            }
+            groups += 1;
+            assert!(
+                tag.contains(r#"class="field""#),
+                "a `role=\"group\"` wrapper in {path} is missing `class=\"field\"`, \
+                 so it drops out of the form's vertical rhythm:\n\n<{tag}>",
+            );
+        }
+    }
+    assert_eq!(
+        groups, 8,
+        "expected the scan to reach all eight workbench group wrappers",
+    );
+}


### PR DESCRIPTION
Fixes #807.

## What changed

- `crates/hts-ui/templates/partials/hts-cm-translate-input.html` — added `class="field"` to the two `role="group"` wrappers that lacked it (Source coding, forward at `:128`; target-code, reverse at `:148`), and reindented the forward block so the nesting reads correctly.
- `crates/hts-ui/tests/chrome_parity.rs` — new `workbench_input_group_wrappers_all_carry_the_field_class`: a source-level guard that scans all three workbench input templates (`hts-cs-validate-input.html`, `hts-cm-translate-input.html`, `hts-vs-expand-input.html`), asserts every `role="group"` wrapper carries `.field`, and pins the count at 8 so the scan can't silently stop matching.

No CSS was added; `.field` already has a rule in the shared `crates/ui/assets/app.css`.

## One correction to the issue

The issue predicts a visible gap loss. **It does not reproduce — this change moves no pixels today**, and I'd rather say so than let the PR imply a spacing fix it doesn't make.

Both wrappers' last child is itself a `.field`. With the wrapper unstyled (no padding, no border, no BFC), that child's `margin-bottom: 14px` collapses straight out through it, so the group already contributed the same 14px it does now.

Measured against the real `app.css` in headless Chromium, reproducing the panel structure with and without the class:

```
before  last-input -> next band: 32.0px      (14px margin + 18px .panel padding)
after   last-input -> next band: 32.0px
```

Adding the class doesn't double the gap either, for the same reason: the wrapper's 14px collapses with its last child's 14px back down to 14px. That also answers the issue's "confirm the spacing inside the group" question — the `.field`-inside-`.builder-grid` stack is unchanged and matches `hts-cs-validate-input.html`.

The comparison in the issue — Source coding looking tighter than Direction — is real but has a different cause: the Direction group's last child is `.facets--bare`, which adds its own `padding: 0 0 12px`. That 12px is the difference, and it's intentional chrome padding on the chip row, not a missing class.

## So why fix it

Because the spacing is correct by coincidence rather than by construction. Change the group's last child to something that isn't a `.field` — a `.facets--bare` row, as the Direction group above it has — or put padding on the wrapper, and the trailing gap silently drops to zero. The class makes the group's own contract explicit and brings the two odd-ones-out in line with the other six wrappers. The new guard is what keeps it that way.

## Acceptance criteria

- [x] The Source coding group has the same separation below it as the Direction group above it — modulo the `.facets--bare` 12px noted above, which is a separate deliberate difference.
- [x] The reverse-direction group is spaced identically when the direction toggle is flipped (same class, same collapse).
- [x] Switching direction does not change the form's overall rhythm.
- [x] The class-existence guard test passes.

## Verification

- `cargo test -p helios-hts-ui` — 74/74 lib + all integration rings green, including `cm_detail_templates_only_use_classes_that_exist_in_app_css`.
- `cargo fmt -p helios-hts-ui -- --check` — clean.
- The new guard was confirmed non-vacuous: with the class removed again it fails, naming the file and printing the offending tag.

https://claude.ai/code/session_01QbXdoi9TYkdiDZHek6pBnn
