### PR TITLE
fix(persistence): serialize concurrent first writes of a user's settings in Postgres

### DIFF
--- a/crates/persistence/src/backends/postgres/user_settings.rs
+++ b/crates/persistence/src/backends/postgres/user_settings.rs
@@ -2,9 +2,13 @@
 //!
 //! Each user owns a single row in the `user_settings` table holding an opaque
 //! JSONB document plus a monotonic `version` used for optimistic locking. Writes
-//! run a `SELECT … FOR UPDATE` read-modify-write inside a transaction so
-//! concurrent updates to the same user serialize correctly and the `If-Match`
-//! precondition is checked against the live row.
+//! take a transaction-scoped, two-part `pg_advisory_xact_lock` — this module's
+//! [`USER_SETTINGS_LOCK_NAMESPACE`] paired with `hashtext(user_key)` — before
+//! the read-modify-write, then run a `SELECT … FOR UPDATE` inside that same
+//! transaction so concurrent updates to the same user serialize correctly and
+//! the `If-Match` precondition is checked against the live row — the advisory
+//! lock is what makes that true even for a user's very first write, where
+//! `FOR UPDATE` has no row yet to lock (see [`PostgresBackend::write_settings`]).
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -17,6 +21,23 @@ use crate::error::{BackendError, ConcurrencyError, StorageError, StorageResult};
 
 use super::PostgresBackend;
 
+/// First key of the two-part [`pg_advisory_xact_lock`][pg-advisory] this module
+/// takes in [`PostgresBackend::write_settings`].
+///
+/// PostgreSQL keeps the single-bigint-key form (used by the migration lock in
+/// [`schema::MIGRATION_LOCK_KEY`](super::schema)) and the two-int4-key form in
+/// entirely separate lock spaces, so `user_settings`' locks can never collide
+/// with the migration lock regardless of this constant's value. What this
+/// namespace guards against is a *future* two-int4-key advisory lock elsewhere
+/// in HFS: pairing every `user_settings` lock with this fixed first key
+/// reserves it as this module's own sub-space of the two-key form, so a later
+/// caller's second key — whatever it hashes to — can never land on a key this
+/// module also holds. Arbitrary but must stay stable across releases: changing
+/// it only changes which in-flight locks a rolling deploy's old and new
+/// instances fail to recognize as the same key, which matters only while an
+/// upgrade is in progress.
+const USER_SETTINGS_LOCK_NAMESPACE: i32 = 0x4855_5354; // "HUST" (HFS User SeTtings)
+
 impl PostgresBackend {
     /// Read-modify-write a user's settings document inside a single transaction,
     /// locking the row with `SELECT … FOR UPDATE`.
@@ -25,6 +46,25 @@ impl PostgresBackend {
     /// has no settings yet) and returns the document to persist. The optimistic
     /// `if_match_version` precondition — where `Some(0)` asserts "does not yet
     /// exist" — is checked against the locked row before `compute` runs.
+    ///
+    /// Before that `SELECT`, this takes a transaction-scoped
+    /// [`pg_advisory_xact_lock`][pg-advisory] keyed on
+    /// `(USER_SETTINGS_LOCK_NAMESPACE, hashtext(user_key))`: `FOR UPDATE`
+    /// only blocks on a row that already exists, so two concurrent writers
+    /// creating the *same* user's first document both read `None`, both compute
+    /// `new_version = 1`, and the `INSERT … ON CONFLICT DO UPDATE` loser
+    /// silently clobbers the winner instead of hitting the `if_match_version`
+    /// check. The advisory lock closes that gap by serializing the whole
+    /// read-modify-write — including the case with no row to lock — per user
+    /// key. It is released automatically on commit or rollback (the `_xact`
+    /// variant), never needs an explicit unlock, and is cheap because
+    /// PostgreSQL hashes the lock id into an in-memory table rather than
+    /// touching disk. Under `READ COMMITTED` (this pool's default), the
+    /// `SELECT` that runs once the lock is acquired sees a fresh snapshot that
+    /// already includes whatever the previous holder committed, so the second
+    /// writer correctly observes the row the first one just created.
+    ///
+    /// [pg-advisory]: https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS
     async fn write_settings(
         &self,
         user_key: &str,
@@ -36,6 +76,21 @@ impl PostgresBackend {
             .transaction()
             .await
             .map_err(|e| backend_err(format!("begin user_settings transaction: {e}")))?;
+
+        // `hashtext` folds the user key into an `int4` lock id computed by the
+        // server, so every HFS instance — even a different version mid rolling
+        // deploy — hashes a given `user_key` to the same id; see
+        // `USER_SETTINGS_LOCK_NAMESPACE` for why it is paired with a fixed
+        // first key. Collisions between unrelated users are possible but
+        // harmless: they only cause writes to two different users to
+        // serialize against each other on rare hash collisions, never a
+        // correctness issue.
+        txn.execute(
+            "SELECT pg_advisory_xact_lock($1, hashtext($2))",
+            &[&USER_SETTINGS_LOCK_NAMESPACE, &user_key],
+        )
+        .await
+        .map_err(|e| backend_err(format!("lock user_settings: {e}")))?;
 
         let current = txn
             .query_opt(
@@ -95,6 +150,18 @@ impl PostgresBackend {
     /// an offboarding must not be able to half-apply, leaving a tenant's saved
     /// queries behind after its records are gone. `FOR UPDATE` serialises against
     /// a concurrent `/_user/settings` write, which locks the same rows.
+    ///
+    /// Deliberately does *not* take [`write_settings`](Self::write_settings)'s
+    /// per-user `pg_advisory_xact_lock` before its bulk `FOR UPDATE`: doing so
+    /// would need one lock per existing row, for no benefit — a purge has no
+    /// "row does not exist yet" case to protect against, since it only ever
+    /// touches rows a `SELECT` already found. Skipping it also rules out a
+    /// deadlock between the two paths. A writer only ever waits on its own
+    /// resources, in order (its advisory lock, then its own row); a purge only
+    /// ever waits on rows locked by another transaction. So the one lock a
+    /// blocked writer can be holding while it waits — its advisory lock — is
+    /// never something a purge waits on, which is what would be required to
+    /// close a cycle.
     ///
     /// The edit is done on a parsed `Value` via the shared
     /// [`purge_tenant_subtree`] rather than with `jsonb #-`, for two reasons: all

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -5693,6 +5693,167 @@ mod postgres_integration {
         assert_eq!(ok.version, 2);
     }
 
+    /// A dedicated backend with one physical connection per writer, so a
+    /// concurrency test can put every racer in flight at once instead of
+    /// queuing behind `create_backend`'s shared 5-connection pool. Mirrors
+    /// `postgres_integration_concurrent_pool_connections_all_carry_statement_timeout`'s
+    /// pattern of building a bespoke config against the shared container.
+    async fn create_backend_with_pool_size(pool_size: usize) -> PostgresBackend {
+        let pg = shared_pg().await;
+        let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.join("data"))
+            .unwrap_or_else(|| PathBuf::from("data"));
+        let config = PostgresConfig {
+            host: pg.host.clone(),
+            port: pg.port,
+            dbname: "postgres".to_string(),
+            user: "postgres".to_string(),
+            password: Some("postgres".to_string()),
+            max_connections: pool_size,
+            data_dir: Some(data_dir),
+            ..Default::default()
+        };
+        PostgresBackend::new(config)
+            .await
+            .expect("Failed to create PostgresBackend")
+    }
+
+    /// Forces `count` physical connections into existence and back into the
+    /// idle pool before a race starts.
+    ///
+    /// deadpool creates connections lazily, and establishing a fresh one
+    /// (TCP handshake + PostgreSQL startup/auth) can take longer than the
+    /// whole read-modify-write these concurrency tests race — so on a cold
+    /// pool, a barrier-released batch can end up serialized by connection
+    /// setup alone: writer 1 finishes its entire transaction while writer 2
+    /// is still waiting for its connection, which defeats the test. Holding
+    /// `count` clients at once (forcing that many distinct connections) and
+    /// then dropping them back into the pool removes that confound.
+    async fn warm_pool(backend: &PostgresBackend, count: usize) {
+        let mut clients = Vec::with_capacity(count);
+        for _ in 0..count {
+            clients.push(backend.get_client().await.expect("warm connection"));
+        }
+        drop(clients);
+    }
+
+    /// A user's very first write is the case `SELECT … FOR UPDATE` cannot
+    /// protect on its own: with no row yet, there is nothing for the lock to
+    /// block on, so racing writers must instead serialize on
+    /// `write_settings`'s `pg_advisory_xact_lock`. Without it, every racer
+    /// reads `None`, computes `new_version = 1` from an empty document, and
+    /// the `INSERT … ON CONFLICT DO UPDATE` losers silently overwrite the
+    /// winner — a lost update on creation. Firing many unconditional
+    /// single-key patches at a brand-new user key and requiring every key to
+    /// survive, with the version landing on exactly the writer count, is the
+    /// same shape as `mongodb_integration_settings_concurrent_patches_serialize`.
+    ///
+    /// Runs on a multi-thread runtime with a dedicated pool sized to the
+    /// writer count and a [`tokio::sync::Barrier`] releasing every task at
+    /// once — a single-threaded runtime, or a shared pool a racer might queue
+    /// behind, can make the whole batch execute close enough to sequentially
+    /// that even the unfixed code never actually hits the race.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn postgres_integration_settings_concurrent_first_writes_never_lose_an_update() {
+        use std::sync::Arc;
+
+        const WRITERS: usize = 8;
+        let backend = Arc::new(create_backend_with_pool_size(WRITERS).await);
+        warm_pool(&backend, WRITERS).await;
+        let user = unique_user_key("concurrent-first-write");
+        let barrier = Arc::new(tokio::sync::Barrier::new(WRITERS));
+
+        let mut handles = Vec::with_capacity(WRITERS);
+        for i in 0..WRITERS {
+            let backend = backend.clone();
+            let user = user.clone();
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                backend
+                    .patch_settings(&user, json!({ format!("k{i}"): i }), None)
+                    .await
+            }));
+        }
+        for h in handles {
+            h.await
+                .expect("patch task panicked")
+                .expect("patch_settings failed");
+        }
+
+        let final_doc = backend
+            .get_settings(&user)
+            .await
+            .unwrap()
+            .expect("settings document missing after concurrent first writes");
+        let obj = final_doc.document.as_object().unwrap();
+        for i in 0..WRITERS {
+            assert_eq!(
+                obj.get(&format!("k{i}")),
+                Some(&json!(i)),
+                "key k{i} was lost to a read-modify-write race on the user's first write"
+            );
+        }
+        // WRITERS patches, each a distinct successful write from version 0 upward.
+        assert_eq!(final_doc.version, WRITERS as i64);
+    }
+
+    /// The `if_match_version = Some(0)` half of the same race: every racer
+    /// asserts "this user does not exist yet", so exactly one `put_settings`
+    /// call may succeed and the rest must observe the loser's own creation as
+    /// an optimistic-lock conflict — never a raw backend error, and never a
+    /// second silent `Ok`. Uses the same error shape as
+    /// `postgres_integration_settings_optimistic_lock`.
+    ///
+    /// Same multi-thread + dedicated-pool + barrier setup as
+    /// `postgres_integration_settings_concurrent_first_writes_never_lose_an_update`,
+    /// for the same reason: this must exercise real concurrent creates, not a
+    /// batch that happens to run one at a time.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn postgres_integration_settings_concurrent_creates_have_a_single_winner() {
+        use std::sync::Arc;
+
+        const WRITERS: usize = 8;
+        let backend = Arc::new(create_backend_with_pool_size(WRITERS).await);
+        warm_pool(&backend, WRITERS).await;
+        let user = unique_user_key("concurrent-create");
+        let barrier = Arc::new(tokio::sync::Barrier::new(WRITERS));
+
+        let mut handles = Vec::with_capacity(WRITERS);
+        for i in 0..WRITERS {
+            let backend = backend.clone();
+            let user = user.clone();
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                backend
+                    .put_settings(&user, json!({"createdBy": i}), Some(0))
+                    .await
+            }));
+        }
+
+        let mut ok_count = 0;
+        let mut conflict_count = 0;
+        for h in handles {
+            match h.await.expect("put task panicked") {
+                Ok(stored) => {
+                    ok_count += 1;
+                    assert_eq!(stored.version, 1);
+                }
+                Err(StorageError::Concurrency(ConcurrencyError::OptimisticLockFailure {
+                    ..
+                })) => {
+                    conflict_count += 1;
+                }
+                Err(other) => panic!("expected an optimistic-lock conflict, got {other:?}"),
+            }
+        }
+        assert_eq!(ok_count, 1, "exactly one create should win the race");
+        assert_eq!(conflict_count, WRITERS - 1);
+    }
+
     /// Issue #313: a tenant purge must reach the PHI-derived query strings a
     /// client stores in its settings document. Those rows are keyed by *user*,
     /// so none of `purge_tenant_data`'s tenant-scoped deletes touch them.

--- a/crates/persistence/tests/sqlite_user_settings_concurrency.rs
+++ b/crates/persistence/tests/sqlite_user_settings_concurrency.rs
@@ -1,12 +1,16 @@
-//! #833 (ticket 02 validation, FALLA V4): concurrent writers to the same
-//! `user_settings` row on a file-backed SQLite store (WAL) used to fail with
-//! a raw "database is locked" backend error instead of either succeeding or
-//! reporting an optimistic-lock conflict — `write_settings` and
-//! `purge_tenant_settings` opened a DEFERRED transaction that reads before it
-//! writes, and under WAL a deferred transaction's read-to-write upgrade fails
-//! with `SQLITE_BUSY_SNAPSHOT` the instant another connection committed in
-//! between, a failure mode the busy handler (and its configured
-//! `busy_timeout`) never sees. This drives the real symptom — the UI's SQL
+//! Regression coverage for #833: concurrent writers racing the same
+//! `user_settings` row on a file-backed SQLite store (WAL) used to surface a
+//! raw "database is locked" backend error instead of either succeeding or
+//! reporting an optimistic-lock conflict. `write_settings` and
+//! `purge_tenant_settings` read the current row before writing the new one,
+//! so opening that transaction as the SQLite default, DEFERRED, let it take
+//! its read snapshot on the first `SELECT` and then fail the read-to-write
+//! upgrade with `SQLITE_BUSY_SNAPSHOT` the instant another connection
+//! committed in between — a failure mode the busy handler (and its
+//! configured `busy_timeout`) never gets a chance to retry. The fix opens
+//! these transactions as `BEGIN IMMEDIATE` instead, taking the write lock up
+//! front so the conflict is resolved by SQLite's normal lock queue rather
+//! than a snapshot failure. This exercises the real symptom — the UI's SQL
 //! Export kick-off, which reads-then-writes the settings document per job —
 //! against a real file, not `:memory:`, since only a real file exercises
 //! WAL's multi-connection snapshot behavior.


### PR DESCRIPTION
Closes #894 (labelled `candidate`; surfaced in the review of #887, see https://github.com/HeliosSoftware/hfs/pull/887#discussion_r3914180678).

## Problem

`PostgresBackend::write_settings` guards its read-modify-write with `SELECT … FOR UPDATE`, which only locks rows that exist. On a user's **first** write there is no row, so two concurrent writers both read "missing", both compute `version = 1`, and the second upsert silently overwrites the first. With `If-Match: W/"0"` ("create only if absent") the loser gets an OK instead of an optimistic-lock failure.

Postgres was the only backend with this gap: SQLite was closed in #887 (`BEGIN IMMEDIATE`), MongoDB rejects the duplicate key, S3 uses `If-None-Match: *`.

## Fix

- `write_settings` takes a transaction-scoped `pg_advisory_xact_lock(USER_SETTINGS_LOCK_NAMESPACE, hashtext($user_key))` right after `BEGIN`, before the existing `FOR UPDATE`. The lock is released with the commit/rollback; no explicit unlock, no retry loop, no isolation-level change.
- The hash is computed by Postgres (`hashtext`), so every HFS instance agrees on the key across a rolling deploy. The `i32` namespace reserves this module's slice of the two-key advisory lock space for any future two-key lock HFS might add. `hashtext` collisions between different users only serialize two unrelated writes.
- The tenant purge deliberately does **not** take the per-user lock: it only touches rows it already found under `FOR UPDATE`, so there is no missing-row case and no wait cycle with `write_settings`. Documented on the function.
- Module doc rewritten to describe the actual locking strategy.

No schema, public signature, error type, or other-backend changes.

## Tests

Two Postgres integration tests (`postgres_tests.rs`, "Per-user settings store") race 8 writers against a fresh user key behind a `tokio::sync::Barrier` on a pre-warmed, dedicated pool (multi-thread runtime, no sleeps):

- unconditional `patch_settings` × 8 → all 8 keys present, `version == 8`
- `put_settings` with `if_match_version = Some(0)` × 8 → exactly one `Ok` (version 1), seven `OptimisticLockFailure`, no raw backend error

Both fail consistently (3/3 runs) with the advisory lock statement removed and pass consistently (6/6 runs) with it. Full Postgres suite: 160 passed.

End-to-end against a real HFS on Postgres: 8 concurrent `PUT /_user/settings` with `If-Match: "0"` → one 200, seven 412; 8 concurrent `PATCH` → ETag 8 with all keys.

## Also in this PR

- `test(persistence)`: the module doc of the #833 SQLite concurrency test opened with planning-process wording that does not belong in the repo. Rewritten to describe DEFERRED vs `BEGIN IMMEDIATE` under WAL on its own terms. Comments only.

## Observed while validating, out of scope

- `patch_user_settings` in `helios-rest` absorbs a lost race for callers without a precondition with only two retries; under very high contention (8 simultaneous PATCHes from one user) a writer can get a 412 after losing three rounds. Backend-independent (reproduced on SQLite too), predates this change, and never loses a confirmed write. Worth its own issue.
- `shared_pg` in `postgres_tests.rs` keeps the container in a static `OnceCell` that is never dropped, so every `cargo test … --test postgres_tests` invocation leaves an orphan `postgres:16-alpine` container behind; enough of them make testcontainers hit `WaitContainer(StartupTimeout)`. Worth its own issue.