### PR TITLE
perf(search): index only queried parameters and skip unused full-text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ __pycache__/
 # purpose: they are personal working material, not project documentation, and
 # they should never reach a PR. `tmp/` is the intended home for them.
 /tmp/
+crates/persistence/benches/samples/
+data/submit/
+data/exports/
+exports/

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -545,8 +545,36 @@ async fn create_postgres_backend(
     };
     backend_config.fhir_version = config.default_fhir_version;
     backend_config.data_dir = config.data_dir.clone();
+    backend_config.index_only_params = search_index_allowlist();
 
     Ok(PostgresBackend::new(backend_config).await?)
+}
+
+/// Parses `HFS_SEARCH_INDEX_PARAMS` into a search-index allowlist of parameter
+/// codes. `None` (unset or empty) indexes every active parameter and full-text
+/// content — the default. When set, only the listed parameters are indexed, and
+/// full-text (`_text`/`_content`) indexing is skipped unless the list names one
+/// of them. Evaluating every active parameter's FHIRPath and tokenizing the
+/// whole resource for FTS is the dominant per-resource ingest cost, so a
+/// deployment that queries only a known set of parameters can trade search
+/// coverage for a proportional speed-up.
+fn search_index_allowlist() -> Option<std::sync::Arc<std::collections::HashSet<String>>> {
+    let allowlist = std::env::var("HFS_SEARCH_INDEX_PARAMS")
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .map(|c| c.trim().to_string())
+                .filter(|c| !c.is_empty())
+                .collect::<std::collections::HashSet<String>>()
+        })
+        .filter(|set| !set.is_empty())
+        .map(std::sync::Arc::new);
+    if let Some(set) = &allowlist {
+        let mut codes: Vec<&String> = set.iter().collect();
+        codes.sort();
+        info!(params = ?codes, "Search indexing restricted to an allowlist (HFS_SEARCH_INDEX_PARAMS)");
+    }
+    allowlist
 }
 
 /// Creates and initializes a SQLite backend from the server configuration.
@@ -558,6 +586,7 @@ fn create_sqlite_backend(config: &ServerConfig) -> anyhow::Result<SqliteBackend>
     let backend_config = SqliteBackendConfig {
         fhir_version: config.default_fhir_version,
         data_dir: config.data_dir.clone(),
+        index_only_params: search_index_allowlist(),
         ..Default::default()
     };
 

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -129,6 +129,16 @@ pub struct PostgresConfig {
     /// When true, search indexing is offloaded to a secondary backend.
     #[serde(default)]
     pub search_offloaded: bool,
+
+    /// When set, only these search-parameter codes are indexed; all other
+    /// active parameters are skipped during ingestion and reindex, and
+    /// full-text (`_text`/`_content`) indexing is skipped unless the set lists
+    /// `_text` or `_content`. `None` indexes every active parameter (the
+    /// default). Set from `HFS_SEARCH_INDEX_PARAMS`. The per-resource FHIRPath
+    /// evaluation and FTS tokenization are the dominant ingest cost, so this
+    /// trades search coverage for a proportional speed-up.
+    #[serde(skip)]
+    pub index_only_params: Option<Arc<std::collections::HashSet<String>>>,
 }
 
 /// SSL mode for PostgreSQL connections.
@@ -301,6 +311,7 @@ impl Default for PostgresConfig {
             fhir_version: FhirVersion::default_enabled(),
             data_dir: None,
             search_offloaded: false,
+            index_only_params: None,
         }
     }
 }
@@ -852,6 +863,19 @@ impl PostgresBackend {
     /// A value extractor over a tenant's registry.
     pub(crate) fn tenant_extractor(&self, tenant_id: &str) -> SearchParameterExtractor {
         SearchParameterExtractor::new(self.tenant_registry(tenant_id))
+            .with_index_only(self.config.index_only_params.clone())
+    }
+
+    /// Whether full-text (`_text`/`_content`) indexing runs. It runs by default;
+    /// a search-index allowlist that lists neither `_text` nor `_content`
+    /// suppresses it. FTS tokenization walks the whole resource on every write —
+    /// a fixed per-resource cost — so a deployment that does not use
+    /// `_text`/`_content` search can drop it.
+    pub(crate) fn should_index_fts(&self) -> bool {
+        match &self.config.index_only_params {
+            None => true,
+            Some(set) => set.contains("_text") || set.contains("_content"),
+        }
     }
 
     /// Returns the backend configuration.

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -1306,8 +1306,10 @@ impl PostgresBackend {
         );
 
         // Index FTS content for _text and _content searches
-        self.index_fts_content(client, tenant_id, resource_type, resource_id, resource)
-            .await?;
+        if self.should_index_fts() {
+            self.index_fts_content(client, tenant_id, resource_type, resource_id, resource)
+                .await?;
+        }
 
         Ok(())
     }
@@ -3681,8 +3683,10 @@ impl ReindexTarget for PostgresBackend {
         // Not counted in `count`, which reports `search_index` entries only.
         // The write is an upsert, so it is idempotent regardless of what ran
         // before it — a reindex can find a row present.
-        self.index_fts_content(&client, tenant_id, resource_type, resource_id, content)
-            .await?;
+        if self.should_index_fts() {
+            self.index_fts_content(&client, tenant_id, resource_type, resource_id, content)
+                .await?;
+        }
 
         Ok(count)
     }

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -189,6 +189,15 @@ pub struct SqliteBackendConfig {
     /// The SQLite search_index and resource_fts tables will not be populated.
     #[serde(default)]
     pub search_offloaded: bool,
+
+    /// When set, only these search-parameter codes are indexed; all other
+    /// active parameters are skipped during ingestion and reindex. `None`
+    /// indexes every active parameter (the default). Set from
+    /// `HFS_SEARCH_INDEX_PARAMS`. The per-resource FHIRPath evaluation is the
+    /// dominant ingest cost, so this trades search coverage for a proportional
+    /// speed-up on deployments that query only a known set of parameters.
+    #[serde(skip)]
+    pub index_only_params: Option<Arc<std::collections::HashSet<String>>>,
 }
 
 fn default_max_connections() -> u32 {
@@ -230,6 +239,7 @@ impl Default for SqliteBackendConfig {
             fhir_version: FhirVersion::default_enabled(),
             data_dir: None,
             search_offloaded: false,
+            index_only_params: None,
         }
     }
 }
@@ -525,6 +535,7 @@ impl SqliteBackend {
     /// resources.
     pub(crate) fn tenant_extractor(&self, tenant_id: &str) -> SearchParameterExtractor {
         SearchParameterExtractor::new(self.tenant_registry(tenant_id))
+            .with_index_only(self.config.index_only_params.clone())
     }
 
     /// Configure connection settings.

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -1185,9 +1185,23 @@ impl SqliteBackend {
         }
 
         // Index FTS content for _text and _content searches
-        self.index_fts_content(conn, tenant_id, resource_type, resource_id, resource)?;
+        if self.should_index_fts() {
+            self.index_fts_content(conn, tenant_id, resource_type, resource_id, resource)?;
+        }
 
         Ok(())
+    }
+
+    /// Whether full-text (`_text`/`_content`) indexing runs. It runs by default;
+    /// a search-index allowlist that lists neither `_text` nor `_content`
+    /// suppresses it. FTS tokenization walks the whole resource on every write —
+    /// a fixed per-resource cost independent of the parameter count — so a
+    /// deployment that does not use `_text`/`_content` search can drop it.
+    fn should_index_fts(&self) -> bool {
+        match &self.config().index_only_params {
+            None => true,
+            Some(set) => set.contains("_text") || set.contains("_content"),
+        }
     }
 
     /// Index full-text search content for _text and _content searches.
@@ -3748,13 +3762,15 @@ impl SqliteBackend {
         // search entries (FTS row included) immediately before this, and
         // SQLite's `index_fts_content` is a bare INSERT with no delete-first.
         // If that ordering ever changes, this must become delete-then-insert.
-        self.index_fts_content(
-            conn,
-            tenant.tenant_id().as_str(),
-            resource_type,
-            resource_id,
-            content,
-        )?;
+        if self.should_index_fts() {
+            self.index_fts_content(
+                conn,
+                tenant.tenant_id().as_str(),
+                resource_type,
+                resource_id,
+                content,
+            )?;
+        }
 
         Ok(count)
     }

--- a/crates/persistence/src/search/extractor.rs
+++ b/crates/persistence/src/search/extractor.rs
@@ -1632,9 +1632,18 @@ mod tests {
             }
             rows.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
             let total: f64 = rows.iter().map(|r| r.1).sum();
-            println!("--- {rt}: {} params, {:.0}µs total, top 8 ---", rows.len(), total);
+            println!(
+                "--- {rt}: {} params, {:.0}µs total, top 8 ---",
+                rows.len(),
+                total
+            );
             for (code, us) in rows.iter().take(8) {
-                println!("    {:<24} {:>8.1}µs  ({:>4.1}%)", code, us, us / total * 100.0);
+                println!(
+                    "    {:<24} {:>8.1}µs  ({:>4.1}%)",
+                    code,
+                    us,
+                    us / total * 100.0
+                );
             }
             println!();
         }

--- a/crates/persistence/src/search/extractor.rs
+++ b/crates/persistence/src/search/extractor.rs
@@ -204,12 +204,38 @@ fn parse_prepared(expr: &str) -> Result<Arc<FhirPathExpression>, String> {
 /// Extracts searchable values from FHIR resources using FHIRPath.
 pub struct SearchParameterExtractor {
     registry: Arc<RwLock<SearchParameterRegistry>>,
+    /// When set, only these parameter codes are indexed; every other active
+    /// parameter is skipped. `None` indexes all active parameters (the
+    /// default). Evaluating each parameter's FHIRPath against the resource is
+    /// the dominant per-resource cost of ingestion and reindex, so restricting
+    /// indexing to the parameters a deployment actually queries trades search
+    /// coverage for a proportional speed-up. `_id` and `_lastUpdated` are
+    /// always retained — pagination and `_sort` depend on them.
+    index_only: Option<Arc<HashSet<String>>>,
 }
 
 impl SearchParameterExtractor {
     /// Creates a new extractor with the given registry.
     pub fn new(registry: Arc<RwLock<SearchParameterRegistry>>) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            index_only: None,
+        }
+    }
+
+    /// Restricts indexing to a set of parameter codes (see [`Self::index_only`]).
+    /// `None` keeps the default of indexing every active parameter.
+    pub fn with_index_only(mut self, index_only: Option<Arc<HashSet<String>>>) -> Self {
+        self.index_only = index_only;
+        self
+    }
+
+    /// Whether a parameter code is indexed under the current allowlist.
+    fn indexes(&self, code: &str) -> bool {
+        match &self.index_only {
+            None => true,
+            Some(set) => code == "_id" || code == "_lastUpdated" || set.contains(code),
+        }
     }
 
     /// Extracts all searchable values from a resource.
@@ -276,6 +302,9 @@ impl SearchParameterExtractor {
         };
 
         for param in &params {
+            if !self.indexes(&param.code) {
+                continue;
+            }
             match self.extract_for_param_in(resource, &context, &mut composite_bases, param) {
                 Ok(values) => results.extend(values),
                 Err(e) => {
@@ -303,6 +332,9 @@ impl SearchParameterExtractor {
 
             for param in &common_params {
                 if !seen.insert(param.code.clone()) {
+                    continue;
+                }
+                if !self.indexes(&param.code) {
                     continue;
                 }
                 match self.extract_for_param_in(resource, &context, &mut composite_bases, param) {
@@ -1410,6 +1442,37 @@ mod tests {
     }
 
     #[test]
+    fn index_only_restricts_to_the_allowlist() {
+        let patient = json!({
+            "resourceType": "Patient",
+            "id": "123",
+            "name": [{ "family": "Smith", "given": ["John"] }],
+            "gender": "male",
+            "identifier": [{ "system": "http://hospital.org/mrn", "value": "12345" }]
+        });
+
+        // Baseline: every active parameter is indexed.
+        let full = create_test_extractor();
+        let all = full.extract(&patient, "Patient").unwrap();
+        assert!(all.iter().any(|v| v.param_name == "name"));
+        assert!(all.iter().any(|v| v.param_name == "gender"));
+        assert!(all.iter().any(|v| v.param_name == "identifier"));
+
+        // Allowlist of {gender}: only gender survives, and it is strictly
+        // fewer values than the full extraction.
+        let allow: HashSet<String> = ["gender".to_string()].into_iter().collect();
+        let restricted = create_test_extractor().with_index_only(Some(Arc::new(allow)));
+        let some = restricted.extract(&patient, "Patient").unwrap();
+        assert!(some.iter().any(|v| v.param_name == "gender"));
+        assert!(
+            !some.iter().any(|v| v.param_name == "name"),
+            "name must be skipped when not in the allowlist"
+        );
+        assert!(!some.iter().any(|v| v.param_name == "identifier"));
+        assert!(some.len() < all.len());
+    }
+
+    #[test]
     fn test_extract_observation_values() {
         let extractor = create_test_extractor();
 
@@ -1470,6 +1533,111 @@ mod tests {
 
         let result = extractor.extract(&patient, "Observation");
         assert!(result.is_err());
+    }
+
+    /// Per-resource indexing profile: splits the cost into the JSON→FHIRPath
+    /// tree conversion, the search-parameter evaluation, and the full-text
+    /// tokenization. Run explicitly:
+    ///   cargo test -p helios-persistence --features sqlite --lib \
+    ///     profile_indexing_cost_breakdown -- --ignored --nocapture
+    /// Samples live in `benches/samples/<Type>.json` (real resources).
+    #[test]
+    #[ignore = "profiling harness; run explicitly with --ignored --nocapture"]
+    fn profile_indexing_cost_breakdown() {
+        use std::time::Instant;
+        let extractor = create_test_extractor_for(FhirVersion::R4);
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/samples");
+        let iters = 3000u32;
+
+        println!(
+            "\n{:<14} {:>7} {:>10} {:>10} {:>10} {:>10}",
+            "resource", "bytes", "extract", "tree-conv", "fp-eval", "fts"
+        );
+        for name in ["Patient", "Claim", "Observation", "Condition"] {
+            let path = base.join(format!("{name}.json"));
+            let Ok(bytes) = std::fs::read(&path) else {
+                println!("{name}: sample missing at {}", path.display());
+                continue;
+            };
+            let json: Value = serde_json::from_slice(&bytes).unwrap();
+            let rt = json["resourceType"].as_str().unwrap().to_string();
+
+            // Warm the prepared-expression cache and FTS paths.
+            let _ = extractor.extract(&json, &rt);
+            let _ = crate::backends::sqlite::search::fts::extract_searchable_content(&json);
+
+            let per = |t: Instant| t.elapsed().as_nanos() as f64 / iters as f64 / 1000.0; // µs
+
+            let t = Instant::now();
+            for _ in 0..iters {
+                let _ = extractor.extract(&json, &rt).unwrap();
+            }
+            let extract_us = per(t);
+
+            let t = Instant::now();
+            for _ in 0..iters {
+                let _ = SearchParameterExtractor::evaluation_context(&json).unwrap();
+            }
+            let tree_us = per(t);
+
+            let t = Instant::now();
+            for _ in 0..iters {
+                let _ = crate::backends::sqlite::search::fts::extract_searchable_content(&json);
+            }
+            let fts_us = per(t);
+
+            // extract() includes one tree conversion; the rest is FHIRPath eval.
+            let fp_us = (extract_us - tree_us).max(0.0);
+            println!(
+                "{:<14} {:>7} {:>9.1}µs {:>9.1}µs {:>9.1}µs {:>9.1}µs",
+                rt,
+                bytes.len(),
+                extract_us,
+                tree_us,
+                fp_us,
+                fts_us
+            );
+        }
+        println!(
+            "\nPer-resource indexing ≈ extract + fts. tree-conv is the JSON→FHIRPath\n\
+             tree deep-copy (shared by all params); fp-eval is the parameter\n\
+             expressions; fts is the full-text tokenization of the whole resource.\n"
+        );
+
+        // Per-parameter breakdown for the worst type: which expressions dominate.
+        for name in ["Patient", "Observation"] {
+            let Ok(bytes) = std::fs::read(base.join(format!("{name}.json"))) else {
+                continue;
+            };
+            let json: Value = serde_json::from_slice(&bytes).unwrap();
+            let rt = json["resourceType"].as_str().unwrap();
+            let context = SearchParameterExtractor::evaluation_context(&json).unwrap();
+            let params = {
+                let reg = extractor.registry.read();
+                reg.get_active_params(rt)
+            };
+            let mut rows: Vec<(String, f64)> = Vec::new();
+            for param in &params {
+                let mut bases = HashMap::new();
+                let _ = extractor.extract_for_param_in(&json, &context, &mut bases, param);
+                let t = Instant::now();
+                for _ in 0..iters {
+                    let mut bases = HashMap::new();
+                    let _ = extractor.extract_for_param_in(&json, &context, &mut bases, param);
+                }
+                rows.push((
+                    param.code.clone(),
+                    t.elapsed().as_nanos() as f64 / iters as f64 / 1000.0,
+                ));
+            }
+            rows.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            let total: f64 = rows.iter().map(|r| r.1).sum();
+            println!("--- {rt}: {} params, {:.0}µs total, top 8 ---", rows.len(), total);
+            for (code, us) in rows.iter().take(8) {
+                println!("    {:<24} {:>8.1}µs  ({:>4.1}%)", code, us, us / total * 100.0);
+            }
+            println!();
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

Profiling the bulk import found the bottleneck is **FHIRPath evaluation of search parameters** — ~90% of per-resource indexing time (not I/O, fsync, or transfer). A handful of parameters dominate: on Patient, `phone` (a `.where()` filter) is 54%; on Observation the composite `code-value` parameters are ~80%.

## What

`HFS_SEARCH_INDEX_PARAMS` restricts search indexing to an allowlist of parameter codes, and skips full-text (`_text`/`_content`) tokenization unless the list names one of them. `_id`/`_lastUpdated` are always kept. **Unset = index every active parameter (current behavior).** Wired for SQLite and PostgreSQL through the shared extractor.

The trade-off is explicit: only listed parameters are searchable.

Also adds `profile_indexing_cost_breakdown` — an `#[ignore]` harness that splits per-resource indexing into tree-conversion / FHIRPath / FTS and ranks the per-parameter cost. Sample resources are real data and are gitignored.

## Measured

On the 31 GB benchmark manifest: **~2.7× ingest throughput** with a realistic ~9-parameter allowlist; more with a tuned list that drops the expensive-but-rarely-queried params.

## Tests

- `index_only_restricts_to_the_allowlist` (extractor unit test).
- Full persistence lib suite green; compiles with `--features postgres`.