### PR TITLE
test(hts-ui): compare the chevron copies with normalized line endings

### DIFF
--- a/crates/hts-ui/tests/chrome_parity.rs
+++ b/crates/hts-ui/tests/chrome_parity.rs
@@ -309,10 +309,16 @@ fn cm_detail_template_carries_backlink_to_concept_maps_browser() {
 /// This test makes the duplication safe by refusing to let the two copies
 /// drift — HFS and HTS back links must render the same glyph at the same
 /// size, since both are styled by the one shared `.back-link` rule.
+///
+/// Line endings are normalized before comparing: the repo has no
+/// `.gitattributes`, so what `include_str!` sees depends on the checkout's
+/// CRLF conversion, and a reused runner workspace can hand the two paths
+/// different endings for byte-identical blobs (seen on #849's CI). The
+/// glyph is the same either way; only real markup drift should fail here.
 #[test]
 fn chevron_left_icon_matches_hfs() {
-    let hfs_icon = include_str!("../../ui/templates/icons/chevron-left.svg");
-    let hts_icon = include_str!("../templates/icons/chevron-left.svg");
+    let hfs_icon = include_str!("../../ui/templates/icons/chevron-left.svg").replace("\r\n", "\n");
+    let hts_icon = include_str!("../templates/icons/chevron-left.svg").replace("\r\n", "\n");
     assert_eq!(
         hfs_icon, hts_icon,
         "chevron-left.svg drifted between crates/ui/templates/icons/ and \


### PR DESCRIPTION
## What

`chevron_left_icon_matches_hfs` failed on #849's CI claiming the two chevron copies drifted — with the diff being **only line endings** (LF vs CRLF). In git the two paths are byte-identical (the same blob, `7878f64`, in every version either path has ever had, and in #849's merge tree), so no real drift exists: the repo has no `.gitattributes`, what `include_str!` sees depends on the checkout's CRLF conversion, and a reused self-hosted runner workspace can hand the two paths different endings for identical content.

The test's intent is "same glyph". It now normalizes `\r\n` → `\n` before comparing, so only real markup drift fails it — robust against runner config, workspace reuse, and any future `.gitattributes`.

(Also re-ran #849's failed job — the current merge is provably clean, so it should go green independently of this.)