### PR TITLE
fix(ui): center the busy-button ring

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -1493,6 +1493,10 @@ select.field__input {
 
 .spinner,
 .btn[aria-busy="true"]::after {
+  /* Explicit border-box (#786): the `*` reset does not match pseudo-elements,
+     and content-box would render the ::after ring at 18px — off center against
+     the -7px offsets below. */
+  box-sizing: border-box;
   width: 14px;
   height: 14px;
   border-radius: 50%;


### PR DESCRIPTION
## Summary

Fixes #786.

The `*` box-sizing reset does not match pseudo-elements, so the `.btn[aria-busy=true]::after` ring rendered content-box at 18px (14px + 2px borders per side) while the `calc(50% - 7px)` centering offsets assumed 14px, leaving the ring 2px down-and-right of center.

This takes option 1 from the issue — the narrowest fix: declare `box-sizing: border-box` on the shared `.spinner, .btn[aria-busy=true]::after` rule, so the declared 14px is the rendered size, the existing `-7px` math is correct, and the in-button ring stays the same visual size as the standalone `.spinner`.

## Verification

Measured against the built stylesheet in Chromium: the ring computes to 14x14 with offset (0, 0) from the button center; forcing `box-sizing: content-box` back reproduces the reported 18px box with a (+2, +2) offset. Screenshots of the running app to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)