### PR TITLE
feat(ui): redirect the bare root to /ui, mirroring HTS

### DIFF
--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -5927,6 +5927,46 @@ mod postgres_integration {
             "expected a backend error from an unmigrated database, got {create:?}"
         );
     }
+    /// Claims manifests in a loop until the lease for `target` comes back,
+    /// holding any other lease it picks up along the way (so the loop cannot
+    /// re-claim the same foreign manifest) and returning those to the queue
+    /// once the target is held. Robust to concurrent tests sharing the
+    /// testcontainers PostgreSQL instance — the submit-side twin of
+    /// `claim_specific` for exports.
+    async fn claim_specific_manifest(
+        backend: &PostgresBackend,
+        worker_id: &helios_persistence::core::WorkerId,
+        submission_id: &helios_persistence::core::SubmissionId,
+        target_manifest_id: &str,
+        lease_duration: std::time::Duration,
+    ) -> helios_persistence::core::ManifestLease {
+        use helios_persistence::core::SubmitClaimStrategy;
+
+        let mut held = Vec::new();
+        let mut found = None;
+        for _ in 0..100 {
+            match backend
+                .claim_next_manifest(worker_id, lease_duration)
+                .await
+                .unwrap()
+            {
+                Some(lease)
+                    if lease.submission_id == *submission_id
+                        && lease.manifest_id == target_manifest_id =>
+                {
+                    found = Some(lease);
+                    break;
+                }
+                Some(other) => held.push(other),
+                None => tokio::time::sleep(std::time::Duration::from_millis(20)).await,
+            }
+        }
+        for other in held {
+            let _ = SubmitClaimStrategy::release(backend, other).await;
+        }
+        found.expect("never claimed the expected manifest")
+    }
+
     /// The `import` / `metadata` kickoff directives must survive the PostgreSQL
     /// round-trip and reach the worker, and `merge` must actually merge.
     ///
@@ -5938,8 +5978,7 @@ mod postgres_integration {
     async fn postgres_bulk_submit_import_directives_round_trip() {
         use helios_persistence::core::{
             BulkProcessingOptions, BulkSubmitProvider, IMPORT_MODE_PARAMETER_URL, ImportMode,
-            ManifestFetchParams, NdjsonEntry, SubmissionId, SubmitClaimStrategy,
-            SubmitWorkerStorage,
+            ManifestFetchParams, NdjsonEntry, SubmissionId, SubmitWorkerStorage,
         };
 
         let backend = create_backend().await;
@@ -5971,15 +6010,25 @@ mod postgres_integration {
             .await
             .unwrap();
 
-        // Claim the manifest the way the worker does, then read its view back.
-        let lease = backend
-            .claim_next_manifest(
-                &helios_persistence::core::WorkerId::new("pg-import-worker"),
-                std::time::Duration::from_secs(60),
-            )
-            .await
-            .unwrap()
-            .expect("claimable manifest");
+        // Claim *this* manifest the way the worker does, then read its view
+        // back. The claim queue is cross-tenant and ordered by `added_at`, and
+        // the test binary shares one container database, so a plain
+        // `claim_next_manifest` can hand back another test's manifest — and
+        // an unleased `processing` manifest (the synchronous `process_entries`
+        // path leaves one behind) is reclaimable, so "move it out of pending"
+        // elsewhere is no defence. Loop until ours comes back, returning
+        // anything else to the queue.
+        let lease = claim_specific_manifest(
+            &backend,
+            &helios_persistence::core::WorkerId::new(format!(
+                "pg-import-worker-{}",
+                uuid::Uuid::new_v4()
+            )),
+            &sub_id,
+            &manifest.manifest_id,
+            std::time::Duration::from_secs(60),
+        )
+        .await;
         let view = backend.get_manifest_for_worker(&lease).await.unwrap();
         assert_eq!(view.import_directives, directives);
         assert_eq!(view.metadata, metadata);
@@ -6055,10 +6104,11 @@ mod postgres_integration {
             .add_manifest(&tenant, &sub_id, Some("https://provider/b.json"), None)
             .await
             .unwrap();
-        // Move the manifest out of `pending` right away: the test binary
-        // shares one container database, and a concurrently running test that
-        // calls claim_next_manifest would otherwise claim this one (the claim
-        // queue is cross-tenant by design).
+        // Mark the manifest `processing` right away. Note this is not a
+        // defence against other tests' `claim_next_manifest` calls — an
+        // unleased `processing` manifest is reclaimable, so a claimant may
+        // still pick this one up transiently — which is why claiming tests use
+        // `claim_specific_manifest` and hand foreign manifests back.
         backend
             .process_entries(
                 &tenant,

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1401,7 +1401,21 @@ pub fn mount_with_conformance_source_and_runtime(
         // in request extensions next to the locale.
         .layer(middleware::from_fn_with_state(state.clone(), resolve_prefs))
         .with_state(state)
+        // Registered after the UI layers so neither arm of `/` picks them up:
+        // the redirect needs none, and `POST /` (FHIR batch) must reach the
+        // fallback with the same middleware stack as every other FHIR route.
+        .route("/", get(root_redirect).fallback_service(fhir_app.clone()))
         .fallback_service(fhir_app)
+}
+
+/// Redirects the bare root to the UI home (#896), mirroring HTS. Registered
+/// on the UI router, so it only exists when the UI is mounted (a headless
+/// build keeps its current behavior) and sits outside the FHIR router's auth
+/// layer — an unauthenticated browser lands on `/ui` instead of a 401.
+/// Temporary (307) rather than HTS's 308: `/` is also the FHIR batch
+/// endpoint, and a permanent redirect gets cached hard by browsers.
+async fn root_redirect() -> axum::response::Redirect {
+    axum::response::Redirect::temporary("/ui")
 }
 
 /// Form body for `POST /ui/version` â€” the sidebar selector's submit.

--- a/crates/ui/tests/router_http.rs
+++ b/crates/ui/tests/router_http.rs
@@ -409,6 +409,51 @@ async fn non_ui_paths_fall_through_to_the_fhir_app() {
     assert_eq!(body_text(response).await, "fhir handled");
 }
 
+/// #896: the bare root redirects a browser to the UI home.
+#[tokio::test]
+async fn root_redirects_to_ui() {
+    let response = app()
+        .oneshot(Request::get("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::TEMPORARY_REDIRECT);
+    assert_eq!(
+        response
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok()),
+        Some("/ui")
+    );
+}
+
+/// #896: owning `GET /` for the redirect must not shadow `POST /` — the FHIR
+/// batch/transaction endpoint on the same path still reaches the fallback.
+#[tokio::test]
+async fn root_post_still_reaches_the_fhir_batch_handler() {
+    let fhir_app = Router::new().route("/", axum::routing::post(|| async { "batch handled" }));
+    let response = helios_ui::mount_with_conformance_source(
+        fhir_app,
+        "9.9.9",
+        Some(std::path::PathBuf::from("../../data")),
+        nl(true, true),
+        None,
+        None,
+        "default".to_string(),
+        std::sync::Arc::new(helios_ui::StaticConformanceSource::empty()),
+        helios_fhir::FhirVersion::R4,
+        None,
+        "http://localhost:8080".to_string(),
+        None,
+    )
+    .oneshot(Request::post("/").body(Body::empty()).unwrap())
+    .await
+    .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_text(response).await, "batch handled");
+}
+
 /// #653: the CapabilityStatement page renders the live /metadata answer —
 /// summary, safe external documentation links, semantic interaction tags, the
 /// progressively enhanced resource filter, and bounded raw JSON shell. Without


### PR DESCRIPTION
Closes #896

## What

`GET /` now redirects to `/ui`, so `https://hfs.heliossoftware.com/` lands a browser on the web UI instead of a 405 (auth off) or 401 (auth on). Mirrors what HTS already does for `/ui/hts`.

## How

The route lives on the **UI router** (the structural equivalent of HTS gating on `ui_enabled`):

- It only exists when the UI is mounted — a headless / `ui`-off build keeps today's behavior instead of redirecting to a nonexistent page.
- It sits **outside the FHIR router's auth layer**, so an unauthenticated visitor gets the redirect, not a 401.
- It is registered **after the UI middleware layers**, with the FHIR app as the `/` method-router's fallback: `POST /` (batch/transaction) still reaches the FHIR handler with an unchanged middleware stack — no UI locale/prefs middleware added to the FHIR write path.
- **307** (temporary) rather than HTS's 308: `/` doubles as the FHIR batch endpoint, and a permanent redirect gets cached hard by browsers.

## Tests

- `root_redirects_to_ui` — `GET /` → 307 + `Location: /ui`.
- `root_post_still_reaches_the_fhir_batch_handler` — the acceptance-criteria regression: owning `GET /` must not shadow `POST /`.
- Full `helios-ui` suite (14 suites) green; clippy clean.