### PR TITLE
fix: Inferno nightly — batch the ES conformance seed under wait_for, ms-precision SQLite dates, ES _count body

### DIFF
--- a/.github/workflows/inferno-us-core.yml
+++ b/.github/workflows/inferno-us-core.yml
@@ -431,12 +431,19 @@ jobs:
           echo "HFS_LOG=$HFS_LOG" >> $GITHUB_ENV
           echo "HFS_BASE_URL=$HFS_BASE_URL" >> $GITHUB_ENV
 
+          # The Elasticsearch legs pair synchronous sync with wait_for so a
+          # write is searchable when the API responds. wait_for blocks each
+          # write until the next refresh, so the refresh interval is the price
+          # of every synchronous write: at the 1s default a 473-entry batch
+          # Bundle (entries synced one at a time, 16-wide) ran into the 30s
+          # request timeout; 200ms keeps it to a few seconds.
           if [ "${{ matrix.backend }}" = "sqlite-elasticsearch" ]; then
             HFS_BASE_URL="$HFS_BASE_URL" \
             HFS_STORAGE_BACKEND=sqlite-elasticsearch \
             HFS_ELASTICSEARCH_NODES=http://$DOCKER_HOST_IP:$ES_PORT \
             HFS_COMPOSITE_SYNC_MODE=synchronous \
             HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for \
+            HFS_ELASTICSEARCH_REFRESH_INTERVAL=200ms \
             ./target/debug/hfs --database-url :memory: --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
           elif [ "${{ matrix.backend }}" = "postgres" ]; then
             HFS_BASE_URL="$HFS_BASE_URL" \
@@ -463,6 +470,7 @@ jobs:
             HFS_ELASTICSEARCH_NODES=http://$DOCKER_HOST_IP:$ES_PORT \
             HFS_COMPOSITE_SYNC_MODE=synchronous \
             HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for \
+            HFS_ELASTICSEARCH_REFRESH_INTERVAL=200ms \
             ./target/debug/hfs --log-level info --port $HFS_PORT --host 0.0.0.0 > "$HFS_LOG" 2>&1 &
           else
             HFS_BASE_URL="$HFS_BASE_URL" \

--- a/.github/workflows/ui-tests-matrix.yml
+++ b/.github/workflows/ui-tests-matrix.yml
@@ -340,6 +340,11 @@ jobs:
              [ "${{ matrix.backend }}" = "mongodb-elasticsearch" ]; then
             export HFS_COMPOSITE_SYNC_MODE=synchronous
             export HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for
+            # wait_for blocks each write until the next refresh, so the
+            # interval is the per-write price of read-after-write: 200ms keeps
+            # a large batch Bundle (entries synced one at a time, 16-wide)
+            # inside the 30s request timeout where 1s did not.
+            export HFS_ELASTICSEARCH_REFRESH_INTERVAL=200ms
           fi
 
           if [ "${{ matrix.backend }}" = "sqlite-elasticsearch" ]; then

--- a/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
@@ -403,22 +403,18 @@ impl<'a> EsQueryBuilder<'a> {
     }
 }
 
-/// Builds a count query (no sorting, no source, size=0).
+/// Builds the body for the `_count` API: the search's `query` clause and
+/// nothing else.
+///
+/// `_count` accepts only `query`; every search-only field the full builder
+/// sets — `sort`, `size`, `from`, `search_after`, `track_total_hits`,
+/// `track_scores` — is a `parsing_exception` there, which surfaced as a 500
+/// on every `_total=accurate` search served by Elasticsearch.
 pub fn build_count_query(tenant_id: &str, resource_type: &str, query: &SearchQuery) -> Value {
     let builder = EsQueryBuilder::new(tenant_id, resource_type, String::new());
-    let es_query = builder.build(query);
+    let mut es_query = builder.build(query);
 
-    // Strip unnecessary fields for count
-    let mut body = es_query.body;
-    if let Some(obj) = body.as_object_mut() {
-        obj.remove("sort");
-        obj.remove("size");
-        obj.remove("from");
-        obj.remove("search_after");
-    }
-    body["size"] = json!(0);
-
-    body
+    json!({ "query": es_query.body["query"].take() })
 }
 
 #[cfg(test)]

--- a/crates/persistence/src/backends/elasticsearch/storage.rs
+++ b/crates/persistence/src/backends/elasticsearch/storage.rs
@@ -6,7 +6,9 @@
 
 use async_trait::async_trait;
 use chrono::Utc;
-use elasticsearch::{DeleteByQueryParts, DeleteParts, GetParts, IndexParts};
+use elasticsearch::{
+    BulkOperation, BulkParts, DeleteByQueryParts, DeleteParts, GetParts, IndexParts,
+};
 use helios_fhir::FhirVersion;
 use serde_json::{Value, json};
 
@@ -20,6 +22,12 @@ use crate::types::StoredResource;
 
 use super::backend::ElasticsearchBackend;
 use super::schema;
+
+/// Upper bound on operations per `_bulk` request in
+/// [`ResourceStorage::create_many`]. Keeps a request body bounded (conformance
+/// resources are a few KB each; contained documents ride along) without
+/// making a load pay one refresh wait per handful of documents.
+const BULK_OPS_PER_REQUEST: usize = 500;
 
 fn internal_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::Internal {
@@ -584,6 +592,236 @@ impl ResourceStorage for ElasticsearchBackend {
             None,
             fhir_version,
         ))
+    }
+
+    /// One `_bulk` request per [`BULK_OPS_PER_REQUEST`] operations, with the
+    /// configured write-refresh policy applied once per request rather than
+    /// once per document.
+    ///
+    /// This is what makes a bulk load survivable under `refresh=wait_for`:
+    /// that policy blocks each write until the next scheduled refresh (the
+    /// index's `refresh_interval`, 1s by default), so N per-document writes
+    /// cost N refresh waits — the ~1.4k-resource conformance seed took over
+    /// twenty minutes and the server never came up — while one bulk request
+    /// costs one.
+    async fn create_many(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        resources: Vec<Value>,
+        fhir_version: FhirVersion,
+    ) -> Vec<StorageResult<StoredResource>> {
+        if resources.is_empty() {
+            return Vec::new();
+        }
+        if tenant
+            .check_permission(Operation::Create, resource_type)
+            .is_err()
+        {
+            return resources
+                .iter()
+                .map(|_| {
+                    tenant
+                        .check_permission(Operation::Create, resource_type)
+                        .map(|()| unreachable!("permission check failed a moment ago"))
+                        .map_err(StorageError::from)
+                })
+                .collect();
+        }
+
+        let tenant_id = tenant.tenant_id().as_str();
+        let version_id = "1";
+        let extractor = self.tenant_extractor(tenant_id);
+
+        // Every document each resource contributes — its own, plus one per
+        // `contained` entry — addressed by (index, doc id). Built up front so
+        // the indices can be ensured once each and the operations streamed
+        // out in a few requests.
+        struct Prepared {
+            id: String,
+            resource: Value,
+            docs: Vec<(String, String, Value)>,
+        }
+        let mut types_touched = vec![resource_type.to_string()];
+        let prepared: Vec<Prepared> = resources
+            .into_iter()
+            .map(|mut resource| {
+                let id = resource
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+                    .unwrap_or_else(crate::types::new_resource_id);
+                if let Some(obj) = resource.as_object_mut() {
+                    obj.insert(
+                        "resourceType".to_string(),
+                        Value::String(resource_type.to_string()),
+                    );
+                    obj.insert("id".to_string(), Value::String(id.clone()));
+                }
+                let extracted_values = extractor
+                    .extract(&resource, resource_type)
+                    .unwrap_or_default();
+                let mut docs = vec![(
+                    self.index_name(tenant_id, resource_type),
+                    Self::document_id(resource_type, &id),
+                    build_es_document(
+                        tenant_id,
+                        resource_type,
+                        &id,
+                        version_id,
+                        &resource,
+                        fhir_version,
+                        &extracted_values,
+                    ),
+                )];
+                for contained in extractor.extract_contained(&resource) {
+                    types_touched.push(contained.contained_type.clone());
+                    docs.push((
+                        self.index_name(tenant_id, &contained.contained_type),
+                        Self::document_id(
+                            &contained.contained_type,
+                            &contained_resource_id(&id, &contained.local_id),
+                        ),
+                        build_es_contained_document(
+                            tenant_id,
+                            resource_type,
+                            &id,
+                            &contained.contained_type,
+                            &contained.local_id,
+                            &contained.content,
+                            version_id,
+                            fhir_version,
+                            &contained.values,
+                        ),
+                    ));
+                }
+                Prepared { id, resource, docs }
+            })
+            .collect();
+
+        // Ensure every index touched exists, once each.
+        let mut ensured = std::collections::HashSet::new();
+        for ty in types_touched {
+            if ensured.insert(ty.clone())
+                && let Err(e) = schema::ensure_index(self, tenant_id, &ty).await
+            {
+                let message = e.to_string();
+                return prepared
+                    .iter()
+                    .map(|_| Err(internal_error(message.clone())))
+                    .collect();
+            }
+        }
+
+        // Flatten to operations, remembering which resource each belongs to,
+        // and send them in bounded requests. A resource's outcome is the first
+        // failure among its own operations, if any.
+        let ops: Vec<(usize, &str, &str, &Value)> = prepared
+            .iter()
+            .enumerate()
+            .flat_map(|(i, p)| {
+                p.docs
+                    .iter()
+                    .map(move |(index, doc_id, doc)| (i, index.as_str(), doc_id.as_str(), doc))
+            })
+            .collect();
+        let mut failures: Vec<Option<String>> = vec![None; prepared.len()];
+        fn fail_chunk(
+            failures: &mut [Option<String>],
+            chunk: &[(usize, &str, &str, &Value)],
+            message: String,
+        ) {
+            for (i, ..) in chunk {
+                failures[*i].get_or_insert_with(|| message.clone());
+            }
+        }
+        for chunk in ops.chunks(BULK_OPS_PER_REQUEST) {
+            let body: Vec<BulkOperation<Value>> = chunk
+                .iter()
+                .map(|(_, index, doc_id, doc)| {
+                    BulkOperation::index((*doc).clone())
+                        .index(*index)
+                        .id(*doc_id)
+                        .into()
+                })
+                .collect();
+            let mut request = self.client().bulk(BulkParts::None).body(body);
+            if let Some(refresh) = self.write_refresh_param() {
+                request = request.refresh(refresh);
+            }
+            let response = match request.send().await {
+                Ok(response) => response,
+                Err(e) => {
+                    fail_chunk(
+                        &mut failures,
+                        chunk,
+                        format!("Failed to send bulk index request: {e}"),
+                    );
+                    continue;
+                }
+            };
+            let status = response.status_code();
+            let payload: Value = match response.json().await {
+                Ok(payload) if status.is_success() => payload,
+                Ok(payload) => {
+                    fail_chunk(
+                        &mut failures,
+                        chunk,
+                        format!("Bulk index request failed (status {status}): {payload}"),
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    fail_chunk(
+                        &mut failures,
+                        chunk,
+                        format!("Failed to read bulk index response: {e}"),
+                    );
+                    continue;
+                }
+            };
+            let items = payload
+                .get("items")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            for (position, (i, ..)) in chunk.iter().enumerate() {
+                let item = items.get(position).and_then(|item| item.get("index"));
+                let item_status = item
+                    .and_then(|v| v.get("status"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                if !(200..300).contains(&item_status) {
+                    let error = item
+                        .and_then(|v| v.get("error"))
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "no item in bulk response".to_string());
+                    failures[*i].get_or_insert_with(|| {
+                        format!("Failed to index document (status {item_status}): {error}")
+                    });
+                }
+            }
+        }
+
+        let now = Utc::now();
+        prepared
+            .into_iter()
+            .zip(failures)
+            .map(|(p, failure)| match failure {
+                Some(message) => Err(internal_error(message)),
+                None => Ok(StoredResource::from_storage(
+                    resource_type,
+                    &p.id,
+                    version_id,
+                    tenant.tenant_id().clone(),
+                    p.resource,
+                    now,
+                    now,
+                    None,
+                    fhir_version,
+                )),
+            })
+            .collect()
     }
 
     async fn create_or_update(

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/date.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/date.rs
@@ -17,8 +17,16 @@ use super::super::query_builder::{SqlFragment, SqlParam};
 /// modifier (`'+1 day'`), so a single parameter serves both ends of the range
 /// wherever the caller can only bind one.
 ///
-/// `datetime()` truncates fractional seconds, so millisecond-precision values
-/// compare at second precision — a match too many beats never matching.
+/// `datetime()` truncates fractional seconds, which is right for a search
+/// value of second precision (its range is the whole second) but not for one
+/// of millisecond precision: `_lastUpdated=eq2026-09-06T08:44:27.804Z` would
+/// match every resource written in that second, which is exactly what a
+/// transaction Bundle produces once the writes are fast enough to land in one.
+/// Millisecond-precision values therefore go through `strftime('%f')`, which
+/// keeps `SS.SSS` (SQLite carries dates as integer milliseconds internally, so
+/// this is exact) and still folds timezone offsets to UTC. The approximate
+/// prefix keeps `datetime()`: its ±10-second window is coarser than a second
+/// anyway.
 ///
 /// Returns the SQL and the value to bind for its (single) parameter.
 pub(crate) fn date_condition(
@@ -38,8 +46,21 @@ pub(crate) fn date_condition(
         _ => (value.to_string(), None),
     };
 
-    let col = format!("datetime({column})");
-    let p = format!("datetime(?{param_num})");
+    // Decided on the value's own text rather than `DatePrecision`, which reads
+    // a negative offset (`...:42-04:00`) as extra length and calls a plain
+    // second-precision value millisecond.
+    let has_fractional_seconds = value
+        .split_once('T')
+        .is_some_and(|(_, time)| time.contains('.'));
+    let normalize = |expr: &str| {
+        if has_fractional_seconds && prefix != SearchPrefix::Ap {
+            format!("strftime('%Y-%m-%d %H:%M:%f', {expr})")
+        } else {
+            format!("datetime({expr})")
+        }
+    };
+    let col = normalize(column);
+    let p = normalize(&format!("?{param_num}"));
     let end = |m: &str| format!("datetime(?{param_num}, '{m}')");
 
     let sql = match (prefix, bump) {
@@ -163,6 +184,111 @@ mod tests {
         let value = SearchValue::new(SearchPrefix::Eq, "2024-01-15");
         let frag = DateHandler::build_sql(&value, 0);
         assert_eq!(frag.params.len(), 1);
+    }
+
+    #[test]
+    fn eq_millisecond_precision_keeps_the_milliseconds() {
+        let (sql, param) = sql_and_param(SearchPrefix::Eq, "2026-09-06T08:44:27.804Z");
+        assert_eq!(
+            sql,
+            "strftime('%Y-%m-%d %H:%M:%f', value_date) = strftime('%Y-%m-%d %H:%M:%f', ?1)"
+        );
+        assert_eq!(param, "2026-09-06T08:44:27.804Z");
+    }
+
+    #[test]
+    fn second_precision_still_covers_the_whole_second() {
+        let (sql, _) = sql_and_param(SearchPrefix::Eq, "2026-09-06T08:44:27Z");
+        assert_eq!(sql, "datetime(value_date) = datetime(?1)");
+        // A negative offset is not fractional seconds.
+        let (sql, _) = sql_and_param(SearchPrefix::Eq, "2026-09-06T04:44:27-04:00");
+        assert_eq!(sql, "datetime(value_date) = datetime(?1)");
+    }
+
+    /// Evaluates the generated condition in SQLite itself against one stored
+    /// `last_updated` value (the `Utc::now().to_rfc3339()` shape the resources
+    /// table holds), returning whether the search value matches it.
+    fn sqlite_matches(prefix: SearchPrefix, search: &str, stored: &str) -> bool {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory sqlite");
+        let (sql, bound) = date_condition("?2", prefix, search, 1);
+        conn.query_row(
+            &format!("SELECT {sql}"),
+            rusqlite::params![bound, stored],
+            |row| row.get::<_, bool>(0),
+        )
+        .unwrap_or_else(|e| panic!("evaluating `{sql}`: {e}"))
+    }
+
+    /// The Inferno US Core `_lastUpdated` case: a transaction Bundle writes
+    /// several resources within one second, and a search for one resource's
+    /// exact `meta.lastUpdated` must not return its neighbours from the same
+    /// second.
+    #[test]
+    fn millisecond_precision_evaluates_at_millisecond_in_sqlite() {
+        let stored = "2026-09-06T08:44:27.828123+00:00";
+
+        assert!(
+            !sqlite_matches(SearchPrefix::Eq, "2026-09-06T08:44:27.804Z", stored),
+            "a different millisecond in the same second is not a match"
+        );
+        assert!(sqlite_matches(
+            SearchPrefix::Eq,
+            "2026-09-06T08:44:27.828Z",
+            stored
+        ));
+        assert!(
+            sqlite_matches(SearchPrefix::Eq, "2026-09-06T08:44:27Z", stored),
+            "a second-precision search still covers the whole second"
+        );
+        assert!(
+            sqlite_matches(SearchPrefix::Eq, "2026-09-06T04:44:27.828-04:00", stored),
+            "timezone offsets still fold to UTC"
+        );
+
+        assert!(sqlite_matches(
+            SearchPrefix::Ne,
+            "2026-09-06T08:44:27.804Z",
+            stored
+        ));
+        assert!(!sqlite_matches(
+            SearchPrefix::Ne,
+            "2026-09-06T08:44:27.828Z",
+            stored
+        ));
+        assert!(sqlite_matches(
+            SearchPrefix::Ge,
+            "2026-09-06T08:44:27.828Z",
+            stored
+        ));
+        assert!(sqlite_matches(
+            SearchPrefix::Gt,
+            "2026-09-06T08:44:27.827Z",
+            stored
+        ));
+        assert!(!sqlite_matches(
+            SearchPrefix::Gt,
+            "2026-09-06T08:44:27.828Z",
+            stored
+        ));
+        assert!(sqlite_matches(
+            SearchPrefix::Lt,
+            "2026-09-06T08:44:27.829Z",
+            stored
+        ));
+        assert!(!sqlite_matches(
+            SearchPrefix::Lt,
+            "2026-09-06T08:44:27.828Z",
+            stored
+        ));
+        assert!(sqlite_matches(
+            SearchPrefix::Le,
+            "2026-09-06T08:44:27.828Z",
+            stored
+        ));
+        assert!(
+            sqlite_matches(SearchPrefix::Ap, "2026-09-06T08:44:30.000Z", stored),
+            "approximate keeps its ±10-second window"
+        );
     }
 }
 

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/date.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/date.rs
@@ -23,8 +23,11 @@ use super::super::query_builder::{SqlFragment, SqlParam};
 /// match every resource written in that second, which is exactly what a
 /// transaction Bundle produces once the writes are fast enough to land in one.
 /// Millisecond-precision values therefore go through `strftime('%f')`, which
-/// keeps `SS.SSS` (SQLite carries dates as integer milliseconds internally, so
-/// this is exact) and still folds timezone offsets to UTC. The approximate
+/// keeps `SS.SSS` and still folds timezone offsets to UTC. Both sides are
+/// first cut to three fractional digits in SQL ([`truncated_to_millis`]):
+/// `last_updated` holds nanoseconds, which SQLite would *round* to the
+/// nearest millisecond while `meta.lastUpdated` (what the client searches
+/// with) truncates — off by one millisecond half the time. The approximate
 /// prefix keeps `datetime()`: its ±10-second window is coarser than a second
 /// anyway.
 ///
@@ -54,7 +57,10 @@ pub(crate) fn date_condition(
         .is_some_and(|(_, time)| time.contains('.'));
     let normalize = |expr: &str| {
         if has_fractional_seconds && prefix != SearchPrefix::Ap {
-            format!("strftime('%Y-%m-%d %H:%M:%f', {expr})")
+            format!(
+                "strftime('%Y-%m-%d %H:%M:%f', {})",
+                truncated_to_millis(expr)
+            )
         } else {
             format!("datetime({expr})")
         }
@@ -91,6 +97,25 @@ pub(crate) fn date_condition(
         }
     };
     (sql, start)
+}
+
+/// SQL for `expr` (a date/time TEXT value or bind parameter) with its
+/// fractional seconds cut to at most three digits — truncated, never rounded
+/// — and everything after the digits (a timezone offset, `Z`, nothing) kept.
+///
+/// `2026-09-06T20:35:32.364567890+00:00` becomes `2026-09-06T20:35:32.364+00:00`;
+/// `2016-01-23T13:07:42.5-04:00` and values without a fraction are unchanged.
+/// SQLite has no regular expressions, so the digit run after the dot is
+/// measured by stripping leading digits with `ltrim`.
+fn truncated_to_millis(expr: &str) -> String {
+    let rest = format!("substr({expr}, instr({expr}, '.') + 1)");
+    let tail = format!("ltrim({rest}, '0123456789')");
+    format!(
+        "CASE WHEN instr({expr}, '.') = 0 THEN {expr} \
+         ELSE substr({expr}, 1, instr({expr}, '.')) \
+         || substr({rest}, 1, min(3, length({rest}) - length({tail}))) \
+         || {tail} END"
+    )
 }
 
 /// Handles date parameter SQL generation.
@@ -189,11 +214,50 @@ mod tests {
     #[test]
     fn eq_millisecond_precision_keeps_the_milliseconds() {
         let (sql, param) = sql_and_param(SearchPrefix::Eq, "2026-09-06T08:44:27.804Z");
-        assert_eq!(
-            sql,
-            "strftime('%Y-%m-%d %H:%M:%f', value_date) = strftime('%Y-%m-%d %H:%M:%f', ?1)"
+        assert!(
+            sql.starts_with("strftime('%Y-%m-%d %H:%M:%f', ")
+                && sql.contains(" = strftime('%Y-%m-%d %H:%M:%f', "),
+            "both sides keep milliseconds: {sql}"
+        );
+        assert!(
+            !sql.contains("datetime("),
+            "no second-precision fold: {sql}"
         );
         assert_eq!(param, "2026-09-06T08:44:27.804Z");
+    }
+
+    /// The SQL truncation, evaluated by SQLite on the shapes that occur:
+    /// nanoseconds (`last_updated`), a short fraction with an offset
+    /// (`value_date` as the resource carried it), and no fraction at all.
+    #[test]
+    fn truncation_cuts_fraction_digits_and_keeps_the_offset() {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory sqlite");
+        let truncate = |value: &str| -> String {
+            conn.query_row(
+                &format!("SELECT {}", truncated_to_millis("?1")),
+                rusqlite::params![value],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("evaluate truncation")
+        };
+        assert_eq!(
+            truncate("2026-09-06T20:35:32.364567890+00:00"),
+            "2026-09-06T20:35:32.364+00:00"
+        );
+        assert_eq!(
+            truncate("2026-09-06T20:35:32.9996Z"),
+            "2026-09-06T20:35:32.999Z"
+        );
+        assert_eq!(
+            truncate("2016-01-23T13:07:42.5-04:00"),
+            "2016-01-23T13:07:42.5-04:00"
+        );
+        assert_eq!(truncate("2016-01-23T13:07:42.25"), "2016-01-23T13:07:42.25");
+        assert_eq!(
+            truncate("2016-01-23T13:07:42-04:00"),
+            "2016-01-23T13:07:42-04:00"
+        );
+        assert_eq!(truncate("1995-10-02"), "1995-10-02");
     }
 
     #[test]
@@ -244,6 +308,32 @@ mod tests {
             sqlite_matches(SearchPrefix::Eq, "2026-09-06T04:44:27.828-04:00", stored),
             "timezone offsets still fold to UTC"
         );
+
+        // Truncated, not rounded: `.828567` is `.828` to the client (that is
+        // what `meta.lastUpdated` says), so `.829` must not match it — and a
+        // fraction that would round up into the next second must not either.
+        let rounds_up = "2026-09-06T08:44:27.828567+00:00";
+        assert!(sqlite_matches(
+            SearchPrefix::Eq,
+            "2026-09-06T08:44:27.828Z",
+            rounds_up
+        ));
+        assert!(!sqlite_matches(
+            SearchPrefix::Eq,
+            "2026-09-06T08:44:27.829Z",
+            rounds_up
+        ));
+        let next_second = "2026-09-06T08:44:27.9996+00:00";
+        assert!(sqlite_matches(
+            SearchPrefix::Eq,
+            "2026-09-06T08:44:27.999Z",
+            next_second
+        ));
+        assert!(!sqlite_matches(
+            SearchPrefix::Eq,
+            "2026-09-06T08:44:28.000Z",
+            next_second
+        ));
 
         assert!(sqlite_matches(
             SearchPrefix::Ne,

--- a/crates/persistence/src/composite/bulk_submit.rs
+++ b/crates/persistence/src/composite/bulk_submit.rs
@@ -195,6 +195,18 @@ impl ResourceStorage for CompositeSubmitJobs {
             .await
     }
 
+    async fn create_many(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        resources: Vec<Value>,
+        fhir_version: FhirVersion,
+    ) -> Vec<StorageResult<StoredResource>> {
+        self.composite
+            .create_many(tenant, resource_type, resources, fhir_version)
+            .await
+    }
+
     async fn create_or_update(
         &self,
         tenant: &TenantContext,

--- a/crates/persistence/src/composite/bulk_submit.rs
+++ b/crates/persistence/src/composite/bulk_submit.rs
@@ -53,6 +53,10 @@ use crate::types::StoredResource;
 use super::storage::CompositeStorage;
 use super::sync::SyncEvent;
 
+/// One batch of ingested resources bound for the secondaries: the resource
+/// type and FHIR version they share, and their `(id, content)` pairs.
+type SyncGroup = ((String, FhirVersion), Vec<(String, Value)>);
+
 /// The composite's `$bulk-submit` job store: the primary's engine for all
 /// state and ingestion, plus secondary-index sync at manifest boundaries.
 pub struct CompositeSubmitJobs {
@@ -105,6 +109,11 @@ impl CompositeSubmitJobs {
                 }
             };
             let n = batch.len() as u32;
+            // One batch per (type, FHIR version) per page, so the secondary
+            // takes a page of ingested resources as one write rather than one
+            // synchronous event each — under Elasticsearch `refresh=wait_for`
+            // that is one refresh wait per page instead of per resource.
+            let mut by_type: Vec<SyncGroup> = Vec::new();
             for entry in batch {
                 let Some(resource_id) = entry.resource_id else {
                     continue;
@@ -112,7 +121,30 @@ impl CompositeSubmitJobs {
                 if !seen.insert((entry.resource_type.clone(), resource_id.clone())) {
                     continue;
                 }
-                self.sync_one(lease, &entry.resource_type, &resource_id)
+                let Some(stored) = self
+                    .read_ingested(lease, &entry.resource_type, &resource_id)
+                    .await
+                else {
+                    continue;
+                };
+                let key = (entry.resource_type.clone(), stored.fhir_version());
+                let group = match by_type.iter_mut().find(|(k, _)| *k == key) {
+                    Some(group) => group,
+                    None => {
+                        by_type.push((key, Vec::new()));
+                        by_type.last_mut().expect("just pushed")
+                    }
+                };
+                group.1.push((resource_id, stored.content().clone()));
+            }
+            for ((resource_type, fhir_version), resources) in by_type {
+                self.composite
+                    .sync_creates_to_secondaries(
+                        &lease.tenant,
+                        &resource_type,
+                        fhir_version,
+                        resources,
+                    )
                     .await;
             }
             if n < limit {
@@ -122,15 +154,21 @@ impl CompositeSubmitJobs {
         }
     }
 
-    /// Reads one resource from the primary and emits the matching sync event.
-    async fn sync_one(&self, lease: &ManifestLease, resource_type: &str, resource_id: &str) {
-        let stored = match self
+    /// Reads one ingested resource back from the primary for syncing. A
+    /// resource deleted (or rolled back) since ingestion is reflected as a
+    /// delete on the secondaries instead, and `None` is returned.
+    async fn read_ingested(
+        &self,
+        lease: &ManifestLease,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Option<StoredResource> {
+        match self
             .primary
             .read(&lease.tenant, resource_type, resource_id)
             .await
         {
-            Ok(Some(stored)) => stored,
-            // Deleted (or rolled back) since ingestion — reflect that instead.
+            Ok(Some(stored)) => Some(stored),
             Ok(None) | Err(_) => {
                 let _ = self
                     .composite
@@ -140,26 +178,8 @@ impl CompositeSubmitJobs {
                         tenant_id: lease.tenant.tenant_id().clone(),
                     })
                     .await;
-                return;
+                None
             }
-        };
-        if let Err(e) = self
-            .composite
-            .sync_to_secondaries(SyncEvent::Create {
-                resource_type: resource_type.to_string(),
-                resource_id: resource_id.to_string(),
-                content: stored.content().clone(),
-                tenant_id: lease.tenant.tenant_id().clone(),
-                fhir_version: stored.fhir_version(),
-            })
-            .await
-        {
-            warn!(
-                resource_type,
-                resource_id,
-                error = %e,
-                "secondary sync of an ingested resource failed; repair via $reindex"
-            );
         }
     }
 }

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -804,6 +804,58 @@ impl ResourceStorage for CompositeStorage {
         Ok(stored)
     }
 
+    /// The batch goes to the primary as a batch, and then what the primary
+    /// accepted goes to every secondary as a batch too
+    /// ([`SyncManager::sync_creates`]): a bulk load pays the secondary's batch
+    /// write (one Elasticsearch `_bulk` request, one refresh wait) rather than
+    /// one synchronous per-resource sync each, which is what turned the
+    /// startup conformance seed into a twenty-minute stall under
+    /// `refresh=wait_for`.
+    async fn create_many(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        resources: Vec<Value>,
+        fhir_version: FhirVersion,
+    ) -> Vec<StorageResult<StoredResource>> {
+        let results = self
+            .primary
+            .create_many(tenant, resource_type, resources, fhir_version)
+            .await;
+
+        // `AlreadyExists` and validation errors are per-resource outcomes, not
+        // evidence about the backend; only a backend error counts against its
+        // health.
+        let primary_id = self.config.primary_id().unwrap_or("primary");
+        let backend_failure = results.iter().find_map(|result| match result {
+            Err(error @ StorageError::Backend(_)) => Some(error.to_string()),
+            _ => None,
+        });
+        self.update_health(primary_id, backend_failure.is_none(), backend_failure);
+
+        let created: Vec<StoredResource> = results
+            .iter()
+            .filter_map(|result| result.as_ref().ok().cloned())
+            .collect();
+        if !created.is_empty()
+            && let Some(ref sync_manager) = self.sync_manager
+            && let Err(e) = sync_manager
+                .sync_creates(
+                    tenant.tenant_id(),
+                    resource_type,
+                    fhir_version,
+                    created,
+                    &self.secondaries,
+                )
+                .await
+        {
+            warn!(error = %e, "Failed to sync batch create to secondaries");
+            // Don't fail the operation - primary succeeded
+        }
+
+        results
+    }
+
     #[instrument(skip(self, tenant, resource), fields(resource_type = %resource_type, id = %id))]
     async fn create_or_update(
         &self,

--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -665,46 +665,86 @@ impl CompositeStorage {
     }
 
     /// Syncs bundle results to secondaries by extracting resource info from responses.
+    ///
+    /// Entries are grouped by resource type and synced as batches
+    /// ([`Self::sync_creates_to_secondaries`]) rather than one event each: a
+    /// transaction Bundle's entries each waited on the secondary in turn, and
+    /// under Elasticsearch `refresh=wait_for` (one refresh interval per write)
+    /// a bundle of a few dozen entries outran the 30s request timeout.
+    /// Ordering across types does not matter to a search secondary, and the
+    /// primary has already committed the whole bundle.
     async fn sync_bundle_results(
         &self,
         tenant: &TenantContext,
         result: &BundleResult,
         fhir_version: FhirVersion,
     ) {
+        let mut by_type: Vec<(String, Vec<(String, Value)>)> = Vec::new();
         for entry_result in &result.entries {
             // Only sync successful mutating operations that have a resource body
-            if let Some(ref resource_json) = entry_result.resource {
-                let resource_type = resource_json
-                    .get("resourceType")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default();
-                let resource_id = resource_json
-                    .get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default();
-
-                if resource_type.is_empty() || resource_id.is_empty() {
-                    continue;
-                }
-
-                if let Err(e) = self
-                    .sync_to_secondaries(SyncEvent::Create {
-                        resource_type: resource_type.to_string(),
-                        resource_id: resource_id.to_string(),
-                        content: resource_json.clone(),
-                        tenant_id: tenant.tenant_id().clone(),
-                        fhir_version,
-                    })
-                    .await
-                {
-                    warn!(
-                        error = %e,
-                        resource_type = resource_type,
-                        resource_id = resource_id,
-                        "Failed to sync bundle entry to secondaries"
-                    );
-                }
+            let Some(ref resource_json) = entry_result.resource else {
+                continue;
+            };
+            let resource_type = resource_json
+                .get("resourceType")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let resource_id = resource_json
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            if resource_type.is_empty() || resource_id.is_empty() {
+                continue;
             }
+            let group = match by_type.iter_mut().find(|(t, _)| t == resource_type) {
+                Some(group) => group,
+                None => {
+                    by_type.push((resource_type.to_string(), Vec::new()));
+                    by_type.last_mut().expect("just pushed")
+                }
+            };
+            group
+                .1
+                .push((resource_id.to_string(), resource_json.clone()));
+        }
+        for (resource_type, resources) in by_type {
+            self.sync_creates_to_secondaries(tenant, &resource_type, fhir_version, resources)
+                .await;
+        }
+    }
+
+    /// Syncs a batch of resources of one type to the secondaries as a batch
+    /// ([`SyncManager::sync_creates`]), logging rather than failing: the
+    /// primary already holds them, and a secondary that missed the batch is
+    /// repaired by `$reindex`.
+    pub(crate) async fn sync_creates_to_secondaries(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        fhir_version: FhirVersion,
+        resources: Vec<(String, Value)>,
+    ) {
+        if resources.is_empty() {
+            return;
+        }
+        let Some(ref sync_manager) = self.sync_manager else {
+            return;
+        };
+        if let Err(e) = sync_manager
+            .sync_creates(
+                tenant.tenant_id(),
+                resource_type,
+                fhir_version,
+                resources,
+                &self.secondaries,
+            )
+            .await
+        {
+            warn!(
+                error = %e,
+                resource_type,
+                "Failed to sync batch of resources to secondaries"
+            );
         }
     }
 
@@ -833,25 +873,13 @@ impl ResourceStorage for CompositeStorage {
         });
         self.update_health(primary_id, backend_failure.is_none(), backend_failure);
 
-        let created: Vec<StoredResource> = results
+        let created: Vec<(String, Value)> = results
             .iter()
-            .filter_map(|result| result.as_ref().ok().cloned())
+            .filter_map(|result| result.as_ref().ok())
+            .map(|stored| (stored.id().to_string(), stored.content().clone()))
             .collect();
-        if !created.is_empty()
-            && let Some(ref sync_manager) = self.sync_manager
-            && let Err(e) = sync_manager
-                .sync_creates(
-                    tenant.tenant_id(),
-                    resource_type,
-                    fhir_version,
-                    created,
-                    &self.secondaries,
-                )
-                .await
-        {
-            warn!(error = %e, "Failed to sync batch create to secondaries");
-            // Don't fail the operation - primary succeeded
-        }
+        self.sync_creates_to_secondaries(tenant, resource_type, fhir_version, created)
+            .await;
 
         results
     }

--- a/crates/persistence/src/composite/sync.rs
+++ b/crates/persistence/src/composite/sync.rs
@@ -311,6 +311,150 @@ impl SyncManager {
         }
     }
 
+    /// Synchronizes a batch of creates — one tenant, one resource type — to
+    /// the secondary backends as a batch.
+    ///
+    /// In the synchronous modes every backend receives the whole batch
+    /// through [`ResourceStorage::create_many`], so a secondary with a native
+    /// batch write (Elasticsearch `_bulk`) pays one round trip and, under
+    /// `refresh=wait_for`, one refresh wait rather than one per resource.
+    /// Items the batch rejects are retried one at a time through the same
+    /// retrying path a single [`sync`](Self::sync) takes, so a partial batch
+    /// failure degrades to per-resource sync rather than to lost writes.
+    /// Asynchronous mode queues one event per resource, exactly as `sync`
+    /// would for each.
+    pub async fn sync_creates(
+        &self,
+        tenant_id: &TenantId,
+        resource_type: &str,
+        fhir_version: FhirVersion,
+        resources: Vec<StoredResource>,
+        backends: &HashMap<String, Arc<dyn ResourceStorage + Send + Sync>>,
+    ) -> StorageResult<Vec<SyncStatus>> {
+        let create_event = |resource: &StoredResource| SyncEvent::Create {
+            resource_type: resource_type.to_string(),
+            resource_id: resource.id().to_string(),
+            content: resource.content().clone(),
+            tenant_id: tenant_id.clone(),
+            fhir_version,
+        };
+        let synchronous = match self.config.mode {
+            SyncMode::Synchronous => true,
+            SyncMode::Asynchronous => false,
+            SyncMode::Hybrid { sync_for_search } => sync_for_search,
+        };
+        if !synchronous {
+            let mut statuses = Vec::new();
+            for resource in &resources {
+                statuses.extend(
+                    self.sync_asynchronous(&create_event(resource), backends)
+                        .await?,
+                );
+            }
+            return Ok(statuses);
+        }
+        if resources.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        use tokio::task::JoinSet;
+
+        let resources = Arc::new(resources);
+        let tenant = TenantContext::new(tenant_id.clone(), TenantPermissions::full_access());
+        let resource_type = resource_type.to_string();
+        let mut tasks: JoinSet<(SyncStatus, usize, usize)> = JoinSet::new();
+
+        for (backend_id, backend) in backends {
+            let resources = resources.clone();
+            let tenant = tenant.clone();
+            let resource_type = resource_type.clone();
+            let backend = backend.clone();
+            let backend_id = backend_id.clone();
+            let retry_config = self.config.retry.clone();
+
+            tasks.spawn(async move {
+                let start = std::time::Instant::now();
+                let contents = resources.iter().map(|r| r.content().clone()).collect();
+                let results = backend
+                    .create_many(&tenant, &resource_type, contents, fhir_version)
+                    .await;
+
+                let mut synced = 0;
+                let mut errors = 0;
+                let mut last_error = None;
+                for (resource, result) in resources.iter().zip(results) {
+                    let Err(batch_error) = result else {
+                        synced += 1;
+                        continue;
+                    };
+                    warn!(
+                        backend_id = %backend_id,
+                        resource_type = %resource_type,
+                        resource_id = %resource.id(),
+                        error = %batch_error,
+                        "Batch sync rejected a resource; retrying it individually"
+                    );
+                    let event = SyncEvent::Create {
+                        resource_type: resource_type.clone(),
+                        resource_id: resource.id().to_string(),
+                        content: resource.content().clone(),
+                        tenant_id: tenant.tenant_id().clone(),
+                        fhir_version,
+                    };
+                    match Self::sync_event_to_backend(&event, backend.as_ref(), &retry_config).await
+                    {
+                        Ok(()) => synced += 1,
+                        Err(e) => {
+                            errors += 1;
+                            last_error = Some(e.to_string());
+                        }
+                    }
+                }
+
+                (
+                    SyncStatus {
+                        backend_id,
+                        success: errors == 0,
+                        error: last_error,
+                        retry_count: if errors == 0 {
+                            0
+                        } else {
+                            retry_config.max_retries
+                        },
+                        duration: start.elapsed(),
+                    },
+                    synced,
+                    errors,
+                )
+            });
+        }
+
+        let mut results = Vec::new();
+        while let Some(result) = tasks.join_next().await {
+            match result {
+                Ok((status, synced, errors)) => {
+                    let mut status_map = self.status.write();
+                    let backend_status = status_map.entry(status.backend_id.clone()).or_default();
+                    if synced > 0 {
+                        backend_status.last_success = Some(std::time::Instant::now());
+                        backend_status.total_synced += synced as u64;
+                    }
+                    backend_status.total_errors += errors as u64;
+                    if status.success {
+                        backend_status.healthy = true;
+                    }
+                    drop(status_map);
+                    results.push(status);
+                }
+                Err(e) => {
+                    warn!(error = %e, "Batch sync task failed");
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Synchronous sync - waits for all backends.
     async fn sync_synchronous(
         &self,

--- a/crates/persistence/src/composite/sync.rs
+++ b/crates/persistence/src/composite/sync.rs
@@ -328,13 +328,13 @@ impl SyncManager {
         tenant_id: &TenantId,
         resource_type: &str,
         fhir_version: FhirVersion,
-        resources: Vec<StoredResource>,
+        resources: Vec<(String, Value)>,
         backends: &HashMap<String, Arc<dyn ResourceStorage + Send + Sync>>,
     ) -> StorageResult<Vec<SyncStatus>> {
-        let create_event = |resource: &StoredResource| SyncEvent::Create {
+        let create_event = |(id, content): &(String, Value)| SyncEvent::Create {
             resource_type: resource_type.to_string(),
-            resource_id: resource.id().to_string(),
-            content: resource.content().clone(),
+            resource_id: id.clone(),
+            content: content.clone(),
             tenant_id: tenant_id.clone(),
             fhir_version,
         };
@@ -374,7 +374,10 @@ impl SyncManager {
 
             tasks.spawn(async move {
                 let start = std::time::Instant::now();
-                let contents = resources.iter().map(|r| r.content().clone()).collect();
+                let contents = resources
+                    .iter()
+                    .map(|(_, content)| content.clone())
+                    .collect();
                 let results = backend
                     .create_many(&tenant, &resource_type, contents, fhir_version)
                     .await;
@@ -382,7 +385,7 @@ impl SyncManager {
                 let mut synced = 0;
                 let mut errors = 0;
                 let mut last_error = None;
-                for (resource, result) in resources.iter().zip(results) {
+                for ((resource_id, content), result) in resources.iter().zip(results) {
                     let Err(batch_error) = result else {
                         synced += 1;
                         continue;
@@ -390,14 +393,14 @@ impl SyncManager {
                     warn!(
                         backend_id = %backend_id,
                         resource_type = %resource_type,
-                        resource_id = %resource.id(),
+                        resource_id = %resource_id,
                         error = %batch_error,
                         "Batch sync rejected a resource; retrying it individually"
                     );
                     let event = SyncEvent::Create {
                         resource_type: resource_type.clone(),
-                        resource_id: resource.id().to_string(),
-                        content: resource.content().clone(),
+                        resource_id: resource_id.clone(),
+                        content: content.clone(),
                         tenant_id: tenant.tenant_id().clone(),
                         fhir_version,
                     };

--- a/crates/persistence/src/core/storage.rs
+++ b/crates/persistence/src/core/storage.rs
@@ -393,6 +393,43 @@ pub trait ResourceStorage: Send + Sync {
         fhir_version: FhirVersion,
     ) -> StorageResult<StoredResource>;
 
+    /// Creates a batch of resources of one type, returning one result per
+    /// input in input order.
+    ///
+    /// Each item has exactly [`create`](Self::create)'s semantics — a server-
+    /// assigned id when the resource carries none, `AlreadyExists` when its id
+    /// is taken — and the items are independent: this is a throughput path,
+    /// not a transaction, so one failure neither stops the rest nor rolls
+    /// anything back.
+    ///
+    /// The default fans `create` out at
+    /// [`bulk_write_concurrency`](Self::bulk_write_concurrency), which is the
+    /// right shape for a store whose per-write cost is one round trip.
+    /// Backends with a native batch write override it so a load of N resources
+    /// is one round trip — and, where the backend pays a per-write visibility
+    /// wait (Elasticsearch `refresh=wait_for`, which blocks each write until
+    /// the next scheduled refresh), one wait instead of N. A composite forwards
+    /// the batch to its primary and then to each secondary *as a batch*, so a
+    /// bulk load pays the secondary's batch cost rather than N synchronous
+    /// per-resource syncs. Conformance seeding
+    /// ([`crate::search::seeder`]) writes through this.
+    async fn create_many(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        resources: Vec<Value>,
+        fhir_version: FhirVersion,
+    ) -> Vec<StorageResult<StoredResource>> {
+        use futures::stream::{self, StreamExt};
+
+        let concurrency = self.bulk_write_concurrency().clamp(1, 32);
+        stream::iter(resources)
+            .map(|resource| self.create(tenant, resource_type, resource, fhir_version))
+            .buffered(concurrency)
+            .collect()
+            .await
+    }
+
     /// Creates a resource with a specific ID (PUT semantics).
     ///
     /// If the resource doesn't exist, creates it with version "1".

--- a/crates/persistence/src/search/seeder.rs
+++ b/crates/persistence/src/search/seeder.rs
@@ -41,14 +41,26 @@ pub struct SeedOutcome {
     pub failed: usize,
 }
 
-/// Writes every resource of `resource_type` for `tenant`, fanning creates out
-/// at the backend's [`bulk_write_concurrency`] so latency-bound backends (one
-/// PUT per resource on S3, one round trip per row on networked databases) pay
-/// round-trips-divided-by-fanout rather than their sum. `AlreadyExists` counts
-/// as already-seeded. Any other error is retried twice with a short backoff —
+/// How many resources go into one [`create_many`] call. Large enough that a
+/// backend with a native batch write sees the seed as a handful of requests
+/// (and, under Elasticsearch `refresh=wait_for`, a handful of refresh waits);
+/// small enough that a failed batch's individual retries stay cheap.
+///
+/// [`create_many`]: ResourceStorage::create_many
+const SEED_BATCH_SIZE: usize = 256;
+
+/// Writes every resource of `resource_type` for `tenant` in
+/// [`SEED_BATCH_SIZE`] batches through [`create_many`], whose default fans
+/// creates out at the backend's [`bulk_write_concurrency`] so latency-bound
+/// backends (one PUT per resource on S3, one round trip per row on networked
+/// databases) pay round-trips-divided-by-fanout rather than their sum, and
+/// whose overrides (Elasticsearch, and a composite feeding it) make each batch
+/// one request. `AlreadyExists` counts as already-seeded. Any other error is
+/// retried resource-by-resource, twice each with a short backoff —
 /// shared-cache SQLite surfaces reader/writer overlap as an immediate `table
 /// is locked` error rather than waiting — before counting as failed.
 ///
+/// [`create_many`]: ResourceStorage::create_many
 /// [`bulk_write_concurrency`]: ResourceStorage::bulk_write_concurrency
 async fn create_all<S>(
     storage: &S,
@@ -61,10 +73,19 @@ where
     S: ResourceStorage + ?Sized,
 {
     let concurrency = storage.bulk_write_concurrency().clamp(1, 32);
-    write_all(
+    write_batched(
+        SEED_BATCH_SIZE,
         concurrency,
         resource_type,
         resources,
+        |batch| async move {
+            storage
+                .create_many(tenant, resource_type, batch, fhir_version)
+                .await
+                .into_iter()
+                .map(|result| result.map(|_| ()))
+                .collect()
+        },
         |resource| async move {
             storage
                 .create(tenant, resource_type, resource, fhir_version)
@@ -73,6 +94,61 @@ where
         },
     )
     .await
+}
+
+/// The batching core of [`create_all`], parameterized over the batch write
+/// and the single write so it can be exercised without a storage backend.
+///
+/// Each batch of `batch_size` goes through `create_many`, which answers one
+/// result per resource in order. Resources it created or found existing are
+/// settled; the rest — a transient error, or a short answer from a backend
+/// that dropped part of the batch — fall through to [`write_all`], which
+/// retries them one at a time.
+async fn write_batched<M, MFut, F, Fut>(
+    batch_size: usize,
+    concurrency: usize,
+    resource_type: &'static str,
+    resources: Vec<Value>,
+    create_many: M,
+    create: F,
+) -> SeedOutcome
+where
+    M: Fn(Vec<Value>) -> MFut,
+    MFut: Future<Output = Vec<StorageResult<()>>>,
+    F: Fn(Value) -> Fut,
+    Fut: Future<Output = StorageResult<()>>,
+{
+    let mut outcome = SeedOutcome {
+        created: 0,
+        existing: 0,
+        failed: 0,
+    };
+    let mut retry = Vec::new();
+    for batch in resources.chunks(batch_size.max(1)) {
+        let mut results = create_many(batch.to_vec()).await.into_iter();
+        for resource in batch {
+            match results.next() {
+                Some(Ok(())) => outcome.created += 1,
+                Some(Err(StorageError::Resource(ResourceError::AlreadyExists { .. }))) => {
+                    outcome.existing += 1;
+                }
+                Some(Err(e)) => {
+                    tracing::debug!(
+                        "{resource_type} seeding: batch write failed, retrying individually: {e}"
+                    );
+                    retry.push(resource.clone());
+                }
+                None => retry.push(resource.clone()),
+            }
+        }
+    }
+    if !retry.is_empty() {
+        let retried = write_all(concurrency, resource_type, retry, create).await;
+        outcome.created += retried.created;
+        outcome.existing += retried.existing;
+        outcome.failed += retried.failed;
+    }
+    outcome
 }
 
 /// The fanout/retry core of [`create_all`], parameterized over the write so it
@@ -418,5 +494,94 @@ mod tests {
     async fn zero_concurrency_is_clamped_not_deadlocked() {
         let outcome = write_all(0, "SearchParameter", resources(3), |_| async { Ok(()) }).await;
         assert_eq!(outcome.created, 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn batches_settle_through_create_many_and_only_rejects_fall_back() {
+        let batch_calls = AtomicUsize::new(0);
+        let single_calls = AtomicUsize::new(0);
+        let outcome = write_batched(
+            2,
+            1,
+            "SearchParameter",
+            resources(5),
+            |batch| {
+                batch_calls.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    batch
+                        .into_iter()
+                        .map(|resource| match resource["id"].as_str() {
+                            Some("r0") => {
+                                Err(StorageError::Resource(ResourceError::AlreadyExists {
+                                    resource_type: "SearchParameter".to_string(),
+                                    id: "r0".to_string(),
+                                }))
+                            }
+                            Some("r3") => Err(transient()),
+                            _ => Ok(()),
+                        })
+                        .collect()
+                }
+            },
+            |resource| {
+                single_calls.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    assert_eq!(resource["id"], json!("r3"), "only the reject is retried");
+                    Ok(())
+                }
+            },
+        )
+        .await;
+        assert_eq!(
+            batch_calls.load(Ordering::SeqCst),
+            3,
+            "5 resources, 2 per batch"
+        );
+        assert_eq!(single_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            outcome,
+            SeedOutcome {
+                created: 4,
+                existing: 1,
+                failed: 0
+            }
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_short_batch_answer_retries_the_unanswered_resources() {
+        // A backend that answers for fewer resources than it was given must
+        // not lose the rest: they go through the single-write path.
+        let single_calls = AtomicUsize::new(0);
+        let outcome = write_batched(
+            4,
+            2,
+            "CompartmentDefinition",
+            resources(3),
+            |_| async move { vec![Ok(())] },
+            |_| {
+                single_calls.fetch_add(1, Ordering::SeqCst);
+                async move { Ok(()) }
+            },
+        )
+        .await;
+        assert_eq!(single_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(outcome.created, 3);
+        assert_eq!(outcome.failed, 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn batch_rejects_that_keep_failing_count_as_failed() {
+        let outcome = write_batched(
+            8,
+            1,
+            "SearchParameter",
+            resources(2),
+            |batch| async move { batch.iter().map(|_| Err(transient())).collect() },
+            |_| async move { Err(transient()) },
+        )
+        .await;
+        assert_eq!(outcome.created, 0);
+        assert_eq!(outcome.failed, 2);
     }
 }

--- a/crates/persistence/tests/composite_conformance_sync.rs
+++ b/crates/persistence/tests/composite_conformance_sync.rs
@@ -89,3 +89,149 @@ async fn conformance_seeding_reaches_the_search_secondary() {
         "secondary CompartmentDefinitions after sync (#462: these were the ones going missing)"
     );
 }
+
+/// Synchronous sync is the mode the Inferno legs run in, and the one where the
+/// seed's writes each waited on the secondary: seeding now goes through
+/// `create_many`, which the composite forwards to the secondary as a batch
+/// (`SyncManager::sync_creates`). Both sets must be in the secondary the
+/// moment seeding returns — no worker to wait for — and a second seed must
+/// find everything already there without writing a duplicate.
+#[tokio::test]
+async fn synchronous_batch_seeding_reaches_the_search_secondary() {
+    let primary = Arc::new(SqliteBackend::in_memory().expect("primary"));
+    primary.init_schema().expect("primary schema");
+    let secondary = Arc::new(SqliteBackend::in_memory().expect("secondary"));
+    secondary.init_schema().expect("secondary schema");
+
+    let config = CompositeConfig::builder()
+        .primary("sqlite", BackendKind::Sqlite)
+        .search_backend("search", BackendKind::Sqlite)
+        .sync_mode(SyncMode::Synchronous)
+        .build()
+        .expect("composite config");
+
+    let mut backends: HashMap<String, DynStorage> = HashMap::new();
+    backends.insert("sqlite".to_string(), primary.clone() as DynStorage);
+    backends.insert("search".to_string(), secondary.clone() as DynStorage);
+
+    let composite = CompositeStorage::new(config, backends).expect("composite");
+
+    let first = helios_persistence::search::seed_tenant_conformance(
+        &composite,
+        FhirVersion::R4,
+        &data_dir(),
+        "default",
+    )
+    .await;
+    assert!(first.created > 1000, "first seed created: {first:?}");
+    assert_eq!(first.failed, 0, "first seed: {first:?}");
+
+    let t = tenant();
+    for resource_type in ["SearchParameter", "CompartmentDefinition"] {
+        let in_primary = primary.count(&t, Some(resource_type)).await.unwrap();
+        let in_secondary = secondary.count(&t, Some(resource_type)).await.unwrap();
+        assert!(in_primary > 0, "{resource_type} in primary");
+        assert_eq!(
+            in_secondary, in_primary,
+            "{resource_type}: synchronous batch sync leaves the secondary complete on return"
+        );
+    }
+
+    let second = helios_persistence::search::seed_tenant_conformance(
+        &composite,
+        FhirVersion::R4,
+        &data_dir(),
+        "default",
+    )
+    .await;
+    assert_eq!(second.created, 0, "second seed: {second:?}");
+    assert_eq!(second.failed, 0, "second seed: {second:?}");
+    assert_eq!(
+        second.existing,
+        first.created + first.existing,
+        "second seed finds every resource already present"
+    );
+    let sp_after = secondary.count(&t, Some("SearchParameter")).await.unwrap();
+    assert_eq!(
+        sp_after,
+        primary.count(&t, Some("SearchParameter")).await.unwrap(),
+        "re-seeding writes nothing new to the secondary"
+    );
+}
+
+/// Per-item semantics survive the batch: the primary's `AlreadyExists` for a
+/// duplicate id comes back in that item's slot, and only the resources the
+/// primary accepted are synced to the secondary.
+#[tokio::test]
+async fn create_many_reports_per_item_outcomes_and_syncs_only_accepted_ones() {
+    use serde_json::json;
+
+    let primary = Arc::new(SqliteBackend::in_memory().expect("primary"));
+    primary.init_schema().expect("primary schema");
+    let secondary = Arc::new(SqliteBackend::in_memory().expect("secondary"));
+    secondary.init_schema().expect("secondary schema");
+
+    let config = CompositeConfig::builder()
+        .primary("sqlite", BackendKind::Sqlite)
+        .search_backend("search", BackendKind::Sqlite)
+        .sync_mode(SyncMode::Synchronous)
+        .build()
+        .expect("composite config");
+    let mut backends: HashMap<String, DynStorage> = HashMap::new();
+    backends.insert("sqlite".to_string(), primary.clone() as DynStorage);
+    backends.insert("search".to_string(), secondary.clone() as DynStorage);
+    let composite = CompositeStorage::new(config, backends).expect("composite");
+
+    let t = tenant();
+    composite
+        .create(
+            &t,
+            "Patient",
+            json!({"resourceType": "Patient", "id": "taken"}),
+            FhirVersion::R4,
+        )
+        .await
+        .expect("seed the duplicate");
+
+    let results = composite
+        .create_many(
+            &t,
+            "Patient",
+            vec![
+                json!({"resourceType": "Patient", "id": "fresh-1"}),
+                json!({"resourceType": "Patient", "id": "taken"}),
+                json!({"resourceType": "Patient", "id": "fresh-2"}),
+            ],
+            FhirVersion::R4,
+        )
+        .await;
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].as_ref().expect("fresh-1").id(), "fresh-1");
+    assert!(
+        matches!(
+            results[1],
+            Err(helios_persistence::error::StorageError::Resource(
+                helios_persistence::error::ResourceError::AlreadyExists { .. }
+            ))
+        ),
+        "duplicate id reports AlreadyExists in its own slot: {:?}",
+        results[1]
+    );
+    assert_eq!(results[2].as_ref().expect("fresh-2").id(), "fresh-2");
+
+    assert_eq!(primary.count(&t, Some("Patient")).await.unwrap(), 3);
+    assert_eq!(
+        secondary.count(&t, Some("Patient")).await.unwrap(),
+        3,
+        "the two accepted resources (plus the earlier one) reached the secondary"
+    );
+    assert!(
+        secondary
+            .read(&t, "Patient", "fresh-2")
+            .await
+            .unwrap()
+            .is_some(),
+        "an item after a rejected one is still synced"
+    );
+}

--- a/crates/persistence/tests/composite_conformance_sync.rs
+++ b/crates/persistence/tests/composite_conformance_sync.rs
@@ -235,3 +235,75 @@ async fn create_many_reports_per_item_outcomes_and_syncs_only_accepted_ones() {
         "an item after a rejected one is still synced"
     );
 }
+
+/// A transaction Bundle's entries used to be synced to the secondary one
+/// event at a time; they now go as one batch per resource type
+/// (`CompositeStorage::sync_bundle_results` → `SyncManager::sync_creates`).
+/// Every entry must be in the secondary when the transaction returns.
+#[tokio::test]
+async fn transaction_entries_reach_the_secondary_as_a_batch() {
+    use helios_persistence::core::{BundleEntry, BundleMethod, BundleProvider};
+    use serde_json::json;
+
+    let primary = Arc::new(SqliteBackend::in_memory().expect("primary"));
+    primary.init_schema().expect("primary schema");
+    let secondary = Arc::new(SqliteBackend::in_memory().expect("secondary"));
+    secondary.init_schema().expect("secondary schema");
+
+    let config = CompositeConfig::builder()
+        .primary("sqlite", BackendKind::Sqlite)
+        .search_backend("search", BackendKind::Sqlite)
+        .sync_mode(SyncMode::Synchronous)
+        .build()
+        .expect("composite config");
+    let mut backends: HashMap<String, DynStorage> = HashMap::new();
+    backends.insert("sqlite".to_string(), primary.clone() as DynStorage);
+    backends.insert("search".to_string(), secondary.clone() as DynStorage);
+    let composite = CompositeStorage::new(config, backends)
+        .expect("composite")
+        .with_full_primary(primary.clone());
+
+    let mut entries = Vec::new();
+    for i in 0..3 {
+        entries.push(BundleEntry {
+            method: BundleMethod::Post,
+            url: "Patient".to_string(),
+            resource: Some(json!({"resourceType": "Patient", "id": format!("tx-p{i}")})),
+            full_url: Some(format!("urn:uuid:tx-p{i}")),
+            ..Default::default()
+        });
+        entries.push(BundleEntry {
+            method: BundleMethod::Post,
+            url: "Observation".to_string(),
+            resource: Some(json!({
+                "resourceType": "Observation",
+                "id": format!("tx-o{i}"),
+                "status": "final",
+                "code": {"text": "hr"},
+                "subject": {"reference": format!("urn:uuid:tx-p{i}")}
+            })),
+            full_url: Some(format!("urn:uuid:tx-o{i}")),
+            ..Default::default()
+        });
+    }
+
+    let result = composite
+        .process_transaction(&tenant(), entries, FhirVersion::R4)
+        .await
+        .expect("transaction");
+    assert_eq!(result.entries.len(), 6);
+
+    let t = tenant();
+    assert_eq!(secondary.count(&t, Some("Patient")).await.unwrap(), 3);
+    assert_eq!(secondary.count(&t, Some("Observation")).await.unwrap(), 3);
+    let synced = secondary
+        .read(&t, "Observation", "tx-o2")
+        .await
+        .unwrap()
+        .expect("last observation synced");
+    assert_eq!(
+        synced.content()["subject"]["reference"],
+        json!("Patient/tx-p2"),
+        "the secondary holds the committed content, references resolved"
+    );
+}

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -2105,6 +2105,142 @@ mod es_integration {
         assert_eq!(result.resources.items[0].id(), "raw-composite-1");
     }
 
+    /// `create_many` is one `_bulk` request per batch, so under
+    /// `refresh=wait_for` a batch pays one refresh wait — not one per
+    /// document. With a 5s refresh interval, 40 per-document writes would
+    /// take over three minutes; the batch must finish in a few seconds. This
+    /// is the shape of the startup conformance seed that stalled the
+    /// sqlite-elasticsearch server past its readiness timeout.
+    #[tokio::test]
+    async fn es_integration_create_many_pays_one_refresh_wait_per_batch() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::SearchQuery;
+
+        let backend = create_backend_with("5s", WriteRefreshPolicy::WaitFor).await;
+        let tenant = create_tenant("bulk-wait-for");
+
+        let patients: Vec<_> = (0..40)
+            .map(|i| {
+                json!({
+                    "resourceType": "Patient",
+                    "id": format!("bulk-{i}"),
+                    "name": [{"family": "Bulk", "given": [format!("P{i}")]}]
+                })
+            })
+            .collect();
+
+        let started = std::time::Instant::now();
+        let results = backend
+            .create_many(&tenant, "Patient", patients, FhirVersion::default())
+            .await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(results.len(), 40, "one result per input");
+        for (i, result) in results.iter().enumerate() {
+            let stored = result
+                .as_ref()
+                .unwrap_or_else(|e| panic!("resource {i} failed: {e}"));
+            assert_eq!(stored.id(), format!("bulk-{i}"), "results keep input order");
+            assert_eq!(stored.version_id(), "1");
+        }
+        assert!(
+            elapsed < std::time::Duration::from_secs(20),
+            "40 resources under wait_for with a 5s refresh interval took {elapsed:?}; \
+             a batch must not pay one refresh wait per document"
+        );
+
+        // wait_for on the bulk request means every document is already
+        // searchable — no refresh needed.
+        let visible = backend
+            .search_count(&tenant, &SearchQuery::new("Patient"))
+            .await
+            .expect("count after batch create");
+        assert_eq!(
+            visible, 40,
+            "the whole batch is visible once the request returns"
+        );
+    }
+
+    /// The bulk path carries every document a resource contributes: a
+    /// server-assigned id when the resource has none, and the `_contained`
+    /// documents, which land in *their* type's index.
+    #[tokio::test]
+    async fn es_integration_create_many_assigns_ids_and_indexes_contained() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{ContainedMode, SearchQuery};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("bulk-contained");
+
+        let results = backend
+            .create_many(
+                &tenant,
+                "Observation",
+                vec![
+                    json!({
+                        "resourceType": "Observation",
+                        "status": "final",
+                        "code": {"text": "no id, server assigns one"}
+                    }),
+                    json!({
+                        "resourceType": "Observation",
+                        "id": "obs-with-contained",
+                        "status": "final",
+                        "code": {"text": "hr"},
+                        "contained": [{
+                            "resourceType": "Patient",
+                            "id": "inner",
+                            "name": [{"family": "Containedbulk"}]
+                        }],
+                        "subject": {"reference": "#inner"}
+                    }),
+                ],
+                FhirVersion::default(),
+            )
+            .await;
+        assert_eq!(results.len(), 2);
+        let assigned = results[0].as_ref().expect("first create").id().to_string();
+        assert!(!assigned.is_empty(), "server-assigned id");
+        assert_eq!(
+            results[0].as_ref().unwrap().content()["id"],
+            json!(assigned),
+            "the returned content carries the assigned id"
+        );
+        assert_eq!(
+            results[1].as_ref().expect("second create").id(),
+            "obs-with-contained"
+        );
+
+        backend
+            .refresh_index("bulk-contained", "Observation")
+            .await
+            .ok();
+        backend
+            .refresh_index("bulk-contained", "Patient")
+            .await
+            .ok();
+
+        let both = backend
+            .search(&tenant, &SearchQuery::new("Observation"))
+            .await
+            .expect("search observations");
+        assert_eq!(both.resources.items.len(), 2);
+
+        // The contained Patient is findable through `_contained=true`, which
+        // only works if its document reached the Patient index.
+        let mut contained = SearchQuery::new("Patient");
+        contained.contained = ContainedMode::On;
+        let found = backend
+            .search(&tenant, &contained)
+            .await
+            .expect("contained search");
+        assert_eq!(
+            found.resources.items.len(),
+            1,
+            "the contained Patient document was written to the Patient index"
+        );
+    }
+
     #[tokio::test]
     async fn es_integration_compartment_search() {
         // Compartment membership: a resource joins the Patient compartment if it

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -351,9 +351,14 @@ mod query_builder_tests {
         let query = SearchQuery::new("Patient");
         let body = build_count_query("acme", "Patient", &query);
 
-        // Count query should have size=0 and no sort
-        assert_eq!(body["size"], 0);
-        assert!(body.get("sort").is_none());
+        // `_count` accepts only `query`: anything else the search builder
+        // sets (size, sort, track_total_hits, ...) is a parsing_exception.
+        let keys: Vec<&String> = body.as_object().expect("object body").keys().collect();
+        assert_eq!(keys, vec!["query"], "count body: {body}");
+        assert!(
+            body["query"]["bool"].is_object(),
+            "the tenant filter survives"
+        );
     }
 }
 

--- a/crates/persistence/tests/sqlite_tests.rs
+++ b/crates/persistence/tests/sqlite_tests.rs
@@ -4205,3 +4205,92 @@ mod cross_tenant_search_isolation {
         );
     }
 }
+
+/// Inferno US Core's `_lastUpdated` search: a resource's own
+/// `meta.lastUpdated`, searched with `eq` at millisecond precision, must find
+/// that resource and only resources sharing that millisecond. Two things
+/// broke this: the date handler compared through `datetime()`, which drops
+/// fractional seconds (so a whole second matched), and the `last_updated`
+/// column carried nanoseconds that SQLite rounds to the nearest millisecond
+/// while `meta.lastUpdated` truncates — off by one millisecond either way.
+mod last_updated_millisecond_precision {
+    use super::*;
+    use helios_persistence::core::SearchProvider;
+    use helios_persistence::types::{
+        SearchParamType, SearchParameter, SearchPrefix, SearchQuery, SearchValue,
+    };
+
+    fn last_updated_query(prefix: SearchPrefix, value: &str) -> SearchQuery {
+        SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "_lastUpdated".to_string(),
+            param_type: SearchParamType::Date,
+            modifier: None,
+            values: vec![SearchValue::new(prefix, value)],
+            chain: vec![],
+            components: vec![],
+        })
+    }
+
+    fn bump_millis(instant: &str, delta_ms: i64) -> String {
+        let parsed = chrono::DateTime::parse_from_rfc3339(instant).expect("rfc3339");
+        (parsed + chrono::Duration::milliseconds(delta_ms))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+    }
+
+    #[tokio::test]
+    async fn eq_on_a_resources_own_last_updated_finds_exactly_that_millisecond() {
+        let backend = create_backend();
+        let tenant = create_tenant("ms-precision");
+
+        // Several resources written back to back land in the same second.
+        let mut ids = Vec::new();
+        for i in 0..5 {
+            let stored = backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({"resourceType": "Patient", "id": format!("ms-{i}")}),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+            let last_updated = stored.content_with_meta()["meta"]["lastUpdated"]
+                .as_str()
+                .expect("meta.lastUpdated")
+                .to_string();
+            ids.push((stored.id().to_string(), last_updated));
+        }
+
+        for (id, last_updated) in &ids {
+            let found = backend
+                .search(&tenant, &last_updated_query(SearchPrefix::Eq, last_updated))
+                .await
+                .unwrap();
+            let found_ids: Vec<&str> = found.resources.items.iter().map(|r| r.id()).collect();
+            assert!(
+                found_ids.contains(&id.as_str()),
+                "{id} must match its own lastUpdated {last_updated}, got {found_ids:?}"
+            );
+            for item in &found.resources.items {
+                assert_eq!(
+                    item.content_with_meta()["meta"]["lastUpdated"].as_str(),
+                    Some(last_updated.as_str()),
+                    "eq at millisecond precision must not return another millisecond"
+                );
+            }
+
+            // The neighbouring milliseconds are not this resource.
+            for delta in [-1, 1] {
+                let neighbour = bump_millis(last_updated, delta);
+                let found = backend
+                    .search(&tenant, &last_updated_query(SearchPrefix::Eq, &neighbour))
+                    .await
+                    .unwrap();
+                assert!(
+                    !found.resources.items.iter().any(|r| r.id() == id),
+                    "{id} ({last_updated}) must not match {neighbour}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The scheduled Inferno US Core run [34020931692](https://github.com/HeliosSoftware/hfs/actions/runs/34020931692) went red for two unrelated reasons. This PR fixes both (each needed a second round after the first branch run, [34056011998](https://github.com/HeliosSoftware/hfs/actions/runs/34056011998), exposed the next layer), plus a third bug found on the way.

### 1. Every `*-elasticsearch` leg: HFS never became ready, then transaction Bundles timed out

Since 2913df484 those legs run with `HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for`. That policy blocks each Elasticsearch write until the next scheduled refresh (1s), and the composite synced resources to ES one synchronous event at a time. Two places paid for it:

- **Startup seed** — ~1.4k conformance resources at concurrency 1 ⇒ ~1.4k refresh waits; `/health` never answered within 60s.
- **Transaction Bundles** — one sync event per entry ⇒ any bundle over ~30 entries hit the 30s request timeout (HTTP 408 on the Inferno data load).

Fix: a batch write on the storage trait, and every multi-resource sync path routed through it.

- `ResourceStorage::create_many` — one result per input, in order. Default fans `create` out at `bulk_write_concurrency`, so no backend changes behaviour unless it overrides.
- Elasticsearch overrides it with one `_bulk` request per 500 operations (contained documents included), applying the write-refresh policy once per request.
- The composite forwards a batch to the primary, then to each secondary as a batch (`SyncManager::sync_creates`); rejected items fall back to the existing per-event retry path; asynchronous mode still queues one event per resource.
- The seeder writes in batches of 256; a transaction's entries are synced one batch per resource type; the bulk-submit manifest sync (#882) batches each page of entry results.

Local reproduction of CI's environment: HFS ready in **11s** (CI run: 8s), 1,374 SearchParameters + 5 CompartmentDefinitions seeded.

The one path that cannot batch is the REST batch handler (heterogeneous entries, per-entry auth and audit): the `s3-elasticsearch` legs load a 473-entry Bundle as a *batch* because S3 has no transactions, and at 16-way concurrency that is ~30 refresh waits. CI now pairs `wait_for` with `HFS_ELASTICSEARCH_REFRESH_INTERVAL=200ms` (Inferno and UI-matrix workflows), which is the per-write price of `wait_for`.

### 2. `sqlite` v7.0.0 / v8.0.0 legs: `_lastUpdated` search failures

The SQLite date handler compared millisecond-precision values at second precision (a documented #456 trade-off). Latent until the recent SQLite write-path speedups let a transaction Bundle land all its resources inside one second; Inferno's exact-timestamp search then returned neighbouring resources. Values with fractional seconds now compare through `strftime('%f')`.

The first branch run then failed by exactly 1ms: `last_updated` holds nanoseconds, which SQLite *rounds* to the millisecond, while `meta.lastUpdated` truncates. Both sides are now cut to three fractional digits in SQL before the comparison. (Writing the column at millisecond precision was tried and rejected — a `since` captured in the same millisecond would then skip that resource in `modified_since`.)

### 3. ES `_total=accurate` returned 500 (since February)

`build_count_query` left `track_total_hits`/`size` in the `_count` body, which the API rejects. The body is now just the query clause.

## Tests

- Seeder unit tests for the batching core.
- ES integration: a 40-document `create_many` under `wait_for` with a 5s refresh interval must finish in seconds and be fully visible on return; contained docs and server-assigned ids through the bulk path.
- Composite (SQLite→SQLite, synchronous): seeding complete on the secondary on return, re-seed writes nothing, per-item `AlreadyExists` in its own slot, a 6-entry transaction fully synced.
- SQLite: the millisecond condition and the SQL truncation evaluated in a real connection; an end-to-end test that creates several resources in one second and searches each one's own `meta.lastUpdated` with `eq` plus its neighbouring milliseconds.

`cargo test -p helios-persistence` (lib, sqlite, composite, bulk-submit, ES via testcontainers), clippy with CI flags, `cargo fmt --check`, and `cargo check -p helios-hfs -p helios-rest --all-features --tests` all pass.

https://claude.ai/code/session_01Nu2HKgueYRegxFYEvV7XKS
