### PR TITLE
fix(persistence,ui): drained bulk-submit submissions stop holding tenant slots

### DIFF
--- a/crates/persistence/src/backends/mongodb/bulk_submit.rs
+++ b/crates/persistence/src/backends/mongodb/bulk_submit.rs
@@ -1670,14 +1670,69 @@ impl SubmitWorkerStorage for MongoBackend {
     }
 
     async fn count_active_submissions(&self, tenant: &TenantContext) -> StorageResult<u64> {
-        self.submissions()
+        let tenant_id = tenant.tenant_id().as_str();
+        let cursor = self
+            .submissions()
             .await?
-            .count_documents(doc! {
-                "tenant_id": tenant.tenant_id().as_str(),
+            .find(doc! {
+                "tenant_id": tenant_id,
                 "status": SubmissionStatus::InProgress.to_string(),
             })
             .await
-            .map_err(|e| internal_error(format!("count active submissions: {e}")))
+            .map_err(|e| internal_error(format!("count active submissions: {e}")))?;
+        let subs = collect(cursor).await?;
+        if subs.is_empty() {
+            return Ok(0);
+        }
+
+        let keys: Vec<Document> = subs
+            .iter()
+            .filter_map(|d| {
+                Some(doc! {
+                    "submitter": opt_str(d, "submitter")?,
+                    "submission_id": opt_str(d, "submission_id")?,
+                })
+            })
+            .collect();
+        let cursor = self
+            .manifests()
+            .await?
+            .find(doc! { "tenant_id": tenant_id, "$or": keys })
+            .await
+            .map_err(|e| internal_error(format!("count active submissions: {e}")))?;
+        // (submitter, submission_id) → has a non-terminal manifest. Presence in
+        // the map at all means the submission has manifests.
+        let mut manifests: std::collections::HashMap<(String, String), bool> =
+            std::collections::HashMap::new();
+        for m in &collect(cursor).await? {
+            let (Some(submitter), Some(submission_id)) =
+                (opt_str(m, "submitter"), opt_str(m, "submission_id"))
+            else {
+                continue;
+            };
+            let live = matches!(
+                m.get_str("status").unwrap_or_default(),
+                "pending" | "processing"
+            );
+            *manifests.entry((submitter, submission_id)).or_insert(false) |= live;
+        }
+
+        Ok(subs
+            .iter()
+            .filter(|d| {
+                let (Some(submitter), Some(submission_id)) =
+                    (opt_str(d, "submitter"), opt_str(d, "submission_id"))
+                else {
+                    return false;
+                };
+                // No manifests yet → awaiting its first kick-off; otherwise it
+                // counts only while a manifest is still pending/processing.
+                manifests
+                    .get(&(submitter, submission_id))
+                    .copied()
+                    .unwrap_or(true)
+            })
+            .count() as u64)
     }
 
     async fn list_expired_submissions(

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -1967,8 +1967,17 @@ impl SubmitWorkerStorage for PostgresBackend {
         let client = self.get_client().await?;
         let row = client
             .query_one(
-                "SELECT COUNT(*) FROM bulk_submissions
-                 WHERE tenant_id = $1 AND status = 'in-progress'",
+                "SELECT COUNT(*) FROM bulk_submissions s
+                 WHERE s.tenant_id = $1 AND s.status = 'in-progress'
+                   AND (NOT EXISTS (SELECT 1 FROM bulk_manifests m
+                                    WHERE m.tenant_id = s.tenant_id
+                                      AND m.submitter = s.submitter
+                                      AND m.submission_id = s.submission_id)
+                        OR EXISTS (SELECT 1 FROM bulk_manifests m
+                                   WHERE m.tenant_id = s.tenant_id
+                                     AND m.submitter = s.submitter
+                                     AND m.submission_id = s.submission_id
+                                     AND m.status IN ('pending', 'processing')))",
                 &[&tenant.tenant_id().as_str()],
             )
             .await

--- a/crates/persistence/src/backends/s3/submit_worker.rs
+++ b/crates/persistence/src/backends/s3/submit_worker.rs
@@ -53,7 +53,7 @@ use uuid::Uuid;
 use crate::core::bulk_export::ExportJobId;
 use crate::core::bulk_export_worker::{LeaseError, WorkerId};
 use crate::core::bulk_submit::{
-    ManifestStatus, SubmissionId, SubmissionManifest, SubmissionStatus,
+    BulkSubmitProvider, ManifestStatus, SubmissionId, SubmissionManifest, SubmissionStatus,
 };
 use crate::core::bulk_submit_worker::{
     ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
@@ -1034,15 +1034,42 @@ impl SubmitWorkerStorage for S3Backend {
         // result. Submissions written before the index existed carry no entry
         // and so do not count toward the cap; that under-counts an old backlog
         // rather than wrongly rejecting new work.
-        Ok(self
+        let tenant_id = tenant.tenant_id().as_str();
+        let open: Vec<SubmitIndexEntry> = self
             .list_index_entries(REGISTRY_NAMESPACE)
             .await?
             .into_iter()
             .filter(|entry| {
-                entry.tenant_id == tenant.tenant_id().as_str()
-                    && entry.status == Some(SubmissionStatus::InProgress)
+                entry.tenant_id == tenant_id && entry.status == Some(SubmissionStatus::InProgress)
             })
-            .count() as u64)
+            .collect();
+        if open.is_empty() {
+            return Ok(0);
+        }
+        // The claim queue holds one entry per pending/processing manifest, so
+        // queue presence is "work in flight". An open submission with no queue
+        // entry counts only while it has no manifests at all (awaiting its
+        // first kick-off); with every manifest terminal it is drained and
+        // holds no slot.
+        let queued: std::collections::HashSet<(String, String)> = self
+            .list_index_entries(QUEUE_NAMESPACE)
+            .await?
+            .into_iter()
+            .filter(|entry| entry.tenant_id == tenant_id)
+            .map(|entry| (entry.submitter, entry.submission_id))
+            .collect();
+        let mut active = 0u64;
+        for entry in open {
+            if queued.contains(&(entry.submitter.clone(), entry.submission_id.clone())) {
+                active += 1;
+                continue;
+            }
+            let id = SubmissionId::new(entry.submitter, entry.submission_id);
+            if self.list_manifests(tenant, &id).await?.is_empty() {
+                active += 1;
+            }
+        }
+        Ok(active)
     }
 
     async fn list_expired_submissions(

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -2035,8 +2035,17 @@ impl SubmitWorkerStorage for SqliteBackend {
         let conn = self.get_connection()?;
         let count: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM bulk_submissions
-                 WHERE tenant_id = ?1 AND status = 'in-progress'",
+                "SELECT COUNT(*) FROM bulk_submissions s
+                 WHERE s.tenant_id = ?1 AND s.status = 'in-progress'
+                   AND (NOT EXISTS (SELECT 1 FROM bulk_manifests m
+                                    WHERE m.tenant_id = s.tenant_id
+                                      AND m.submitter = s.submitter
+                                      AND m.submission_id = s.submission_id)
+                        OR EXISTS (SELECT 1 FROM bulk_manifests m
+                                   WHERE m.tenant_id = s.tenant_id
+                                     AND m.submitter = s.submitter
+                                     AND m.submission_id = s.submission_id
+                                     AND m.status IN ('pending', 'processing')))",
                 params![tenant.tenant_id().as_str()],
                 |r| r.get(0),
             )

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -324,7 +324,17 @@ pub trait SubmitWorkerStorage: Send + Sync {
         id: &SubmissionId,
     ) -> StorageResult<()>;
 
-    /// Counts non-terminal submissions for a tenant (per-tenant concurrency cap).
+    /// Counts submissions with work in flight for a tenant (per-tenant
+    /// concurrency cap).
+    ///
+    /// A submission counts while it is `in-progress` **and** still has work
+    /// pending: either no manifests yet (opened, awaiting its first kick-off)
+    /// or at least one non-terminal manifest. A drained submission — open per
+    /// the spec so `replacesManifestUrl` can still land, but with every
+    /// manifest terminal — holds no slot: the cap bounds concurrent
+    /// ingestion, and a submitter that never sends the closing
+    /// `submissionStatus=completed` must not leak its tenant's slots forever
+    /// (#850). A new manifest on a drained submission makes it count again.
     async fn count_active_submissions(&self, tenant: &TenantContext) -> StorageResult<u64>;
 
     /// Lists submissions whose `updated_at` is older than `now - ttl`, across all

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -331,6 +331,55 @@ async fn test_completed_status_finalizes_submission() {
     );
 }
 
+/// #850: a drained submission — every manifest terminal, but never closed
+/// with `submissionStatus=completed` — must not hold a tenant concurrency
+/// slot. A submitter that ingests and walks away used to leak its slot
+/// forever, until the tenant's every kick-off returned 429.
+#[tokio::test]
+async fn test_drained_submission_frees_its_concurrency_slot() {
+    let (server, backend, fetcher, output, _tmp) = create_submit_server_with(
+        mock_fetcher(),
+        BulkSubmitConfig {
+            max_concurrent_per_tenant: 1,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // First submission ingests to the end; the submitter never closes it.
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_with_status("leak-1", "in-progress"))
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+    drain_submit(&backend, &fetcher, &output).await;
+
+    // Drained, the open submission holds no slot: a second one is admitted.
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_with_status("leak-2", "in-progress"))
+            .await
+            .status_code(),
+        StatusCode::OK,
+        "a drained submission must not consume the tenant's only slot"
+    );
+
+    // The second one's manifest is still pending, so the cap is now real.
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_with_status("leak-3", "in-progress"))
+            .await
+            .status_code(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "a submission with work in flight must still count toward the cap"
+    );
+}
+
 /// A completed submission's already-registered manifests SHALL still be ingested.
 ///
 /// `completed` means "no further manifests are coming", not "stop processing".

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -1076,6 +1076,19 @@ pub async fn abort(
     set_status(state, rt, _principal, id, "stopped").await
 }
 
+/// `POST /ui/bulk-import/{id}/complete` — status-only kick-off, `completed`:
+/// the Data Provider's signal that no further manifests are coming. The
+/// recipient keeps draining already-registered manifests and frees the
+/// submission's concurrency slot (#850).
+pub async fn complete(
+    State(state): State<WebState>,
+    rt: RequestTenant,
+    _principal: Option<Extension<helios_auth::Principal>>,
+    Path(id): Path<String>,
+) -> Response {
+    set_status(state, rt, _principal, id, "completed").await
+}
+
 async fn set_status(
     state: WebState,
     rt: RequestTenant,

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1297,6 +1297,10 @@ pub fn mount_with_conformance_source_and_runtime(
             "/ui/bulk-import/{id}/abort",
             axum::routing::post(bulk_import::abort),
         )
+        .route(
+            "/ui/bulk-import/{id}/complete",
+            axum::routing::post(bulk_import::complete),
+        )
         .route("/ui/tenants", get(tenants::page).post(tenants::create))
         .route("/ui/tenants/rows", get(tenants::rows))
         .route("/ui/tenants/{id}", axum::routing::delete(tenants::delete))

--- a/crates/ui/templates/partials/bulk_import_status.html
+++ b/crates/ui/templates/partials/bulk_import_status.html
@@ -23,6 +23,9 @@
     <form method="post" action="/ui/bulk-import/{{ id }}/abort">
       <button type="submit" class="btn">{% include "icons/stop-circle.svg" %}{{ i18n.t("bulk-import-abort") }}</button>
     </form>
+    <form method="post" action="/ui/bulk-import/{{ id }}/complete">
+      <button type="submit" class="btn">{% include "icons/check-circle.svg" %}{{ i18n.t("bulk-import-mark-completed") }}</button>
+    </form>
   </div>
   {% endif %}
 </div>

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -598,6 +598,31 @@ async fn abort_sends_a_status_only_kickoff() {
     assert_eq!(status_code, "stopped");
 }
 
+/// #850: "Mark completed" is the Data Provider's closing signal — without it
+/// the recipient keeps the submission open and its concurrency slot held.
+#[tokio::test]
+async fn complete_sends_a_status_only_kickoff() {
+    let (recipient_url, received) = mock_recipient(StatusCode::OK).await;
+    let ctx = ctx(&recipient_url);
+
+    let detail_path = create_submission(&ctx).await;
+    set_submission_status(&ctx, &detail_path, "in-progress").await;
+    post_form(&ctx, &format!("{detail_path}/complete"), "").await;
+    let (_, html) = get(&ctx, &detail_path).await;
+    assert!(html.contains("Completed"), "{html}");
+    assert!(html.contains("Recipient acknowledged (200)"), "{html}");
+
+    let bodies = received.lock().unwrap().clone();
+    let params = bodies.last().unwrap()["parameter"].as_array().unwrap();
+    assert!(params.iter().all(|p| p["name"] != "manifestUrl"));
+    let status_code = params
+        .iter()
+        .find(|p| p["name"] == "submissionStatus")
+        .and_then(|p| p["valueCoding"]["code"].as_str())
+        .unwrap();
+    assert_eq!(status_code, "completed");
+}
+
 #[tokio::test]
 async fn a_rejected_status_change_keeps_the_status_and_logs_it() {
     let (recipient_url, _) = mock_recipient(StatusCode::CONFLICT).await;
@@ -1183,6 +1208,10 @@ async fn status_polling_tracks_progress_and_lands_the_result() {
     assert!(
         html.contains(&format!(r#"action="{detail_path}/abort""#)),
         "abort on the progress card: {html}"
+    );
+    assert!(
+        html.contains(&format!(r#"action="{detail_path}/complete""#)),
+        "mark-completed on the progress card: {html}"
     );
     assert!(!html.contains(r#"class="card detail""#));
 

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -607,6 +607,7 @@ bulk-import-detail-created = Erstellt
 bulk-import-detail-status = Status
 bulk-import-detail-auth = Authentifizierung
 bulk-import-abort = Abbrechen
+bulk-import-mark-completed = Als abgeschlossen markieren
 bulk-import-delete = Löschen
 bulk-import-edit = Bearbeiten
 bulk-import-edit-title = Submission bearbeiten

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -610,6 +610,7 @@ bulk-import-detail-created = Created
 bulk-import-detail-status = Status
 bulk-import-detail-auth = Authentication
 bulk-import-abort = Abort
+bulk-import-mark-completed = Mark completed
 bulk-import-delete = Delete
 bulk-import-edit = Edit
 bulk-import-edit-title = Edit Submission

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -607,6 +607,7 @@ bulk-import-detail-created = Creada
 bulk-import-detail-status = Estado
 bulk-import-detail-auth = Autenticación
 bulk-import-abort = Abortar
+bulk-import-mark-completed = Marcar completada
 bulk-import-delete = Eliminar
 bulk-import-edit = Editar
 bulk-import-edit-title = Editar submission


### PR DESCRIPTION
Closes #850

Stacked on #849 (shares files with the byte-progress branch); merge that one first.

## What

A recipient-side submission only turns terminal when the submitter sends `submissionStatus=completed`, and nothing guarantees any submitter ever does — our own UI never did. Every drained-but-open submission kept its slot against `HFS_BULK_SUBMIT_MAX_CONCURRENT_PER_TENANT` (default 4) until the tenant's every kick-off returned 429. Reproduced live: four finished UI imports bricked the demo tenant.

Two complementary fixes:

**Recipient (systemic)** — `count_active_submissions` now counts submissions with *work in flight*: `in-progress` **and** either no manifests yet (opened, awaiting its first kick-off) or ≥1 pending/processing manifest. A drained submission stays open per the spec — `replacesManifestUrl` (#531) still lands on it — but holds no slot; a new manifest makes it count again immediately, so the cap still bounds concurrent ingestion. Implemented on all four backends: SQLite/PostgreSQL (EXISTS subqueries), MongoDB (two-pass in-memory join over the in-progress set), S3 (registry + claim-queue indexes; a queue-less submission falls back to one manifest listing).

**Provider (explicit control)** — the UI gains a **Mark completed** action beside Abort on in-progress submissions: a status-only kick-off with `completed`, the closing signal the spec expects from a Data Provider. The recipient keeps draining already-registered manifests (`completed` ≠ stop) and the submission stops rejecting nothing — it just closes. This matters against third-party recipients too, which don't get the counting fix.

Deliberately **not** done: auto-sending `completed` when the UI's poll sees the finished status manifest — that would close the submission and break replace-after-finish (#531). With the counting fix, leaving it open costs nothing.

## Tests

- `test_drained_submission_frees_its_concurrency_slot` (rest): cap of 1 — a drained submission admits the next kick-off, while one with a pending manifest still 429s.
- `complete_sends_a_status_only_kickoff` (ui): the action sends `completed` with no `manifestUrl`, flips the card, logs the ack.
- Existing S3 cap test still passes (a pending-manifest submission counts; `complete_submission` frees).
- Suites: persistence lib (41 bulk-submit), s3 (106), rest bulk_submit (22), full helios-ui (127 lib + 5 integration files, incl. i18n key parity for the new label in en/es/de).