### PR TITLE
feat: hts-ui: Concept Explorer and import Raw response folds render unhighlighted JSON

### DIFF
--- a/crates/hts-ui/src/concepts.rs
+++ b/crates/hts-ui/src/concepts.rs
@@ -441,7 +441,15 @@ async fn respond(
         fhir_version: state.fhir_version,
         version: state.version,
     };
-    let view = load(state, form, panel).await;
+    let mut view = load(state, form, panel).await;
+
+    // Highlight raw JSON payloads for the "Raw response" disclosures (#897).
+    if let Some(Ok(identity)) = &mut view.identity {
+        identity.highlight(&chrome.i18n);
+    }
+    if let Some(Ok(mappings)) = &mut view.mappings {
+        mappings.highlight(&chrome.i18n);
+    }
 
     if is_htmx {
         return match panel {

--- a/crates/hts-ui/src/import.rs
+++ b/crates/hts-ui/src/import.rs
@@ -106,6 +106,10 @@ struct StatusView {
     outcome: Option<OutcomeView>,
     request_url: String,
     raw_body: String,
+    /// The `raw_body` rendered into the shared highlighted JSON view, or empty
+    /// when the payload exceeded the budget and the partial should fall back to
+    /// a `<pre>`. Filled by [`StatusView::highlight`] at the response funnel.
+    raw_body_json: String,
     /// Reason key for the shared degraded partial when the upstream
     /// import round-trip failed at the transport layer (5xx / connect
     /// / timeout). `None` for the normal 200/207/400/413 arms.
@@ -137,6 +141,7 @@ impl StatusView {
             outcome: result.outcome,
             request_url: result.request_url,
             raw_body: result.raw_body,
+            raw_body_json: String::new(),
             degraded_reason: None,
         }
     }
@@ -155,6 +160,7 @@ impl StatusView {
             outcome: Some(outcome),
             request_url: String::new(),
             raw_body: String::new(),
+            raw_body_json: String::new(),
             degraded_reason: None,
         }
     }
@@ -173,8 +179,18 @@ impl StatusView {
             outcome: None,
             request_url,
             raw_body: String::new(),
+            raw_body_json: String::new(),
             degraded_reason: Some(err.degraded_reason()),
         }
+    }
+
+    /// Renders `raw_body` into the shared JSON view.
+    ///
+    /// Non-JSON or over-budget text leaves `raw_body_json` empty; the partial
+    /// then shows the raw string in a `<pre>`, which is what the fold did for
+    /// every payload before #897.
+    fn highlight(&mut self, i18n: &I18n) {
+        self.raw_body_json = crate::raw_fold::highlight_json(i18n, &self.raw_body);
     }
 
     fn issue_count(&self) -> usize {
@@ -303,11 +319,14 @@ async fn import_run(
 
     match state.upstream.import_bundle(bundle_trim).await {
         Ok(result) => {
-            let view = StatusView::from_result(result);
+            let mut view = StatusView::from_result(result);
+            // Highlight raw JSON payload for the "Raw response" disclosure (#897).
+            view.highlight(&chrome.i18n);
             respond(&chrome, view, is_htmx, target_url)
         }
         Err(err) => {
-            let view = StatusView::from_error(target_url.clone(), &err);
+            let mut view = StatusView::from_error(target_url.clone(), &err);
+            view.highlight(&chrome.i18n);
             respond(&chrome, view, is_htmx, target_url)
         }
     }

--- a/crates/hts-ui/src/raw_fold.rs
+++ b/crates/hts-ui/src/raw_fold.rs
@@ -93,7 +93,16 @@ impl RawFold {
     }
 }
 
-fn highlight_one(i18n: &I18n, payload: &str) -> String {
+/// Renders a JSON payload into the shared highlighted JSON view.
+///
+/// Returns the highlighted HTML, or an empty string when the payload is empty,
+/// not valid JSON, or exceeds the render budget. The empty return signals that
+/// the caller's template should fall back to a bare `<pre>` block.
+///
+/// This is the shared entry point for all raw-payload highlighting in HTS-UI:
+/// the workbench fold (`RawFold::highlight`), the Concept Explorer panels, and
+/// the import status page.
+pub fn highlight_json(i18n: &I18n, payload: &str) -> String {
     if payload.is_empty() {
         return String::new();
     }
@@ -117,6 +126,10 @@ fn highlight_one(i18n: &I18n, payload: &str) -> String {
         tracing::error!(%error, "hts-ui raw fold json view render failed");
         String::new()
     })
+}
+
+fn highlight_one(i18n: &I18n, payload: &str) -> String {
+    highlight_json(i18n, payload)
 }
 
 #[cfg(test)]

--- a/crates/hts-ui/src/upstream.rs
+++ b/crates/hts-ui/src/upstream.rs
@@ -4786,10 +4786,24 @@ pub struct ConceptIdentity {
     pub designations: Vec<LookupDesignation>,
     pub used_supplements: Vec<String>,
     pub raw_body: String,
+    /// The `raw_body` rendered into the shared highlighted JSON view, or empty
+    /// when the payload exceeded the budget and the partial should fall back to
+    /// a `<pre>`. Filled by [`ConceptIdentity::highlight`] at the response
+    /// funnel, because the viewer's fold buttons carry a translated label and
+    /// the upstream layer has no business knowing the request locale.
+    pub raw_body_json: String,
     pub request_url: String,
 }
 
 impl ConceptIdentity {
+    /// Renders `raw_body` into the shared JSON view.
+    ///
+    /// Non-JSON or over-budget text leaves `raw_body_json` empty; the partial
+    /// then shows the raw string in a `<pre>`, which is what the fold did for
+    /// every payload before #897.
+    pub fn highlight(&mut self, i18n: &crate::i18n::I18n) {
+        self.raw_body_json = crate::raw_fold::highlight_json(i18n, &self.raw_body);
+    }
     /// Human label for the page heading: display falls back to name falls back
     /// to the code, so the operator always sees something legible.
     pub fn heading(&self) -> &str {
@@ -5048,10 +5062,24 @@ pub struct ConceptMappings {
     /// em-dash Origin cell and its footnote.
     pub unattributable: bool,
     pub raw_body: String,
+    /// The `raw_body` rendered into the shared highlighted JSON view, or empty
+    /// when the payload exceeded the budget and the partial should fall back to
+    /// a `<pre>`. Filled by [`ConceptMappings::highlight`] at the response
+    /// funnel.
+    pub raw_body_json: String,
     pub request_url: String,
 }
 
 impl ConceptMappings {
+    /// Renders `raw_body` into the shared JSON view.
+    ///
+    /// Non-JSON or over-budget text leaves `raw_body_json` empty; the partial
+    /// then shows the raw string in a `<pre>`, which is what the fold did for
+    /// every payload before #897.
+    pub fn highlight(&mut self, i18n: &crate::i18n::I18n) {
+        self.raw_body_json = crate::raw_fold::highlight_json(i18n, &self.raw_body);
+    }
+
     pub fn is_empty(&self) -> bool {
         self.match_count == 0
     }

--- a/crates/hts-ui/templates/partials/hts-concept-identity.html
+++ b/crates/hts-ui/templates/partials/hts-concept-identity.html
@@ -124,7 +124,7 @@
 
     <details>
       <summary>{{ chrome.i18n.t("hts-concept-raw-response") }}</summary>
-      <pre class="detail__code">{{ identity.raw_body }}</pre>
+      {% if !identity.raw_body_json.is_empty() %}{{ identity.raw_body_json|safe }}{% else %}<pre class="detail__code" tabindex="0">{{ identity.raw_body }}</pre>{% endif %}
     </details>
   </div>
   {% endif %}

--- a/crates/hts-ui/templates/partials/hts-concept-mappings.html
+++ b/crates/hts-ui/templates/partials/hts-concept-mappings.html
@@ -127,7 +127,7 @@
 
     <details>
       <summary>{{ chrome.i18n.t("hts-concept-raw-response") }}</summary>
-      <pre class="detail__code">{{ mappings.raw_body }}</pre>
+      {% if !mappings.raw_body_json.is_empty() %}{{ mappings.raw_body_json|safe }}{% else %}<pre class="detail__code" tabindex="0">{{ mappings.raw_body }}</pre>{% endif %}
     </details>
   {% endif %}
 </section>

--- a/crates/hts-ui/templates/partials/hts-import-status.html
+++ b/crates/hts-ui/templates/partials/hts-import-status.html
@@ -67,7 +67,7 @@
   {% if !view.raw_body.is_empty() %}
     <details>
       <summary><span class="detail__hint-inline">{{ chrome.i18n.t("hts-import-raw-toggle") }}</span> <code>{{ view.request_url }}</code></summary>
-      <pre class="detail__code">{{ view.raw_body }}</pre>
+      {% if !view.raw_body_json.is_empty() %}{{ view.raw_body_json|safe }}{% else %}<pre class="detail__code" tabindex="0">{{ view.raw_body }}</pre>{% endif %}
     </details>
   {% endif %}
 {% else if view.is_success || view.is_partial %}
@@ -126,7 +126,7 @@
   {% if !view.raw_body.is_empty() %}
     <details>
       <summary><span class="detail__hint-inline">{{ chrome.i18n.t("hts-import-raw-toggle") }}</span> <code>{{ view.request_url }}</code></summary>
-      <pre class="detail__code">{{ view.raw_body }}</pre>
+      {% if !view.raw_body_json.is_empty() %}{{ view.raw_body_json|safe }}{% else %}<pre class="detail__code" tabindex="0">{{ view.raw_body }}</pre>{% endif %}
     </details>
   {% endif %}
 {% endif %}


### PR DESCRIPTION
Closes #897

The "Raw response" folds in the Concept Explorer (Identity and Mappings panels) and
on the import status page rendered unformatted monochrome text, while the workbench
folds fixed in #803 showed syntax-highlighted, foldable JSON. Factor `highlight_json()`
out of `raw_fold.rs` as a public helper, add a `raw_body_json` field to
`ConceptIdentity`, `ConceptMappings` and the import status view, and update the HTML
partials to use the existing if/safe/else pattern from `hts-raw-fold.html`.

_PR auto-generated by claude-agent; fix implemented with Claude Code and validated with the Playwright e2e suite._
