### PR TITLE
fix(hts-ui): flip CS $validate-code form by input mode, center chip radios

### DIFF
--- a/crates/hts-ui/src/code_systems.rs
+++ b/crates/hts-ui/src/code_systems.rs
@@ -375,6 +375,13 @@ impl<'a> DetailPageTemplate<'a> {
     fn summary(&self) -> Option<&CodeSystemSummary> {
         self.detail.as_ref().ok()
     }
+
+    /// Validate input-mode echo for the Validate-input partial (#804).
+    /// `None` workbench (first GET of the tab) falls back to the `code`
+    /// default via `ValidateInputMode::default()`.
+    fn mode(&self) -> ValidateInputMode {
+        self.workbench.as_ref().map(|w| w.mode).unwrap_or_default()
+    }
 }
 
 /// Base detail URL — permanent-redirects to the default operation tab
@@ -488,6 +495,10 @@ pub struct WorkbenchResultView {
     /// through a wrapper struct — the doc-comment cost is smaller.
     #[allow(dead_code)]
     pub op: CsTab,
+    /// The Validate input-mode the operator submitted. Echoed back so the
+    /// no-JS re-render keeps the same radio checked (#804); irrelevant to
+    /// the other two ops, which just carry the default.
+    pub mode: ValidateInputMode,
     pub request_url: String,
     pub raw_body: String,
     pub lookup: Option<LookupResult>,
@@ -501,6 +512,7 @@ impl WorkbenchResultView {
     fn empty(op: CsTab) -> Self {
         Self {
             op,
+            mode: ValidateInputMode::default(),
             request_url: String::new(),
             raw_body: String::new(),
             lookup: None,
@@ -598,6 +610,7 @@ async fn lookup_run(
         match result {
             Ok(result) => WorkbenchResultView {
                 op: CsTab::Lookup,
+                mode: ValidateInputMode::default(),
                 request_url: result.request_url.clone(),
                 raw_body: result.raw_body.clone(),
                 lookup: Some(result),
@@ -638,6 +651,10 @@ async fn validate_run(
         coding_display: opt(&form, "coding.display"),
         display_language: opt(&form, "displayLanguage"),
     };
+    // `params` moves into `cs_validate_code` below; capture the submitted
+    // mode up front so every branch can echo it back into the re-rendered
+    // form (#804 — the no-JS path must keep the same radio checked).
+    let submitted_mode = params.mode;
     let chrome = Chrome {
         i18n: I18n::new(locale),
         active_page: "code-systems",
@@ -651,6 +668,7 @@ async fn validate_run(
     let canonical = cs.as_ref().map(|s| s.url.clone()).unwrap_or_default();
     let view = if canonical.is_empty() {
         WorkbenchResultView {
+            mode: submitted_mode,
             outcome: Some(OutcomeView::invalid_input(
                 "CodeSystem canonical url unavailable".to_string(),
             )),
@@ -658,6 +676,7 @@ async fn validate_run(
         }
     } else if matches!(params.mode, ValidateInputMode::Code) && params.code.trim().is_empty() {
         WorkbenchResultView {
+            mode: submitted_mode,
             outcome: Some(OutcomeView::invalid_input("code is required".to_string())),
             ..WorkbenchResultView::empty(CsTab::Validate)
         }
@@ -665,6 +684,7 @@ async fn validate_run(
         && (params.coding_code.trim().is_empty() || params.coding_system.trim().is_empty())
     {
         WorkbenchResultView {
+            mode: submitted_mode,
             outcome: Some(OutcomeView::invalid_input(
                 "coding.system and coding.code are required".to_string(),
             )),
@@ -674,6 +694,7 @@ async fn validate_run(
         match state.upstream.cs_validate_code(&canonical, params).await {
             Ok(result) => WorkbenchResultView {
                 op: CsTab::Validate,
+                mode: submitted_mode,
                 request_url: result.request_url.clone(),
                 raw_body: result.raw_body.clone(),
                 lookup: None,
@@ -685,7 +706,9 @@ async fn validate_run(
             Err(err) => {
                 let request_url =
                     format!("{}/CodeSystem/$validate-code", state.upstream.base_url());
-                WorkbenchResultView::from_error(CsTab::Validate, request_url, &err)
+                let mut view = WorkbenchResultView::from_error(CsTab::Validate, request_url, &err);
+                view.mode = submitted_mode;
+                view
             }
         }
     };
@@ -731,6 +754,7 @@ async fn subsumes_run(
         match state.upstream.cs_subsumes(&canonical, params).await {
             Ok(result) => WorkbenchResultView {
                 op: CsTab::Subsumes,
+                mode: ValidateInputMode::default(),
                 request_url: result.request_url.clone(),
                 raw_body: result.raw_body.clone(),
                 lookup: None,

--- a/crates/hts-ui/templates/pages/cs-detail.html
+++ b/crates/hts-ui/templates/pages/cs-detail.html
@@ -241,6 +241,7 @@
           {% include "partials/hts-cs-lookup-input.html" %}
         {% when CsTab::Validate %}
           {% let summary = Some(summary.clone()) %}
+          {% let mode = self.mode() %}
           {% include "partials/hts-cs-validate-input.html" %}
         {% when CsTab::Subsumes %}
           {% let summary = Some(summary.clone()) %}

--- a/crates/hts-ui/templates/partials/hts-cs-validate-input.html
+++ b/crates/hts-ui/templates/partials/hts-cs-validate-input.html
@@ -6,9 +6,15 @@
   detail-page surface stays terse. The mode selector is still a real
   radio pair (now chip-shaped) so the nojs path submits a mode.
 
-  V3 layout: the form IS the card. `.card-head` + `.panel` for the bare-code
-  half, a second `.card-head` + `.panel` for the Coding half — the same
-  two-band idiom the workbench result uses.
+  V3 layout: the form IS the card. `.card-head` + `.panel` for the shared
+  heading and mode radios, then one `.validate-mode-panel` per mode so the
+  CSS-only `:has()` reveal (app.css, #804) can show only the active half —
+  mirroring the Bulk Export scope reveal. `mode` (`ValidateInputMode`,
+  context-provided by cs-detail.html's `{% let mode = self.mode() %}`)
+  drives which radio is `checked`, so a no-JS re-render keeps the
+  submitted mode selected and the CSS reveal in sync without a page
+  reload. Browsers without `:has()` show both halves — today's (buggy)
+  fallback behavior, same as Bulk Export.
 -#}
 <form id="hts-workbench-input"
       class="card"
@@ -27,51 +33,59 @@
     <div class="field" role="group" aria-labelledby="validate-mode-label">
       <span class="field__label" id="validate-mode-label">{{ chrome.i18n.t("hts-cs-validate-mode-legend") }}</span>
       <div class="facets facets--bare">
-        <label class="chip"><input type="radio" name="mode" value="code" checked> {{ chrome.i18n.t("hts-cs-validate-mode-code") }}</label>
-        <label class="chip"><input type="radio" name="mode" value="coding"> {{ chrome.i18n.t("hts-cs-validate-mode-coding") }}</label>
+        <label class="chip"><input type="radio" name="mode" value="code"{% if mode == ValidateInputMode::Code %} checked{% endif %}> {{ chrome.i18n.t("hts-cs-validate-mode-code") }}</label>
+        <label class="chip"><input type="radio" name="mode" value="coding"{% if mode == ValidateInputMode::Coding %} checked{% endif %}> {{ chrome.i18n.t("hts-cs-validate-mode-coding") }}</label>
       </div>
-    </div>
-
-    <div class="builder-grid">
-      <div class="field">
-        <label class="field__label" for="validate-code">{{ chrome.i18n.t("hts-cs-validate-code") }}</label>
-        <input class="field__input" id="validate-code" name="code" type="text" autocomplete="off" spellcheck="false">
-      </div>
-      <div class="field">
-        <label class="field__label" for="validate-display">{{ chrome.i18n.t("hts-cs-validate-display") }}</label>
-        <input class="field__input" id="validate-display" name="display" type="text" autocomplete="off" spellcheck="false">
-      </div>
-    </div>
-
-    <div class="field">
-      <label class="field__label" for="validate-display-language">{{ chrome.i18n.t("hts-cs-lookup-display-language") }}</label>
-      <input class="field__input" id="validate-display-language" name="displayLanguage" type="text" autocomplete="off" spellcheck="false"
-             placeholder="{{ chrome.i18n.t("hts-cs-lookup-display-language-placeholder") }}">
     </div>
   </div>
 
-  <div class="card-head">
-    <h3>{{ chrome.i18n.t("hts-cs-validate-coding-legend") }}</h3>
+  <div class="validate-mode-panel validate-mode-panel--code">
+    <div class="panel">
+      <div class="builder-grid">
+        <div class="field">
+          <label class="field__label" for="validate-code">{{ chrome.i18n.t("hts-cs-validate-code") }}</label>
+          <input class="field__input" id="validate-code" name="code" type="text" autocomplete="off" spellcheck="false">
+        </div>
+        <div class="field">
+          <label class="field__label" for="validate-display">{{ chrome.i18n.t("hts-cs-validate-display") }}</label>
+          <input class="field__input" id="validate-display" name="display" type="text" autocomplete="off" spellcheck="false">
+        </div>
+      </div>
+
+      <div class="field">
+        <label class="field__label" for="validate-display-language">{{ chrome.i18n.t("hts-cs-lookup-display-language") }}</label>
+        <input class="field__input" id="validate-display-language" name="displayLanguage" type="text" autocomplete="off" spellcheck="false"
+               placeholder="{{ chrome.i18n.t("hts-cs-lookup-display-language-placeholder") }}">
+      </div>
+    </div>
+  </div>
+
+  <div class="validate-mode-panel validate-mode-panel--coding">
+    <div class="card-head">
+      <h3>{{ chrome.i18n.t("hts-cs-validate-coding-legend") }}</h3>
+    </div>
+
+    <div class="panel">
+      <div class="builder-grid">
+        <div class="field">
+          <label class="field__label" for="validate-coding-system">{{ chrome.i18n.t("hts-cs-validate-coding-system") }}</label>
+          <input class="field__input" id="validate-coding-system" name="coding.system" type="text" autocomplete="off" spellcheck="false"
+                 value="{% if let Some(s) = summary %}{{ s.url }}{% endif %}">
+        </div>
+        <div class="field">
+          <label class="field__label" for="validate-coding-code">{{ chrome.i18n.t("hts-cs-validate-coding-code") }}</label>
+          <input class="field__input" id="validate-coding-code" name="coding.code" type="text" autocomplete="off" spellcheck="false">
+        </div>
+      </div>
+
+      <div class="field">
+        <label class="field__label" for="validate-coding-display">{{ chrome.i18n.t("hts-cs-validate-coding-display") }}</label>
+        <input class="field__input" id="validate-coding-display" name="coding.display" type="text" autocomplete="off" spellcheck="false">
+      </div>
+    </div>
   </div>
 
   <div class="panel">
-    <div class="builder-grid">
-      <div class="field">
-        <label class="field__label" for="validate-coding-system">{{ chrome.i18n.t("hts-cs-validate-coding-system") }}</label>
-        <input class="field__input" id="validate-coding-system" name="coding.system" type="text" autocomplete="off" spellcheck="false"
-               value="{% if let Some(s) = summary %}{{ s.url }}{% endif %}">
-      </div>
-      <div class="field">
-        <label class="field__label" for="validate-coding-code">{{ chrome.i18n.t("hts-cs-validate-coding-code") }}</label>
-        <input class="field__input" id="validate-coding-code" name="coding.code" type="text" autocomplete="off" spellcheck="false">
-      </div>
-    </div>
-
-    <div class="field">
-      <label class="field__label" for="validate-coding-display">{{ chrome.i18n.t("hts-cs-validate-coding-display") }}</label>
-      <input class="field__input" id="validate-coding-display" name="coding.display" type="text" autocomplete="off" spellcheck="false">
-    </div>
-
     <div class="form-actions">
       <button type="submit" class="btn btn--primary">{{ chrome.i18n.t("hts-workbench-run") }}</button>
     </div>

--- a/crates/hts-ui/templates/partials/hts-cs-validate-input.html
+++ b/crates/hts-ui/templates/partials/hts-cs-validate-input.html
@@ -40,6 +40,10 @@
   </div>
 
   <div class="validate-mode-panel validate-mode-panel--code">
+    <div class="card-head">
+      <h3>{{ chrome.i18n.t("hts-cs-validate-code-legend") }}</h3>
+    </div>
+
     <div class="panel">
       <div class="builder-grid">
         <div class="field">

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2848,6 +2848,18 @@ details.json-fold[open] > summary .icon {
   font-variant-numeric: tabular-nums;
 }
 
+/* A native radio/checkbox carries a UA margin that .chip's
+   align-items: center centers by margin box, not visible box — the
+   control lands a couple of px below the chip's vertical center (#804).
+   Same reset .choice-card already applies to its radios. */
+.chip input[type="radio"],
+.chip input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
 /* Data table */
 
 .table-wrap {
@@ -3319,6 +3331,22 @@ details.json-fold[open] > summary .icon {
 }
 
 .bulk-export-form:has(input[name="scope"][value="group"]:checked) .field--group-id {
+  display: block;
+}
+
+/* HTS CodeSystem $validate-code: show only the fields for the selected
+   input mode (#804), same CSS-only reveal idiom as the Bulk Export scope
+   field above. Browsers without :has() keep both halves visible — today's
+   (buggy) fallback behavior. */
+#hts-workbench-input .validate-mode-panel--coding {
+  display: none;
+}
+
+#hts-workbench-input:has(input[name="mode"][value="coding"]:checked) .validate-mode-panel--code {
+  display: none;
+}
+
+#hts-workbench-input:has(input[name="mode"][value="coding"]:checked) .validate-mode-panel--coding {
   display: block;
 }
 

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -1032,6 +1032,7 @@ hts-cs-validate-heading = Code validieren
 hts-cs-validate-mode-legend = Eingabemodus
 hts-cs-validate-mode-code = Einzelcode
 hts-cs-validate-mode-coding = Coding
+hts-cs-validate-code-legend = Einzelcode
 hts-cs-validate-code = Code
 hts-cs-validate-display = Anzeige
 hts-cs-validate-coding-legend = Coding

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -1033,6 +1033,7 @@ hts-cs-validate-heading = Validate a code
 hts-cs-validate-mode-legend = Input mode
 hts-cs-validate-mode-code = Bare code
 hts-cs-validate-mode-coding = Coding
+hts-cs-validate-code-legend = Bare code
 hts-cs-validate-code = Code
 hts-cs-validate-display = Display
 hts-cs-validate-coding-legend = Coding

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -1032,6 +1032,7 @@ hts-cs-validate-heading = Validar un código
 hts-cs-validate-mode-legend = Modo de entrada
 hts-cs-validate-mode-code = Código simple
 hts-cs-validate-mode-coding = Coding
+hts-cs-validate-code-legend = Código simple
 hts-cs-validate-code = Código
 hts-cs-validate-display = Visualización
 hts-cs-validate-coding-legend = Coding


### PR DESCRIPTION
## Summary

- The Bare code / Coding radio pair on the CodeSystem `$validate-code` workbench (`/ui/hts/code-systems/{id}/validate`) never hid the inactive half — both sets of fields rendered unconditionally regardless of the selected radio.
- The submitted mode never round-tripped into `checked` on a no-JS full-page re-render, so the form always came back showing "Bare code" selected.
- The chip radio control sat a couple of pixels below center in its `.chip` due to the browser's default UA margin on `<input type="radio">`.

## Fix

- `crates/hts-ui/templates/partials/hts-cs-validate-input.html`: split the bare-code and Coding sections into `.validate-mode-panel--code` / `.validate-mode-panel--coding` wrappers, and bind the radio `checked` state to a `mode` template variable.
- `crates/ui/assets/app.css`: add a CSS-only `:has()` reveal (`#hts-workbench-input:has(input[name="mode"][value="coding"]:checked) ...`), mirroring the existing Bulk Export scope-field pattern (`.bulk-export-form .field--group-id`). Also reset the UA margin on `.chip input[type="radio"|"checkbox"]` so the control is vertically centered, matching `.choice-card`'s existing reset.
- `crates/hts-ui/src/code_systems.rs`: thread the submitted `ValidateInputMode` from `validate_run` through `WorkbenchResultView` into `DetailPageTemplate::mode()`, so a no-JS re-render keeps the same radio checked.
- `crates/hts-ui/templates/pages/cs-detail.html`: pass `mode` into the Validate tab's input partial.

Closes #804

## Test plan

- [x] `cargo test -p helios-hts-ui` — all tests pass (including `cs_detail_templates_only_use_classes_that_exist_in_app_css`), except the pre-existing `chrome_parity::chevron_left_icon_matches_hfs` CRLF/LF drift on this Windows checkout, unrelated to this change.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (with the repo's standard `-A` allowlist) — clean.
- [x] `cargo fmt` — no changes needed.
- [ ] Manual check in browser: toggling Bare code / Coding shows only the active half's fields, and a no-JS submit preserves the selected mode.
