### PR TITLE
fix: UI backend-matrix nightly — base URL, diff race, MongoDB/S3 compartment filters

### DIFF
--- a/.github/workflows/ui-tests-matrix.yml
+++ b/.github/workflows/ui-tests-matrix.yml
@@ -326,21 +326,33 @@ jobs:
           export HFS_DATA_DIR="$GITHUB_WORKSPACE/data"
           export HFS_NL_SEARCH_API_KEY="e2e-placeholder-not-a-real-key"
           export HFS_DEFAULT_FHIR_VERSION=R4
+          # The browser runs in the Playwright container and reaches HFS over
+          # the runner's IP, so that is the origin HFS must advertise: every
+          # Bundle paging link, fullUrl and export manifest URL is built from
+          # HFS_BASE_URL, and the default (http://localhost:8080) is dead from
+          # inside the container — the results table's Next button fetched it
+          # and rendered nothing (nightly reds on every leg since #629 / PR #720 made the
+          # links honor the configured base).
+          export HFS_BASE_URL="http://$RUNNER_IP:$HFS_PORT"
           # The suite creates and immediately searches; on the ES composites
           # the default asynchronous sync races the specs (nightly reds since
           # the SearchParameter CRUD spec landed). Synchronous puts the write
           # in ES before the API responds, and wait_for blocks the write until
           # the index refresh so the document is searchable on return (the
-          # specs' waitSearchable remains as a backstop). Only the S3 composite stays
-          # asynchronous: against real S3 the extra per-write latency tipped
-          # the seed-heavy dashboard specs over their budgets (run 62), so
-          # that leg stays asynchronous and leans on the polls alone.
-          if [ "${{ matrix.backend }}" = "sqlite-elasticsearch" ] || \
-             [ "${{ matrix.backend }}" = "postgres-elasticsearch" ] || \
-             [ "${{ matrix.backend }}" = "mongodb-elasticsearch" ]; then
-            export HFS_COMPOSITE_SYNC_MODE=synchronous
-            export HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for
-          fi
+          # specs' waitSearchable remains as a backstop). The conformance
+          # seed at boot and on tenant provisioning goes through ES `_bulk`,
+          # so wait_for is paid once per batch, not once per resource (#962).
+          #
+          # The S3 composite joins in now that it runs against MinIO on the
+          # Docker host: the real-S3 latency that once tipped the seed-heavy
+          # specs over budget (run 62) is gone, and asynchronous indexing left
+          # the SQL pages reading stale rails after every save.
+          case "${{ matrix.backend }}" in
+            *elasticsearch*)
+              export HFS_COMPOSITE_SYNC_MODE=synchronous
+              export HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for
+              ;;
+          esac
 
           if [ "${{ matrix.backend }}" = "sqlite-elasticsearch" ]; then
             HFS_STORAGE_BACKEND=sqlite-elasticsearch \

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -429,6 +429,55 @@ fn document_to_stored_resource(
     ))
 }
 
+/// The in-process SQL-on-FHIR runner's view of the `resources` collection:
+/// every live resource of one type for a tenant, as FHIR JSON with the
+/// server's `meta.versionId`/`meta.lastUpdated` merged in (a `since` filter
+/// reads the latter). Backs the compartment-filter fallback in
+/// [`MongoBackend::sof_runner`](crate::core::ResourceStorage::sof_runner).
+struct MongoResourceScan {
+    client: std::sync::Arc<tokio::sync::OnceCell<mongodb::Client>>,
+    config: super::backend::MongoBackendConfig,
+}
+
+#[async_trait]
+impl crate::sof::in_process::ResourceScan for MongoResourceScan {
+    async fn scan_resources(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+    ) -> Result<Vec<Value>, crate::core::sof_runner::SofError> {
+        use crate::core::sof_runner::SofError;
+
+        let client = self
+            .client
+            .get_or_try_init(|| super::backend::connect_client(&self.config))
+            .await
+            .map_err(|e| SofError::Storage(e.to_string()))?;
+        let resources = client
+            .database(&self.config.database_name)
+            .collection::<Document>(MongoBackend::RESOURCES_COLLECTION);
+        let filter = doc! {
+            "tenant_id": tenant.tenant_id().as_str(),
+            "resource_type": resource_type,
+            "is_deleted": false,
+        };
+        let cursor = resources
+            .find(filter)
+            .await
+            .map_err(|e| SofError::Storage(e.to_string()))?;
+        let docs = collect_documents(cursor)
+            .await
+            .map_err(|e| SofError::Storage(e.to_string()))?;
+        docs.iter()
+            .map(|doc| {
+                document_to_stored_resource(doc, tenant, resource_type)
+                    .map(StoredResource::into_content_with_meta)
+                    .map_err(|e| SofError::Storage(e.to_string()))
+            })
+            .collect()
+    }
+}
+
 async fn begin_required_bundle_transaction_session(
     db: &mongodb::Database,
 ) -> Result<ClientSession, TransactionError> {
@@ -540,13 +589,25 @@ impl ResourceStorage for MongoBackend {
     }
 
     fn sof_runner(&self) -> Option<std::sync::Arc<dyn crate::core::sof_runner::SofRunner>> {
+        use crate::sof::in_process::{InProcessSofRunner, ResourceScan};
         use crate::sof::mongodb::MongoInDbRunner;
         // Native in-DB runner: compiles the ViewDefinition to an aggregation
-        // pipeline executed against the `resources` collection.
-        Some(std::sync::Arc::new(MongoInDbRunner::new(
-            self.client_cell(),
-            self.config().clone(),
-        )))
+        // pipeline executed against the `resources` collection. Patient/group
+        // compartment filters are the one thing the pipeline compiler does not
+        // cover, so runs carrying them go to the in-process engine over a scan
+        // of the same collection — the runner S3 uses for everything — rather
+        // than failing as uncompilable (the SQL Export UI's job-wide filters
+        // ended every such job as `failed` on this backend).
+        let scan: std::sync::Arc<dyn ResourceScan> = std::sync::Arc::new(MongoResourceScan {
+            client: self.client_cell(),
+            config: self.config().clone(),
+        });
+        let fallback =
+            InProcessSofRunner::new(scan, self.config().fhir_version, "mongo-in-process");
+        Some(std::sync::Arc::new(
+            MongoInDbRunner::new(self.client_cell(), self.config().clone())
+                .with_compartment_fallback(std::sync::Arc::new(fallback)),
+        ))
     }
 
     async fn create(

--- a/crates/persistence/src/sof/in_process.rs
+++ b/crates/persistence/src/sof/in_process.rs
@@ -150,6 +150,21 @@ impl SofRunner for InProcessSofRunner {
             resources = filter_resources_by_since(resources, since).map_err(map_engine_error)?;
         }
         if !filters.patient.is_empty() || !filters.group.is_empty() {
+            // The compartment filter resolves `patient`/`group` references
+            // against the resources it is handed — a `Group/{id}` it cannot
+            // find is a hard error, and a Group's members are read off the
+            // Group itself — so the referenced types ride along with the
+            // scanned target type. They are pooled for the filter only: the
+            // engine evaluates the view's target type and ignores the rest.
+            for supporting in ["Patient", "Group"] {
+                let wanted = match supporting {
+                    "Patient" => !filters.patient.is_empty() || !filters.group.is_empty(),
+                    _ => !filters.group.is_empty(),
+                };
+                if wanted && supporting != resource_type {
+                    resources.extend(self.scan.scan_resources(tenant, supporting).await?);
+                }
+            }
             resources = filter_resources_by_patient_and_group(
                 resources,
                 &filters.patient,
@@ -157,6 +172,9 @@ impl SofRunner for InProcessSofRunner {
                 self.fhir_version,
             )
             .map_err(map_engine_error)?;
+            resources.retain(|r| {
+                r.get("resourceType").and_then(Value::as_str) == Some(resource_type.as_str())
+            });
         }
 
         // Storage-backed `resolve()` (opt-in): dereference the relative `Type/id`
@@ -385,6 +403,125 @@ mod tests {
             Value::Null,
             "without a resolver the Patient must not resolve: {:?}",
             rows[0]
+        );
+    }
+
+    fn compartment_pool() -> Vec<Value> {
+        vec![
+            json!({ "resourceType": "Patient", "id": "p1" }),
+            json!({ "resourceType": "Patient", "id": "p2" }),
+            json!({
+                "resourceType": "Group",
+                "id": "g1",
+                "type": "person",
+                "actual": true,
+                "member": [{ "entity": { "reference": "Patient/p1" } }]
+            }),
+            json!({
+                "resourceType": "Observation",
+                "id": "o1",
+                "status": "final",
+                "code": { "text": "x" },
+                "subject": { "reference": "Patient/p1" }
+            }),
+            json!({
+                "resourceType": "Observation",
+                "id": "o2",
+                "status": "final",
+                "code": { "text": "x" },
+                "subject": { "reference": "Patient/p2" }
+            }),
+        ]
+    }
+
+    fn observation_ids_view() -> Value {
+        json!({
+            "resourceType": "ViewDefinition",
+            "resource": "Observation",
+            "status": "active",
+            "select": [{ "column": [{ "path": "id", "name": "obs_id" }] }]
+        })
+    }
+
+    async fn observation_ids(runner: &InProcessSofRunner, filters: ViewFilters) -> Vec<String> {
+        let mut stream = runner
+            .run_view(&tenant(), observation_ids_view(), filters)
+            .await
+            .expect("run_view");
+        let mut ids = Vec::new();
+        while let Some(row) = stream.next().await {
+            ids.push(row.expect("row")["obs_id"].as_str().unwrap().to_string());
+        }
+        ids.sort();
+        ids
+    }
+
+    /// A `patient` filter on a view whose target type is not Patient: the
+    /// scan only yields Observations, so the referenced Patients have to be
+    /// pulled in for the compartment filter to recognise them.
+    #[tokio::test]
+    async fn patient_filter_scans_the_referenced_patients() {
+        let scan = std::sync::Arc::new(StaticScan {
+            resources: compartment_pool(),
+        });
+        let runner = InProcessSofRunner::new(scan, FhirVersion::R4, "test");
+
+        let ids = observation_ids(
+            &runner,
+            ViewFilters {
+                patient: vec!["Patient/p2".to_string()],
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_eq!(ids, vec!["o2"]);
+    }
+
+    /// A `group` filter: the Group and its member Patients ride along with
+    /// the scan, the members' compartment decides the rows, and neither the
+    /// Group nor the Patients leak into the view's output.
+    #[tokio::test]
+    async fn group_filter_scans_the_group_and_its_members() {
+        let scan = std::sync::Arc::new(StaticScan {
+            resources: compartment_pool(),
+        });
+        let runner = InProcessSofRunner::new(scan, FhirVersion::R4, "test");
+
+        let ids = observation_ids(
+            &runner,
+            ViewFilters {
+                group: vec!["Group/g1".to_string()],
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_eq!(ids, vec!["o1"]);
+    }
+
+    /// A `group` reference that resolves to no stored Group is still the
+    /// spec's absent-target error, not an empty result.
+    #[tokio::test]
+    async fn absent_group_is_an_error() {
+        let scan = std::sync::Arc::new(StaticScan {
+            resources: compartment_pool(),
+        });
+        let runner = InProcessSofRunner::new(scan, FhirVersion::R4, "test");
+
+        let err = runner
+            .run_view(
+                &tenant(),
+                observation_ids_view(),
+                ViewFilters {
+                    group: vec!["Group/nope".to_string()],
+                    ..Default::default()
+                },
+            )
+            .await
+            .err()
+            .expect("an absent Group is refused");
+        assert!(
+            matches!(err, SofError::InvalidViewDefinition(ref m) if m.contains("Group/nope")),
+            "{err:?}"
         );
     }
 }

--- a/crates/persistence/src/sof/mongodb.rs
+++ b/crates/persistence/src/sof/mongodb.rs
@@ -35,12 +35,28 @@ pub struct MongoInDbRunner {
     /// Shared (lazily initialised) client cell — the same pool the backend uses.
     client: Arc<OnceCell<Client>>,
     config: MongoBackendConfig,
+    /// Where a run with `patient`/`group` filters goes: the pipeline compiler
+    /// has no compartment predicate yet, so those runs are handed to another
+    /// runner (the backend wires the in-process engine over a scan of the
+    /// same collection) instead of failing as uncompilable.
+    compartment_fallback: Option<Arc<dyn SofRunner>>,
 }
 
 impl MongoInDbRunner {
     /// Creates a runner sharing the backend's client cell and configuration.
     pub fn new(client: Arc<OnceCell<Client>>, config: MongoBackendConfig) -> Self {
-        Self { client, config }
+        Self {
+            client,
+            config,
+            compartment_fallback: None,
+        }
+    }
+
+    /// Routes runs that carry `patient`/`group` filters to `runner`. Without
+    /// one, such a run is refused as uncompilable.
+    pub fn with_compartment_fallback(mut self, runner: Arc<dyn SofRunner>) -> Self {
+        self.compartment_fallback = Some(runner);
+        self
     }
 
     /// Resolves the `resources` collection, initialising the shared client on
@@ -70,11 +86,22 @@ impl SofRunner for MongoInDbRunner {
         filters: ViewFilters,
     ) -> Result<RowStream, SofError> {
         if !filters.patient.is_empty() || !filters.group.is_empty() {
-            // Compartment filtering for the Mongo runner lands in a later stage.
-            return Err(SofError::Uncompilable {
-                reason: "patient/group filters are not yet supported by the MongoDB runner"
-                    .to_string(),
-            });
+            // Compartment filtering has no pipeline form yet: hand the run to
+            // the fallback runner when the backend wired one.
+            return match &self.compartment_fallback {
+                Some(runner) => {
+                    debug!(
+                        runner = runner.runner_name(),
+                        tenant = %tenant.tenant_id(),
+                        "patient/group filters: delegating the view run"
+                    );
+                    runner.run_view(tenant, view_definition, filters).await
+                }
+                None => Err(SofError::Uncompilable {
+                    reason: "patient/group filters are not yet supported by the MongoDB runner"
+                        .to_string(),
+                }),
+            };
         }
 
         let compiled = compile_view_definition_mongo(&view_definition, self.config.fhir_version)?;

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -2688,6 +2688,112 @@ async fn mongodb_integration_search_missing_not_and_param_sort() {
     assert!(page2.resources.page_info.has_previous);
 }
 
+/// The in-DB runner compiles no compartment predicate, so a run carrying
+/// `patient`/`group` filters is handed to the in-process engine over a scan
+/// of the same collection instead of failing as uncompilable — and answers
+/// the rows the SQL runners answer for the same filters. An unfiltered run
+/// still takes the aggregation pipeline.
+#[tokio::test]
+async fn mongodb_integration_sof_runner_compartment_filters_fall_back_in_process() {
+    use helios_persistence::core::sof_runner::{SofRunner, ViewFilters};
+    use tokio_stream::StreamExt;
+
+    let Some(backend) = create_backend("sof_compartment_fallback").await else {
+        eprintln!(
+            "Skipping mongodb_integration_sof_runner_compartment_filters_fall_back_in_process (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let tenant = create_tenant("tenant-sof-compartment-fallback");
+
+    for resource in [
+        json!({ "resourceType": "Patient", "id": "sof-p1" }),
+        json!({ "resourceType": "Patient", "id": "sof-p2" }),
+        json!({
+            "resourceType": "Group",
+            "id": "sof-g1",
+            "type": "person",
+            "actual": true,
+            "member": [{ "entity": { "reference": "Patient/sof-p1" } }]
+        }),
+        json!({
+            "resourceType": "Observation",
+            "id": "sof-o1",
+            "status": "final",
+            "code": { "text": "x" },
+            "subject": { "reference": "Patient/sof-p1" }
+        }),
+        json!({
+            "resourceType": "Observation",
+            "id": "sof-o2",
+            "status": "final",
+            "code": { "text": "x" },
+            "subject": { "reference": "Patient/sof-p2" }
+        }),
+    ] {
+        let resource_type = resource["resourceType"].as_str().unwrap().to_string();
+        backend
+            .create(&tenant, &resource_type, resource, FhirVersion::default())
+            .await
+            .unwrap();
+    }
+
+    async fn observation_ids(
+        runner: &dyn SofRunner,
+        tenant: &TenantContext,
+        filters: ViewFilters,
+    ) -> Vec<String> {
+        let view = json!({
+            "resourceType": "ViewDefinition",
+            "resource": "Observation",
+            "status": "active",
+            "select": [{ "column": [{ "path": "id", "name": "obs_id" }] }]
+        });
+        let mut stream = runner
+            .run_view(tenant, view, filters)
+            .await
+            .expect("run_view must succeed");
+        let mut ids = Vec::new();
+        while let Some(row) = stream.next().await {
+            let row = row.expect("row must not be an error");
+            ids.push(row["obs_id"].as_str().unwrap().to_string());
+        }
+        ids.sort();
+        ids
+    }
+
+    let runner = backend.sof_runner().expect("MongoDB provides a SOF runner");
+
+    assert_eq!(
+        observation_ids(runner.as_ref(), &tenant, ViewFilters::default()).await,
+        vec!["sof-o1", "sof-o2"]
+    );
+    assert_eq!(
+        observation_ids(
+            runner.as_ref(),
+            &tenant,
+            ViewFilters {
+                patient: vec!["Patient/sof-p2".to_string()],
+                ..Default::default()
+            },
+        )
+        .await,
+        vec!["sof-o2"]
+    );
+    assert_eq!(
+        observation_ids(
+            runner.as_ref(),
+            &tenant,
+            ViewFilters {
+                group: vec!["Group/sof-g1".to_string()],
+                ..Default::default()
+            },
+        )
+        .await,
+        vec!["sof-o1"]
+    );
+}
+
 #[tokio::test]
 async fn mongodb_integration_conditional_create_exists() {
     let Some(backend) = create_backend_with_full_registry("conditional_create").await else {

--- a/crates/ui/assets/history.js
+++ b/crates/ui/assets/history.js
@@ -164,6 +164,13 @@
 
   /* ---- post the two versions to be diffed ------------------------------ */
 
+  /* Each renderDiff() call takes a ticket; a response only lands if its
+   * ticket is still the newest. Two quick selections (a `change` on each
+   * select, say) start two fetches, and the server does not answer them in
+   * order — the first one's HTML arriving last would leave the diff showing
+   * a comparison nobody is asking for any more. */
+  var diffTicket = 0;
+
   function renderDiff() {
     var fromIndex = Number(fromSel.value);
     var toIndex = Number(toSel.value);
@@ -172,6 +179,7 @@
     if (!from || !to) return;
 
     markSelected(fromIndex, toIndex);
+    var ticket = ++diffTicket;
 
     var body = new URLSearchParams();
     body.set("from", JSON.stringify(from.resource));
@@ -186,6 +194,7 @@
         return response.text();
       })
       .then(function (html) {
+        if (ticket !== diffTicket) return;
         diffEl.innerHTML = html;
       });
   }

--- a/crates/ui/e2e/pages/api.ts
+++ b/crates/ui/e2e/pages/api.ts
@@ -97,6 +97,23 @@ export async function deleteResources(
   ids: string[],
   tenant?: string,
 ): Promise<void> {
+  // One request per DELETE_BATCH ids: a batch runs its entries at the
+  // backend's write concurrency inside the server's 30s request timeout,
+  // and on the ES composites (synchronous sync, refreshed writes) a 400-entry
+  // padding cleanup ran past it — a 408 with half the entries still live.
+  for (let start = 0; start < ids.length; start += DELETE_BATCH) {
+    await deleteBatch(request, type, ids.slice(start, start + DELETE_BATCH), tenant);
+  }
+}
+
+const DELETE_BATCH = 100;
+
+async function deleteBatch(
+  request: APIRequestContext,
+  type: string,
+  ids: string[],
+  tenant?: string,
+): Promise<void> {
   if (ids.length === 0) return;
   const bundle = {
     resourceType: "Bundle",

--- a/crates/ui/e2e/tests/resources.spec.ts
+++ b/crates/ui/e2e/tests/resources.spec.ts
@@ -456,9 +456,16 @@ test("the recently-used selection survives a reload", async ({ resources, page }
   // writes anything on its own — only the two picks in between do.
   await resources.goto();
   await resources.pickType("Encounter");
+  // The rail chains its writes (each PATCH waits for the previous one to
+  // settle), so the PATCH to wait on is specifically the one carrying the
+  // second pick: the first match on "any settings PATCH" is Encounter's when
+  // the server is more than a loopback away, and reloading on that one
+  // cancels Observation's before it is even sent.
   const persisted = page.waitForResponse(
     (response) =>
-      response.url().includes("/_user/settings") && response.request().method() === "PATCH",
+      response.url().includes("/_user/settings") &&
+      response.request().method() === "PATCH" &&
+      (response.request().postData() ?? "").includes('"Observation"'),
   );
   await resources.pickType("Observation");
   await persisted;

--- a/crates/ui/src/conformance.rs
+++ b/crates/ui/src/conformance.rs
@@ -701,7 +701,11 @@ impl ConformanceSource for HttpConformanceSource {
         }
         let url = format!("{}/{resource_type}", self.base_url);
         let mut query: Vec<(String, String)> = params.to_vec();
-        query.push(("_count".to_string(), count.to_string()));
+        // One more than the page: whether a further page exists is read off
+        // the overflow row, not only the Bundle's `next` link — MongoDB
+        // issues no page cursors (and so no `next` link) for a search sorted
+        // by a search parameter, and the rails always sort by `name`.
+        query.push(("_count".to_string(), (count + 1).to_string()));
         query.push(("_offset".to_string(), offset.to_string()));
         let request = self.client.get(&url).query(&query).header(
             "Accept",
@@ -722,9 +726,12 @@ impl ConformanceSource for HttpConformanceSource {
             .json()
             .await
             .map_err(|e| format!("parsing {resource_type} search results failed: {e}"))?;
+        let mut resources = extract_bundle_resources(&bundle);
+        let overflow = resources.len() > count;
+        resources.truncate(count);
         Ok(SearchPage {
-            resources: extract_bundle_resources(&bundle),
-            has_next: next_link(&bundle).is_some(),
+            resources,
+            has_next: overflow || next_link(&bundle).is_some(),
         })
     }
 
@@ -1524,8 +1531,10 @@ mod tests {
     }
 
     /// #741: `search_page` issues one request with the given params plus
-    /// `_count`/`_offset`, and derives `has_next` from the response Bundle's
-    /// `next` link (present or absent).
+    /// `_count` (one over the page, so a further page shows up as an
+    /// overflow row even from a server that issues no `next` link — MongoDB
+    /// on a parameter sort) and `_offset`, and derives `has_next` from that
+    /// overflow or the response Bundle's `next` link (present or absent).
     #[tokio::test]
     async fn http_search_page_sends_params_count_offset_and_reports_has_next() {
         use axum::extract::Query;
@@ -1579,7 +1588,7 @@ mod tests {
             .await
             .expect("search succeeds");
         assert_eq!(first.resources[0]["name:contains"], "pat");
-        assert_eq!(first.resources[0]["_count"], "50");
+        assert_eq!(first.resources[0]["_count"], "51");
         assert_eq!(first.resources[0]["_offset"], "0");
         assert!(first.has_next, "server advertised a next link");
 


### PR DESCRIPTION
## Summary

The nightly **UI Tests (backend matrix)** run ([34015624145](https://github.com/HeliosSoftware/hfs/actions/runs/34015624145)) has been red every night since 2026-08-26. It is a stack of unrelated causes; this PR fixes everything that #962 does not. **Land #962 first**: it batches the ES conformance seed so the `sqlite-elasticsearch` leg actually starts under `wait_for` — this PR keeps `wait_for` and relies on that.

### Workflow (`ui-tests-matrix.yml`)
- **Every leg, `queries.spec.ts:45` (results table paging):** the matrix never set `HFS_BASE_URL`. Since #629 / #720 every Bundle paging link is built from it, and the default `http://localhost:8080` is dead from inside the Playwright container, so *Next* fetched nothing. Now `HFS_BASE_URL=http://$RUNNER_IP:$HFS_PORT`. (The per-PR `ui-tests.yml` was unaffected because `boot.mjs` sets it to the loopback port.)
- **`s3-elasticsearch`:** joins the synchronous + `wait_for` legs. It runs on MinIO now, and asynchronous indexing left the SQL pages reading stale rails after every save (the CodeMirror/rail-filter/subject-list failures on that leg).

### UI
- **`history.js` (`history.spec.ts:76` on postgres, mongodb, mongodb-es):** two quick select changes start two `/ui/history/diff` POSTs and the server does not answer in order; the older HTML landing last left the diff on the wrong comparison. A request ticket now drops stale responses.
- **`conformance.rs` `search_page` (`sql-view-definitions.spec.ts:244` on mongodb):** MongoDB issues no page cursor, hence no `next` link, for a parameter-sorted search (documented, #881), and the rails always sort by `name`, so the View Definitions rail never showed *Next* past 50 there. The page now requests `_count+1` and reads *has next* off the overflow row as well as the link.

### Persistence
- **MongoDB SOF runner (`sql-export.spec.ts:529`, `nojs/sql-export.spec.ts:235` on both mongodb legs):** runs with `patient`/`group` filters were refused as uncompilable, so every SQL Export with job-wide Patients/Groups ended `failed`. `MongoInDbRunner` now delegates such runs to a fallback; `MongoBackend` wires the in-process engine over a scan of the `resources` collection (the runner S3 uses for everything). Unfiltered runs still take the aggregation pipeline. New integration test in `mongodb_tests.rs`.
- **In-process SOF runner (same specs on `s3-elasticsearch`):** it only scanned the view's target type, so a `group` filter (or a `patient` filter on a non-Patient view) always failed with `not found in supplied resources`. Referenced Patient/Group resources are now scanned alongside the target type for the compartment filter, and dropped from the engine's input afterwards. Unit tests added.

### e2e
- **`resources.spec.ts:453` (every leg):** the rail chains its settings PATCHes, so waiting on "any settings PATCH" matched the first pick's and the reload cancelled the second's. The spec now waits for the PATCH carrying the second pick.
- **`api.ts` `deleteResources` (`nojs/sql-export.spec.ts:68` on the ES legs):** a 400-entry cleanup batch ran past the 30s request timeout under synchronous ES writes and came back 408 with half the entries live. Deletes go 100 per batch Bundle.

## Verification
- `cargo test -p helios-persistence --lib sof::in_process` and `cargo test -p helios-ui search_page`: pass.
- `mongodb_integration_sof_runner_compartment_filters_fall_back_in_process` against a MongoDB testcontainer: pass.
- `cargo clippy` with CI's flag set on `helios-persistence` and `helios-ui`: clean.
- Touched Playwright specs (`history`, `resources`, `queries`, `sql-view-definitions`, `sql-export`) against a booted sqlite `hfs`: 140 passed.
- Merged cleanly against #962's branch in a dry run (different files).

The matrix itself is nightly/manual; a `workflow_dispatch` run on this branch after #962 lands is the real check.

https://claude.ai/code/session_01H4MrhvPKTWfb5H3ESJvruw
