### PR TITLE
feat(persistence): expose configurable Elasticsearch write refresh 

### DIFF
--- a/.claude/skills/run-hfs-server/SKILL.md
+++ b/.claude/skills/run-hfs-server/SKILL.md
@@ -69,9 +69,11 @@ HFS_SERVER_PORT=3000 HFS_LOG_LEVEL=debug cargo run --bin hfs
 | `HFS_ELASTICSEARCH_INDEX_PREFIX` | `hfs` | Elasticsearch index prefix |
 | `HFS_ELASTICSEARCH_USERNAME` | none | Elasticsearch basic auth username |
 | `HFS_ELASTICSEARCH_PASSWORD` | none | Elasticsearch basic auth password |
+| `HFS_ELASTICSEARCH_REFRESH_INTERVAL` | `1s` | Index `refresh_interval` applied when an index is created (`-1` disables periodic refresh) |
+| `HFS_ELASTICSEARCH_WRITE_REFRESH` | `false` | `refresh` parameter on index/delete writes: `false`, `wait_for`, or `true` |
 | `HFS_COMPOSITE_SYNC_MODE` | `asynchronous` | ES-backed composite write sync mode: asynchronous, synchronous, or hybrid |
 
-Use `HFS_COMPOSITE_SYNC_MODE=synchronous` when callers need read-your-write search semantics, such as integration tests or bulk loads that immediately search.
+Use `HFS_COMPOSITE_SYNC_MODE=synchronous` **and** `HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for` when callers need read-your-write search semantics, such as integration tests or bulk loads that immediately search. Either alone still leaves a window: synchronous mode only guarantees the document reached Elasticsearch, and it is not searchable until the next index refresh. See `crates/persistence/README.md` (Search visibility on Elasticsearch-backed composites).
 
 ## Storage Backends
 

--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -433,6 +433,7 @@ jobs:
             HFS_STORAGE_BACKEND=sqlite-elasticsearch \
             HFS_ELASTICSEARCH_NODES=http://$DOCKER_HOST_IP:$ES_PORT \
             HFS_COMPOSITE_SYNC_MODE=synchronous \
+            HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for \
             ./target/debug/hfs --database-url :memory: --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
           elif [ "${{ matrix.backend }}" = "postgres" ]; then
             HFS_STORAGE_BACKEND=postgres \
@@ -455,6 +456,7 @@ jobs:
             HFS_S3_VALIDATE_BUCKETS=false \
             HFS_ELASTICSEARCH_NODES=http://$DOCKER_HOST_IP:$ES_PORT \
             HFS_COMPOSITE_SYNC_MODE=synchronous \
+            HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for \
             ./target/debug/hfs --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
           else
             ./target/debug/hfs --database-url :memory: --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &

--- a/.github/workflows/ui-tests-matrix.yml
+++ b/.github/workflows/ui-tests-matrix.yml
@@ -329,8 +329,9 @@ jobs:
           # The suite creates and immediately searches; on the ES composites
           # the default asynchronous sync races the specs (nightly reds since
           # the SearchParameter CRUD spec landed). Synchronous puts the write
-          # in ES before the API responds; the specs' waitSearchable covers
-          # the index-refresh window that remains. Only the S3 composite stays
+          # in ES before the API responds, and wait_for blocks the write until
+          # the index refresh so the document is searchable on return (the
+          # specs' waitSearchable remains as a backstop). Only the S3 composite stays
           # asynchronous: against real S3 the extra per-write latency tipped
           # the seed-heavy dashboard specs over their budgets (run 62), so
           # that leg stays asynchronous and leans on the polls alone.
@@ -338,6 +339,7 @@ jobs:
              [ "${{ matrix.backend }}" = "postgres-elasticsearch" ] || \
              [ "${{ matrix.backend }}" = "mongodb-elasticsearch" ]; then
             export HFS_COMPOSITE_SYNC_MODE=synchronous
+            export HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for
           fi
 
           if [ "${{ matrix.backend }}" = "sqlite-elasticsearch" ]; then

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ compressed when the client sends `Accept-Encoding`.
 | `HFS_ELASTICSEARCH_INDEX_PREFIX` | `hfs` | ES index name prefix |
 | `HFS_ELASTICSEARCH_USERNAME` | *(none)* | ES basic auth username |
 | `HFS_ELASTICSEARCH_PASSWORD` | *(none)* | ES basic auth password |
+| `HFS_ELASTICSEARCH_REFRESH_INTERVAL` | `1s` | Index `refresh_interval` applied when an index is created (`-1` disables periodic refresh) |
+| `HFS_ELASTICSEARCH_WRITE_REFRESH` | `false` | `refresh` parameter on index/delete writes: `false`, `wait_for`, or `true` |
 
 **PostgreSQL** (used to assemble a connection when `HFS_DATABASE_URL` is not set)
 

--- a/book/src/configuration/environment-variables.md
+++ b/book/src/configuration/environment-variables.md
@@ -52,6 +52,8 @@ are compressed when the client sends `Accept-Encoding`.
 | `HFS_ELASTICSEARCH_INDEX_PREFIX` | `hfs` | Elasticsearch index name prefix |
 | `HFS_ELASTICSEARCH_USERNAME` | *(none)* | Elasticsearch basic auth username |
 | `HFS_ELASTICSEARCH_PASSWORD` | *(none)* | Elasticsearch basic auth password |
+| `HFS_ELASTICSEARCH_REFRESH_INTERVAL` | `1s` | Index `refresh_interval` applied when an index is created (`-1` disables periodic refresh) |
+| `HFS_ELASTICSEARCH_WRITE_REFRESH` | `false` | `refresh` parameter on index/delete writes: `false`, `wait_for`, or `true` |
 | `HFS_S3_BUCKET` | `hfs` | S3 bucket name |
 | `HFS_S3_REGION` | *(AWS chain)* | AWS region override |
 | `HFS_S3_PREFIX` | *(none)* | Optional key prefix for all S3 object keys |

--- a/crates/hfs/README.md
+++ b/crates/hfs/README.md
@@ -96,17 +96,11 @@ Options:
 | `HFS_ELASTICSEARCH_REFRESH_INTERVAL` | `1s` | Elasticsearch index `refresh_interval` for ES-backed backends. Controls how quickly indexed documents become searchable when no per-write refresh is requested. `-1` disables periodic refresh entirely. Applied when an index is created; indices that already exist keep their current setting. |
 | `HFS_ELASTICSEARCH_WRITE_REFRESH` | `false` | The `refresh` parameter applied to Elasticsearch index/delete operations. One of `false` (no per-write refresh), `wait_for` (block each write until the affected shards refresh), or `true` (force a refresh per write; expensive, low-volume deployments only). |
 
-In the ES-backed composite modes the search secondary is **eventually
-consistent** by default: a write can return `201`/`200` before the resource is
-findable via search. Two independent delays contribute. First, the composite
-forwards the index write to Elasticsearch on a background worker unless
-`HFS_COMPOSITE_SYNC_MODE=synchronous`. Second, Elasticsearch only makes an
-indexed document searchable at the next index refresh, which happens every
-`HFS_ELASTICSEARCH_REFRESH_INTERVAL` unless the write itself requests a refresh
-via `HFS_ELASTICSEARCH_WRITE_REFRESH`. Read-after-write search therefore
-requires **both** `HFS_COMPOSITE_SYNC_MODE=synchronous` and
-`HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for`; either setting alone still leaves a
-window in which an immediate follow-up search misses the write.
+Read-after-write search on an ES-backed composite needs **both**
+`HFS_COMPOSITE_SYNC_MODE=synchronous` and
+`HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for`. See
+[Search visibility on Elasticsearch-backed composites](../persistence/README.md#search-visibility-on-elasticsearch-backed-composites)
+in the persistence crate for why either setting alone still leaves a window.
 
 Set `HFS_BASE_URL` to the public address clients can reach. The value may
 contain a path prefix. It must be an absolute `http` or `https` URL without

--- a/crates/hfs/README.md
+++ b/crates/hfs/README.md
@@ -93,6 +93,20 @@ Options:
 | `HFS_DEFAULT_TENANT` | default | Default tenant ID |
 | `HFS_TERMINOLOGY_SERVER` | (none) | Terminology server URL for `:in`/`:not-in` modifiers and FHIRPath `memberOf()`/`subsumes()` |
 | `HFS_COMPOSITE_SYNC_MODE` | `asynchronous` | Composite-store write sync mode for ES-backed backends (`sqlite-elasticsearch`, `postgres-elasticsearch`, `mongodb-elasticsearch`, `s3-elasticsearch`). One of `asynchronous`, `synchronous`, `hybrid`. With `asynchronous` (default) the write returns as soon as the primary commits and the search backend is updated on a background worker — lowest latency, but a follow-up search can race the indexing. Use `synchronous` when callers need read-your-write semantics (e.g. integration tests, bulk-load flows that immediately search). Ignored when the storage backend has no search secondary. |
+| `HFS_ELASTICSEARCH_REFRESH_INTERVAL` | `1s` | Elasticsearch index `refresh_interval` for ES-backed backends. Controls how quickly indexed documents become searchable when no per-write refresh is requested. `-1` disables periodic refresh entirely. Applied when an index is created; indices that already exist keep their current setting. |
+| `HFS_ELASTICSEARCH_WRITE_REFRESH` | `false` | The `refresh` parameter applied to Elasticsearch index/delete operations. One of `false` (no per-write refresh), `wait_for` (block each write until the affected shards refresh), or `true` (force a refresh per write; expensive, low-volume deployments only). |
+
+In the ES-backed composite modes the search secondary is **eventually
+consistent** by default: a write can return `201`/`200` before the resource is
+findable via search. Two independent delays contribute. First, the composite
+forwards the index write to Elasticsearch on a background worker unless
+`HFS_COMPOSITE_SYNC_MODE=synchronous`. Second, Elasticsearch only makes an
+indexed document searchable at the next index refresh, which happens every
+`HFS_ELASTICSEARCH_REFRESH_INTERVAL` unless the write itself requests a refresh
+via `HFS_ELASTICSEARCH_WRITE_REFRESH`. Read-after-write search therefore
+requires **both** `HFS_COMPOSITE_SYNC_MODE=synchronous` and
+`HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for`; either setting alone still leaves a
+window in which an immediate follow-up search misses the write.
 
 Set `HFS_BASE_URL` to the public address clients can reach. The value may
 contain a path prefix. It must be an absolute `http` or `https` URL without

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -148,6 +148,16 @@ fn composite_sync_mode_from_env() -> helios_persistence::composite::SyncMode {
     }
 }
 
+#[cfg(feature = "elasticsearch")]
+fn es_write_refresh_from_config(
+    config: &ServerConfig,
+) -> anyhow::Result<helios_persistence::backends::elasticsearch::WriteRefreshPolicy> {
+    config
+        .elasticsearch_write_refresh
+        .parse()
+        .map_err(|e: String| anyhow::anyhow!("{} (from HFS_ELASTICSEARCH_WRITE_REFRESH)", e))
+}
+
 #[cfg(feature = "mongodb")]
 fn build_mongodb_config(config: &ServerConfig, search_offloaded: bool) -> MongoBackendConfig {
     build_mongodb_config_with_env(config, search_offloaded, |name| std::env::var(name).ok())
@@ -1810,6 +1820,8 @@ async fn start_sqlite_elasticsearch(
         index_prefix: config.elasticsearch_index_prefix.clone(),
         auth: es_auth,
         fhir_version: config.default_fhir_version,
+        refresh_interval: config.elasticsearch_refresh_interval.clone(),
+        write_refresh: es_write_refresh_from_config(&config)?,
         ..Default::default()
     };
 
@@ -2061,6 +2073,8 @@ async fn start_postgres_elasticsearch(
         index_prefix: config.elasticsearch_index_prefix.clone(),
         auth: es_auth,
         fhir_version: config.default_fhir_version,
+        refresh_interval: config.elasticsearch_refresh_interval.clone(),
+        write_refresh: es_write_refresh_from_config(&config)?,
         ..Default::default()
     };
 
@@ -2245,6 +2259,8 @@ async fn start_mongodb_elasticsearch(
         index_prefix: config.elasticsearch_index_prefix.clone(),
         auth: es_auth,
         fhir_version: config.default_fhir_version,
+        refresh_interval: config.elasticsearch_refresh_interval.clone(),
+        write_refresh: es_write_refresh_from_config(&config)?,
         ..Default::default()
     };
 
@@ -2641,6 +2657,8 @@ async fn start_s3_elasticsearch(
         index_prefix: config.elasticsearch_index_prefix.clone(),
         auth: es_auth,
         fhir_version: config.default_fhir_version,
+        refresh_interval: config.elasticsearch_refresh_interval.clone(),
+        write_refresh: es_write_refresh_from_config(&config)?,
         ..Default::default()
     };
 

--- a/crates/persistence/README.md
+++ b/crates/persistence/README.md
@@ -1350,6 +1350,31 @@ let async_mode = SyncMode::Asynchronous;
 let hybrid = SyncMode::Hybrid { sync_for_search: true };
 ```
 
+#### Search visibility on Elasticsearch-backed composites
+
+When Elasticsearch is the search secondary, a write can return before the
+resource is findable via search. Two independent delays contribute:
+
+1. **Composite forwarding.** In `Asynchronous` mode the composite returns as
+   soon as the primary commits and forwards the index write to Elasticsearch on
+   a background worker. `Synchronous` (or `Hybrid { sync_for_search: true }`)
+   puts the document in Elasticsearch before the write returns.
+2. **Elasticsearch refresh.** An indexed document only becomes searchable at the
+   next index refresh. By default that happens on a timer
+   (`ElasticsearchConfig::refresh_interval`, applied when an index is created;
+   existing indices keep their setting). `ElasticsearchConfig::write_refresh`
+   sets the `refresh` parameter on each index/delete request instead:
+   `WriteRefreshPolicy::False` (default) leaves it to the timer, `WaitFor`
+   blocks the write until the affected shards refresh, and `True` forces a
+   refresh per write (expensive; low-volume deployments only).
+
+Read-after-write search therefore requires **both** a synchronous sync mode and
+`write_refresh: WaitFor`; either alone still leaves a window in which an
+immediate follow-up search misses the write. The `hfs` binary exposes these as
+`HFS_COMPOSITE_SYNC_MODE`, `HFS_ELASTICSEARCH_REFRESH_INTERVAL`, and
+`HFS_ELASTICSEARCH_WRITE_REFRESH` (see the
+[hfs README](../hfs/README.md#environment-variables)).
+
 ### Cost-Based Optimization
 
 The cost estimator uses benchmark-derived costs to make routing decisions:

--- a/crates/persistence/src/backends/elasticsearch/backend.rs
+++ b/crates/persistence/src/backends/elasticsearch/backend.rs
@@ -22,6 +22,55 @@ use crate::search::{
     TenantSearchRegistries,
 };
 
+/// The `refresh` query parameter applied to Elasticsearch index and delete operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteRefreshPolicy {
+    /// Do not refresh on write (Elasticsearch default behavior).
+    #[default]
+    False,
+    /// Wait for the next refresh to make the write visible before returning.
+    WaitFor,
+    /// Force a refresh of the affected shards immediately after the write.
+    True,
+}
+
+impl WriteRefreshPolicy {
+    pub(crate) fn as_refresh_param(self) -> Option<elasticsearch::params::Refresh> {
+        match self {
+            WriteRefreshPolicy::False => None,
+            WriteRefreshPolicy::WaitFor => Some(elasticsearch::params::Refresh::WaitFor),
+            WriteRefreshPolicy::True => Some(elasticsearch::params::Refresh::True),
+        }
+    }
+}
+
+impl std::str::FromStr for WriteRefreshPolicy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "false" => Ok(WriteRefreshPolicy::False),
+            "wait_for" | "wait-for" => Ok(WriteRefreshPolicy::WaitFor),
+            "true" => Ok(WriteRefreshPolicy::True),
+            other => Err(format!(
+                "Invalid Elasticsearch write refresh policy '{}'. Valid values: false, wait_for, true",
+                other
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for WriteRefreshPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WriteRefreshPolicy::False => write!(f, "false"),
+            WriteRefreshPolicy::WaitFor => write!(f, "wait_for"),
+            WriteRefreshPolicy::True => write!(f, "true"),
+        }
+    }
+}
+
 /// Authentication configuration for Elasticsearch.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ElasticsearchAuth {
@@ -62,6 +111,10 @@ pub struct ElasticsearchConfig {
     /// Refresh interval (default: "1s").
     #[serde(default = "default_refresh_interval")]
     pub refresh_interval: String,
+
+    /// Refresh behavior for index/delete operations (default: [`WriteRefreshPolicy::False`]).
+    #[serde(default)]
+    pub write_refresh: WriteRefreshPolicy,
 
     /// Maximum result window size (default: 10000).
     #[serde(default = "default_max_result_window")]
@@ -117,6 +170,7 @@ impl Default for ElasticsearchConfig {
             number_of_shards: default_shards(),
             number_of_replicas: default_replicas(),
             refresh_interval: default_refresh_interval(),
+            write_refresh: WriteRefreshPolicy::default(),
             max_result_window: default_max_result_window(),
             request_timeout_ms: default_request_timeout_ms(),
             auth: None,
@@ -304,6 +358,10 @@ impl ElasticsearchBackend {
     /// Returns the backend configuration.
     pub fn config(&self) -> &ElasticsearchConfig {
         &self.config
+    }
+
+    pub(crate) fn write_refresh_param(&self) -> Option<elasticsearch::params::Refresh> {
+        self.config.write_refresh.as_refresh_param()
     }
 
     /// Returns the per-tenant search parameter registries (shared base + tenant

--- a/crates/persistence/src/backends/elasticsearch/mod.rs
+++ b/crates/persistence/src/backends/elasticsearch/mod.rs
@@ -47,4 +47,6 @@ pub mod search;
 mod search_impl;
 mod storage;
 
-pub use backend::{ElasticsearchAuth, ElasticsearchBackend, ElasticsearchConfig};
+pub use backend::{
+    ElasticsearchAuth, ElasticsearchBackend, ElasticsearchConfig, WriteRefreshPolicy,
+};

--- a/crates/persistence/src/backends/elasticsearch/storage.rs
+++ b/crates/persistence/src/backends/elasticsearch/storage.rs
@@ -441,10 +441,14 @@ impl ElasticsearchBackend {
                 &contained.contained_type,
                 &contained_resource_id(container_id, &contained.local_id),
             );
-            let response = self
+            let mut request = self
                 .client()
                 .index(IndexParts::IndexId(&index, &doc_id))
-                .body(doc)
+                .body(doc);
+            if let Some(refresh) = self.write_refresh_param() {
+                request = request.refresh(refresh);
+            }
+            let response = request
                 .send()
                 .await
                 .map_err(|e| internal_error(format!("Failed to index contained doc: {}", e)))?;
@@ -528,10 +532,14 @@ impl ResourceStorage for ElasticsearchBackend {
         let index = self.index_name(tenant_id, resource_type);
         let doc_id = Self::document_id(resource_type, &id);
 
-        let response = self
+        let mut request = self
             .client()
             .index(IndexParts::IndexId(&index, &doc_id))
-            .body(doc)
+            .body(doc);
+        if let Some(refresh) = self.write_refresh_param() {
+            request = request.refresh(refresh);
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| internal_error(format!("Failed to index document: {}", e)))?;
@@ -694,10 +702,14 @@ impl ResourceStorage for ElasticsearchBackend {
         // Ensure index exists
         schema::ensure_index(self, tenant_id, resource_type).await?;
 
-        let response = self
+        let mut request = self
             .client()
             .index(IndexParts::IndexId(&index, &doc_id))
-            .body(doc)
+            .body(doc);
+        if let Some(refresh) = self.write_refresh_param() {
+            request = request.refresh(refresh);
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| internal_error(format!("Failed to index document: {}", e)))?;
@@ -859,10 +871,14 @@ impl ResourceStorage for ElasticsearchBackend {
         let index = self.index_name(tenant_id, resource_type);
         let doc_id = Self::document_id(resource_type, id);
 
-        let response = self
+        let mut request = self
             .client()
             .index(IndexParts::IndexId(&index, &doc_id))
-            .body(doc)
+            .body(doc);
+        if let Some(refresh) = self.write_refresh_param() {
+            request = request.refresh(refresh);
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| internal_error(format!("Failed to update document: {}", e)))?;
@@ -902,9 +918,11 @@ impl ResourceStorage for ElasticsearchBackend {
         let index = self.index_name(tenant_id, resource_type);
         let doc_id = Self::document_id(resource_type, id);
 
-        let response = self
-            .client()
-            .delete(DeleteParts::IndexId(&index, &doc_id))
+        let mut request = self.client().delete(DeleteParts::IndexId(&index, &doc_id));
+        if let Some(refresh) = self.write_refresh_param() {
+            request = request.refresh(refresh);
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| internal_error(format!("Failed to delete document: {}", e)))?;
@@ -1193,10 +1211,14 @@ impl ReindexTarget for ElasticsearchBackend {
         let index = self.index_name(tenant_id, resource_type);
         let doc_id = Self::document_id(resource_type, resource_id);
 
-        let response = self
+        let mut request = self
             .client()
             .index(IndexParts::IndexId(&index, &doc_id))
-            .body(doc)
+            .body(doc);
+        if let Some(refresh) = self.write_refresh_param() {
+            request = request.refresh(refresh);
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| internal_error(format!("Failed to index document: {e}")))?;

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -8,7 +8,9 @@
 
 #![cfg(feature = "elasticsearch")]
 
-use helios_persistence::backends::elasticsearch::{ElasticsearchBackend, ElasticsearchConfig};
+use helios_persistence::backends::elasticsearch::{
+    ElasticsearchBackend, ElasticsearchConfig, WriteRefreshPolicy,
+};
 use helios_persistence::core::{Backend, BackendCapability, BackendKind};
 
 // ============================================================================
@@ -37,6 +39,44 @@ fn test_elasticsearch_config_serialization() {
     let deserialized: ElasticsearchConfig = serde_json::from_str(&json).unwrap();
     assert_eq!(deserialized.nodes, config.nodes);
     assert_eq!(deserialized.index_prefix, "test");
+}
+
+#[test]
+fn test_write_refresh_policy_default_is_false() {
+    assert_eq!(
+        ElasticsearchConfig::default().write_refresh,
+        WriteRefreshPolicy::False
+    );
+
+    let json = r#"{"nodes": ["http://localhost:9200"]}"#;
+    let config: ElasticsearchConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.write_refresh, WriteRefreshPolicy::False);
+}
+
+#[test]
+fn test_write_refresh_policy_parsing() {
+    assert_eq!(
+        "false".parse::<WriteRefreshPolicy>().unwrap(),
+        WriteRefreshPolicy::False
+    );
+    assert_eq!(
+        "wait_for".parse::<WriteRefreshPolicy>().unwrap(),
+        WriteRefreshPolicy::WaitFor
+    );
+    assert_eq!(
+        "wait-for".parse::<WriteRefreshPolicy>().unwrap(),
+        WriteRefreshPolicy::WaitFor
+    );
+    assert_eq!(
+        "true".parse::<WriteRefreshPolicy>().unwrap(),
+        WriteRefreshPolicy::True
+    );
+    assert_eq!(
+        " WAIT_FOR ".parse::<WriteRefreshPolicy>().unwrap(),
+        WriteRefreshPolicy::WaitFor
+    );
+    assert!("refresh-me".parse::<WriteRefreshPolicy>().is_err());
+    assert!("".parse::<WriteRefreshPolicy>().is_err());
 }
 
 #[test]
@@ -609,7 +649,9 @@ mod es_integration {
     use helios_fhir::FhirVersion;
     use serde_json::json;
 
-    use helios_persistence::backends::elasticsearch::{ElasticsearchBackend, ElasticsearchConfig};
+    use helios_persistence::backends::elasticsearch::{
+        ElasticsearchBackend, ElasticsearchConfig, WriteRefreshPolicy,
+    };
     use helios_persistence::core::{Backend, BackendCapability, BackendKind, ResourceStorage};
     use helios_persistence::error::{ResourceError, StorageError};
     use helios_persistence::search::{
@@ -723,6 +765,13 @@ mod es_integration {
     /// Each call uses a unique index prefix (via UUID) so tests are fully isolated
     /// without needing separate containers.
     async fn create_backend() -> ElasticsearchBackend {
+        create_backend_with("1ms", WriteRefreshPolicy::default()).await
+    }
+
+    async fn create_backend_with(
+        refresh_interval: &str,
+        write_refresh: WriteRefreshPolicy,
+    ) -> ElasticsearchBackend {
         let es = shared_es().await;
         let unique_prefix = format!("hfs_{}", uuid::Uuid::new_v4().simple());
 
@@ -730,7 +779,8 @@ mod es_integration {
             nodes: vec![format!("http://{}:{}", es.host, es.port)],
             index_prefix: unique_prefix,
             number_of_replicas: 0, // single-node, no replicas needed
-            refresh_interval: "1ms".to_string(), // near-instant refresh for tests
+            refresh_interval: refresh_interval.to_string(),
+            write_refresh,
             ..Default::default()
         };
 
@@ -1860,6 +1910,152 @@ mod es_integration {
             "Search by name should find the patient"
         );
         assert_eq!(result.resources.items[0].id(), "p1");
+    }
+
+    #[tokio::test]
+    async fn es_integration_write_refresh_wait_for_read_after_write() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let backend = create_backend_with("5s", WriteRefreshPolicy::WaitFor).await;
+        let tenant = create_tenant("raw-tenant");
+
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "raw-1",
+                    "name": [{"family": "Readafterwrite", "given": ["Direct"]}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "name".to_string(),
+            param_type: SearchParamType::String,
+            modifier: None,
+            values: vec![SearchValue::eq("Readafterwrite")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = backend.search(&tenant, &query).await.unwrap();
+        assert_eq!(
+            result.resources.items.len(),
+            1,
+            "wait_for write must be searchable immediately"
+        );
+        assert_eq!(result.resources.items[0].id(), "raw-1");
+
+        backend.delete(&tenant, "Patient", "raw-1").await.unwrap();
+
+        let result = backend.search(&tenant, &query).await.unwrap();
+        assert!(
+            result.resources.items.is_empty(),
+            "wait_for delete must drop out of search immediately"
+        );
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn es_integration_composite_synchronous_wait_for_read_after_write() {
+        use std::collections::HashMap;
+
+        use helios_persistence::backends::sqlite::SqliteBackend;
+        use helios_persistence::composite::{
+            CompositeConfig, CompositeStorage, DynSearchProvider, DynStorage, SyncMode,
+        };
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{
+            SearchParamType, SearchParameter, SearchQuery, SearchValue,
+        };
+
+        let es = shared_es().await;
+        let unique_prefix = format!("hfs_{}", uuid::Uuid::new_v4().simple());
+        let es_config = ElasticsearchConfig {
+            nodes: vec![format!("http://{}:{}", es.host, es.port)],
+            index_prefix: unique_prefix,
+            number_of_replicas: 0,
+            refresh_interval: "5s".to_string(),
+            write_refresh: WriteRefreshPolicy::WaitFor,
+            ..Default::default()
+        };
+        let es_backend = Arc::new(
+            ElasticsearchBackend::with_shared_registry(es_config, build_search_registry())
+                .expect("create ES backend"),
+        );
+        es_backend
+            .initialize()
+            .await
+            .expect("initialize ES backend");
+
+        let sqlite = Arc::new(SqliteBackend::in_memory().expect("create SQLite backend"));
+        sqlite.init_schema().expect("init SQLite schema");
+
+        let composite_config = CompositeConfig::builder()
+            .primary("sqlite", BackendKind::Sqlite)
+            .search_backend("es", BackendKind::Elasticsearch)
+            .sync_mode(SyncMode::Synchronous)
+            .build()
+            .expect("build composite config");
+
+        let mut backends: HashMap<String, DynStorage> = HashMap::new();
+        backends.insert("sqlite".to_string(), sqlite.clone() as DynStorage);
+        backends.insert("es".to_string(), es_backend.clone() as DynStorage);
+
+        let mut search_providers: HashMap<String, DynSearchProvider> = HashMap::new();
+        search_providers.insert("sqlite".to_string(), sqlite.clone() as DynSearchProvider);
+        search_providers.insert("es".to_string(), es_backend.clone() as DynSearchProvider);
+
+        let composite = CompositeStorage::new(composite_config, backends)
+            .expect("create composite storage")
+            .with_search_providers(search_providers)
+            .with_full_primary(sqlite);
+
+        let tenant = create_tenant("raw-composite-tenant");
+        composite
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "raw-composite-1",
+                    "text": {
+                        "status": "generated",
+                        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Compositeraw Sync</div>"
+                    },
+                    "name": [{"family": "Compositeraw", "given": ["Sync"]}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .expect("create through composite");
+
+        let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "_text".to_string(),
+            param_type: SearchParamType::String,
+            modifier: None,
+            values: vec![SearchValue::eq("Compositeraw")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = composite
+            .search(&tenant, &query)
+            .await
+            .expect("search through composite");
+        assert_eq!(
+            result.resources.items.len(),
+            1,
+            "synchronous sync + wait_for must give read-after-write search"
+        );
+        assert_eq!(result.resources.items[0].id(), "raw-composite-1");
     }
 
     #[tokio::test]

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -1006,6 +1006,19 @@ pub struct ServerConfig {
     #[arg(long, env = "HFS_ELASTICSEARCH_PASSWORD")]
     pub elasticsearch_password: Option<String>,
 
+    /// Elasticsearch index refresh interval (e.g. "1s", "200ms", "-1" to disable
+    /// periodic refresh). Controls how quickly indexed documents become
+    /// searchable when no per-write refresh is requested.
+    #[arg(long, env = "HFS_ELASTICSEARCH_REFRESH_INTERVAL", default_value = "1s")]
+    pub elasticsearch_refresh_interval: String,
+
+    /// Refresh behavior applied to Elasticsearch index/delete operations:
+    /// "false" (no per-write refresh), "wait_for" (block each write until the
+    /// affected shards refresh, giving read-after-write search visibility), or
+    /// "true" (force a refresh per write).
+    #[arg(long, env = "HFS_ELASTICSEARCH_WRITE_REFRESH", default_value = "false")]
+    pub elasticsearch_write_refresh: String,
+
     /// Enable SQL-on-FHIR operations ($sql-run, $sql-export).
     /// When enabled, the configured storage backend MUST provide an in-DB
     /// SOF runner (sqlite or postgres) — there is no in-process fallback.
@@ -1224,6 +1237,8 @@ impl Default for ServerConfig {
             elasticsearch_index_prefix: "hfs".to_string(),
             elasticsearch_username: None,
             elasticsearch_password: None,
+            elasticsearch_refresh_interval: "1s".to_string(),
+            elasticsearch_write_refresh: "false".to_string(),
             sof_enabled: true,
             nl_search_enabled: true,
             nl_search_api_key: None,
@@ -1444,6 +1459,8 @@ impl ServerConfig {
             elasticsearch_index_prefix: "hfs".to_string(),
             elasticsearch_username: None,
             elasticsearch_password: None,
+            elasticsearch_refresh_interval: "1s".to_string(),
+            elasticsearch_write_refresh: "false".to_string(),
             sof_enabled: true,
             nl_search_enabled: true,
             nl_search_api_key: None,


### PR DESCRIPTION
 Adds HFS_ELASTICSEARCH_REFRESH_INTERVAL and HFS_ELASTICSEARCH_WRITE_REFRESH (false/wait_for/true) so ES-backed deployments can get read-after-write search visibility when combined with HFS_COMPOSITE_SYNC_MODE=synchronous, closing #814.