### PR TITLE
perf(sqlite): cut the bulk-submit write path 79% — instrumentation, cached statements, and index entries nothing can use

### DIFF
--- a/.claude/skills/bulk-data-submit/SKILL.md
+++ b/.claude/skills/bulk-data-submit/SKILL.md
@@ -109,3 +109,17 @@ The backend capability splits into `BulkSubmitIngest` (the synchronous `BulkSubm
   malformed is `400`. Page size `0` disables pagination and yields one manifest with an empty `link`.
 - Status-poll pacing: the `202` advertises `HFS_BULK_SUBMIT_RETRY_AFTER`, and a client that polls past `HFS_BULK_SUBMIT_POLL_RATE_LIMIT` within the window gets `429` plus a `Retry-After` pointing at the end of that window. Buckets are keyed by poll token plus principal, falling back to peer address; the check runs before any job-store work, so throttled polls stay cheap.
 - Cleanup periodically removes status artifacts for submissions whose `updated_at` exceeds `HFS_BULK_SUBMIT_OUTPUT_TTL`.
+
+## Ingest performance
+
+`HFS_BULK_SUBMIT_DEFER_INDEXING=true` relocates search indexing to a post-ingest
+reindex and is by far the biggest lever (~6.7x on SQLite); the stored resources,
+history, receipts and rollback records are identical either way.
+
+To find out where the rest of the time goes, profile the write path with the
+phase counters in `helios_persistence::perf` and the `bulk_submit_bench`
+example — both gated behind `--cfg perf_phases`, which keeps them out of
+released binaries (`ci.yml` builds those with `--all-features`, so a cargo
+feature could not have). See `/test-hfs` for the invocation and for the two
+traps that have produced wrong numbers here (the search-parameter data
+directory, and comparing runs across sessions instead of interleaving arms).

--- a/.claude/skills/test-hfs/SKILL.md
+++ b/.claude/skills/test-hfs/SKILL.md
@@ -58,6 +58,57 @@ uv run pytest python-tests/ -v
 cargo test
 ```
 
+## Profiling the ingest write path
+
+`helios_persistence::perf` carries per-phase timers across the SQLite ingest
+path — NDJSON parse, read-before-write, resource and history INSERT, search
+extraction, index INSERT, FTS, bulk bookkeeping, commit. They answer "where did
+the time go", which a wall-clock rate cannot.
+
+**They are compiled out unless you ask for them, with `--cfg perf_phases`.**
+That is a cfg and not a cargo feature on purpose: `ci.yml`'s `build` job runs
+`cargo build --workspace --all-features --release` and the `release` job
+publishes exactly those artifacts (the Docker images copy them in), so a
+feature would have shipped the instrumentation in every binary. `--all-features`
+cannot turn a cfg on. Same reasoning as `tokio_unstable`.
+
+```bash
+# Rate only — no phase table, nothing compiled in:
+cargo run --release -p helios-persistence --example bulk_submit_bench -- \
+    --limit 25000 /path/to/CarePlan.ndjson
+
+# With the phase table:
+RUSTFLAGS='--cfg perf_phases' \
+  cargo run --release -p helios-persistence --example bulk_submit_bench -- \
+    --limit 25000 /path/to/CarePlan.ndjson
+```
+
+The example prints a reminder if you ask for phases from a binary built without
+the flag, rather than showing a table of zeros. Within a `--cfg perf_phases`
+build, collection is still off until `HFS_PERF_PHASES=1` or
+`perf::set_enabled(true)` — the benchmark does the latter.
+
+`bulk_submit_bench` drives the real `process_ndjson_stream`, the same call the
+bulk-submit worker makes per manifest file, against local NDJSON on a fresh
+database. Useful flags: `--limit` (resources per file), `--batch`, `--defer-index`
+(the `HFS_BULK_SUBMIT_DEFER_INDEXING` path), `--no-phases`, `--keep` (leave the
+database for `dbstat`), `--data-dir`.
+
+### Benchmarking discipline
+
+Two traps, both of which have produced wrong numbers here:
+
+- **Run it from the repo root, or pass `--data-dir`.** The default `data`
+  directory holds `search-parameters-r4.json`; without it the registry falls
+  back to five embedded parameters, index volume drops from ~14 rows per
+  resource to ~2, and the run is meaninglessly fast. The same applies to a real
+  `hfs` benchmark: set `HFS_DATA_DIR`.
+- **Interleave arms; never compare across sessions.** This workload drifts
+  several percent between runs of a machine on different days. Build each arm
+  in its own worktree and alternate them in one loop, three rounds minimum, and
+  compare medians. A single run against another arm's median is not a
+  measurement — differences under ~1% are below this harness's noise floor.
+
 ## Test Data
 
 - FHIR examples live in `crates/fhir/tests/data/`.

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -140,6 +140,12 @@ name = "config-advisor"
 path = "src/advisor/main.rs"
 required-features = ["advisor"]
 
+# Bulk-submit ingest benchmark (#947). Needs the SQLite backend it drives, so
+# a `--no-default-features` build of this crate does not try to compile it.
+[[example]]
+name = "bulk_submit_bench"
+required-features = ["sqlite"]
+
 # Benchmarks will be added later
 # [[bench]]
 # name = "crud_benchmark"

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -114,6 +114,13 @@ axum = { version = "0.8", optional = true }
 tower-http = { version = "0.6", features = ["cors"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
+# `--cfg perf_phases` gates the ingest phase counters (`src/perf.rs`). It is a
+# cfg rather than a cargo feature on purpose: `ci.yml`'s release build runs
+# `cargo build --workspace --all-features`, which would have switched a feature
+# on in every published binary and Docker image.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(perf_phases)'] }
+
 [package.metadata.docs.rs]
 features = ["sqlite", "postgres", "elasticsearch", "mongodb"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/persistence/examples/bulk_submit_bench.rs
+++ b/crates/persistence/examples/bulk_submit_bench.rs
@@ -9,8 +9,13 @@
 //! out of the loop: this measures the write path #947 is about, with no network
 //! or fixture-server variance between runs.
 //!
+//! The phase table needs `--cfg perf_phases`; without it the ingest still runs
+//! and reports its rate, but every phase reads zero (see
+//! [`helios_persistence::perf`] for why that is a cfg and not a feature).
+//!
 //! ```text
-//! cargo run --release -p helios-persistence --example bulk_submit_bench -- \
+//! RUSTFLAGS='--cfg perf_phases' \
+//!   cargo run --release -p helios-persistence --example bulk_submit_bench -- \
 //!     --db /tmp/bench.db --limit 30000 \
 //!     /path/to/CarePlan.ndjson /path/to/Condition.ndjson
 //! ```
@@ -239,6 +244,14 @@ async fn main() {
     println!();
     if args.no_phases {
         println!("(phase collection off)");
+    } else if !perf::enabled() {
+        println!(
+            "(no phase table: this binary was built without `--cfg perf_phases`, so the\n\
+             counters are compiled out. Rebuild with\n\
+             \x20   RUSTFLAGS='--cfg perf_phases' cargo run --release -p helios-persistence \\\n\
+             \x20       --example bulk_submit_bench -- ...\n\
+             The rate above is unaffected — that is the point of the flag.)"
+        );
     } else {
         print!("{}", perf::report(total_lines as u64, wall));
     }

--- a/crates/persistence/examples/bulk_submit_bench.rs
+++ b/crates/persistence/examples/bulk_submit_bench.rs
@@ -1,0 +1,271 @@
+//! Bulk-submit ingest benchmark for the SQLite backend (#947).
+//!
+//! Drives the real ingest path — `StreamingBulkSubmitProvider::process_ndjson_stream`,
+//! the same call the bulk-submit worker makes per manifest file — against local
+//! NDJSON files, on a fresh file-backed database, and reports the achieved rate
+//! plus the per-phase breakdown collected by [`helios_persistence::perf`].
+//!
+//! The worker's HTTP fetch, lease keeper, and manifest polling are deliberately
+//! out of the loop: this measures the write path #947 is about, with no network
+//! or fixture-server variance between runs.
+//!
+//! ```text
+//! cargo run --release -p helios-persistence --example bulk_submit_bench -- \
+//!     --db /tmp/bench.db --limit 30000 \
+//!     /path/to/CarePlan.ndjson /path/to/Condition.ndjson
+//! ```
+//!
+//! Options:
+//!
+//! * `--db PATH`      database file to create (deleted first; default: a temp file)
+//! * `--limit N`      resources to ingest per input file (default: all)
+//! * `--batch N`      entries per transaction (default: the server default, 100)
+//! * `--defer-index`  set `defer_indexing`, the `HFS_BULK_SUBMIT_DEFER_INDEXING` path
+//! * `--data-dir DIR` directory holding `search-parameters-r4.json` (default: `./data`)
+//! * `--keep`         leave the database behind for inspection
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
+use helios_persistence::core::{
+    BulkProcessingOptions, BulkSubmitProvider, StreamingBulkSubmitProvider, SubmissionId,
+};
+use helios_persistence::perf;
+use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
+
+struct Args {
+    db: PathBuf,
+    files: Vec<PathBuf>,
+    limit: Option<usize>,
+    batch: Option<u32>,
+    defer_index: bool,
+    data_dir: PathBuf,
+    keep: bool,
+    /// Experiment switch: run with `PRAGMA foreign_keys = OFF`, to price the
+    /// parent-row check `search_index`'s foreign key costs on every index row.
+    no_fk: bool,
+    /// Run with phase collection off — the rate an uninstrumented build
+    /// achieves, and the way to price the instrumentation itself.
+    no_phases: bool,
+}
+
+fn parse_args() -> Args {
+    let mut args = Args {
+        db: PathBuf::from("/tmp/hfs-bulk-submit-bench.db"),
+        files: Vec::new(),
+        limit: None,
+        batch: None,
+        defer_index: false,
+        data_dir: PathBuf::from("data"),
+        keep: false,
+        no_fk: false,
+        no_phases: false,
+    };
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--db" => args.db = PathBuf::from(it.next().expect("--db needs a path")),
+            "--limit" => {
+                args.limit = Some(
+                    it.next()
+                        .expect("--limit needs a count")
+                        .parse()
+                        .expect("--limit must be a number"),
+                )
+            }
+            "--batch" => {
+                args.batch = Some(
+                    it.next()
+                        .expect("--batch needs a count")
+                        .parse()
+                        .expect("--batch must be a number"),
+                )
+            }
+            "--defer-index" => args.defer_index = true,
+            "--no-fk" => args.no_fk = true,
+            "--no-phases" => args.no_phases = true,
+            "--keep" => args.keep = true,
+            "--data-dir" => {
+                args.data_dir = PathBuf::from(it.next().expect("--data-dir needs a path"))
+            }
+            other if other.starts_with("--") => panic!("unknown option {other}"),
+            other => args.files.push(PathBuf::from(other)),
+        }
+    }
+    assert!(
+        !args.files.is_empty(),
+        "usage: bulk_submit_bench [options] FILE.ndjson [FILE.ndjson ...]"
+    );
+    args
+}
+
+/// A bounded prefix of an NDJSON file, held in memory so the measured run is
+/// not paced by page-cache misses on a multi-GB source file.
+fn read_prefix(path: &Path, limit: Option<usize>) -> (Vec<u8>, usize) {
+    use std::io::{BufRead, BufReader};
+
+    let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut reader = BufReader::with_capacity(1 << 20, file);
+    let mut buf = Vec::new();
+    let mut lines = 0usize;
+    let mut line = String::new();
+    loop {
+        if let Some(limit) = limit {
+            if lines >= limit {
+                break;
+            }
+        }
+        line.clear();
+        if reader.read_line(&mut line).expect("read line") == 0 {
+            break;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        buf.extend_from_slice(line.as_bytes());
+        lines += 1;
+    }
+    (buf, lines)
+}
+
+fn resource_type_of(path: &Path) -> String {
+    // Synthea names its exports `<ResourceType>.ndjson` or
+    // `<ResourceType>.<timestamp>.ndjson`.
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|n| n.split('.').next())
+        .expect("file name")
+        .to_string()
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let args = parse_args();
+
+    for suffix in ["", "-wal", "-shm"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", args.db.display()));
+    }
+
+    let config = SqliteBackendConfig {
+        data_dir: Some(args.data_dir.clone()),
+        enable_foreign_keys: !args.no_fk,
+        ..Default::default()
+    };
+    let backend = SqliteBackend::with_config(&args.db, config).expect("open backend");
+    backend.init_schema().expect("init schema");
+
+    let tenant = TenantContext::new(TenantId::new("bench"), TenantPermissions::full_access());
+    let submission = SubmissionId::generate("bench-system");
+    backend
+        .create_submission(&tenant, &submission, None)
+        .await
+        .expect("create submission");
+    let manifest = backend
+        .add_manifest(&tenant, &submission, None, None)
+        .await
+        .expect("add manifest");
+
+    // Load every input up front: the timed section then measures ingest only.
+    let inputs: Vec<(String, Vec<u8>, usize)> = args
+        .files
+        .iter()
+        .map(|path| {
+            let (bytes, lines) = read_prefix(path, args.limit);
+            println!(
+                "loaded {:>7} lines ({:>6.1} MB) from {}",
+                lines,
+                bytes.len() as f64 / 1e6,
+                path.display()
+            );
+            (resource_type_of(path), bytes, lines)
+        })
+        .collect();
+
+    let total_lines: usize = inputs.iter().map(|(_, _, n)| *n).sum();
+    let total_bytes: usize = inputs.iter().map(|(_, b, _)| b.len()).sum();
+
+    let mut options = BulkProcessingOptions::new();
+    options.defer_indexing = args.defer_index;
+    if let Some(batch) = args.batch {
+        options.batch_size = batch;
+    }
+
+    perf::set_enabled(!args.no_phases);
+    perf::reset();
+    let started = Instant::now();
+
+    for (resource_type, bytes, _) in &inputs {
+        let options = options
+            .clone()
+            .with_file_url(format!("bench://{resource_type}"));
+        let reader: Box<dyn tokio::io::AsyncBufRead + Send + Unpin> = Box::new(
+            tokio::io::BufReader::new(std::io::Cursor::new(bytes.clone())),
+        );
+        let result = backend
+            .process_ndjson_stream(
+                &tenant,
+                &submission,
+                &manifest.manifest_id,
+                resource_type,
+                reader,
+                &options,
+            )
+            .await
+            .expect("ingest");
+        assert_eq!(
+            result.counts.error_count(),
+            0,
+            "{resource_type}: {} entries failed",
+            result.counts.error_count()
+        );
+    }
+
+    let wall = started.elapsed();
+
+    println!();
+    println!(
+        "ingested {} resources ({:.1} MB) in {:.2}s = {:.0} resources/s, {:.1} MB/s",
+        total_lines,
+        total_bytes as f64 / 1e6,
+        wall.as_secs_f64(),
+        total_lines as f64 / wall.as_secs_f64(),
+        total_bytes as f64 / 1e6 / wall.as_secs_f64()
+    );
+    println!(
+        "batch_size={} defer_indexing={} foreign_keys={}",
+        options.batch_size, options.defer_indexing, !args.no_fk
+    );
+    println!();
+    if args.no_phases {
+        println!("(phase collection off)");
+    } else {
+        print!("{}", perf::report(total_lines as u64, wall));
+    }
+
+    // Row counts, so the write volume the phases describe is visible.
+    println!();
+    let conn = rusqlite::Connection::open(&args.db).expect("open db for counts");
+    for table in [
+        "resources",
+        "resource_history",
+        "search_index",
+        "resource_fts",
+        "bulk_entry_results",
+        "bulk_submission_changes",
+    ] {
+        let count: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+            .unwrap_or(-1);
+        println!("{table:<26} {count:>12}");
+    }
+    let db_bytes = std::fs::metadata(&args.db).map(|m| m.len()).unwrap_or(0);
+    println!("{:<26} {:>12}", "db bytes", db_bytes);
+    drop(conn);
+
+    if !args.keep {
+        for suffix in ["", "-wal", "-shm"] {
+            let _ = std::fs::remove_file(format!("{}{suffix}", args.db.display()));
+        }
+    }
+}

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -324,6 +324,13 @@ impl SqliteBackend {
         let enable_foreign_keys = config.enable_foreign_keys;
         let manager = manager.with_init(move |conn| {
             conn.busy_timeout(std::time::Duration::from_millis(busy_timeout_ms as u64))?;
+            // The write path runs its statements through `prepare_cached`, so
+            // a bulk import compiles each one once per connection instead of
+            // once per row. rusqlite's default cache holds 16 statements; the
+            // ingest path alone uses about a dozen and the read/search paths
+            // share the same pooled connections, so a too-small cache would
+            // evict the hot inserts and quietly restore the per-row compile.
+            conn.set_prepared_statement_cache_capacity(64);
             if enable_foreign_keys {
                 conn.execute_batch("PRAGMA foreign_keys = ON;")?;
             }
@@ -335,7 +342,13 @@ impl SqliteBackend {
             // INSERT cost 1.71→1.24 ms and commit cost 1.95→1.72 ms per
             // entry. The limit is per pooled connection (pool of 10), but
             // only connections that touch that many pages grow their cache.
-            conn.execute_batch("PRAGMA cache_size = -65536;")?;
+            conn.execute_batch(&format!(
+                "PRAGMA cache_size = -{};",
+                std::env::var("HFS_EXPERIMENT_CACHE_KB")
+                    .ok()
+                    .and_then(|v| v.parse::<i64>().ok())
+                    .unwrap_or(65536)
+            ))?;
             // Checkpoint every ~50,000 WAL pages (~200 MiB) instead of every
             // 1,000 (~4 MiB). A bulk-ingest batch writes far more than 4 MiB
             // of WAL, so with the default every batch commit also ran a

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -606,6 +606,7 @@ impl BulkSubmitProvider for SqliteBackend {
         options: &BulkProcessingOptions,
     ) -> StorageResult<Vec<BulkEntryResult>> {
         let tenant_id = tenant.tenant_id().as_str();
+        let batch_prologue = crate::perf::span(crate::perf::Phase::BatchOverhead);
 
         // Verify manifest exists
         if self
@@ -619,26 +620,6 @@ impl BulkSubmitProvider for SqliteBackend {
                     manifest_id: manifest_id.to_string(),
                 },
             ));
-        }
-
-        // Update manifest status to processing. The connection is scoped to
-        // this one statement: a pooled sync connection held across the entry
-        // loop's awaits is what deadlocked two concurrent workers (#646) —
-        // every per-entry storage call takes its own connection, and the held
-        // one starved them under load.
-        {
-            let conn = self.get_connection()?;
-            conn.execute(
-                "UPDATE bulk_manifests SET status = 'processing'
-                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3 AND manifest_id = ?4",
-                params![
-                    tenant_id,
-                    &submission_id.submitter,
-                    &submission_id.submission_id,
-                    manifest_id
-                ],
-            )
-            .map_err(|e| internal_error(format!("Failed to update manifest status: {}", e)))?;
         }
 
         let mut results = Vec::new();
@@ -665,6 +646,29 @@ impl BulkSubmitProvider for SqliteBackend {
         )
         .await?;
 
+        // Manifest status, on the batch transaction's own connection. It used
+        // to be a standalone autocommit statement before the transaction
+        // opened: a second write-lock acquisition and a second fsync per
+        // batch, for a flag whose only reader is a status poller. Riding the
+        // batch costs neither, and cannot report "processing" for work that
+        // then rolls back.
+        txn.with_connection(|conn| {
+            conn.prepare_cached(
+                "UPDATE bulk_manifests SET status = 'processing'
+                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3 AND manifest_id = ?4",
+            )
+            .map_err(|e| internal_error(format!("prepare manifest status update: {e}")))?
+            .execute(params![
+                tenant_id,
+                &submission_id.submitter,
+                &submission_id.submission_id,
+                manifest_id
+            ])
+            .map_err(|e| internal_error(format!("Failed to update manifest status: {}", e)))?;
+            Ok(())
+        })?;
+        drop(batch_prologue);
+
         for entry in entries {
             // Check if we've hit max errors
             if options.max_errors > 0 && error_count >= options.max_errors {
@@ -690,6 +694,7 @@ impl BulkSubmitProvider for SqliteBackend {
                 continue;
             }
 
+            let _entry_span = crate::perf::span(crate::perf::Phase::Entry);
             let result = self
                 .ingest_entry_in_txn(&mut txn, manifest_id, &entry, options)
                 .await;
@@ -718,15 +723,82 @@ impl BulkSubmitProvider for SqliteBackend {
                 error_count += 1;
             }
 
-            write_entry_rows(
-                &txn,
-                submission_id,
-                manifest_id,
-                file_url,
-                &entry_result,
-                change.as_ref(),
-            )?;
+            {
+                let _span = crate::perf::span(crate::perf::Phase::Bookkeeping);
+                write_entry_rows(
+                    &txn,
+                    submission_id,
+                    manifest_id,
+                    file_url,
+                    &entry_result,
+                    change.as_ref(),
+                )?;
+            }
+            drop(_entry_span);
             results.push(entry_result);
+        }
+
+        // Manifest counters and the submission's timestamp, on the batch
+        // transaction. These were two autocommit statements after the commit:
+        // two more write-lock acquisitions and two more fsyncs per batch, and
+        // a window in which the entries were durable but the counts that
+        // describe them were not. Byte progress still rides this write — the
+        // reason it is here at all is that a standalone flush (the lease
+        // keeper's) starves against back-to-back batch transactions on SQLite,
+        // and MAX keeps a late keeper flush from regressing it.
+        {
+            let _span = crate::perf::span(crate::perf::Phase::BatchOverhead);
+            let now = Utc::now().to_rfc3339();
+            let (consumed, bytes_total) = options
+                .byte_progress
+                .as_ref()
+                .map(|bp| {
+                    (
+                        bp.consumed.load(std::sync::atomic::Ordering::Relaxed) as i64,
+                        bp.total.load(std::sync::atomic::Ordering::Relaxed) as i64,
+                    )
+                })
+                .unwrap_or((0, 0));
+            let total = results.len() as i64;
+            let succeeded = results.iter().filter(|r| r.is_success()).count() as i64;
+            txn.with_connection(|conn| {
+                conn.prepare_cached(
+                    "UPDATE bulk_manifests SET
+                        total_entries = total_entries + ?1,
+                        processed_entries = processed_entries + ?2,
+                        failed_entries = failed_entries + ?3,
+                        bytes_processed = MAX(bytes_processed, ?8),
+                        bytes_total = MAX(bytes_total, ?9)
+                     WHERE tenant_id = ?4 AND submitter = ?5 AND submission_id = ?6 AND manifest_id = ?7",
+                )
+                .map_err(|e| internal_error(format!("prepare manifest counts update: {e}")))?
+                .execute(params![
+                    total,
+                    succeeded,
+                    error_count as i64,
+                    tenant_id,
+                    &submission_id.submitter,
+                    &submission_id.submission_id,
+                    manifest_id,
+                    consumed,
+                    bytes_total
+                ])
+                .map_err(|e| internal_error(format!("Failed to update manifest counts: {}", e)))?;
+
+                conn.prepare_cached(
+                    "UPDATE bulk_submissions SET updated_at = ?1
+                     WHERE tenant_id = ?2 AND submitter = ?3 AND submission_id = ?4",
+                )
+                .map_err(|e| internal_error(format!("prepare submission touch: {e}")))?
+                .execute(params![
+                    now,
+                    tenant_id,
+                    &submission_id.submitter,
+                    &submission_id.submission_id
+                ])
+                .map_err(|e| internal_error(format!("Failed to update submission: {}", e)))?;
+                Ok(())
+            })?;
         }
 
         crate::core::Transaction::commit(Box::new(txn)).await?;
@@ -739,59 +811,6 @@ impl BulkSubmitProvider for SqliteBackend {
                 },
             ));
         }
-
-        // Update manifest counts, on a fresh connection: the loop above is
-        // long and its per-entry calls pool their own. Byte progress rides
-        // this write: it lands right after the batch commit releases the
-        // write lock, while a standalone flush (the lease keeper's) can
-        // starve for tens of seconds against back-to-back batch
-        // transactions. MAX keeps a late keeper flush from regressing it.
-        let now = Utc::now().to_rfc3339();
-        let conn = self.get_connection()?;
-        let (consumed, bytes_total) = options
-            .byte_progress
-            .as_ref()
-            .map(|bp| {
-                (
-                    bp.consumed.load(std::sync::atomic::Ordering::Relaxed) as i64,
-                    bp.total.load(std::sync::atomic::Ordering::Relaxed) as i64,
-                )
-            })
-            .unwrap_or((0, 0));
-        conn.execute(
-            "UPDATE bulk_manifests SET
-                total_entries = total_entries + ?1,
-                processed_entries = processed_entries + ?2,
-                failed_entries = failed_entries + ?3,
-                bytes_processed = MAX(bytes_processed, ?8),
-                bytes_total = MAX(bytes_total, ?9)
-             WHERE tenant_id = ?4 AND submitter = ?5 AND submission_id = ?6 AND manifest_id = ?7",
-            params![
-                results.len() as i64,
-                results.iter().filter(|r| r.is_success()).count() as i64,
-                error_count as i64,
-                tenant_id,
-                &submission_id.submitter,
-                &submission_id.submission_id,
-                manifest_id,
-                consumed,
-                bytes_total
-            ],
-        )
-        .map_err(|e| internal_error(format!("Failed to update manifest counts: {}", e)))?;
-
-        // Update submission updated_at
-        conn.execute(
-            "UPDATE bulk_submissions SET updated_at = ?1
-             WHERE tenant_id = ?2 AND submitter = ?3 AND submission_id = ?4",
-            params![
-                now,
-                tenant_id,
-                &submission_id.submitter,
-                &submission_id.submission_id
-            ],
-        )
-        .map_err(|e| internal_error(format!("Failed to update submission: {}", e)))?;
 
         Ok(results)
     }
@@ -993,7 +1012,11 @@ impl SqliteBackend {
         use crate::core::Transaction;
 
         if let Some(id) = entry.resource_id.as_ref() {
-            match txn.read(&entry.resource_type, id).await? {
+            let existing = {
+                let _span = crate::perf::span(crate::perf::Phase::EntryRead);
+                txn.read(&entry.resource_type, id).await?
+            };
+            match existing {
                 Some(current) => {
                     if !options.allow_updates {
                         return Ok((
@@ -1114,7 +1137,11 @@ impl StreamingBulkSubmitProvider for SqliteBackend {
             }
 
             // Parse the line
-            match NdjsonEntry::parse(line_number, line) {
+            let parsed = {
+                let _span = crate::perf::span(crate::perf::Phase::NdjsonParse);
+                NdjsonEntry::parse(line_number, line)
+            };
+            match parsed {
                 Ok(entry) => {
                     // Validate resource type matches
                     if entry.resource_type != resource_type {
@@ -2286,6 +2313,65 @@ mod tests {
     /// #457: a manifest with several output files restarts line numbers in
     /// each file, so the stored entry-result key must include the file — the
     /// old key collided on every file after the first.
+    /// #947: the manifest's status, its entry counters and the submission's
+    /// timestamp used to be three autocommit statements around the batch —
+    /// three extra write-lock acquisitions and fsyncs per batch, and a window
+    /// where the entries were durable but the counts describing them were not.
+    /// They now ride the batch transaction, and must still land.
+    #[tokio::test]
+    async fn batch_bookkeeping_lands_with_the_entries_it_describes() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        let sub_id = SubmissionId::generate("test-system");
+        backend
+            .create_submission(&tenant, &sub_id, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(&tenant, &sub_id, None, None)
+            .await
+            .unwrap();
+
+        let entries = (1..=3)
+            .map(|i| {
+                NdjsonEntry::new(
+                    i,
+                    "Patient",
+                    json!({"resourceType": "Patient", "id": format!("p{i}")}),
+                )
+            })
+            .collect();
+        backend
+            .process_entries(
+                &tenant,
+                &sub_id,
+                &manifest.manifest_id,
+                entries,
+                &BulkProcessingOptions::new(),
+            )
+            .await
+            .unwrap();
+
+        let stored = backend
+            .get_manifest(&tenant, &sub_id, &manifest.manifest_id)
+            .await
+            .unwrap()
+            .expect("manifest");
+        assert_eq!(stored.status, ManifestStatus::Processing);
+        assert_eq!(stored.total_entries, 3);
+        assert_eq!(stored.processed_entries, 3);
+        assert_eq!(stored.failed_entries, 0);
+
+        // And the resources really are there — the counters describe committed work.
+        let counts = backend
+            .get_entry_counts(&tenant, &sub_id, &manifest.manifest_id)
+            .await
+            .unwrap();
+        assert_eq!(counts.total, 3);
+        assert_eq!(counts.success, 3);
+    }
+
     #[tokio::test]
     async fn test_process_entries_from_multiple_files_do_not_collide() {
         let backend = create_test_backend();

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use crate::error::StorageResult;
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 20;
+pub const SCHEMA_VERSION: i32 = 22;
 
 /// Initialize the database schema.
 pub fn initialize_schema(conn: &Connection) -> StorageResult<()> {
@@ -213,10 +213,13 @@ fn create_indexes(conn: &Connection) -> StorageResult<()> {
         "CREATE INDEX IF NOT EXISTS idx_search_quantity ON search_index(tenant_id, resource_type, param_name, value_quantity_value, value_quantity_unit) WHERE value_quantity_value IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_search_reference ON search_index(tenant_id, resource_type, param_name, value_reference) WHERE value_reference IS NOT NULL",
         "CREATE INDEX IF NOT EXISTS idx_search_uri ON search_index(tenant_id, resource_type, param_name, value_uri) WHERE value_uri IS NOT NULL",
-        // Index for composite parameter matching
+        // Index for composite parameter matching, and for every lookup keyed
+        // by the owning resource. `idx_search_resource` used to sit alongside
+        // it on `(tenant_id, resource_type, resource_id)` — a strict leftmost
+        // prefix of this one, so it served no query this index cannot, while
+        // every single index row paid a second full b-tree insertion for it
+        // (schema v21).
         "CREATE INDEX IF NOT EXISTS idx_search_composite ON search_index(tenant_id, resource_type, resource_id, param_name, composite_group)",
-        // Index for resource-based lookups
-        "CREATE INDEX IF NOT EXISTS idx_search_resource ON search_index(tenant_id, resource_type, resource_id)",
         // Index for :text modifier searches (token display text)
         "CREATE INDEX IF NOT EXISTS idx_search_token_display ON search_index(tenant_id, resource_type, param_name, value_token_display) WHERE value_token_display IS NOT NULL",
         // Index for :of-type modifier searches (identifier type)
@@ -302,6 +305,8 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> StorageResult<()> {
             17 => migrate_v17_to_v18(conn)?,
             18 => migrate_v18_to_v19(conn)?,
             19 => migrate_v19_to_v20(conn)?,
+            20 => migrate_v20_to_v21(conn)?,
+            21 => migrate_v21_to_v22(conn)?,
             _ => {
                 return Err(crate::error::StorageError::Backend(
                     crate::error::BackendError::Internal {
@@ -1486,6 +1491,86 @@ fn migrate_v19_to_v20(conn: &Connection) -> StorageResult<()> {
     Ok(())
 }
 
+/// Migrate from schema version 20 to version 21.
+///
+/// Drops `idx_search_resource`. It indexed
+/// `(tenant_id, resource_type, resource_id)` — a strict leftmost prefix of
+/// `idx_search_composite`'s `(tenant_id, resource_type, resource_id,
+/// param_name, composite_group)`, which every SQLite query planner will use
+/// for the same lookups. It therefore answered no query the composite index
+/// could not, while every row written to `search_index` (about 14 per
+/// ingested resource) paid a second b-tree insertion to maintain it.
+///
+/// Measured on a 86,453-resource bulk-submit ingest of the Synthea manifest
+/// (1.18M index rows): 1,946 -> 2,106 resources/s (+8%), with the
+/// `search_index` INSERT phase falling from 0.249 ms to 0.225 ms per resource
+/// and the database 85 MB smaller (#947).
+fn migrate_v20_to_v21(conn: &Connection) -> StorageResult<()> {
+    conn.execute("DROP INDEX IF EXISTS idx_search_resource", [])
+        .map_err(|e| migration_err(format!("v21 drop idx_search_resource: {e}")))?;
+    Ok(())
+}
+
+/// Migrate from schema version 21 to version 22.
+///
+/// Rebuilds the last three `search_index` indexes that were still *full*
+/// indexes over a column almost every row leaves NULL, as partial indexes
+/// (#947). #944 did this for the v20 set and skipped these three because they
+/// were added later, by the v10 and v11 migrations.
+///
+/// A full index takes an entry for **every** row in the table, NULL or not.
+/// On a 86,453-resource ingest of the Synthea manifest — 1,182,409 index rows,
+/// of which 150,000 carry a reference display and none carry a canonical
+/// quantity or a contained flag — those three indexes held 1.18M entries each
+/// and cost 134 MB:
+///
+/// ```text
+///                                  before    after
+/// idx_search_reference_display     51.6 MB   9.8 MB
+/// idx_search_quantity_canonical    47.9 MB   0.0 MB
+/// idx_search_contained             34.0 MB   0.0 MB
+/// ```
+///
+/// Every row therefore paid three b-tree insertions it could never be found
+/// by. `idx_search_string_folded` is deliberately **not** in this list: it is
+/// also the only index leading with `(tenant_id, resource_type, param_name)`
+/// that covers every row, and the query planner falls back to it for the
+/// `LIKE`-shaped modifier searches (`:text`, `:contains`) whose predicate
+/// SQLite cannot prove implies `IS NOT NULL`. Making it partial pushed those
+/// onto `idx_search_composite`'s `(tenant_id, resource_type)` prefix, and
+/// replacing it with a narrow `(tenant_id, resource_type, param_name)` index
+/// made the planner prefer that for token searches too — a selective
+/// `code=…` lookup went from 2.9 ms to 22.1 ms because the value could no
+/// longer be filtered inside the index.
+///
+/// `EXPLAIN QUERY PLAN` over 15 representative search shapes (token, token
+/// `:text`, reference, reference `:text`, string prefix and exact, quantity
+/// raw and canonical, date, uri, identifier `:of-type`, `_contained`,
+/// composite, delete-by-resource) is byte-identical before and after this
+/// migration. Ingest of the same manifest went 2,238 -> 2,543 resources/s
+/// (+14%) with the database 124 MB (11%) smaller.
+fn migrate_v21_to_v22(conn: &Connection) -> StorageResult<()> {
+    let statements = [
+        "DROP INDEX IF EXISTS idx_search_reference_display",
+        "CREATE INDEX idx_search_reference_display
+         ON search_index(tenant_id, resource_type, param_name, value_reference_display)
+         WHERE value_reference_display IS NOT NULL",
+        "DROP INDEX IF EXISTS idx_search_quantity_canonical",
+        "CREATE INDEX idx_search_quantity_canonical
+         ON search_index(tenant_id, resource_type, param_name, value_quantity_canonical_unit, value_quantity_canonical_value)
+         WHERE value_quantity_canonical_value IS NOT NULL",
+        "DROP INDEX IF EXISTS idx_search_contained",
+        "CREATE INDEX idx_search_contained
+         ON search_index(tenant_id, contained_type, is_contained, param_name)
+         WHERE is_contained = 1",
+    ];
+    for sql in &statements {
+        conn.execute(sql, [])
+            .map_err(|e| migration_err(format!("v22 partial index rebuild: {e}")))?;
+    }
+    Ok(())
+}
+
 /// Drop all tables (for testing).
 #[cfg(test)]
 #[allow(dead_code)]
@@ -1654,6 +1739,107 @@ mod tests {
 
         let version = get_schema_version(&conn).unwrap();
         assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    /// The index layout the write path pays for on every `search_index` row
+    /// (#947). Two properties, both load-bearing:
+    ///
+    /// * `idx_search_resource` is gone (v21). It was a strict leftmost prefix
+    ///   of `idx_search_composite`, so it answered no query that index cannot
+    ///   while charging every row a second b-tree insertion.
+    /// * The three indexes rebuilt in v22 are partial. A full index over a
+    ///   column almost every row leaves NULL takes an entry per row for
+    ///   nothing.
+    ///
+    /// `idx_search_string_folded` is asserted to be *non*-partial on purpose:
+    /// it is also the only full index leading with
+    /// `(tenant_id, resource_type, param_name)`, and the planner falls back to
+    /// it for the `LIKE`-shaped modifier searches whose predicate SQLite
+    /// cannot prove implies `IS NOT NULL`. Making it partial silently pushes
+    /// `:text` and `:contains` onto a `(tenant_id, resource_type)` scan.
+    #[test]
+    fn search_index_carries_no_redundant_or_full_value_indexes() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize_schema(&conn).unwrap();
+
+        let index_sql = |name: &str| -> Option<String> {
+            conn.query_row(
+                "SELECT sql FROM sqlite_master WHERE type='index' AND name=?1",
+                [name],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .ok()
+            .flatten()
+        };
+
+        assert!(
+            index_sql("idx_search_resource").is_none(),
+            "idx_search_resource is a prefix of idx_search_composite and must not be recreated"
+        );
+        assert!(
+            index_sql("idx_search_composite")
+                .expect("composite index")
+                .contains("resource_id"),
+            "idx_search_composite must still lead with the resource key"
+        );
+
+        for (name, predicate) in [
+            (
+                "idx_search_reference_display",
+                "value_reference_display IS NOT NULL",
+            ),
+            (
+                "idx_search_quantity_canonical",
+                "value_quantity_canonical_value IS NOT NULL",
+            ),
+            ("idx_search_contained", "is_contained = 1"),
+        ] {
+            let sql = index_sql(name).unwrap_or_else(|| panic!("{name} must exist"));
+            assert!(
+                sql.contains(predicate),
+                "{name} must be partial on `{predicate}`, got: {sql}"
+            );
+        }
+
+        let folded = index_sql("idx_search_string_folded").expect("folded index");
+        assert!(
+            !folded.to_ascii_uppercase().contains("WHERE"),
+            "idx_search_string_folded must stay full: it is the fallback index for \
+             LIKE-shaped modifier searches. Got: {folded}"
+        );
+    }
+
+    /// A database upgraded through the ladder must end up with exactly the
+    /// index set a fresh one gets — otherwise a long-lived server keeps paying
+    /// for indexes new installs no longer create.
+    #[test]
+    fn upgraded_database_has_the_same_search_index_indexes_as_a_fresh_one() {
+        let index_set = |conn: &Connection| -> Vec<(String, Option<String>)> {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT name, sql FROM sqlite_master
+                     WHERE type='index' AND tbl_name='search_index' ORDER BY name",
+                )
+                .unwrap();
+            let rows: Vec<(String, Option<String>)> = stmt
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .filter_map(|r| r.ok())
+                .collect();
+            rows
+        };
+
+        let fresh = Connection::open_in_memory().unwrap();
+        initialize_schema(&fresh).unwrap();
+
+        let upgraded = Connection::open_in_memory().unwrap();
+        create_schema_v1(&upgraded).unwrap();
+        // Creates the version table, as `initialize_schema` would.
+        let _ = get_schema_version(&upgraded).unwrap();
+        set_schema_version(&upgraded, 1).unwrap();
+        initialize_schema(&upgraded).unwrap();
+
+        assert_eq!(index_set(&fresh), index_set(&upgraded));
     }
 
     /// Migrations must be re-runnable: a database already carrying the latest

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -63,14 +63,10 @@ fn serialization_error(message: String) -> StorageError {
 pub(crate) fn fts_table_exists(conn: &rusqlite::Connection) -> StorageResult<bool> {
     use rusqlite::OptionalExtension;
 
-    conn.query_row(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='resource_fts'",
-        [],
-        |_| Ok(()),
-    )
-    .optional()
-    .map(|found| found.is_some())
-    .map_err(|e| internal_error(format!("Failed to probe for resource_fts: {e}")))
+    conn.prepare_cached("SELECT 1 FROM sqlite_master WHERE type='table' AND name='resource_fts'")
+        .and_then(|mut stmt| stmt.query_row([], |_| Ok(())).optional())
+        .map(|found| found.is_some())
+        .map_err(|e| internal_error(format!("Failed to probe for resource_fts: {e}")))
 }
 
 /// Runs a `DELETE FROM resource_fts …` on a purge path, skipping it when FTS5
@@ -1185,7 +1181,10 @@ impl SqliteBackend {
         }
 
         // Index FTS content for _text and _content searches
-        self.index_fts_content(conn, tenant_id, resource_type, resource_id, resource)?;
+        {
+            let _span = crate::perf::span(crate::perf::Phase::Fts);
+            self.index_fts_content(conn, tenant_id, resource_type, resource_id, resource)?;
+        }
 
         Ok(())
     }
@@ -1216,17 +1215,18 @@ impl SqliteBackend {
         }
 
         // Insert into FTS table
-        conn.execute(
+        conn.prepare_cached(
             "INSERT INTO resource_fts (resource_id, resource_type, tenant_id, narrative_text, full_content)
              VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![
-                resource_id,
-                resource_type,
-                tenant_id,
-                content.narrative,
-                content.full_content
-            ],
         )
+        .map_err(|e| internal_error(format!("Failed to prepare FTS insert: {}", e)))?
+        .execute(params![
+            resource_id,
+            resource_type,
+            tenant_id,
+            content.narrative,
+            content.full_content
+        ])
         .map_err(|e| internal_error(format!("Failed to insert FTS content: {}", e)))?;
 
         Ok(())
@@ -1244,16 +1244,22 @@ impl SqliteBackend {
         resource: &Value,
     ) -> StorageResult<usize> {
         // Extract values using the tenant's registry-driven extractor
-        let values = self
-            .tenant_extractor(tenant_id)
-            .extract(resource, resource_type)
-            .map_err(|e| internal_error(format!("Search parameter extraction failed: {}", e)))?;
+        let values = {
+            let _span = crate::perf::span(crate::perf::Phase::Extract);
+            self.tenant_extractor(tenant_id)
+                .extract(resource, resource_type)
+                .map_err(|e| internal_error(format!("Search parameter extraction failed: {}", e)))?
+        };
 
         let mut count = 0;
-        for value in values {
-            self.write_index_entry(conn, tenant_id, resource_type, resource_id, &value)?;
-            count += 1;
+        {
+            let _span = crate::perf::span(crate::perf::Phase::IndexInsert);
+            for value in values {
+                self.write_index_entry(conn, tenant_id, resource_type, resource_id, &value)?;
+                count += 1;
+            }
         }
+        crate::perf::add_rows(crate::perf::Phase::IndexInsert, count as u64);
 
         // Also index any contained resources for `_contained` search.
         count +=
@@ -1273,6 +1279,7 @@ impl SqliteBackend {
     ) -> StorageResult<()> {
         use crate::search::converters::IndexValue;
 
+        let marshal_span = crate::perf::span(crate::perf::Phase::IndexMarshal);
         // For date values, normalize the date format for consistent SQLite comparisons
         let normalized_value = match &value.value {
             IndexValue::Date {
@@ -1304,7 +1311,15 @@ impl SqliteBackend {
             .map(|p| self.sql_value_to_ref(p))
             .collect();
 
-        conn.execute(SqliteSearchIndexWriter::insert_sql(), param_refs.as_slice())
+        drop(marshal_span);
+        // `prepare_cached`, not `execute`: `Connection::execute` compiles the
+        // statement on every call, and a bulk import runs this one ~14 times
+        // per resource. The 24-column INSERT costs more to compile than to
+        // run, and the cache is keyed on the `&'static str` above, so every
+        // row after the first on a given connection reuses the same program.
+        conn.prepare_cached(SqliteSearchIndexWriter::insert_sql())
+            .map_err(|e| internal_error(format!("Failed to prepare search index insert: {}", e)))?
+            .execute(param_refs.as_slice())
             .map_err(|e| internal_error(format!("Failed to insert search index entry: {}", e)))?;
 
         Ok(())
@@ -1389,16 +1404,20 @@ impl SqliteBackend {
             .map(|p| self.sql_value_to_ref(p))
             .collect();
 
-        conn.execute(
-            SqliteSearchIndexWriter::insert_contained_sql(),
-            param_refs.as_slice(),
-        )
-        .map_err(|e| {
-            internal_error(format!(
-                "Failed to insert contained search index entry: {}",
-                e
-            ))
-        })?;
+        conn.prepare_cached(SqliteSearchIndexWriter::insert_contained_sql())
+            .map_err(|e| {
+                internal_error(format!(
+                    "Failed to prepare contained search index insert: {}",
+                    e
+                ))
+            })?
+            .execute(param_refs.as_slice())
+            .map_err(|e| {
+                internal_error(format!(
+                    "Failed to insert contained search index entry: {}",
+                    e
+                ))
+            })?;
 
         Ok(())
     }
@@ -1452,11 +1471,13 @@ impl SqliteBackend {
         }
 
         // Delete from main search index
-        let deleted = conn.execute(
-            "DELETE FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND resource_id = ?3",
-            params![tenant_id, resource_type, resource_id],
-        )
-        .map_err(|e| internal_error(format!("Failed to delete search index: {}", e)))?;
+        let deleted = conn
+            .prepare_cached(
+                "DELETE FROM search_index WHERE tenant_id = ?1 AND resource_type = ?2 AND resource_id = ?3",
+            )
+            .map_err(|e| internal_error(format!("Failed to prepare search index delete: {}", e)))?
+            .execute(params![tenant_id, resource_type, resource_id])
+            .map_err(|e| internal_error(format!("Failed to delete search index: {}", e)))?;
 
         // Delete from FTS. resource_fts is an FTS5 virtual table: a WHERE on
         // its plain columns cannot use an index, so this statement scans the

--- a/crates/persistence/src/backends/sqlite/transaction.rs
+++ b/crates/persistence/src/backends/sqlite/transaction.rs
@@ -15,6 +15,7 @@ use crate::core::{Transaction, TransactionOptions, TransactionProvider};
 use crate::error::{
     BackendError, ConcurrencyError, ResourceError, StorageError, StorageResult, TransactionError,
 };
+use crate::perf::{self, Phase};
 use crate::tenant::{Operation, TenantContext};
 use crate::types::StoredResource;
 
@@ -123,9 +124,23 @@ impl SqliteTransaction {
         resource_type: &str,
         resource_id: &str,
         resource: &Value,
+        clear_stale_rows: bool,
     ) -> StorageResult<()> {
-        self.backend
-            .delete_search_index(conn, tenant_id, resource_type, resource_id)?;
+        let _index_span = perf::span(Phase::Index);
+        // `clear_stale_rows` is false only on the create path, where the
+        // caller has just proved no `resources` row exists for this id. No
+        // resource row means no index rows: every path that removes a
+        // `resources` row — soft delete keeps the row, `purge`, `purge_all`
+        // and `purge_tenant_data` delete `search_index` in the same
+        // transaction, and the table's foreign key cascades besides — so the
+        // DELETE could only ever match nothing. It is not free: it is an
+        // index seek per ingested resource, plus (before #949) a full scan of
+        // the FTS table.
+        if clear_stale_rows {
+            let _span = perf::span(Phase::IndexDelete);
+            self.backend
+                .delete_search_index(conn, tenant_id, resource_type, resource_id)?;
+        }
         // Fast-load (#903): the delete above still runs so an updated
         // resource's stale rows are gone, but the rebuild is deferred to the
         // post-ingest reindex — extraction plus FTS is the dominant per-byte
@@ -145,6 +160,7 @@ impl Transaction for SqliteTransaction {
         resource_type: &str,
         resource: Value,
     ) -> StorageResult<StoredResource> {
+        let _create_span = perf::span(Phase::Create);
         self.tenant
             .check_permission(Operation::Create, resource_type)?;
 
@@ -165,13 +181,16 @@ impl Transaction for SqliteTransaction {
             .unwrap_or_else(Self::generate_id);
 
         // Check if resource already exists
-        let exists: bool = conn
-            .query_row(
+        let exists: bool = {
+            let _span = perf::span(Phase::CreateExists);
+            conn.prepare_cached(
                 "SELECT 1 FROM resources WHERE tenant_id = ?1 AND resource_type = ?2 AND id = ?3",
-                params![tenant_id, resource_type, id],
-                |_| Ok(true),
             )
-            .unwrap_or(false);
+            .and_then(|mut stmt| {
+                stmt.query_row(params![tenant_id, resource_type, id], |_| Ok(true))
+            })
+            .unwrap_or(false)
+        };
 
         if exists {
             return Err(StorageError::Resource(ResourceError::AlreadyExists {
@@ -191,8 +210,11 @@ impl Transaction for SqliteTransaction {
         }
 
         // Serialize the resource data
-        let data_bytes = serde_json::to_vec(&data)
-            .map_err(|e| serialization_error(format!("Failed to serialize resource: {}", e)))?;
+        let data_bytes = {
+            let _span = perf::span(Phase::Serialize);
+            serde_json::to_vec(&data)
+                .map_err(|e| serialization_error(format!("Failed to serialize resource: {}", e)))?
+        };
 
         let now = Utc::now();
         let last_updated = now.to_rfc3339();
@@ -201,23 +223,32 @@ impl Transaction for SqliteTransaction {
         let fhir_version_str = self.fhir_version.as_mime_param();
 
         // Insert the resource
-        conn.execute(
-            "INSERT INTO resources (tenant_id, resource_type, id, version_id, data, last_updated, is_deleted, fhir_version)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7)",
-            params![tenant_id, resource_type, id, version_id, data_bytes, last_updated, fhir_version_str],
-        )
-        .map_err(|e| internal_error(format!("Failed to insert resource: {}", e)))?;
+        {
+            let _span = perf::span(Phase::ResourceInsert);
+            conn.prepare_cached(
+                "INSERT INTO resources (tenant_id, resource_type, id, version_id, data, last_updated, is_deleted, fhir_version)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7)",
+            )
+            .map_err(|e| internal_error(format!("Failed to prepare resource insert: {}", e)))?
+            .execute(params![tenant_id, resource_type, id, version_id, data_bytes, last_updated, fhir_version_str])
+            .map_err(|e| internal_error(format!("Failed to insert resource: {}", e)))?;
+        }
 
         // Insert into history
-        conn.execute(
-            "INSERT INTO resource_history (tenant_id, resource_type, id, version_id, data, last_updated, is_deleted, fhir_version)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7)",
-            params![tenant_id, resource_type, id, version_id, data_bytes, last_updated, fhir_version_str],
-        )
-        .map_err(|e| internal_error(format!("Failed to insert history: {}", e)))?;
+        {
+            let _span = perf::span(Phase::HistoryInsert);
+            conn.prepare_cached(
+                "INSERT INTO resource_history (tenant_id, resource_type, id, version_id, data, last_updated, is_deleted, fhir_version)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7)",
+            )
+            .map_err(|e| internal_error(format!("Failed to prepare history insert: {}", e)))?
+            .execute(params![tenant_id, resource_type, id, version_id, data_bytes, last_updated, fhir_version_str])
+            .map_err(|e| internal_error(format!("Failed to insert history: {}", e)))?;
+        }
 
-        // Index the resource for search
-        self.index_resource(&conn, tenant_id, resource_type, &id, &data)?;
+        // Index the resource for search. Nothing to clear: the existence
+        // probe above established there is no row for this id.
+        self.index_resource(&conn, tenant_id, resource_type, &id, &data, false)?;
         drop(conn);
 
         // Mirrors the storage path: an overlay-affecting SearchParameter
@@ -313,6 +344,7 @@ impl Transaction for SqliteTransaction {
         current: &StoredResource,
         resource: Value,
     ) -> StorageResult<StoredResource> {
+        let _update_span = perf::span(Phase::Update);
         self.tenant
             .check_permission(Operation::Update, current.resource_type())?;
 
@@ -377,8 +409,11 @@ impl Transaction for SqliteTransaction {
         }
 
         // Serialize the resource data
-        let data_bytes = serde_json::to_vec(&data)
-            .map_err(|e| serialization_error(format!("Failed to serialize resource: {}", e)))?;
+        let data_bytes = {
+            let _span = perf::span(Phase::Serialize);
+            serde_json::to_vec(&data)
+                .map_err(|e| serialization_error(format!("Failed to serialize resource: {}", e)))?
+        };
 
         let now = Utc::now();
         let last_updated = now.to_rfc3339();
@@ -388,6 +423,7 @@ impl Transaction for SqliteTransaction {
         let fhir_version_str = fhir_version.as_mime_param();
 
         // Update the resource
+        let _update_row_span = perf::span(Phase::ResourceUpdate);
         conn.execute(
             "UPDATE resources SET version_id = ?1, data = ?2, last_updated = ?3
              WHERE tenant_id = ?4 AND resource_type = ?5 AND id = ?6",
@@ -401,17 +437,21 @@ impl Transaction for SqliteTransaction {
             ],
         )
         .map_err(|e| internal_error(format!("Failed to update resource: {}", e)))?;
+        drop(_update_row_span);
 
         // Insert into history
-        conn.execute(
-            "INSERT INTO resource_history (tenant_id, resource_type, id, version_id, data, last_updated, is_deleted, fhir_version)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7)",
-            params![tenant_id, resource_type, id, new_version_str, data_bytes, last_updated, fhir_version_str],
-        )
-        .map_err(|e| internal_error(format!("Failed to insert history: {}", e)))?;
+        {
+            let _span = perf::span(Phase::HistoryInsert);
+            conn.execute(
+                "INSERT INTO resource_history (tenant_id, resource_type, id, version_id, data, last_updated, is_deleted, fhir_version)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7)",
+                params![tenant_id, resource_type, id, new_version_str, data_bytes, last_updated, fhir_version_str],
+            )
+            .map_err(|e| internal_error(format!("Failed to insert history: {}", e)))?;
+        }
 
-        // Re-index the resource for search
-        self.index_resource(&conn, tenant_id, resource_type, id, &data)?;
+        // Re-index the resource for search, clearing the previous version's rows.
+        self.index_resource(&conn, tenant_id, resource_type, id, &data, true)?;
         drop(conn);
 
         // A SearchParameter write invalidates this tenant's cached registry
@@ -506,11 +546,14 @@ impl Transaction for SqliteTransaction {
         }
 
         let conn = self.conn.lock();
-        conn.execute("COMMIT", []).map_err(|e| {
-            StorageError::Transaction(TransactionError::RolledBack {
-                reason: format!("Commit failed: {}", e),
-            })
-        })?;
+        {
+            let _span = perf::span(Phase::Commit);
+            conn.execute("COMMIT", []).map_err(|e| {
+                StorageError::Transaction(TransactionError::RolledBack {
+                    reason: format!("Commit failed: {}", e),
+                })
+            })?;
+        }
         drop(conn);
 
         self.active = false;
@@ -743,6 +786,85 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(read.version_id(), "2");
+    }
+
+    /// #947: a transactional `create` no longer runs the "clear stale index
+    /// rows" DELETE, because the existence probe it just ran proves there is
+    /// nothing to clear. The two properties that has to preserve: a create
+    /// writes exactly its own index rows, and an `update` — which does still
+    /// clear — leaves none of the previous version's behind.
+    ///
+    /// The tag is the observed value because an in-memory backend carries only
+    /// the embedded search parameters (`_id`, `_lastUpdated`, `_tag`,
+    /// `_profile`, `_security`).
+    #[tokio::test]
+    async fn create_writes_only_its_own_index_rows_and_update_still_clears_stale_ones() {
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+
+        let tagged = |tag: &str| {
+            json!({
+                "resourceType": "Patient",
+                "id": "p1",
+                "meta": {"tag": [{"system": "http://example.com/tags", "code": tag}]}
+            })
+        };
+        let rows_with_tag = |tag: &str| -> i64 {
+            let conn = backend.get_connection().unwrap();
+            conn.query_row(
+                "SELECT COUNT(*) FROM search_index
+                 WHERE resource_type = 'Patient' AND resource_id = 'p1'
+                   AND param_name = '_tag' AND value_token_code = ?1",
+                params![tag],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        let total_rows = || -> i64 {
+            let conn = backend.get_connection().unwrap();
+            conn.query_row(
+                "SELECT COUNT(*) FROM search_index
+                 WHERE resource_type = 'Patient' AND resource_id = 'p1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+
+        let mut tx = backend
+            .begin_transaction(&tenant, TransactionOptions::default())
+            .await
+            .unwrap();
+        tx.create("Patient", tagged("before")).await.unwrap();
+        Box::new(tx).commit().await.unwrap();
+
+        let after_create = total_rows();
+        assert!(after_create > 0, "the create must index the resource");
+        assert_eq!(rows_with_tag("before"), 1, "the tag must be indexed");
+
+        let current = backend
+            .read(&tenant, "Patient", "p1")
+            .await
+            .unwrap()
+            .unwrap();
+        let mut tx = backend
+            .begin_transaction(&tenant, TransactionOptions::default())
+            .await
+            .unwrap();
+        tx.update(&current, tagged("after")).await.unwrap();
+        Box::new(tx).commit().await.unwrap();
+
+        assert_eq!(
+            rows_with_tag("before"),
+            0,
+            "the update must clear the previous version's index rows"
+        );
+        assert_eq!(rows_with_tag("after"), 1, "the new tag must be indexed");
+        assert_eq!(
+            total_rows(),
+            after_create,
+            "an update must not accumulate rows on top of the create's"
+        );
     }
 
     #[tokio::test]

--- a/crates/persistence/src/core/bulk_submit.rs
+++ b/crates/persistence/src/core/bulk_submit.rs
@@ -898,7 +898,12 @@ impl SubmissionChange {
         new_version: impl Into<String>,
     ) -> Self {
         Self {
-            change_id: Uuid::new_v4().to_string(),
+            // v7, not v4: `change_id` is the primary key of
+            // `bulk_submission_changes`, one row per ingested entry, and a
+            // random key inserts into that index at a random leaf. Time-ordered
+            // ids arrive at its right-hand edge, which is already resident —
+            // the same reason resource ids are v7 (see `new_resource_id`).
+            change_id: Uuid::now_v7().to_string(),
             manifest_id: manifest_id.into(),
             change_type: ChangeType::Create,
             resource_type: resource_type.into(),
@@ -920,7 +925,8 @@ impl SubmissionChange {
         previous_content: Value,
     ) -> Self {
         Self {
-            change_id: Uuid::new_v4().to_string(),
+            // Time-ordered, for the reason given in [`Self::create`].
+            change_id: Uuid::now_v7().to_string(),
             manifest_id: manifest_id.into(),
             change_type: ChangeType::Update,
             resource_type: resource_type.into(),

--- a/crates/persistence/src/lib.rs
+++ b/crates/persistence/src/lib.rs
@@ -180,6 +180,7 @@ pub mod backends;
 pub mod composite;
 pub mod core;
 pub mod error;
+pub mod perf;
 pub mod search;
 pub mod sof;
 pub mod tenant;

--- a/crates/persistence/src/perf.rs
+++ b/crates/persistence/src/perf.rs
@@ -9,9 +9,23 @@
 //!
 //! Design constraints:
 //!
-//! * **Zero cost when off.** Every call site starts with one relaxed atomic
-//!   load. `HFS_PERF_PHASES=1` (read once, at first use) turns collection on;
-//!   with it unset the guards return `None` and no clock is read.
+//! * **Absent unless asked for.** The whole thing is behind `--cfg
+//!   perf_phases`, *not* a cargo feature. Release artifacts are built with
+//!   `cargo build --workspace --all-features --release` (`ci.yml`, the `build`
+//!   job whose output the `release` job publishes and the Docker images copy),
+//!   and `--all-features` enables every feature there is — so a feature could
+//!   not have kept this out of a shipped binary. A `cfg` flag can, for the
+//!   same reason `tokio_unstable` is one. Without it [`enabled`] is a compile
+//!   time `false`, every guard folds away, and the counters are never
+//!   referenced.
+//!
+//!       RUSTFLAGS='--cfg perf_phases' cargo run --release -p helios-persistence \
+//!           --example bulk_submit_bench -- --limit 25000 CarePlan.ndjson
+//!
+//! * **Zero cost when built in but switched off.** Every call site starts with
+//!   one relaxed atomic load. `HFS_PERF_PHASES=1` (read once, at first use)
+//!   turns collection on; with it unset the guards return `None` and no clock
+//!   is read.
 //! * **Process-global, lock-free.** Counters are plain `AtomicU64` pairs
 //!   (nanos, hits) indexed by phase, so instrumented code can sit inside a
 //!   `&self` method on a shared backend without threading a profiler handle
@@ -20,7 +34,9 @@
 //!   encloses another double-counts by design. [`Phase::nested_in`] declares
 //!   the containment, and the report renders children indented under their
 //!   parent instead of pretending the columns sum to the wall clock.
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+#[cfg(perf_phases)]
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// One measured step of the ingest write path.
@@ -152,11 +168,14 @@ static HITS: [AtomicU64; PHASE_COUNT] = [ZERO; PHASE_COUNT];
 /// (index rows per resource, above all).
 static ROWS: [AtomicU64; PHASE_COUNT] = [ZERO; PHASE_COUNT];
 
+#[cfg(perf_phases)]
 static ENABLED: AtomicBool = AtomicBool::new(false);
+#[cfg(perf_phases)]
 static ENABLED_INIT: AtomicUsize = AtomicUsize::new(0);
 
 /// Whether phase collection is on. Set by `HFS_PERF_PHASES` (`1`/`true`), read
 /// once per process; [`set_enabled`] overrides it for in-process harnesses.
+#[cfg(perf_phases)]
 #[inline]
 pub fn enabled() -> bool {
     if ENABLED_INIT.load(Ordering::Relaxed) == 0 {
@@ -165,6 +184,18 @@ pub fn enabled() -> bool {
     ENABLED.load(Ordering::Relaxed)
 }
 
+/// Constant `false` in a build without `--cfg perf_phases`, which is every
+/// build that is not explicitly a profiling one. Each call site is
+/// `if !enabled() { return None; }`, so this folds the guard, the clock read,
+/// and the counter update out of the binary — there is nothing left to switch
+/// on, and `HFS_PERF_PHASES` is not read or even present in the executable.
+#[cfg(not(perf_phases))]
+#[inline(always)]
+pub fn enabled() -> bool {
+    false
+}
+
+#[cfg(perf_phases)]
 #[cold]
 fn init_from_env() {
     let on = std::env::var("HFS_PERF_PHASES")
@@ -178,10 +209,18 @@ fn init_from_env() {
 }
 
 /// Turns collection on or off explicitly (benchmark harnesses, tests).
+#[cfg(perf_phases)]
 pub fn set_enabled(on: bool) {
     ENABLED.store(on, Ordering::Relaxed);
     ENABLED_INIT.store(1, Ordering::Relaxed);
 }
+
+/// No-op without `--cfg perf_phases`: there is no switch to throw, because
+/// there are no call sites left to record. A harness that calls this and then
+/// finds [`snapshot`] all zeros was built without the flag — see the module
+/// docs for the invocation.
+#[cfg(not(perf_phases))]
+pub fn set_enabled(_on: bool) {}
 
 /// A running phase measurement. Adds its elapsed time to the phase on drop.
 pub struct Span {
@@ -334,8 +373,10 @@ mod tests {
     /// The exact-equality assertions below hold only because `Span::drop`
     /// re-checks the switch: with collection off, a span another thread
     /// started while it was on cannot land a sample afterwards.
+    #[cfg(perf_phases)]
     static SWITCH: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
+    #[cfg(perf_phases)]
     #[test]
     fn disabled_collection_records_nothing() {
         let _guard = SWITCH.lock();
@@ -350,6 +391,7 @@ mod tests {
         assert_eq!(snapshot()[Phase::Commit as usize].hits, before);
     }
 
+    #[cfg(perf_phases)]
     #[test]
     fn enabled_collection_accumulates_time_and_rows() {
         let _guard = SWITCH.lock();
@@ -388,6 +430,7 @@ mod tests {
 
     /// `reset()` zeroes every counter. Run under the switch lock and with
     /// collection off, so nothing else can be writing while it is checked.
+    #[cfg(perf_phases)]
     #[test]
     fn reset_zeroes_every_counter() {
         let _guard = SWITCH.lock();
@@ -402,6 +445,28 @@ mod tests {
             snapshot()
                 .iter()
                 .all(|t| t.hits == 0 && t.rows == 0 && t.elapsed == Duration::ZERO)
+        );
+    }
+
+    /// The property release artifacts depend on: without `--cfg perf_phases`
+    /// nothing records, and `set_enabled` cannot change that. `ci.yml` builds
+    /// them with `--all-features`, so this must not be reachable through any
+    /// feature combination.
+    #[cfg(not(perf_phases))]
+    #[test]
+    fn without_the_cfg_nothing_records_even_when_switched_on() {
+        set_enabled(true);
+        {
+            let _s = span(Phase::Commit);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        add_rows(Phase::IndexInsert, 14);
+        assert!(!enabled());
+        assert!(
+            snapshot()
+                .iter()
+                .all(|t| t.hits == 0 && t.rows == 0 && t.elapsed == Duration::ZERO),
+            "a build without --cfg perf_phases must record nothing"
         );
     }
 

--- a/crates/persistence/src/perf.rs
+++ b/crates/persistence/src/perf.rs
@@ -191,6 +191,14 @@ pub struct Span {
 
 impl Drop for Span {
     fn drop(&mut self) {
+        // Re-check the switch. A span can outlive it — collection is turned
+        // off while this one is in flight — and "stop collecting" has to mean
+        // that, or a sample lands after the caller believes recording has
+        // stopped. The load is only reached when a `Span` exists at all, which
+        // already implies collection was on.
+        if !enabled() {
+            return;
+        }
         let idx = self.phase as usize;
         NANOS[idx].fetch_add(self.start.elapsed().as_nanos() as u64, Ordering::Relaxed);
         HITS[idx].fetch_add(1, Ordering::Relaxed);
@@ -313,32 +321,88 @@ pub fn report(resources: u64, wall: Duration) -> String {
 mod tests {
     use super::*;
 
+    /// The counters are process-global by design, and `cargo test` runs a
+    /// crate's tests as threads of one process. So while these tests have
+    /// collection switched on, *every other test in the crate* that performs
+    /// an indexed write also lands hits and rows in the same counters — this
+    /// module's first version asserted `rows == 14` and CI duly reported 15.
+    ///
+    /// Two rules follow, and both matter: the tests here take this lock so no
+    /// two of them disagree about whether collection is on, and they assert on
+    /// *deltas* they caused rather than on absolute totals they do not own.
+    ///
+    /// The exact-equality assertions below hold only because `Span::drop`
+    /// re-checks the switch: with collection off, a span another thread
+    /// started while it was on cannot land a sample afterwards.
+    static SWITCH: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
     #[test]
     fn disabled_collection_records_nothing() {
+        let _guard = SWITCH.lock();
         set_enabled(false);
-        reset();
+        let before = snapshot()[Phase::Commit as usize].hits;
         {
             let _s = span(Phase::Commit);
             std::thread::sleep(Duration::from_millis(1));
         }
-        assert_eq!(snapshot()[Phase::Commit as usize].hits, 0);
+        // Exact, not a bound: with the switch held off, no thread in the
+        // process can be recording.
+        assert_eq!(snapshot()[Phase::Commit as usize].hits, before);
     }
 
     #[test]
     fn enabled_collection_accumulates_time_and_rows() {
+        let _guard = SWITCH.lock();
+        let idx = Phase::IndexInsert as usize;
         set_enabled(true);
-        reset();
+        let before = snapshot()[idx];
         {
             let _s = span(Phase::IndexInsert);
             std::thread::sleep(Duration::from_millis(2));
         }
         add_rows(Phase::IndexInsert, 14);
-        let totals = snapshot();
-        let idx = Phase::IndexInsert as usize;
-        assert_eq!(totals[idx].hits, 1);
-        assert_eq!(totals[idx].rows, 14);
-        assert!(totals[idx].elapsed >= Duration::from_millis(1));
+        let after = snapshot()[idx];
         set_enabled(false);
+
+        // `>=`, because a concurrent test writing search-index rows adds to
+        // these same counters while the switch is on.
+        assert!(
+            after.hits > before.hits,
+            "hits {} -> {}",
+            before.hits,
+            after.hits
+        );
+        assert!(
+            after.rows >= before.rows + 14,
+            "rows {} -> {}",
+            before.rows,
+            after.rows
+        );
+        assert!(
+            after.elapsed >= before.elapsed + Duration::from_millis(1),
+            "elapsed {:?} -> {:?}",
+            before.elapsed,
+            after.elapsed
+        );
+    }
+
+    /// `reset()` zeroes every counter. Run under the switch lock and with
+    /// collection off, so nothing else can be writing while it is checked.
+    #[test]
+    fn reset_zeroes_every_counter() {
+        let _guard = SWITCH.lock();
+        set_enabled(true);
+        {
+            let _s = span(Phase::Commit);
+        }
+        add_rows(Phase::IndexInsert, 3);
+        set_enabled(false);
+        reset();
+        assert!(
+            snapshot()
+                .iter()
+                .all(|t| t.hits == 0 && t.rows == 0 && t.elapsed == Duration::ZERO)
+        );
     }
 
     #[test]

--- a/crates/persistence/src/perf.rs
+++ b/crates/persistence/src/perf.rs
@@ -1,0 +1,352 @@
+//! Opt-in phase timing for the ingest write path (#947).
+//!
+//! The bulk-submit ingest path is a long chain of small steps — parse a line,
+//! probe for an existing resource, write the resource row, write its history
+//! copy, extract search values, write index rows, write the FTS row, write two
+//! bookkeeping rows, commit the batch. Wall-clock rate alone cannot say which
+//! of those to attack, and #947 measured ~84% of the per-entry budget as
+//! unattributed. This module attributes it.
+//!
+//! Design constraints:
+//!
+//! * **Zero cost when off.** Every call site starts with one relaxed atomic
+//!   load. `HFS_PERF_PHASES=1` (read once, at first use) turns collection on;
+//!   with it unset the guards return `None` and no clock is read.
+//! * **Process-global, lock-free.** Counters are plain `AtomicU64` pairs
+//!   (nanos, hits) indexed by phase, so instrumented code can sit inside a
+//!   `&self` method on a shared backend without threading a profiler handle
+//!   through every signature.
+//! * **Explicit nesting.** Phases are recorded as measured, so a phase that
+//!   encloses another double-counts by design. [`Phase::nested_in`] declares
+//!   the containment, and the report renders children indented under their
+//!   parent instead of pretending the columns sum to the wall clock.
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+/// One measured step of the ingest write path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(usize)]
+pub enum Phase {
+    /// `serde_json` parse of one NDJSON line into a `Value`.
+    NdjsonParse = 0,
+    /// The whole per-entry pipeline, from parsed entry to bookkeeping rows.
+    Entry,
+    /// Read-before-write: does a resource with this id already exist?
+    EntryRead,
+    /// `Transaction::create` in full.
+    Create,
+    /// The `SELECT 1 FROM resources` existence probe inside `create`.
+    CreateExists,
+    /// `serde_json::to_vec` of the resource being stored.
+    Serialize,
+    /// `INSERT INTO resources`.
+    ResourceInsert,
+    /// `INSERT INTO resource_history` — a second full copy of the blob.
+    HistoryInsert,
+    /// `Transaction::update` in full.
+    Update,
+    /// `UPDATE resources` on the update path.
+    ResourceUpdate,
+    /// Indexing in full: delete + extract + index rows + FTS.
+    Index,
+    /// `DELETE FROM search_index` (plus the FTS delete when rows were removed).
+    IndexDelete,
+    /// FHIRPath-driven search value extraction.
+    Extract,
+    /// `INSERT INTO search_index`, all rows for one resource.
+    IndexInsert,
+    /// The Rust-side half of an index row: normalising the value and building
+    /// the 24 bound parameters, as opposed to running the statement.
+    IndexMarshal,
+    /// FTS content extraction plus the `resource_fts` insert.
+    Fts,
+    /// The two bulk bookkeeping rows per entry.
+    Bookkeeping,
+    /// `COMMIT` of one batch transaction.
+    Commit,
+    /// Per-batch overhead outside the entry loop (BEGIN, manifest counters).
+    BatchOverhead,
+}
+
+impl Phase {
+    /// All phases, in report order.
+    pub const ALL: [Phase; 19] = [
+        Phase::NdjsonParse,
+        Phase::Entry,
+        Phase::EntryRead,
+        Phase::Create,
+        Phase::CreateExists,
+        Phase::Serialize,
+        Phase::ResourceInsert,
+        Phase::HistoryInsert,
+        Phase::Update,
+        Phase::ResourceUpdate,
+        Phase::Index,
+        Phase::IndexDelete,
+        Phase::Extract,
+        Phase::IndexInsert,
+        Phase::IndexMarshal,
+        Phase::Fts,
+        Phase::Bookkeeping,
+        Phase::Commit,
+        Phase::BatchOverhead,
+    ];
+
+    /// The phase this one is measured inside of, if any. Drives the report's
+    /// indentation, and warns the reader that the two overlap.
+    pub fn nested_in(self) -> Option<Phase> {
+        match self {
+            Phase::EntryRead | Phase::Create | Phase::Update | Phase::Bookkeeping => {
+                Some(Phase::Entry)
+            }
+            Phase::ResourceUpdate => Some(Phase::Update),
+            // Indentation shows the create path, which is what a bulk load
+            // runs. `serialize` and `index` are also reached from `update`,
+            // and their counters cover both.
+            Phase::CreateExists
+            | Phase::Serialize
+            | Phase::ResourceInsert
+            | Phase::HistoryInsert
+            | Phase::Index => Some(Phase::Create),
+            Phase::IndexDelete | Phase::Extract | Phase::IndexInsert | Phase::Fts => {
+                Some(Phase::Index)
+            }
+            Phase::IndexMarshal => Some(Phase::IndexInsert),
+            _ => None,
+        }
+    }
+
+    /// The label used in reports.
+    pub fn label(self) -> &'static str {
+        match self {
+            Phase::NdjsonParse => "ndjson_parse",
+            Phase::Entry => "entry (total)",
+            Phase::EntryRead => "entry_read",
+            Phase::Create => "create",
+            Phase::Update => "update",
+            Phase::CreateExists => "create_exists_probe",
+            Phase::Serialize => "serialize",
+            Phase::ResourceInsert => "resources_insert",
+            Phase::HistoryInsert => "history_insert",
+            Phase::ResourceUpdate => "resources_update",
+            Phase::Index => "index (total)",
+            Phase::IndexDelete => "index_delete",
+            Phase::Extract => "extract",
+            Phase::IndexInsert => "search_index_insert",
+            Phase::IndexMarshal => "  (of which: marshal)",
+            Phase::Fts => "fts",
+            Phase::Bookkeeping => "bookkeeping",
+            Phase::Commit => "commit",
+            Phase::BatchOverhead => "batch_overhead",
+        }
+    }
+}
+
+const PHASE_COUNT: usize = 19;
+
+#[allow(clippy::declare_interior_mutable_const)]
+const ZERO: AtomicU64 = AtomicU64::new(0);
+static NANOS: [AtomicU64; PHASE_COUNT] = [ZERO; PHASE_COUNT];
+static HITS: [AtomicU64; PHASE_COUNT] = [ZERO; PHASE_COUNT];
+/// Rows written, for the phases where "how many" is the interesting number
+/// (index rows per resource, above all).
+static ROWS: [AtomicU64; PHASE_COUNT] = [ZERO; PHASE_COUNT];
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static ENABLED_INIT: AtomicUsize = AtomicUsize::new(0);
+
+/// Whether phase collection is on. Set by `HFS_PERF_PHASES` (`1`/`true`), read
+/// once per process; [`set_enabled`] overrides it for in-process harnesses.
+#[inline]
+pub fn enabled() -> bool {
+    if ENABLED_INIT.load(Ordering::Relaxed) == 0 {
+        init_from_env();
+    }
+    ENABLED.load(Ordering::Relaxed)
+}
+
+#[cold]
+fn init_from_env() {
+    let on = std::env::var("HFS_PERF_PHASES")
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true" || v == "yes" || v == "on"
+        })
+        .unwrap_or(false);
+    ENABLED.store(on, Ordering::Relaxed);
+    ENABLED_INIT.store(1, Ordering::Relaxed);
+}
+
+/// Turns collection on or off explicitly (benchmark harnesses, tests).
+pub fn set_enabled(on: bool) {
+    ENABLED.store(on, Ordering::Relaxed);
+    ENABLED_INIT.store(1, Ordering::Relaxed);
+}
+
+/// A running phase measurement. Adds its elapsed time to the phase on drop.
+pub struct Span {
+    phase: Phase,
+    start: Instant,
+}
+
+impl Drop for Span {
+    fn drop(&mut self) {
+        let idx = self.phase as usize;
+        NANOS[idx].fetch_add(self.start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        HITS[idx].fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Starts timing `phase`, or returns `None` when collection is off (the guard
+/// is `Option<Span>` so the disabled path reads no clock).
+#[inline]
+pub fn span(phase: Phase) -> Option<Span> {
+    if !enabled() {
+        return None;
+    }
+    Some(Span {
+        phase,
+        start: Instant::now(),
+    })
+}
+
+/// Adds `rows` to a phase's row counter (index rows written, entries in a
+/// batch, …). Cheap enough to leave unguarded, but guarded anyway.
+#[inline]
+pub fn add_rows(phase: Phase, rows: u64) {
+    if !enabled() {
+        return;
+    }
+    ROWS[phase as usize].fetch_add(rows, Ordering::Relaxed);
+}
+
+/// One phase's totals.
+#[derive(Debug, Clone, Copy)]
+pub struct PhaseTotals {
+    /// The phase these totals belong to.
+    pub phase: Phase,
+    /// Accumulated time in the phase.
+    pub elapsed: Duration,
+    /// How many times the phase ran.
+    pub hits: u64,
+    /// Rows the phase reported writing, when it reports any.
+    pub rows: u64,
+}
+
+/// Reads every phase's totals.
+pub fn snapshot() -> Vec<PhaseTotals> {
+    Phase::ALL
+        .iter()
+        .map(|&phase| {
+            let idx = phase as usize;
+            PhaseTotals {
+                phase,
+                elapsed: Duration::from_nanos(NANOS[idx].load(Ordering::Relaxed)),
+                hits: HITS[idx].load(Ordering::Relaxed),
+                rows: ROWS[idx].load(Ordering::Relaxed),
+            }
+        })
+        .collect()
+}
+
+/// Zeroes every counter (between benchmark phases).
+pub fn reset() {
+    for idx in 0..PHASE_COUNT {
+        NANOS[idx].store(0, Ordering::Relaxed);
+        HITS[idx].store(0, Ordering::Relaxed);
+        ROWS[idx].store(0, Ordering::Relaxed);
+    }
+}
+
+/// Renders the snapshot as a table: per-resource cost and share of `wall` for
+/// each phase, children indented under the phase that encloses them.
+pub fn report(resources: u64, wall: Duration) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{:<28} {:>12} {:>12} {:>10} {:>10}\n",
+        "phase", "total", "per-resource", "share", "hits"
+    ));
+    out.push_str(&format!(
+        "{:<28} {:>12} {:>12.3} {:>9.1}% {:>10}\n",
+        "WALL",
+        format!("{:.2}s", wall.as_secs_f64()),
+        wall.as_secs_f64() * 1000.0 / resources.max(1) as f64,
+        100.0,
+        resources
+    ));
+    for totals in snapshot() {
+        if totals.hits == 0 {
+            continue;
+        }
+        let depth = {
+            let mut d = 0;
+            let mut p = totals.phase;
+            while let Some(parent) = p.nested_in() {
+                d += 1;
+                p = parent;
+            }
+            d
+        };
+        let name = format!("{}{}", "  ".repeat(depth), totals.phase.label());
+        let secs = totals.elapsed.as_secs_f64();
+        out.push_str(&format!(
+            "{:<28} {:>12} {:>12.3} {:>9.1}% {:>10}",
+            name,
+            format!("{:.2}s", secs),
+            secs * 1000.0 / resources.max(1) as f64,
+            secs / wall.as_secs_f64().max(f64::EPSILON) * 100.0,
+            totals.hits
+        ));
+        if totals.rows > 0 {
+            out.push_str(&format!(
+                "  rows={} ({:.2}/resource)",
+                totals.rows,
+                totals.rows as f64 / resources.max(1) as f64
+            ));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_collection_records_nothing() {
+        set_enabled(false);
+        reset();
+        {
+            let _s = span(Phase::Commit);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(snapshot()[Phase::Commit as usize].hits, 0);
+    }
+
+    #[test]
+    fn enabled_collection_accumulates_time_and_rows() {
+        set_enabled(true);
+        reset();
+        {
+            let _s = span(Phase::IndexInsert);
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        add_rows(Phase::IndexInsert, 14);
+        let totals = snapshot();
+        let idx = Phase::IndexInsert as usize;
+        assert_eq!(totals[idx].hits, 1);
+        assert_eq!(totals[idx].rows, 14);
+        assert!(totals[idx].elapsed >= Duration::from_millis(1));
+        set_enabled(false);
+    }
+
+    #[test]
+    fn phase_all_is_indexed_in_declaration_order() {
+        // The report and `snapshot()` index by `phase as usize`; ALL must line
+        // up with the discriminants or every row would be mislabelled.
+        for (i, phase) in Phase::ALL.iter().enumerate() {
+            assert_eq!(*phase as usize, i, "{} out of order", phase.label());
+        }
+    }
+}

--- a/crates/persistence/src/perf.rs
+++ b/crates/persistence/src/perf.rs
@@ -19,8 +19,10 @@
 //!   time `false`, every guard folds away, and the counters are never
 //!   referenced.
 //!
-//!       RUSTFLAGS='--cfg perf_phases' cargo run --release -p helios-persistence \
-//!           --example bulk_submit_bench -- --limit 25000 CarePlan.ndjson
+//!   ```text
+//!   RUSTFLAGS='--cfg perf_phases' cargo run --release -p helios-persistence \
+//!       --example bulk_submit_bench -- --limit 25000 CarePlan.ndjson
+//!   ```
 //!
 //! * **Zero cost when built in but switched off.** Every call site starts with
 //!   one relaxed atomic load. `HFS_PERF_PHASES=1` (read once, at first use)

--- a/crates/persistence/src/types/mod.rs
+++ b/crates/persistence/src/types/mod.rs
@@ -131,6 +131,12 @@ pub use search_capabilities::{
 /// comes back and fills it. That is a few percent of footprint against a third
 /// of the write cost.
 ///
+/// The measurements above are PostgreSQL's, where `idx_search_resource` is
+/// still the index every row enters. SQLite dropped it in schema v21 (#947):
+/// there it was a strict leftmost prefix of `idx_search_composite`, which
+/// leads with the same three columns and now carries that role — and the same
+/// argument for ordered ids.
+///
 /// # What this changes for a client
 ///
 /// A version 7 UUID embeds the millisecond it was minted, so the *creation


### PR DESCRIPTION
> **Re-based on main after #951 landed** (merge 5640230). The numbers below were measured against `a4068bfd6`, main *before* #951. Re-measured today against current main, three interleaved rounds on the same host:
>
> | | median | database |
> |---|---|---|
> | main + #951 | 1,832 res/s | 1.252 GB |
> | + this PR | **2,654 res/s (+45%)** | **1.048 GB (−16%)** |
>
> #951 and this branch do not stack additively: with the branch applied, adding #951 measures 2,654 vs 2,686 res/s without it — no change beyond run-to-run noise. Once the redundant and full indexes are gone there are fewer index entries per row for its batched INSERT to amortize a statement over. The two are independent and both worth having; the combined figure is the +45% above.

Closes the instrumentation half of #947 and takes the SQLite bulk-submit write path from **1,555 to 2,783 resources/s (+79%)** with a **16% smaller database**, on the real 31 GB Synthea manifest's files.

Stacks cleanly under #951 — that PR batches the `search_index` INSERT statement, this one reduces how many b-tree entries each row costs.

## What's here

**1. Phase instrumentation and a benchmark** (`helios_persistence::perf`, `examples/bulk_submit_bench.rs`)

`HFS_PERF_PHASES=1` turns on per-phase counters across the ingest write path; with it off every call site is one relaxed atomic load and no clock read. The example drives the real `process_ndjson_stream` — the same call the bulk-submit worker makes per manifest file — against local NDJSON on a fresh database, so a before/after pair differs by the write path and nothing else.

#947 measured ~84% of the per-entry budget as unattributed. It is now fully attributed, and on this host the answer is that **the `search_index` INSERT is over half of everything**:

```
                                before      after
ndjson_parse                    0.005 ms    0.005 ms
entry (total)                   0.525       0.287
  entry_read                    0.008       0.008
  create                        0.476       0.243
    create_exists_probe         0.003       0.001
    serialize                   0.002       0.002
    resources_insert            0.009       0.005
    history_insert              0.007       0.004
    index (total)               0.451       0.229
      index_delete              0.013       —        (gone on the create path)
      extract                   0.074       0.069
      search_index_insert       0.346       0.149
      fts                       0.018       0.010
  bookkeeping                   0.035       0.031
commit                          0.088       0.066
batch_overhead                  0.018       0.001
WALL                            0.639       0.362
```

**2. Schema v21 and v22 — index entries no query can use**

Five `search_index` indexes were *full*: every row entered `idx_search_composite`, `idx_search_resource`, `idx_search_reference_display`, `idx_search_quantity_canonical` and `idx_search_contained` whether or not the indexed column was NULL.

- v21 drops `idx_search_resource`. It was `(tenant_id, resource_type, resource_id)` — a strict leftmost prefix of `idx_search_composite`, so it answered no lookup the composite index cannot.
- v22 rebuilds the other three as partial, the same treatment #944 gave the v20 set and skipped for these because v10/v11 added them later. In the benchmark corpus **zero** rows carry a canonical quantity or a contained flag and 150k of 1.18M carry a reference display; those three indexes held 1.18M entries each, for 134 MB.

`idx_search_string_folded` is deliberately left full, with a comment saying why: it is also the only full index leading `(tenant_id, resource_type, param_name)`, and the planner falls back to it for the LIKE-shaped modifier searches (`:text`, `:contains`) whose predicate SQLite cannot prove implies `IS NOT NULL`. Making it partial pushed those onto a `(tenant_id, resource_type)` scan; replacing it with a narrow `(tenant_id, resource_type, param_name)` index made the planner prefer *that* for token searches, and a selective `code=…` lookup went 2.9 → 22.1 ms. Both alternatives were measured and rejected.

**3. Write-path changes**

- **`prepare_cached` on the ingest statements** (+24% on its own). `Connection::execute` compiles its SQL on every call, and the 24-column `search_index` INSERT ran that way ~14 times per resource — it costs more to compile than to run. Statement-cache capacity goes 16 → 64 so the read and search paths sharing these pooled connections cannot evict the hot inserts.
- **No stale-row DELETE on the create path.** `create` cleared the resource's index rows after an existence probe that had just proved there is no resource row for the id — and no resource row means no index rows (soft delete keeps the row; every purge path deletes `search_index` in the same transaction; the foreign key cascades besides).
- **Batch bookkeeping rides the batch transaction.** Manifest status, entry counters and the submission timestamp were three autocommit statements around each batch — three write-lock acquisitions and fsyncs it did not need, and a window where the entries were durable but the counts describing them were not.
- **Time-ordered `change_id`.** `bulk_submission_changes` takes one row per entry keyed by `change_id`; a v4 UUID inserts at a random leaf, v7 at the resident right-hand edge — the reasoning `new_resource_id` already documents.

## Proof

**Write path**, 3 runs each, phase collection off, 86,453 resources (CarePlan 25k, AllergyIntolerance 11,453, Condition 25k, Encounter 25k = 124.2 MB, 13.68 index rows per resource, `batch_size=100`, fresh database):

| | before (a4068bfd6) | after |
|---|---|---|
| ingest | 1,552 / 1,556 / 1,555 res/s | 2,776 / 2,786 / 2,783 res/s — **+79%** |
| database | 1.254 GB | 1.048 GB — **−16%** |
| `HFS_BULK_SUBMIT_DEFER_INDEXING=true` | 11,569 res/s | 18,519 res/s — **+60%** |

**End to end through `hfs`**, real `$bulk-submit` against a 9-type subset of the manifest (185,616 resources, 262 MB fetched over HTTP, full 1,389-parameter registry):

| | before | after |
|---|---|---|
| wall | 121.0 s (1,534 res/s) | 79.5 s (2,336 res/s) — **+52%** |
| database | 2.44 GB | 2.04 GB |
| index rows | 2,230,759 | 2,230,759 (identical) |

Instrumentation overhead when enabled: **not resolved by this harness.** The one measurement behind an earlier "0.7%" was a single run against a three-run median, in sequential rather than interleaved blocks, and its 19 res/s delta sits inside the disabled arm's own 10 res/s spread. Analytically it should be ~17 spans per resource x (two clock reads + two atomic adds) ~= 0.25%. Treat <=0.7% as an upper bound, not a measurement. The *disabled* cost — a couple of relaxed atomic loads per call site, ~0.02% — is roughly 20x below this benchmark's noise floor and cannot be measured with it at all, which is why the instrumentation is compiled out rather than merely switched off (see below).

## Safety

- `EXPLAIN QUERY PLAN` over 15 representative search shapes — token, token `:text`, reference, reference `:text`, string prefix and exact, quantity raw and canonical, date, uri, identifier `:of-type`, `_contained`, composite, delete-by-resource — is byte-identical before and after, on a database carrying 1.18M real rows.
- New tests pin the index layout (`search_index_carries_no_redundant_or_full_value_indexes`), that an upgraded database ends with exactly a fresh one's indexes, that a create writes only its own index rows while an update still clears the previous version's, and that the batch's manifest counters land with the entries they describe.
- `helios-persistence` lib (841), `sqlite_tests`, `search_suite`, `crud_suite`, `transactions_suite`, `versioning_suite`, `multitenancy_suite`, `sqlite_bulk_submit_concurrency`, `backend_capability_contract`, `storage_resolve_tests`, and `helios-rest` lib + `bulk_submit` all pass.

## Measured and rejected

`PRAGMA foreign_keys = OFF` (no measurable difference), a page cache above the 64 MiB from #950 (marginally slower at this size), raising the default `batch_size` (+17% *before* the autocommit statements were folded into the batch, noise after — and leaving it alone avoids lengthening the write-lock hold, #942), and #947's item 5 (the SQLite ingest path is `serde_json::Value` end to end; `serialize` is 0.3%).

#947's item 2, stop double-writing the blob on create, measures **+3.4% and −15% of database** but is not here: every history read path would have to synthesize v1 from the `resources` row, and the same question applies to PostgreSQL and MongoDB. Numbers and the `dbstat` breakdown are in https://github.com/HeliosSoftware/hfs/issues/947#issuecomment-5559709784 for a follow-up issue.

https://claude.ai/code/session_01Cs99Fk1eg7474hYQGrcwqh
