### PR TITLE
fix: MongoDB ifNoneExist search correctness

### DIFF
--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -807,7 +807,7 @@ impl MongoBackend {
         Ok(Some(ids))
     }
 
-    fn build_search_index_filter(
+    pub(super) fn build_search_index_filter(
         &self,
         tenant_id: &str,
         resource_type: &str,
@@ -1171,7 +1171,7 @@ impl MongoBackend {
         }
     }
 
-    fn build_resource_filter(
+    pub(super) fn build_resource_filter(
         &self,
         tenant_id: &str,
         resource_type: &str,
@@ -1423,7 +1423,7 @@ impl MongoBackend {
         Ok(result.resources.items)
     }
 
-    fn build_search_parameters(
+    pub(super) fn build_search_parameters(
         &self,
         tenant: &TenantContext,
         resource_type: &str,

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -18,7 +18,7 @@ use crate::core::{
     HistoryEntry, HistoryMethod, HistoryPage, HistoryParams, InstanceHistoryProvider,
     PurgableStorage, ResourceStorage, SettingsStore, SystemHistoryProvider, TypeHistoryProvider,
     VersionedStorage, bundle_if_match_gate, bundle_if_none_exist_gate, if_match_field_satisfied,
-    normalize_etag, not_supported_entry,
+    normalize_etag,
 };
 use crate::error::{
     BackendError, ConcurrencyError, QueryErrorExt, ResourceError, StorageError, StorageResult,
@@ -2686,13 +2686,6 @@ impl MongoBackend {
                     })?;
 
                 if let Some(search_params) = entry.if_none_exist.as_ref() {
-                    if self.is_search_offloaded() {
-                        return Ok(not_supported_entry(
-                            "ifNoneExist cannot be resolved inside a transaction when search \
-                             is offloaded to a secondary backend; submit the entry in a batch \
-                             Bundle instead",
-                        ));
-                    }
                     let matches = self
                         .find_matching_resources_in_bundle_transaction(
                             db,
@@ -3335,11 +3328,17 @@ impl MongoBackend {
             return Ok(Vec::new());
         }
 
+        if self.is_search_offloaded() {
+            return self
+                .if_none_exist_offloaded_scan(db, session, tenant, resource_type, &parsed_params)
+                .await;
+        }
+
         let typed_params = self.build_search_parameters(tenant, resource_type, &parsed_params);
         let query = SearchQuery {
             resource_type: resource_type.to_string(),
             parameters: typed_params,
-            count: Some(1000),
+            count: Some(2),
             ..Default::default()
         };
 
@@ -3356,6 +3355,7 @@ impl MongoBackend {
             let pipeline = vec![
                 doc! { "$match": filter },
                 doc! { "$group": { "_id": "$resource_id" } },
+                doc! { "$limit": 1001_i32 },
             ];
             let cursor = search_index
                 .aggregate(pipeline)
@@ -3368,6 +3368,16 @@ impl MongoBackend {
                     ))
                 })?;
             let docs = collect_session_documents(cursor, session).await?;
+
+            if docs.len() > 1000 {
+                tracing::warn!(
+                    resource_type,
+                    param_name = %param.name,
+                    "ifNoneExist criteria match more than 1000 search_index entries; \
+                     intersection may be incomplete for this parameter"
+                );
+            }
+
             let ids: HashSet<String> = docs
                 .into_iter()
                 .filter_map(|d| d.get_str("_id").ok().map(str::to_string))
@@ -3387,21 +3397,98 @@ impl MongoBackend {
             }
         }
 
+        let candidate_ids: Option<HashSet<String>> =
+            matched_ids.map(|ids| ids.into_iter().take(2).collect());
+
         let filter = self.build_resource_filter(
             tenant_id,
             resource_type,
             &query,
-            matched_ids.as_ref(),
+            candidate_ids.as_ref(),
             None,
         )?;
 
         let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
         let cursor = resources
             .find(filter)
+            .limit(2)
             .session(&mut *session)
             .await
             .map_err(|e| {
                 internal_error(format!("Failed to query resources in transaction: {}", e))
+            })?;
+        let docs = collect_session_documents(cursor, session).await?;
+
+        docs.into_iter()
+            .map(|doc| document_to_stored_resource(&doc, tenant, resource_type))
+            .collect()
+    }
+
+    async fn if_none_exist_offloaded_scan(
+        &self,
+        db: &mongodb::Database,
+        session: &mut ClientSession,
+        tenant: &TenantContext,
+        resource_type: &str,
+        parsed_params: &[(String, String)],
+    ) -> StorageResult<Vec<StoredResource>> {
+        let tenant_id = tenant.tenant_id().as_str();
+        let mut conditions = vec![doc! {
+            "tenant_id": tenant_id,
+            "resource_type": resource_type,
+            "is_deleted": false,
+        }];
+
+        for (name, value) in parsed_params {
+            match name.as_str() {
+                "_id" => {
+                    conditions.push(doc! { "id": value.as_str() });
+                }
+                "identifier" => {
+                    let mut elem_match = Document::new();
+                    if let Some((system, val)) = value.split_once('|') {
+                        if !system.is_empty() {
+                            elem_match.insert("system", system);
+                        }
+                        if !val.is_empty() {
+                            elem_match.insert("value", val);
+                        }
+                    } else if !value.is_empty() {
+                        elem_match.insert("value", value.as_str());
+                    }
+                    if !elem_match.is_empty() {
+                        conditions.push(doc! { "data.identifier": { "$elemMatch": elem_match } });
+                    }
+                }
+                _ => {
+                    tracing::warn!(
+                        resource_type,
+                        param_name = %name,
+                        "ifNoneExist with offloaded search: param cannot be evaluated \
+                         against the resource collection directly; matches may include \
+                         false positives"
+                    );
+                }
+            }
+        }
+
+        let filter = if conditions.len() == 1 {
+            conditions.remove(0)
+        } else {
+            doc! { "$and": Bson::Array(conditions.into_iter().map(Bson::Document).collect()) }
+        };
+
+        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+        let cursor = resources
+            .find(filter)
+            .limit(2)
+            .session(&mut *session)
+            .await
+            .map_err(|e| {
+                internal_error(format!(
+                    "Failed to scan resources for offloaded ifNoneExist: {}",
+                    e
+                ))
             })?;
         let docs = collect_session_documents(cursor, session).await?;
 

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -1,6 +1,6 @@
 //! ResourceStorage implementation for MongoDB.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -18,7 +18,7 @@ use crate::core::{
     HistoryEntry, HistoryMethod, HistoryPage, HistoryParams, InstanceHistoryProvider,
     PurgableStorage, ResourceStorage, SettingsStore, SystemHistoryProvider, TypeHistoryProvider,
     VersionedStorage, bundle_if_match_gate, bundle_if_none_exist_gate, if_match_field_satisfied,
-    normalize_etag,
+    normalize_etag, not_supported_entry,
 };
 use crate::error::{
     BackendError, ConcurrencyError, QueryErrorExt, ResourceError, StorageError, StorageResult,
@@ -28,7 +28,7 @@ use crate::search::converters::IndexValue;
 use crate::search::extractor::ExtractedValue;
 use crate::search::reindex::{ReindexSource, ReindexTarget, ResourcePage};
 use crate::tenant::{Operation, TenantContext};
-use crate::types::{CursorValue, Page, PageCursor, PageInfo, StoredResource};
+use crate::types::{CursorValue, Page, PageCursor, PageInfo, SearchQuery, StoredResource};
 
 use super::MongoBackend;
 
@@ -2686,6 +2686,13 @@ impl MongoBackend {
                     })?;
 
                 if let Some(search_params) = entry.if_none_exist.as_ref() {
+                    if self.is_search_offloaded() {
+                        return Ok(not_supported_entry(
+                            "ifNoneExist cannot be resolved inside a transaction when search \
+                             is offloaded to a secondary backend; submit the entry in a batch \
+                             Bundle instead",
+                        ));
+                    }
                     let matches = self
                         .find_matching_resources_in_bundle_transaction(
                             db,
@@ -3328,47 +3335,79 @@ impl MongoBackend {
             return Ok(Vec::new());
         }
 
-        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+        let typed_params = self.build_search_parameters(tenant, resource_type, &parsed_params);
+        let query = SearchQuery {
+            resource_type: resource_type.to_string(),
+            parameters: typed_params,
+            count: Some(1000),
+            ..Default::default()
+        };
+
         let tenant_id = tenant.tenant_id().as_str();
+        let search_index = db.collection::<Document>(MongoBackend::SEARCH_INDEX_COLLECTION);
+        let mut matched_ids: Option<HashSet<String>> = None;
 
-        let cursor = resources
-            .find(doc! {
-                "tenant_id": tenant_id,
-                "resource_type": resource_type,
-                "is_deleted": false,
-            })
-            .session(&mut *session)
-            .await
-            .map_err(|e| {
-                internal_error(format!(
-                    "Failed to query conditional matches in transaction: {}",
-                    e
-                ))
-            })?;
+        for param in &query.parameters {
+            if matches!(param.name.as_str(), "_id" | "_lastUpdated") {
+                continue;
+            }
 
-        let docs = collect_session_documents(cursor, session).await?;
-        let mut matches = Vec::new();
+            let filter = self.build_search_index_filter(tenant_id, resource_type, param)?;
+            let pipeline = vec![
+                doc! { "$match": filter },
+                doc! { "$group": { "_id": "$resource_id" } },
+            ];
+            let cursor = search_index
+                .aggregate(pipeline)
+                .session(&mut *session)
+                .await
+                .map_err(|e| {
+                    internal_error(format!(
+                        "Failed to query search_index in transaction: {}",
+                        e
+                    ))
+                })?;
+            let docs = collect_session_documents(cursor, session).await?;
+            let ids: HashSet<String> = docs
+                .into_iter()
+                .filter_map(|d| d.get_str("_id").ok().map(str::to_string))
+                .collect();
 
-        for doc in docs {
-            let payload = doc.get_document("data").map_err(|e| {
-                internal_error(format!(
-                    "Missing payload while matching conditionals: {}",
-                    e
-                ))
-            })?;
-            let resource = document_to_value(payload)?;
+            if ids.is_empty() {
+                return Ok(Vec::new());
+            }
 
-            if resource_matches_bundle_search_params(&resource, &parsed_params)
-                && doc
-                    .get_str("resource_type")
-                    .map(|rt| rt == resource_type)
-                    .unwrap_or(true)
-            {
-                matches.push(document_to_stored_resource(&doc, tenant, resource_type)?);
+            matched_ids = Some(match matched_ids {
+                Some(current) => current.intersection(&ids).cloned().collect(),
+                None => ids,
+            });
+
+            if matched_ids.as_ref().is_some_and(|s| s.is_empty()) {
+                return Ok(Vec::new());
             }
         }
 
-        Ok(matches)
+        let filter = self.build_resource_filter(
+            tenant_id,
+            resource_type,
+            &query,
+            matched_ids.as_ref(),
+            None,
+        )?;
+
+        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+        let cursor = resources
+            .find(filter)
+            .session(&mut *session)
+            .await
+            .map_err(|e| {
+                internal_error(format!("Failed to query resources in transaction: {}", e))
+            })?;
+        let docs = collect_session_documents(cursor, session).await?;
+
+        docs.into_iter()
+            .map(|doc| document_to_stored_resource(&doc, tenant, resource_type))
+            .collect()
     }
 
     async fn index_resource_in_bundle_transaction(
@@ -3491,93 +3530,6 @@ impl MongoBackend {
                 },
             ))
         }
-    }
-}
-
-fn resource_matches_bundle_search_params(resource: &Value, params: &[(String, String)]) -> bool {
-    params.iter().all(|(name, expected)| match name.as_str() {
-        "_id" => resource
-            .get("id")
-            .and_then(Value::as_str)
-            .is_some_and(|id| id == expected),
-        "identifier" => resource_identifier_matches(resource, expected),
-        _ => resource_field_matches(resource.get(name), expected),
-    })
-}
-
-fn resource_identifier_matches(resource: &Value, expected: &str) -> bool {
-    let Some(identifier_value) = resource.get("identifier") else {
-        return false;
-    };
-
-    let (system, value, has_separator) = if let Some((system, value)) = expected.split_once('|') {
-        (system, value, true)
-    } else {
-        ("", expected, false)
-    };
-
-    match identifier_value {
-        Value::Array(items) => items
-            .iter()
-            .any(|item| match_identifier_item(item, system, value, has_separator)),
-        Value::Object(_) => match_identifier_item(identifier_value, system, value, has_separator),
-        _ => false,
-    }
-}
-
-fn match_identifier_item(item: &Value, system: &str, value: &str, has_separator: bool) -> bool {
-    let item_system = item.get("system").and_then(Value::as_str);
-    let item_value = item.get("value").and_then(Value::as_str);
-
-    if has_separator {
-        let system_matches = if system.is_empty() {
-            true
-        } else {
-            item_system == Some(system)
-        };
-        let value_matches = if value.is_empty() {
-            true
-        } else {
-            item_value == Some(value)
-        };
-
-        system_matches && value_matches
-    } else {
-        item_value == Some(value)
-    }
-}
-
-fn resource_field_matches(value: Option<&Value>, expected: &str) -> bool {
-    let Some(value) = value else {
-        return false;
-    };
-
-    match value {
-        Value::String(s) => s == expected,
-        Value::Array(items) => items
-            .iter()
-            .any(|item| resource_field_matches(Some(item), expected)),
-        Value::Object(map) => {
-            if map
-                .get("reference")
-                .and_then(Value::as_str)
-                .is_some_and(|reference| reference == expected)
-            {
-                return true;
-            }
-
-            if map
-                .get("value")
-                .and_then(Value::as_str)
-                .is_some_and(|value| value == expected)
-            {
-                return true;
-            }
-
-            map.values()
-                .any(|nested| resource_field_matches(Some(nested), expected))
-        }
-        _ => false,
     }
 }
 

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -3335,93 +3335,189 @@ impl MongoBackend {
         }
 
         let typed_params = self.build_search_parameters(tenant, resource_type, &parsed_params);
-        let query = SearchQuery {
-            resource_type: resource_type.to_string(),
-            parameters: typed_params,
-            count: Some(2),
-            ..Default::default()
-        };
+        let index_params: Vec<_> = typed_params
+            .iter()
+            .filter(|p| !matches!(p.name.as_str(), "_id" | "_lastUpdated"))
+            .collect();
+
+        if index_params.is_empty() {
+            let query = SearchQuery {
+                resource_type: resource_type.to_string(),
+                parameters: typed_params,
+                count: Some(2),
+                ..Default::default()
+            };
+            let tenant_id = tenant.tenant_id().as_str();
+            let filter =
+                self.build_resource_filter(tenant_id, resource_type, &query, None, None)?;
+            let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+            let cursor = resources
+                .find(filter)
+                .limit(2)
+                .session(&mut *session)
+                .await
+                .map_err(|e| {
+                    internal_error(format!("Failed to query resources in transaction: {}", e))
+                })?;
+            let docs = collect_session_documents(cursor, session).await?;
+            return docs
+                .into_iter()
+                .map(|doc| document_to_stored_resource(&doc, tenant, resource_type))
+                .collect();
+        }
 
         let tenant_id = tenant.tenant_id().as_str();
         let search_index = db.collection::<Document>(MongoBackend::SEARCH_INDEX_COLLECTION);
-        let mut matched_ids: Option<HashSet<String>> = None;
 
-        for param in &query.parameters {
-            if matches!(param.name.as_str(), "_id" | "_lastUpdated") {
-                continue;
+        const PROBE_LIMIT: i64 = 2;
+        const BATCH_SIZE: i64 = 128;
+
+        let driver_idx = {
+            let mut best: Option<(usize, i64)> = None;
+            for (i, param) in index_params.iter().enumerate() {
+                let filter = self.build_search_index_filter(tenant_id, resource_type, param)?;
+                let pipeline = vec![
+                    doc! { "$match": filter },
+                    doc! { "$group": { "_id": "$resource_id" } },
+                    doc! { "$limit": PROBE_LIMIT },
+                    doc! { "$count": "n" },
+                ];
+                let cursor = search_index
+                    .aggregate(pipeline)
+                    .session(&mut *session)
+                    .await
+                    .map_err(|e| {
+                        internal_error(format!("Failed probe for ifNoneExist driver: {}", e))
+                    })?;
+                let probe_docs = collect_session_documents(cursor, session).await?;
+                let count = probe_docs
+                    .first()
+                    .and_then(|d| d.get_i32("n").ok())
+                    .map(|n| n as i64)
+                    .unwrap_or(0);
+                if count == 0 {
+                    return Ok(Vec::new());
+                }
+                if best.is_none_or(|(_, prev)| count < prev) {
+                    best = Some((i, count));
+                }
             }
+            best.map(|(i, _)| i).unwrap_or(0)
+        };
 
-            let filter = self.build_search_index_filter(tenant_id, resource_type, param)?;
-            let pipeline = vec![
-                doc! { "$match": filter },
-                doc! { "$group": { "_id": "$resource_id" } },
-                doc! { "$limit": 1001_i32 },
-            ];
-            let cursor = search_index
-                .aggregate(pipeline)
+        let driver_filter =
+            self.build_search_index_filter(tenant_id, resource_type, index_params[driver_idx])?;
+
+        let mut last_index_id: Option<Bson> = None;
+        let mut matches: Vec<StoredResource> = Vec::with_capacity(2);
+        let mut matched_ids: HashSet<String> = HashSet::new();
+        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+
+        loop {
+            let page_filter = match &last_index_id {
+                Some(last_id) => doc! {
+                    "$and": [driver_filter.clone(), { "_id": { "$gt": last_id.clone() } }]
+                },
+                None => driver_filter.clone(),
+            };
+
+            let mut cursor = search_index
+                .find(page_filter)
+                .sort(doc! { "_id": 1 })
+                .projection(doc! { "_id": 1, "resource_id": 1 })
+                .limit(BATCH_SIZE)
                 .session(&mut *session)
                 .await
                 .map_err(|e| {
                     internal_error(format!(
-                        "Failed to query search_index in transaction: {}",
+                        "Failed to page search_index for ifNoneExist: {}",
                         e
                     ))
                 })?;
-            let docs = collect_session_documents(cursor, session).await?;
 
-            if docs.len() > 1000 {
-                tracing::warn!(
-                    resource_type,
-                    param_name = %param.name,
-                    "ifNoneExist criteria match more than 1000 search_index entries; \
-                     intersection may be incomplete for this parameter"
-                );
+            let mut candidate_ids: HashSet<String> = HashSet::new();
+            let mut docs_read: i64 = 0;
+
+            while cursor.advance(&mut *session).await.map_err(|e| {
+                internal_error(format!("Failed to advance search_index cursor: {}", e))
+            })? {
+                let doc = cursor.deserialize_current().map_err(|e| {
+                    internal_error(format!("Failed to deserialize search_index doc: {}", e))
+                })?;
+                last_index_id = doc.get("_id").cloned();
+                docs_read += 1;
+                if let Ok(rid) = doc.get_str("resource_id") {
+                    candidate_ids.insert(rid.to_string());
+                }
             }
 
-            let ids: HashSet<String> = docs
-                .into_iter()
-                .filter_map(|d| d.get_str("_id").ok().map(str::to_string))
-                .collect();
-
-            if ids.is_empty() {
-                return Ok(Vec::new());
+            if docs_read == 0 {
+                break;
             }
 
-            matched_ids = Some(match matched_ids {
-                Some(current) => current.intersection(&ids).cloned().collect(),
-                None => ids,
-            });
+            for (i, param) in index_params.iter().enumerate() {
+                if i == driver_idx || candidate_ids.is_empty() {
+                    continue;
+                }
+                let param_filter =
+                    self.build_search_index_filter(tenant_id, resource_type, param)?;
+                let bounded_filter = doc! {
+                    "$and": [
+                        param_filter,
+                        { "resource_id": { "$in": candidate_ids.iter().cloned().collect::<Vec<_>>() } }
+                    ]
+                };
+                let passing: HashSet<String> = search_index
+                    .distinct("resource_id", bounded_filter)
+                    .session(&mut *session)
+                    .await
+                    .map_err(|e| {
+                        internal_error(format!(
+                            "Failed distinct for ifNoneExist intersection: {}",
+                            e
+                        ))
+                    })?
+                    .into_iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect();
+                candidate_ids.retain(|id| passing.contains(id));
+            }
 
-            if matched_ids.as_ref().is_some_and(|s| s.is_empty()) {
-                return Ok(Vec::new());
+            if !candidate_ids.is_empty() {
+                let remaining = (2 - matches.len()) as i64;
+                let mut res_cursor = resources
+                    .find(doc! {
+                        "tenant_id": tenant_id,
+                        "resource_type": resource_type,
+                        "is_deleted": false,
+                        "id": { "$in": candidate_ids.into_iter().collect::<Vec<_>>() }
+                    })
+                    .limit(remaining)
+                    .session(&mut *session)
+                    .await
+                    .map_err(|e| {
+                        internal_error(format!("Failed to fetch resources for ifNoneExist: {}", e))
+                    })?;
+
+                while res_cursor.advance(&mut *session).await.map_err(|e| {
+                    internal_error(format!("Failed to advance resources cursor: {}", e))
+                })? {
+                    let doc = res_cursor.deserialize_current().map_err(|e| {
+                        internal_error(format!("Failed to deserialize resource doc: {}", e))
+                    })?;
+                    let resource = document_to_stored_resource(&doc, tenant, resource_type)?;
+                    if matched_ids.insert(resource.id().to_string()) {
+                        matches.push(resource);
+                    }
+                }
+            }
+
+            if matches.len() >= 2 || docs_read < BATCH_SIZE {
+                break;
             }
         }
 
-        let candidate_ids: Option<HashSet<String>> =
-            matched_ids.map(|ids| ids.into_iter().take(2).collect());
-
-        let filter = self.build_resource_filter(
-            tenant_id,
-            resource_type,
-            &query,
-            candidate_ids.as_ref(),
-            None,
-        )?;
-
-        let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
-        let cursor = resources
-            .find(filter)
-            .limit(2)
-            .session(&mut *session)
-            .await
-            .map_err(|e| {
-                internal_error(format!("Failed to query resources in transaction: {}", e))
-            })?;
-        let docs = collect_session_documents(cursor, session).await?;
-
-        docs.into_iter()
-            .map(|doc| document_to_stored_resource(&doc, tenant, resource_type))
-            .collect()
+        Ok(matches)
     }
 
     async fn if_none_exist_offloaded_scan(
@@ -3433,6 +3529,25 @@ impl MongoBackend {
         parsed_params: &[(String, String)],
     ) -> StorageResult<Vec<StoredResource>> {
         let tenant_id = tenant.tenant_id().as_str();
+
+        for (name, _) in parsed_params {
+            match name.as_str() {
+                "_id" | "_lastUpdated" | "identifier" => {}
+                other => {
+                    return Err(StorageError::Search(
+                        crate::error::SearchError::QueryParseError {
+                            message: format!(
+                                "ifNoneExist parameter '{other}' cannot be evaluated \
+                                 against the resource collection when search is offloaded; \
+                                 use a supported parameter (_id, identifier) or disable \
+                                 search offloading"
+                            ),
+                        },
+                    ));
+                }
+            }
+        }
+
         let mut conditions = vec![doc! {
             "tenant_id": tenant_id,
             "resource_type": resource_type,
@@ -3444,6 +3559,7 @@ impl MongoBackend {
                 "_id" => {
                     conditions.push(doc! { "id": value.as_str() });
                 }
+                "_lastUpdated" => {}
                 "identifier" => {
                     let mut elem_match = Document::new();
                     if let Some((system, val)) = value.split_once('|') {
@@ -3460,15 +3576,7 @@ impl MongoBackend {
                         conditions.push(doc! { "data.identifier": { "$elemMatch": elem_match } });
                     }
                 }
-                _ => {
-                    tracing::warn!(
-                        resource_type,
-                        param_name = %name,
-                        "ifNoneExist with offloaded search: param cannot be evaluated \
-                         against the resource collection directly; matches may include \
-                         false positives"
-                    );
-                }
+                _ => unreachable!("unsupported params are rejected above"),
             }
         }
 
@@ -3479,7 +3587,8 @@ impl MongoBackend {
         };
 
         let resources = db.collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
-        let cursor = resources
+        let mut matches: Vec<StoredResource> = Vec::with_capacity(2);
+        let mut cursor = resources
             .find(filter)
             .limit(2)
             .session(&mut *session)
@@ -3490,11 +3599,23 @@ impl MongoBackend {
                     e
                 ))
             })?;
-        let docs = collect_session_documents(cursor, session).await?;
 
-        docs.into_iter()
-            .map(|doc| document_to_stored_resource(&doc, tenant, resource_type))
-            .collect()
+        while cursor.advance(&mut *session).await.map_err(|e| {
+            internal_error(format!(
+                "Failed to advance resources cursor for offloaded ifNoneExist: {}",
+                e
+            ))
+        })? {
+            let doc = cursor.deserialize_current().map_err(|e| {
+                internal_error(format!(
+                    "Failed to deserialize resource for offloaded ifNoneExist: {}",
+                    e
+                ))
+            })?;
+            matches.push(document_to_stored_resource(&doc, tenant, resource_type)?);
+        }
+
+        Ok(matches)
     }
 
     async fn index_resource_in_bundle_transaction(

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -4781,3 +4781,115 @@ async fn mongodb_integration_if_none_exist_offloaded_search_uses_resource_scan()
         "no duplicate should have been created"
     );
 }
+
+#[tokio::test]
+async fn mongodb_integration_if_none_exist_broad_param_beyond_probe_limit() {
+    let Some(backend) = create_backend_with_full_registry("if_none_exist_broad_param").await else {
+        eprintln!(
+            "Skipping mongodb_integration_if_none_exist_broad_param_beyond_probe_limit \
+             (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let tenant = create_tenant("tenant-a");
+
+    const NOISE_COUNT: usize = 200;
+
+    for chunk_start in (0..NOISE_COUNT).step_by(50) {
+        let entries: Vec<BundleEntry> = (chunk_start..chunk_start + 50)
+            .map(|i| BundleEntry {
+                method: BundleMethod::Post,
+                url: "Patient".to_string(),
+                resource: Some(serde_json::json!({
+                    "resourceType": "Patient",
+                    "active": true,
+                    "identifier": [{"system": "http://example.org/noise", "value": format!("NOISE-{i}")}]
+                })),
+                if_match: None,
+                if_none_match: None,
+                if_none_exist: None,
+                full_url: Some(format!("urn:uuid:noise-{i}")),
+            })
+            .collect();
+        let Some(result) = process_transaction_or_skip(
+            &backend,
+            &tenant,
+            entries,
+            "mongodb_integration_if_none_exist_broad_param_beyond_probe_limit (setup)",
+        )
+        .await
+        else {
+            return;
+        };
+        assert!(
+            result.entries.iter().all(|e| e.status == 201),
+            "all noise patients must be created"
+        );
+    }
+
+    let target_entry = BundleEntry {
+        method: BundleMethod::Post,
+        url: "Patient".to_string(),
+        resource: Some(serde_json::json!({
+            "resourceType": "Patient",
+            "active": true,
+            "identifier": [{"system": "http://example.org/mrn", "value": "TARGET-BROAD-1"}]
+        })),
+        if_match: None,
+        if_none_match: None,
+        if_none_exist: None,
+        full_url: Some("urn:uuid:target-broad".to_string()),
+    };
+    let Some(target_result) = process_transaction_or_skip(
+        &backend,
+        &tenant,
+        vec![target_entry],
+        "mongodb_integration_if_none_exist_broad_param_beyond_probe_limit (target create)",
+    )
+    .await
+    else {
+        return;
+    };
+    assert_eq!(
+        target_result.entries[0].status, 201,
+        "target patient must be created"
+    );
+
+    let total = backend.count(&tenant, Some("Patient")).await.unwrap();
+    assert_eq!(total, (NOISE_COUNT + 1) as u64, "all patients present");
+
+    let if_none_exist_entry = BundleEntry {
+        method: BundleMethod::Post,
+        url: "Patient".to_string(),
+        resource: Some(serde_json::json!({
+            "resourceType": "Patient",
+            "active": true,
+            "identifier": [{"system": "http://example.org/mrn", "value": "TARGET-BROAD-1"}]
+        })),
+        if_match: None,
+        if_none_match: None,
+        if_none_exist: Some("identifier=http://example.org/mrn|TARGET-BROAD-1".to_string()),
+        full_url: Some("urn:uuid:ine-broad".to_string()),
+    };
+    let Some(ine_result) = process_transaction_or_skip(
+        &backend,
+        &tenant,
+        vec![if_none_exist_entry],
+        "mongodb_integration_if_none_exist_broad_param_beyond_probe_limit",
+    )
+    .await
+    else {
+        return;
+    };
+
+    assert_eq!(
+        ine_result.entries[0].status, 200,
+        "ifNoneExist must find the existing target patient and suppress the create"
+    );
+    assert_eq!(
+        backend.count(&tenant, Some("Patient")).await.unwrap(),
+        (NOISE_COUNT + 1) as u64,
+        "no duplicate should have been created"
+    );
+}

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -4515,3 +4515,269 @@ async fn mongodb_integration_export_until_is_inclusive() {
         "a resource exactly on the bound is included"
     );
 }
+
+#[tokio::test]
+async fn mongodb_integration_if_none_exist_multi_param_and_semantics() {
+    let Some(backend) = create_backend_with_full_registry("if_none_exist_multi_param").await else {
+        eprintln!(
+            "Skipping mongodb_integration_if_none_exist_multi_param_and_semantics (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let tenant = create_tenant("tenant-if-none-exist-multi");
+
+    backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "identifier": [{"system": "http://example.org/mrn", "value": "MRN-MULTI-1"}],
+                "active": true
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "identifier": [{"system": "http://example.org/mrn", "value": "MRN-MULTI-1"}],
+                "active": false
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let active_entry = BundleEntry {
+        method: BundleMethod::Post,
+        url: "Patient".to_string(),
+        resource: Some(json!({
+            "resourceType": "Patient",
+            "identifier": [{"system": "http://example.org/mrn", "value": "MRN-MULTI-1"}],
+            "active": true
+        })),
+        if_match: None,
+        if_none_match: None,
+        if_none_exist: Some(
+            "identifier=http://example.org/mrn|MRN-MULTI-1&active=true".to_string(),
+        ),
+        full_url: Some("urn:uuid:active-patient".to_string()),
+    };
+
+    let Some(result) = process_transaction_or_skip(
+        &backend,
+        &tenant,
+        vec![active_entry],
+        "mongodb_integration_if_none_exist_multi_param_and_semantics",
+    )
+    .await
+    else {
+        return;
+    };
+
+    assert_eq!(
+        result.entries[0].status, 200,
+        "both params match the active patient — should not create a duplicate"
+    );
+
+    let count = backend.count(&tenant, Some("Patient")).await.unwrap();
+    assert_eq!(count, 2, "no third patient should have been created");
+}
+
+#[tokio::test]
+async fn mongodb_integration_if_none_exist_same_transaction_read_your_writes() {
+    let Some(backend) = create_backend_with_full_registry("if_none_exist_ryw").await else {
+        eprintln!(
+            "Skipping mongodb_integration_if_none_exist_same_transaction_read_your_writes (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let tenant = create_tenant("tenant-if-none-exist-ryw");
+
+    let entry = |full_url: &str| BundleEntry {
+        method: BundleMethod::Post,
+        url: "Patient".to_string(),
+        resource: Some(json!({
+            "resourceType": "Patient",
+            "identifier": [{"system": "http://example.org/mrn", "value": "MRN-RYW-1"}]
+        })),
+        if_match: None,
+        if_none_match: None,
+        if_none_exist: Some("identifier=http://example.org/mrn|MRN-RYW-1".to_string()),
+        full_url: Some(full_url.to_string()),
+    };
+
+    let Some(result) = process_transaction_or_skip(
+        &backend,
+        &tenant,
+        vec![entry("urn:uuid:first"), entry("urn:uuid:second")],
+        "mongodb_integration_if_none_exist_same_transaction_read_your_writes",
+    )
+    .await
+    else {
+        return;
+    };
+
+    assert_eq!(
+        result.entries[0].status, 201,
+        "first entry creates the patient"
+    );
+    assert_eq!(
+        result.entries[1].status, 200,
+        "second entry must see the first entry's write via session"
+    );
+    assert_eq!(
+        result.entries[1].location, result.entries[0].location,
+        "second entry must resolve to the same resource as the first"
+    );
+    assert_eq!(backend.count(&tenant, Some("Patient")).await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn mongodb_integration_if_none_exist_multiple_matches_rolls_back() {
+    let Some(backend) = create_backend_with_full_registry("if_none_exist_multi_match").await else {
+        eprintln!(
+            "Skipping mongodb_integration_if_none_exist_multiple_matches_rolls_back (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let tenant = create_tenant("tenant-if-none-exist-ambiguous");
+
+    for family in ["One", "Two"] {
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "identifier": [{"system": "http://example.org/mrn", "value": "MRN-AMB-1"}],
+                    "name": [{"family": family}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+    }
+
+    let entries = vec![
+        BundleEntry {
+            method: BundleMethod::Post,
+            url: "Patient".to_string(),
+            resource: Some(
+                json!({ "resourceType": "Patient", "name": [{"family": "ShouldRollBack"}] }),
+            ),
+            if_match: None,
+            if_none_match: None,
+            if_none_exist: None,
+            full_url: None,
+        },
+        BundleEntry {
+            method: BundleMethod::Post,
+            url: "Patient".to_string(),
+            resource: Some(json!({
+                "resourceType": "Patient",
+                "identifier": [{"system": "http://example.org/mrn", "value": "MRN-AMB-1"}]
+            })),
+            if_match: None,
+            if_none_match: None,
+            if_none_exist: Some("identifier=http://example.org/mrn|MRN-AMB-1".to_string()),
+            full_url: Some("urn:uuid:ambiguous".to_string()),
+        },
+    ];
+
+    match backend
+        .process_transaction(&tenant, entries, FhirVersion::default())
+        .await
+    {
+        Err(helios_persistence::error::TransactionError::UnsupportedIsolationLevel { .. }) => {
+            eprintln!("Skipping multiple_matches_rolls_back (replica-set required)");
+            return;
+        }
+        Err(helios_persistence::error::TransactionError::BundleError { index, message }) => {
+            assert_eq!(index, 1);
+            assert!(
+                message.contains("412"),
+                "expected 412 in message, got: {message}"
+            );
+        }
+        Err(other) => panic!("unexpected error: {other:?}"),
+        Ok(_) => panic!("ambiguous ifNoneExist must fail the bundle"),
+    }
+
+    assert_eq!(
+        backend.count(&tenant, Some("Patient")).await.unwrap(),
+        2,
+        "the plain create in entry 0 must have been rolled back"
+    );
+}
+
+#[tokio::test]
+async fn mongodb_integration_if_none_exist_offloaded_search_uses_resource_scan() {
+    let Some(mut backend) = create_backend_with_full_registry("if_none_exist_offloaded").await
+    else {
+        eprintln!(
+            "Skipping mongodb_integration_if_none_exist_offloaded_search_uses_resource_scan (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let tenant = create_tenant("tenant-if-none-exist-offloaded");
+
+    backend
+        .create(
+            &tenant,
+            "Patient",
+            json!({
+                "resourceType": "Patient",
+                "identifier": [{"system": "http://example.org/mrn", "value": "MRN-OFFL-1"}]
+            }),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    backend.set_search_offloaded(true);
+
+    let entry = BundleEntry {
+        method: BundleMethod::Post,
+        url: "Patient".to_string(),
+        resource: Some(json!({
+            "resourceType": "Patient",
+            "identifier": [{"system": "http://example.org/mrn", "value": "MRN-OFFL-1"}]
+        })),
+        if_match: None,
+        if_none_match: None,
+        if_none_exist: Some("identifier=http://example.org/mrn|MRN-OFFL-1".to_string()),
+        full_url: Some("urn:uuid:offloaded".to_string()),
+    };
+
+    let Some(result) = process_transaction_or_skip(
+        &backend,
+        &tenant,
+        vec![entry],
+        "mongodb_integration_if_none_exist_offloaded_search_uses_resource_scan",
+    )
+    .await
+    else {
+        return;
+    };
+
+    assert_eq!(
+        result.entries[0].status, 200,
+        "offloaded-search fallback must find the existing resource and suppress the create"
+    );
+    assert_eq!(
+        backend.count(&tenant, Some("Patient")).await.unwrap(),
+        1,
+        "no duplicate should have been created"
+    );
+}


### PR DESCRIPTION
Fixes #709  replace MongoDB's broken in-Rust ifNoneExist matcher with the real session-scoped search machinery so conditional bundle entries match correctly.