### PR TITLE
fix(ui): separate All Resources from the resource grid

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -5783,6 +5783,7 @@ details.json-fold[open] > summary .icon {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 6px 18px;
+  margin-top: 8px;
   padding: 6px 0;
 }
 

--- a/crates/ui/e2e/tests/bulk-export.spec.ts
+++ b/crates/ui/e2e/tests/bulk-export.spec.ts
@@ -31,6 +31,28 @@ test("All Resources is the enhanced default", async ({ bulkExport }) => {
   ).toBe(true);
 });
 
+test("All Resources is visually separated from the resource grid", async ({
+  page,
+  bulkExport,
+}) => {
+  for (const viewport of [
+    { width: 1280, height: 800 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await bulkExport.goto();
+
+    const allResourcesBottom = await bulkExport.allResources.evaluate(
+      (input) => input.closest("label")!.getBoundingClientRect().bottom,
+    );
+    const firstResourceTop = await bulkExport.typeCheckboxes.first().evaluate(
+      (input) => input.closest("label")!.getBoundingClientRect().top,
+    );
+
+    expect(Math.abs(firstResourceTop - allResourcesBottom - 14)).toBeLessThanOrEqual(0.5);
+  }
+});
+
 test("long resource names stay in their grid cell and reveal the full name", async ({
   page,
   bulkExport,


### PR DESCRIPTION
## Summary

- add an 8 px top margin to the Bulk Export resource grid, producing a nominal 14 px separation from the master toggle
- add responsive geometry regression coverage at desktop and mobile viewport sizes
- preserve the existing grid layout and checkbox behavior

## Tests

- `cargo test -p helios-ui`
- `cargo build -p helios-hfs --features ui`
- `npm run test:unit`
- focused Bulk Export Playwright suite: 11 passed
- design-system Playwright suite: 14 passed
- full Playwright suite: 317 passed, 6 skipped

## QA

- verified the 14 px separation at 1280×800 and 390×844
- verified initial, uncheck, recheck, and Clear checkbox states

Closes #828
