### PR TITLE
fix(hts-ui): give the disclosure folds a real expand affordance

### DIFF
--- a/crates/hts-ui/templates/pages/cm-detail.html
+++ b/crates/hts-ui/templates/pages/cm-detail.html
@@ -7,8 +7,10 @@
   Facts collapse into the page head as a `.facets.facets--bare` chip row
   (version / status / group count / publisher) plus the canonical URL in a
   `.detail__field--wide`; the full fact set — including the source/target
-  URIs — lives in a collapsed bare `<details>` disclosure inside a `.card`
-  so the Translate workbench starts high on the page.
+  URIs — lives in a collapsed fold inside a `.card` so the Translate
+  workbench starts high on the page. The fold uses HFS's shared
+  `.disclosure` / `.disclosure__summary` pattern (chevron icon included),
+  so it reads as clickable instead of as an inert label.
 
   Zero new CSS — see the guard test in tests/concept_maps.rs.
 -#}
@@ -89,8 +91,11 @@
     </header>
 
     <section class="card panel" style="margin-bottom:16px">
-      <details>
-        <summary class="field__label">{{ chrome.i18n.t("hts-cm-detail-facts-summary") }}</summary>
+      <details class="disclosure">
+        <summary class="disclosure__summary">
+          <span class="icon disclosure__chevron" aria-hidden="true">{% include "icons/chevron-down.svg" %}</span>
+          {{ chrome.i18n.t("hts-cm-detail-facts-summary") }}
+        </summary>
         <div class="kv-grid" style="margin:14px 0 0">
           <div class="detail__field detail__field--wide">
             <span>{{ chrome.i18n.t("hts-detail-canonical-url") }}</span>

--- a/crates/hts-ui/templates/pages/cs-detail.html
+++ b/crates/hts-ui/templates/pages/cs-detail.html
@@ -10,11 +10,14 @@
   fact set moves into a collapsed `<details>` disclosure so the workbench
   (tab strip + input form + result) starts high on the page.
 
-  The disclosure is a bare `<details>`/`<summary>` inside a `.card`,
-  exactly the idiom `crates/ui/templates/pages/capability-statement.html`
-  uses for its raw payload. It deliberately does NOT use `.addbox`: that
-  class is the Add-tenant dropdown, whose `.addbox__panel` is
-  `position: absolute` and would render this as a floating popover.
+  The disclosure is the shared `.disclosure` / `.disclosure__summary`
+  pattern from `crates/ui` (see `templates/pages/bulk-import.html`),
+  wrapped in a `.card`. It renders its own chevron `<span>` rather than
+  leaning on the native `::marker`: a `<summary>` paints that marker only
+  at `display: list-item`, so any class that restyles the summary drops
+  it. It deliberately does NOT use `.addbox`: that class is the
+  Add-tenant dropdown, whose `.addbox__panel` is `position: absolute` and
+  would render this as a floating popover.
 
   Zero new CSS: every class here already has a rule in
   `crates/ui/assets/app.css` (guarded by
@@ -108,13 +111,17 @@
     </header>
 
     {#-
-      Full fact set, collapsed. Bare <details>/<summary> so the native
-      disclosure triangle survives (a `display:flex` summary loses its
-      ::marker in every engine).
+      Full fact set, collapsed, on the shared `.disclosure` pattern. The
+      chevron is explicit markup because the native `::marker` only paints
+      at `display: list-item`: a styled summary — the old `.field__label`
+      included — loses the triangle and reads as an inert grey label.
     -#}
     <section class="card panel" style="margin-bottom:16px">
-      <details>
-        <summary class="field__label">{{ chrome.i18n.t("hts-cs-detail-facts-summary") }}</summary>
+      <details class="disclosure">
+        <summary class="disclosure__summary">
+          <span class="icon disclosure__chevron" aria-hidden="true">{% include "icons/chevron-down.svg" %}</span>
+          {{ chrome.i18n.t("hts-cs-detail-facts-summary") }}
+        </summary>
         <div class="kv-grid" style="margin:14px 0 0">
           <div class="detail__field detail__field--wide">
             <span>{{ chrome.i18n.t("hts-detail-canonical-url") }}</span>

--- a/crates/hts-ui/templates/pages/vs-detail.html
+++ b/crates/hts-ui/templates/pages/vs-detail.html
@@ -92,8 +92,11 @@
     </header>
 
     <section class="card panel" style="margin-bottom:16px">
-      <details>
-        <summary class="field__label">{{ chrome.i18n.t("hts-vs-detail-facts-summary") }}</summary>
+      <details class="disclosure">
+        <summary class="disclosure__summary">
+          <span class="icon disclosure__chevron" aria-hidden="true">{% include "icons/chevron-down.svg" %}</span>
+          {{ chrome.i18n.t("hts-vs-detail-facts-summary") }}
+        </summary>
         <div class="kv-grid" style="margin:14px 0 0">
           <div class="detail__field detail__field--wide">
             <span>{{ chrome.i18n.t("hts-detail-canonical-url") }}</span>

--- a/crates/hts-ui/templates/partials/hts-cm-translate-result.html
+++ b/crates/hts-ui/templates/partials/hts-cm-translate-result.html
@@ -143,8 +143,11 @@
       readable summary stays visually primary. -#}
   {% if !view.raw_body.is_empty() || !view.request_url.is_empty() %}
   <section class="card panel">
-    <details>
-      <summary class="field__label">{{ chrome.i18n.t("hts-workbench-raw-response") }}</summary>
+    <details class="disclosure">
+      <summary class="disclosure__summary">
+        <span class="icon disclosure__chevron" aria-hidden="true">{% include "icons/chevron-down.svg" %}</span>
+        {{ chrome.i18n.t("hts-workbench-raw-response") }}
+      </summary>
       {% if !view.request_url.is_empty() %}
       <div class="kv-grid" style="margin:14px 0">
         <div class="detail__field detail__field--wide">

--- a/crates/hts-ui/templates/partials/hts-cs-workbench-result.html
+++ b/crates/hts-ui/templates/partials/hts-cs-workbench-result.html
@@ -11,10 +11,12 @@
   V3 layout: every result is a `.card` with a `.card-head` (`<h3>`, not the
   old `<h5>`-shaped hook that rendered below body size) and one or more
   `.panel` bands of `.kv-grid` / `.detail__field` pairs. The raw echo is a
-  bare `<details>` inside its own `.card`, exactly as
-  `crates/ui/templates/pages/capability-statement.html` renders its raw
-  payload — deliberately NOT `.addbox`, which is the Add-tenant dropdown
-  and would float this over the page.
+  `.disclosure` — the shared fold pattern from `crates/ui` (see
+  `templates/pages/bulk-import.html`) — inside its own `.card`. It draws
+  its own chevron `<span>`: a `<summary>` shows the native `::marker` only
+  at `display: list-item`, so a styled summary has no marker to inherit.
+  Deliberately NOT `.addbox`, which is the Add-tenant dropdown and would
+  float this over the page.
 
   Fluent keys: op-specific under `hts-cs-lookup-*` / `hts-cs-validate-*` /
   `hts-cs-subsumes-*`; shared under `hts-workbench-*` (reused by Slice C/D/E).
@@ -191,13 +193,18 @@
   {% endif %}
 
   {#- Raw request + response echo (§7.3 wireframe). Kept last so the
-      readable summary above stays visually primary. A bare
-      <details>/<summary> keeps the native disclosure marker; `.detail__code`
-      is the shared preformatted-payload token. -#}
+      readable summary above stays visually primary. The shared
+      `.disclosure` pattern supplies the chevron and the pointer cursor —
+      the native `::marker` needs `display: list-item` and no styled
+      summary keeps it; `.detail__code` is the shared preformatted-payload
+      token. -#}
   {% if !view.raw_body.is_empty() || !view.request_url.is_empty() %}
   <section class="card panel">
-    <details>
-      <summary class="field__label">{{ chrome.i18n.t("hts-workbench-raw-response") }}</summary>
+    <details class="disclosure">
+      <summary class="disclosure__summary">
+        <span class="icon disclosure__chevron" aria-hidden="true">{% include "icons/chevron-down.svg" %}</span>
+        {{ chrome.i18n.t("hts-workbench-raw-response") }}
+      </summary>
       {% if !view.request_url.is_empty() %}
       <div class="kv-grid" style="margin:14px 0">
         <div class="detail__field detail__field--wide">

--- a/crates/hts-ui/templates/partials/hts-vs-expand-input.html
+++ b/crates/hts-ui/templates/partials/hts-vs-expand-input.html
@@ -29,8 +29,16 @@
                                             _SIZE_HINT for the tooltip
 
   V3 layout: the form IS the card — `.card-head` heading + `.panel` field
-  stack (design doc §9 form contract); the Advanced disclosure is a bare
-  `<details>` (never `.addbox`, which floats as a dropdown panel).
+  stack (design doc §9 form contract); the Advanced fold is the shared
+  `.disclosure` pattern (never `.addbox`, which floats as a dropdown panel).
+
+  #806: the fold used to be a `<details>` whose `<summary>` carried
+  `.field__label`. That is `display:block`, and a `<summary>` only draws its
+  native ::marker at `display:list-item` — so the triangle was gone in every
+  engine and `.field__label` sets no `cursor`, leaving the fold looking like
+  the inert grey labels around it. `.disclosure` (crates/ui/assets/app.css,
+  shared with HFS via the embedded asset dir) draws an explicit chevron that
+  rotates on `[open]` instead of relying on a marker no styled summary keeps.
 -#}
 <form id="hts-workbench-input"
       class="card"
@@ -121,13 +129,14 @@
       </div>
     </div>
 
-    <details id="expand-advanced">
-      <summary class="field__label"
+    <details class="disclosure" id="expand-advanced">
+      <summary class="disclosure__summary"
                title="{{ chrome.i18n.t_arg("hts-vs-expand-ceiling-tooltip", "ceiling", ceiling.to_string()) }}">
+        <span class="icon disclosure__chevron" aria-hidden="true">{% include "icons/chevron-down.svg" %}</span>
         {{ chrome.i18n.t("hts-vs-expand-advanced-summary") }}
       </summary>
 
-      <div style="margin-top:14px">
+      <div class="disclosure__body">
         <div class="field">
           <label class="field__label" for="expand-date">{{ chrome.i18n.t("hts-vs-expand-date") }}</label>
           <input class="field__input" id="expand-date" name="date" type="text" autocomplete="off" spellcheck="false"

--- a/crates/hts-ui/templates/partials/hts-vs-expand-result.html
+++ b/crates/hts-ui/templates/partials/hts-vs-expand-result.html
@@ -202,8 +202,11 @@
 
       {% if !result.echoed_parameters.is_empty() %}
       <div class="panel">
-        <details>
-          <summary class="field__label">{{ chrome.i18n.t("hts-vs-expand-echoed-parameters") }}</summary>
+        <details class="disclosure">
+          <summary class="disclosure__summary">
+            <span class="icon disclosure__chevron" aria-hidden="true">{% include "icons/chevron-down.svg" %}</span>
+            {{ chrome.i18n.t("hts-vs-expand-echoed-parameters") }}
+          </summary>
           <div class="kv-grid" style="margin:14px 0 0">
             {% for entry in result.echoed_parameters %}
             <div class="detail__field">
@@ -222,8 +225,11 @@
       readable summary stays visually primary. -#}
   {% if !view.raw_body.is_empty() || !view.request_url.is_empty() %}
   <section class="card panel">
-    <details>
-      <summary class="field__label">{{ chrome.i18n.t("hts-workbench-raw-response") }}</summary>
+    <details class="disclosure">
+      <summary class="disclosure__summary">
+        <span class="icon disclosure__chevron" aria-hidden="true">{% include "icons/chevron-down.svg" %}</span>
+        {{ chrome.i18n.t("hts-workbench-raw-response") }}
+      </summary>
       {% if !view.request_url.is_empty() %}
       <div class="kv-grid" style="margin:14px 0">
         <div class="detail__field detail__field--wide">

--- a/crates/hts-ui/tests/code_systems.rs
+++ b/crates/hts-ui/tests/code_systems.rs
@@ -659,11 +659,16 @@ fn cs_detail_templates_only_use_classes_that_exist_in_app_css() {
 
 /// The V3 compact header: facts collapse into a `.facets.facets--bare`
 /// chip row plus one `.detail__field--wide` canonical URL, and the full
-/// fact set lives behind a collapsed bare `<details>` — never `.addbox`,
+/// fact set lives behind a collapsed `.disclosure` fold — never `.addbox`,
 /// which is the Add-tenant dropdown and renders as a floating popover.
 /// Since #801 the head also takes the HFS back-link idiom: a
 /// `.page-head--back-link` modifier, a leading `.back-link`, and the rest
 /// of the head wrapped in `.page-head__copy`.
+///
+/// Since #806 the fold is the shared `.disclosure` pattern rather than a
+/// `<summary class="field__label">`: that class is `display: block`, which
+/// suppresses the native `::marker` (it only paints at
+/// `display: list-item`) and sets no `cursor`, so the fold looked inert.
 #[test]
 fn cs_detail_page_uses_the_v3_compact_header_shape() {
     const PAGE: &str = include_str!("../templates/pages/cs-detail.html");
@@ -678,13 +683,21 @@ fn cs_detail_page_uses_the_v3_compact_header_shape() {
         r#"class="facets facets--bare""#,
         r#"class="facet-label""#,
         r#"class="detail__field detail__field--wide""#,
-        r#"<summary class="field__label">"#,
+        r#"<details class="disclosure">"#,
+        r#"<summary class="disclosure__summary">"#,
+        r#"<span class="icon disclosure__chevron" aria-hidden="true">"#,
     ] {
         assert!(
             body.contains(hook),
             "V3 compact header must render `{hook}`"
         );
     }
+    // The summary now spans several lines (chevron span, then the label),
+    // so the label text is asserted separately from the markup shape.
+    assert!(
+        body.contains(r#"{{ chrome.i18n.t("hts-cs-detail-facts-summary") }}"#),
+        "the facts fold must still be labelled by `hts-cs-detail-facts-summary`",
+    );
     for dead in [
         "page-header",
         "addbox",
@@ -704,4 +717,43 @@ fn cs_detail_page_uses_the_v3_compact_header_shape() {
         !body.contains("<details open"),
         "the facts disclosure must render collapsed",
     );
+}
+
+/// Regression guard for #806: no CodeSystem-surface fold may go back to
+/// `<summary class="field__label">`. `.field__label` is `display: block`,
+/// which strips the native `::marker` (a `<summary>` only draws one at
+/// `display: list-item`) and sets no `cursor`, so such a fold renders as an
+/// inert grey label with no disclosure affordance at all. Folds use the
+/// shared `.disclosure` pattern, which ships its own chevron and cursor.
+#[test]
+fn cs_detail_folds_never_reuse_the_markerless_field_label_summary() {
+    let templates = [
+        (
+            "pages/cs-detail.html",
+            include_str!("../templates/pages/cs-detail.html"),
+        ),
+        (
+            "partials/hts-cs-workbench-result.html",
+            include_str!("../templates/partials/hts-cs-workbench-result.html"),
+        ),
+    ];
+
+    for (name, template) in templates {
+        let body = strip_template_comments(template);
+        assert!(
+            !body.contains(r#"<summary class="field__label""#),
+            "{name} must fold with `.disclosure`, not a markerless \
+             `<summary class=\"field__label\">`",
+        );
+        // …and it must actually carry the replacement, so deleting the fold
+        // outright cannot satisfy the guard above.
+        assert!(
+            body.contains(r#"<summary class="disclosure__summary">"#),
+            "{name} must render the shared `.disclosure__summary` fold",
+        );
+        assert!(
+            body.contains(r#"class="icon disclosure__chevron""#),
+            "{name}'s fold must render the explicit `.disclosure__chevron`",
+        );
+    }
 }

--- a/crates/hts-ui/tests/concept_maps.rs
+++ b/crates/hts-ui/tests/concept_maps.rs
@@ -1272,7 +1272,15 @@ fn cm_detail_page_uses_the_v3_compact_header_shape() {
         r#"class="page-head__title""#,
         r#"class="facets facets--bare""#,
         r#"class="detail__field detail__field--wide""#,
-        r#"<summary class="field__label">"#,
+        // #806: the facts fold uses HFS's shared `.disclosure` pattern, so
+        // the summary is a `list-item` with a chevron and a pointer cursor.
+        // The summary now spans several lines, so the class and the label
+        // are pinned separately rather than as one `<summary …>…</summary>`.
+        r#"<details class="disclosure">"#,
+        r#"<summary class="disclosure__summary">"#,
+        r#"<span class="icon disclosure__chevron" aria-hidden="true">"#,
+        r#"{% include "icons/chevron-down.svg" %}"#,
+        r#"{{ chrome.i18n.t("hts-cm-detail-facts-summary") }}"#,
     ] {
         assert!(
             body.contains(hook),
@@ -1296,6 +1304,40 @@ fn cm_detail_page_uses_the_v3_compact_header_shape() {
         !body.contains("<details open"),
         "the facts disclosure must render collapsed",
     );
+}
+
+/// #806 regression guard: a `<summary>` carrying `.field__label` is
+/// `display: block`, so the browser draws no disclosure marker, and the
+/// rule sets no `cursor` — the fold looked like an inert grey label. The
+/// ConceptMap templates must keep using the shared `.disclosure` pattern
+/// and must never reintroduce that summary class.
+#[test]
+fn cm_detail_folds_never_reintroduce_the_markerless_field_label_summary() {
+    let templates = [
+        (
+            "pages/cm-detail.html",
+            include_str!("../templates/pages/cm-detail.html"),
+        ),
+        (
+            "partials/hts-cm-translate-result.html",
+            include_str!("../templates/partials/hts-cm-translate-result.html"),
+        ),
+    ];
+
+    for (name, template) in templates {
+        let body = strip_template_comments(template);
+        assert!(
+            !body.contains(r#"<summary class="field__label""#),
+            "{name} must not pin a `.field__label` summary: it kills the \
+             native disclosure marker and leaves no pointer cursor (#806)",
+        );
+        assert!(
+            body.contains(r#"<details class="disclosure">"#)
+                && body.contains(r#"<summary class="disclosure__summary">"#)
+                && body.contains(r#"class="icon disclosure__chevron""#),
+            "{name} must use the shared `.disclosure` fold shape",
+        );
+    }
 }
 
 /// Reverse-mode `$translate` responses carry no `originMap`, so the Origin

--- a/crates/hts-ui/tests/value_sets.rs
+++ b/crates/hts-ui/tests/value_sets.rs
@@ -619,10 +619,21 @@ async fn expand_input_shows_advanced_details_and_threshold_field() {
         "Advanced panel must expose a `threshold` numeric input",
     );
     // The V3 layout pass dropped every `hts-*` class hook (none of them had
-    // a rule in app.css); the Advanced disclosure is now addressed by id.
+    // a rule in app.css); the Advanced disclosure is now addressed by id and
+    // takes the shared `.disclosure` pattern from app.css (#806).
     assert!(
-        html.contains(r#"<details id="expand-advanced">"#),
-        "Advanced <details> must render with its stable id",
+        html.contains(r#"<details class="disclosure" id="expand-advanced">"#),
+        "Advanced <details> must render as a `.disclosure` with its stable id",
+    );
+    // Affordance guard (#806): a bare `<summary class="field__label">` has no
+    // marker and no pointer cursor, so the fold reads as an inert label.
+    assert!(
+        html.contains(r#"<summary class="disclosure__summary""#),
+        "the Advanced summary must carry `disclosure__summary`",
+    );
+    assert!(
+        html.contains(r#"<span class="icon disclosure__chevron" aria-hidden="true">"#),
+        "the Advanced summary must render the disclosure chevron",
     );
     assert!(
         html.contains("value=\"tree\"") && html.contains("value=\"flat\""),
@@ -1154,6 +1165,53 @@ fn vs_detail_templates_only_use_classes_that_exist_in_app_css() {
     );
 }
 
+/// #806 regression guard: no ValueSet detail template may fold content
+/// behind a `<summary class="field__label">`. `.field__label` is
+/// `display:block`, and a `<summary>` only paints its native ::marker at
+/// `display:list-item` — so such a fold renders as an inert grey label with
+/// no triangle and no pointer cursor. Every fold must take the shared
+/// `.disclosure` / `.disclosure__summary` pattern from app.css instead.
+#[test]
+fn vs_detail_templates_never_fold_behind_a_bare_field_label_summary() {
+    let templates = [
+        (
+            "pages/vs-detail.html",
+            include_str!("../templates/pages/vs-detail.html"),
+        ),
+        (
+            "partials/hts-vs-expand-input.html",
+            include_str!("../templates/partials/hts-vs-expand-input.html"),
+        ),
+        (
+            "partials/hts-vs-expand-result.html",
+            include_str!("../templates/partials/hts-vs-expand-result.html"),
+        ),
+    ];
+
+    let mut summaries = 0usize;
+    for (name, template) in templates {
+        let body = strip_template_comments(template);
+        assert!(
+            !body.contains(r#"<summary class="field__label""#),
+            "{name} still folds content behind `<summary class=\"field__label\"`; \
+             use the shared `.disclosure` pattern (app.css) so the fold keeps \
+             its marker and pointer cursor",
+        );
+        for chunk in body.split("<summary").skip(1) {
+            let open = chunk.split('>').next().unwrap_or_default();
+            assert!(
+                open.contains(r#"class="disclosure__summary""#),
+                "a <summary> in {name} must carry `disclosure__summary`, got `<summary{open}>`",
+            );
+            summaries += 1;
+        }
+    }
+    assert!(
+        summaries >= 4,
+        "expected the scan to reach every fold, only saw {summaries}",
+    );
+}
+
 /// The V3 compact header on the ValueSet detail page. Since #801 it also
 /// takes the HFS back-link idiom: a `.page-head--back-link` modifier, a
 /// leading `.back-link`, and the rest of the head wrapped in
@@ -1170,7 +1228,11 @@ fn vs_detail_page_uses_the_v3_compact_header_shape() {
         r#"class="page-head__title""#,
         r#"class="facets facets--bare""#,
         r#"class="detail__field detail__field--wide""#,
-        r#"<summary class="field__label">"#,
+        // #806: the facts fold uses the shared `.disclosure` pattern, so it
+        // keeps a native marker and a pointer cursor.
+        r#"<details class="disclosure">"#,
+        r#"<summary class="disclosure__summary">"#,
+        r#"<span class="icon disclosure__chevron" aria-hidden="true">"#,
     ] {
         assert!(
             body.contains(hook),
@@ -1222,7 +1284,13 @@ async fn vs_detail_renders_the_compact_header_from_a_live_summary() {
         r#"class="facets facets--bare""#,
         ">Facts<",
         "http://example.org/vs/example",
-        r#"<summary class="field__label">All ValueSet facts</summary>"#,
+        // #806: the facts fold takes the shared `.disclosure` pattern, so the
+        // summary is a multi-line element (chevron span + label) rather than
+        // the old flat `<summary class="field__label">…</summary>`.
+        r#"<details class="disclosure">"#,
+        r#"<summary class="disclosure__summary">"#,
+        r#"<span class="icon disclosure__chevron" aria-hidden="true">"#,
+        "All ValueSet facts",
     ] {
         assert!(
             html.contains(hook),
@@ -1244,8 +1312,23 @@ async fn vs_detail_renders_the_compact_header_from_a_live_summary() {
     let workbench = html
         .find(r#"id="hts-workbench-input""#)
         .expect("workbench form present");
+    // `All ValueSet facts` is rendered exactly once (only `pages/vs-detail.html`
+    // uses `hts-vs-detail-facts-summary`), so it is a stable ordering anchor
+    // now that the summary itself spans multiple lines.
     let disclosure = html
-        .find(r#"<summary class="field__label">All ValueSet facts</summary>"#)
+        .find("All ValueSet facts")
         .expect("facts disclosure present");
+    // …and that label must sit inside the disclosure summary, not loose in
+    // the body: the affordance and the text belong to the same element.
+    let summary = html
+        .find(r#"<summary class="disclosure__summary">"#)
+        .expect("facts disclosure summary present");
+    assert!(
+        html[summary..]
+            .split("</summary>")
+            .next()
+            .is_some_and(|open| open.contains("All ValueSet facts")),
+        "the facts label must render inside the `.disclosure__summary`",
+    );
     assert!(head < disclosure && disclosure < workbench);
 }

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -3226,6 +3226,16 @@ details.json-fold[open] > summary .icon {
   margin: 14px 0;
 }
 
+/* #806: the HTS folds adopting this pattern sit directly in a `.panel`,
+   usually as the card's only child. `.panel`'s own 18px padding already
+   spaces them, and a panel is a plain block — so the margin above cannot
+   collapse into anything and would simply make every collapsed card 28px
+   taller. The dialog folds this pattern was written for are not in a
+   `.panel`, so they keep the default. */
+.panel > .disclosure {
+  margin: 0;
+}
+
 .disclosure__summary {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Closes #806.

## The bug

Every collapsible fold in the HTS UI rendered as `<details>` with `<summary class="field__label">`. That looks harmless, but:

- `.field__label` is `display: block`, and a `<summary>` paints its native `::marker` only at `display: list-item` — so the disclosure triangle was gone in **every** engine.
- `.field__label` sets no `cursor`, so the pointer stayed an arrow.
- It inherits the same muted colour and weight as every field label beside it.

The result read as an inert grey line, with nothing to suggest it opens.

## The fix

Adopt HFS's existing `.disclosure` pattern — a chevron that rotates on `[open]`, `cursor: pointer`, and a `:hover` shift from `--muted` to `--text`. `hts-ui` embeds `crates/ui/assets`, so those rules were already being served, and `chevron-down.svg` was already in `crates/hts-ui/templates/icons/`. No new classes were needed.

The issue was raised against the ValueSet `$expand` Advanced fold, but the same defect was on all eight folds, so they are all converted here rather than left for seven follow-ups:

| Fold | File |
|---|---|
| `$expand` Advanced panel | `partials/hts-vs-expand-input.html` |
| ValueSet facts | `pages/vs-detail.html` |
| CodeSystem facts | `pages/cs-detail.html` |
| ConceptMap facts | `pages/cm-detail.html` |
| Echoed parameters | `partials/hts-vs-expand-result.html` |
| Raw request/response ×3 | `partials/hts-vs-expand-result.html`, `partials/hts-cs-workbench-result.html`, `partials/hts-cm-translate-result.html` |

`#expand-advanced` keeps its id, and the ceiling tooltip stays on the summary.

## One deviation from the issue

The issue expected zero new CSS. One rule was needed:

```css
.panel > .disclosure { margin: 0; }
```

`.disclosure`'s `margin: 14px 0` was written for the Bulk Submission dialog, where it collapses against sibling form fields. Inside a `.panel` the fold is the card's only child and the panel's own 18px padding is a block boundary, so the margin cannot collapse — all seven card-hosted folds would have grown 28px taller. With this rule the rendered spacing is identical to before, keeping the change purely about affordance.

Also worth recording: the issue states the too-costly banner's "Raise" action references `#expand-advanced`. It does not — the Raise form is self-contained and merely shares the `threshold` key. The id is kept regardless (a test pins it).

## Tests

Six assertions across `value_sets.rs`, `code_systems.rs` and `concept_maps.rs` pinned the old markup as an exact string. They now pin the new shape, and each ended up **stricter** — a multi-line summary needs its class, its chevron and its label asserted separately, so single hooks became three to five.

Three new regression guards fail if any of these templates reverts to a markerless `<summary class="field__label">`. Each asserts the positive shape too, so deleting a fold cannot satisfy the negative half.

The existing `*_templates_only_use_classes_that_exist_in_app_css` guards stay green.

## Verification

- `cargo clippy --all-targets --all-features` with CI's eight `-A` flags — clean, zero warnings
- `cargo fmt` — clean
- `cargo test --no-fail-fast` — 5758 passed, 84 ignored

Two pre-existing failures are unrelated to this branch and untouched by it:

- `chevron_left_icon_matches_hfs` — the committed `crates/hts-ui/templates/icons/chevron-left.svg` has CRLF where the `crates/ui` copy has LF. `origin/fix/chevron-parity-line-endings` already exists for this.
- `helios-auth --test jwks_bearer_e2e` (10 tests) — the local wiremock JWKS server is unreachable over loopback on the dev machine; environmental, reproduces with the sandbox disabled.

## Notes for review

- #803 also touches the raw request/response fold as part of a larger change. It has no branch or PR yet, so there is no collision today — but whoever picks it up should rebase onto this.
- Four other bare-`<summary>` folds exist outside this issue's scope (`hts-concept-identity`, `hts-concept-mappings`, `hts-import-status` ×4, `capability-statement`). Those have no class on the summary, so they *do* show the native marker and are functional — just visually inconsistent with the new pattern. Left alone deliberately; converting them is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
