### PR TITLE
fix(bulk-submit): operator-legible progress line

### DIFF
--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -774,10 +774,11 @@ where
                     .await
                 {
                     Ok(result) => {
-                        processed_ref.fetch_add(
-                            result.counts.success + result.counts.skipped,
-                            Ordering::Relaxed,
-                        );
+                        // Successes only, matching the per-batch increment on the
+                        // storage side: `processed_entries` means resources written
+                        // to the store, and the progress line words it that way
+                        // (#954). Skipped entries surface through their receipts.
+                        processed_ref.fetch_add(result.counts.success, Ordering::Relaxed);
                         failed_ref.fetch_add(result.counts.error_count(), Ordering::Relaxed);
                     }
                     Err(e) => {

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -38,6 +38,20 @@ const SUBMIT_SCOPE: &str = "bulk-submit";
 /// Query parameter selecting a status-manifest page (1-based).
 const PAGE_PARAM: &str = "page";
 
+/// Groups a count into thousands (`609191` → `"609,191"`) for the
+/// operator-facing progress line (#954).
+fn group_thousands(n: u64) -> String {
+    let digits = n.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, c) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
 fn external_download_url(download: &DownloadUrl) -> Option<String> {
     (!download.requires_access_token).then(|| download.url.clone())
 }
@@ -807,9 +821,16 @@ where
             );
             format!("stalled at {pct}% - a worker stopped without handoff; see server logs")
         } else if entries > 0 {
-            format!("processing {pct}% complete ({entries} entries ingested)")
+            // Operator-facing wording (#954): the percentage is byte progress,
+            // the count is FHIR resources written to the store ("written", not
+            // "searchable" — under deferred indexing search follows the
+            // per-manifest reindex).
+            format!(
+                "Processing {pct}% of bytes — {} resources written",
+                group_thousands(entries)
+            )
         } else {
-            format!("processing {pct}% complete")
+            format!("Processing {pct}% of bytes")
         };
         return Response::builder()
             .status(StatusCode::ACCEPTED)

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -44,7 +44,7 @@ fn group_thousands(n: u64) -> String {
     let digits = n.to_string();
     let mut out = String::with_capacity(digits.len() + digits.len() / 3);
     for (i, c) in digits.chars().enumerate() {
-        if i > 0 && (digits.len() - i) % 3 == 0 {
+        if i > 0 && (digits.len() - i).is_multiple_of(3) {
             out.push(',');
         }
         out.push(c);

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -1169,6 +1169,17 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn group_thousands_groups_digits_from_the_right() {
+        assert_eq!(group_thousands(0), "0");
+        assert_eq!(group_thousands(7), "7");
+        assert_eq!(group_thousands(999), "999");
+        assert_eq!(group_thousands(1_000), "1,000");
+        assert_eq!(group_thousands(609_191), "609,191");
+        assert_eq!(group_thousands(14_709_697), "14,709,697");
+        assert_eq!(group_thousands(100_000_000), "100,000,000");
+    }
+
+    #[test]
     fn presigned_download_url_is_preserved_byte_for_byte() {
         let url = "https://s3.example/object?X-Amz-Signature=a%2Fb&x=1";
         let download = DownloadUrl {

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -1174,7 +1174,7 @@ async fn test_poll_percentage_tracks_ingested_bytes() {
         .unwrap()
         .to_string();
     assert!(
-        progress.contains("processing 35% complete"),
+        progress.contains("Processing 35% of bytes"),
         "the percentage must follow ingested bytes, got: {progress}"
     );
 }

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -1187,7 +1187,13 @@ pub async fn status_fragment(
 /// bar about to fill, not a percentage that never moves — the indeterminate
 /// sweep is reserved for recipients that report no percentage at all.
 fn progress_percent(progress: &str) -> Option<u8> {
-    let rest = progress.strip_prefix("processing ")?;
+    // Case-insensitive: HFS capitalizes the line ("Processing 3% of bytes —
+    // …", #954), older HFS versions and foreign recipients may send lowercase
+    // "processing 3% complete …". Either way the digits follow the prefix.
+    let rest = progress
+        .get(..11)
+        .filter(|p| p.eq_ignore_ascii_case("processing "))
+        .and_then(|_| progress.get(11..))?;
     let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
     let pct: u8 = digits.parse().ok().filter(|p| *p <= 100)?;
     Some(pct)
@@ -1241,6 +1247,24 @@ pub async fn test_auth(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn progress_percent_reads_both_hfs_wordings_and_foreign_case() {
+        // Current HFS wording (#954).
+        assert_eq!(
+            progress_percent("Processing 3% of bytes — 609,191 resources written"),
+            Some(3)
+        );
+        assert_eq!(progress_percent("Processing 0% of bytes"), Some(0));
+        // Pre-#954 HFS and lowercase foreign recipients.
+        assert_eq!(
+            progress_percent("processing 10% complete (5 entries ingested)"),
+            Some(10)
+        );
+        // Non-matching recipients keep the indeterminate sweep.
+        assert_eq!(progress_percent("halfway there"), None);
+        assert_eq!(progress_percent("processing lots"), None);
+    }
 
     #[test]
     fn recipient_base_preserves_prefix_and_adds_path_tenant() {


### PR DESCRIPTION
Closes #954.

Reproduced live before the change, against a 6.4M-entry import running on stock main:

```
x-progress: processing 5% complete (227700 entries ingested)
```

## What changed

- **The line** is now `Processing 5% of bytes — 227,700 resources written`: capitalized (it sits under a card heading reading "Processing"), the percentage names its unit (it is *byte* progress), the count says "resources" instead of the internal "entries", with thousands separators.
- **"written", deliberately** — not "ingested" and not implying searchable: under `HFS_BULK_SUBMIT_DEFER_INDEXING` resources are durable before they are findable, which is exactly the ambiguity the old wording invited.
- **The UI parser** (`progress_percent`) is now case-insensitive and keeps accepting the older lowercase wording. This is the trap the issue calls out: capitalizing the server string alone would have silently degraded the determinate bar to the indeterminate sweep (the #827 regression), and the UI renders `X-Progress` from whatever recipient it polls, not only HFS. New unit test covers current wording, pre-change wording, and non-matching foreign strings.
- **The counter now means one thing.** Per-batch updates added successes only while the file-boundary overwrite wrote success + skipped; both now count successes, matching "written". Skipped entries surface through their receipts.

## Tests

helios-ui lib + `bulk_import_http` integration (29), helios-rest lib (580), persistence `bulk_submit` (47) — all green.

Out of scope, per the issue: pre-ingest phase reporting (#953) and localization of the line (would need a structured status contract rather than a prose header — noted in #954 for a separate decision).