### PR TITLE
fix(persistence,rest): pre-size bulk-submit byte progress via HEAD

### DIFF
--- a/crates/persistence/src/core/bulk_submit_input.rs
+++ b/crates/persistence/src/core/bulk_submit_input.rs
@@ -93,6 +93,26 @@ pub trait SubmitInputFetcher: Send + Sync {
         oauth_metadata_urls: &[String],
         encryption_key: Option<&Value>,
     ) -> StorageResult<(Box<dyn AsyncBufRead + Send + Unpin>, Option<u64>)>;
+
+    /// Returns the advertised size in bytes of the file at `url` without
+    /// opening its body, or `None` when the source cannot cheaply say (no
+    /// HEAD support, no `Content-Length`, or a JWE file whose decrypted
+    /// length differs from the wire length).
+    ///
+    /// The worker calls this for every manifest file up front so the byte
+    /// progress denominator is complete before ingestion starts — learned
+    /// lazily per file, each newly opened file yanks the percentage
+    /// backwards (#874). Best-effort: any `None` (the default) falls back
+    /// to lazy accumulation.
+    async fn file_size(
+        &self,
+        _url: &str,
+        _request_headers: &[(String, String)],
+        _requires_access_token: bool,
+        _oauth_metadata_urls: &[String],
+    ) -> StorageResult<Option<u64>> {
+        Ok(None)
+    }
 }
 
 /// Maps a submission to the stable [`ExportJobId`] used as the output-store key

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -623,7 +623,9 @@ where
                     }
                 }
             }
-            if all_known {
+            // A zero sum (every file empty, or a source misreporting sizes)
+            // presizes nothing — the lazy path below stays the authority.
+            if all_known && sum > 0 {
                 progress.total.store(sum, Ordering::Relaxed);
                 presized = true;
             }

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -595,6 +595,39 @@ where
             .with_byte_progress(progress.clone());
         let mut processed: u64 = 0;
         let mut failed: u64 = 0;
+        // Pre-size the byte denominator: every output file's advertised size
+        // up front, so the percentage never recomputes against a partial
+        // total — learned lazily per file, each newly opened file yanked the
+        // bar backwards on multi-file manifests (#874). Encrypted files are
+        // skipped (wire length ≠ decrypted length); any unknown size falls
+        // back to lazy accumulation below.
+        let mut presized = false;
+        if view.file_encryption_key.is_none() && !manifest.output.is_empty() {
+            let mut sum: u64 = 0;
+            let mut all_known = true;
+            for file in &manifest.output {
+                match self
+                    .fetcher
+                    .file_size(
+                        &file.url,
+                        &view.file_request_headers,
+                        manifest.requires_access_token,
+                        &view.oauth_metadata_urls,
+                    )
+                    .await
+                {
+                    Ok(Some(len)) => sum += len,
+                    _ => {
+                        all_known = false;
+                        break;
+                    }
+                }
+            }
+            if all_known {
+                progress.total.store(sum, Ordering::Relaxed);
+                presized = true;
+            }
+        }
         // The lease must stay heartbeated *through* a file, not only between
         // files, and independently of how often the ingest future yields; the
         // keeper renews from its own task until dropped.
@@ -637,6 +670,7 @@ where
                 }
             };
             match file_bytes_total {
+                _ if presized => {}
                 Some(len) if totals_known => {
                     progress.total.fetch_add(len, Ordering::Relaxed);
                 }
@@ -1139,6 +1173,16 @@ mod tests {
                 Some(len),
             ))
         }
+
+        async fn file_size(
+            &self,
+            url: &str,
+            _headers: &[(String, String)],
+            _requires_access_token: bool,
+            _oauth: &[String],
+        ) -> StorageResult<Option<u64>> {
+            Ok(self.files.get(url).map(|d| d.len() as u64))
+        }
     }
 
     fn tenant() -> TenantContext {
@@ -1226,6 +1270,85 @@ mod tests {
         // Byte progress reached the file's full advertised size.
         assert_eq!(manifests[0].bytes_total, ndjson.len() as u64);
         assert_eq!(manifests[0].bytes_processed, ndjson.len() as u64);
+    }
+
+    /// #874: with every file's size known up front, the byte denominator is
+    /// the full manifest total from the start — the percentage never
+    /// recomputes against a partial sum as later files open.
+    #[tokio::test]
+    async fn test_multi_file_manifest_presizes_the_byte_total() {
+        let backend = Arc::new(SqliteBackend::in_memory().unwrap());
+        backend.init_schema().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let output = Arc::new(LocalFsOutputStore::new(
+            tmp.path().to_path_buf(),
+            "http://localhost:8080",
+        ));
+
+        let tenant = tenant();
+        let sub_id = SubmissionId::generate("mock-system");
+        backend
+            .create_submission(&tenant, &sub_id, None)
+            .await
+            .unwrap();
+        backend
+            .add_manifest(
+                &tenant,
+                &sub_id,
+                Some("http://provider/manifest.json"),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let f1 = "{\"resourceType\":\"Patient\",\"id\":\"m1\"}\n";
+        let f2 = "{\"resourceType\":\"Patient\",\"id\":\"m2\"}\n{\"resourceType\":\"Patient\",\"id\":\"m3\"}\n";
+        let mut files = std::collections::HashMap::new();
+        files.insert(
+            "http://provider/a.ndjson".to_string(),
+            f1.as_bytes().to_vec(),
+        );
+        files.insert(
+            "http://provider/b.ndjson".to_string(),
+            f2.as_bytes().to_vec(),
+        );
+        let fetcher = Arc::new(MockFetcher {
+            files,
+            manifest: RemoteManifest {
+                requires_access_token: false,
+                output: vec![
+                    RemoteFile {
+                        resource_type: Some("Patient".to_string()),
+                        url: "http://provider/a.ndjson".to_string(),
+                        count: None,
+                    },
+                    RemoteFile {
+                        resource_type: Some("Patient".to_string()),
+                        url: "http://provider/b.ndjson".to_string(),
+                        count: None,
+                    },
+                ],
+                deleted: vec![],
+            },
+        });
+
+        let worker = DefaultSubmitWorker::new(
+            backend.clone(),
+            fetcher,
+            output,
+            WorkerId::new("presize-worker"),
+        );
+        let lease = backend
+            .claim_next_manifest(&WorkerId::new("presize-worker"), StdDuration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("claimable manifest");
+        worker.run_job(lease).await.unwrap();
+
+        let manifests = backend.list_manifests(&tenant, &sub_id).await.unwrap();
+        let expected = (f1.len() + f2.len()) as u64;
+        assert_eq!(manifests[0].bytes_total, expected);
+        assert_eq!(manifests[0].bytes_processed, expected);
 
         // An `output` artifact for Patient was recorded.
         let files = backend.list_submit_files(&tenant, &sub_id).await.unwrap();

--- a/crates/rest/src/bulk_submit_fetcher.rs
+++ b/crates/rest/src/bulk_submit_fetcher.rs
@@ -351,6 +351,40 @@ impl SubmitInputFetcher for HttpSubmitInputFetcher {
             content_length,
         ))
     }
+
+    async fn file_size(
+        &self,
+        url: &str,
+        request_headers: &[(String, String)],
+        requires_access_token: bool,
+        oauth_metadata_urls: &[String],
+    ) -> StorageResult<Option<u64>> {
+        // Identity encoding on purpose: a gzip Content-Length would be the
+        // compressed size, and the ingestion counts decompressed bytes.
+        let mut rb = self.client.head(url);
+        if requires_access_token {
+            let Some(provider) = &self.token_provider else {
+                return Ok(None);
+            };
+            let Some(token) = provider
+                .token(oauth_metadata_urls, &self.outbound_scope)
+                .await
+            else {
+                return Ok(None);
+            };
+            rb = rb.bearer_auth(token);
+        }
+        for (name, value) in request_headers {
+            rb = rb.header(name.as_str(), value.as_str());
+        }
+        // Strictly best-effort: providers without HEAD support (405, 4xx/5xx,
+        // network refusal) degrade to lazy per-file accumulation, never to an
+        // error.
+        match rb.send().await {
+            Ok(resp) if resp.status().is_success() => Ok(resp.content_length()),
+            _ => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/rest/src/bulk_submit_fetcher.rs
+++ b/crates/rest/src/bulk_submit_fetcher.rs
@@ -379,9 +379,15 @@ impl SubmitInputFetcher for HttpSubmitInputFetcher {
         }
         // Strictly best-effort: providers without HEAD support (405, 4xx/5xx,
         // network refusal) degrade to lazy per-file accumulation, never to an
-        // error.
+        // error. The size comes from the Content-Length *header* — a HEAD
+        // response has no payload, so `Response::content_length()` (the body
+        // size hint) reports 0 regardless of what the header advertises.
         match rb.send().await {
-            Ok(resp) if resp.status().is_success() => Ok(resp.content_length()),
+            Ok(resp) if resp.status().is_success() => Ok(resp
+                .headers()
+                .get(reqwest::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok())),
             _ => Ok(None),
         }
     }


### PR DESCRIPTION
Closes #874

Stacked on #849 (which now carries #851's merge); merge that one first.

## What

On a multi-file manifest the byte-progress denominator was learned lazily — each file's size arrived only when its stream opened — so the percentage kept recomputing against a partial total and every newly opened file yanked the bar backwards. Observed live on the #448 Postgres leg's 20-file run: `99% → 54% → 95% → 34% → …`.

`SubmitInputFetcher` gains `file_size()` — a best-effort HEAD returning the advertised `Content-Length`, with a default implementation returning `None` so every existing mock keeps compiling — and the worker sums all output files up front, storing the complete denominator before ingestion starts. Fallbacks stay honest:

- any file with an unknown size → lazy accumulation exactly as before;
- encrypted (JWE) submissions skip pre-sizing entirely (wire length ≠ decrypted length);
- HEAD requests deliberately skip `Accept-Encoding: gzip` so the size matches the decompressed bytes the ingest counts.

New worker test: a two-file manifest lands `bytes_total == bytes_processed == sum` of both files through the pre-sized path. Suites: worker units (6), rest `bulk_submit` (22) + `bulk_submit_jwe` (6).