### PR TITLE
feat(ui): enhance CapabilityStatement cards and JSON controls

### DIFF
--- a/crates/hts-ui/e2e/tests/a11y.spec.ts
+++ b/crates/hts-ui/e2e/tests/a11y.spec.ts
@@ -80,4 +80,20 @@ for (const theme of THEMES) {
       ).toEqual([]);
     });
   }
+
+  test(`expanded HTS CapabilityStatement JSON is accessible — ${theme}`, async ({ page }) => {
+    test.setTimeout(120_000);
+    await page.addInitScript((t) => {
+      try {
+        localStorage.setItem("hfs-theme", t as string);
+      } catch {}
+    }, theme);
+    await page.goto("/ui/hts/capability-statement", { waitUntil: "networkidle" });
+    const region = page.locator("#capability-json-body");
+    await page.locator("[data-capability-json-expand-all]").click();
+    await expect(region).not.toHaveAttribute("aria-busy", "true");
+    await expect(page.locator("[data-capability-json-tree] > [data-expansion-state]")).toBeVisible();
+    const { violations } = await new AxeBuilder({ page }).withTags(WCAG).analyze();
+    expect(violations).toEqual([]);
+  });
 }

--- a/crates/hts-ui/e2e/tests/capability.spec.ts
+++ b/crates/hts-ui/e2e/tests/capability.spec.ts
@@ -1,4 +1,17 @@
 import { expect, test } from "@playwright/test";
+import type { Locator } from "@playwright/test";
+
+async function openJsonNode(scope: Locator, key: string): Promise<Locator> {
+  const node = scope
+    .locator("summary.capability-json-row")
+    .filter({ hasText: `"${key}":` })
+    .locator("..")
+    .first();
+  const body = node.locator(":scope > [data-capability-json-body]");
+  await node.locator(":scope > summary").click();
+  await expect(body.locator("[data-capability-json-page], .json-view").first()).toBeVisible();
+  return node;
+}
 
 // The Capability & Conformance page at `/ui/hts/capability-statement`.
 //
@@ -9,8 +22,8 @@ import { expect, test } from "@playwright/test";
 // lived at `/ui/hts/diagnostics` until this rename; that path now 308s here.
 //
 // Mirrors the Rust-side coverage in `crates/hts-ui/tests/capability.rs` but
-// exercises what HTML-only Rust tests cannot reach: real layout, real
-// `<details>` disclosure behaviour, and heading structure as the
+// exercises what HTML-only Rust tests cannot reach: real layout, aggregate
+// expansion behaviour, and heading structure as the
 // accessibility tree sees it.
 //
 // Handler: `crates/hts-ui/src/capability.rs`. Template:
@@ -66,7 +79,7 @@ test.describe("HTS Capability & Conformance shell", () => {
     ).toBe(PATH);
   });
 
-  test("carries no tab strip and no JS-only affordance", async ({ page }) => {
+  test("carries no tab strip and uses the shared raw-tree affordance", async ({ page }) => {
     await page.goto(PATH);
     // The tab era is over: no tablist, no tabs, no tabpanel, no
     // `#diag-panel` swap target.
@@ -74,8 +87,10 @@ test.describe("HTS Capability & Conformance shell", () => {
     await expect(page.getByRole("tab")).toHaveCount(0);
     await expect(page.getByRole("tabpanel")).toHaveCount(0);
     await expect(page.locator("#diag-panel")).toHaveCount(0);
-    // Nothing on the page swaps over htmx, so nothing breaks without JS.
-    await expect(page.locator("[hx-get]")).toHaveCount(0);
+    const raw = page.locator("#capability-json-fold");
+    await expect(raw.locator(":scope > .card-head > h3")).toHaveText(/^Raw CapabilityStatement/);
+    await expect(raw.locator(":scope > .card-head > [data-capability-json-actions]")).toBeVisible();
+    await expect(raw.locator("[data-capability-json-tree] > [data-path='']")).toBeVisible();
   });
 
   test("nav exposes HFS's own label, after Import", async ({ page }) => {
@@ -152,21 +167,151 @@ test.describe("HTS Capability & Conformance card content", () => {
     await expect(card).not.toContainText(/Base URL/i);
   });
 
-  test("the raw statement hides behind a <details>", async ({ page }) => {
+  test("the raw statement starts at the first level and expands through one POST", async ({ page }) => {
+    test.setTimeout(120_000);
     await page.goto(PATH);
-    const card = page.locator("section.card").last();
-    // A bare <details> + <summary> + `.detail__code`, the same disclosure
-    // HFS uses. Never `.addbox` — that is the Add-tenant dropdown and
-    // `.addbox__panel` is absolutely positioned, so it would float a 340px
-    // popover.
+    const card = page.locator("#capability-json-fold");
     await expect(card.locator(".addbox")).toHaveCount(0);
-    const body = card.locator("pre.detail__code");
-    // Collapsed by default — the payload is opt-in noise.
-    await expect(body).toBeHidden();
-    await card.locator("details summary").click();
-    await expect(body).toBeVisible();
-    await expect(body).toContainText(/CapabilityStatement/);
+    const region = card.locator("#capability-json-body");
+    const tree = card.locator("[data-capability-json-tree]");
+    const initial = await tree.innerHTML();
+    await expect(region).toHaveAttribute("role", "region");
+    await expect(region).toHaveAttribute("aria-labelledby", "capability-json-heading");
+    await expect(region).toHaveAttribute("tabindex", "0");
+    await expect(region).toHaveCSS("overflow-y", "auto");
+    expect(parseFloat(await region.evaluate((node) => getComputedStyle(node).maxHeight))).toBeGreaterThan(0);
+    await expect(tree.locator(":scope > [data-path=''][data-offset='0']")).toBeVisible();
+    await expect(tree.locator("details[open]")).toHaveCount(0);
+
+    const requests: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    page.on("request", (request) => {
+      if (request.method() === "POST" && new URL(request.url()).pathname.endsWith("/json-expand")) {
+        requests.push(request.postData() ?? "");
+      }
+    });
+    await page.route("**/ui/hts/capability-statement/json-expand", async (route) => {
+      await gate;
+      await route.continue();
+    });
+    await card.locator("[data-capability-json-expand-all]").click();
+    await expect(region).toHaveAttribute("aria-busy", "true");
+    await expect(card.locator("[data-capability-json-status]")).toContainText(/Expanding/i);
+    await expect(card.locator("[data-capability-json-collapse-all]")).toBeEnabled();
+    expect(requests).toHaveLength(1);
+    release();
+    await expect(region).not.toHaveAttribute("aria-busy", "true");
+    expect(requests).toHaveLength(1);
+    const form = new URLSearchParams(requests[0]);
+    expect(form.getAll("path")).toContain("");
+    await expect(tree.locator(":scope > [data-expansion-state]")).toHaveAttribute(
+      "data-expansion-state", /complete|partial/,
+    );
+    await expect(card.locator("[data-capability-json-status]")).toContainText(/expanded|limit|partially/i);
+
+    await card.locator("[data-capability-json-collapse-all]").click();
+    expect(await tree.innerHTML()).toBe(initial);
+    await expect(card).toBeVisible();
+    await expect(tree.locator("details[open]")).toHaveCount(0);
+
+    const outline = tree.locator(":scope > [data-capability-json-page]");
+    const format = await openJsonNode(outline, "format");
+    const rest = await openJsonNode(outline, "rest");
+    await expect(format).toHaveAttribute("open", "");
+    await expect(rest).toHaveAttribute("open", "");
   });
+
+  test("Collapse all cancels a late HTS aggregate response", async ({ page }) => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    await page.route("**/ui/hts/capability-statement/json-expand", async (route) => {
+      await gate;
+      try {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/html",
+          body: '<div data-expansion-state="complete"><p id="late-hts-json">late</p></div>',
+        });
+      } catch {}
+    });
+    await page.goto(PATH);
+    const card = page.locator("#capability-json-fold");
+    const region = card.locator("#capability-json-body");
+    const tree = card.locator("[data-capability-json-tree]");
+    const initial = await tree.innerHTML();
+    await card.locator("[data-capability-json-expand-all]").click();
+    await expect(region).toHaveAttribute("aria-busy", "true");
+    await card.locator("[data-capability-json-collapse-all]").click();
+    release();
+    await page.waitForTimeout(100);
+    await expect(page.locator("#late-hts-json")).toHaveCount(0);
+    await expect(region).not.toHaveAttribute("aria-busy", "true");
+    expect(await tree.innerHTML()).toBe(initial);
+  });
+
+  test("the expanded HTS tree scrolls by wheel and PageDown", async ({ page }) => {
+    test.setTimeout(120_000);
+    await page.setViewportSize({ width: 1280, height: 500 });
+    await page.goto(PATH);
+    const card = page.locator("#capability-json-fold");
+    const region = card.locator("#capability-json-body");
+    await card.locator("[data-capability-json-expand-all]").click();
+    await expect(region).not.toHaveAttribute("aria-busy", "true");
+    expect(await region.evaluate((node) => node.scrollHeight)).toBeGreaterThan(
+      await region.evaluate((node) => node.clientHeight),
+    );
+    await region.evaluate((node) => { node.scrollTop = 0; });
+    await region.hover();
+    await page.mouse.wheel(0, 500);
+    await expect.poll(() => region.evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
+    const afterWheel = await region.evaluate((node) => node.scrollTop);
+    await region.focus();
+    await page.keyboard.press("PageDown");
+    await expect.poll(() => region.evaluate((node) => node.scrollTop)).toBeGreaterThan(afterWheel);
+  });
+
+  test("aggregate failure retains the HTS tree and retry succeeds", async ({ page }) => {
+    let fail = true;
+    await page.route("**/ui/hts/capability-statement/json-expand", async (route) => {
+      if (fail) {
+        fail = false;
+        await route.fulfill({ status: 503, body: "temporarily unavailable" });
+      } else {
+        await route.continue();
+      }
+    });
+    await page.goto(PATH);
+    const card = page.locator("#capability-json-fold");
+    const tree = card.locator("[data-capability-json-tree]");
+    const initial = await tree.innerHTML();
+    await card.locator("[data-capability-json-expand-all]").click();
+    await expect(card.locator("[data-capability-json-status]")).toContainText(/could not|try again|error/i);
+    expect(await tree.innerHTML()).toBe(initial);
+    await card.locator("[data-capability-json-expand-all]").click();
+    await expect(tree.locator(":scope > [data-expansion-state]")).toBeVisible();
+  });
+
+  for (const theme of ["light", "dark"] as const) {
+    test(`raw toolbar wraps without horizontal overflow at 390px — ${theme}`, async ({ page }) => {
+      await page.addInitScript((value) => localStorage.setItem("hfs-theme", value), theme);
+      await page.setViewportSize({ width: 390, height: 844 });
+      await page.goto(PATH);
+      await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+      const metrics = await page.locator("#capability-json-fold").evaluate((card) => {
+        const header = card.querySelector<HTMLElement>(":scope > .card-head")!;
+        const tools = header.querySelector<HTMLElement>("[data-capability-json-actions]")!;
+        const box = card.getBoundingClientRect();
+        const toolsBox = tools.getBoundingClientRect();
+        return {
+          wraps: getComputedStyle(header).flexWrap,
+          toolsInside: toolsBox.left >= box.left && toolsBox.right <= box.right + 1,
+          overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        };
+      });
+      expect(metrics).toEqual({ wraps: "wrap", toolsInside: true, overflow: false });
+    });
+  }
 });
 
 test.describe("HTS Capability & Conformance per-source isolation", () => {

--- a/crates/hts-ui/e2e/tests/nojs/capability.spec.ts
+++ b/crates/hts-ui/e2e/tests/nojs/capability.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+const PATH = "/ui/hts/capability-statement";
+
+test("HTS exposes the first-level CapabilityStatement and a plain-JSON fallback without JavaScript", async ({
+  page,
+}) => {
+  await page.goto(PATH);
+  const card = page.locator("#capability-json-fold");
+  await expect(card).toBeVisible();
+  await expect(card.locator("[data-capability-json-actions]")).toBeHidden();
+  await expect(card.locator("[data-capability-json-tree] > [data-path=''][data-offset='0']")).toBeVisible();
+  await expect(card.locator("details[open]")).toHaveCount(0);
+
+  const fallback = card.getByRole("link", { name: "Open plain JSON" });
+  await expect(fallback).toBeVisible();
+  await fallback.click();
+  const url = new URL(page.url());
+  expect(url.pathname).toBe(PATH);
+  expect(url.searchParams.get("raw")).toBe("1");
+  await expect(card.locator("pre.detail__code")).toBeVisible();
+  await expect(card).toContainText(/Plain JSON fallback/i);
+  await expect(card.locator("[data-capability-json-actions], #capability-json-body")).toHaveCount(0);
+});

--- a/crates/hts-ui/src/capability.rs
+++ b/crates/hts-ui/src/capability.rs
@@ -44,9 +44,11 @@
 use askama::Template;
 use axum::{
     Router,
+    body::Bytes,
     extract::{Query, State},
+    http::HeaderMap,
     response::{Html, IntoResponse, Redirect, Response},
-    routing::get,
+    routing::{get, post},
 };
 use axum_htmx::HxRequest;
 use helios_ui_chrome::capability::{CapabilityCards, DocsVersion};
@@ -67,16 +69,18 @@ const JSON_FRAGMENT_ROUTE: &str = "/hts/capability-statement/json-fragment";
 /// point at. Must stay `/ui` + [`JSON_FRAGMENT_ROUTE`] in sync with the mount
 /// point [`crate::router`] documents.
 const JSON_FRAGMENT_URL: &str = "/ui/hts/capability-statement/json-fragment";
+const JSON_EXPAND_ROUTE: &str = "/hts/capability-statement/json-expand";
+const JSON_EXPAND_URL: &str = "/ui/hts/capability-statement/json-expand";
 /// The no-JS fallback link: the page itself, requested with the plain-text
 /// query flag. HTS carries no filter or version query params to preserve, so
 /// (unlike HFS's `capability_raw_url`) this needs no builder.
 const PAGE_RAW_URL: &str = "/ui/hts/capability-statement?raw=1";
 
-fn root_fragment_url(state: &HtsUiState) -> String {
-    capability_json::root_fragment_url(FragmentEndpoint {
+fn fragment_endpoint(state: &HtsUiState) -> FragmentEndpoint<'_> {
+    FragmentEndpoint {
         base_path: JSON_FRAGMENT_URL,
         version: state.fhir_version,
-    })
+    }
 }
 
 // ── Routing ─────────────────────────────────────────────────────────────
@@ -85,6 +89,7 @@ pub(crate) fn routes() -> Router<Arc<HtsUiState>> {
     Router::new()
         .route("/hts/capability-statement", get(capability_page))
         .route(JSON_FRAGMENT_ROUTE, get(capability_json_fragment))
+        .route(JSON_EXPAND_ROUTE, post(capability_json_expand))
         // The page shipped as `/ui/hts/diagnostics` before it was renamed to
         // match HFS. Keep the old path working — it may be bookmarked, and
         // the docs and e2e specs referenced it. `Redirect::permanent` emits
@@ -190,13 +195,30 @@ async fn build_view(
     } else {
         String::new()
     };
+    let initial_outline = if raw_requested {
+        None
+    } else {
+        statement.and_then(|statement| {
+            match capability_json::plan(
+                &statement.document,
+                "",
+                0,
+                capability_json::DEFAULT_PAGE_SIZE,
+                fragment_endpoint(state),
+            ) {
+                Ok(capability_json::View::Outline(outline)) => Some(outline),
+                Ok(capability_json::View::Full(_)) | Err(_) => None,
+            }
+        })
+    };
     let raw_card = statement
         .map(|_| {
             cards.raw(
                 raw_requested,
                 &raw_text,
                 PAGE_RAW_URL,
-                &root_fragment_url(state),
+                JSON_EXPAND_URL,
+                initial_outline.as_ref(),
             )
         })
         .transpose()?;
@@ -289,10 +311,7 @@ async fn capability_json_fragment(
     };
     let limit = query.limit.unwrap_or(capability_json::DEFAULT_PAGE_SIZE);
     let i18n = I18n::new(locale);
-    let endpoint = FragmentEndpoint {
-        base_path: JSON_FRAGMENT_URL,
-        version: state.fhir_version,
-    };
+    let endpoint = fragment_endpoint(&state);
     match capability_json::plan(&document, &query.path, query.offset, limit, endpoint) {
         Ok(capability_json::View::Full(json_lines)) => bounded_fragment(
             capability_json::render_full(&i18n, json_lines, query.path.is_empty()),
@@ -306,6 +325,77 @@ async fn capability_json_fragment(
         Err(capability_json::Error::InvalidPointer | capability_json::Error::InvalidPage) => (
             axum::http::StatusCode::BAD_REQUEST,
             "Invalid JSON fragment request",
+        )
+            .into_response(),
+    }
+}
+
+async fn capability_json_expand(
+    State(state): State<Arc<HtsUiState>>,
+    locale: RequestLocale,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if !headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .is_some_and(|value| {
+            value
+                .trim()
+                .eq_ignore_ascii_case("application/x-www-form-urlencoded")
+        })
+    {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            "Invalid JSON page state",
+        )
+            .into_response();
+    }
+    let pages = match capability_json::parse_page_descriptors(&body) {
+        Ok(pages) => pages,
+        Err(_) => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                "Invalid JSON page state",
+            )
+                .into_response();
+        }
+    };
+    let version = DocsVersion::from_code(state.fhir_version).unwrap_or_default();
+    let document = match state.upstream.capability_statement(version).await {
+        Ok(statement) => statement.document,
+        Err(error) => {
+            tracing::warn!("CapabilityStatement aggregate fetch failed: {error}");
+            return (
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                "CapabilityStatement is unavailable",
+            )
+                .into_response();
+        }
+    };
+    let expanded =
+        match capability_json::plan_expanded(&document, &pages, fragment_endpoint(&state)) {
+            Ok(expanded) => expanded,
+            Err(_) => {
+                return (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    "Invalid JSON page state",
+                )
+                    .into_response();
+            }
+        };
+    let i18n = I18n::new(locale);
+    match capability_json::render_expanded(&i18n, &expanded) {
+        Ok(html) => Html(html).into_response(),
+        Err(capability_json::ExpandedRenderError::TooLarge) => (
+            axum::http::StatusCode::PAYLOAD_TOO_LARGE,
+            "CapabilityStatement expansion exceeds the rendering budget",
+        )
+            .into_response(),
+        Err(capability_json::ExpandedRenderError::Template(error)) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("template render error: {error}"),
         )
             .into_response(),
     }

--- a/crates/hts-ui/templates/pages/capability-statement.html
+++ b/crates/hts-ui/templates/pages/capability-statement.html
@@ -97,10 +97,10 @@
 </section>
 
 {#-
-  6. Raw CapabilityStatement — the same htmx-lazy, paginated fold HFS renders
-  (#798, shared in #808's follow-up). Its own fragment endpoint
-  (`/ui/hts/capability-statement/json-fragment`) re-fetches `/metadata`
-  against this server's own upstream, so a statement that grows with the
+  6. Raw CapabilityStatement — the same bounded, paginated tree HFS renders
+  (#798/#808/#902). The page's existing `/metadata` result renders its first
+  level; its fragment endpoint (`/ui/hts/capability-statement/json-fragment`)
+  re-fetches only for deeper manual expansion, so a statement that grows with the
   loaded code systems — one `capabilitystatement-supported-system` extension
   per system, ~422 KB against the bundled seeds — pages through the same
   bounded engine rather than needing its own byte cap.
@@ -109,13 +109,11 @@
 {{ raw_card|safe }}
 {% endif %}
 {#-
-  The fold's auto-loader, exactly as HFS wires it on its own copy of this
-  page (`crates/ui/templates/pages/capability-statement.html`): it listens
-  for the native `toggle` event on `details[data-capability-json-node]` and
-  fires the htmx GET against `data-fragment-url`, so opening the fold shows
-  the tree instead of the server-rendered "Load JSON" fallback. Without this
-  include the shared card still renders — it just degrades silently, with no
-  compile-time signal; see the regression tests in `tests/chrome_parity.rs`.
+  The tree enhancer, exactly as HFS wires it on its own page: it reveals the
+  aggregate controls, sends one HTML POST for Expand all, and keeps native
+  `details[data-capability-json-node]` incremental. Without it the first level
+  and plain-JSON link still work, while deeper controls remain inert; see the
+  regression tests in `tests/chrome_parity.rs`.
 
   Kept outside the `{% if %}` above to mirror HFS, whose tag likewise sits
   after its own conditional. The per-node arrow toggles come from

--- a/crates/hts-ui/tests/capability.rs
+++ b/crates/hts-ui/tests/capability.rs
@@ -435,10 +435,9 @@ async fn capability_page_mirrors_hfs_and_declares_terminology_capabilities() {
         &closure_row[..closure_row.len().min(60)],
     );
 
-    // ── Raw CapabilityStatement, the same htmx-lazy fold HFS renders ────
-    // (#808 follow-up to #798). The default view never inlines the
-    // statement — it holds a "Load JSON" link against this server's own
-    // fragment endpoint, not HFS's.
+    // ── Raw CapabilityStatement, the same bounded tree HFS renders ──────
+    // The root outline is part of the first page response; deeper nodes use
+    // HTS's own incremental endpoint and Expand all uses one HTML POST.
     assert!(
         html.contains(r#"id="capability-json-fold""#),
         "the raw fold should use HFS's shared shell",
@@ -447,6 +446,9 @@ async fn capability_page_mirrors_hfs_and_declares_terminology_capabilities() {
         html.contains(r#"data-fragment-url="/ui/hts/capability-statement/json-fragment"#),
         "the fold should lazy-load from HTS's own fragment endpoint, not HFS's",
     );
+    assert!(html.contains(r#"data-expand-url="/ui/hts/capability-statement/json-expand""#));
+    assert!(html.contains(r#"data-capability-json-page data-path="""#));
+    assert!(html.contains(r#"data-capability-json-actions hidden"#));
     assert!(
         !html.contains(r#"<pre class="detail__code">"#),
         "the default view must not inline the statement any more",
@@ -652,6 +654,39 @@ async fn interactions_appear_when_declared_and_one_failure_degrades_only_its_car
     // rule the root page just proved.
     assert_eq!(extension_html.matches("{ 2 }").count(), 100);
 
+    let expanded = app
+        .clone()
+        .oneshot(
+            axum::http::Request::post("/ui/hts/capability-statement/json-expand")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "path=&offset=0&limit=100&path=%2Fextension&offset=100&limit=100",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(expanded.status(), StatusCode::OK);
+    let expanded_html = body_text(expanded).await;
+    assert!(expanded_html.len() <= 1024 * 1024);
+    assert!(expanded_html.contains(r#"data-expansion-state="partial""#));
+    assert!(expanded_html.contains(r#"data-path="/extension""#));
+    assert!(expanded_html.contains(r#"data-offset="100""#));
+    assert!(expanded_html.contains("101–200 / 400"));
+    assert!(!expanded_html.contains("201–300 / 400"));
+
+    let invalid = app
+        .clone()
+        .oneshot(
+            axum::http::Request::post("/ui/hts/capability-statement/json-expand")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("path=%2Fextension&offset=0"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(invalid.status(), StatusCode::BAD_REQUEST);
+
     // Drilling one level further reaches the actual padding value.
     let item_html = body_text(
         app.clone()
@@ -667,6 +702,20 @@ async fn interactions_appear_when_declared_and_one_failure_degrades_only_its_car
     )
     .await;
     assert!(item_html.contains("padding-0"));
+
+    state
+        .set_capability(StatusCode::SERVICE_UNAVAILABLE, None)
+        .await;
+    let unavailable = app
+        .oneshot(
+            axum::http::Request::post("/ui/hts/capability-statement/json-expand")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("path=&offset=0&limit=100"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unavailable.status(), StatusCode::SERVICE_UNAVAILABLE);
 }
 
 /// Guard: the page adds **no** CSS. Every class it names must already have

--- a/crates/hts-ui/tests/chrome_parity.rs
+++ b/crates/hts-ui/tests/chrome_parity.rs
@@ -848,14 +848,14 @@ async fn capability_page_loads_the_raw_fold_scripts() {
     // — but its *behavior* is two vanilla-JS files that each page has to
     // include itself:
     //
-    //   * `capability-json.js` listens for the native `toggle` event on
-    //     `details[data-capability-json-node]` and fires the htmx GET at
-    //     `data-fragment-url`, so opening the fold shows the tree;
+    //   * `capability-json.js` enhances the server-rendered first level,
+    //     coordinates the aggregate HTML POST, and keeps native nested
+    //     `details[data-capability-json-node]` incremental;
     //   * `json-view.js` binds the per-node fold arrows inside the
     //     fragment that swap brings back.
     //
-    // HTS adopted the shared card while loading neither, so the fold opened
-    // onto the server-rendered "Load JSON" fallback and simply sat there.
+    // HTS adopted the shared card while loading neither, so the controls and
+    // nested levels remained inert.
     // Nothing failed to compile and no template error surfaced — a missing
     // `<script>` degrades in total silence, which is exactly why this
     // assertion has to exist.

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -797,6 +797,7 @@ mod postgres_integration {
 
     static SHARED_PG: OnceCell<SharedPg> = OnceCell::const_new();
     static BULK_EXPORT_TEST_LOCK: Mutex<()> = Mutex::const_new(());
+    static BULK_SUBMIT_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
     async fn shared_pg() -> &'static SharedPg {
         SHARED_PG
@@ -5942,6 +5943,9 @@ mod postgres_integration {
             SubmitWorkerStorage,
         };
 
+        // The worker claim queue is intentionally cross-tenant, so keep this
+        // claim isolated from the synchronous bulk-submit test below.
+        let _guard = BULK_SUBMIT_TEST_LOCK.lock().await;
         let backend = create_backend().await;
         let tenant = create_tenant("bulk_submit_import");
         let sub_id = SubmissionId::generate("pg-import-test");
@@ -6044,6 +6048,10 @@ mod postgres_integration {
             SubmissionId,
         };
 
+        // A synchronous manifest has no worker lease. Serialize it with the
+        // worker claim test above so the cross-tenant queue cannot hand it to
+        // that test while this one is processing the batch.
+        let _guard = BULK_SUBMIT_TEST_LOCK.lock().await;
         let backend = create_backend().await;
         let tenant = create_tenant("bulk_submit_batch");
         let sub_id = SubmissionId::generate("pg-batch-test");
@@ -6055,21 +6063,6 @@ mod postgres_integration {
             .add_manifest(&tenant, &sub_id, Some("https://provider/b.json"), None)
             .await
             .unwrap();
-        // Move the manifest out of `pending` right away: the test binary
-        // shares one container database, and a concurrently running test that
-        // calls claim_next_manifest would otherwise claim this one (the claim
-        // queue is cross-tenant by design).
-        backend
-            .process_entries(
-                &tenant,
-                &sub_id,
-                &manifest.manifest_id,
-                Vec::new(),
-                &BulkProcessingOptions::new(),
-            )
-            .await
-            .unwrap();
-
         // An existing resource for the update path, and a soft-deleted id
         // whose create fails with AlreadyExists inside the batch.
         backend
@@ -6122,6 +6115,18 @@ mod postgres_integration {
             )
             .await
             .unwrap();
+
+        // `process_entries` leaves synchronous manifests in `processing`
+        // without a worker lease. Such rows remain eligible for the worker
+        // claim queue, so terminate this test submission before releasing the
+        // lock shared with the claim round-trip test.
+        assert_eq!(
+            backend
+                .abort_submission(&tenant, &sub_id, "test cleanup")
+                .await
+                .unwrap(),
+            1
+        );
 
         assert!(results[0].is_success() && results[0].created);
         assert!(

--- a/crates/ui-chrome/README.md
+++ b/crates/ui-chrome/README.md
@@ -32,9 +32,9 @@ feeds it:
 - `ChromeLabels` — the narrow i18n slice the chrome needs (`lang()`, `t(key)`).
   This crate depends on no i18n library; each product adapts its own bundle.
 - `UserIdentity` — who the menu says is signed in.
-- `capability` — the CapabilityStatement read model and the four cards both
+- `capability` — the CapabilityStatement read model and the five cards both
   products stack on their Capability & Conformance page (#808):
-  `templates/partials/capability-{summary,interactions,operations,resources}-card.html`
+  `templates/partials/capability-{summary,interactions,operations,resources,raw}-card.html`
   plus the projection behind them. More than markup, because HFS and HTS were
   each parsing the same `/metadata` document into their own `CapabilityView`
   and each fixing the result separately — HFS had version-correct
@@ -48,11 +48,19 @@ feeds it:
   HFS answers from the validator's core packs, HTS from the three types a
   terminology server serves).
 
-  What is *not* here: fetching, and the raw-statement block. HFS self-calls
-  over loopback and streams the raw document through a paginated fragment
-  endpoint; HTS proxies two upstreams, needs per-card isolation, and byte-caps
-  an inline `<pre>` because its statement grows with the code systems it
-  loads. Those differences are real, not drift.
+  The raw card also lives here. Both products render the root plus its first
+  level server-side, load an individual open branch through their own bounded
+  `json-fragment` GET route, and submit the currently visible page descriptors
+  to their own `json-expand` POST route for one aggregate Expand-all response.
+  The shared browser enhancer enforces request, row, and byte ceilings; it does
+  not follow pagination beyond the page currently in view. Collapse-all aborts
+  in-flight work and restores that initial first-level tree. Without JavaScript,
+  the initial tree remains readable and a real `raw=1` link opens plain JSON.
+
+  Fetching and route ownership remain outside this crate: HFS and HTS build the
+  same card contract from their respective CapabilityStatement sources and
+  expose product-specific endpoints. This crate owns the bounded tree model and
+  shared markup, not either server's HTTP client or router.
 
 The user-menu partial is a byte-verbatim extract of what was
 `crates/ui/templates/layouts/base.html:233-267`, so the move changed no HFS page

--- a/crates/ui-chrome/src/capability.rs
+++ b/crates/ui-chrome/src/capability.rs
@@ -583,12 +583,12 @@ impl<'a> CapabilityCards<'a> {
         .render()
     }
 
-    /// Raw CapabilityStatement — the foldable, htmx-lazy JSON block shared by
-    /// both products (#808 follow-up to #798). Neither the fetch nor the
-    /// fragment endpoint lives here — see [`crate::capability_json`] — this
-    /// card is only the shell: a "Load JSON" link against `fragment_url` by
-    /// default, or the fully resolved `raw` text when `raw_requested` (the
-    /// no-JS fallback, driven by `raw_url`).
+    /// Raw CapabilityStatement — the always-visible, bounded JSON block shared
+    /// by both products. The caller supplies the root outline planned from its
+    /// existing metadata fetch; deeper nodes remain incremental and the
+    /// progressively enhanced toolbar posts visible page state to `expand_url`.
+    /// `raw_requested` keeps the fully resolved plain `<pre>` fallback driven
+    /// by `raw_url` and renders no inert JavaScript controls.
     ///
     /// Unlike the other four cards this one ignores `self.notice`: a failed
     /// fetch means the caller has no statement to fold at all, and skips
@@ -598,14 +598,16 @@ impl<'a> CapabilityCards<'a> {
         raw_requested: bool,
         raw: &str,
         raw_url: &str,
-        fragment_url: &str,
+        expand_url: &str,
+        initial_outline: Option<&crate::capability_json::Outline>,
     ) -> Result<String, askama::Error> {
         RawCardTemplate {
             i18n: self.i18n,
             raw_requested,
             raw,
             raw_url,
-            fragment_url,
+            expand_url,
+            initial_outline,
         }
         .render()
     }
@@ -618,7 +620,8 @@ struct RawCardTemplate<'a> {
     raw_requested: bool,
     raw: &'a str,
     raw_url: &'a str,
-    fragment_url: &'a str,
+    expand_url: &'a str,
+    initial_outline: Option<&'a crate::capability_json::Outline>,
 }
 
 #[derive(Template)]
@@ -1257,5 +1260,62 @@ mod tests {
         assert!(summary.contains("&#60;script&#62;"));
         let resources = cards.resources().unwrap();
         assert!(!resources.contains("<img src=x"));
+    }
+
+    #[test]
+    fn raw_card_is_an_open_section_with_an_initial_outline_and_adjacent_controls() {
+        let document = json!({"resourceType": "CapabilityStatement", "rest": []});
+        let outline = match crate::capability_json::plan(
+            &document,
+            "",
+            0,
+            crate::capability_json::DEFAULT_PAGE_SIZE,
+            crate::capability_json::FragmentEndpoint {
+                base_path: "/ui/capability-statement/json-fragment",
+                version: "R4",
+            },
+        )
+        .unwrap()
+        {
+            crate::capability_json::View::Outline(outline) => outline,
+            crate::capability_json::View::Full(_) => panic!("root must be an outline"),
+        };
+        let html = CapabilityCards::new(&Labels, &sample_view())
+            .raw(
+                false,
+                "",
+                "/ui/capability-statement?raw=1",
+                "/ui/capability-statement/json-expand?version=R4",
+                Some(&outline),
+            )
+            .unwrap();
+
+        assert!(html.contains(r#"<section class="card capability-raw-card""#));
+        assert!(!html.contains("<details class=\"card json-fold\""));
+        assert!(html.contains(r#"<h3 id="capability-json-heading">"#));
+        assert!(html.contains(r#"data-capability-json-actions hidden"#));
+        assert!(html.contains(r#"role="region""#));
+        assert!(html.contains(r#"aria-labelledby="capability-json-heading""#));
+        assert!(html.contains(r#"tabindex="0""#));
+        assert!(html.contains(r#"data-path="""#));
+    }
+
+    #[test]
+    fn raw_plain_fallback_has_no_inert_enhancement_controls() {
+        let html = CapabilityCards::new(&Labels, &sample_view())
+            .raw(
+                true,
+                r#"{"resourceType":"CapabilityStatement"}"#,
+                "/ui/capability-statement?raw=1",
+                "/ui/capability-statement/json-expand?version=R4",
+                None,
+            )
+            .unwrap();
+
+        assert!(html.contains(r#"<section class="card capability-raw-card""#));
+        assert!(html.contains(r#"<pre class="detail__code">"#));
+        assert!(!html.contains("data-capability-json-actions"));
+        assert!(!html.contains("data-capability-json-expand-all"));
+        assert!(!html.contains("data-capability-json-body"));
     }
 }

--- a/crates/ui-chrome/src/capability_json.rs
+++ b/crates/ui-chrome/src/capability_json.rs
@@ -19,10 +19,14 @@ use crate::ChromeLabels;
 use crate::json_view;
 use askama::Template;
 use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 pub const DEFAULT_PAGE_SIZE: usize = 100;
 pub const MAX_PAGE_SIZE: usize = 100;
 pub const MAX_FRAGMENT_HTML_BYTES: usize = 1024 * 1024;
+pub const MAX_EXPANDED_ROWS: usize = 1_000;
+pub const MAX_PAGE_DESCRIPTORS: usize = 64;
+pub const MAX_PAGE_STATE_FORM_BYTES: usize = 256 * 1024;
 
 const MAX_POINTER_BYTES: usize = 1024;
 const MAX_POINTER_DEPTH: usize = 32;
@@ -49,6 +53,9 @@ pub enum View {
 
 pub struct Outline {
     pub rows: Vec<Row>,
+    pub pointer: String,
+    pub offset: usize,
+    pub limit: usize,
     pub opening: &'static str,
     pub closing: &'static str,
     pub has_previous: bool,
@@ -69,6 +76,148 @@ pub struct Row {
     pub expandable: bool,
     pub truncated: bool,
     pub comma: bool,
+}
+
+/// One visible page that an aggregate expansion should preserve.
+///
+/// Callers collect these from the rendered `data-path`, `data-offset`, and
+/// `data-limit` attributes. The planner validates every descriptor against
+/// the current document before it starts selecting containers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PageDescriptor {
+    pub pointer: String,
+    pub offset: usize,
+    pub limit: usize,
+}
+
+impl PageDescriptor {
+    pub fn new(pointer: impl Into<String>, offset: usize, limit: usize) -> Self {
+        Self {
+            pointer: pointer.into(),
+            offset,
+            limit,
+        }
+    }
+}
+
+/// Parses the parallel repeated fields sent by the progressively enhanced
+/// Raw CapabilityStatement toolbar.
+///
+/// HTML form encoding represents every visible page as one `path`, `offset`,
+/// and `limit` occurrence. Axum's ordinary `Form` extractor cannot retain
+/// repeated keys, so both HFS and HTS hand the bounded body to this shared
+/// parser before calling [`plan_expanded`].
+pub fn parse_page_descriptors(body: &[u8]) -> Result<Vec<PageDescriptor>, Error> {
+    if body.len() > MAX_PAGE_STATE_FORM_BYTES {
+        return Err(Error::InvalidPage);
+    }
+
+    let mut paths = Vec::new();
+    let mut offsets = Vec::new();
+    let mut limits = Vec::new();
+    for (key, value) in form_urlencoded::parse(body) {
+        match key.as_ref() {
+            "path" => paths.push(value.into_owned()),
+            "offset" => offsets.push(value.parse::<usize>().map_err(|_| Error::InvalidPage)?),
+            "limit" => limits.push(value.parse::<usize>().map_err(|_| Error::InvalidPage)?),
+            _ => return Err(Error::InvalidPage),
+        }
+        if paths.len() > MAX_PAGE_DESCRIPTORS
+            || offsets.len() > MAX_PAGE_DESCRIPTORS
+            || limits.len() > MAX_PAGE_DESCRIPTORS
+        {
+            return Err(Error::InvalidPage);
+        }
+    }
+    if paths.len() != offsets.len() || paths.len() != limits.len() {
+        return Err(Error::InvalidPage);
+    }
+
+    Ok(paths
+        .into_iter()
+        .zip(offsets)
+        .zip(limits)
+        .map(|((pointer, offset), limit)| PageDescriptor::new(pointer, offset, limit))
+        .collect())
+}
+
+/// Whether the aggregate response contains every item in the document.
+///
+/// A paginated container makes the response partial even when the planner
+/// expands every item on its visible page. The response never follows a page
+/// link on the user's behalf.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExpansionState {
+    Complete,
+    Partial,
+}
+
+impl ExpansionState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Partial => "partial",
+        }
+    }
+}
+
+/// A fully planned aggregate expansion, ready for one Askama render.
+pub struct Expanded {
+    root: PageFrame,
+    events: Vec<ExpandedEvent>,
+    state: ExpansionState,
+    row_count: usize,
+}
+
+impl Expanded {
+    pub fn state(&self) -> ExpansionState {
+        self.state
+    }
+
+    pub fn row_count(&self) -> usize {
+        self.row_count
+    }
+}
+
+struct PageFrame {
+    pointer: String,
+    offset: usize,
+    limit: usize,
+    item_count: usize,
+    opening: &'static str,
+    closing: &'static str,
+    has_previous: bool,
+    previous_url: String,
+    has_next: bool,
+    next_url: String,
+    first_item: usize,
+    last_item: usize,
+    total_items: usize,
+}
+
+struct ExpandedContainer {
+    row: Row,
+    page: PageFrame,
+}
+
+enum ExpandedEvent {
+    Scalar(Row),
+    Collapsed(Row),
+    Open(ExpandedContainer),
+    Close(PageFrame),
+}
+
+/// Rendering can fail at template time or at the final byte guard.
+#[derive(Debug)]
+pub enum ExpandedRenderError {
+    Template(askama::Error),
+    TooLarge,
+}
+
+impl From<askama::Error> for ExpandedRenderError {
+    fn from(error: askama::Error) -> Self {
+        Self::Template(error)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -96,7 +245,11 @@ pub fn plan(
         document.pointer(pointer).ok_or(Error::NotFound)?
     };
 
-    if offset == 0
+    // The root is always an outline. That gives every CapabilityStatement the
+    // same initial shape: root braces and first-level keys, with containers
+    // closed. Small nested values still use the denser shared renderer.
+    if !pointer.is_empty()
+        && offset == 0
         && container_len(value).is_none_or(|length| length <= MAX_PAGE_SIZE)
         && let Ok(lines) = json_view::try_lines(
             value,
@@ -157,6 +310,9 @@ fn outline(
 
     Ok(Outline {
         rows,
+        pointer: pointer.to_string(),
+        offset,
+        limit,
         opening: if value.is_object() { "{" } else { "[" },
         closing: if value.is_object() { "}" } else { "]" },
         has_previous: offset > 0,
@@ -167,6 +323,433 @@ fn outline(
         last_item: end,
         total_items,
     })
+}
+
+#[derive(Clone, Copy)]
+struct ExpansionBudget {
+    max_rows: usize,
+    max_estimated_html_bytes: usize,
+}
+
+struct Selection {
+    expanded: BTreeSet<String>,
+    pages: BTreeMap<String, (usize, usize)>,
+    state: ExpansionState,
+    row_count: usize,
+}
+
+/// Plans one bounded, aggregate expansion of the CapabilityStatement.
+///
+/// Selection is breadth-first so a large early branch cannot starve its
+/// siblings. Rendering later walks the selected tree depth-first, preserving
+/// document order and balanced markup. Only the supplied page for each
+/// container is considered; containers without a descriptor use their first
+/// page. No next/previous link is followed automatically.
+pub fn plan_expanded(
+    document: &Value,
+    page_descriptors: &[PageDescriptor],
+    endpoint: FragmentEndpoint,
+) -> Result<Expanded, Error> {
+    plan_expanded_with_budget(
+        document,
+        page_descriptors,
+        endpoint,
+        ExpansionBudget {
+            max_rows: MAX_EXPANDED_ROWS,
+            max_estimated_html_bytes: MAX_FRAGMENT_HTML_BYTES,
+        },
+    )
+}
+
+fn plan_expanded_with_budget(
+    document: &Value,
+    page_descriptors: &[PageDescriptor],
+    endpoint: FragmentEndpoint,
+    budget: ExpansionBudget,
+) -> Result<Expanded, Error> {
+    let pages = validate_page_descriptors(document, page_descriptors)?;
+    let root_value = document;
+    container_len(root_value).ok_or(Error::InvalidPointer)?;
+    let (root_offset, root_limit) = page_for(&pages, "");
+    let root_frame = page_frame(root_value, "", root_offset, root_limit, endpoint)?;
+
+    let mut state = if root_frame.has_previous || root_frame.has_next {
+        ExpansionState::Partial
+    } else {
+        ExpansionState::Complete
+    };
+    // Opening and closing delimiters are visible rows and consume the same
+    // global DOM budget as entries do.
+    let mut row_count = root_frame.item_count.saturating_add(2);
+    let mut estimated_bytes = estimate_page(root_value, "", root_offset, root_limit, endpoint)?;
+    let mut expanded = BTreeSet::new();
+    let mut queue = VecDeque::new();
+    enqueue_containers(
+        root_value,
+        "",
+        root_offset,
+        root_limit,
+        &mut queue,
+        &mut state,
+    )?;
+
+    while let Some(pointer) = queue.pop_front() {
+        let value = document.pointer(&pointer).ok_or(Error::NotFound)?;
+        let (offset, limit) = page_for(&pages, &pointer);
+        let total_items = container_len(value).ok_or(Error::InvalidPage)?;
+        if offset > total_items || limit == 0 || limit > MAX_PAGE_SIZE {
+            return Err(Error::InvalidPage);
+        }
+        let added_rows = total_items
+            .min(offset.saturating_add(limit))
+            .saturating_sub(offset)
+            .saturating_add(2);
+        let added_bytes = estimate_page(value, &pointer, offset, limit, endpoint)?
+            .saturating_add(ESTIMATED_EXPANDED_CONTAINER_BYTES);
+
+        if row_count.saturating_add(added_rows) > budget.max_rows
+            || estimated_bytes.saturating_add(added_bytes) > budget.max_estimated_html_bytes
+        {
+            state = ExpansionState::Partial;
+            continue;
+        }
+
+        let frame = page_frame(value, &pointer, offset, limit, endpoint)?;
+        row_count += added_rows;
+        estimated_bytes = estimated_bytes.saturating_add(added_bytes);
+        if frame.has_previous || frame.has_next {
+            state = ExpansionState::Partial;
+        }
+        expanded.insert(pointer.clone());
+        enqueue_containers(value, &pointer, offset, limit, &mut queue, &mut state)?;
+    }
+
+    let selection = Selection {
+        expanded,
+        pages,
+        state,
+        row_count,
+    };
+    let mut events = Vec::with_capacity(selection.row_count.saturating_mul(2));
+    emit_page(
+        document,
+        document,
+        "",
+        root_offset,
+        root_limit,
+        endpoint,
+        &selection,
+        &mut events,
+    )?;
+
+    Ok(Expanded {
+        root: root_frame,
+        events,
+        state: selection.state,
+        row_count: selection.row_count,
+    })
+}
+
+fn validate_page_descriptors(
+    document: &Value,
+    descriptors: &[PageDescriptor],
+) -> Result<BTreeMap<String, (usize, usize)>, Error> {
+    if descriptors.len() > MAX_PAGE_DESCRIPTORS {
+        return Err(Error::InvalidPage);
+    }
+    let mut pages = BTreeMap::new();
+    for descriptor in descriptors {
+        validate_pointer(&descriptor.pointer)?;
+        if descriptor.limit == 0 || descriptor.limit > MAX_PAGE_SIZE {
+            return Err(Error::InvalidPage);
+        }
+        let value = if descriptor.pointer.is_empty() {
+            document
+        } else {
+            document
+                .pointer(&descriptor.pointer)
+                .ok_or(Error::NotFound)?
+        };
+        let length = container_len(value).ok_or(Error::InvalidPage)?;
+        if descriptor.offset > length
+            || pages
+                .insert(
+                    descriptor.pointer.clone(),
+                    (descriptor.offset, descriptor.limit),
+                )
+                .is_some()
+        {
+            return Err(Error::InvalidPage);
+        }
+    }
+    Ok(pages)
+}
+
+fn page_for(pages: &BTreeMap<String, (usize, usize)>, pointer: &str) -> (usize, usize) {
+    pages
+        .get(pointer)
+        .copied()
+        .unwrap_or((0, DEFAULT_PAGE_SIZE))
+}
+
+fn page_frame(
+    value: &Value,
+    pointer: &str,
+    offset: usize,
+    limit: usize,
+    endpoint: FragmentEndpoint,
+) -> Result<PageFrame, Error> {
+    let total_items = container_len(value).ok_or(Error::InvalidPage)?;
+    if offset > total_items || limit == 0 || limit > MAX_PAGE_SIZE {
+        return Err(Error::InvalidPage);
+    }
+    let end = offset.saturating_add(limit).min(total_items);
+    Ok(PageFrame {
+        pointer: pointer.to_string(),
+        offset,
+        limit,
+        item_count: end.saturating_sub(offset),
+        opening: if value.is_object() { "{" } else { "[" },
+        closing: if value.is_object() { "}" } else { "]" },
+        has_previous: offset > 0,
+        previous_url: fragment_url(endpoint, pointer, offset.saturating_sub(limit), limit),
+        has_next: end < total_items,
+        next_url: fragment_url(endpoint, pointer, end, limit),
+        first_item: if total_items == 0 { 0 } else { offset + 1 },
+        last_item: end,
+        total_items,
+    })
+}
+
+fn enqueue_containers(
+    value: &Value,
+    pointer: &str,
+    offset: usize,
+    limit: usize,
+    queue: &mut VecDeque<String>,
+    state: &mut ExpansionState,
+) -> Result<(), Error> {
+    let total = container_len(value).ok_or(Error::InvalidPage)?;
+    if offset > total || limit == 0 || limit > MAX_PAGE_SIZE {
+        return Err(Error::InvalidPage);
+    }
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map.iter().skip(offset).take(limit) {
+                if child.is_object() || child.is_array() {
+                    if let Some(child) = child_pointer(pointer, key) {
+                        queue.push_back(child);
+                    } else {
+                        *state = ExpansionState::Partial;
+                    }
+                }
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate().skip(offset).take(limit) {
+                if child.is_object() || child.is_array() {
+                    if let Some(child) = child_pointer(pointer, &index.to_string()) {
+                        queue.push_back(child);
+                    } else {
+                        *state = ExpansionState::Partial;
+                    }
+                }
+            }
+        }
+        _ => return Err(Error::InvalidPage),
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_page(
+    document: &Value,
+    value: &Value,
+    pointer: &str,
+    offset: usize,
+    limit: usize,
+    endpoint: FragmentEndpoint,
+    selection: &Selection,
+    events: &mut Vec<ExpandedEvent>,
+) -> Result<(), Error> {
+    let total_items = container_len(value).ok_or(Error::InvalidPage)?;
+    match value {
+        Value::Object(map) => {
+            for (index, (key, child)) in map.iter().enumerate().skip(offset).take(limit) {
+                emit_node(
+                    document,
+                    Some(key),
+                    child,
+                    child_pointer(pointer, key),
+                    index + 1 < total_items,
+                    endpoint,
+                    selection,
+                    events,
+                )?;
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate().skip(offset).take(limit) {
+                emit_node(
+                    document,
+                    None,
+                    child,
+                    child_pointer(pointer, &index.to_string()),
+                    index + 1 < total_items,
+                    endpoint,
+                    selection,
+                    events,
+                )?;
+            }
+        }
+        _ => return Err(Error::InvalidPage),
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_node(
+    document: &Value,
+    key: Option<&str>,
+    value: &Value,
+    pointer: Option<String>,
+    comma: bool,
+    endpoint: FragmentEndpoint,
+    selection: &Selection,
+    events: &mut Vec<ExpandedEvent>,
+) -> Result<(), Error> {
+    let rendered_row = row(key, value, pointer.clone(), comma, endpoint);
+    if !(value.is_object() || value.is_array()) {
+        events.push(ExpandedEvent::Scalar(rendered_row));
+        return Ok(());
+    }
+    let Some(pointer) = pointer else {
+        events.push(ExpandedEvent::Collapsed(rendered_row));
+        return Ok(());
+    };
+    if !selection.expanded.contains(&pointer) {
+        events.push(ExpandedEvent::Collapsed(rendered_row));
+        return Ok(());
+    }
+
+    let child = document.pointer(&pointer).ok_or(Error::NotFound)?;
+    let (offset, limit) = page_for(&selection.pages, &pointer);
+    let frame = page_frame(child, &pointer, offset, limit, endpoint)?;
+    events.push(ExpandedEvent::Open(ExpandedContainer {
+        row: rendered_row,
+        page: frame,
+    }));
+    emit_page(
+        document,
+        document.pointer(&pointer).ok_or(Error::NotFound)?,
+        &pointer,
+        offset,
+        limit,
+        endpoint,
+        selection,
+        events,
+    )?;
+    events.push(ExpandedEvent::Close(page_frame(
+        child, &pointer, offset, limit, endpoint,
+    )?));
+    Ok(())
+}
+
+const ESTIMATED_PAGE_BYTES: usize = 2_048;
+const ESTIMATED_ROW_BYTES: usize = 1_024;
+const ESTIMATED_EXPANDED_CONTAINER_BYTES: usize = 2_048;
+const MAX_ESCAPED_BYTES_PER_SOURCE_BYTE: usize = 6;
+
+fn estimate_page(
+    value: &Value,
+    pointer: &str,
+    offset: usize,
+    limit: usize,
+    endpoint: FragmentEndpoint,
+) -> Result<usize, Error> {
+    let total = container_len(value).ok_or(Error::InvalidPage)?;
+    if offset > total || limit == 0 || limit > MAX_PAGE_SIZE {
+        return Err(Error::InvalidPage);
+    }
+    let mut bytes =
+        ESTIMATED_PAGE_BYTES.saturating_add(estimate_url_bytes(endpoint, pointer, offset, limit));
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map.iter().skip(offset).take(limit) {
+                let child_pointer = child_pointer(pointer, key);
+                bytes = bytes.saturating_add(estimate_row_bytes(
+                    Some(key),
+                    child,
+                    child_pointer.as_deref().unwrap_or(pointer),
+                    endpoint,
+                ));
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate().skip(offset).take(limit) {
+                let index = index.to_string();
+                let child_pointer = child_pointer(pointer, &index);
+                bytes = bytes.saturating_add(estimate_row_bytes(
+                    None,
+                    child,
+                    child_pointer.as_deref().unwrap_or(pointer),
+                    endpoint,
+                ));
+            }
+        }
+        _ => return Err(Error::InvalidPage),
+    }
+    Ok(bytes)
+}
+
+fn estimate_row_bytes(
+    key: Option<&str>,
+    value: &Value,
+    pointer: &str,
+    endpoint: FragmentEndpoint,
+) -> usize {
+    let key_bytes = key
+        .map(|key| capped_utf8_bytes(key, MAX_DISPLAY_KEY_CHARS))
+        .unwrap_or(0);
+    let value_bytes = match value {
+        Value::String(text) => capped_utf8_bytes(text, MAX_DISPLAY_STRING_CHARS),
+        _ => 64,
+    };
+    let url_bytes = if value.is_object() || value.is_array() {
+        estimate_url_bytes(endpoint, pointer, 0, DEFAULT_PAGE_SIZE)
+    } else {
+        0
+    };
+    ESTIMATED_ROW_BYTES
+        .saturating_add(
+            key_bytes
+                .saturating_add(value_bytes)
+                .saturating_mul(MAX_ESCAPED_BYTES_PER_SOURCE_BYTE),
+        )
+        .saturating_add(url_bytes)
+}
+
+fn capped_utf8_bytes(value: &str, max_chars: usize) -> usize {
+    value
+        .chars()
+        .take(max_chars)
+        .map(char::len_utf8)
+        .fold(0usize, usize::saturating_add)
+}
+
+fn estimate_url_bytes(
+    endpoint: FragmentEndpoint,
+    pointer: &str,
+    _offset: usize,
+    _limit: usize,
+) -> usize {
+    endpoint
+        .base_path
+        .len()
+        .saturating_add(endpoint.version.len())
+        .saturating_add(pointer.len().saturating_mul(3))
+        .saturating_add(96)
+        .saturating_mul(MAX_ESCAPED_BYTES_PER_SOURCE_BYTE)
 }
 
 fn row(
@@ -254,7 +837,7 @@ fn container_len(value: &Value) -> Option<usize> {
 fn child_pointer(parent: &str, segment: &str) -> Option<String> {
     let escaped = segment.replace('~', "~0").replace('/', "~1");
     let pointer = format!("{parent}/{escaped}");
-    (pointer.len() <= MAX_POINTER_BYTES).then_some(pointer)
+    validate_pointer(&pointer).is_ok().then_some(pointer)
 }
 
 fn fragment_url(endpoint: FragmentEndpoint, pointer: &str, offset: usize, limit: usize) -> String {
@@ -335,6 +918,14 @@ struct OutlineFragmentTemplate<'a> {
     outline: &'a Outline,
 }
 
+/// One aggregate response selected breadth-first and emitted depth-first.
+#[derive(Template)]
+#[template(path = "partials/capability-json-expanded.html")]
+struct ExpandedFragmentTemplate<'a> {
+    i18n: &'a dyn ChromeLabels,
+    expanded: &'a Expanded,
+}
+
 /// Renders a [`View::Full`] payload. `is_root` selects the DOM id the page's
 /// own fold controls key off (`#capability-json`); a nested fragment gets no
 /// id of its own.
@@ -357,6 +948,21 @@ pub fn render_outline(i18n: &dyn ChromeLabels, outline: &Outline) -> Result<Stri
     OutlineFragmentTemplate { i18n, outline }.render()
 }
 
+/// Renders an aggregate expansion and enforces the final response-size cap.
+///
+/// The planner applies a conservative estimate before it adds a page. This
+/// final check covers template fixed costs and future markup changes.
+pub fn render_expanded(
+    i18n: &dyn ChromeLabels,
+    expanded: &Expanded,
+) -> Result<String, ExpandedRenderError> {
+    let html = ExpandedFragmentTemplate { i18n, expanded }.render()?;
+    if html.len() > MAX_FRAGMENT_HTML_BYTES {
+        return Err(ExpandedRenderError::TooLarge);
+    }
+    Ok(html)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -366,6 +972,29 @@ mod tests {
         base_path: "/ui/capability-statement/json-fragment",
         version: "R4",
     };
+
+    struct Labels;
+
+    impl ChromeLabels for Labels {
+        fn lang(&self) -> String {
+            "en".to_string()
+        }
+
+        fn t(&self, key: &str) -> String {
+            format!("[{key}]")
+        }
+    }
+
+    fn open_paths(expanded: &Expanded) -> Vec<&str> {
+        expanded
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                ExpandedEvent::Open(node) => Some(node.page.pointer.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
 
     fn expect_outline(view: View) -> Outline {
         match view {
@@ -426,8 +1055,19 @@ mod tests {
     }
 
     #[test]
-    fn small_values_keep_using_the_shared_renderer() {
-        let lines = expect_full(plan(&json!({"ok": true}), "", 0, 100, ENDPOINT).unwrap());
+    fn a_small_root_is_an_outline_with_only_its_first_level() {
+        let outline =
+            expect_outline(plan(&json!({"nested": {"ok": true}}), "", 0, 100, ENDPOINT).unwrap());
+        assert_eq!(outline.rows.len(), 1);
+        assert!(outline.rows[0].is_container);
+        assert_eq!(outline.rows[0].summary, "{ 1 }");
+        assert_eq!(outline.pointer, "");
+    }
+
+    #[test]
+    fn small_nested_values_keep_using_the_shared_renderer() {
+        let document = json!({"nested": {"ok": true}});
+        let lines = expect_full(plan(&document, "/nested", 0, 100, ENDPOINT).unwrap());
         assert!(
             lines
                 .iter()
@@ -453,7 +1093,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "expected an outline")]
     fn outline_test_helper_rejects_full_views() {
-        let view = plan(&json!({"ok": true}), "", 0, 100, ENDPOINT).unwrap();
+        let document = json!({"nested": {"ok": true}});
+        let view = plan(&document, "/nested", 0, 100, ENDPOINT).unwrap();
         expect_outline(view);
     }
 
@@ -473,5 +1114,276 @@ mod tests {
         let url = root_fragment_url(hts_endpoint);
         assert!(url.starts_with("/ui/hts/capability-statement/json-fragment?"));
         assert!(url.contains("version=R4"));
+    }
+
+    #[test]
+    fn aggregate_selection_is_breadth_first_and_fair_to_root_siblings() {
+        let document = json!({
+            "a": {"a1": {"value": 1}},
+            "b": {"b1": {"value": 2}}
+        });
+        let expanded = plan_expanded_with_budget(
+            &document,
+            &[],
+            ENDPOINT,
+            ExpansionBudget {
+                max_rows: 10,
+                max_estimated_html_bytes: usize::MAX,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(open_paths(&expanded), vec!["/a", "/b"]);
+        assert_eq!(expanded.row_count(), 10);
+        assert_eq!(expanded.state(), ExpansionState::Partial);
+    }
+
+    #[test]
+    fn aggregate_row_and_byte_budgets_are_inclusive_at_the_boundary() {
+        let document = json!({"a": {"value": 1}});
+        let root_bytes = estimate_page(&document, "", 0, 100, ENDPOINT).unwrap();
+        let child = document.pointer("/a").unwrap();
+        let full_bytes = root_bytes
+            + estimate_page(child, "/a", 0, 100, ENDPOINT).unwrap()
+            + ESTIMATED_EXPANDED_CONTAINER_BYTES;
+
+        let exact = plan_expanded_with_budget(
+            &document,
+            &[],
+            ENDPOINT,
+            ExpansionBudget {
+                max_rows: 6,
+                max_estimated_html_bytes: full_bytes,
+            },
+        )
+        .unwrap();
+        assert_eq!(exact.state(), ExpansionState::Complete);
+        assert_eq!(open_paths(&exact), vec!["/a"]);
+
+        let one_byte_short = plan_expanded_with_budget(
+            &document,
+            &[],
+            ENDPOINT,
+            ExpansionBudget {
+                max_rows: 6,
+                max_estimated_html_bytes: full_bytes - 1,
+            },
+        )
+        .unwrap();
+        assert_eq!(one_byte_short.state(), ExpansionState::Partial);
+        assert!(open_paths(&one_byte_short).is_empty());
+
+        let one_row_short = plan_expanded_with_budget(
+            &document,
+            &[],
+            ENDPOINT,
+            ExpansionBudget {
+                max_rows: 3,
+                max_estimated_html_bytes: usize::MAX,
+            },
+        )
+        .unwrap();
+        assert_eq!(one_row_short.state(), ExpansionState::Partial);
+        assert_eq!(one_row_short.row_count(), 3);
+    }
+
+    #[test]
+    fn aggregate_render_is_deterministic_balanced_and_marked() {
+        let document = json!({
+            "a": {"nested": {"value": true}},
+            "b": [1, 2]
+        });
+        let first = plan_expanded(&document, &[], ENDPOINT).unwrap();
+        let second = plan_expanded(&document, &[], ENDPOINT).unwrap();
+        let first_html = render_expanded(&Labels, &first).unwrap();
+        let second_html = render_expanded(&Labels, &second).unwrap();
+
+        assert_eq!(first_html, second_html);
+        assert_eq!(
+            first_html.matches("<details").count(),
+            first_html.matches("</details>").count()
+        );
+        assert!(first_html.contains(r#"data-expansion-state="complete""#));
+        assert!(first_html.contains(r#"data-path="/a/nested""#));
+        assert!(first_html.contains(r#"aria-expanded"#) || first_html.contains(" open>"));
+    }
+
+    #[test]
+    fn aggregate_never_follows_a_later_page() {
+        let items: Vec<Value> = (0..205)
+            .map(|index| json!({"marker": format!("page-{index}")}))
+            .collect();
+        let document = json!({"items": items});
+        let expanded = plan_expanded(&document, &[], ENDPOINT).unwrap();
+        let html = render_expanded(&Labels, &expanded).unwrap();
+
+        assert_eq!(expanded.state(), ExpansionState::Partial);
+        assert!(html.contains("page-99"));
+        assert!(!html.contains("page-100"));
+        assert!(html.contains("1–100 / 205"));
+        assert!(html.contains("offset=100"));
+    }
+
+    #[test]
+    fn aggregate_preserves_a_valid_visible_page_offset() {
+        let items: Vec<Value> = (0..205)
+            .map(|index| json!({"marker": format!("page-{index}")}))
+            .collect();
+        let document = json!({"items": items});
+        let pages = [PageDescriptor::new("/items", 100, 100)];
+        let expanded = plan_expanded(&document, &pages, ENDPOINT).unwrap();
+        let html = render_expanded(&Labels, &expanded).unwrap();
+
+        assert!(html.contains("page-100"));
+        assert!(!html.contains("page-0"));
+        assert!(html.contains("101–200 / 205"));
+        assert!(html.contains(r#"data-offset="100""#));
+    }
+
+    #[test]
+    fn aggregate_rejects_duplicate_excessive_and_invalid_page_state() {
+        let document = json!({"items": [1, 2], "scalar": true});
+        assert_eq!(
+            plan_expanded(
+                &document,
+                &[
+                    PageDescriptor::new("/items", 0, 100),
+                    PageDescriptor::new("/items", 0, 100),
+                ],
+                ENDPOINT,
+            )
+            .err(),
+            Some(Error::InvalidPage)
+        );
+        assert_eq!(
+            plan_expanded(
+                &document,
+                &[PageDescriptor::new("/items", 3, 100)],
+                ENDPOINT,
+            )
+            .err(),
+            Some(Error::InvalidPage)
+        );
+        assert_eq!(
+            plan_expanded(
+                &document,
+                &[PageDescriptor::new("/items", 0, 101)],
+                ENDPOINT,
+            )
+            .err(),
+            Some(Error::InvalidPage)
+        );
+        assert_eq!(
+            plan_expanded(
+                &document,
+                &[PageDescriptor::new("/scalar", 0, 100)],
+                ENDPOINT,
+            )
+            .err(),
+            Some(Error::InvalidPage)
+        );
+        let too_many: Vec<_> = (0..=MAX_PAGE_DESCRIPTORS)
+            .map(|index| PageDescriptor::new(format!("/missing-{index}"), 0, 100))
+            .collect();
+        assert_eq!(
+            plan_expanded(&document, &too_many, ENDPOINT).err(),
+            Some(Error::InvalidPage)
+        );
+    }
+
+    #[test]
+    fn aggregate_form_parser_preserves_parallel_visible_page_state() {
+        let pages =
+            parse_page_descriptors(b"path=&offset=0&limit=100&path=%2Fitems&offset=100&limit=50")
+                .unwrap();
+
+        assert_eq!(
+            pages,
+            vec![
+                PageDescriptor::new("", 0, 100),
+                PageDescriptor::new("/items", 100, 50),
+            ]
+        );
+    }
+
+    #[test]
+    fn aggregate_form_parser_rejects_mismatched_unknown_and_oversized_state() {
+        for body in [
+            b"path=&offset=0".as_slice(),
+            b"path=&offset=nope&limit=100".as_slice(),
+            b"path=&offset=0&limit=100&extra=true".as_slice(),
+        ] {
+            assert_eq!(parse_page_descriptors(body), Err(Error::InvalidPage));
+        }
+        assert_eq!(
+            parse_page_descriptors(&vec![b'x'; MAX_PAGE_STATE_FORM_BYTES + 1]),
+            Err(Error::InvalidPage)
+        );
+    }
+
+    #[test]
+    fn aggregate_escapes_hostile_keys_values_and_urls() {
+        let document = json!({
+            "<script>&/": {"value": "</span><img src=x onerror=alert(1)>"}
+        });
+        let expanded = plan_expanded(&document, &[], ENDPOINT).unwrap();
+        let html = render_expanded(&Labels, &expanded).unwrap();
+
+        assert!(!html.contains("<script>"));
+        assert!(!html.contains("<img src=x"));
+        assert!(html.contains("&#60;script&#62;"));
+        assert!(html.contains("%3Cscript%3E%26%7E1"), "{html}");
+    }
+
+    #[test]
+    fn aggregate_stops_at_the_pointer_depth_limit() {
+        let mut document = json!(true);
+        for _ in 0..=MAX_POINTER_DEPTH + 1 {
+            document = json!({"x": document});
+        }
+        let expanded = plan_expanded(&document, &[], ENDPOINT).unwrap();
+
+        assert_eq!(expanded.state(), ExpansionState::Partial);
+        assert!(open_paths(&expanded).len() <= MAX_POINTER_DEPTH);
+        let html = render_expanded(&Labels, &expanded).unwrap();
+        assert!(html.contains("[cap-json-path-too-deep]"));
+    }
+
+    #[test]
+    fn aggregate_public_plan_and_final_render_stay_within_the_html_cap() {
+        let branches: Vec<Value> = (0..100)
+            .map(|index| {
+                json!({
+                    "name": format!("branch-{index}"),
+                    "payload": "<&>\"".repeat(300)
+                })
+            })
+            .collect();
+        let document = json!({"branches": branches});
+        let expanded = plan_expanded(&document, &[], ENDPOINT).unwrap();
+        let html = render_expanded(&Labels, &expanded).unwrap();
+
+        assert!(html.len() <= MAX_FRAGMENT_HTML_BYTES);
+        assert!(expanded.row_count() <= MAX_EXPANDED_ROWS);
+    }
+
+    #[test]
+    fn final_render_guard_rejects_oversized_template_output() {
+        let document = json!({"value": true});
+        let mut expanded = plan_expanded(&document, &[], ENDPOINT).unwrap();
+        let row = expanded
+            .events
+            .iter_mut()
+            .find_map(|event| match event {
+                ExpandedEvent::Scalar(row) => Some(row),
+                _ => None,
+            })
+            .unwrap();
+        row.prefix = "x".repeat(MAX_FRAGMENT_HTML_BYTES + 1);
+
+        assert!(matches!(
+            render_expanded(&Labels, &expanded),
+            Err(ExpandedRenderError::TooLarge)
+        ));
     }
 }

--- a/crates/ui-chrome/templates/partials/capability-interactions-card.html
+++ b/crates/ui-chrome/templates/partials/capability-interactions-card.html
@@ -24,7 +24,7 @@
   <p class="notice notice--warn">{{ notice }}</p>
   {%- else %}
   <div class="card__body">
-    <p>
+    <div class="detail__tags cap-interaction-tags">
       {% for i in interactions %}
       {% if !i.href.is_empty() %}
       <a class="tag {{ i.tag_class }}" href="{{ i.href }}" target="_blank" rel="noopener">{{ i.code }}</a>
@@ -32,7 +32,7 @@
       <span class="tag {{ i.tag_class }}">{{ i.code }}</span>
       {% endif %}
       {% endfor %}
-    </p>
+    </div>
     {% if let Some(href) = transaction_note_href %}
     <p class="cap-transaction-note">
       {{ i18n.t("cap-transaction-note") }}

--- a/crates/ui-chrome/templates/partials/capability-json-expanded.html
+++ b/crates/ui-chrome/templates/partials/capability-json-expanded.html
@@ -1,0 +1,85 @@
+<div class="capability-json-outline"
+     data-capability-json-page
+     data-path="{{ expanded.root.pointer }}"
+     data-offset="{{ expanded.root.offset }}"
+     data-limit="{{ expanded.root.limit }}"
+     data-item-count="{{ expanded.root.item_count }}"
+     data-expansion-state="{{ expanded.state.as_str() }}">
+  <div class="capability-json-bracket"><span class="jt--punct">{{ expanded.root.opening }}</span></div>
+  <div class="capability-json-rows">
+    {% for event in expanded.events %}
+    {% match event %}
+    {% when ExpandedEvent::Scalar(row) %}
+    <div class="capability-json-row">
+      <span class="capability-json-row__fold" aria-hidden="true"></span>
+      <code><span class="jt--key">{{ row.prefix }}</span>{% for token in row.tokens %}<span class="jt--{{ token.kind }}">{{ token.text }}</span>{% endfor %}<span class="jt--punct">{% if row.comma %},{% endif %}</span></code>
+      {% if row.truncated %}<span class="capability-json-truncated">{{ i18n.t("cap-json-truncated") }}</span>{% endif %}
+    </div>
+    {% when ExpandedEvent::Collapsed(row) %}
+    <details class="capability-json-node" data-capability-json-node>
+      <summary class="capability-json-row">
+        <span class="capability-json-row__fold" aria-hidden="true">▸</span>
+        <code><span class="jt--key">{{ row.prefix }}</span><span class="jt--punct">{{ row.summary }}{% if row.comma %},{% endif %}</span></code>
+        {% if row.truncated %}<span class="capability-json-truncated">{{ i18n.t("cap-json-truncated") }}</span>{% endif %}
+        {% if !row.expandable %}<span class="capability-json-truncated">{{ i18n.t("cap-json-path-too-deep") }}</span>{% endif %}
+      </summary>
+      {% if row.expandable %}
+      <div class="capability-json-node__body"
+           data-capability-json-body
+           data-loading-text="{{ i18n.t("cap-raw-loading") }}"
+           data-error-text="{{ i18n.t("cap-json-load-error") }}"
+           data-fragment-url="{{ row.fragment_url }}">
+        <p class="busy-status" role="status"><span class="spinner" aria-hidden="true"></span>{{ i18n.t("cap-raw-loading") }}</p>
+      </div>
+      {% endif %}
+    </details>
+    {% when ExpandedEvent::Open(node) %}
+    <details class="capability-json-node" data-capability-json-node open>
+      <summary class="capability-json-row">
+        <span class="capability-json-row__fold" aria-hidden="true">▸</span>
+        <code><span class="jt--key">{{ node.row.prefix }}</span><span class="jt--punct">{{ node.row.summary }}{% if node.row.comma %},{% endif %}</span></code>
+        {% if node.row.truncated %}<span class="capability-json-truncated">{{ i18n.t("cap-json-truncated") }}</span>{% endif %}
+      </summary>
+      <div class="capability-json-node__body"
+           data-capability-json-body
+           data-capability-json-loaded="true"
+           data-loading-text="{{ i18n.t("cap-raw-loading") }}"
+           data-error-text="{{ i18n.t("cap-json-load-error") }}"
+           data-fragment-url="{{ node.row.fragment_url }}">
+        <div class="capability-json-outline"
+             data-capability-json-page
+             data-path="{{ node.page.pointer }}"
+             data-offset="{{ node.page.offset }}"
+             data-limit="{{ node.page.limit }}"
+             data-item-count="{{ node.page.item_count }}">
+          <div class="capability-json-bracket"><span class="jt--punct">{{ node.page.opening }}</span></div>
+          <div class="capability-json-rows">
+    {% when ExpandedEvent::Close(page) %}
+          </div>
+          <div class="capability-json-bracket"><span class="jt--punct">{{ page.closing }}</span></div>
+          {% if page.has_previous || page.has_next %}
+          <nav class="capability-json-pagination" aria-label="{{ i18n.t("cap-json-pagination-label") }}">
+            <button type="button" class="btn" data-capability-json-page-direction="previous"{% if page.has_previous %}
+                    hx-get="{{ page.previous_url }}" hx-target="closest [data-capability-json-body]" hx-swap="innerHTML"{% else %} disabled{% endif %}>{{ i18n.t("cap-json-page-prev") }}</button>
+            <span>{{ page.first_item }}–{{ page.last_item }} / {{ page.total_items }}</span>
+            <button type="button" class="btn" data-capability-json-page-direction="next"{% if page.has_next %}
+                    hx-get="{{ page.next_url }}" hx-target="closest [data-capability-json-body]" hx-swap="innerHTML"{% else %} disabled{% endif %}>{{ i18n.t("cap-json-page-next") }}</button>
+          </nav>
+          {% endif %}
+        </div>
+      </div>
+    </details>
+    {% endmatch %}
+    {% endfor %}
+  </div>
+  <div class="capability-json-bracket"><span class="jt--punct">{{ expanded.root.closing }}</span></div>
+  {% if expanded.root.has_previous || expanded.root.has_next %}
+  <nav class="capability-json-pagination" aria-label="{{ i18n.t("cap-json-pagination-label") }}">
+    <button type="button" class="btn" data-capability-json-page-direction="previous"{% if expanded.root.has_previous %}
+            hx-get="{{ expanded.root.previous_url }}" hx-target="closest [data-capability-json-body]" hx-swap="innerHTML"{% else %} disabled{% endif %}>{{ i18n.t("cap-json-page-prev") }}</button>
+    <span>{{ expanded.root.first_item }}–{{ expanded.root.last_item }} / {{ expanded.root.total_items }}</span>
+    <button type="button" class="btn" data-capability-json-page-direction="next"{% if expanded.root.has_next %}
+            hx-get="{{ expanded.root.next_url }}" hx-target="closest [data-capability-json-body]" hx-swap="innerHTML"{% else %} disabled{% endif %}>{{ i18n.t("cap-json-page-next") }}</button>
+  </nav>
+  {% endif %}
+</div>

--- a/crates/ui-chrome/templates/partials/capability-json-outline.html
+++ b/crates/ui-chrome/templates/partials/capability-json-outline.html
@@ -1,4 +1,4 @@
-<div class="capability-json-outline" data-capability-json-page data-item-count="{{ outline.rows.len() }}">
+<div class="capability-json-outline" data-capability-json-page data-path="{{ outline.pointer }}" data-offset="{{ outline.offset }}" data-limit="{{ outline.limit }}" data-item-count="{{ outline.rows.len() }}">
   <div class="capability-json-bracket"><span class="jt--punct">{{ outline.opening }}</span></div>
   <div class="capability-json-rows">
     {% for row in outline.rows %}

--- a/crates/ui-chrome/templates/partials/capability-operations-card.html
+++ b/crates/ui-chrome/templates/partials/capability-operations-card.html
@@ -13,7 +13,7 @@
   renders no empty row, HTS names a Fluent key for the case where a
   terminology server declares none.
 #}
-<section class="card table-card">
+<section class="card table-card cap-operations-card">
   <div class="card-head">
     <h3>{{ i18n.t("cap-operations-heading") }}</h3>
   </div>

--- a/crates/ui-chrome/templates/partials/capability-raw-card.html
+++ b/crates/ui-chrome/templates/partials/capability-raw-card.html
@@ -1,46 +1,47 @@
 {#
-  SHARED CAPABILITY CARD -- Raw CapabilityStatement (#808 follow-up to #798).
+  SHARED CAPABILITY CARD -- Raw CapabilityStatement (#902).
 
-  Rendered by `helios_ui_chrome::capability::CapabilityCards::raw()` and
-  consumed by BOTH `crates/ui` (HFS) and `crates/hts-ui` (HTS). One edit here
-  changes both products' raw fold.
-
-  Bounded, incremental JSON rendering (the fragment endpoint this card's
-  `fragment_url` and `data-fragment-url` point at) lives in
-  `crate::capability_json`, not here — this file is only the shell:
-
-  * `raw_requested` false (the default): a "Load JSON" link plus a hidden
-    htmx-driven body. Nothing is fetched until the fold opens.
-  * `raw_requested` true (the `?raw=1` no-JS fallback): the full,
-    already-resolved `raw` text in a plain `<pre>`, no htmx involved. The
-    caller supplies it *unbounded* — this is an explicit, opt-in request for
-    the whole document, not the default page weight.
-
-  Both products' statements can be large (HFS's grows with registered search
-  parameters, HTS's with loaded code systems), which is exactly why the
-  default path never inlines the tree: see #798 for HFS and #808 for why HTS
-  no longer byte-caps a `<pre>` instead of sharing this.
+  The ordinary page already owns the metadata document, so it includes the
+  bounded root outline immediately. Nested levels remain incremental.
+  JavaScript reveals the aggregate controls; the plain-JSON link is the no-JS
+  path and `raw=1` remains an unbounded, explicit fallback.
 #}
-<details class="card json-fold" id="capability-json-fold"{% if raw_requested %} open{% else %} data-capability-json-node{% endif %}>
-  <summary class="card-head">
-    <h3>{{ i18n.t("cap-raw-toggle") }}</h3>
-    <span class="icon">{% include "icons/chevron-down.svg" %}</span>
-  </summary>
-  <div class="card__body" id="capability-json-body"{% if !raw_requested %}
-       data-capability-json-body
-       data-loading-text="{{ i18n.t("cap-raw-loading") }}"
-       data-error-text="{{ i18n.t("cap-json-load-error") }}"
-       data-fragment-url="{{ fragment_url }}"
-       hx-indicator="#capability-json-loading"{% endif %}>
+<section class="card capability-raw-card" id="capability-json-fold"{% if !raw_requested %}
+         data-capability-json-root
+         data-expand-url="{{ expand_url }}"
+         data-expanding-text="{{ i18n.t("cap-json-expanding") }}"
+         data-complete-text="{{ i18n.t("cap-json-expand-complete") }}"
+         data-partial-text="{{ i18n.t("cap-json-expand-partial") }}"
+         data-limit-text="{{ i18n.t("cap-json-limit-reached") }}"
+         data-error-text="{{ i18n.t("cap-json-expand-error") }}"{% endif %}>
+  <div class="card-head">
+    <h3 id="capability-json-heading">{{ i18n.t("cap-raw-toggle") }}</h3>
+    {% if !raw_requested %}
+    <div class="card-head__tools capability-json-actions" data-capability-json-actions hidden>
+      <button type="button" class="btn" data-capability-json-collapse-all disabled>{{ i18n.t("cap-json-collapse-all") }}</button>
+      <button type="button" class="btn" data-capability-json-expand-all>{{ i18n.t("cap-json-expand-all") }}</button>
+      <span class="busy-status capability-json-actions__status" role="status" aria-live="polite" data-capability-json-status></span>
+    </div>
+    {% endif %}
+  </div>
+  <div class="card__body">
     {% if raw_requested %}
     <p class="notice">{{ i18n.t("cap-raw-plain") }}</p>
     <pre class="detail__code">{{ raw }}</pre>
     {% else %}
-    <a class="btn" href="{{ raw_url }}#capability-json-fold">{{ i18n.t("cap-raw-load") }}</a>
-    <p class="busy-status htmx-indicator" id="capability-json-loading" role="status">
-      <span class="spinner" aria-hidden="true"></span>
-      {{ i18n.t("cap-raw-loading") }}
-    </p>
+    <p class="capability-json-fallback" data-capability-json-fallback><a class="btn" href="{{ raw_url }}#capability-json-fold">{{ i18n.t("cap-raw-load") }}</a></p>
+    <div id="capability-json-body"
+         role="region"
+         aria-labelledby="capability-json-heading"
+         tabindex="0"
+         data-capability-json-body{% if let Some(outline) = initial_outline %}
+         data-fragment-url="{{ outline.previous_url }}"{% endif %}>
+      <div data-capability-json-tree>
+        {% if let Some(outline) = initial_outline %}
+        {% include "partials/capability-json-outline.html" %}
+        {% endif %}
+      </div>
+    </div>
     {% endif %}
   </div>
-</details>
+</section>

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -43,8 +43,23 @@
 }
 
 @layer pages {
-/* CapabilityStatement-only presentation: keep the backend note subordinate to
-   its interaction tags, and let the resource filter fit a phone-width card. */
+/* CapabilityStatement-only presentation: all card headers stay edge-to-edge,
+   while their bodies own the content rhythm appropriate to fields, tags, or
+   tables. The generic table-card keeps its padded treatment elsewhere. */
+.cap-operations-card,
+.cap-resource-card {
+  padding: 0;
+}
+
+.cap-interaction-tags {
+  margin: 0;
+}
+
+.cap-interaction-tags > .tag {
+  margin-left: 0;
+}
+
+/* Keep the backend note subordinate to its interaction tags. */
 .cap-transaction-note {
   margin: 8px 0 0 16px;
   padding-left: 10px;
@@ -64,6 +79,25 @@
   min-width: 0;
 }
 
+.capability-raw-card > .card-head {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.capability-json-actions {
+  align-items: center;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.capability-json-actions__status:empty {
+  display: none;
+}
+
+.capability-json-fallback {
+  margin: 0 0 10px;
+}
+
 @media (max-width: 520px) {
   .cap-resource-card > .card-head {
     flex-direction: column;
@@ -73,6 +107,18 @@
   .cap-resource-filter {
     flex-basis: auto;
     width: 100%;
+  }
+
+  .capability-raw-card > .card-head {
+    align-items: stretch;
+  }
+
+  .capability-json-actions {
+    width: 100%;
+  }
+
+  .capability-json-actions__status {
+    flex-basis: 100%;
   }
 }
 }
@@ -1601,23 +1647,18 @@ select.field__input {
   color: var(--muted);
 }
 
-/* The CapabilityStatement raw view is a real link without JavaScript. Keep its
-   htmx-only progress message out of that fallback, then reveal it only while
-   htmx marks this explicit indicator as the active request indicator. */
-#capability-json-loading {
-  display: none;
-}
-
-#capability-json-loading.htmx-request {
-  display: inline-flex;
-}
-
-/* Large CapabilityStatements use a page-specific incremental tree. Only the
-   currently expanded, bounded fragments exist in the DOM. */
+/* The Raw CapabilityStatement has one keyboard-focusable scroll owner. Every
+   nested outline and shared JSON fragment remains overflow-visible inside it. */
 #capability-json-body {
   max-height: 70vh;
   overflow: auto;
-  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  outline: none;
+}
+
+#capability-json-body:focus-visible {
+  border-radius: 8px;
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .capability-json-outline {
@@ -1654,11 +1695,14 @@ select.field__input {
 .capability-json-node > summary::-webkit-details-marker { display: none; }
 .capability-json-row__fold { flex: 0 0 18px; color: var(--muted); }
 .capability-json-node[open] > summary .capability-json-row__fold { transform: rotate(90deg); }
-.capability-json-node__body { padding-left: 18px; }
+.capability-json-node__body {
+  padding-left: 18px;
+  overflow: visible;
+}
 
 .capability-json-truncated {
   color: var(--muted);
-  font-family: var(--font-sans);
+  font-family: Figtree, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   font-size: 11px;
 }
 
@@ -1668,7 +1712,7 @@ select.field__input {
   justify-content: center;
   gap: 10px;
   padding: 10px;
-  font-family: var(--font-sans);
+  font-family: Figtree, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
 }
 
 /* Centered-popup variant of the addbox (the Bulk Import dialogs, #527): the

--- a/crates/ui/assets/capability-json.js
+++ b/crates/ui/assets/capability-json.js
@@ -1,9 +1,26 @@
-/* Incremental CapabilityStatement JSON only. Shared JSON viewers are untouched. */
+/* Bounded CapabilityStatement JSON tree, shared by HFS and HTS. */
 (function () {
   "use strict";
 
+  var MAX_ROWS = 1000;
+  var MAX_BYTES = 1024 * 1024;
+  var MAX_PAGES = 64;
+  var ROOT_SELECTOR = "[data-capability-json-root]";
+
+  function rootFor(element) {
+    return element && element.closest ? element.closest(ROOT_SELECTOR) : null;
+  }
+
+  function regionFor(root) {
+    return root && root.querySelector("#capability-json-body");
+  }
+
+  function treeFor(root) {
+    return root && root.querySelector("[data-capability-json-tree]");
+  }
+
   function bodyFor(details) {
-    for (var i = 0; i < details.children.length; i++) {
+    for (var i = 0; i < details.children.length; i += 1) {
       if (details.children[i].hasAttribute("data-capability-json-body")) {
         return details.children[i];
       }
@@ -11,72 +28,229 @@
     return null;
   }
 
-  function status(body, failed) {
-    var message = document.createElement("p");
-    message.className = failed ? "notice notice--warn" : "busy-status";
-    message.setAttribute("role", "status");
-    if (!failed) {
+  function utf8Bytes(value) {
+    if (window.TextEncoder) return new TextEncoder().encode(value).length;
+    return unescape(encodeURIComponent(value)).length;
+  }
+
+  function withinBudget(tree) {
+    return (
+      tree.querySelectorAll(".capability-json-row").length <= MAX_ROWS &&
+      utf8Bytes(tree.innerHTML) <= MAX_BYTES
+    );
+  }
+
+  function hasRoom(tree) {
+    return (
+      tree.querySelectorAll(".capability-json-row").length < MAX_ROWS &&
+      utf8Bytes(tree.innerHTML) < MAX_BYTES
+    );
+  }
+
+  function nodePath(ancestor, node) {
+    var path = [];
+    while (node && node !== ancestor) {
+      var parent = node.parentNode;
+      if (!parent) return null;
+      path.push(Array.prototype.indexOf.call(parent.childNodes, node));
+      node = parent;
+    }
+    return node === ancestor ? path.reverse() : null;
+  }
+
+  function nodeAtPath(ancestor, path) {
+    var node = ancestor;
+    for (var i = 0; i < path.length; i += 1) {
+      node = node.childNodes[path[i]];
+      if (!node) return null;
+    }
+    return node;
+  }
+
+  function prospectiveFits(tree, target, response) {
+    var path = nodePath(tree, target);
+    if (!path) return false;
+    var clone = tree.cloneNode(true);
+    var cloneTarget = nodeAtPath(clone, path);
+    if (!cloneTarget) return false;
+    cloneTarget.innerHTML = response;
+    return withinBudget(clone);
+  }
+
+  function responseFits(response) {
+    if (utf8Bytes(response) > MAX_BYTES) return false;
+    var template = document.createElement("template");
+    template.innerHTML = response;
+    return (
+      template.content.querySelectorAll(".capability-json-row").length <= MAX_ROWS &&
+      utf8Bytes(template.innerHTML) <= MAX_BYTES
+    );
+  }
+
+  function setStatus(root, message) {
+    var status = root.querySelector("[data-capability-json-status]");
+    if (status) status.textContent = message || "";
+  }
+
+  function text(root, name) {
+    return root.dataset[name] || "";
+  }
+
+  function statusNode(message, failed, spinning) {
+    var node = document.createElement("p");
+    node.className = failed ? "notice notice--warn" : "busy-status";
+    node.setAttribute("role", "status");
+    if (spinning) {
       var spinner = document.createElement("span");
       spinner.className = "spinner";
       spinner.setAttribute("aria-hidden", "true");
-      message.appendChild(spinner);
+      node.appendChild(spinner);
     }
-    message.appendChild(
-      document.createTextNode(
-        failed ? body.dataset.errorText || "" : body.dataset.loadingText || "",
-      ),
-    );
-    return message;
+    node.appendChild(document.createTextNode(message || ""));
+    return node;
   }
 
-  function abortBody(body) {
-    var xhr = body.capabilityJsonXhr;
+  function clearBodySnapshot(body) {
+    delete body.capabilityJsonPreviousHtml;
+    delete body.capabilityJsonPreviousLoaded;
+  }
+
+  function clearBodyLifecycle(body) {
     body.capabilityJsonXhr = null;
+    body.dataset.capabilityJsonLoading = "false";
+    body.removeAttribute("aria-busy");
+    delete body.dataset.capabilityJsonFocusDirection;
+  }
+
+  function resetBody(body, failed) {
+    body.replaceChildren(
+      statusNode(
+        failed ? body.dataset.errorText : body.dataset.loadingText,
+        failed,
+        !failed,
+      ),
+    );
+    body.dataset.capabilityJsonLoaded = "false";
+    clearBodyLifecycle(body);
+    clearBodySnapshot(body);
+  }
+
+  function restoreBody(body, outcome, message) {
+    if (
+      body.capabilityJsonPreviousLoaded === true &&
+      typeof body.capabilityJsonPreviousHtml === "string"
+    ) {
+      body.innerHTML = body.capabilityJsonPreviousHtml;
+      body.dataset.capabilityJsonLoaded = "true";
+    } else if (outcome === "error") {
+      resetBody(body, true);
+      return;
+    } else if (outcome === "limit") {
+      body.replaceChildren(statusNode(message, true, false));
+      body.dataset.capabilityJsonLoaded = "false";
+    } else {
+      resetBody(body, false);
+      return;
+    }
+    clearBodyLifecycle(body);
+    clearBodySnapshot(body);
+  }
+
+  function completeBody(body) {
+    body.dataset.capabilityJsonLoaded = "true";
+    clearBodyLifecycle(body);
+    clearBodySnapshot(body);
+  }
+
+  function updateControls(root) {
+    var tree = treeFor(root);
+    var expand = root.querySelector("[data-capability-json-expand-all]");
+    var collapse = root.querySelector("[data-capability-json-collapse-all]");
+    if (!tree || !expand || !collapse) return;
+    var busy = !!root.capabilityJsonAggregateController;
+    var state = tree.firstElementChild && tree.firstElementChild.dataset.expansionState;
+    var hasExpandable = !!tree.querySelector(
+      "details[data-capability-json-node] [data-capability-json-body]",
+    );
+    expand.disabled = busy || state === "complete" || !hasExpandable;
+    collapse.disabled = busy ? false : tree.innerHTML === root.capabilityJsonInitialMarkup;
+  }
+
+  function queue(root, item) {
+    root.capabilityJsonQueue = root.capabilityJsonQueue || [];
+    var duplicate = root.capabilityJsonQueue.some(function (queued) {
+      return queued.kind === item.kind && queued.element === item.element;
+    });
+    if (!duplicate) root.capabilityJsonQueue.push(item);
+  }
+
+  function drainQueue(root) {
+    if (root.capabilityJsonAggregateController || root.capabilityJsonActiveBody) return;
+    var queued = root.capabilityJsonQueue || [];
+    while (queued.length) {
+      var item = queued.shift();
+      if (!item.element || !item.element.isConnected) continue;
+      if (item.element.closest("details[data-capability-json-node]:not([open])")) {
+        continue;
+      }
+      if (item.kind === "body") {
+        var details = item.element.closest("details[data-capability-json-node]");
+        if (details && details.open) requestBody(root, item.element);
+      } else {
+        item.element.click();
+      }
+      break;
+    }
+  }
+
+  function finishManual(root, body) {
+    if (!body.capabilityJsonRequestActive && root.capabilityJsonActiveBody !== body) {
+      return;
+    }
+    body.capabilityJsonRequestActive = false;
+    if (root.capabilityJsonActiveBody === body) root.capabilityJsonActiveBody = null;
+    updateControls(root);
+    drainQueue(root);
+  }
+
+  function cancelBody(root, body) {
+    var xhr = body.capabilityJsonXhr;
+    var inFlight =
+      body.capabilityJsonRequestActive ||
+      body.dataset.capabilityJsonLoading === "true" ||
+      (xhr && xhr.readyState !== 4);
+    if (!inFlight) return;
+    body.capabilityJsonCancelled = true;
+    restoreBody(body, "cancel");
+    finishManual(root, body);
     if (xhr && xhr.readyState !== 4) xhr.abort();
   }
 
-  function abortTree(body) {
-    abortBody(body);
-    body.querySelectorAll("[data-capability-json-body]").forEach(function (descendant) {
-      abortBody(descendant);
+  function cancelBodies(root, element) {
+    element.querySelectorAll("[data-capability-json-body]").forEach(function (body) {
+      cancelBody(root, body);
     });
   }
 
-  function reset(body, failed) {
-    // Abort from the outside in while every descendant body is still reachable.
-    // Replacing the children afterward cannot leave a detached request able to
-    // swap stale content back into an ancestor that was already collapsed.
-    abortTree(body);
-    body.replaceChildren(status(body, failed));
-    body.dataset.capabilityJsonLoaded = "false";
-    body.dataset.capabilityJsonLoading = "false";
-    delete body.dataset.capabilityJsonFocusDirection;
-    body.removeAttribute("aria-busy");
-  }
-
-  function collapse(details) {
-    if (!details || !details.isConnected) return;
-    details.open = false;
-    var body = bodyFor(details);
-    if (body) reset(body, false);
-  }
-
-  function closeOtherBranches(details) {
-    var root = details.closest("#capability-json-fold");
-    if (!root || details === root) return;
-    root.querySelectorAll("details[data-capability-json-node][open]").forEach(function (open) {
-      if (open === details || open === root || open.contains(details)) return;
-      collapse(open);
-    });
-  }
-
-  function triggerLoad(body) {
+  function requestBody(root, body) {
     if (
       body.dataset.capabilityJsonLoaded === "true" ||
       body.dataset.capabilityJsonLoading === "true"
     ) {
       return;
     }
+    var tree = treeFor(root);
+    if (!hasRoom(tree)) {
+      body.replaceChildren(statusNode(text(root, "limitText"), true, false));
+      setStatus(root, text(root, "limitText"));
+      return;
+    }
+    if (root.capabilityJsonAggregateController || root.capabilityJsonActiveBody) {
+      queue(root, { kind: "body", element: body });
+      return;
+    }
+    root.capabilityJsonActiveBody = body;
+    body.capabilityJsonRequestActive = true;
     body.dataset.capabilityJsonLoading = "true";
     body.setAttribute("aria-busy", "true");
     if (window.htmx && typeof window.htmx.ajax === "function") {
@@ -87,27 +261,176 @@
           swap: "innerHTML",
         })
         .catch(function () {
-          // Lifecycle events below restore a localized, retryable state.
+          // htmx lifecycle events retain or restore the usable tree.
         });
+    } else {
+      resetBody(body, false);
+      finishManual(root, body);
     }
   }
+
+  function cancelManual(root) {
+    root.capabilityJsonQueue = [];
+    var region = regionFor(root);
+    if (region) cancelBodies(root, region);
+    root.capabilityJsonActiveBody = null;
+  }
+
+  function collectPages(tree) {
+    var pages = Array.prototype.slice.call(
+      tree.querySelectorAll("[data-capability-json-page]"),
+    );
+    if (pages.length > MAX_PAGES) return null;
+    var body = new URLSearchParams();
+    pages.forEach(function (page) {
+      body.append("path", page.dataset.path || "");
+      body.append("offset", page.dataset.offset || "0");
+      body.append("limit", page.dataset.limit || "100");
+    });
+    return body;
+  }
+
+  function stopAggregate(root) {
+    root.capabilityJsonGeneration = (root.capabilityJsonGeneration || 0) + 1;
+    if (root.capabilityJsonAggregateController) {
+      root.capabilityJsonAggregateController.abort();
+      root.capabilityJsonAggregateController = null;
+    }
+    var region = regionFor(root);
+    if (region) region.removeAttribute("aria-busy");
+  }
+
+  function expandAll(root) {
+    var tree = treeFor(root);
+    var region = regionFor(root);
+    if (!tree || !region || root.capabilityJsonAggregateController) return;
+    var body = collectPages(tree);
+    if (!body) {
+      setStatus(root, text(root, "limitText"));
+      return;
+    }
+
+    cancelManual(root);
+    var controller = new AbortController();
+    var generation = (root.capabilityJsonGeneration || 0) + 1;
+    root.capabilityJsonGeneration = generation;
+    root.capabilityJsonAggregateController = controller;
+    region.setAttribute("aria-busy", "true");
+    setStatus(root, text(root, "expandingText"));
+    updateControls(root);
+
+    fetch(root.dataset.expandUrl, {
+      method: "POST",
+      headers: {
+        Accept: "text/html",
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+      },
+      body: body.toString(),
+      signal: controller.signal,
+    })
+      .then(function (response) {
+        if (!response.ok) throw new Error("HTTP " + response.status);
+        return response.text();
+      })
+      .then(function (html) {
+        if (
+          controller.signal.aborted ||
+          root.capabilityJsonGeneration !== generation ||
+          root.capabilityJsonAggregateController !== controller
+        ) {
+          return;
+        }
+        if (!responseFits(html)) {
+          setStatus(root, text(root, "limitText"));
+          return;
+        }
+        tree.innerHTML = html;
+        if (window.htmx && typeof window.htmx.process === "function") {
+          window.htmx.process(tree);
+        }
+        var state = tree.firstElementChild && tree.firstElementChild.dataset.expansionState;
+        setStatus(
+          root,
+          state === "complete" ? text(root, "completeText") : text(root, "partialText"),
+        );
+      })
+      .catch(function (error) {
+        if (error.name !== "AbortError" && root.capabilityJsonGeneration === generation) {
+          setStatus(root, text(root, "errorText"));
+        }
+      })
+      .finally(function () {
+        if (root.capabilityJsonAggregateController === controller) {
+          root.capabilityJsonAggregateController = null;
+          region.removeAttribute("aria-busy");
+          updateControls(root);
+          drainQueue(root);
+        }
+      });
+  }
+
+  function collapseAll(root, control) {
+    var tree = treeFor(root);
+    if (!tree) return;
+    stopAggregate(root);
+    cancelManual(root);
+    tree.innerHTML = root.capabilityJsonInitialMarkup;
+    if (window.htmx && typeof window.htmx.process === "function") {
+      window.htmx.process(tree);
+    }
+    setStatus(root, "");
+    updateControls(root);
+    if (control && control.isConnected) control.focus({ preventScroll: true });
+  }
+
+  function enhance(root) {
+    if (root.dataset.capabilityJsonEnhanced === "true") return;
+    var tree = treeFor(root);
+    var actions = root.querySelector("[data-capability-json-actions]");
+    var initial = tree && tree.querySelector('[data-capability-json-page][data-path=""]');
+    if (!tree || !actions || !initial) return;
+    root.dataset.capabilityJsonEnhanced = "true";
+    root.capabilityJsonInitialMarkup = tree.innerHTML;
+    root.capabilityJsonGeneration = 0;
+    root.capabilityJsonQueue = [];
+    actions.hidden = false;
+    var fallback = root.querySelector("[data-capability-json-fallback]");
+    if (fallback) fallback.hidden = true;
+    updateControls(root);
+  }
+
+  function enhanceAll(scope) {
+    if (scope.matches && scope.matches(ROOT_SELECTOR)) enhance(scope);
+    scope.querySelectorAll(ROOT_SELECTOR).forEach(enhance);
+  }
+
+  document.addEventListener("click", function (event) {
+    var expand = event.target.closest("[data-capability-json-expand-all]");
+    if (expand) {
+      expandAll(rootFor(expand));
+      return;
+    }
+    var collapse = event.target.closest("[data-capability-json-collapse-all]");
+    if (collapse) collapseAll(rootFor(collapse), collapse);
+  });
 
   document.addEventListener(
     "toggle",
     function (event) {
       var details = event.target;
       if (!details.matches || !details.matches("details[data-capability-json-node]")) return;
+      var root = rootFor(details);
       var body = bodyFor(details);
-      if (!body) return;
-
+      if (!root || !body) return;
       if (details.open) {
-        closeOtherBranches(details);
-        triggerLoad(body);
+        requestBody(root, body);
       } else {
-        // Removing the swapped subtree is the DOM budget: reopening issues a
-        // fresh, bounded request rather than retaining descendants invisibly.
-        reset(body, false);
+        cancelBodies(root, body);
+        cancelBody(root, body);
+        resetBody(body, false);
+        finishManual(root, body);
       }
+      updateControls(root);
     },
     true,
   );
@@ -115,53 +438,106 @@
   document.addEventListener("htmx:beforeRequest", function (event) {
     var target = event.detail && event.detail.target;
     if (!target || !target.hasAttribute("data-capability-json-body")) return;
-    target.dataset.capabilityJsonLoading = "true";
-    target.setAttribute("aria-busy", "true");
-    target.capabilityJsonXhr = event.detail.xhr;
+    var root = rootFor(target);
+    var region = regionFor(root);
+    if (!root || target === region) return;
     var source =
       (event.detail.requestConfig && event.detail.requestConfig.elt) ||
       event.detail.elt ||
       event.target;
-    if (source && source.dataset.capabilityJsonPageDirection) {
-      target.dataset.capabilityJsonFocusDirection =
-        source.dataset.capabilityJsonPageDirection;
+    if (
+      root.capabilityJsonAggregateController ||
+      (root.capabilityJsonActiveBody && root.capabilityJsonActiveBody !== target)
+    ) {
+      event.preventDefault();
+      queue(root, {
+        kind: source && source.dataset.capabilityJsonPageDirection ? "source" : "body",
+        element: source && source.dataset.capabilityJsonPageDirection ? source : target,
+      });
+      return;
     }
+    root.capabilityJsonActiveBody = target;
+    target.capabilityJsonRequestActive = true;
+    delete target.capabilityJsonCancelled;
+    delete target.capabilityJsonBudgetRejected;
+    target.capabilityJsonPreviousHtml = target.innerHTML;
+    target.capabilityJsonPreviousLoaded = target.dataset.capabilityJsonLoaded === "true";
+    target.dataset.capabilityJsonLoading = "true";
+    target.setAttribute("aria-busy", "true");
+    target.capabilityJsonXhr = event.detail.xhr;
+    if (source && source.dataset.capabilityJsonPageDirection) {
+      target.dataset.capabilityJsonFocusDirection = source.dataset.capabilityJsonPageDirection;
+    }
+  });
+
+  document.addEventListener("htmx:beforeSwap", function (event) {
+    var target = event.detail && event.detail.target;
+    if (!target || !target.hasAttribute("data-capability-json-body")) return;
+    var root = rootFor(target);
+    var tree = treeFor(root);
+    var response =
+      (event.detail && event.detail.serverResponse) ||
+      (event.detail.xhr && event.detail.xhr.responseText) ||
+      "";
+    if (!root || !tree || prospectiveFits(tree, target, response)) return;
+    event.detail.shouldSwap = false;
+    target.capabilityJsonBudgetRejected = true;
+    restoreBody(target, "limit", text(root, "limitText"));
+    setStatus(root, text(root, "limitText"));
   });
 
   document.addEventListener("htmx:afterSwap", function (event) {
     var target = event.detail && event.detail.target;
     if (!target || !target.hasAttribute("data-capability-json-body")) return;
+    var root = rootFor(target);
+    var tree = treeFor(root);
     var details = target.closest("details[data-capability-json-node]");
-    if (details && !details.open) {
-      reset(target, false);
-      return;
+    if (!root || !tree) return;
+    if (!withinBudget(tree)) {
+      target.capabilityJsonBudgetRejected = true;
+      restoreBody(target, "limit", text(root, "limitText"));
+      setStatus(root, text(root, "limitText"));
+    } else if (details && !details.open) {
+      resetBody(target, false);
+    } else {
+      var direction = target.dataset.capabilityJsonFocusDirection;
+      completeBody(target);
+      if (direction) {
+        var preferred = target.querySelector(
+          '[data-capability-json-page-direction="' + direction + '"]:not(:disabled)',
+        );
+        var fallback = target.querySelector(
+          "[data-capability-json-page-direction]:not(:disabled)",
+        );
+        if (preferred || fallback) (preferred || fallback).focus({ preventScroll: true });
+      }
     }
-    target.dataset.capabilityJsonLoaded = "true";
-    target.dataset.capabilityJsonLoading = "false";
-    target.removeAttribute("aria-busy");
-    target.capabilityJsonXhr = null;
-    var direction = target.dataset.capabilityJsonFocusDirection;
-    delete target.dataset.capabilityJsonFocusDirection;
-    if (direction) {
-      var preferred = target.querySelector(
-        '[data-capability-json-page-direction="' + direction + '"]:not(:disabled)',
-      );
-      var fallback = target.querySelector(
-        "[data-capability-json-page-direction]:not(:disabled)",
-      );
-      var control = preferred || fallback;
-      if (control) control.focus({ preventScroll: true });
-    }
+    updateControls(root);
   });
 
   document.addEventListener("htmx:afterRequest", function (event) {
     var target = event.detail && event.detail.target;
     if (!target || !target.hasAttribute("data-capability-json-body")) return;
-    target.capabilityJsonXhr = null;
+    var root = rootFor(target);
+    if (!root) return;
     var status = event.detail.xhr && event.detail.xhr.status;
-    if (!(status >= 200 && status < 400)) {
-      var details = target.closest("details[data-capability-json-node]");
-      reset(target, !!(details && details.open));
+    if (target.capabilityJsonCancelled) {
+      delete target.capabilityJsonCancelled;
+    } else if (target.capabilityJsonBudgetRejected) {
+      delete target.capabilityJsonBudgetRejected;
+    } else if (!(status >= 200 && status < 400)) {
+      restoreBody(target, "error");
+      setStatus(root, text(root, "errorText"));
+    } else if (target.dataset.capabilityJsonLoading === "true") {
+      restoreBody(target, "error");
+      setStatus(root, text(root, "errorText"));
     }
+    finishManual(root, target);
   });
+
+  document.addEventListener("htmx:load", function (event) {
+    enhanceAll(event.detail && event.detail.elt ? event.detail.elt : document);
+  });
+
+  enhanceAll(document);
 })();

--- a/crates/ui/e2e/pages/capability-statement.ts
+++ b/crates/ui/e2e/pages/capability-statement.ts
@@ -41,12 +41,28 @@ export class CapabilityStatementPage {
       .locator(":scope > div");
   }
 
-  get rawDisclosure(): Locator {
+  get rawCard(): Locator {
     return this.page.locator("#capability-json-fold");
   }
 
-  get rawSummary(): Locator {
-    return this.rawDisclosure.locator(":scope > summary");
+  get rawHeader(): Locator {
+    return this.rawCard.locator(":scope > .card-head");
+  }
+
+  get rawActions(): Locator {
+    return this.rawHeader.locator("[data-capability-json-actions]");
+  }
+
+  get collapseAll(): Locator {
+    return this.rawActions.locator("[data-capability-json-collapse-all]");
+  }
+
+  get expandAll(): Locator {
+    return this.rawActions.locator("[data-capability-json-expand-all]");
+  }
+
+  get rawStatus(): Locator {
+    return this.rawActions.locator("[data-capability-json-status]");
   }
 
   get rawBody(): Locator {
@@ -54,19 +70,15 @@ export class CapabilityStatementPage {
   }
 
   get rawLoadLink(): Locator {
-    return this.rawBody.getByRole("link", { name: "Open plain JSON" });
+    return this.rawCard.getByRole("link", { name: "Open plain JSON" });
   }
 
-  get rawLoading(): Locator {
-    return this.rawBody.locator("#capability-json-loading");
-  }
-
-  get jsonView(): Locator {
-    return this.rawBody.locator("#capability-json");
+  get jsonTree(): Locator {
+    return this.rawBody.locator(":scope > [data-capability-json-tree]");
   }
 
   get jsonOutline(): Locator {
-    return this.rawBody.locator(":scope > .capability-json-outline");
+    return this.jsonTree.locator(":scope > [data-capability-json-page]");
   }
 
   jsonNode(scope: Locator, key: string): Locator {

--- a/crates/ui/e2e/tests/a11y.spec.ts
+++ b/crates/ui/e2e/tests/a11y.spec.ts
@@ -76,6 +76,18 @@ for (const theme of THEMES) {
     const { violations } = await new AxeBuilder({ page }).withTags(WCAG).analyze();
     expect(violations).toEqual([]);
   });
+
+  test(`expanded CapabilityStatement JSON is accessible — ${theme}`, async ({ page, chrome }) => {
+    test.setTimeout(120_000);
+    await chrome.seedTheme(theme);
+    await page.goto("/ui/capability-statement", { waitUntil: "networkidle" });
+    const body = page.locator("#capability-json-body");
+    await page.locator("[data-capability-json-expand-all]").click();
+    await expect(body).not.toHaveAttribute("aria-busy", "true");
+    await expect(page.locator("[data-capability-json-tree] > [data-expansion-state]")).toBeVisible();
+    const { violations } = await new AxeBuilder({ page }).withTags(WCAG).analyze();
+    expect(violations).toEqual([]);
+  });
 }
 
 test("terminal export delete disclosure is accessible and viewport-bound", async ({ page }) => {

--- a/crates/ui/e2e/tests/capability-statement.spec.ts
+++ b/crates/ui/e2e/tests/capability-statement.spec.ts
@@ -1,235 +1,303 @@
 import { test, expect } from "../pages/fixtures";
+import type { Locator } from "@playwright/test";
 
-type CapabilityJsonBody = HTMLElement & {
-  capabilityJsonXhr?: XMLHttpRequest | null;
-};
+async function openNode(node: Locator): Promise<Locator> {
+  const body = node.locator(":scope > [data-capability-json-body]");
+  await node.locator(":scope > summary").click();
+  await expect(body.locator("[data-capability-json-page], .json-view").first()).toBeVisible();
+  return body;
+}
 
 test("Capability Statement links follow the active FHIR version", async ({
   capabilityStatement,
   chrome,
 }) => {
   await capabilityStatement.goto("?filter=Patient");
-
   const version = await chrome.currentVersion();
   const configuredVersion = process.env.HFS_DEFAULT_FHIR_VERSION;
-  if (configuredVersion) {
-    expect(version).toBe(configuredVersion);
-  }
+  if (configuredVersion) expect(version).toBe(configuredVersion);
   const expected = {
-    R4: {
-      summary: "4.0.1",
-      patientHref: "https://hl7.org/fhir/R4/patient.html",
-    },
-    R4B: {
-      summary: "4.3.0",
-      patientHref: "https://hl7.org/fhir/R4B/patient.html",
-    },
-    R5: {
-      summary: "5.0.0",
-      patientHref: "https://hl7.org/fhir/R5/patient.html",
-    },
-    R6: {
-      summary: "6.0.0",
-      patientHref: "https://hl7.org/fhir/6.0.0-ballot4/patient.html",
-    },
+    R4: { summary: "4.0.1", patientHref: "https://hl7.org/fhir/R4/patient.html" },
+    R4B: { summary: "4.3.0", patientHref: "https://hl7.org/fhir/R4B/patient.html" },
+    R5: { summary: "5.0.0", patientHref: "https://hl7.org/fhir/R5/patient.html" },
+    R6: { summary: "6.0.0", patientHref: "https://hl7.org/fhir/6.0.0-ballot4/patient.html" },
   }[version];
   expect(expected, `No Capability Statement expectation is defined for ${version}`).toBeTruthy();
-
   await expect(capabilityStatement.resourceFilterVersion).toHaveValue(version);
   await expect(capabilityStatement.fhirVersionSummary).toHaveText(expected!.summary);
-  await expect(capabilityStatement.resourceLink("Patient")).toHaveAttribute(
-    "href",
-    expected!.patientHref,
-  );
+  await expect(capabilityStatement.resourceLink("Patient")).toHaveAttribute("href", expected!.patientHref);
 });
 
-test("Capability Statement JSON expands in bounded reloadable fragments", async ({
+test("raw JSON starts at the first level with an accessible enhanced toolbar", async ({
+  capabilityStatement,
+}) => {
+  await capabilityStatement.goto();
+  await expect(capabilityStatement.rawCard).toBeVisible();
+  await expect(capabilityStatement.rawCard).not.toHaveAttribute("open", "");
+  await expect(capabilityStatement.rawHeader.locator(":scope > h3")).toHaveText(/^Raw CapabilityStatement/);
+  await expect(capabilityStatement.rawHeader.locator(":scope > [data-capability-json-actions]")).toBeVisible();
+  await expect(capabilityStatement.rawActions).not.toHaveAttribute("hidden", "");
+  await expect(capabilityStatement.rawLoadLink).toBeHidden();
+  await expect(capabilityStatement.jsonOutline).toBeVisible();
+  await expect(capabilityStatement.jsonOutline).toHaveAttribute("data-path", "");
+  await expect(capabilityStatement.jsonOutline).toHaveAttribute("data-offset", "0");
+  await expect(capabilityStatement.jsonOutline.locator("details[data-capability-json-node][open]")).toHaveCount(0);
+  await expect(capabilityStatement.rawBody).toHaveAttribute("role", "region");
+  await expect(capabilityStatement.rawBody).toHaveAttribute("aria-labelledby", "capability-json-heading");
+  await expect(capabilityStatement.rawBody).toHaveAttribute("tabindex", "0");
+  await expect(capabilityStatement.rawBody).toHaveCSS("overflow-y", "auto");
+  expect(parseFloat(await capabilityStatement.rawBody.evaluate((node) => getComputedStyle(node).maxHeight))).toBeGreaterThan(0);
+  await expect(capabilityStatement.collapseAll).toBeDisabled();
+  await expect(capabilityStatement.expandAll).toBeEnabled();
+  await expect(capabilityStatement.page.locator("#capability-json")).toHaveCount(0);
+});
+
+test("Expand all is one bounded POST and Collapse all restores the first level", async ({
   page,
   capabilityStatement,
-  chrome,
 }) => {
   test.setTimeout(120_000);
-  const fragmentRequests = new Map<string, number>();
-  let releaseRoot!: () => void;
-  const rootGate = new Promise<void>((resolve) => {
-    releaseRoot = resolve;
-  });
-  let releaseRest!: () => void;
-  const restGate = new Promise<void>((resolve) => {
-    releaseRest = resolve;
-  });
-  let releaseRestItem!: () => void;
-  const restItemGate = new Promise<void>((resolve) => {
-    releaseRestItem = resolve;
-  });
-  const fragmentPath = (url: string): string | null => {
-    const parsed = new URL(url);
-    if (parsed.pathname !== "/ui/capability-statement/json-fragment") return null;
-    return parsed.searchParams.get("path");
-  };
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const requests: string[] = [];
   page.on("request", (request) => {
-    const path = fragmentPath(request.url());
-    if (path !== null) fragmentRequests.set(path, (fragmentRequests.get(path) ?? 0) + 1);
+    if (request.method() === "POST" && new URL(request.url()).pathname.endsWith("/json-expand")) {
+      requests.push(request.postData() ?? "");
+    }
   });
-  await page.route("**/ui/capability-statement/json-fragment?*", async (route) => {
-    const path = fragmentPath(route.request().url());
-    if (path === "") await rootGate;
-    if (path === "/rest" && fragmentRequests.get(path) === 1) await restGate;
-    if (path === "/rest/0" && fragmentRequests.get(path) === 1) await restItemGate;
+  await page.route("**/ui/capability-statement/json-expand?*", async (route) => {
+    await gate;
     await route.continue();
   });
-
-  await capabilityStatement.goto("?filter=Patient");
-  const version = await chrome.currentVersion();
-  await expect(capabilityStatement.jsonView).toHaveCount(0);
-
-  const rootResponse = page.waitForResponse((response) => fragmentPath(response.url()) === "");
-  await capabilityStatement.rawSummary.click();
-  await expect(capabilityStatement.rawLoading).toBeVisible();
-  releaseRoot();
-  const response = await rootResponse;
-  expect(response.ok()).toBeTruthy();
-  const requested = new URL(response.url());
-  expect(requested.searchParams.get("version")).toBe(version);
-  expect(requested.searchParams.get("path")).toBe("");
-  expect(requested.searchParams.get("limit")).toBe("100");
-  expect(fragmentRequests.get("")).toBe(1);
-
-  await expect(capabilityStatement.jsonOutline).toBeVisible();
-  await expect(capabilityStatement.jsonOutline).toHaveAttribute("data-item-count", /\d+/);
-
-  const format = capabilityStatement.jsonNode(capabilityStatement.jsonOutline, "format");
-  const formatBody = capabilityStatement.nodeBody(format);
-  await format.locator(":scope > summary").click();
-  await expect(formatBody.locator("[data-capability-json-page], .json-view").first()).toBeVisible();
-  await expect(capabilityStatement.rawBody).toHaveCSS("overflow-y", "auto");
-  await expect(formatBody.locator(".json-view")).toHaveCSS("max-height", "none");
-  await expect(formatBody.locator(".json-view")).toHaveCSS("overflow-y", "visible");
-
-  const rest = capabilityStatement.jsonNode(capabilityStatement.jsonOutline, "rest");
-  const restBody = capabilityStatement.nodeBody(rest);
-  // An in-flight request is aborted and its busy state cleared when the node
-  // closes. Opening this sibling also closes and unloads the format branch.
-  await rest.locator(":scope > summary").click();
-  await expect(format).not.toHaveAttribute("open", "");
-  await expect(formatBody.locator("[data-capability-json-page], .json-view")).toHaveCount(0);
-  await expect(restBody).toHaveAttribute("aria-busy", "true");
-  await rest.locator(":scope > summary").click();
-  await expect(restBody).not.toHaveAttribute("aria-busy", "true");
-  releaseRest();
-  await rest.locator(":scope > summary").click();
-  await expect(restBody.locator("[data-capability-json-page], .json-view").first()).toBeVisible();
-  expect(fragmentRequests.get("/rest")).toBe(2);
-
-  // A collapsing ancestor aborts every descendant request before removing its
-  // DOM. Releasing the intercepted response afterward cannot perform a stale
-  // swap into the collapsed branch.
-  const restItem = restBody
-    .locator(":scope > .capability-json-outline > .capability-json-rows > details")
-    .first();
-  const restItemBody = capabilityStatement.nodeBody(restItem);
-  await restItem.locator(":scope > summary").click();
-  await expect(restItemBody).toHaveAttribute("aria-busy", "true");
-  const blockedBody = await restItemBody.elementHandle();
-  expect(blockedBody).not.toBeNull();
-  await expect
-    .poll(() =>
-      blockedBody!.evaluate((body) =>
-        Boolean((body as CapabilityJsonBody).capabilityJsonXhr),
-      ),
-    )
-    .toBe(true);
-  await rest.locator(":scope > summary").click();
-  expect(
-    await blockedBody!.evaluate(
-      (body) => (body as CapabilityJsonBody).capabilityJsonXhr === null,
-    ),
-  ).toBe(true);
-  expect(await blockedBody!.evaluate((body) => body.isConnected)).toBe(false);
-  releaseRestItem();
-  await expect(restBody.locator("[data-capability-json-page], .json-view")).toHaveCount(0);
-  await rest.locator(":scope > summary").click();
-  await expect(restBody.locator("[data-capability-json-page], .json-view").first()).toBeVisible();
-  expect(fragmentRequests.get("/rest")).toBe(3);
-
-  const reloadedRestItem = restBody
-    .locator(":scope > .capability-json-outline > .capability-json-rows > details")
-    .first();
-  const restItemBodyReloaded = capabilityStatement.nodeBody(reloadedRestItem);
-  await reloadedRestItem.locator(":scope > summary").click();
-  await expect(restItemBodyReloaded.locator(":scope > .capability-json-outline")).toBeVisible();
-
-  // The resource array is larger than one page on every supported version.
-  // Paging replaces the current 100-item page instead of accumulating rows.
-  const resource = capabilityStatement.jsonNode(
-    restItemBodyReloaded.locator(":scope > .capability-json-outline"),
-    "resource",
+  await capabilityStatement.goto();
+  const initial = await capabilityStatement.jsonTree.innerHTML();
+  await capabilityStatement.expandAll.click();
+  await expect(capabilityStatement.rawBody).toHaveAttribute("aria-busy", "true");
+  await expect(capabilityStatement.rawStatus).toContainText(/Expanding/i);
+  await expect(capabilityStatement.collapseAll).toBeEnabled();
+  expect(requests).toHaveLength(1);
+  const form = new URLSearchParams(requests[0]);
+  expect(form.getAll("path")).toEqual([""]);
+  expect(form.getAll("offset")).toEqual(["0"]);
+  expect(form.getAll("limit")).toEqual(["100"]);
+  release();
+  await expect(capabilityStatement.rawBody).not.toHaveAttribute("aria-busy", "true");
+  await expect(capabilityStatement.rawStatus).toContainText(/expanded|limit|partially/i);
+  await expect(capabilityStatement.jsonTree.locator(":scope > [data-expansion-state]")).toHaveAttribute(
+    "data-expansion-state", /complete|partial/,
   );
-  const resourceBody = capabilityStatement.nodeBody(resource);
-  await resource.locator(":scope > summary").click();
-  await expect(resourceBody.locator("[data-capability-json-page]")).toHaveAttribute(
-    "data-item-count",
-    "100",
+  expect(requests).toHaveLength(1);
+  await capabilityStatement.collapseAll.click();
+  await expect(capabilityStatement.rawCard).toBeVisible();
+  await expect(capabilityStatement.rawStatus).toHaveText("");
+  await expect(capabilityStatement.collapseAll).toBeDisabled();
+  expect(await capabilityStatement.jsonTree.innerHTML()).toBe(initial);
+  await expect(capabilityStatement.jsonOutline.locator("details[data-capability-json-node][open]")).toHaveCount(0);
+  const format = capabilityStatement.jsonNode(capabilityStatement.jsonOutline, "format");
+  const rest = capabilityStatement.jsonNode(capabilityStatement.jsonOutline, "rest");
+  await openNode(format);
+  await openNode(rest);
+  await expect(format).toHaveAttribute("open", "");
+  await expect(rest).toHaveAttribute("open", "");
+});
+
+test("Expand all preserves visible pagination offsets and never follows the next page", async ({
+  page,
+  capabilityStatement,
+}) => {
+  test.setTimeout(120_000);
+  await capabilityStatement.goto();
+  const restBody = await openNode(capabilityStatement.jsonNode(capabilityStatement.jsonOutline, "rest"));
+  const firstRestBody = await openNode(restBody.locator("details[data-capability-json-node]").first());
+  const resourceBody = await openNode(
+    capabilityStatement.jsonNode(firstRestBody.locator(":scope > [data-capability-json-page]"), "resource"),
   );
   const next = capabilityStatement.pageControl(resourceBody, "next");
   await expect(next).toBeEnabled();
   await next.click();
-  await expect(resourceBody.locator(".capability-json-pagination")).toContainText(/101–/);
-  const focusedPageControl = resourceBody.locator(
-    "[data-capability-json-page-direction]:focus",
+  const visiblePage = resourceBody.locator(":scope > [data-capability-json-page]");
+  await expect(visiblePage).toHaveAttribute("data-offset", "100");
+  const fragmentRequests: string[] = [];
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname.endsWith("/json-fragment") && url.searchParams.get("path") === "/rest/0/resource") {
+      fragmentRequests.push(url.searchParams.get("offset") ?? "");
+    }
+  });
+  const expandRequest = page.waitForRequest(
+    (request) => request.method() === "POST" && new URL(request.url()).pathname.endsWith("/json-expand"),
   );
-  await expect(focusedPageControl).toHaveCount(1);
-  const expectedFocusDirection = (await next.isEnabled()) ? "next" : "previous";
-  await expect(focusedPageControl).toHaveAttribute(
-    "data-capability-json-page-direction",
-    expectedFocusDirection,
+  await capabilityStatement.expandAll.click();
+  const body = new URLSearchParams((await expandRequest).postData() ?? "");
+  const paths = body.getAll("path");
+  const offsets = body.getAll("offset");
+  expect(paths.map((path, index) => ({ path, offset: offsets[index] }))).toContainEqual({
+    path: "/rest/0/resource", offset: "100",
+  });
+  await expect(capabilityStatement.rawBody).not.toHaveAttribute("aria-busy", "true");
+  await expect(capabilityStatement.jsonTree.locator('[data-path="/rest/0/resource"]')).toHaveAttribute(
+    "data-offset", "100",
   );
-  const secondPageCount = Number(
-    await resourceBody.locator("[data-capability-json-page]").getAttribute("data-item-count"),
-  );
-  expect(secondPageCount).toBeGreaterThan(0);
-  expect(secondPageCount).toBeLessThanOrEqual(100);
-  expect(fragmentRequests.get("/rest/0/resource")).toBe(2);
-
-  // Closing the top-level disclosure unloads the entire incremental tree.
-  await capabilityStatement.rawSummary.click();
-  await expect(capabilityStatement.rawDisclosure).not.toHaveAttribute("open", "");
-  await expect(capabilityStatement.rawBody.locator("[data-capability-json-page], .json-view")).toHaveCount(0);
-  await capabilityStatement.rawSummary.click();
-  await expect(capabilityStatement.rawDisclosure).toHaveAttribute("open", "");
-  await expect(capabilityStatement.jsonOutline).toBeVisible();
-  expect(fragmentRequests.get("")).toBe(2);
+  expect(fragmentRequests).not.toContain("200");
 });
+
+test("Collapse all cancels a late aggregate response without swapping it", async ({
+  page,
+  capabilityStatement,
+}) => {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  await page.route("**/ui/capability-statement/json-expand?*", async (route) => {
+    await gate;
+    try {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: '<div data-expansion-state="complete"><p id="late-json-response">late</p></div>',
+      });
+    } catch {
+      // Chromium may dispose an intercepted route immediately after AbortController fires.
+    }
+  });
+  await capabilityStatement.goto();
+  const initial = await capabilityStatement.jsonTree.innerHTML();
+  await capabilityStatement.expandAll.click();
+  await expect(capabilityStatement.rawBody).toHaveAttribute("aria-busy", "true");
+  await capabilityStatement.collapseAll.click();
+  await expect(capabilityStatement.rawBody).not.toHaveAttribute("aria-busy", "true");
+  release();
+  await page.waitForTimeout(100);
+  await expect(page.locator("#late-json-response")).toHaveCount(0);
+  expect(await capabilityStatement.jsonTree.innerHTML()).toBe(initial);
+});
+
+test("an aggregate HTTP failure retains the tree and permits retry", async ({
+  page,
+  capabilityStatement,
+}) => {
+  let fail = true;
+  await page.route("**/ui/capability-statement/json-expand?*", async (route) => {
+    if (fail) {
+      fail = false;
+      await route.fulfill({ status: 503, body: "temporarily unavailable" });
+    } else {
+      await route.continue();
+    }
+  });
+  await capabilityStatement.goto();
+  const initial = await capabilityStatement.jsonTree.innerHTML();
+  await capabilityStatement.expandAll.click();
+  await expect(capabilityStatement.rawStatus).toContainText(/could not|try again|error/i);
+  expect(await capabilityStatement.jsonTree.innerHTML()).toBe(initial);
+  await expect(capabilityStatement.expandAll).toBeEnabled();
+  await capabilityStatement.expandAll.click();
+  await expect(capabilityStatement.rawBody).not.toHaveAttribute("aria-busy", "true");
+  await expect(capabilityStatement.jsonTree.locator(":scope > [data-expansion-state]")).toHaveAttribute(
+    "data-expansion-state", /complete|partial/,
+  );
+});
+
+test("the expanded tree owns keyboard and wheel scrolling", async ({ page, capabilityStatement }) => {
+  test.setTimeout(120_000);
+  await page.setViewportSize({ width: 1280, height: 500 });
+  await capabilityStatement.goto();
+  await capabilityStatement.expandAll.click();
+  await expect(capabilityStatement.rawBody).not.toHaveAttribute("aria-busy", "true");
+  const dimensions = await capabilityStatement.rawBody.evaluate((node) => ({
+    clientHeight: node.clientHeight,
+    scrollHeight: node.scrollHeight,
+  }));
+  expect(dimensions.scrollHeight).toBeGreaterThan(dimensions.clientHeight);
+  await capabilityStatement.rawBody.evaluate((node) => { node.scrollTop = 0; });
+  await capabilityStatement.rawBody.hover();
+  await page.mouse.wheel(0, 500);
+  await expect.poll(() => capabilityStatement.rawBody.evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
+  const afterWheel = await capabilityStatement.rawBody.evaluate((node) => node.scrollTop);
+  await capabilityStatement.rawBody.focus();
+  await page.keyboard.press("PageDown");
+  await expect.poll(() => capabilityStatement.rawBody.evaluate((node) => node.scrollTop)).toBeGreaterThan(afterWheel);
+});
+
+test("wheel scrolling chains to the page at the expanded tree boundary", async ({
+  page,
+  capabilityStatement,
+}) => {
+  test.setTimeout(120_000);
+  await page.setViewportSize({ width: 1280, height: 500 });
+  await capabilityStatement.goto();
+  await capabilityStatement.expandAll.click();
+  await expect(capabilityStatement.rawBody).not.toHaveAttribute("aria-busy", "true");
+  await capabilityStatement.rawBody.evaluate((node) => {
+    node.scrollTop = 0;
+  });
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+  await capabilityStatement.rawBody.hover();
+  const pageScrollBeforeWheel = await page.evaluate(() => window.scrollY);
+  expect(pageScrollBeforeWheel).toBeGreaterThan(0);
+
+  await page.mouse.wheel(0, -240);
+
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeLessThan(pageScrollBeforeWheel);
+  await expect(capabilityStatement.rawBody).toHaveJSProperty("scrollTop", 0);
+
+  const regionScrollBottom = await capabilityStatement.rawBody.evaluate((node) => {
+    node.scrollTop = node.scrollHeight;
+    return node.scrollTop;
+  });
+  await capabilityStatement.rawBody.hover();
+  const pageScrollBeforeDownwardWheel = await page.evaluate(() => window.scrollY);
+  await page.mouse.wheel(0, 240);
+
+  await expect
+    .poll(() => page.evaluate(() => window.scrollY))
+    .toBeGreaterThan(pageScrollBeforeDownwardWheel);
+  await expect(capabilityStatement.rawBody).toHaveJSProperty("scrollTop", regionScrollBottom);
+});
+
+for (const theme of ["light", "dark"] as const) {
+  test(`raw toolbar stays inside the card at phone width — ${theme}`, async ({
+    page,
+    capabilityStatement,
+    chrome,
+  }) => {
+    await chrome.seedTheme(theme);
+    await page.setViewportSize({ width: 390, height: 844 });
+    await capabilityStatement.goto();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+    const metrics = await capabilityStatement.rawCard.evaluate((card) => {
+      const actions = card.querySelector<HTMLElement>("[data-capability-json-actions]")!;
+      const header = card.querySelector<HTMLElement>(":scope > .card-head")!;
+      const cardBox = card.getBoundingClientRect();
+      const actionsBox = actions.getBoundingClientRect();
+      return {
+        actionsInside: actionsBox.left >= cardBox.left && actionsBox.right <= cardBox.right + 1,
+        wraps: getComputedStyle(header).flexWrap,
+        overflows: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      };
+    });
+    expect(metrics).toEqual({ actionsInside: true, wraps: "wrap", overflows: false });
+  });
+}
 
 test("typing filters resource capabilities live", async ({ capabilityStatement }) => {
   await capabilityStatement.goto();
   await expect(capabilityStatement.resourceRow("Patient")).toBeVisible();
   await expect(capabilityStatement.resourceRow("Observation")).toBeVisible();
-
   await capabilityStatement.filter.fill("Patient");
-
   await expect(capabilityStatement.resourceRow("Patient")).toBeVisible();
   await expect(capabilityStatement.resourceRow("Observation")).toHaveCount(0);
 });
 
-test("the resource filter stacks inside the card at phone width", async ({
-  page,
-  capabilityStatement,
-}) => {
+test("the resource filter stacks inside the card at phone width", async ({ page, capabilityStatement }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await capabilityStatement.goto();
-
   const header = page.locator(".cap-resource-card > .card-head");
   const filter = page.locator(".cap-resource-filter");
   await expect(header).toHaveCSS("flex-direction", "column");
-  await expect(filter).toBeVisible();
-
   const headerBox = await header.boundingBox();
   const filterBox = await filter.boundingBox();
   expect(headerBox).not.toBeNull();
   expect(filterBox).not.toBeNull();
   expect(filterBox!.x).toBeGreaterThanOrEqual(headerBox!.x);
-  expect(filterBox!.x + filterBox!.width).toBeLessThanOrEqual(
-    headerBox!.x + headerBox!.width + 1,
-  );
+  expect(filterBox!.x + filterBox!.width).toBeLessThanOrEqual(headerBox!.x + headerBox!.width + 1);
 });

--- a/crates/ui/e2e/tests/design-system.spec.ts
+++ b/crates/ui/e2e/tests/design-system.spec.ts
@@ -532,6 +532,42 @@ test("every exercised detail field gets external spacing from its direct parent"
   }
 });
 
+test("Capability cards share edge-to-edge headers and compact interaction spacing", async ({ page }) => {
+  await page.goto("/ui/capability-statement", { waitUntil: "networkidle" });
+
+  for (const selector of [".cap-operations-card", ".cap-resource-card"]) {
+    const geometry = await page.locator(selector).evaluate((card) => {
+      const header = card.querySelector<HTMLElement>(":scope > .card-head")!;
+      const cardBox = card.getBoundingClientRect();
+      const headerBox = header.getBoundingClientRect();
+      const heading = header.querySelector<HTMLElement>("h3")!;
+      return {
+        leftInset: headerBox.left - cardBox.left,
+        rightInset: cardBox.right - headerBox.right,
+        headingFont: getComputedStyle(heading).fontSize,
+      };
+    });
+    expect(Math.abs(geometry.leftInset)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.rightInset)).toBeLessThanOrEqual(1);
+    expect(geometry.headingFont).toBe("13px");
+  }
+
+  const interactions = page.locator(".cap-interaction-tags");
+  await expect(interactions).toHaveCSS("display", "flex");
+  await expect(interactions).toHaveCSS("margin-top", "0px");
+  await expect(interactions).toHaveCSS("margin-left", "0px");
+  const firstTag = interactions.locator(":scope > .tag").first();
+  const alignment = await interactions.evaluate((row) => {
+    const tag = row.querySelector<HTMLElement>(":scope > .tag")!;
+    const rowBox = row.getBoundingClientRect();
+    const tagBox = tag.getBoundingClientRect();
+    return { left: tagBox.left - rowBox.left, top: tagBox.top - rowBox.top };
+  });
+  expect(alignment.left).toBe(0);
+  expect(alignment.top).toBe(0);
+  await expect(firstTag).toBeVisible();
+});
+
 for (const viewport of [
   { width: 1440, height: 900, columns: 2 },
   { width: 1240, height: 800, columns: 1 },

--- a/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
+++ b/crates/ui/e2e/tests/nojs/progressive-enhancement.spec.ts
@@ -202,8 +202,12 @@ test("the CapabilityStatement raw fallback is plain JSON with no JavaScript", as
   capabilityStatement,
 }) => {
   await capabilityStatement.goto("?filter=Patient");
-  await capabilityStatement.rawSummary.click();
-  await expect(capabilityStatement.rawLoading).toBeHidden();
+  await expect(capabilityStatement.rawCard).toBeVisible();
+  await expect(capabilityStatement.jsonOutline).toBeVisible();
+  await expect(capabilityStatement.jsonOutline).toHaveAttribute("data-path", "");
+  await expect(capabilityStatement.jsonOutline.locator("details[open]")).toHaveCount(0);
+  await expect(capabilityStatement.rawActions).toBeHidden();
+  await expect(capabilityStatement.rawLoadLink).toBeVisible();
   await capabilityStatement.rawLoadLink.click();
 
   const url = new URL(page.url());
@@ -211,11 +215,11 @@ test("the CapabilityStatement raw fallback is plain JSON with no JavaScript", as
   expect(url.searchParams.get("raw")).toBe("1");
   expect(url.searchParams.get("version")).toBe("R4");
   expect(url.searchParams.get("filter")).toBe("Patient");
-  await expect(capabilityStatement.rawDisclosure).toHaveAttribute("open", "");
-  await expect(capabilityStatement.rawBody.locator("pre.detail__code")).toBeVisible();
-  await expect(capabilityStatement.rawBody.getByText("Plain JSON fallback", { exact: false })).toBeVisible();
-  await expect(capabilityStatement.jsonView).toHaveCount(0);
-  await expect(capabilityStatement.rawBody.locator(".json-line")).toHaveCount(0);
+  await expect(capabilityStatement.rawCard.locator("pre.detail__code")).toBeVisible();
+  await expect(capabilityStatement.rawCard.getByText("Plain JSON fallback", { exact: false })).toBeVisible();
+  await expect(capabilityStatement.rawActions).toHaveCount(0);
+  await expect(capabilityStatement.rawBody).toHaveCount(0);
+  await expect(capabilityStatement.rawCard.locator(".json-line, [data-capability-json-page]")).toHaveCount(0);
 });
 
 test("a hard navigation returns the full page, not an htmx fragment", async ({ page, chrome }) => {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1225,6 +1225,10 @@ pub fn mount_with_conformance_source_and_runtime(
             "/ui/capability-statement/json-fragment",
             get(capability_json_fragment),
         )
+        .route(
+            "/ui/capability-statement/json-expand",
+            axum::routing::post(capability_json_expand),
+        )
         // Batch/Transaction workspace (#476): upload â†’ preflight â†’ response.
         .route("/ui/batch", get(batch_page))
         // SQL on FHIR workspaces (#649).
@@ -3523,7 +3527,8 @@ impl RenderedCapabilityCards {
         raw_requested: bool,
         raw_text: &str,
         raw_url: &str,
-        fragment_url: &str,
+        expand_url: &str,
+        initial_outline: Option<&capability_json::Outline>,
     ) -> Result<Self, askama::Error> {
         let cards = helios_ui_chrome::capability::CapabilityCards::new(i18n, view)
             .transaction_note_href(Some(ROLE_MATRIX_URL))
@@ -3538,7 +3543,13 @@ impl RenderedCapabilityCards {
             interactions: cards.interactions()?,
             operations: cards.operations()?,
             resources: cards.resources()?,
-            raw: cards.raw(raw_requested, raw_text, raw_url, fragment_url)?,
+            raw: cards.raw(
+                raw_requested,
+                raw_text,
+                raw_url,
+                expand_url,
+                initial_outline,
+            )?,
         })
     }
 }
@@ -3617,6 +3628,12 @@ fn capability_json_fragment_endpoint(
     }
 }
 
+fn capability_json_expand_url(version: helios_fhir::FhirVersion) -> String {
+    let mut query = form_urlencoded::Serializer::new(String::new());
+    query.append_pair("version", version.as_str());
+    format!("/ui/capability-statement/json-expand?{}", query.finish())
+}
+
 async fn capability_json_fragment(
     State(state): State<WebState>,
     locale: RequestLocale,
@@ -3661,6 +3678,73 @@ async fn capability_json_fragment(
     }
 }
 
+async fn capability_json_expand(
+    State(state): State<WebState>,
+    locale: RequestLocale,
+    rv: RequestVersion,
+    rt: RequestTenant,
+    Query(query): Query<CapabilityJsonQuery>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let version = match query.version.as_deref() {
+        Some(value) => match search_params::version_from_str(value) {
+            Some(version) => version,
+            None => return (StatusCode::BAD_REQUEST, "Unsupported FHIR version").into_response(),
+        },
+        None => rv.0,
+    };
+    if !headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .is_some_and(|value| {
+            value
+                .trim()
+                .eq_ignore_ascii_case("application/x-www-form-urlencoded")
+        })
+    {
+        return (StatusCode::BAD_REQUEST, "Invalid JSON page state").into_response();
+    }
+    let pages = match capability_json::parse_page_descriptors(&body) {
+        Ok(pages) => pages,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid JSON page state").into_response(),
+    };
+    let statement = match state.conformance.metadata(version, &rt.id).await {
+        Ok(statement) => statement,
+        Err(error) => {
+            tracing::warn!("CapabilityStatement aggregate fetch failed: {error}");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "CapabilityStatement is unavailable",
+            )
+                .into_response();
+        }
+    };
+    let i18n = I18n::new(locale);
+    let expanded = match capability_json::plan_expanded(
+        &statement,
+        &pages,
+        capability_json_fragment_endpoint(version),
+    ) {
+        Ok(expanded) => expanded,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid JSON page state").into_response(),
+    };
+    match capability_json::render_expanded(&i18n, &expanded) {
+        Ok(html) => Html(html).into_response(),
+        Err(capability_json::ExpandedRenderError::TooLarge) => (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "CapabilityStatement expansion exceeds the rendering budget",
+        )
+            .into_response(),
+        Err(capability_json::ExpandedRenderError::Template(error)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("template render error: {error}"),
+        )
+            .into_response(),
+    }
+}
+
 async fn capability_page(
     State(state): State<WebState>,
     locale: RequestLocale,
@@ -3676,8 +3760,7 @@ async fn capability_page(
         .unwrap_or(rv.0);
     let raw_requested = query.raw.as_deref() == Some("1");
     let raw_url = capability_raw_url(&filter, version);
-    let fragment_url =
-        capability_json::root_fragment_url(capability_json_fragment_endpoint(version));
+    let expand_url = capability_json_expand_url(version);
     let i18n = I18n::new(locale);
     let fetched = state.conformance.metadata(version, &rt.id).await;
     let cards = match fetched {
@@ -3693,6 +3776,20 @@ async fn capability_page(
             } else {
                 String::new()
             };
+            let initial_outline = if raw_requested {
+                None
+            } else {
+                match capability_json::plan(
+                    &statement,
+                    "",
+                    0,
+                    capability_json::DEFAULT_PAGE_SIZE,
+                    capability_json_fragment_endpoint(version),
+                ) {
+                    Ok(capability_json::View::Outline(outline)) => Some(outline),
+                    Ok(capability_json::View::Full(_)) | Err(_) => None,
+                }
+            };
             match RenderedCapabilityCards::render(
                 &i18n,
                 &view,
@@ -3701,7 +3798,8 @@ async fn capability_page(
                 raw_requested,
                 &raw_text,
                 &raw_url,
-                &fragment_url,
+                &expand_url,
+                initial_outline.as_ref(),
             ) {
                 Ok(cards) => Some(cards),
                 Err(error) => {

--- a/crates/ui/templates/pages/capability-statement.html
+++ b/crates/ui/templates/pages/capability-statement.html
@@ -8,9 +8,10 @@
   exactly what #808 removed. Card *content* changes belong in
   `crates/ui-chrome/templates/partials/capability-*.html`.
 
-  The raw fold is not a `<pre>` of the whole document but a bounded,
-  paginated JSON-fragment tree loaded on demand (#798, generalized in #808).
-  Its endpoint (`/ui/capability-statement/json-fragment`) stays HFS's own —
+  Raw is not a `<pre>` of the whole document: its first level is rendered
+  from the page's existing metadata fetch, then nested nodes load bounded,
+  paginated HTML fragments (#798/#808/#902). Its incremental endpoint
+  (`/ui/capability-statement/json-fragment`) stays HFS's own —
   HTS mounts an equivalent at `/ui/hts/capability-statement/json-fragment`
   against its own upstream fetch — but the card shell, the fragment
   templates and the JSON-rendering engine behind both are the same code.

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -540,11 +540,15 @@ async fn capability_statement_page_renders_summary_and_degrades() {
     assert!(html.contains(r#"class="tag tag--member">read</span>"#));
     assert!(html.contains(r#"class="tag tag--config">create</span>"#));
     assert!(html.contains(r#"class="tag tag--excluded">delete</span>"#));
-    // The ordinary page carries only a lazy shell. It neither renders nor
-    // pretty-prints the large CapabilityStatement before the fold is opened.
+    // The ordinary page carries the bounded root outline immediately. It
+    // does not pretty-print the entire CapabilityStatement or need a second
+    // metadata request before the first level becomes usable.
     assert!(html.contains(r#"id="capability-json-fold""#));
     assert!(html.contains(r#"id="capability-json-body""#));
     assert!(html.contains(r#"data-fragment-url="/ui/capability-statement/json-fragment?"#));
+    assert!(html.contains(r#"data-expand-url="/ui/capability-statement/json-expand?version=R4""#));
+    assert!(html.contains(r#"data-capability-json-actions hidden"#));
+    assert!(html.contains(r#"data-capability-json-page"#));
     assert!(html.contains("/ui/capability-statement/json-fragment?"));
     assert!(html.contains("raw=1"));
     assert!(html.contains("version=R4"));
@@ -553,7 +557,7 @@ async fn capability_statement_page_renders_summary_and_degrades() {
     assert!(!html.contains(r#"id="capability-json""#));
     assert!(!html.contains(r#"class="json-line"#));
     assert!(!html.contains(r#"<pre class="detail__code">"#));
-    assert!(!html.contains("RAW_ONLY_CAPABILITY_MARKER"));
+    assert!(html.contains("RAW_ONLY_CAPABILITY_MARKER"));
 
     // An explicit raw request is the no-JavaScript fallback: plain JSON in an
     // open disclosure, never the expensive highlighted DOM.
@@ -568,7 +572,7 @@ async fn capability_statement_page_renders_summary_and_degrades() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let raw_html = body_text(response).await;
-    assert!(raw_html.contains(r#"id="capability-json-fold" open"#));
+    assert!(raw_html.contains(r#"<section class="card capability-raw-card""#));
     assert!(raw_html.contains(r#"<pre class="detail__code">"#));
     assert!(raw_html.contains("RAW_ONLY_CAPABILITY_MARKER"));
     assert!(raw_html.contains("Plain JSON fallback"));
@@ -576,8 +580,7 @@ async fn capability_statement_page_renders_summary_and_degrades() {
     assert!(!raw_html.contains(r#"class="json-line"#));
     assert!(!raw_html.contains(r#"data-capability-json-body""#));
 
-    // This small statement still uses the unchanged shared renderer when the
-    // bounded fragment endpoint is requested.
+    // Root fragments always keep the same first-level outline contract.
     let response = app
         .clone()
         .oneshot(
@@ -591,9 +594,9 @@ async fn capability_statement_page_renders_summary_and_degrades() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let fragment = body_text(response).await;
-    assert!(fragment.contains(r#"class="json-view" id="capability-json""#));
+    assert!(fragment.contains(r#"class="capability-json-outline""#));
     assert!(fragment.contains(r#"class="jt--key""#));
-    assert!(fragment.contains("data-fold="));
+    assert!(fragment.contains(r#"data-path="""#));
     // The real GET form remains the fallback while htmx enhances live input.
     assert!(html.contains(r#"method="get" action="/ui/capability-statement""#));
     assert!(html.contains(r#"<input type="hidden" name="version" value="R4">"#));
@@ -769,6 +772,41 @@ async fn capability_statement_large_json_is_plain_without_js_and_paged_with_htmx
     assert!(first_page.contains("offset=100"));
     assert!(!first_page.contains(">100<"));
 
+    // Expand all is one HTML POST. The parallel form state preserves the
+    // currently visible offset and the planner never follows the next page.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/ui/capability-statement/json-expand?version=R4")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "path=&offset=0&limit=100&path=%2Fextension&offset=100&limit=100",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let expanded = body_text(response).await;
+    assert!(expanded.len() <= 1024 * 1024);
+    assert!(expanded.contains(r#"data-expansion-state="partial""#));
+    assert!(expanded.contains(r#"data-path="/extension""#));
+    assert!(expanded.contains(r#"data-offset="100""#));
+    assert!(expanded.contains("101–200 / 100001"));
+    assert!(!expanded.contains("201–300 / 100001"));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/ui/capability-statement/json-expand?version=R4")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("path=%2Fextension&offset=0"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
     let response = app
         .clone()
         .oneshot(
@@ -857,6 +895,7 @@ async fn capability_statement_json_fragment_degrades_when_metadata_is_unavailabl
     );
 
     let response = app
+        .clone()
         .oneshot(
             Request::get("/ui/capability-statement/json-fragment")
                 .body(Body::empty())
@@ -869,6 +908,17 @@ async fn capability_statement_json_fragment_degrades_when_metadata_is_unavailabl
         body_text(response).await,
         "CapabilityStatement is unavailable"
     );
+
+    let response = app
+        .oneshot(
+            Request::post("/ui/capability-statement/json-expand")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("path=&offset=0&limit=100"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 }
 
 #[tokio::test]

--- a/locales/de/main.ftl
+++ b/locales/de/main.ftl
@@ -778,6 +778,13 @@ cap-json-path-too-deep = maximale Aufklapptiefe erreicht
 cap-json-pagination-label = JSON-Elemente
 cap-json-page-prev = Zurück
 cap-json-page-next = Weiter
+cap-json-collapse-all = Alle einklappen
+cap-json-expand-all = Alle ausklappen
+cap-json-expanding = Sichtbares JSON wird ausgeklappt…
+cap-json-expand-complete = Das gesamte JSON ist ausgeklappt.
+cap-json-expand-partial = Die aktuellen Seiten wurden bis zum sicheren Limit ausgeklappt. Die übrigen Knoten bleiben eingeklappt.
+cap-json-limit-reached = Das Anzeigelimit für JSON wurde erreicht. Klappen Sie einen anderen Zweig ein, bevor Sie weitere Daten laden.
+cap-json-expand-error = Der JSON-Baum konnte nicht ausgeklappt werden. Die aktuelle Ansicht wurde beibehalten; versuchen Sie es erneut.
 cap-unavailable = Das CapabilityStatement konnte nicht vom Server geladen werden — der Selbstaufruf benötigt bei aktivierter Authentifizierung eventuell ein Ausgangs-Token.
 
 ## Stubs der SQL-on-FHIR-Sektion (#649)

--- a/locales/en/main.ftl
+++ b/locales/en/main.ftl
@@ -781,6 +781,13 @@ cap-json-path-too-deep = maximum expansion depth reached
 cap-json-pagination-label = JSON items
 cap-json-page-prev = Previous
 cap-json-page-next = Next
+cap-json-collapse-all = Collapse all
+cap-json-expand-all = Expand all
+cap-json-expanding = Expanding visible JSON…
+cap-json-expand-complete = All JSON is expanded.
+cap-json-expand-partial = Expanded the current pages up to the safe limit. Remaining nodes stay collapsed.
+cap-json-limit-reached = The JSON display limit was reached. Collapse another branch before loading more.
+cap-json-expand-error = The JSON tree could not be expanded. The current view was kept; try again.
 cap-unavailable = The CapabilityStatement could not be fetched from the server — the self-call may need an outbound token when authentication is enabled.
 
 ## SQL on FHIR section stubs (#649)

--- a/locales/es/main.ftl
+++ b/locales/es/main.ftl
@@ -778,6 +778,13 @@ cap-json-path-too-deep = se alcanzó la profundidad máxima de expansión
 cap-json-pagination-label = Elementos JSON
 cap-json-page-prev = Anterior
 cap-json-page-next = Siguiente
+cap-json-collapse-all = Colapsar todo
+cap-json-expand-all = Expandir todo
+cap-json-expanding = Expandiendo el JSON visible…
+cap-json-expand-complete = Todo el JSON está expandido.
+cap-json-expand-partial = Se expandieron las páginas actuales hasta el límite seguro. Los nodos restantes permanecen colapsados.
+cap-json-limit-reached = Se alcanzó el límite de visualización del JSON. Colapsa otra rama antes de cargar más.
+cap-json-expand-error = No se pudo expandir el árbol JSON. Se conservó la vista actual; inténtalo de nuevo.
 cap-unavailable = No se pudo obtener la CapabilityStatement del servidor — la autollamada puede necesitar un token saliente cuando la autenticación está activada.
 
 ## Stubs de la sección SQL on FHIR (#649)


### PR DESCRIPTION
Closes #902

### Summary

- Normalize CapabilityStatement card headers, dividers, spacing, and typography.
- Reduce excess spacing in System Interactions.
- Place Collapse all and Expand all beside the Raw CapabilityStatement title.
- Render the JSON root and first level by default, while preserving independent branch expansion.
- Give the JSON viewer one accessible, bounded scroll region with natural page-scroll chaining.
- Share the behavior across HFS and HTS, including light/dark themes, mobile layouts, localization, and no-JavaScript fallback.

### Expand-all behavior

Expand all is intentionally bounded to 1,000 rows and 1 MiB of rendered HTML. It preserves visible page offsets, does not fetch later pages automatically, and reports when the safe rendering limit is reached.

Sending the complete CapabilityStatement over the wire is not the main constraint. Rendering every node as an interactive tree can amplify a multi-megabyte JSON document into hundreds of thousands of DOM and accessibility-tree nodes, increasing memory use and potentially blocking layout and interaction.

A genuinely complete interactive expansion should use virtualization/windowing so only visible rows are mounted. The shared JSON renderer does not currently provide that capability, so this PR keeps aggregate expansion within explicit browser-safe budgets while retaining manual expansion for individual branches.

### Testing

- UI Chrome unit, integration, and doctests
- HFS and HTS CapabilityStatement integration tests
- HFS and HTS Playwright coverage for default, aggregate, manual, scrolling, theme, mobile, accessibility, and no-JavaScript states
- Rust formatting, JavaScript syntax check, diff check, and strict Clippy for the affected crates
- Manual verification in HFS and HTS; HITL approved
