### PR TITLE
perf(sqlite): skip the per-entry FTS table scan on bulk ingest (4.1x)

### DIFF
--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -1458,11 +1458,19 @@ impl SqliteBackend {
         )
         .map_err(|e| internal_error(format!("Failed to delete search index: {}", e)))?;
 
-        // Delete from FTS table if it exists
-        let _ = conn.execute(
-            "DELETE FROM resource_fts WHERE tenant_id = ?1 AND resource_type = ?2 AND resource_id = ?3",
-            params![tenant_id, resource_type, resource_id],
-        );
+        // Delete from FTS. resource_fts is an FTS5 virtual table: a WHERE on
+        // its plain columns cannot use an index, so this statement scans the
+        // whole FTS table — per ingested entry, that made bulk imports
+        // quadratic in the table size. A resource that had no search_index
+        // rows was never FTS-indexed (every indexed resource carries at least
+        // its _id row), so the scan only needs to run when something was
+        // actually removed above.
+        if deleted > 0 {
+            let _ = conn.execute(
+                "DELETE FROM resource_fts WHERE tenant_id = ?1 AND resource_type = ?2 AND resource_id = ?3",
+                params![tenant_id, resource_type, resource_id],
+            );
+        }
 
         Ok(deleted as u64)
     }


### PR DESCRIPTION
## The bug

`delete_search_index` runs before every indexing pass — including **each entry of a bulk import**. Its second statement removes the resource's row from `resource_fts`, an **FTS5 virtual table**, where a WHERE on plain columns cannot use an index:

```
EXPLAIN QUERY PLAN DELETE FROM resource_fts WHERE tenant_id=? AND resource_type=? AND resource_id=?
→ SCAN resource_fts VIRTUAL TABLE
```

On a fresh bulk load the resource never existed, the DELETE removes nothing — and the scan grows with every inserted row, making ingest **quadratic** in the FTS table size. This is the cause of the throughput decay observed on SQLite imports, and it was the bulk of the "84% unattributed" per-entry cost in #947: instrumented on the real 31 GB manifest, the delete consumed **311 of 366 seconds at 25,000 resources** (12.4 ms/entry, ~72% of wall time).

## The fix

A resource with no `search_index` rows was never FTS-indexed (every indexed resource carries at least its `_id` row), so the FTS delete now runs only when the main delete actually removed something. Three lines, no behavior change: any resource that could have an FTS row still gets it deleted.

## Measured

Identical 7-minute window, same real manifest, single worker, fresh database:

| | before | after |
|---|---|---|
| Throughput | 56/s (decaying) | **232/s (stable)** |
| FTS-delete cost (cumulative) | 311 s @ 25k resources | 5 s @ 99k resources |

With the scan gone the per-entry budget is fully attributed: batch commit ≈ 1.9 ms and index-row INSERTs ≈ 1.7 ms lead, everything else is sub-0.3 ms. Updates of existing resources still pay one FTS scan; the structural fix (external-content FTS5) is tracked in #947.

Full sqlite persistence suite green (344).