### PR TITLE
perf(sqlite): bulk-ingest write-path defaults — 64 MiB page cache + 50k WAL autocheckpoint

### DIFF
--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -336,15 +336,16 @@ impl SqliteBackend {
             // entry. The limit is per pooled connection (pool of 10), but
             // only connections that touch that many pages grow their cache.
             conn.execute_batch("PRAGMA cache_size = -65536;")?;
-            // Checkpoint every ~10,000 WAL pages (~40 MiB) instead of every
+            // Checkpoint every ~50,000 WAL pages (~200 MiB) instead of every
             // 1,000 (~4 MiB). A bulk-ingest batch writes far more than 4 MiB
             // of WAL, so with the default every batch commit also ran a
             // checkpoint and paid the WAL->database copy inline; fewer,
             // larger checkpoints move the same bytes sequentially. Measured
-            // on the same real-manifest window: 289/s -> 382/s (+32%), with
-            // batch-commit cost falling 1.72 -> 0.96 ms per entry. Cost: the
-            // -wal file grows to ~40 MiB between checkpoints.
-            conn.execute_batch("PRAGMA wal_autocheckpoint = 10000;")?;
+            // stepwise on the same real-manifest window: 10,000 pages took
+            // 289/s -> 382/s (commit 1.72 -> 0.96 ms per entry) and 50,000
+            // took 417/s -> 501/s on the multi-row branch (commit -> 0.55 ms).
+            // Cost: the -wal file grows to ~200 MiB under sustained writes.
+            conn.execute_batch("PRAGMA wal_autocheckpoint = 50000;")?;
             crate::sof::sqlite_udfs::register(conn).map_err(|e| {
                 rusqlite::Error::SqliteFailure(
                     rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -336,6 +336,15 @@ impl SqliteBackend {
             // entry. The limit is per pooled connection (pool of 10), but
             // only connections that touch that many pages grow their cache.
             conn.execute_batch("PRAGMA cache_size = -65536;")?;
+            // Checkpoint every ~10,000 WAL pages (~40 MiB) instead of every
+            // 1,000 (~4 MiB). A bulk-ingest batch writes far more than 4 MiB
+            // of WAL, so with the default every batch commit also ran a
+            // checkpoint and paid the WAL->database copy inline; fewer,
+            // larger checkpoints move the same bytes sequentially. Measured
+            // on the same real-manifest window: 289/s -> 382/s (+32%), with
+            // batch-commit cost falling 1.72 -> 0.96 ms per entry. Cost: the
+            // -wal file grows to ~40 MiB between checkpoints.
+            conn.execute_batch("PRAGMA wal_autocheckpoint = 10000;")?;
             crate::sof::sqlite_udfs::register(conn).map_err(|e| {
                 rusqlite::Error::SqliteFailure(
                     rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -327,6 +327,15 @@ impl SqliteBackend {
             if enable_foreign_keys {
                 conn.execute_batch("PRAGMA foreign_keys = ON;")?;
             }
+            // 64 MiB page cache (negative = KiB). SQLite's 2 MiB default
+            // thrashes once the search_index B-trees outgrow it: during a
+            // bulk import every index INSERT and batch commit evicts and
+            // rewrites hot pages. Measured on a real 31 GB import, raising it
+            // took ingest from 232/s to 289/s (+25%), cutting index-row
+            // INSERT cost 1.71→1.24 ms and commit cost 1.95→1.72 ms per
+            // entry. The limit is per pooled connection (pool of 10), but
+            // only connections that touch that many pages grow their cache.
+            conn.execute_batch("PRAGMA cache_size = -65536;")?;
             crate::sof::sqlite_udfs::register(conn).map_err(|e| {
                 rusqlite::Error::SqliteFailure(
                     rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),


### PR DESCRIPTION
Two internal SQLite defaults on the write path, measured independently on identical 7-minute windows of the real 31 GB bulk-submit manifest (single worker, fresh database, on top of #949):

## 1. Page cache: 2 MiB → 64 MiB per connection

SQLite's default page cache is 2 MiB. The `search_index` B-trees outgrow that immediately, so bulk ingest spends its time evicting and rewriting hot pages.

| | cache 2 MiB | cache 64 MiB |
|---|---|---|
| Throughput | 232/s | **289/s (+25%)** |
| index-row INSERTs | 1.71 ms/entry | 1.24 ms |
| batch commit | 1.95 ms/entry | 1.72 ms |

A larger batch size was tried first and measured **slower** (205/s at 5,000 entries): bigger transactions overflow the small cache and grow the commit-time checkpoint. Recorded so it isn't re-run.

## 2. WAL autocheckpoint: 1,000 pages → 50,000 pages

A bulk batch writes far more than the default 4 MiB threshold, so **every batch commit also ran a checkpoint** and paid the WAL→database copy inline.

Measured stepwise on identical windows:

| | 1,000 (default) | 10,000 | 50,000 |
|---|---|---|---|
| Throughput | 289/s | 382/s (+32%) | **501/s** (on the #951 branch, +20% further) |
| batch commit | 1.72 ms/entry | 0.96 ms | 0.55 ms |

Cost: the `-wal` file grows to ~200 MiB under sustained writes (measured 207 MiB); light workloads rarely reach the threshold between their own commits.

## Memory ceiling

The cache limit is per pooled connection (pool of 10 → ~640 MiB theoretical worst case), but a connection's cache only grows with pages it actually touches — in practice the write connection fills it and idle/read-only connections stay small. No configuration is added; both are internal defaults in the same spirit as WAL mode itself.

## Stacked

With #944 + #949 + this PR, the full 954,288-entry import measured **51 minutes** end to end before the checkpoint change (comment on #947); the stacked increments here and in #951 project to **~32 minutes**, single worker, out of the box. Full sqlite persistence suite green (344).