### PR TITLE
fix(postgres): make the legacy composite read form match promoted rows (#279)

### DIFF
--- a/crates/persistence/src/backends/postgres/search/query_builder.rs
+++ b/crates/persistence/src/backends/postgres/search/query_builder.rs
@@ -1397,9 +1397,16 @@ impl PostgresQueryBuilder {
             let mut next = current;
             let mut ok = true;
 
-            for (part, component) in parts.iter().zip(param.components.iter()) {
+            for (idx, (part, component)) in parts.iter().zip(param.components.iter()).enumerate() {
                 let cv = Self::parse_component_value(part);
-                match Self::build_composite_component(&cv, component.param_type, next, 1) {
+                // 1-based, and the same order the extractor assigns slots from.
+                let slot = (idx + 1).min(u8::MAX as usize) as u8;
+                match Self::build_composite_component_transitional(
+                    &cv,
+                    component.param_type,
+                    next,
+                    slot,
+                ) {
                     Some((sql, params)) => {
                         next += params.len();
                         staged_params.extend(params);
@@ -1492,6 +1499,66 @@ impl PostgresQueryBuilder {
         } else {
             base.to_string()
         }
+    }
+
+    /// A component predicate that matches **both** composite layouts, for use
+    /// while a database is being promoted from legacy to denormalized.
+    ///
+    /// Promotion rewrites resources one page at a time, so for the length of the
+    /// run the table holds both shapes at once and reads must still be correct
+    /// against each. For most component types the two shapes are already
+    /// indistinguishable to a read: only Token and Number have `_2` columns
+    /// (`CompositeRow::place`), so a slot-2 component of any other type writes
+    /// the base columns either way and needs nothing special.
+    ///
+    /// Token and Number in slot 2 are the exception, and getting them wrong is
+    /// silent. A promoted token+token row puts component 2 in `value_token_code_2`,
+    /// which the legacy `HAVING` never reads — so the plain legacy form stops
+    /// matching a resource the moment it is rewritten, and 24 of the 46 R4
+    /// composites pair two components of the same type. That is a false
+    /// *negative*: the resource simply disappears from composite search until
+    /// the marker flips.
+    ///
+    /// The repair is to read the `_2` column when it is populated and fall back
+    /// to the base column when it is not:
+    ///
+    /// ```sql
+    /// (code_2 = $1 OR (code_2 IS NULL AND system_2 IS NULL AND code = $2))
+    /// ```
+    ///
+    /// The `IS NULL` guard is what keeps this from introducing a false
+    /// *positive*. Simply OR-ing the two columns would let a denormalized row
+    /// satisfy a query with its components **swapped** — component 1 matching via
+    /// `_2` and component 2 via the base column — which is a different clinical
+    /// fact than the one asked for. Component 1 therefore always reads the base
+    /// columns only, and component 2 reads the base columns only on rows that
+    /// have no slot-2 payload at all, i.e. legacy rows.
+    fn build_composite_component_transitional(
+        value: &SearchValue,
+        param_type: SearchParamType,
+        offset: usize,
+        slot: u8,
+    ) -> Option<(String, Vec<SqlParam>)> {
+        // Slot 1 is the base columns under either layout.
+        if slot < 2 {
+            return Self::build_composite_component(value, param_type, offset, 1);
+        }
+        // Only Token and Number ever occupy a `_2` column.
+        let guard = match param_type {
+            SearchParamType::Token => "value_token_code_2 IS NULL AND value_token_system_2 IS NULL",
+            SearchParamType::Number => "value_number_2 IS NULL",
+            _ => return Self::build_composite_component(value, param_type, offset, 1),
+        };
+
+        let (denorm_sql, denorm_params) =
+            Self::build_composite_component(value, param_type, offset, slot)?;
+        let (legacy_sql, legacy_params) =
+            Self::build_composite_component(value, param_type, offset + denorm_params.len(), 1)?;
+
+        let sql = format!("(({denorm_sql}) OR ({guard} AND ({legacy_sql})))");
+        let mut params = denorm_params;
+        params.extend(legacy_params);
+        Some((sql, params))
     }
 
     /// Builds a single composite component as a bare column predicate (no
@@ -2296,6 +2363,99 @@ mod tests {
         let frag = PostgresQueryBuilder::build_search_query(&query, 2).expect("condition");
 
         assert!(PostgresQueryBuilder::single_index_predicate(&frag.sql).is_none());
+    }
+
+    /// A slot-2 token component must read the `_2` column **and** fall back to
+    /// the base column, so the legacy read form keeps matching a resource that
+    /// promotion has already rewritten. Without this, 24 of the 46 R4
+    /// composites silently vanish from search for the length of the run.
+    #[test]
+    fn transitional_legacy_form_reads_both_layouts_for_token_token() {
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "code-value-concept".to_string(),
+            param_type: SearchParamType::Composite,
+            modifier: None,
+            values: vec![SearchValue::eq("8480-6$271649006")],
+            chain: vec![],
+            components: vec![
+                CompositeSearchComponent {
+                    param_type: SearchParamType::Token,
+                    param_name: "code".into(),
+                },
+                CompositeSearchComponent {
+                    param_type: SearchParamType::Token,
+                    param_name: "value-concept".into(),
+                },
+            ],
+        });
+
+        let frag = PostgresQueryBuilder::build_search_query_for(&query, 2, IndexLayout::Legacy)
+            .expect("fragment");
+
+        assert!(
+            frag.sql.contains("value_token_code_2 = $4"),
+            "component 2 must read the denormalized _2 column: {}",
+            frag.sql
+        );
+        assert!(
+            frag.sql
+                .contains("value_token_code_2 IS NULL AND value_token_system_2 IS NULL"),
+            "the fallback must be guarded on the row having no slot-2 payload: {}",
+            frag.sql
+        );
+        // Component 1 must NEVER read `_2`. If it did, a denormalized row whose
+        // components are SWAPPED would satisfy the query — a different clinical
+        // fact than the one asked for, returned as a match.
+        let having = frag.sql.split("HAVING ").nth(1).expect("a HAVING clause");
+        let comp_one_arm = having
+            .split(" AND MAX(")
+            .next()
+            .expect("component 1's MAX arm");
+        assert!(
+            !comp_one_arm.contains("_2"),
+            "component 1's HAVING arm must read only the base columns, got `{}` in: {}",
+            comp_one_arm,
+            frag.sql
+        );
+        // Still the grouped form — this is the legacy layout.
+        assert!(
+            frag.sql
+                .contains("GROUP BY resource_id, composite_group HAVING")
+        );
+    }
+
+    /// A component type with no `_2` column is identical under both layouts, so
+    /// the transitional form must not widen it — a quantity component writes
+    /// `value_quantity_value` whatever slot it occupies.
+    #[test]
+    fn transitional_legacy_form_is_unchanged_where_no_slot_2_column_exists() {
+        let query = SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "code-value-quantity".to_string(),
+            param_type: SearchParamType::Composite,
+            modifier: None,
+            values: vec![SearchValue::eq("8480-6$ge100")],
+            chain: vec![],
+            components: vec![
+                CompositeSearchComponent {
+                    param_type: SearchParamType::Token,
+                    param_name: "code".into(),
+                },
+                CompositeSearchComponent {
+                    param_type: SearchParamType::Quantity,
+                    param_name: "value-quantity".into(),
+                },
+            ],
+        });
+
+        let frag = PostgresQueryBuilder::build_search_query_for(&query, 2, IndexLayout::Legacy)
+            .expect("fragment");
+
+        assert!(
+            !frag.sql.contains("_2"),
+            "token+quantity needs no transitional widening: {}",
+            frag.sql
+        );
+        assert_eq!(frag.params.len(), 2, "and binds no extra parameters");
     }
 
     #[test]


### PR DESCRIPTION
Prerequisite for #279's remaining work item — letting an **existing** database reach the denormalized composite layout. This PR lands the correctness fix that makes an online promotion possible at all; the driver follows on this branch.

## Why #279 is not actually finished

The denormalized layout shipped in #747 and works — verified on `origin/main` @ `f3d04e3af` against a real PostgreSQL 18.6, not by reading the diff: the marker reads `denormalized`, a BP panel stores as one row per `(resource, composite_group)` carrying every component, the emitted SQL is the flat conjunction with no `GROUP BY … HAVING`, and the covering index is in place.

But `migrate_v17_to_v18` marks any **populated** `search_index` as `legacy` and says so outright:

> Only the write path can populate the column, so an existing table is left alone and marked `legacy` … (Promoting a populated database, by re-extracting under `$reindex` and flipping the marker, is not implemented here.)

`read_index_layout` is consulted only at backend init and in the v26→v27 / v27→v28 migrations; `$reindex` never flips the marker. **The last release, v0.2.1, shipped `SCHEMA_VERSION = 12`** — so every deployment that exists today is populated and pre-v18, and on upgrade all of them land on `legacy` permanently. They keep the 9.2 s composite path and skip the v18, v27 and v28 index sets. Greenfield installs only.

## The defect this PR fixes

Promotion has to rewrite resources a page at a time, so for the length of the run `search_index` holds both shapes at once and reads must stay correct against each. They do not, and the failure is silent.

A promoted token+token row puts component 2 in `value_token_code_2`, which the legacy `GROUP BY / HAVING` form never reads. The resource stops matching composite search the moment it is rewritten — and **24 of the 46 R4 composites pair two components of the same type**. Measured on real rows, a `code-value-concept` query returned the un-promoted resource and silently dropped the promoted one:

```
=== LEGACY query form, token+token ===
 resource_id
-------------
 legacy-tt        <- denorm-tt is missing
```

That is a false *negative* in clinical search, for the whole duration of a migration.

## The fix, and the trap inside it

The legacy form now reads the `_2` column when it is populated and falls back to the base column when it is not:

```sql
(code_2 = $4 OR (code_2 IS NULL AND system_2 IS NULL AND code = $5))
```

**The `IS NULL` guard is load-bearing.** Simply OR-ing the two columns — the obvious repair — lets a denormalized row satisfy a query with its components *swapped*, matching component 1 via `_2` and component 2 via the base column. That is a different clinical fact returned as a hit. Verified against real rows, with a deliberately swapped fixture:

| form | `legacy-tt` | `denorm-tt` | `denorm-swapped` |
|---|:--:|:--:|:--:|
| legacy (before) | ✅ | ❌ **dropped** | — |
| naive `(base OR _2)` | ✅ | ✅ | ❌ **false positive** |
| **this PR** | ✅ | ✅ | ✅ correctly excluded |

Component 1 therefore always reads the base columns only, and component 2 reads the base columns only on rows with no slot-2 payload at all — i.e. legacy rows.

Only Token and Number have `_2` columns (`CompositeRow::place`), so every other component type is untouched and binds no extra parameters. On a database that has never been promoted, `_2` is NULL on every row and the added disjunct reduces to the predicate already emitted — existing behaviour is unchanged.

## What else the investigation established

Four things worth recording, each measured:

1. **`last_updated` *is* backfillable by SQL.** The v18 doc claim that it "cannot be" is wrong: `UPDATE search_index si SET last_updated = r.last_updated FROM resources r WHERE si.tenant_id = r.tenant_id AND si.resource_type = r.resource_type AND si.resource_id = r.id` did **880k rows in 17.9 s with 0 mismatches**. Only orphan index rows (no backing resource — there is deliberately no FK) stayed NULL. The doc is left uncorrected until the code matches it.
2. **A faithful SQL composite fold is not possible.** `fold_composites` needs `composite_slot` and `composite_arity`, which come from the registry and are absent from legacy rows; slot is unrecoverable for token+token, and arity is needed to drop the partial groups legacy wrote. Promotion must re-extract. A SQL re-fold would be a second implementation of fold semantics — precisely the thing that returns the wrong patients quietly.
3. **The writer is layout-aware** (`split_for_layout`), so a plain reindex on a legacy database rewrites *legacy* rows. Promotion must force `IndexLayout::Denormalized` writes; flipping the marker first is not an option, because reads would break for the length of the run.
4. **`ReindexRequest::search_param_urls` is dead code** — declared and constructible via `for_params`, never read by the engine. The "targeted reindex of composite params" #279 assumes does not exist; reindex is whole-resource. Calling `for_params` today silently performs a full reindex.

## Testing

- Two new unit tests: the transitional form reads both layouts for token+token, and is not widened where no `_2` column exists (token+quantity binds exactly 2 params).
- `cargo test -p helios-persistence --features postgres --lib` — **979 passed, 0 failed**.
- End-to-end against a local PostgreSQL 18.6 with a purpose-built legacy fixture (880k index rows, `last_updated` NULL, marker `legacy`), replaying the SQL the builder actually emits.
- `cargo fmt` clean. The two clippy warnings in `query_builder.rs` are pre-existing at line 1811, unrelated to this change.

## Still to come on this branch

- The promotion driver: reindex every tenant with forced denormalized writes → verify no legacy-shaped rows remain → flip the marker → apply the index sets v18 / v26→v27 / v27→v28 skip on a legacy database.
- Orphan-row cleanup (finding 1).
- Correcting the `migrate_v17_to_v18` doc claim once behaviour matches it.
- Integration test: legacy fixture → promote → denormalized layout with correct composite results.

## Follow-up, deliberately not in scope

The layout marker conflates two independent concerns: *"rows carry a sort key"* and *"composites are denormalized"*. Splitting it would let the 17.9 s SQL backfill deliver the entire sort-key/fast-path win — most of the v18–v28 search campaign — without anyone running a multi-hour re-extraction, leaving only composite search on the legacy path until they choose to. That is a materially more adoptable migration, but it widens this PR and wants its own review.

Closes nothing yet; #279 stays open until the driver lands.
