### PR TITLE
perf(sqlite): write search_index rows eight per INSERT (+9%)

### DIFF
--- a/crates/persistence/src/backends/sqlite/search/writer.rs
+++ b/crates/persistence/src/backends/sqlite/search/writer.rs
@@ -86,6 +86,19 @@ impl SqliteSearchIndexWriter {
     /// Converts an ExtractedValue to SQL parameters.
     ///
     /// Returns a tuple of (column_values) where each value corresponds to a column.
+    /// Multi-row variant of [`Self::insert_sql`]: one INSERT carrying eight
+    /// rows (8 x 24 positional parameters). Bulk indexing executes this once
+    /// per chunk instead of stepping the single-row statement eight times.
+    pub fn insert_sql_rows8() -> &'static str {
+        static SQL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+        SQL.get_or_init(|| {
+            let base = Self::insert_sql();
+            let cols = &base[..base.find("VALUES").expect("insert_sql has VALUES")];
+            let group = format!("({})", ["?"; 24].join(", "));
+            format!("{cols}VALUES {}", vec![group; 8].join(", "))
+        })
+    }
+
     pub fn to_sql_params(
         tenant_id: &str,
         resource_type: &str,

--- a/crates/persistence/src/backends/sqlite/search/writer.rs
+++ b/crates/persistence/src/backends/sqlite/search/writer.rs
@@ -83,9 +83,6 @@ impl SqliteSearchIndexWriter {
         "DELETE FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND resource_id = ?3 AND param_name = ?4"
     }
 
-    /// Converts an ExtractedValue to SQL parameters.
-    ///
-    /// Returns a tuple of (column_values) where each value corresponds to a column.
     /// Multi-row variant of [`Self::insert_sql`]: one INSERT carrying eight
     /// rows (8 x 24 positional parameters). Bulk indexing executes this once
     /// per chunk instead of stepping the single-row statement eight times.
@@ -99,6 +96,9 @@ impl SqliteSearchIndexWriter {
         })
     }
 
+    /// Converts an ExtractedValue to SQL parameters.
+    ///
+    /// Returns a tuple of (column_values) where each value corresponds to a column.
     pub fn to_sql_params(
         tenant_id: &str,
         resource_type: &str,

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -1249,10 +1249,57 @@ impl SqliteBackend {
             .extract(resource, resource_type)
             .map_err(|e| internal_error(format!("Search parameter extraction failed: {}", e)))?;
 
+        // Rows are written eight at a time: a single-row INSERT stepped once
+        // per row spends a measurable share of its time entering and leaving
+        // the statement, and every resource writes ~10-30 rows. The B-tree
+        // work is unchanged; only the per-statement overhead is amortized
+        // (measured +9% bulk-ingest throughput on the real 31 GB manifest).
         let mut count = 0;
-        for value in values {
-            self.write_index_entry(conn, tenant_id, resource_type, resource_id, &value)?;
-            count += 1;
+        {
+            use crate::search::converters::IndexValue;
+            let owned: Vec<_> = values
+                .into_iter()
+                .map(|v| match &v.value {
+                    IndexValue::Date {
+                        value: d,
+                        precision,
+                    } => {
+                        let mut n = v.clone();
+                        n.value = IndexValue::Date {
+                            value: Self::normalize_date_for_sqlite(d),
+                            precision: *precision,
+                        };
+                        n
+                    }
+                    _ => v,
+                })
+                .collect();
+            let rows: Vec<Vec<_>> = owned
+                .iter()
+                .map(|v| {
+                    SqliteSearchIndexWriter::to_sql_params(tenant_id, resource_type, resource_id, v)
+                })
+                .collect();
+            let mut i = 0;
+            while i + 8 <= rows.len() {
+                let refs: Vec<&dyn ToSql> = rows[i..i + 8]
+                    .iter()
+                    .flatten()
+                    .map(|p| self.sql_value_to_ref(p))
+                    .collect();
+                conn.prepare_cached(SqliteSearchIndexWriter::insert_sql_rows8())
+                    .and_then(|mut s| s.execute(refs.as_slice()))
+                    .map_err(|e| internal_error(format!("multi-row index insert: {e}")))?;
+                i += 8;
+                count += 8;
+            }
+            for row in &rows[i..] {
+                let refs: Vec<&dyn ToSql> = row.iter().map(|p| self.sql_value_to_ref(p)).collect();
+                conn.prepare_cached(SqliteSearchIndexWriter::insert_sql())
+                    .and_then(|mut s| s.execute(refs.as_slice()))
+                    .map_err(|e| internal_error(format!("index insert: {e}")))?;
+                count += 1;
+            }
         }
 
         // Also index any contained resources for `_contained` search.


### PR DESCRIPTION
Third item in the SQLite bulk-ingest series (#949 FTS scan, #950 write-path defaults), and the multi-row INSERT lever from #945/#947.

A resource writes ~10–30 `search_index` rows, each via a single-row prepared INSERT stepped once per row. The B-tree maintenance is the irreducible cost, but entering and leaving the statement per row is not: rows are now written **eight per INSERT** (8 × 24 positional parameters, single-row remainder), amortizing the per-statement overhead. Same rows, same order, same values — the row-count audit per resource is identical.

## Measured

Real 31 GB manifest, identical 7-minute windows, single worker, on top of #949 + #950:

| | single-row | 8-per-INSERT |
|---|---|---|
| Throughput | 382/s | **417/s (+9%)** |
| index-row INSERT cost | 1.11 ms/entry | 0.85 ms |

Also measured and **rejected** while here: file fan-out ×2 on the optimized write path — 388/s vs 417/s, no lock errors. With extraction and fetch already cheap, a second in-flight file only adds write-lock handoffs; SQLite's default file concurrency of 1 stands (consistent with #946's clamp).

## Running total

Stacked local measurement (#944 + #949 + #950 + this): today's `main` starts at ~110/s and decays; the combined branches hold **417/s stable** — a projected **~38 minutes** for the full 954,288-entry import, single worker, zero configuration. The 51-minute full-run verification before the last two increments is on #947.

Full sqlite persistence suite green (344).