### PR TITLE
ui: show the Bulk Export name in the builder heading

### DIFF
--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -5895,7 +5895,11 @@ details.json-fold[open] > summary .icon {
   color: var(--muted);
 }
 
-/* ---- Exports job cards (#735, #795) ---------------------------------- */
+/* ---- Exports builder and job cards (#735, #795, #832) ---------------- */
+
+[data-bulk-export-name-heading] {
+  overflow-wrap: anywhere;
+}
 
 .job-card {
   padding: 14px;
@@ -5909,10 +5913,12 @@ details.json-fold[open] > summary .icon {
 }
 
 .job-card__name {
+  min-width: 0;
   margin: 0;
   font-size: 15px;
   font-weight: 600;
   color: var(--text-strong);
+  overflow-wrap: anywhere;
 }
 
 .job-card__actions {

--- a/crates/ui/assets/bulk-export.js
+++ b/crates/ui/assets/bulk-export.js
@@ -10,6 +10,8 @@
   var allTypes = form.querySelector('input[name="all_types"]');
   var types = Array.prototype.slice.call(form.querySelectorAll('input[name="types"]'));
   var nameInput = form.querySelector('input[name="name"]');
+  var nameHeading = document.querySelector("[data-bulk-export-name-heading]");
+  var defaultHeading = nameHeading ? nameHeading.textContent : "";
   var nameError = form.querySelector("#bulk-export-name-error");
   var sincePreset = form.querySelector('select[name="since_preset"]');
   var sinceCustom = form.querySelector('input[name="since_custom"]');
@@ -48,6 +50,11 @@
     var invalid = Boolean(nameInput && !nameInput.value.trim());
     setFieldError(nameInput, nameError, invalid);
     return !invalid;
+  }
+
+  function synchronizeName() {
+    if (!nameInput || !nameHeading) return;
+    nameHeading.textContent = nameInput.value.trim() || defaultHeading;
   }
 
   function isValidFhirInstant(value) {
@@ -128,6 +135,7 @@
   // their restored individual selections; only the default checked state
   // upgrades the grid to its checked-and-disabled presentation.
   synchronizeTypes(false);
+  synchronizeName();
   synchronizeSince();
   synchronizePatientScope();
 
@@ -139,6 +147,7 @@
 
   if (nameInput) {
     nameInput.addEventListener("input", function () {
+      synchronizeName();
       if (validationStarted) validateName();
     });
   }
@@ -179,6 +188,7 @@
     validationStarted = false;
     window.setTimeout(function () {
       synchronizeTypes(false);
+      synchronizeName();
       synchronizeSince();
       synchronizePatientScope();
       setFieldError(nameInput, nameError, false);

--- a/crates/ui/e2e/pages/bulk-export.ts
+++ b/crates/ui/e2e/pages/bulk-export.ts
@@ -13,6 +13,10 @@ export class BulkExportPage {
     return this.page.locator("form.bulk-export-form");
   }
 
+  get nameHeading(): Locator {
+    return this.page.locator("[data-bulk-export-name-heading]");
+  }
+
   get nameInput(): Locator {
     return this.form.locator('input[name="name"]');
   }

--- a/crates/ui/e2e/tests/bulk-export.spec.ts
+++ b/crates/ui/e2e/tests/bulk-export.spec.ts
@@ -31,6 +31,94 @@ test("All Resources is the enhanced default", async ({ bulkExport }) => {
   ).toBe(true);
 });
 
+test("Name updates the heading as safe text and clearing restores the default", async ({
+  page,
+  bulkExport,
+}) => {
+  await bulkExport.goto();
+
+  const defaultDocumentTitle = await page.title();
+  await expect(bulkExport.nameHeading).toHaveText("Bulk Export");
+  await expect(bulkExport.nameHeading).not.toHaveAttribute("aria-live", /.+/);
+  await expect(bulkExport.nameHeading).not.toHaveAttribute("role", "status");
+
+  await bulkExport.nameInput.fill("  Diabetes registry 2024  ");
+  await expect(bulkExport.nameHeading).toHaveText("Diabetes registry 2024");
+  await expect(page).toHaveTitle(defaultDocumentTitle);
+
+  await bulkExport.nameInput.fill("<img src=x>");
+  await expect(bulkExport.nameHeading).toHaveText("<img src=x>");
+  await expect(bulkExport.nameHeading.locator("img")).toHaveCount(0);
+
+  await bulkExport.nameInput.fill("   ");
+  await expect(bulkExport.nameHeading).toHaveText("Bulk Export");
+
+  await page.goto("/ui/bulk-export/new?lang=es", { waitUntil: "networkidle" });
+  await expect(bulkExport.nameHeading).toHaveText("Exportación masiva");
+  await bulkExport.nameInput.fill("Registro de diabetes");
+  await expect(bulkExport.nameHeading).toHaveText("Registro de diabetes");
+  await bulkExport.nameInput.fill("");
+  await expect(bulkExport.nameHeading).toHaveText("Exportación masiva");
+});
+
+test("a long unbroken Name stays inside the heading and card at narrow width", async ({
+  page,
+  bulkExport,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await bulkExport.goto();
+  const longName = "Export".repeat(41);
+
+  await bulkExport.nameInput.fill(longName);
+  await expect(bulkExport.nameHeading).toHaveText(longName);
+  const headingGeometry = await bulkExport.nameHeading.evaluate((heading) => {
+    const headingRect = heading.getBoundingClientRect();
+    const containerRect = heading.parentElement!.getBoundingClientRect();
+    return {
+      withinContainer:
+        headingRect.left >= containerRect.left - 1 &&
+        headingRect.right <= containerRect.right + 1,
+      noPageOverflow:
+        document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    };
+  });
+  expect(headingGeometry).toEqual({ withinContainer: true, noPageOverflow: true });
+
+  await bulkExport.form.evaluate((form, name) => {
+    const card = document.createElement("div");
+    card.className = "card job-card";
+    const head = document.createElement("div");
+    head.className = "job-card__head";
+    const cardName = document.createElement("h2");
+    cardName.className = "job-card__name";
+    cardName.textContent = name;
+    const actions = document.createElement("div");
+    actions.className = "job-card__actions";
+    const status = document.createElement("span");
+    status.className = "tag tag--in-progress";
+    status.textContent = "In progress";
+    actions.append(status);
+    head.append(cardName, actions);
+    card.append(head);
+    form.after(card);
+  }, longName);
+
+  const card = page.locator(".job-card");
+  const cardName = card.locator(".job-card__name");
+  await expect(cardName).toHaveText(longName);
+  const cardGeometry = await cardName.evaluate((name) => {
+    const nameRect = name.getBoundingClientRect();
+    const cardRect = name.closest(".job-card")!.getBoundingClientRect();
+    return {
+      withinCard:
+        nameRect.left >= cardRect.left - 1 && nameRect.right <= cardRect.right + 1,
+      noPageOverflow:
+        document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    };
+  });
+  expect(cardGeometry).toEqual({ withinCard: true, noPageOverflow: true });
+});
+
 test("long resource names stay in their grid cell and reveal the full name", async ({
   page,
   bulkExport,
@@ -454,6 +542,7 @@ test("server rejects an impossible Custom date without creating an export", asyn
 
   await expect(page).toHaveURL(/\/ui\/bulk-export$/);
   await expect(bulkExport.nameInput).toHaveValue(exportName);
+  await expect(bulkExport.nameHeading).toHaveText(exportName);
   await expect(bulkExport.nameError).toBeHidden();
   await expect(bulkExport.scopeRadio("group")).toBeChecked();
   await expect(bulkExport.form.locator('input[name="group_id"]')).toHaveValue(
@@ -786,6 +875,7 @@ test("re-checking and Clear restore the All Resources state", async ({ bulkExpor
   await bulkExport.clearButton.click();
 
   await expect(bulkExport.nameInput).toHaveValue("");
+  await expect(bulkExport.nameHeading).toHaveText("Bulk Export");
   await expect(bulkExport.scopeRadio("system")).toBeChecked();
   await expect(bulkExport.sincePreset).toHaveValue("");
   await expect(bulkExport.sinceCustom).toHaveValue("");

--- a/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
+++ b/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
@@ -181,7 +181,9 @@ test("Bulk Export can narrow through a conflicting native form without JavaScrip
   bulkExport,
 }) => {
   await page.goto("/ui/bulk-export/new");
+  await expect(bulkExport.nameHeading).toHaveText("Bulk Export");
   await bulkExport.nameInput.fill("No-JS All Resources");
+  await expect(bulkExport.nameHeading).toHaveText("Bulk Export");
 
   await expect(bulkExport.allResources).toBeChecked();
   await expect(bulkExport.typeCheckboxes).not.toHaveCount(0);
@@ -340,12 +342,13 @@ test("Bulk Export lifecycle works without JavaScript", async ({ page }) => {
   await expect(startExport).toBeVisible();
 
   const exportName = `no-js-export-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  await form.locator('input[name="name"]').fill(exportName);
+  await form.locator('input[name="name"]').fill(`  ${exportName}  `);
   await form.locator('input[name="scope"][value="system"]').check();
   await startExport.click();
   await expect(page).toHaveURL(/\/ui\/bulk-export$/);
   let card = page.locator(".job-card").filter({ hasText: exportName });
   await expect(card).toBeVisible();
+  await expect(card.locator(".job-card__name")).toHaveText(exportName);
 
   await card.getByRole("button", { name: "Cancel" }).click();
   await expect(page).toHaveURL(/\/ui\/bulk-export$/);

--- a/crates/ui/templates/pages/bulk-export.html
+++ b/crates/ui/templates/pages/bulk-export.html
@@ -12,7 +12,7 @@
     <span>{{ i18n.t("bulk-export-active-title") }}</span>
   </a>
   <div class="page-head__copy">
-    <h1 class="page-head__title">{{ i18n.t("bulk-export-title") }}</h1>
+    <h1 class="page-head__title" data-bulk-export-name-heading>{{ i18n.t("bulk-export-title") }}</h1>
     <p class="page-head__lede">{{ i18n.t("bulk-export-lede") }}</p>
   </div>
 </header>

--- a/crates/ui/tests/bulk_export_http.rs
+++ b/crates/ui/tests/bulk_export_http.rs
@@ -743,6 +743,9 @@ async fn the_root_is_the_management_page_and_new_is_the_builder() {
     assert!(html.contains(r#"<span class="typegrid__label">Patient</span>"#));
     assert!(html.contains("Narrow it down"));
     assert!(html.contains("Start Export"));
+    assert!(html.contains(
+        r#"<h1 class="page-head__title" data-bulk-export-name-heading>Bulk Export</h1>"#
+    ));
     assert!(html.contains(r#"<script src="/ui/assets/resource-filter.js" defer></script>"#));
     assert!(html.contains(r#"<script src="/ui/assets/bulk-export.js" defer></script>"#));
     assert!(html.contains(r#"<form method="post" action="/ui/bulk-export""#));
@@ -930,7 +933,7 @@ async fn starting_a_system_export_kicks_off_and_tracks_the_job() {
         &base,
         "/ui/bulk-export",
         &[
-            ("name", "Everything"),
+            ("name", "  Everything <img src=x>  "),
             ("scope", "system"),
             ("types", "Patient"),
             ("types", "Observation"),
@@ -953,7 +956,10 @@ async fn starting_a_system_export_kicks_off_and_tracks_the_job() {
 
     // The Exports page shows it in progress.
     let (_, html) = get_text(&base, "/ui/bulk-export").await;
-    assert!(html.contains("Everything"));
+    assert!(
+        html.contains(r#"<h2 class="job-card__name">Everything &#60;img src=x&#62;</h2>"#),
+        "{html}"
+    );
     assert!(html.contains("In progress"));
     // The card's own poll URL (not the layout's tenant-menu hx-get).
     let card_path = html
@@ -965,11 +971,19 @@ async fn starting_a_system_export_kicks_off_and_tracks_the_job() {
 
     // First card fetch: one poll -> 202 with progress, still polling.
     let (_, html) = get_text(&base, &card_path).await;
+    assert!(
+        html.contains(r#"<h2 class="job-card__name">Everything &#60;img src=x&#62;</h2>"#),
+        "{html}"
+    );
     assert!(html.contains("18% complete"), "{html}");
     assert!(html.contains("every 5s"));
 
     // Second: the mock flips to 200 -> complete with two files, no polling.
     let (_, html) = get_text(&base, &card_path).await;
+    assert!(
+        html.contains(r#"<h2 class="job-card__name">Everything &#60;img src=x&#62;</h2>"#),
+        "{html}"
+    );
     assert!(html.contains("Complete"), "{html}");
     assert!(html.contains("Patient"));
     assert!(html.contains("Observation"));


### PR DESCRIPTION
## Summary

- Mirror the trimmed Bulk Export Name into the builder heading as the user types.
- Restore the localized default heading when Name is empty or the form resets.
- Keep markup-looking names as text and avoid live-region announcements.
- Wrap long unbroken names inside the builder heading and export cards.
- Verify that the same normalized name appears on the export card throughout polling.

This change depends on #852, which adds the Name validation and persistence behavior used by the card flow.

## Compatibility

- JavaScript disabled: the server-rendered localized heading remains visible and the form still works.
- Server validation errors: a preserved valid Name initializes the heading after the `400` response.
- Localization: the fallback comes from server-rendered content rather than a hardcoded English string.
- Existing exports without a saved name keep the historical `system` fallback.
- `document.title` and screen-reader announcement behavior do not change.

## Testing

- `cargo fmt --check`
- `cargo test -p helios-ui --test bulk_export_http`
- `cargo build -p helios-hfs --features ui`
- Chromium Bulk Export browser spec, 18 passed
- No-JavaScript progressive enhancement spec, 19 passed
- Manual desktop and mobile QA in English, Spanish, and German

Closes #832
