### PR TITLE
feat(persistence,rest,ui): byte-based bulk-submit ingest progress

### DIFF
--- a/crates/persistence/src/backends/mongodb/bulk_submit.rs
+++ b/crates/persistence/src/backends/mongodb/bulk_submit.rs
@@ -202,6 +202,8 @@ fn decode_manifest(doc: &Document) -> StorageResult<SubmissionManifest> {
         total_entries: doc.get_i64("total_entries").unwrap_or(0).max(0) as u64,
         processed_entries: doc.get_i64("processed_entries").unwrap_or(0).max(0) as u64,
         failed_entries: doc.get_i64("failed_entries").unwrap_or(0).max(0) as u64,
+        bytes_processed: doc.get_i64("bytes_processed").unwrap_or(0).max(0) as u64,
+        bytes_total: doc.get_i64("bytes_total").unwrap_or(0).max(0) as u64,
     })
 }
 
@@ -769,6 +771,8 @@ impl BulkSubmitProvider for MongoBackend {
             processed_entries: 0,
             failed_entries: 0,
             lease_expiry: None,
+            bytes_processed: 0,
+            bytes_total: 0,
         };
 
         let mut document = manifest_filter(tenant, submission_id, &manifest.manifest_id);
@@ -784,6 +788,8 @@ impl BulkSubmitProvider for MongoBackend {
         document.insert("failed_entries", 0_i64);
         document.insert("fencing_token", 0_i64);
         document.insert("last_processed_line", 0_i64);
+        document.insert("bytes_processed", 0_i64);
+        document.insert("bytes_total", 0_i64);
 
         self.manifests()
             .await?
@@ -1342,6 +1348,22 @@ impl SubmitWorkerStorage for MongoBackend {
                 "processed_entries": processed_entries as i64,
                 "failed_entries": failed_entries as i64,
                 "last_processed_line": last_processed_line as i64,
+            }},
+        )
+        .await
+    }
+
+    async fn update_manifest_bytes(
+        &self,
+        lease: &ManifestLease,
+        bytes_processed: u64,
+        bytes_total: u64,
+    ) -> Result<(), LeaseError> {
+        self.fenced_update(
+            lease,
+            doc! { "$set": {
+                "bytes_processed": bytes_processed as i64,
+                "bytes_total": bytes_total as i64,
             }},
         )
         .await

--- a/crates/persistence/src/backends/mongodb/bulk_submit.rs
+++ b/crates/persistence/src/backends/mongodb/bulk_submit.rs
@@ -1670,14 +1670,69 @@ impl SubmitWorkerStorage for MongoBackend {
     }
 
     async fn count_active_submissions(&self, tenant: &TenantContext) -> StorageResult<u64> {
-        self.submissions()
+        let tenant_id = tenant.tenant_id().as_str();
+        let cursor = self
+            .submissions()
             .await?
-            .count_documents(doc! {
-                "tenant_id": tenant.tenant_id().as_str(),
+            .find(doc! {
+                "tenant_id": tenant_id,
                 "status": SubmissionStatus::InProgress.to_string(),
             })
             .await
-            .map_err(|e| internal_error(format!("count active submissions: {e}")))
+            .map_err(|e| internal_error(format!("count active submissions: {e}")))?;
+        let subs = collect(cursor).await?;
+        if subs.is_empty() {
+            return Ok(0);
+        }
+
+        let keys: Vec<Document> = subs
+            .iter()
+            .filter_map(|d| {
+                Some(doc! {
+                    "submitter": opt_str(d, "submitter")?,
+                    "submission_id": opt_str(d, "submission_id")?,
+                })
+            })
+            .collect();
+        let cursor = self
+            .manifests()
+            .await?
+            .find(doc! { "tenant_id": tenant_id, "$or": keys })
+            .await
+            .map_err(|e| internal_error(format!("count active submissions: {e}")))?;
+        // (submitter, submission_id) → has a non-terminal manifest. Presence in
+        // the map at all means the submission has manifests.
+        let mut manifests: std::collections::HashMap<(String, String), bool> =
+            std::collections::HashMap::new();
+        for m in &collect(cursor).await? {
+            let (Some(submitter), Some(submission_id)) =
+                (opt_str(m, "submitter"), opt_str(m, "submission_id"))
+            else {
+                continue;
+            };
+            let live = matches!(
+                m.get_str("status").unwrap_or_default(),
+                "pending" | "processing"
+            );
+            *manifests.entry((submitter, submission_id)).or_insert(false) |= live;
+        }
+
+        Ok(subs
+            .iter()
+            .filter(|d| {
+                let (Some(submitter), Some(submission_id)) =
+                    (opt_str(d, "submitter"), opt_str(d, "submission_id"))
+                else {
+                    return false;
+                };
+                // No manifests yet → awaiting its first kick-off; otherwise it
+                // counts only while a manifest is still pending/processing.
+                manifests
+                    .get(&(submitter, submission_id))
+                    .copied()
+                    .unwrap_or(true)
+            })
+            .count() as u64)
     }
 
     async fn list_expired_submissions(

--- a/crates/persistence/src/backends/mongodb/bulk_submit.rs
+++ b/crates/persistence/src/backends/mongodb/bulk_submit.rs
@@ -1361,7 +1361,7 @@ impl SubmitWorkerStorage for MongoBackend {
     ) -> Result<(), LeaseError> {
         self.fenced_update(
             lease,
-            doc! { "$set": {
+            doc! { "$max": {
                 "bytes_processed": bytes_processed as i64,
                 "bytes_total": bytes_total as i64,
             }},

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -1550,7 +1550,8 @@ impl SubmitWorkerStorage for PostgresBackend {
         let affected = client
             .execute(
                 "UPDATE bulk_manifests
-                 SET bytes_processed = $1, bytes_total = $2
+                 SET bytes_processed = GREATEST(bytes_processed, $1),
+                     bytes_total = GREATEST(bytes_total, $2)
                  WHERE tenant_id = $3 AND submitter = $4 AND submission_id = $5
                    AND manifest_id = $6 AND worker_id = $7 AND fencing_token = $8",
                 &[

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -505,6 +505,8 @@ impl BulkSubmitProvider for PostgresBackend {
             processed_entries: 0,
             failed_entries: 0,
             lease_expiry: None,
+            bytes_processed: 0,
+            bytes_total: 0,
         })
     }
 
@@ -519,7 +521,7 @@ impl BulkSubmitProvider for PostgresBackend {
 
         let rows = client
             .query(
-                "SELECT manifest_url, replaces_manifest_url, status, added_at, total_entries, processed_entries, failed_entries, lease_expiry
+                "SELECT manifest_url, replaces_manifest_url, status, added_at, total_entries, processed_entries, failed_entries, lease_expiry, bytes_processed, bytes_total
                  FROM bulk_manifests
                  WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3 AND manifest_id = $4",
                 &[
@@ -545,6 +547,8 @@ impl BulkSubmitProvider for PostgresBackend {
         let processed: i32 = row.get(5);
         let failed: i32 = row.get(6);
         let lease_expiry: Option<chrono::DateTime<Utc>> = row.get(7);
+        let bytes_processed: i64 = row.get(8);
+        let bytes_total: i64 = row.get(9);
 
         let status: ManifestStatus = status_str
             .parse()
@@ -560,6 +564,8 @@ impl BulkSubmitProvider for PostgresBackend {
             processed_entries: processed as u64,
             failed_entries: failed as u64,
             lease_expiry,
+            bytes_processed: bytes_processed.max(0) as u64,
+            bytes_total: bytes_total.max(0) as u64,
         }))
     }
 
@@ -1527,6 +1533,39 @@ impl SubmitWorkerStorage for PostgresBackend {
             )
             .await
             .map_err(|e| LeaseError::Storage(internal_error(format!("update progress: {e}"))))?;
+        if affected == 0 {
+            Err(lease_lost(lease))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn update_manifest_bytes(
+        &self,
+        lease: &ManifestLease,
+        bytes_processed: u64,
+        bytes_total: u64,
+    ) -> Result<(), LeaseError> {
+        let client = self.get_client().await.map_err(LeaseError::Storage)?;
+        let affected = client
+            .execute(
+                "UPDATE bulk_manifests
+                 SET bytes_processed = $1, bytes_total = $2
+                 WHERE tenant_id = $3 AND submitter = $4 AND submission_id = $5
+                   AND manifest_id = $6 AND worker_id = $7 AND fencing_token = $8",
+                &[
+                    &(bytes_processed as i64),
+                    &(bytes_total as i64),
+                    &lease.tenant.tenant_id().as_str(),
+                    &lease.submission_id.submitter,
+                    &lease.submission_id.submission_id,
+                    &lease.manifest_id,
+                    &lease.worker_id.as_str(),
+                    &(lease.fencing_token as i64),
+                ],
+            )
+            .await
+            .map_err(|e| LeaseError::Storage(internal_error(format!("update bytes: {e}"))))?;
         if affected == 0 {
             Err(lease_lost(lease))
         } else {

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -1967,8 +1967,17 @@ impl SubmitWorkerStorage for PostgresBackend {
         let client = self.get_client().await?;
         let row = client
             .query_one(
-                "SELECT COUNT(*) FROM bulk_submissions
-                 WHERE tenant_id = $1 AND status = 'in-progress'",
+                "SELECT COUNT(*) FROM bulk_submissions s
+                 WHERE s.tenant_id = $1 AND s.status = 'in-progress'
+                   AND (NOT EXISTS (SELECT 1 FROM bulk_manifests m
+                                    WHERE m.tenant_id = s.tenant_id
+                                      AND m.submitter = s.submitter
+                                      AND m.submission_id = s.submission_id)
+                        OR EXISTS (SELECT 1 FROM bulk_manifests m
+                                   WHERE m.tenant_id = s.tenant_id
+                                     AND m.submitter = s.submitter
+                                     AND m.submission_id = s.submission_id
+                                     AND m.status IN ('pending', 'processing')))",
                 &[&tenant.tenant_id().as_str()],
             )
             .await

--- a/crates/persistence/src/backends/postgres/schema.rs
+++ b/crates/persistence/src/backends/postgres/schema.rs
@@ -738,6 +738,8 @@ async fn add_bulk_submit_worker_schema(
         "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS last_processed_line BIGINT NOT NULL DEFAULT 0",
         "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS import_directives TEXT",
         "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS submission_metadata TEXT",
+        "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS bytes_processed BIGINT NOT NULL DEFAULT 0",
+        "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS bytes_total BIGINT NOT NULL DEFAULT 0",
     ];
     for sql in &migrations {
         client

--- a/crates/persistence/src/backends/s3/submit_worker.rs
+++ b/crates/persistence/src/backends/s3/submit_worker.rs
@@ -53,7 +53,7 @@ use uuid::Uuid;
 use crate::core::bulk_export::ExportJobId;
 use crate::core::bulk_export_worker::{LeaseError, WorkerId};
 use crate::core::bulk_submit::{
-    ManifestStatus, SubmissionId, SubmissionManifest, SubmissionStatus,
+    BulkSubmitProvider, ManifestStatus, SubmissionId, SubmissionManifest, SubmissionStatus,
 };
 use crate::core::bulk_submit_worker::{
     ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
@@ -1034,15 +1034,42 @@ impl SubmitWorkerStorage for S3Backend {
         // result. Submissions written before the index existed carry no entry
         // and so do not count toward the cap; that under-counts an old backlog
         // rather than wrongly rejecting new work.
-        Ok(self
+        let tenant_id = tenant.tenant_id().as_str();
+        let open: Vec<SubmitIndexEntry> = self
             .list_index_entries(REGISTRY_NAMESPACE)
             .await?
             .into_iter()
             .filter(|entry| {
-                entry.tenant_id == tenant.tenant_id().as_str()
-                    && entry.status == Some(SubmissionStatus::InProgress)
+                entry.tenant_id == tenant_id && entry.status == Some(SubmissionStatus::InProgress)
             })
-            .count() as u64)
+            .collect();
+        if open.is_empty() {
+            return Ok(0);
+        }
+        // The claim queue holds one entry per pending/processing manifest, so
+        // queue presence is "work in flight". An open submission with no queue
+        // entry counts only while it has no manifests at all (awaiting its
+        // first kick-off); with every manifest terminal it is drained and
+        // holds no slot.
+        let queued: std::collections::HashSet<(String, String)> = self
+            .list_index_entries(QUEUE_NAMESPACE)
+            .await?
+            .into_iter()
+            .filter(|entry| entry.tenant_id == tenant_id)
+            .map(|entry| (entry.submitter, entry.submission_id))
+            .collect();
+        let mut active = 0u64;
+        for entry in open {
+            if queued.contains(&(entry.submitter.clone(), entry.submission_id.clone())) {
+                active += 1;
+                continue;
+            }
+            let id = SubmissionId::new(entry.submitter, entry.submission_id);
+            if self.list_manifests(tenant, &id).await?.is_empty() {
+                active += 1;
+            }
+        }
+        Ok(active)
     }
 
     async fn list_expired_submissions(

--- a/crates/persistence/src/backends/s3/submit_worker.rs
+++ b/crates/persistence/src/backends/s3/submit_worker.rs
@@ -670,6 +670,19 @@ impl SubmitWorkerStorage for S3Backend {
         .await
     }
 
+    async fn update_manifest_bytes(
+        &self,
+        lease: &ManifestLease,
+        bytes_processed: u64,
+        bytes_total: u64,
+    ) -> Result<(), LeaseError> {
+        self.fenced_mutate(lease, |state| {
+            state.manifest.bytes_processed = bytes_processed;
+            state.manifest.bytes_total = bytes_total;
+        })
+        .await
+    }
+
     async fn record_submit_file(
         &self,
         lease: &ManifestLease,

--- a/crates/persistence/src/backends/s3/submit_worker.rs
+++ b/crates/persistence/src/backends/s3/submit_worker.rs
@@ -677,8 +677,8 @@ impl SubmitWorkerStorage for S3Backend {
         bytes_total: u64,
     ) -> Result<(), LeaseError> {
         self.fenced_mutate(lease, |state| {
-            state.manifest.bytes_processed = bytes_processed;
-            state.manifest.bytes_total = bytes_total;
+            state.manifest.bytes_processed = state.manifest.bytes_processed.max(bytes_processed);
+            state.manifest.bytes_total = state.manifest.bytes_total.max(bytes_total);
         })
         .await
     }

--- a/crates/persistence/src/backends/s3/tests.rs
+++ b/crates/persistence/src/backends/s3/tests.rs
@@ -3528,9 +3528,10 @@ mod bulk_submit_worker {
                 _requires_access_token: bool,
                 _oauth: &[String],
                 _key: Option<&serde_json::Value>,
-            ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
+            ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)>
+            {
                 let data = self.files.get(url).cloned().unwrap_or_default();
-                Ok(Box::new(BufReader::new(Cursor::new(data))))
+                Ok((Box::new(BufReader::new(Cursor::new(data))), None))
             }
         }
 

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -2035,8 +2035,17 @@ impl SubmitWorkerStorage for SqliteBackend {
         let conn = self.get_connection()?;
         let count: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM bulk_submissions
-                 WHERE tenant_id = ?1 AND status = 'in-progress'",
+                "SELECT COUNT(*) FROM bulk_submissions s
+                 WHERE s.tenant_id = ?1 AND s.status = 'in-progress'
+                   AND (NOT EXISTS (SELECT 1 FROM bulk_manifests m
+                                    WHERE m.tenant_id = s.tenant_id
+                                      AND m.submitter = s.submitter
+                                      AND m.submission_id = s.submission_id)
+                        OR EXISTS (SELECT 1 FROM bulk_manifests m
+                                   WHERE m.tenant_id = s.tenant_id
+                                     AND m.submitter = s.submitter
+                                     AND m.submission_id = s.submission_id
+                                     AND m.status IN ('pending', 'processing')))",
                 params![tenant.tenant_id().as_str()],
                 |r| r.get(0),
             )

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -474,6 +474,8 @@ impl BulkSubmitProvider for SqliteBackend {
             processed_entries: 0,
             failed_entries: 0,
             lease_expiry: None,
+            bytes_processed: 0,
+            bytes_total: 0,
         })
     }
 
@@ -487,7 +489,7 @@ impl BulkSubmitProvider for SqliteBackend {
         let tenant_id = tenant.tenant_id().as_str();
 
         let result = conn.query_row(
-            "SELECT manifest_url, replaces_manifest_url, status, added_at, total_entries, processed_entries, failed_entries, lease_expiry
+            "SELECT manifest_url, replaces_manifest_url, status, added_at, total_entries, processed_entries, failed_entries, lease_expiry, bytes_processed, bytes_total
              FROM bulk_manifests
              WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3 AND manifest_id = ?4",
             params![tenant_id, &submission_id.submitter, &submission_id.submission_id, manifest_id],
@@ -501,6 +503,8 @@ impl BulkSubmitProvider for SqliteBackend {
                     row.get::<_, i64>(5)?,
                     row.get::<_, i64>(6)?,
                     row.get::<_, Option<String>>(7)?,
+                    row.get::<_, i64>(8)?,
+                    row.get::<_, i64>(9)?,
                 ))
             },
         );
@@ -515,6 +519,8 @@ impl BulkSubmitProvider for SqliteBackend {
                 processed,
                 failed,
                 lease_expiry,
+                bytes_processed,
+                bytes_total,
             )) => {
                 let status: ManifestStatus = status_str.parse().map_err(|_| {
                     internal_error(format!("Invalid manifest status: {}", status_str))
@@ -533,6 +539,8 @@ impl BulkSubmitProvider for SqliteBackend {
                     total_entries: total as u64,
                     processed_entries: processed as u64,
                     failed_entries: failed as u64,
+                    bytes_processed: bytes_processed.max(0) as u64,
+                    bytes_total: bytes_total.max(0) as u64,
                     lease_expiry: lease_expiry.and_then(|s| {
                         chrono::DateTime::parse_from_rfc3339(&s)
                             .ok()
@@ -1598,6 +1606,38 @@ impl SubmitWorkerStorage for SqliteBackend {
                 ],
             )
             .map_err(|e| LeaseError::Storage(internal_error(format!("update progress: {e}"))))?;
+        if affected == 0 {
+            Err(lease_lost(lease))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn update_manifest_bytes(
+        &self,
+        lease: &ManifestLease,
+        bytes_processed: u64,
+        bytes_total: u64,
+    ) -> Result<(), LeaseError> {
+        let conn = self.get_connection().map_err(LeaseError::Storage)?;
+        let affected = conn
+            .execute(
+                "UPDATE bulk_manifests
+                 SET bytes_processed = ?1, bytes_total = ?2
+                 WHERE tenant_id = ?3 AND submitter = ?4 AND submission_id = ?5
+                   AND manifest_id = ?6 AND worker_id = ?7 AND fencing_token = ?8",
+                params![
+                    bytes_processed as i64,
+                    bytes_total as i64,
+                    lease.tenant.tenant_id().as_str(),
+                    lease.submission_id.submitter,
+                    lease.submission_id.submission_id,
+                    lease.manifest_id,
+                    lease.worker_id.as_str(),
+                    lease.fencing_token as i64
+                ],
+            )
+            .map_err(|e| LeaseError::Storage(internal_error(format!("update bytes: {e}"))))?;
         if affected == 0 {
             Err(lease_lost(lease))
         } else {

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -740,14 +740,30 @@ impl BulkSubmitProvider for SqliteBackend {
         }
 
         // Update manifest counts, on a fresh connection: the loop above is
-        // long and its per-entry calls pool their own.
+        // long and its per-entry calls pool their own. Byte progress rides
+        // this write: it lands right after the batch commit releases the
+        // write lock, while a standalone flush (the lease keeper's) can
+        // starve for tens of seconds against back-to-back batch
+        // transactions. MAX keeps a late keeper flush from regressing it.
         let now = Utc::now().to_rfc3339();
         let conn = self.get_connection()?;
+        let (consumed, bytes_total) = options
+            .byte_progress
+            .as_ref()
+            .map(|bp| {
+                (
+                    bp.consumed.load(std::sync::atomic::Ordering::Relaxed) as i64,
+                    bp.total.load(std::sync::atomic::Ordering::Relaxed) as i64,
+                )
+            })
+            .unwrap_or((0, 0));
         conn.execute(
             "UPDATE bulk_manifests SET
                 total_entries = total_entries + ?1,
                 processed_entries = processed_entries + ?2,
-                failed_entries = failed_entries + ?3
+                failed_entries = failed_entries + ?3,
+                bytes_processed = MAX(bytes_processed, ?8),
+                bytes_total = MAX(bytes_total, ?9)
              WHERE tenant_id = ?4 AND submitter = ?5 AND submission_id = ?6 AND manifest_id = ?7",
             params![
                 results.len() as i64,
@@ -756,7 +772,9 @@ impl BulkSubmitProvider for SqliteBackend {
                 tenant_id,
                 &submission_id.submitter,
                 &submission_id.submission_id,
-                manifest_id
+                manifest_id,
+                consumed,
+                bytes_total
             ],
         )
         .map_err(|e| internal_error(format!("Failed to update manifest counts: {}", e)))?;
@@ -1623,7 +1641,8 @@ impl SubmitWorkerStorage for SqliteBackend {
         let affected = conn
             .execute(
                 "UPDATE bulk_manifests
-                 SET bytes_processed = ?1, bytes_total = ?2
+                 SET bytes_processed = MAX(bytes_processed, ?1),
+                     bytes_total = MAX(bytes_total, ?2)
                  WHERE tenant_id = ?3 AND submitter = ?4 AND submission_id = ?5
                    AND manifest_id = ?6 AND worker_id = ?7 AND fencing_token = ?8",
                 params![

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use crate::error::StorageResult;
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 17;
+pub const SCHEMA_VERSION: i32 = 18;
 
 /// Initialize the database schema.
 pub fn initialize_schema(conn: &Connection) -> StorageResult<()> {
@@ -298,6 +298,7 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> StorageResult<()> {
             14 => migrate_v14_to_v15(conn)?,
             15 => migrate_v15_to_v16(conn)?,
             16 => migrate_v16_to_v17(conn)?,
+            17 => migrate_v17_to_v18(conn)?,
             _ => {
                 return Err(crate::error::StorageError::Backend(
                     crate::error::BackendError::Internal {
@@ -1385,6 +1386,20 @@ fn migrate_v16_to_v17(conn: &Connection) -> StorageResult<()> {
         [],
     )
     .map_err(|e| migration_err(format!("create bulk_provider_submissions table: {e}")))?;
+    Ok(())
+}
+
+/// Migrate from schema version 17 to version 18: byte-level ingest
+/// progress on manifests, so the status endpoint can report a real
+/// percentage while a file streams in.
+fn migrate_v17_to_v18(conn: &Connection) -> StorageResult<()> {
+    for sql in [
+        "ALTER TABLE bulk_manifests ADD COLUMN bytes_processed INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE bulk_manifests ADD COLUMN bytes_total INTEGER NOT NULL DEFAULT 0",
+    ] {
+        conn.execute(sql, [])
+            .map_err(|e| migration_err(format!("add manifest byte columns: {e}")))?;
+    }
     Ok(())
 }
 

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -1393,12 +1393,34 @@ fn migrate_v16_to_v17(conn: &Connection) -> StorageResult<()> {
 /// progress on manifests, so the status endpoint can report a real
 /// percentage while a file streams in.
 fn migrate_v17_to_v18(conn: &Connection) -> StorageResult<()> {
-    for sql in [
-        "ALTER TABLE bulk_manifests ADD COLUMN bytes_processed INTEGER NOT NULL DEFAULT 0",
-        "ALTER TABLE bulk_manifests ADD COLUMN bytes_total INTEGER NOT NULL DEFAULT 0",
-    ] {
-        conn.execute(sql, [])
-            .map_err(|e| migration_err(format!("add manifest byte columns: {e}")))?;
+    // The columns already exist when the table was created fresh at v18 — guard
+    // with PRAGMA table_info since SQLite has no `ADD COLUMN IF NOT EXISTS`.
+    let manifest_columns: Vec<String> = {
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(bulk_manifests)")
+            .map_err(|e| migration_err(format!("pragma bulk_manifests: {e}")))?;
+        let cols: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| migration_err(format!("pragma rows: {e}")))?
+            .filter_map(|r| r.ok())
+            .collect();
+        cols
+    };
+    let adds = [
+        (
+            "bytes_processed",
+            "ALTER TABLE bulk_manifests ADD COLUMN bytes_processed INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "bytes_total",
+            "ALTER TABLE bulk_manifests ADD COLUMN bytes_total INTEGER NOT NULL DEFAULT 0",
+        ),
+    ];
+    for (col, sql) in &adds {
+        if !manifest_columns.iter().any(|c| c == col) {
+            conn.execute(sql, [])
+                .map_err(|e| migration_err(format!("add manifest byte columns: {e}")))?;
+        }
     }
     Ok(())
 }
@@ -1571,6 +1593,23 @@ mod tests {
 
         let version = get_schema_version(&conn).unwrap();
         assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    /// Migrations must be re-runnable: a database already carrying the latest
+    /// columns can be replayed from any earlier recorded version (tests do this,
+    /// and so does a build that stamped a version before finishing its work).
+    /// SQLite has no `ADD COLUMN IF NOT EXISTS`, so every `ALTER TABLE ... ADD
+    /// COLUMN` step has to guard against the column already being there.
+    #[test]
+    fn test_migration_ladder_replays_on_a_current_database() {
+        for from in 1..SCHEMA_VERSION {
+            let conn = Connection::open_in_memory().unwrap();
+            initialize_schema(&conn).unwrap();
+            set_schema_version(&conn, from).unwrap();
+            initialize_schema(&conn)
+                .unwrap_or_else(|e| panic!("replay from v{from} failed: {e:?}"));
+            assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+        }
     }
 
     #[test]

--- a/crates/persistence/src/core/bulk_submit.rs
+++ b/crates/persistence/src/core/bulk_submit.rs
@@ -289,6 +289,14 @@ pub struct SubmissionManifest {
     /// stall signal the status poll surfaces (#646).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lease_expiry: Option<DateTime<Utc>>,
+    /// Bytes consumed so far across the manifest's files — the status
+    /// endpoint's real percentage while a file streams in.
+    #[serde(default)]
+    pub bytes_processed: u64,
+    /// Summed advertised size of the files opened so far; `0` when no file
+    /// carried a length, which degrades the status to count-only progress.
+    #[serde(default)]
+    pub bytes_total: u64,
 }
 
 impl SubmissionManifest {
@@ -304,6 +312,8 @@ impl SubmissionManifest {
             processed_entries: 0,
             failed_entries: 0,
             lease_expiry: None,
+            bytes_processed: 0,
+            bytes_total: 0,
         }
     }
 

--- a/crates/persistence/src/core/bulk_submit.rs
+++ b/crates/persistence/src/core/bulk_submit.rs
@@ -673,6 +673,19 @@ fn merge_patch(target: &Value, patch: &Value) -> Value {
     Value::Object(out)
 }
 
+/// Live byte counters for a manifest ingest in flight, shared between the
+/// reader that counts consumption and the writers that persist it.
+///
+/// `total` stays `0` until every opened file has advertised a size, so a
+/// partial total never inflates a percentage.
+#[derive(Debug, Clone, Default)]
+pub struct ByteProgress {
+    /// Bytes the ingestion engine has consumed across the manifest's files.
+    pub consumed: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    /// Summed advertised size of the files opened so far.
+    pub total: std::sync::Arc<std::sync::atomic::AtomicU64>,
+}
+
 /// Options for bulk processing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BulkProcessingOptions {
@@ -696,6 +709,13 @@ pub struct BulkProcessingOptions {
     /// file every file after the first collides on the stored key (#457).
     #[serde(default)]
     pub file_url: Option<String>,
+    /// Live byte counters for the manifest ingest, when the caller tracks
+    /// them. Batch bookkeeping persists these alongside the entry counters —
+    /// that write already wins the database's write lock between batches,
+    /// where a standalone flush starves against back-to-back batch
+    /// transactions on SQLite.
+    #[serde(skip)]
+    pub byte_progress: Option<ByteProgress>,
 }
 
 fn default_submit_batch_size() -> u32 {
@@ -726,12 +746,19 @@ impl BulkProcessingOptions {
             allow_updates: default_allow_updates(),
             import_mode: ImportMode::default(),
             file_url: None,
+            byte_progress: None,
         }
     }
 
     /// Names the manifest output file the entries come from (#457).
     pub fn with_file_url(mut self, file_url: impl Into<String>) -> Self {
         self.file_url = Some(file_url.into());
+        self
+    }
+
+    /// Attaches live byte counters for batch bookkeeping to persist.
+    pub fn with_byte_progress(mut self, byte_progress: ByteProgress) -> Self {
+        self.byte_progress = Some(byte_progress);
         self
     }
 

--- a/crates/persistence/src/core/bulk_submit_input.rs
+++ b/crates/persistence/src/core/bulk_submit_input.rs
@@ -75,7 +75,11 @@ pub trait SubmitInputFetcher: Send + Sync {
         encryption_key: Option<&Value>,
     ) -> StorageResult<RemoteManifest>;
 
-    /// Opens a streaming, line-buffered reader over the NDJSON file at `url`.
+    /// Opens a streaming, line-buffered reader over the NDJSON file at `url`,
+    /// with the file's total size in bytes when the source advertises one
+    /// (`Content-Length`, or the decrypted length of a buffered JWE file).
+    /// The size is what turns the status endpoint's progress into a real
+    /// percentage; `None` degrades to count-only progress.
     ///
     /// Implementations apply `request_headers`, request `gzip` via `Accept-Encoding`
     /// and transparently decompress, and — when `requires_access_token` is true —
@@ -88,7 +92,7 @@ pub trait SubmitInputFetcher: Send + Sync {
         requires_access_token: bool,
         oauth_metadata_urls: &[String],
         encryption_key: Option<&Value>,
-    ) -> StorageResult<Box<dyn AsyncBufRead + Send + Unpin>>;
+    ) -> StorageResult<(Box<dyn AsyncBufRead + Send + Unpin>, Option<u64>)>;
 }
 
 /// Maps a submission to the stable [`ExportJobId`] used as the output-store key

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -324,7 +324,17 @@ pub trait SubmitWorkerStorage: Send + Sync {
         id: &SubmissionId,
     ) -> StorageResult<()>;
 
-    /// Counts non-terminal submissions for a tenant (per-tenant concurrency cap).
+    /// Counts submissions with work in flight for a tenant (per-tenant
+    /// concurrency cap).
+    ///
+    /// A submission counts while it is `in-progress` **and** still has work
+    /// pending: either no manifests yet (opened, awaiting its first kick-off)
+    /// or at least one non-terminal manifest. A drained submission — open per
+    /// the spec so `replacesManifestUrl` can still land, but with every
+    /// manifest terminal — holds no slot: the cap bounds concurrent
+    /// ingestion, and a submitter that never sends the closing
+    /// `submissionStatus=completed` must not leak its tenant's slots forever
+    /// (#850). A new manifest on a drained submission makes it count again.
     async fn count_active_submissions(&self, tenant: &TenantContext) -> StorageResult<u64>;
 
     /// Lists submissions whose `updated_at` is older than `now - ttl`, across all

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -223,6 +223,17 @@ pub trait SubmitWorkerStorage: Send + Sync {
         last_processed_line: u64,
     ) -> Result<(), LeaseError>;
 
+    /// Idempotent update of the manifest's byte progress — bytes consumed so
+    /// far across its files, and the summed advertised size of the files
+    /// opened so far (both monotonic within a run). What the status
+    /// endpoint's percentage is computed from. Fenced.
+    async fn update_manifest_bytes(
+        &self,
+        lease: &ManifestLease,
+        bytes_processed: u64,
+        bytes_total: u64,
+    ) -> Result<(), LeaseError>;
+
     /// Idempotent upsert of a finalized status-manifest artifact row. Fenced.
     async fn record_submit_file(
         &self,
@@ -373,6 +384,55 @@ pub struct DefaultSubmitWorker<Js: ?Sized, Fetcher: ?Sized, Os: ?Sized> {
     worker_id: WorkerId,
 }
 
+/// Byte-level ingest progress shared between the streaming reader, the
+/// [`LeaseKeeper`] (which flushes it on every heartbeat), and `run_job`.
+#[derive(Clone, Default)]
+struct ByteProgress {
+    /// Bytes the ingestion engine has consumed across the manifest's files.
+    consumed: Arc<std::sync::atomic::AtomicU64>,
+    /// Summed advertised size of the files opened so far; stays `0` unless
+    /// every opened file carried a length, so a partial total never inflates
+    /// the percentage.
+    total: Arc<std::sync::atomic::AtomicU64>,
+}
+
+/// A pass-through [`AsyncBufRead`] that adds every consumed byte to a shared
+/// counter — the live half of the status endpoint's percentage.
+struct CountingReader {
+    inner: Box<dyn tokio::io::AsyncBufRead + Send + Unpin>,
+    consumed: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl tokio::io::AsyncRead for CountingReader {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let before = buf.filled().len();
+        let poll = std::pin::Pin::new(&mut self.inner).poll_read(cx, buf);
+        if let std::task::Poll::Ready(Ok(())) = &poll {
+            let read = buf.filled().len() - before;
+            self.consumed.fetch_add(read as u64, Ordering::Relaxed);
+        }
+        poll
+    }
+}
+
+impl tokio::io::AsyncBufRead for CountingReader {
+    fn poll_fill_buf(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<&[u8]>> {
+        std::pin::Pin::new(&mut self.get_mut().inner).poll_fill_buf(cx)
+    }
+
+    fn consume(mut self: std::pin::Pin<&mut Self>, amt: usize) {
+        self.consumed.fetch_add(amt as u64, Ordering::Relaxed);
+        std::pin::Pin::new(&mut self.inner).consume(amt);
+    }
+}
+
 /// Renews a [`ManifestLease`] from a dedicated task for as long as it is alive.
 ///
 /// The renewal must not share a future with the ingestion: a fast local stream
@@ -383,6 +443,11 @@ pub struct DefaultSubmitWorker<Js: ?Sized, Fetcher: ?Sized, Os: ?Sized> {
 /// idempotently. A separately spawned task renews on schedule no matter how the
 /// ingest future behaves.
 ///
+/// The keeper's task also flushes the shared byte progress every few seconds
+/// — a status poll must see the bar move *while* a large file streams, not
+/// once per lease renewal. The flush is a fenced best-effort write; the
+/// heartbeat alone decides lease health.
+///
 /// Dropping the keeper stops the renewal task.
 struct LeaseKeeper {
     lost: Arc<AtomicBool>,
@@ -390,20 +455,35 @@ struct LeaseKeeper {
 }
 
 impl LeaseKeeper {
-    fn spawn<Js>(jobs: Arc<Js>, lease: ManifestLease) -> Self
+    fn spawn<Js>(jobs: Arc<Js>, lease: ManifestLease, progress: ByteProgress) -> Self
     where
         Js: BulkSubmitJobStore + ?Sized + 'static,
     {
+        const FLUSH_EVERY: Duration = Duration::from_secs(3);
         let lost = Arc::new(AtomicBool::new(false));
         let flag = Arc::clone(&lost);
         let handle = tokio::spawn(async move {
             let mut expiry = lease.lease_expiry;
+            let mut last_flushed: u64 = 0;
             loop {
                 let remaining = (expiry - Utc::now())
                     .to_std()
                     .unwrap_or(Duration::from_secs(1));
                 let wait = (remaining / 3).clamp(Duration::from_secs(1), Duration::from_secs(60));
-                tokio::time::sleep(wait).await;
+                let heartbeat_at = tokio::time::Instant::now() + wait;
+                loop {
+                    let now = tokio::time::Instant::now();
+                    if now >= heartbeat_at {
+                        break;
+                    }
+                    tokio::time::sleep(FLUSH_EVERY.min(heartbeat_at - now)).await;
+                    let total = progress.total.load(Ordering::Relaxed);
+                    let consumed = progress.consumed.load(Ordering::Relaxed);
+                    if total > 0 && consumed != last_flushed {
+                        last_flushed = consumed;
+                        let _ = jobs.update_manifest_bytes(&lease, consumed, total).await;
+                    }
+                }
                 match jobs.heartbeat(&lease).await {
                     Ok(new_expiry) => expiry = new_expiry,
                     Err(LeaseError::LeaseLost { .. }) => {
@@ -514,7 +594,12 @@ where
         // The lease must stay heartbeated *through* a file, not only between
         // files, and independently of how often the ingest future yields; the
         // keeper renews from its own task until dropped.
-        let keeper = LeaseKeeper::spawn(Arc::clone(&self.jobs), lease.clone());
+        let progress = ByteProgress::default();
+        // Percentages need every file's size; one sizeless file (e.g. a
+        // gzip-decompressed stream) poisons the total for the whole manifest
+        // and the status endpoint falls back to manifest-count progress.
+        let mut totals_known = true;
+        let keeper = LeaseKeeper::spawn(Arc::clone(&self.jobs), lease.clone(), progress.clone());
 
         // 2. Ingest each output file via the existing streaming engine.
         for file in &manifest.output {
@@ -525,7 +610,7 @@ where
                 .resource_type
                 .clone()
                 .unwrap_or_else(|| "Resource".into());
-            let stream = match self
+            let (stream, file_bytes_total) = match self
                 .fetcher
                 .open_file_stream(
                     &file.url,
@@ -548,6 +633,21 @@ where
                     continue;
                 }
             };
+            match file_bytes_total {
+                Some(len) if totals_known => {
+                    progress.total.fetch_add(len, Ordering::Relaxed);
+                }
+                Some(_) => {}
+                None => {
+                    totals_known = false;
+                    progress.total.store(0, Ordering::Relaxed);
+                }
+            }
+            let stream: Box<dyn tokio::io::AsyncBufRead + Send + Unpin> =
+                Box::new(CountingReader {
+                    inner: stream,
+                    consumed: Arc::clone(&progress.consumed),
+                });
 
             // Per-file options: the file url is part of every entry result's
             // identity, since line numbers restart in each file (#457).
@@ -586,6 +686,13 @@ where
             {
                 return Err(e);
             }
+            let total = progress.total.load(Ordering::Relaxed);
+            if total > 0 {
+                let _ = self
+                    .jobs
+                    .update_manifest_bytes(&lease, progress.consumed.load(Ordering::Relaxed), total)
+                    .await;
+            }
         }
 
         // 2b. Process `deleted` files — transaction Bundles / resource refs to remove.
@@ -605,7 +712,7 @@ where
                 )
                 .await
             {
-                Ok(reader) => {
+                Ok((reader, _)) => {
                     self.process_deleted_stream(&lease, reader, &mut deleted_refs)
                         .await;
                 }
@@ -1021,11 +1128,13 @@ mod tests {
             _requires_access_token: bool,
             _oauth: &[String],
             _encryption_key: Option<&Value>,
-        ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
+        ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
             let data = self.files.get(url).cloned().unwrap_or_default();
-            Ok(Box::new(tokio::io::BufReader::new(std::io::Cursor::new(
-                data,
-            ))))
+            let len = data.len() as u64;
+            Ok((
+                Box::new(tokio::io::BufReader::new(std::io::Cursor::new(data))),
+                Some(len),
+            ))
         }
     }
 
@@ -1111,6 +1220,10 @@ mod tests {
             crate::core::bulk_submit::ManifestStatus::Completed
         );
 
+        // Byte progress reached the file's full advertised size.
+        assert_eq!(manifests[0].bytes_total, ndjson.len() as u64);
+        assert_eq!(manifests[0].bytes_processed, ndjson.len() as u64);
+
         // An `output` artifact for Patient was recorded.
         let files = backend.list_submit_files(&tenant, &sub_id).await.unwrap();
         assert!(
@@ -1146,10 +1259,11 @@ mod tests {
             _r: bool,
             _o: &[String],
             _k: Option<&Value>,
-        ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
-            Ok(Box::new(tokio::io::BufReader::new(std::io::Cursor::new(
-                Vec::new(),
-            ))))
+        ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
+            Ok((
+                Box::new(tokio::io::BufReader::new(std::io::Cursor::new(Vec::new()))),
+                Some(0),
+            ))
         }
     }
 

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -22,7 +22,7 @@ use crate::core::bulk_export_output::{ExportOutputStore, ExportPartKey};
 use crate::core::bulk_export_worker::{LeaseError, WorkerId};
 use crate::core::bulk_submit::{
     BulkEntryOutcome, BulkProcessingOptions, BulkSubmitProvider, BulkSubmitRollbackProvider,
-    ImportMode, StreamingBulkSubmitProvider, SubmissionId,
+    ByteProgress, ImportMode, StreamingBulkSubmitProvider, SubmissionId,
 };
 use crate::core::bulk_submit_input::{SubmitInputFetcher, submission_output_job_id};
 use crate::error::StorageResult;
@@ -384,18 +384,6 @@ pub struct DefaultSubmitWorker<Js: ?Sized, Fetcher: ?Sized, Os: ?Sized> {
     worker_id: WorkerId,
 }
 
-/// Byte-level ingest progress shared between the streaming reader, the
-/// [`LeaseKeeper`] (which flushes it on every heartbeat), and `run_job`.
-#[derive(Clone, Default)]
-struct ByteProgress {
-    /// Bytes the ingestion engine has consumed across the manifest's files.
-    consumed: Arc<std::sync::atomic::AtomicU64>,
-    /// Summed advertised size of the files opened so far; stays `0` unless
-    /// every opened file carried a length, so a partial total never inflates
-    /// the percentage.
-    total: Arc<std::sync::atomic::AtomicU64>,
-}
-
 /// A pass-through [`AsyncBufRead`] that adds every consumed byte to a shared
 /// counter — the live half of the status endpoint's percentage.
 struct CountingReader {
@@ -443,10 +431,13 @@ impl tokio::io::AsyncBufRead for CountingReader {
 /// idempotently. A separately spawned task renews on schedule no matter how the
 /// ingest future behaves.
 ///
-/// The keeper's task also flushes the shared byte progress every few seconds
-/// — a status poll must see the bar move *while* a large file streams, not
-/// once per lease renewal. The flush is a fenced best-effort write; the
-/// heartbeat alone decides lease health.
+/// The keeper's task also flushes the shared byte progress every few seconds,
+/// best-effort. On backends whose batch bookkeeping persists the counters
+/// itself (SQLite) this is only a fallback — a standalone write can starve
+/// for tens of seconds behind back-to-back batch transactions there, and the
+/// value it finally lands is as old as the wait. All byte writes are
+/// monotonic (`MAX`), so a stale flush can never walk progress backwards.
+/// The heartbeat alone decides lease health.
 ///
 /// Dropping the keeper stops the renewal task.
 struct LeaseKeeper {
@@ -588,13 +579,15 @@ where
                 "ingesting manifest with submission metadata"
             );
         }
-        let opts = BulkProcessingOptions::new().with_import_mode(import_mode);
+        let progress = ByteProgress::default();
+        let opts = BulkProcessingOptions::new()
+            .with_import_mode(import_mode)
+            .with_byte_progress(progress.clone());
         let mut processed: u64 = 0;
         let mut failed: u64 = 0;
         // The lease must stay heartbeated *through* a file, not only between
         // files, and independently of how often the ingest future yields; the
         // keeper renews from its own task until dropped.
-        let progress = ByteProgress::default();
         // Percentages need every file's size; one sizeless file (e.g. a
         // gzip-decompressed stream) poisons the total for the whole manifest
         // and the status endpoint falls back to manifest-count progress.

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -3736,11 +3736,13 @@ mod bulk_submit {
             _requires_access_token: bool,
             _oauth: &[String],
             _key: Option<&serde_json::Value>,
-        ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
+        ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
             let data = self.files.get(url).cloned().unwrap_or_default();
-            Ok(Box::new(tokio::io::BufReader::new(std::io::Cursor::new(
-                data,
-            ))))
+            let len = data.len() as u64;
+            Ok((
+                Box::new(tokio::io::BufReader::new(std::io::Cursor::new(data))),
+                Some(len),
+            ))
         }
     }
 

--- a/crates/persistence/tests/sqlite_bulk_submit_concurrency.rs
+++ b/crates/persistence/tests/sqlite_bulk_submit_concurrency.rs
@@ -154,11 +154,13 @@ async fn two_workers_run_whole_manifests_to_completion() {
             _requires_access_token: bool,
             _oauth: &[String],
             _key: Option<&serde_json::Value>,
-        ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
+        ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
             let data = self.files.get(url).cloned().unwrap_or_default();
-            Ok(Box::new(tokio::io::BufReader::new(std::io::Cursor::new(
-                data,
-            ))))
+            let len = data.len() as u64;
+            Ok((
+                Box::new(tokio::io::BufReader::new(std::io::Cursor::new(data))),
+                Some(len),
+            ))
         }
     }
 
@@ -283,7 +285,7 @@ async fn a_file_slower_than_the_lease_stays_leased_to_completion() {
             _requires_access_token: bool,
             _oauth: &[String],
             _key: Option<&serde_json::Value>,
-        ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
+        ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
             // Trickle the file over ~6 seconds — three times the lease.
             let (reader, mut writer) = tokio::io::duplex(1024);
             let lines = self.lines.clone();
@@ -296,7 +298,7 @@ async fn a_file_slower_than_the_lease_stays_leased_to_completion() {
                     tokio::time::sleep(Duration::from_millis(150)).await;
                 }
             });
-            Ok(Box::new(tokio::io::BufReader::new(reader)))
+            Ok((Box::new(tokio::io::BufReader::new(reader)), None))
         }
     }
 
@@ -509,11 +511,14 @@ async fn a_ready_heavy_stream_still_renews_the_lease() {
             _requires_access_token: bool,
             _oauth: &[String],
             _key: Option<&serde_json::Value>,
-        ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
-            Ok(Box::new(tokio::io::BufReader::new(BusyReader {
-                data: self.lines.clone(),
-                pos: 0,
-            })))
+        ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
+            Ok((
+                Box::new(tokio::io::BufReader::new(BusyReader {
+                    data: self.lines.clone(),
+                    pos: 0,
+                })),
+                None,
+            ))
         }
     }
 
@@ -612,7 +617,7 @@ async fn a_lost_lease_aborts_the_run_quietly() {
             _requires_access_token: bool,
             _oauth: &[String],
             _key: Option<&serde_json::Value>,
-        ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
+        ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
             let (reader, mut writer) = tokio::io::duplex(1024);
             let lines = self.lines.clone();
             tokio::spawn(async move {
@@ -624,7 +629,7 @@ async fn a_lost_lease_aborts_the_run_quietly() {
                     tokio::time::sleep(std::time::Duration::from_millis(150)).await;
                 }
             });
-            Ok(Box::new(tokio::io::BufReader::new(reader)))
+            Ok((Box::new(tokio::io::BufReader::new(reader)), None))
         }
     }
 

--- a/crates/rest/src/bulk_submit_fetcher.rs
+++ b/crates/rest/src/bulk_submit_fetcher.rs
@@ -295,7 +295,7 @@ impl SubmitInputFetcher for HttpSubmitInputFetcher {
         requires_access_token: bool,
         oauth_metadata_urls: &[String],
         encryption_key: Option<&Value>,
-    ) -> StorageResult<Box<dyn AsyncBufRead + Send + Unpin>> {
+    ) -> StorageResult<(Box<dyn AsyncBufRead + Send + Unpin>, Option<u64>)> {
         // Resolve the key before the fetch so a misconfigured submission fails
         // without pulling the file body.
         let keys = self.resolve_keys(encryption_key)?;
@@ -329,10 +329,16 @@ impl SubmitInputFetcher for HttpSubmitInputFetcher {
             let bytes = self
                 .decrypt_file(bytes.to_vec(), Some(keys))
                 .map_err(|e| Self::err(format!("decrypting file {url}: {e}")))?;
-            return Ok(Box::new(tokio::io::BufReader::new(std::io::Cursor::new(
-                bytes,
-            ))));
+            let len = bytes.len() as u64;
+            return Ok((
+                Box::new(tokio::io::BufReader::new(std::io::Cursor::new(bytes))),
+                Some(len),
+            ));
         }
+        // The advertised size, when trustworthy: reqwest reports None for a
+        // transparently decompressed body, where Content-Length would be the
+        // compressed size and a byte-based percentage would overshoot.
+        let content_length = resp.content_length();
         // Stream the (gzip-decoded) body straight through to the ingestion
         // engine, so peak memory stays bounded by the buffer size rather than
         // by the file size.
@@ -340,9 +346,10 @@ impl SubmitInputFetcher for HttpSubmitInputFetcher {
         let stream = resp
             .bytes_stream()
             .map_err(move |e| std::io::Error::other(format!("reading file {owned_url}: {e}")));
-        Ok(Box::new(tokio::io::BufReader::new(StreamReader::new(
-            stream,
-        ))))
+        Ok((
+            Box::new(tokio::io::BufReader::new(StreamReader::new(stream))),
+            content_length,
+        ))
     }
 }
 
@@ -482,7 +489,7 @@ mod tests {
         let url = serve_two_chunks(wait).await;
         let fetcher = fetcher();
 
-        let reader = tokio::time::timeout(
+        let (reader, _len) = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             fetcher.open_file_stream(&url, &[], false, &[], None),
         )

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -760,7 +760,26 @@ where
     let stopped = summary.status == SubmissionStatus::Aborted;
 
     if !all_terminal && !stopped {
-        let pct = if manifests.is_empty() {
+        // Byte-level progress when the workers know every file's size: the
+        // percentage then moves *while* a file streams in, instead of jumping
+        // 0 → 100 on a single-manifest submission. A manifest with an unknown
+        // total (sizeless stream) contributes nothing to either sum, and when
+        // no totals are known at all the manifest-count fraction remains the
+        // fallback. Capped at 99 — 100 is reserved for the terminal manifest.
+        let bytes_total: u64 = manifests.iter().map(|m| m.bytes_total).sum();
+        let bytes_done: u64 = manifests
+            .iter()
+            .map(|m| {
+                if m.status.is_terminal() {
+                    m.bytes_total
+                } else {
+                    m.bytes_processed.min(m.bytes_total)
+                }
+            })
+            .sum();
+        let pct = if bytes_total > 0 {
+            (((bytes_done as u128 * 100) / bytes_total as u128) as u64).min(99) as usize
+        } else if manifests.is_empty() {
             0
         } else {
             (manifests.iter().filter(|m| m.status.is_terminal()).count() * 100) / manifests.len()
@@ -777,9 +796,8 @@ where
             m.status == helios_persistence::core::ManifestStatus::Processing
                 && m.lease_expiry.is_some_and(|e| now - e > stall_after)
         });
-        // The percentage is manifest-granular, so a single-manifest
-        // submission reads 0% until the very end; the entry counter is what
-        // actually moves while a file streams in (#790).
+        // The entry counter complements the percentage with absolute volume,
+        // and carries the progress alone when no byte totals are known (#790).
         let entries: u64 = manifests.iter().map(|m| m.processed_entries).sum();
         let progress = if stalled {
             tracing::warn!(

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -15,7 +15,8 @@ use helios_persistence::backends::local_fs::LocalFsOutputStore;
 use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
 use helios_persistence::core::{
     BulkSubmitJobStore, BulkSubmitProvider, DefaultSubmitWorker, ExportOutputStore, RemoteFile,
-    RemoteManifest, ResourceStorage, SubmitClaimStrategy, SubmitInputFetcher, WorkerId,
+    RemoteManifest, ResourceStorage, SubmitClaimStrategy, SubmitInputFetcher, SubmitWorkerStorage,
+    WorkerId,
 };
 use helios_persistence::error::StorageResult;
 use helios_rest::ServerConfig;
@@ -52,11 +53,13 @@ impl SubmitInputFetcher for MockFetcher {
         _requires_access_token: bool,
         _oauth: &[String],
         _encryption_key: Option<&Value>,
-    ) -> StorageResult<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>> {
+    ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
         let data = self.files.get(url).cloned().unwrap_or_default();
-        Ok(Box::new(tokio::io::BufReader::new(std::io::Cursor::new(
-            data,
-        ))))
+        let len = data.len() as u64;
+        Ok((
+            Box::new(tokio::io::BufReader::new(std::io::Cursor::new(data))),
+            Some(len),
+        ))
     }
 }
 
@@ -1091,6 +1094,40 @@ async fn test_poll_rate_limit_of_zero_disables_throttling() {
             "poll rate limiting must be off when the limit is 0"
         );
     }
+}
+
+/// The in-progress percentage is byte-based: a worker that has streamed part
+/// of a file moves the poll's X-Progress long before any manifest turns
+/// terminal, instead of a single-manifest submission sitting at 0% to the end.
+#[tokio::test]
+async fn test_poll_percentage_tracks_ingested_bytes() {
+    let (server, backend, _fetcher, _output, _tmp) =
+        create_submit_server_with(mock_fetcher(), BulkSubmitConfig::default()).await;
+    let poll_path = start_and_get_poll_path(&server).await;
+
+    let lease = backend
+        .claim_next_manifest(&WorkerId::new("byte-worker"), Duration::from_secs(60))
+        .await
+        .expect("claim")
+        .expect("a manifest to claim");
+    backend
+        .update_manifest_bytes(&lease, 350, 1_000)
+        .await
+        .expect("bytes update");
+
+    let resp = server.get(&poll_path).await;
+    assert_eq!(resp.status_code(), StatusCode::ACCEPTED);
+    let progress = resp
+        .headers()
+        .get("x-progress")
+        .expect("X-Progress")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        progress.contains("processing 35% complete"),
+        "the percentage must follow ingested bytes, got: {progress}"
+    );
 }
 
 /// #646: a `processing` manifest whose worker lease expired without renewal

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -331,6 +331,55 @@ async fn test_completed_status_finalizes_submission() {
     );
 }
 
+/// #850: a drained submission — every manifest terminal, but never closed
+/// with `submissionStatus=completed` — must not hold a tenant concurrency
+/// slot. A submitter that ingests and walks away used to leak its slot
+/// forever, until the tenant's every kick-off returned 429.
+#[tokio::test]
+async fn test_drained_submission_frees_its_concurrency_slot() {
+    let (server, backend, fetcher, output, _tmp) = create_submit_server_with(
+        mock_fetcher(),
+        BulkSubmitConfig {
+            max_concurrent_per_tenant: 1,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // First submission ingests to the end; the submitter never closes it.
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_with_status("leak-1", "in-progress"))
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+    drain_submit(&backend, &fetcher, &output).await;
+
+    // Drained, the open submission holds no slot: a second one is admitted.
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_with_status("leak-2", "in-progress"))
+            .await
+            .status_code(),
+        StatusCode::OK,
+        "a drained submission must not consume the tenant's only slot"
+    );
+
+    // The second one's manifest is still pending, so the cap is now real.
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_with_status("leak-3", "in-progress"))
+            .await
+            .status_code(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "a submission with work in flight must still count toward the cap"
+    );
+}
+
 /// A completed submission's already-registered manifests SHALL still be ingested.
 ///
 /// `completed` means "no further manifests are coming", not "stop processing".

--- a/crates/rest/tests/bulk_submit_jwe.rs
+++ b/crates/rest/tests/bulk_submit_jwe.rs
@@ -80,7 +80,7 @@ async fn serve(build: impl FnOnce(SocketAddr) -> (String, String)) -> SocketAddr
 }
 
 async fn read_all(fetcher: &HttpSubmitInputFetcher, url: &str, key: Option<&Value>) -> String {
-    let mut reader = fetcher
+    let (mut reader, _len) = fetcher
         .open_file_stream(url, &[], false, &[], key)
         .await
         .expect("open file stream");

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -1076,6 +1076,19 @@ pub async fn abort(
     set_status(state, rt, _principal, id, "stopped").await
 }
 
+/// `POST /ui/bulk-import/{id}/complete` — status-only kick-off, `completed`:
+/// the Data Provider's signal that no further manifests are coming. The
+/// recipient keeps draining already-registered manifests and frees the
+/// submission's concurrency slot (#850).
+pub async fn complete(
+    State(state): State<WebState>,
+    rt: RequestTenant,
+    _principal: Option<Extension<helios_auth::Principal>>,
+    Path(id): Path<String>,
+) -> Response {
+    set_status(state, rt, _principal, id, "completed").await
+}
+
 async fn set_status(
     state: WebState,
     rt: RequestTenant,

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -1170,13 +1170,13 @@ pub async fn status_fragment(
 }
 
 /// The determinate share of the recipient's `X-Progress`, when it reports
-/// one. The percentage is manifest-granular, so a one-shot submission reads
-/// `0%` for its whole run — that renders as an indeterminate bar rather than
-/// a permanently empty one.
+/// one. `0%` counts: HFS reports byte-level progress, so an early zero is a
+/// bar about to fill, not a percentage that never moves — the indeterminate
+/// sweep is reserved for recipients that report no percentage at all.
 fn progress_percent(progress: &str) -> Option<u8> {
     let rest = progress.strip_prefix("processing ")?;
     let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
-    let pct: u8 = digits.parse().ok().filter(|p| *p > 0 && *p <= 100)?;
+    let pct: u8 = digits.parse().ok().filter(|p| *p <= 100)?;
     Some(pct)
 }
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1297,6 +1297,10 @@ pub fn mount_with_conformance_source_and_runtime(
             "/ui/bulk-import/{id}/abort",
             axum::routing::post(bulk_import::abort),
         )
+        .route(
+            "/ui/bulk-import/{id}/complete",
+            axum::routing::post(bulk_import::complete),
+        )
         .route("/ui/tenants", get(tenants::page).post(tenants::create))
         .route("/ui/tenants/rows", get(tenants::rows))
         .route("/ui/tenants/{id}", axum::routing::delete(tenants::delete))

--- a/crates/ui/templates/partials/bulk_import_status.html
+++ b/crates/ui/templates/partials/bulk_import_status.html
@@ -23,6 +23,9 @@
     <form method="post" action="/ui/bulk-import/{{ id }}/abort">
       <button type="submit" class="btn">{% include "icons/stop-circle.svg" %}{{ i18n.t("bulk-import-abort") }}</button>
     </form>
+    <form method="post" action="/ui/bulk-import/{{ id }}/complete">
+      <button type="submit" class="btn">{% include "icons/check-circle.svg" %}{{ i18n.t("bulk-import-mark-completed") }}</button>
+    </form>
   </div>
   {% endif %}
 </div>

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -1169,12 +1169,14 @@ async fn status_polling_tracks_progress_and_lands_the_result() {
 
     // First status fetch: one poll happens -> 202 progress recorded, the
     // fragment keeps polling, and the in-progress card offers Abort. A 0%
-    // report renders the indeterminate bar (manifest-granular percentages
-    // sit at 0 for a one-shot submission's whole run).
+    // report renders a determinate bar at zero — the recipient's percentage
+    // is byte-based now, so an early zero fills within seconds instead of
+    // sweeping indeterminately for the whole run.
     let (status, html) = get(&ctx, &format!("{detail_path}/status")).await;
     assert_eq!(status, StatusCode::OK);
     assert!(html.contains("processing 0% complete"), "{html}");
-    assert!(html.contains("progress-track--indeterminate"), "{html}");
+    assert!(html.contains(r#"aria-valuenow="0""#), "{html}");
+    assert!(!html.contains("progress-track--indeterminate"), "{html}");
     assert!(html.contains("every 5s"), "keeps polling: {html}");
     assert!(html.contains(r#"id="bulk-status" class="card panel bulk-import-section""#));
     assert!(html.contains(r#"class="kv-grid kv-grid--flush""#));

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -598,6 +598,31 @@ async fn abort_sends_a_status_only_kickoff() {
     assert_eq!(status_code, "stopped");
 }
 
+/// #850: "Mark completed" is the Data Provider's closing signal — without it
+/// the recipient keeps the submission open and its concurrency slot held.
+#[tokio::test]
+async fn complete_sends_a_status_only_kickoff() {
+    let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+    let ctx = ctx(&recipient_url);
+
+    let detail_path = create_submission(&ctx).await;
+    set_submission_status(&ctx, &detail_path, "in-progress").await;
+    post_form(&ctx, &format!("{detail_path}/complete"), "").await;
+    let (_, html) = get(&ctx, &detail_path).await;
+    assert!(html.contains("Completed"), "{html}");
+    assert!(html.contains("Recipient acknowledged (200)"), "{html}");
+
+    let bodies = received.lock().unwrap().clone();
+    let params = bodies.last().unwrap()["parameter"].as_array().unwrap();
+    assert!(params.iter().all(|p| p["name"] != "manifestUrl"));
+    let status_code = params
+        .iter()
+        .find(|p| p["name"] == "submissionStatus")
+        .and_then(|p| p["valueCoding"]["code"].as_str())
+        .unwrap();
+    assert_eq!(status_code, "completed");
+}
+
 #[tokio::test]
 async fn a_rejected_status_change_keeps_the_status_and_logs_it() {
     let (recipient_url, _) = mock_recipient(StatusCode::CONFLICT).await;
@@ -1183,6 +1208,10 @@ async fn status_polling_tracks_progress_and_lands_the_result() {
     assert!(
         html.contains(&format!(r#"action="{detail_path}/abort""#)),
         "abort on the progress card: {html}"
+    );
+    assert!(
+        html.contains(&format!(r#"action="{detail_path}/complete""#)),
+        "mark-completed on the progress card: {html}"
     );
     assert!(!html.contains(r#"class="card detail""#));
 

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -607,6 +607,7 @@ bulk-import-detail-created = Erstellt
 bulk-import-detail-status = Status
 bulk-import-detail-auth = Authentifizierung
 bulk-import-abort = Abbrechen
+bulk-import-mark-completed = Als abgeschlossen markieren
 bulk-import-delete = Löschen
 bulk-import-edit = Bearbeiten
 bulk-import-edit-title = Submission bearbeiten

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -610,6 +610,7 @@ bulk-import-detail-created = Created
 bulk-import-detail-status = Status
 bulk-import-detail-auth = Authentication
 bulk-import-abort = Abort
+bulk-import-mark-completed = Mark completed
 bulk-import-delete = Delete
 bulk-import-edit = Edit
 bulk-import-edit-title = Edit Submission

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -607,6 +607,7 @@ bulk-import-detail-created = Creada
 bulk-import-detail-status = Estado
 bulk-import-detail-auth = Autenticación
 bulk-import-abort = Abortar
+bulk-import-mark-completed = Marcar completada
 bulk-import-delete = Eliminar
 bulk-import-edit = Editar
 bulk-import-edit-title = Editar submission


### PR DESCRIPTION
Closes #848
Closes #827

## What

The in-progress percentage behind `X-Progress` was manifest-granular (completed manifests / total), so a one-shot submission read **0% for its entire run** and the UI bar swept indeterminately without ever filling. The percentage is now **byte-based**: consumed bytes over the files' advertised sizes, updated every few seconds while a file streams.

## How

- **Fetcher** — `SubmitInputFetcher::open_file_stream` returns the stream plus its `Content-Length` (`None` for sizeless streams, e.g. gzip-decompressed bodies; JWE-buffered files report the decrypted length).
- **Worker** — each output file is wrapped in a counting `AsyncBufRead`; the `LeaseKeeper`'s task flushes `bytes_processed`/`bytes_total` to the manifest row every ~3s (plus after each file), through the same fenced update discipline as every other worker write. One sizeless file poisons the total for the whole manifest, so a partial total never inflates the percentage.
- **Storage** — `bytes_processed`/`bytes_total` on manifests across all four backends: SQLite (schema v18 migration), PostgreSQL (`ADD COLUMN IF NOT EXISTS`), MongoDB, S3.
- **Status endpoint** — percentage = summed bytes ratio, capped at 99 until terminal; falls back to the manifest-count fraction when no totals are known. The `(N entries ingested)` suffix stays.
- **UI** — a reported 0% now renders a determinate empty bar (it fills within seconds); the indeterminate sweep is reserved for recipients that report no percentage at all.

## Verified

Live run against a release build, 20,000 Patients (2.7 MB NDJSON, single manifest, single file): the poll reported 1% → 43% → 54% → … → 92% → completed, monotonically, alongside the entry counter. Suites: persistence lib (805), sqlite concurrency (6), rest `bulk_submit` (21, incl. a new byte-percentage test) + `bulk_submit_jwe` (6), ui `bulk_import_http` (28). Worker unit test asserts `bytes_total`/`bytes_processed` land at the file's full size.

### Mid-run: determinate bar at 54%
![bar](https://raw.githubusercontent.com/HeliosSoftware/hfs/assets/255-nl-search-screenshots/848-byte-progress/bar-54.png)

### Completed, with the percentage climbing in the submission log
![log](https://raw.githubusercontent.com/HeliosSoftware/hfs/assets/255-nl-search-screenshots/848-byte-progress/completed-log.png)