### PR TITLE
fix(hts-ui): add vertical rhythm to detail page headers

### DIFF
--- a/crates/hts-ui/templates/pages/cm-detail.html
+++ b/crates/hts-ui/templates/pages/cm-detail.html
@@ -48,7 +48,7 @@
         <span aria-hidden="true">{% include "icons/chevron-left.svg" %}</span>
         <span>{{ chrome.i18n.t("hts-cm-browser-title") }}</span>
       </a>
-      <div class="page-head__copy">
+      <div class="page-head__copy page-head__copy--spaced">
         <span class="stat__label">{{ chrome.i18n.t("hts-cm-detail-eyebrow") }}</span>
         <h1 id="hts-cm-detail-heading" class="page-head__title">
           {{ summary.heading() }}

--- a/crates/hts-ui/templates/pages/cs-detail.html
+++ b/crates/hts-ui/templates/pages/cs-detail.html
@@ -60,7 +60,7 @@
         <span aria-hidden="true">{% include "icons/chevron-left.svg" %}</span>
         <span>{{ chrome.i18n.t("hts-cs-browser-title") }}</span>
       </a>
-      <div class="page-head__copy">
+      <div class="page-head__copy page-head__copy--spaced">
         <span class="stat__label">{{ chrome.i18n.t("hts-cs-detail-eyebrow") }}</span>
         <h1 id="hts-cs-detail-heading" class="page-head__title">
           {{ summary.heading() }}

--- a/crates/hts-ui/templates/pages/vs-detail.html
+++ b/crates/hts-ui/templates/pages/vs-detail.html
@@ -49,7 +49,7 @@
         <span aria-hidden="true">{% include "icons/chevron-left.svg" %}</span>
         <span>{{ chrome.i18n.t("hts-vs-browser-title") }}</span>
       </a>
-      <div class="page-head__copy">
+      <div class="page-head__copy page-head__copy--spaced">
         <span class="stat__label">{{ chrome.i18n.t("hts-vs-detail-eyebrow") }}</span>
         <h1 id="hts-vs-detail-heading" class="page-head__title">
           {{ summary.heading() }}

--- a/crates/hts-ui/tests/chrome_parity.rs
+++ b/crates/hts-ui/tests/chrome_parity.rs
@@ -247,9 +247,16 @@ fn assert_back_link(source: &str, page: &str, href: &str, key: &str) {
     let back_link_position = source
         .find("class=\"back-link\"")
         .expect("back link marker was located above");
-    let copy_position = source.find("class=\"page-head__copy\"").unwrap_or_else(|| {
-        panic!("{page}'s header children must live inside `<div class=\"page-head__copy\">` (#801)")
-    });
+    // Match `class="page-head__copy"` or `class="page-head__copy page-head__copy--*"`
+    // (the detail pages use the `--spaced` modifier for vertical rhythm #900).
+    let copy_position = source
+        .find("class=\"page-head__copy\"")
+        .or_else(|| source.find("class=\"page-head__copy "))
+        .unwrap_or_else(|| {
+            panic!(
+                "{page}'s header children must live inside `<div class=\"page-head__copy\">` (#801)"
+            )
+        });
     assert!(
         back_link_position < copy_position,
         "{page}'s back link must precede `.page-head__copy` inside the header",

--- a/crates/hts-ui/tests/code_systems.rs
+++ b/crates/hts-ui/tests/code_systems.rs
@@ -684,7 +684,7 @@ fn cs_detail_page_uses_the_v3_compact_header_shape() {
     for hook in [
         r#"<header class="page-head page-head--back-link">"#,
         r#"class="back-link""#,
-        r#"class="page-head__copy""#,
+        r#"class="page-head__copy "#, // may carry modifiers like --spaced
         r#"class="page-head__title""#,
         r#"class="stat__label""#,
         r#"class="facets facets--bare""#,

--- a/crates/hts-ui/tests/concept_maps.rs
+++ b/crates/hts-ui/tests/concept_maps.rs
@@ -1268,7 +1268,7 @@ fn cm_detail_page_uses_the_v3_compact_header_shape() {
     for hook in [
         r#"<header class="page-head page-head--back-link">"#,
         r#"class="back-link""#,
-        r#"class="page-head__copy""#,
+        r#"class="page-head__copy "#, // may carry modifiers like --spaced
         r#"class="page-head__title""#,
         r#"class="facets facets--bare""#,
         r#"class="detail__field detail__field--wide""#,

--- a/crates/hts-ui/tests/value_sets.rs
+++ b/crates/hts-ui/tests/value_sets.rs
@@ -1232,7 +1232,7 @@ fn vs_detail_page_uses_the_v3_compact_header_shape() {
     for hook in [
         r#"<header class="page-head page-head--back-link">"#,
         r#"class="back-link""#,
-        r#"class="page-head__copy""#,
+        r#"class="page-head__copy "#, // may carry modifiers like --spaced
         r#"class="page-head__title""#,
         r#"class="facets facets--bare""#,
         r#"class="detail__field detail__field--wide""#,

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -2029,6 +2029,24 @@ select.field__input {
   min-width: 0;
 }
 
+/* Vertical-rhythm variant for detail-page headers with eyebrow + title +
+   optional lede + chips + kv-grid (HTS CodeSystem / ValueSet / ConceptMap).
+   HFS pages with simpler title+lede keep the base `.page-head__copy`. */
+.page-head__copy--spaced {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.page-head__copy--spaced > .page-head__title {
+  margin-bottom: 0; /* gap handles spacing */
+}
+.page-head__copy--spaced > .facets--bare {
+  padding-bottom: 6px; /* reduce from 12px; gap adds rest */
+}
+.page-head__copy--spaced > .kv-grid {
+  margin-bottom: 0; /* final child; no trailing margin needed */
+}
+
 .page-head--back-link > .page-head__action {
   grid-area: action;
   min-width: 0;


### PR DESCRIPTION
## Summary
- Add `.page-head__copy--spaced` modifier class with flexbox column layout and 6px gap
- Apply to CodeSystem, ValueSet, and ConceptMap detail page headers
- HFS pages (Bulk Export, Bulk Import detail) unchanged using base `.page-head__copy`

Closes #900

## Test plan
- [x] `cargo fmt -p helios-ui` — clean
- [x] CSS class guard tests pass for all 3 detail pages
- [x] HFS pages verified unchanged
- [x] Playwright E2E: 355 passed, 3 failed (unrelated timeouts/flakiness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)