### PR TITLE
fix(bulk-export): apply _until in the SQLite, PostgreSQL and MongoDB backends

### DIFF
--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -519,7 +519,15 @@ impl MongoBackend {
     }
 
     /// Returns the configured MongoDB database handle.
-    pub(crate) async fn get_database(&self) -> StorageResult<Database> {
+    ///
+    /// `#[doc(hidden)] pub` rather than `pub(crate)` only so the out-of-crate
+    /// bulk-export window tests (`tests/mongodb_tests.rs`) can pin a stored
+    /// resource's `last_updated` and assert on `_since`/`_until` without
+    /// depending on wall-clock timing. It hands out a raw database handle that
+    /// bypasses tenant scoping, so it is not stable API — workspace callers
+    /// should use the `ResourceStorage`/`SearchProvider` methods instead.
+    #[doc(hidden)]
+    pub async fn get_database(&self) -> StorageResult<Database> {
         let client = self.get_client().await?;
         Ok(client.database(&self.config.database_name))
     }

--- a/crates/persistence/src/backends/mongodb/bulk_export.rs
+++ b/crates/persistence/src/backends/mongodb/bulk_export.rs
@@ -35,6 +35,26 @@ fn chrono_to_bson(dt: DateTime<Utc>) -> BsonDateTime {
     BsonDateTime::from_millis(dt.timestamp_millis())
 }
 
+/// The `last_updated` range an export request asks for, or `None` when it is
+/// unbounded.
+///
+/// Both bounds are inclusive, matching the S3 backend's
+/// `last_modified() < since` / `> until` skips.
+///
+/// The two bounds must share one document: `last_updated` is a single key, so a
+/// second `filter.insert("last_updated", ...)` would REPLACE the first rather
+/// than narrow it, silently dropping whichever bound was written first.
+fn last_updated_range(request: &ExportRequest) -> Option<Document> {
+    let mut range = Document::new();
+    if let Some(since) = request.since {
+        range.insert("$gte", chrono_to_bson(since));
+    }
+    if let Some(until) = request.until {
+        range.insert("$lte", chrono_to_bson(until));
+    }
+    (!range.is_empty()).then_some(range)
+}
+
 fn bson_to_chrono(dt: &BsonDateTime) -> DateTime<Utc> {
     DateTime::<Utc>::from_timestamp_millis(dt.timestamp_millis()).unwrap_or_else(Utc::now)
 }
@@ -166,8 +186,8 @@ impl ExportDataProvider for MongoBackend {
             "resource_type": resource_type,
             "is_deleted": false,
         };
-        if let Some(since) = request.since {
-            filter.insert("last_updated", doc! { "$gte": chrono_to_bson(since) });
+        if let Some(range) = last_updated_range(request) {
+            filter.insert("last_updated", range);
         }
 
         resources
@@ -193,8 +213,8 @@ impl ExportDataProvider for MongoBackend {
             "resource_type": resource_type,
             "is_deleted": false,
         };
-        if let Some(since) = request.since {
-            filter.insert("last_updated", doc! { "$gte": chrono_to_bson(since) });
+        if let Some(range) = last_updated_range(request) {
+            filter.insert("last_updated", range);
         }
         if let Some((cur_dt, cur_id)) = cursor.and_then(parse_cursor) {
             filter.insert(
@@ -241,6 +261,12 @@ impl PatientExportProvider for MongoBackend {
             "resource_type": "Patient",
             "is_deleted": false,
         };
+        // `_since` only, deliberately: this selects WHICH patients are in scope,
+        // not which of their resources are exported. Bounding it above by
+        // `_until` would drop a patient whose own record was touched after the
+        // window and take their in-window compartment resources with them. The
+        // Patient resource itself is still bounded, by the compartment fetch.
+        // S3 makes the same distinction (`backends/s3/bulk_export.rs:216`).
         if let Some(since) = request.since {
             filter.insert("last_updated", doc! { "$gte": chrono_to_bson(since) });
         }
@@ -296,8 +322,8 @@ impl PatientExportProvider for MongoBackend {
                 "is_deleted": false,
                 "id": { "$in": patient_ids.to_vec() },
             };
-            if let Some(since) = request.since {
-                filter.insert("last_updated", doc! { "$gte": chrono_to_bson(since) });
+            if let Some(range) = last_updated_range(request) {
+                filter.insert("last_updated", range);
             }
             if let Some((cur_dt, cur_id)) = cursor.and_then(parse_cursor) {
                 filter.insert(
@@ -338,8 +364,8 @@ impl PatientExportProvider for MongoBackend {
                 doc! { "data.patient.reference": { "$in": &refs } },
             ],
         };
-        if let Some(since) = request.since {
-            filter.insert("last_updated", doc! { "$gte": chrono_to_bson(since) });
+        if let Some(range) = last_updated_range(request) {
+            filter.insert("last_updated", range);
         }
         if let Some((cur_dt, cur_id)) = cursor.and_then(parse_cursor) {
             // Combine compartment-match $or with cursor keyset $or via $and.

--- a/crates/persistence/src/backends/postgres/bulk_export.rs
+++ b/crates/persistence/src/backends/postgres/bulk_export.rs
@@ -20,6 +20,36 @@ use crate::tenant::{TenantContext, TenantId, TenantPermissions};
 
 use super::PostgresBackend;
 
+/// Appends the `_since` / `_until` window to an export query, binds the bounds,
+/// and returns the next free parameter index.
+///
+/// Both are inclusive, matching the S3 backend's `last_modified() < since` /
+/// `> until` skips. Every export query path uses this, so a job's count and its
+/// emitted rows cannot disagree about the window.
+///
+/// The bounds bind as `DateTime<Utc>`, never as a string: `tokio_postgres`
+/// will not bind `String`/`&str` to `TIMESTAMPTZ`, and a `$n::timestamptz` cast
+/// does not change that — it only tells PG what type to infer for the
+/// parameter.
+fn push_export_window(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
+    request: &ExportRequest,
+    mut param_idx: usize,
+) -> usize {
+    if let Some(since) = request.since {
+        sql.push_str(&format!(" AND last_updated >= ${}", param_idx));
+        params.push(Box::new(since));
+        param_idx += 1;
+    }
+    if let Some(until) = request.until {
+        sql.push_str(&format!(" AND last_updated <= ${}", param_idx));
+        params.push(Box::new(until));
+        param_idx += 1;
+    }
+    param_idx
+}
+
 fn internal_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::Internal {
         backend_name: "postgres".to_string(),
@@ -1002,27 +1032,16 @@ impl ExportDataProvider for PostgresBackend {
         let client = self.get_client().await?;
         let tenant_id = tenant.tenant_id().as_str();
 
-        let (sql, params): (
-            String,
-            Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
-        ) = if let Some(since) = request.since {
-            (
-                "SELECT COUNT(*) FROM resources WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE AND last_updated >= $3".to_string(),
-                vec![
-                    Box::new(tenant_id.to_string()),
-                    Box::new(resource_type.to_string()),
-                    Box::new(since),
-                ],
-            )
-        } else {
-            (
-                "SELECT COUNT(*) FROM resources WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE".to_string(),
-                vec![
-                    Box::new(tenant_id.to_string()),
-                    Box::new(resource_type.to_string()),
-                ],
-            )
-        };
+        // Built incrementally rather than as one SQL string per combination of
+        // bounds: with both `_since` and `_until` that is four spellings to keep
+        // in step with `fetch_export_batch`, which is how a count and its rows
+        // drift apart.
+        let mut sql = "SELECT COUNT(*) FROM resources WHERE tenant_id = $1 AND resource_type = $2 AND is_deleted = FALSE".to_string();
+        let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![
+            Box::new(tenant_id.to_string()),
+            Box::new(resource_type.to_string()),
+        ];
+        push_export_window(&mut sql, &mut params, request, 3);
 
         let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
             .iter()
@@ -1054,13 +1073,7 @@ impl ExportDataProvider for PostgresBackend {
             Box::new(tenant_id.to_string()),
             Box::new(resource_type.to_string()),
         ];
-        let mut param_idx = 3;
-
-        if let Some(since) = request.since {
-            sql.push_str(&format!(" AND last_updated >= ${}", param_idx));
-            params.push(Box::new(since));
-            param_idx += 1;
-        }
+        let param_idx = push_export_window(&mut sql, &mut params, request, 3);
 
         if let Some(cursor) = cursor {
             let parts: Vec<&str> = cursor.splitn(2, '|').collect();
@@ -1138,6 +1151,12 @@ impl PatientExportProvider for PostgresBackend {
             vec![Box::new(tenant_id.to_string())];
         let mut param_idx = 2;
 
+        // `_since` only, deliberately: this selects WHICH patients are in scope,
+        // not which of their resources are exported. Bounding it above by
+        // `_until` would drop a patient whose own record was touched after the
+        // window and take their in-window compartment resources with them. The
+        // Patient resource itself is still bounded, by the compartment fetch.
+        // S3 makes the same distinction (`backends/s3/bulk_export.rs:216`).
         if let Some(since) = request.since {
             sql.push_str(&format!(" AND last_updated >= ${}", param_idx));
             params.push(Box::new(since));
@@ -1199,7 +1218,15 @@ impl PatientExportProvider for PostgresBackend {
                 Box::new(resource_type.to_string()),
                 Box::new(patient_ids.to_vec()),
             ];
-            let param_idx = 4;
+            // Upper bound only. This branch has never applied `_since` either —
+            // that gap is #658, which replaces both of these with
+            // `push_export_window`.
+            let mut param_idx = 4;
+            if let Some(until) = request.until {
+                sql.push_str(&format!(" AND last_updated <= ${}", param_idx));
+                params.push(Box::new(until));
+                param_idx += 1;
+            }
 
             if let Some(cursor) = cursor {
                 let parts: Vec<&str> = cursor.splitn(2, '|').collect();
@@ -1283,13 +1310,7 @@ impl PatientExportProvider for PostgresBackend {
             Box::new(resource_type.to_string()),
             Box::new(patient_refs),
         ];
-        let mut param_idx = 4;
-
-        if let Some(since) = request.since {
-            sql.push_str(&format!(" AND last_updated >= ${}", param_idx));
-            params.push(Box::new(since));
-            param_idx += 1;
-        }
+        let param_idx = push_export_window(&mut sql, &mut params, request, 4);
 
         if let Some(cursor) = cursor {
             let parts: Vec<&str> = cursor.splitn(2, '|').collect();

--- a/crates/persistence/src/backends/sqlite/bulk_export.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_export.rs
@@ -53,6 +53,31 @@ fn parse_part_segment(part: &str) -> Option<(String, u32)> {
     Some((resource_type.to_string(), part_index))
 }
 
+/// Appends the `_since` / `_until` window to an export query and binds the
+/// bounds.
+///
+/// Both are inclusive, matching the S3 backend's `last_modified() < since` /
+/// `> until` skips. Every export query path uses this, so a job's count and its
+/// emitted rows cannot disagree about the window.
+///
+/// The placeholders are anonymous on purpose. SQLite gives each `?` one more
+/// than the highest index used so far, so a query that binds only the upper
+/// bound cannot mis-number it the way a hard-coded `?3` would.
+fn push_export_window(
+    query: &mut String,
+    params: &mut Vec<Box<dyn rusqlite::ToSql>>,
+    request: &ExportRequest,
+) {
+    if let Some(since) = request.since {
+        query.push_str(" AND last_updated >= ?");
+        params.push(Box::new(since.to_rfc3339()));
+    }
+    if let Some(until) = request.until {
+        query.push_str(" AND last_updated <= ?");
+        params.push(Box::new(until.to_rfc3339()));
+    }
+}
+
 fn internal_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::Internal {
         backend_name: "sqlite".to_string(),
@@ -1094,11 +1119,7 @@ impl ExportDataProvider for SqliteBackend {
             Box::new(resource_type.to_string()),
         ];
 
-        // Apply _since filter if present
-        if let Some(since) = request.since {
-            query.push_str(" AND last_updated >= ?3");
-            params_vec.push(Box::new(since.to_rfc3339()));
-        }
+        push_export_window(&mut query, &mut params_vec, request);
 
         let params_slice: Vec<&dyn rusqlite::ToSql> =
             params_vec.iter().map(|p| p.as_ref()).collect();
@@ -1127,11 +1148,7 @@ impl ExportDataProvider for SqliteBackend {
             Box::new(resource_type.to_string()),
         ];
 
-        // Apply _since filter if present
-        if let Some(since) = request.since {
-            query.push_str(" AND last_updated >= ?");
-            params_vec.push(Box::new(since.to_rfc3339()));
-        }
+        push_export_window(&mut query, &mut params_vec, request);
 
         // Apply cursor (keyset pagination)
         if let Some(cursor) = cursor {
@@ -1208,6 +1225,12 @@ impl PatientExportProvider for SqliteBackend {
         let mut query = "SELECT id FROM resources WHERE tenant_id = ?1 AND resource_type = 'Patient' AND is_deleted = 0".to_string();
         let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(tenant_id.to_string())];
 
+        // `_since` only, deliberately: this selects WHICH patients are in scope,
+        // not which of their resources are exported. Bounding it above by
+        // `_until` would drop a patient whose own record was touched after the
+        // window and take their in-window compartment resources with them. The
+        // Patient resource itself is still bounded, by the compartment fetch.
+        // S3 makes the same distinction (`backends/s3/bulk_export.rs:216`).
         if let Some(since) = request.since {
             query.push_str(" AND last_updated >= ?");
             params_vec.push(Box::new(since.to_rfc3339()));
@@ -1279,6 +1302,15 @@ impl PatientExportProvider for SqliteBackend {
             ];
             for id in patient_ids {
                 params_vec.push(Box::new(id.clone()));
+            }
+
+            // Upper bound only. This branch has never applied `_since` either —
+            // that gap is #658, which replaces both of these with
+            // `push_export_window`. Bind before the cursor so the anonymous
+            // placeholders stay in the order they were pushed.
+            if let Some(until) = request.until {
+                query.push_str(" AND last_updated <= ?");
+                params_vec.push(Box::new(until.to_rfc3339()));
             }
 
             if let Some(cursor) = cursor {
@@ -1357,10 +1389,7 @@ impl PatientExportProvider for SqliteBackend {
              WHERE tenant_id = ? AND resource_type = ? AND is_deleted = 0"
             .to_string();
 
-        if let Some(since) = request.since {
-            query.push_str(" AND last_updated >= ?");
-            params_vec.push(Box::new(since.to_rfc3339()));
-        }
+        push_export_window(&mut query, &mut params_vec, request);
 
         let placeholders: Vec<&str> = patient_refs.iter().map(|_| "?").collect();
         let in_list = placeholders.join(",");
@@ -2094,6 +2123,170 @@ mod tests {
 
         assert_eq!(batch2.lines.len(), 2);
         assert!(batch2.is_last);
+    }
+
+    /// Pins a stored resource's `last_updated` so a window test does not depend
+    /// on wall-clock timing.
+    fn pin_last_updated(backend: &SqliteBackend, id: &str, rfc3339: &str) {
+        let conn = backend.get_connection().unwrap();
+        conn.execute(
+            "UPDATE resources SET last_updated = ?1 WHERE id = ?2",
+            rusqlite::params![rfc3339, id],
+        )
+        .unwrap();
+    }
+
+    async fn seed_patient_at(backend: &SqliteBackend, tenant: &TenantContext, at: &str) -> String {
+        let stored = backend
+            .create(
+                tenant,
+                "Patient",
+                json!({"resourceType": "Patient"}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        let id = stored.id().to_string();
+        pin_last_updated(backend, &id, at);
+        id
+    }
+
+    fn instant(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    /// `_until` excludes a resource modified after the bound — and the count
+    /// agrees with what the fetch emits, so a job's total cannot promise rows
+    /// the export never writes.
+    #[tokio::test]
+    async fn until_excludes_resources_modified_after_the_bound() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        let early = seed_patient_at(&backend, &tenant, "2026-01-01T00:00:00+00:00").await;
+        let _late = seed_patient_at(&backend, &tenant, "2026-03-01T00:00:00+00:00").await;
+
+        let request = ExportRequest::system().with_until(instant("2026-02-01T00:00:00Z"));
+
+        let count = backend
+            .count_export_resources(&tenant, &request, "Patient")
+            .await
+            .unwrap();
+        let batch = backend
+            .fetch_export_batch(&tenant, &request, "Patient", None, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 1, "count must apply the upper bound");
+        assert_eq!(batch.lines.len(), 1, "fetch must apply the upper bound");
+        assert_eq!(
+            count as usize,
+            batch.lines.len(),
+            "count and fetch must agree"
+        );
+        assert!(
+            batch.lines[0].contains(&early),
+            "the surviving row is the early one"
+        );
+    }
+
+    /// The bound is inclusive, matching S3's `last_modified() > until` skip: a
+    /// resource sitting exactly on `_until` is exported.
+    #[tokio::test]
+    async fn until_is_inclusive() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        seed_patient_at(&backend, &tenant, "2026-02-01T00:00:00+00:00").await;
+
+        let request = ExportRequest::system().with_until(instant("2026-02-01T00:00:00Z"));
+
+        let batch = backend
+            .fetch_export_batch(&tenant, &request, "Patient", None, 10)
+            .await
+            .unwrap();
+        assert_eq!(
+            batch.lines.len(),
+            1,
+            "a resource exactly on the bound is included"
+        );
+    }
+
+    /// `_since` and `_until` together produce a bounded window: rows on either
+    /// side are dropped and only the middle one survives.
+    #[tokio::test]
+    async fn since_and_until_together_bound_the_window() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        let _before = seed_patient_at(&backend, &tenant, "2025-12-01T00:00:00+00:00").await;
+        let inside = seed_patient_at(&backend, &tenant, "2026-01-15T00:00:00+00:00").await;
+        let _after = seed_patient_at(&backend, &tenant, "2026-03-01T00:00:00+00:00").await;
+
+        let request = ExportRequest::system()
+            .with_since(instant("2026-01-01T00:00:00Z"))
+            .with_until(instant("2026-02-01T00:00:00Z"));
+
+        let count = backend
+            .count_export_resources(&tenant, &request, "Patient")
+            .await
+            .unwrap();
+        let batch = backend
+            .fetch_export_batch(&tenant, &request, "Patient", None, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(batch.lines.len(), 1);
+        assert!(
+            batch.lines[0].contains(&inside),
+            "only the in-window row survives"
+        );
+    }
+
+    /// An unbounded request is unchanged by the window plumbing — the bound is
+    /// opt-in, so nothing regresses for callers that pass neither parameter.
+    #[tokio::test]
+    async fn no_bounds_exports_everything() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        seed_patient_at(&backend, &tenant, "2025-12-01T00:00:00+00:00").await;
+        seed_patient_at(&backend, &tenant, "2026-03-01T00:00:00+00:00").await;
+
+        let request = ExportRequest::system();
+        let count = backend
+            .count_export_resources(&tenant, &request, "Patient")
+            .await
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    /// The patient-compartment path applies the bound too. Exercised through
+    /// the `Patient` branch, which builds its own query separate from
+    /// `fetch_export_batch`.
+    #[tokio::test]
+    async fn until_bounds_the_patient_compartment_fetch() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        let early = seed_patient_at(&backend, &tenant, "2026-01-01T00:00:00+00:00").await;
+        let late = seed_patient_at(&backend, &tenant, "2026-03-01T00:00:00+00:00").await;
+
+        let request = ExportRequest::patient().with_until(instant("2026-02-01T00:00:00Z"));
+        let ids = vec![early.clone(), late.clone()];
+
+        let batch = backend
+            .fetch_patient_compartment_batch(&tenant, &request, "Patient", &ids, None, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            batch.lines.len(),
+            1,
+            "the compartment fetch applies the upper bound"
+        );
+        assert!(batch.lines[0].contains(&early));
     }
 
     #[tokio::test]

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -4275,3 +4275,151 @@ mod bulk_submit {
         );
     }
 }
+
+// ============================================================================
+// Bulk Export — the `_since` / `_until` window (#657).
+// ============================================================================
+
+/// Pins a stored resource's `last_updated` so a window test does not depend on
+/// wall-clock timing.
+async fn pin_last_updated(backend: &MongoBackend, id: &str, at: chrono::DateTime<chrono::Utc>) {
+    use mongodb::bson::{DateTime as BsonDateTime, Document, doc};
+    let db = backend.get_database().await.unwrap();
+    let resources = db.collection::<Document>("resources");
+    resources
+        .update_one(
+            doc! { "id": id },
+            doc! { "$set": { "last_updated": BsonDateTime::from_millis(at.timestamp_millis()) } },
+        )
+        .await
+        .unwrap();
+}
+
+async fn seed_patient_at(
+    backend: &MongoBackend,
+    tenant: &TenantContext,
+    at: chrono::DateTime<chrono::Utc>,
+) -> String {
+    let stored = backend
+        .create(
+            tenant,
+            "Patient",
+            serde_json::json!({"resourceType": "Patient"}),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+    let id = stored.id().to_string();
+    pin_last_updated(backend, &id, at).await;
+    id
+}
+
+fn instant(s: &str) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .unwrap()
+        .with_timezone(&chrono::Utc)
+}
+
+/// `_until` excludes a resource modified after the bound, and the count agrees
+/// with what the fetch emits.
+#[tokio::test]
+async fn mongodb_integration_export_until_bounds_count_and_fetch() {
+    use helios_persistence::core::bulk_export::{ExportDataProvider, ExportRequest};
+
+    let Some(backend) = create_backend("export_until").await else {
+        eprintln!(
+            "Skipping mongodb_integration_export_until_bounds_count_and_fetch (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let tenant = create_tenant("export-until");
+
+    let early = seed_patient_at(&backend, &tenant, instant("2026-01-01T00:00:00Z")).await;
+    let _late = seed_patient_at(&backend, &tenant, instant("2026-03-01T00:00:00Z")).await;
+
+    let request = ExportRequest::system().with_until(instant("2026-02-01T00:00:00Z"));
+
+    let count = backend
+        .count_export_resources(&tenant, &request, "Patient")
+        .await
+        .unwrap();
+    let batch = backend
+        .fetch_export_batch(&tenant, &request, "Patient", None, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(count, 1, "count must apply the upper bound");
+    assert_eq!(batch.lines.len(), 1, "fetch must apply the upper bound");
+    assert_eq!(
+        count as usize,
+        batch.lines.len(),
+        "count and fetch must agree about the window"
+    );
+    assert!(batch.lines[0].contains(&early));
+}
+
+/// `_since` and `_until` together bound the window at both ends.
+///
+/// This is the case that catches the document-shape trap: `last_updated` is one
+/// key, so writing the two bounds as two `insert`s would keep only the second.
+#[tokio::test]
+async fn mongodb_integration_export_since_and_until_bound_the_window() {
+    use helios_persistence::core::bulk_export::{ExportDataProvider, ExportRequest};
+
+    let Some(backend) = create_backend("export_window").await else {
+        eprintln!(
+            "Skipping mongodb_integration_export_since_and_until_bound_the_window (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let tenant = create_tenant("export-window");
+
+    let _before = seed_patient_at(&backend, &tenant, instant("2025-12-01T00:00:00Z")).await;
+    let inside = seed_patient_at(&backend, &tenant, instant("2026-01-15T00:00:00Z")).await;
+    let _after = seed_patient_at(&backend, &tenant, instant("2026-03-01T00:00:00Z")).await;
+
+    let request = ExportRequest::system()
+        .with_since(instant("2026-01-01T00:00:00Z"))
+        .with_until(instant("2026-02-01T00:00:00Z"));
+
+    let count = backend
+        .count_export_resources(&tenant, &request, "Patient")
+        .await
+        .unwrap();
+    let batch = backend
+        .fetch_export_batch(&tenant, &request, "Patient", None, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(count, 1, "both bounds must survive into one range document");
+    assert_eq!(batch.lines.len(), 1);
+    assert!(batch.lines[0].contains(&inside));
+}
+
+/// The bound is inclusive, matching S3.
+#[tokio::test]
+async fn mongodb_integration_export_until_is_inclusive() {
+    use helios_persistence::core::bulk_export::{ExportDataProvider, ExportRequest};
+
+    let Some(backend) = create_backend("export_until_incl").await else {
+        eprintln!(
+            "Skipping mongodb_integration_export_until_is_inclusive (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let tenant = create_tenant("export-until-incl");
+
+    seed_patient_at(&backend, &tenant, instant("2026-02-01T00:00:00Z")).await;
+
+    let request = ExportRequest::system().with_until(instant("2026-02-01T00:00:00Z"));
+    let batch = backend
+        .fetch_export_batch(&tenant, &request, "Patient", None, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        batch.lines.len(),
+        1,
+        "a resource exactly on the bound is included"
+    );
+}

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -4979,9 +4979,10 @@ mod postgres_integration {
     // Bulk Export — Phase 2 multi-instance job state on Postgres.
     // ========================================================================
 
-    use chrono::Utc;
+    use chrono::{DateTime, Utc};
     use helios_persistence::core::bulk_export::{
-        BulkExportStorage, ExportRequest, ExportStatus, StartExportInput, TypeExportProgress,
+        BulkExportStorage, ExportDataProvider, ExportRequest, ExportStatus, PatientExportProvider,
+        StartExportInput, TypeExportProgress,
     };
     use helios_persistence::core::bulk_export_worker::{
         ExportClaimStrategy, ExportWorkerStorage, LeaseError, WorkerId,
@@ -5069,6 +5070,152 @@ mod postgres_integration {
 
         let progress = backend.get_export_status(&tenant, &job_id).await.unwrap();
         assert_eq!(progress.status, ExportStatus::Complete);
+    }
+
+    /// Pins a stored resource's `last_updated` so a window test does not depend
+    /// on wall-clock timing.
+    async fn pin_last_updated(backend: &PostgresBackend, id: &str, at: DateTime<Utc>) {
+        let client = backend.get_client().await.unwrap();
+        client
+            .execute(
+                "UPDATE resources SET last_updated = $1 WHERE id = $2",
+                &[&at, &id],
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn seed_patient_at(
+        backend: &PostgresBackend,
+        tenant: &TenantContext,
+        at: DateTime<Utc>,
+    ) -> String {
+        let stored = backend
+            .create(
+                tenant,
+                "Patient",
+                serde_json::json!({"resourceType": "Patient"}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        let id = stored.id().to_string();
+        pin_last_updated(backend, &id, at).await;
+        id
+    }
+
+    fn instant(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    /// `_until` excludes a resource modified after the bound, and the count
+    /// agrees with what the fetch emits.
+    #[tokio::test]
+    async fn postgres_integration_export_until_bounds_count_and_fetch() {
+        let _guard = BULK_EXPORT_TEST_LOCK.lock().await;
+        let backend = create_backend().await;
+        let tenant = create_tenant("export-until");
+
+        let early = seed_patient_at(&backend, &tenant, instant("2026-01-01T00:00:00Z")).await;
+        let _late = seed_patient_at(&backend, &tenant, instant("2026-03-01T00:00:00Z")).await;
+
+        let request = ExportRequest::system().with_until(instant("2026-02-01T00:00:00Z"));
+
+        let count = backend
+            .count_export_resources(&tenant, &request, "Patient")
+            .await
+            .unwrap();
+        let batch = backend
+            .fetch_export_batch(&tenant, &request, "Patient", None, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 1, "count must apply the upper bound");
+        assert_eq!(batch.lines.len(), 1, "fetch must apply the upper bound");
+        assert_eq!(
+            count as usize,
+            batch.lines.len(),
+            "count and fetch must agree about the window"
+        );
+        assert!(batch.lines[0].contains(&early));
+    }
+
+    /// The bound is inclusive, matching S3.
+    #[tokio::test]
+    async fn postgres_integration_export_until_is_inclusive() {
+        let _guard = BULK_EXPORT_TEST_LOCK.lock().await;
+        let backend = create_backend().await;
+        let tenant = create_tenant("export-until-incl");
+
+        seed_patient_at(&backend, &tenant, instant("2026-02-01T00:00:00Z")).await;
+
+        let request = ExportRequest::system().with_until(instant("2026-02-01T00:00:00Z"));
+        let batch = backend
+            .fetch_export_batch(&tenant, &request, "Patient", None, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            batch.lines.len(),
+            1,
+            "a resource exactly on the bound is included"
+        );
+    }
+
+    /// `_since` and `_until` together bound the window at both ends.
+    #[tokio::test]
+    async fn postgres_integration_export_since_and_until_bound_the_window() {
+        let _guard = BULK_EXPORT_TEST_LOCK.lock().await;
+        let backend = create_backend().await;
+        let tenant = create_tenant("export-window");
+
+        let _before = seed_patient_at(&backend, &tenant, instant("2025-12-01T00:00:00Z")).await;
+        let inside = seed_patient_at(&backend, &tenant, instant("2026-01-15T00:00:00Z")).await;
+        let _after = seed_patient_at(&backend, &tenant, instant("2026-03-01T00:00:00Z")).await;
+
+        let request = ExportRequest::system()
+            .with_since(instant("2026-01-01T00:00:00Z"))
+            .with_until(instant("2026-02-01T00:00:00Z"));
+
+        let count = backend
+            .count_export_resources(&tenant, &request, "Patient")
+            .await
+            .unwrap();
+        let batch = backend
+            .fetch_export_batch(&tenant, &request, "Patient", None, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(batch.lines.len(), 1);
+        assert!(batch.lines[0].contains(&inside));
+    }
+
+    /// The patient-compartment path applies the bound too — it builds its own
+    /// query, separate from `fetch_export_batch`.
+    #[tokio::test]
+    async fn postgres_integration_export_until_bounds_patient_compartment() {
+        let _guard = BULK_EXPORT_TEST_LOCK.lock().await;
+        let backend = create_backend().await;
+        let tenant = create_tenant("export-compartment");
+
+        let early = seed_patient_at(&backend, &tenant, instant("2026-01-01T00:00:00Z")).await;
+        let late = seed_patient_at(&backend, &tenant, instant("2026-03-01T00:00:00Z")).await;
+
+        let request = ExportRequest::patient().with_until(instant("2026-02-01T00:00:00Z"));
+        let ids = vec![early.clone(), late.clone()];
+
+        let batch = backend
+            .fetch_patient_compartment_batch(&tenant, &request, "Patient", &ids, None, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            batch.lines.len(),
+            1,
+            "the compartment fetch applies the upper bound"
+        );
+        assert!(batch.lines[0].contains(&early));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #657.

`_until` was parsed, validated and threaded into `ExportRequest.until`, then
applied by the S3 backend alone. On SQLite, PostgreSQL and MongoDB a caller got
a `202` and an export containing everything modified up to *now* — the bound
was not rejected, not warned about, and not recorded on the job.

Each backend gains one window helper used by every export query path, so a
job's count and the rows it emits cannot disagree about the bound.

## Three traps that were not visible from the call sites

**MongoDB — `last_updated` is a single key.** Writing the upper bound as a
second `filter.insert("last_updated", ...)` *replaces* the lower one instead of
narrowing it, so `_since` would have gone silently missing precisely when both
bounds were supplied. Both bounds now build one range document, and
`mongodb_integration_export_since_and_until_bound_the_window` is the test that
would catch a regression to two inserts.

**SQLite — a hard-coded placeholder.** `count_export_resources` bound `_since`
to `?3`. A second bound after it mis-numbers whenever only `_until` is given.
Both bounds now use anonymous `?`, which SQLite numbers in sequence.

**PostgreSQL — one SQL string per combination of bounds.**
`count_export_resources` wrote the whole query twice, once per `_since` arm.
Two bounds makes four spellings to hold in step with `fetch_export_batch` —
which is exactly how a count and its rows drift apart — so it now builds
incrementally the way the fetch already did. Bounds bind as `DateTime<Utc>`:
`tokio_postgres` will not bind a string to `TIMESTAMPTZ`, and a
`$n::timestamptz` cast does not change that.

## Two paths deliberately left unbounded

This departs from the issue, which lists "type listing" and "patient ids" among
the paths to fix.

**`list_patient_ids` must not take an upper bound.** It chooses *which
patients* are in scope, not which of their resources are exported. Bounding it
above drops a patient whose own record was touched after the window — and takes
their in-window compartment resources with them. That is a data-loss bug, not a
tightening. S3 makes the same distinction (`backends/s3/bulk_export.rs:216`
applies `since` there and nothing else), and the Patient resource itself is
still bounded, by the compartment fetch.

**`list_export_types` filters by neither bound in any backend, S3 included.**
Adding only the upper bound would make `_until` stricter than `_since` and
change the manifest's shape; that is a separate decision, not this fix.

Both sites now carry a comment saying so, so the omission reads as a decision.

## Scope handoff to #658

The `Patient` branch of `fetch_patient_compartment_batch` takes the upper bound
inline rather than through the helper. That branch has never applied `_since`
either — that gap is #658 — and the two predicates collapse into a single
helper call when it lands. **#658 and this PR touch those same two branches in
SQLite and PostgreSQL, so whichever merges second needs a small conflict
resolution.** Nothing else overlaps.

## Tests

Twelve, where the repository had none: a repo-wide grep for `_until` in test
code returned nothing before this.

Per backend: exclusion above the bound, count and fetch agreeing, inclusivity
on the boundary (matching S3's `> until` skip), `_since` + `_until` as a
window, unbounded behaviour unchanged as a control, and the compartment path,
which builds its own query.

**Verified against a negative control.** With the upper bound disabled, the
three discriminating SQLite tests fail and the two controls stay green:

```
until_excludes_resources_modified_after_the_bound ... FAILED
since_and_until_together_bound_the_window         ... FAILED
until_bounds_the_patient_compartment_fetch        ... FAILED
until_is_inclusive                                ... ok   (boundary, not presence)
no_bounds_exports_everything                      ... ok   (control)
```

⚠ **The PostgreSQL four and MongoDB three have been compiled but not run
locally** — they need testcontainers, which this environment has no Docker for.
CI runs them. The SQLite five pass locally (19/19 in that module, including
every pre-existing test).

## One API widening for review

MongoDB's `get_database` moves from `pub(crate)` to `#[doc(hidden)] pub` so the
out-of-crate window tests can pin `last_updated` deterministically rather than
depend on sleeps. This mirrors the existing precedent on PostgreSQL's
`get_client`, and carries the same "hands out a raw handle that bypasses tenant
scoping, not stable API" caveat.

## Unblocks

#656 (the Bulk Export `_until` UI control) is blocked on this and can proceed
once it lands.
