### PR TITLE
fix(hts-ui): give the OperationOutcome box its own spacing scope

### DIFF
--- a/crates/hts-ui/templates/partials/hts-outcome.html
+++ b/crates/hts-ui/templates/partials/hts-outcome.html
@@ -22,10 +22,17 @@
     • `location[]` renders as a small monospace list, useful for form-field
       wiring in Wave 2 slices (Ops workbench).
 -#}
-{#- `.hts-outcome*` had no rule in app.css, so severity was invisible.
-    Severity now rides on `data-severity` (no styling attached) and the box
-    reuses `.notice.notice--warn`, matching every other warning surface. -#}
-<aside class="notice notice--warn" data-severity="{{ outcome.severity }}"
+{#- Severity rides on `data-severity` (no styling attached) and the box's
+    tone comes from `.notice.notice--warn`, matching every other warning
+    surface — the old `.hts-outcome--<severity>` hooks had no rule in
+    app.css, so they painted nothing.
+
+    `.hts-outcome` is back as a *spacing* scope only, and this time with a
+    rule (#805). `.notice` is shared with HFS, whose uses put bare text in
+    the box; this partial stacks `<p>` rows instead, so it needs the
+    paragraph reset and the gap to preceding content that the primitive
+    deliberately does not carry. -#}
+<aside class="hts-outcome notice notice--warn" data-severity="{{ outcome.severity }}"
        role="{% if outcome.severity == "fatal" || outcome.severity == "error" %}alert{% else %}status{% endif %}"
        aria-live="polite">
   <p class="field__label">
@@ -40,7 +47,7 @@
   <p>{{ outcome.diagnostics }}</p>
   {% endif %}
   {% if !outcome.location.is_empty() %}
-  <ul class="filter-rail__list">
+  <ul class="hts-outcome__locations">
     {% for loc in outcome.location %}
     <li><code>{{ loc }}</code></li>
     {% endfor %}

--- a/crates/hts-ui/tests/code_systems.rs
+++ b/crates/hts-ui/tests/code_systems.rs
@@ -632,6 +632,13 @@ fn cs_detail_templates_only_use_classes_that_exist_in_app_css() {
             "partials/hts-cs-workbench-result.html",
             include_str!("../templates/partials/hts-cs-workbench-result.html"),
         ),
+        // Included by the workbench result and by cs-detail directly. It is
+        // the one template allowed its own hooks (`.hts-outcome*`, #805) —
+        // scanning it here is what keeps the rule and the class together.
+        (
+            "partials/hts-outcome.html",
+            include_str!("../templates/partials/hts-outcome.html"),
+        ),
     ];
 
     let mut checked = 0usize;

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2456,6 +2456,45 @@ select.field__input {
   border: 1px solid var(--warn);
 }
 
+/* The HTS OperationOutcome box (`crates/hts-ui/templates/partials/
+   hts-outcome.html`, #805). It is a `.notice` whose body is a stack of
+   `<p>` rows, which the primitive alone cannot spell: HFS's own notices
+   put bare text in the box, so `.notice` carries no paragraph reset and
+   the UA's `margin: 1em 0` pushed the first line ~13px below a box padded
+   for 10px. Scope the rhythm here rather than touching `.notice`, which is
+   shared with every HFS warning surface. */
+.hts-outcome > * {
+  margin: 0;
+}
+
+.hts-outcome > * + * {
+  margin-top: 6px;
+}
+
+/* The box follows result content — the `$validate-code` field grid is
+   pinned flush on the assumption it is the panel's last child. The margin
+   collapses against a preceding notice's 16px, so stacked warnings stay
+   16px apart rather than 30. */
+.hts-outcome:not(:first-child) {
+  margin-top: 14px;
+}
+
+/* Last child of a `.panel` / `.card`: the container's 18px padding is the
+   gap, and the primitive's 16px on top of it reads as a doubled band. */
+.hts-outcome:last-child {
+  margin-bottom: 0;
+}
+
+/* FHIRPath locations. Previously borrowed `.filter-rail__list`, the
+   scrolling type-rail container, which indented them 40px (its rules never
+   touch the UA list padding) inside a needless scroll region. */
+.hts-outcome__locations {
+  display: grid;
+  gap: 2px;
+  padding-left: 0;
+  list-style: none;
+}
+
 /* 280px matches .nav-panel and .queries-layout's rail column (#603 follow-up):
    one rail width across Resources, Search, Saved Queries, and Search
    Parameters. */


### PR DESCRIPTION
Closes #805.

## What was wrong

The shared HTS error renderer (`partials/hts-outcome.html`) is a `.notice`
whose body is a stack of `<p>` rows. `.notice` carries no paragraph reset —
HFS's own uses put bare text inside the box — so four spacing problems stacked
up on the `$validate-code` result card:

1. The `.kv-grid` above it is pinned flush (`style="margin-bottom:0"`, correct
   when the grid is the panel's last child), leaving nothing between the last
   field and the box's top border.
2. `.field__label` sets no `margin-top`, so the first line kept the UA's `1em`
   — ~23px above the first line against 10px below the last.
3. The diagnostics `<p>` carried full UA `margin: 1em 0`.
4. `.notice`'s `margin-bottom: 16px` landed inside the `.panel`'s 18px padding,
   producing a 34px band under the box.

Plus the location list borrowed `.filter-rail__list` — the scrolling type-rail
container — whose rules never touch the UA list padding, so locations rendered
indented 40px inside a needless scroll region. Same class-borrowing problem as
 #801.

## What changed

`.hts-outcome` comes back as a **spacing scope**, this time with a rule in
`crates/ui/assets/app.css`:

- `> *` margins zeroed, `> * + *` spaces the rows from one place, so the box's
  internal padding is symmetric;
- `:not(:first-child)` restores a 14px top margin where the box follows result
  content. It collapses against a preceding notice's 16px, so stacked warnings
  stay 16px apart rather than 30;
- `:last-child` drops the bottom margin, letting the container's padding be the
  gap;
- `.hts-outcome__locations` replaces the borrowed rail class.

`.notice` itself is untouched, so every HFS warning surface keeps its spacing.
Severity still rides on `data-severity` with no styling attached — the tone
still comes from `.notice--warn`.

The partial's history is why the rule and the class ship together: the previous
`.hts-outcome*` hooks were deleted precisely because they had no rule. The
class-existence guard (`crates/hts-ui/tests/code_systems.rs`) now scans
`hts-outcome.html` too, so they can't drift apart again.

## Verification

- `cargo test -p helios-hts-ui -p helios-ui` — green.
  (`chrome_parity::chevron_left_icon_matches_hfs` fails on Windows checkouts
  for an unrelated reason: `crates/ui/**` is pinned to LF by `.gitattributes`
  and `crates/hts-ui/templates/icons/` is not, so `core.autocrlf` splits them.
  Pre-existing, untouched here.)
- Rendered the before/after of the validate card, the standalone use at
  `cs-detail.html:51`, and the degraded-notice-then-outcome stack against the
  real `app.css`: gap above restored, padding symmetric, no doubled band below,
  locations flush.

## Note for a follow-up (not in this PR)

`crates/hts-ui/e2e/tests/{code-systems,value-sets,concept-maps,import}.spec.ts`
still assert `.hts-outcome--error` is visible. Nothing has emitted that
modifier since it was removed, and the hts-ui e2e suite is not wired into any
workflow (only `crates/ui/e2e` runs in `ui-tests.yml`), which is why it went
unnoticed. Emitting `hts-outcome--{{ severity }}` here would make the whole
`class` attribute interpolated and silently opt the aside out of the guard
above, so it belongs in its own change alongside a decision about what the
modifier should paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)