### PR TITLE
ui: keep bulk export kickoff visibly busy

### DIFF
--- a/crates/ui/assets/bulk-export.js
+++ b/crates/ui/assets/bulk-export.js
@@ -13,6 +13,44 @@
   var sinceCustom = form.querySelector('input[name="since_custom"]');
   var scopeRadios = Array.prototype.slice.call(form.querySelectorAll('input[name="scope"]'));
   var patientCombobox = form.querySelector(".combobox--scope-patient");
+  var submitButton = form.querySelector('button[type="submit"]');
+  var releaseSubmitBusy = null;
+  var submitAttempt = 0;
+
+  function prefetchNavigationAsset(href, as) {
+    var link = document.createElement("link");
+    if (link.relList && link.relList.supports && !link.relList.supports("prefetch")) {
+      return Promise.resolve();
+    }
+
+    return new Promise(function (resolve) {
+      var settled = false;
+      var timeout = window.setTimeout(settle, 1000);
+
+      function settle() {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timeout);
+        link.removeEventListener("load", settle);
+        link.removeEventListener("error", settle);
+        resolve();
+      }
+
+      link.rel = "prefetch";
+      link.href = href;
+      link.as = as;
+      link.addEventListener("load", settle);
+      link.addEventListener("error", settle);
+      document.head.appendChild(link);
+    });
+  }
+
+  function prefetchNavigationAssets() {
+    return Promise.all([
+      prefetchNavigationAsset("/ui/assets/app.css", "style"),
+      prefetchNavigationAsset("/ui/assets/theme.js", "script"),
+    ]);
+  }
 
   function synchronizeTypes(clearIndividualTypes) {
     if (!allTypes) return;
@@ -63,6 +101,35 @@
   });
   if (patientCombobox) {
     patientCombobox.addEventListener("hfs:combobox-change", synchronizePatientScope);
+  }
+
+  if (submitButton && window.hfsBusy) {
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      window.hfsBusy.during([submitButton], function () {
+        submitAttempt += 1;
+        var currentAttempt = submitAttempt;
+
+        prefetchNavigationAssets().then(function () {
+          if (currentAttempt !== submitAttempt) return;
+          HTMLFormElement.prototype.submit.call(form);
+        });
+
+        // Navigation normally discards this document. A bfcache restore keeps
+        // it alive, so pageshow below releases the state in that one case.
+        return new Promise(function (resolve) {
+          releaseSubmitBusy = resolve;
+        });
+      });
+    });
+
+    window.addEventListener("pageshow", function (event) {
+      if (!event.persisted || !releaseSubmitBusy) return;
+      submitAttempt += 1;
+      var release = releaseSubmitBusy;
+      releaseSubmitBusy = null;
+      release();
+    });
   }
 
   // The reset event fires before native controls regain their default values.

--- a/crates/ui/e2e/tests/bulk-export.spec.ts
+++ b/crates/ui/e2e/tests/bulk-export.spec.ts
@@ -448,6 +448,220 @@ test("keyboard narrowing submits exactly the two selected resource types", async
   expect(params.getAll("types").sort()).toEqual(["Observation", "Patient"]);
 });
 
+test("critical destination assets are ready before kickoff navigation starts", async ({
+  page,
+  bulkExport,
+}) => {
+  await bulkExport.goto();
+  await page.evaluate(() => {
+    type PrefetchState = { links: HTMLLinkElement[]; submitCalls: number };
+    type PrefetchWindow = Window & typeof globalThis & { __issue831Prefetch: PrefetchState };
+    const state: PrefetchState = { links: [], submitCalls: 0 };
+    (window as PrefetchWindow).__issue831Prefetch = state;
+
+    const nativeAppendChild = document.head.appendChild.bind(document.head);
+    document.head.appendChild = ((node: Node) => {
+      if (node instanceof HTMLLinkElement && node.rel === "prefetch") {
+        state.links.push(node);
+        return node;
+      }
+      return nativeAppendChild(node);
+    }) as typeof document.head.appendChild;
+    HTMLFormElement.prototype.submit = function () {
+      state.submitCalls++;
+    };
+  });
+
+  let exportRequests = 0;
+  let markPostReceived!: () => void;
+  const postReceived = new Promise<void>((resolve) => {
+    markPostReceived = resolve;
+  });
+  await page.route("**/ui/bulk-export", async (route) => {
+    if (route.request().method() !== "POST") return route.continue().catch(() => {});
+    exportRequests++;
+    markPostReceived();
+    await route
+      .fulfill({ status: 303, headers: { location: "/ui/bulk-export" } })
+      .catch(() => {});
+  });
+
+  const startButton = await bulkExport.startButton.elementHandle();
+  expect(startButton).not.toBeNull();
+  const criticalAssetsReady = page
+    .waitForFunction(() => {
+      type PrefetchWindow = Window &
+        typeof globalThis & { __issue831Prefetch: { links: HTMLLinkElement[] } };
+      return (window as PrefetchWindow).__issue831Prefetch.links.length === 2;
+    })
+    .then(() => "critical-assets" as const);
+  await startButton!.click({ noWaitAfter: true });
+
+  expect(
+    await Promise.race([criticalAssetsReady, postReceived.then(() => "post" as const)]),
+  ).toBe("critical-assets");
+  expect(exportRequests).toBe(0);
+  expect(
+    await page.evaluate(() => {
+      type PrefetchWindow = Window &
+        typeof globalThis & {
+          __issue831Prefetch: { links: HTMLLinkElement[]; submitCalls: number };
+        };
+      const state = (window as PrefetchWindow).__issue831Prefetch;
+      return {
+        assets: state.links.map((link) => [new URL(link.href).pathname, link.as]),
+        submitCalls: state.submitCalls,
+      };
+    }),
+  ).toEqual({
+    assets: [
+      ["/ui/assets/app.css", "style"],
+      ["/ui/assets/theme.js", "script"],
+    ],
+    submitCalls: 0,
+  });
+  expect(
+    await startButton!.evaluate((button) => ({
+      ariaBusy: button.getAttribute("aria-busy"),
+      disabled: button.disabled,
+    })),
+  ).toEqual({ ariaBusy: "true", disabled: true });
+
+  await page.evaluate(() => {
+    type PrefetchWindow = Window &
+      typeof globalThis & { __issue831Prefetch: { links: HTMLLinkElement[] } };
+    for (const link of (window as PrefetchWindow).__issue831Prefetch.links) {
+      link.dispatchEvent(new Event("load"));
+    }
+  });
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        type PrefetchWindow = Window &
+          typeof globalThis & { __issue831Prefetch: { submitCalls: number } };
+        return (window as PrefetchWindow).__issue831Prefetch.submitCalls;
+      }),
+    )
+    .toBe(1);
+  expect(exportRequests).toBe(0);
+});
+
+test("Start Export stays busy for the kickoff navigation and ignores repeat clicks", async ({
+  page,
+  bulkExport,
+}) => {
+  let exportRequests = 0;
+  let markRequestReceived!: () => void;
+  const requestReceived = new Promise<void>((resolve) => {
+    markRequestReceived = resolve;
+  });
+  let releaseRequest!: () => void;
+  const parkedRequest = new Promise<void>((resolve) => {
+    releaseRequest = resolve;
+  });
+  await page.route("**/ui/bulk-export", async (route) => {
+    if (route.request().method() !== "POST") return route.continue().catch(() => {});
+    exportRequests++;
+    markRequestReceived();
+    await parkedRequest;
+    await route
+      .fulfill({ status: 303, headers: { location: "/ui/bulk-export" } })
+      .catch(() => {});
+  });
+
+  await bulkExport.goto();
+  const startButton = await bulkExport.startButton.elementHandle();
+  expect(startButton).not.toBeNull();
+  const stateWhileHeld = startButton!.evaluate(async (button) => {
+    await new Promise<void>((resolve) => {
+      if (button.getAttribute("aria-busy") === "true") return resolve();
+      const observer = new MutationObserver(() => {
+        if (button.getAttribute("aria-busy") !== "true") return;
+        observer.disconnect();
+        resolve();
+      });
+      observer.observe(button, { attributes: true, attributeFilter: ["aria-busy"] });
+    });
+    const entered = {
+      ariaBusy: button.getAttribute("aria-busy"),
+      disabled: button.disabled,
+      spinnerContent: getComputedStyle(button, "::after").content,
+      spinnerAnimation: getComputedStyle(button, "::after").animationName,
+    };
+    button.click();
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+    return {
+      entered,
+      held: {
+        ariaBusy: button.getAttribute("aria-busy"),
+        disabled: button.disabled,
+      },
+    };
+  });
+  await startButton!.click({ noWaitAfter: true });
+  await requestReceived;
+
+  const { entered, held } = await stateWhileHeld;
+  expect(entered).toEqual({
+    ariaBusy: "true",
+    disabled: true,
+    spinnerContent: '""',
+    spinnerAnimation: "spin",
+  });
+  expect(exportRequests).toBe(1);
+  expect(held).toEqual({ ariaBusy: "true", disabled: true });
+
+  releaseRequest();
+  await expect(page).toHaveURL(/\/ui\/bulk-export$/);
+});
+
+test("a persisted pageshow clears the restored Start Export busy state", async ({
+  page,
+  bulkExport,
+}) => {
+  await bulkExport.goto();
+  await bulkExport.form.evaluate((form) => {
+    HTMLFormElement.prototype.submit = function () {};
+    form.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+  });
+
+  await expect(bulkExport.startButton).toHaveAttribute("aria-busy", "true");
+  await expect(bulkExport.startButton).toBeDisabled();
+  await page.evaluate(() => {
+    window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true }));
+  });
+  await expect(bulkExport.startButton).toBeEnabled();
+  expect(await bulkExport.startButton.getAttribute("aria-busy")).toBeNull();
+});
+
+test("native validation rejects the form before Start Export becomes busy", async ({
+  page,
+  bulkExport,
+}) => {
+  let exportRequests = 0;
+  await page.route("**/ui/bulk-export", (route) => {
+    if (route.request().method() !== "POST") return route.continue();
+    exportRequests++;
+    return route.fulfill({ status: 204 });
+  });
+  await bulkExport.goto();
+
+  const name = bulkExport.form.locator('input[name="name"]');
+  await name.evaluate((input: HTMLInputElement) => {
+    input.required = true;
+  });
+  await bulkExport.startButton.click();
+
+  await expect(name).toBeFocused();
+  expect(await name.evaluate((input: HTMLInputElement) => input.validity.valid)).toBe(false);
+  await expect(bulkExport.startButton).toBeEnabled();
+  expect(await bulkExport.startButton.getAttribute("aria-busy")).toBeNull();
+  expect(exportRequests).toBe(0);
+});
+
 test("re-checking and Clear restore the All Resources state", async ({ bulkExport }) => {
   await bulkExport.goto();
 

--- a/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
+++ b/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
@@ -261,6 +261,8 @@ test("Bulk Export lifecycle works without JavaScript", async ({ page }) => {
   await expect(form.locator(".form-actions > a")).toHaveCount(0);
   const startExport = form.getByRole("button", { name: "Start Export" });
   await expect(startExport).toBeVisible();
+  await expect(startExport).toBeEnabled();
+  expect(await startExport.getAttribute("aria-busy")).toBeNull();
 
   const exportName = `no-js-export-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   await form.locator('input[name="name"]').fill(exportName);


### PR DESCRIPTION
## Summary

- Keep Start Export in the shared busy state for the full kickoff navigation and ignore repeat clicks.
- Prime the destination stylesheet and theme script before native submission so the spinner keeps moving until the redirect takes over on a slow connection.
- Preserve native validation, no-JavaScript submission, form serialization, and restored-page cleanup.

## Testing

- `node --check crates/ui/assets/bulk-export.js`
- `cargo build -p helios-hfs --features ui`
- `cargo test -p helios-ui`, 302 tests passed
- Chromium Bulk Export end-to-end tests, 14 passed
- No-JavaScript progressive enhancement tests, 18 passed
- Manual 3G verification
- Two final read-only reviews, no actionable findings

## UI evidence

Baseline reproduction under 3G: the kickoff document request is pending while Start Export remains busy.

<img width="1429" height="768" alt="Start Export busy during the pending kickoff request under 3G" src="https://github.com/user-attachments/assets/9317b615-7b6b-4ca7-b164-9280a11a8d08" />

Remediated build prepared for the HITL verification under 3G.

<img width="1429" height="768" alt="Remediated Bulk Export form prepared for HITL verification under 3G" src="https://github.com/user-attachments/assets/5bd32766-4874-4528-807b-9b6455def781" />

The accepted final run used 3G with `Disable cache` unchecked. Critical asset prefetches completed before the POST, the last observed spinner movement was about 11 ms before `pagehide`, and destination first contentful paint followed about 55 ms later.

Closes #831