### PR TITLE
fix(ui): diagnose bulk-submit poll failures and back off after one

### DIFF
--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -718,7 +718,7 @@ async fn backend_services_token(client_id: &str, token_url: &str) -> Result<Stri
     header.kid = signing_kid(&pem, &alg);
     let assertion = encode(&header, &claims, &key).map_err(|e| e.to_string())?;
 
-    let response = reqwest::Client::new()
+    let response = http_client()
         .post(token_url)
         .form(&[
             ("grant_type", "client_credentials"),
@@ -759,7 +759,7 @@ async fn post_kickoff(
     parameters: &Value,
 ) -> Result<(u16, String, String), String> {
     let target = kickoff_target(submission);
-    let mut request = reqwest::Client::new()
+    let mut request = http_client()
         .post(&target)
         .header("Content-Type", "application/fhir+json")
         .header("Accept", "application/fhir+json")
@@ -837,7 +837,7 @@ async fn status_kickoff(submission: &Submission, id: &str) -> Result<String, Str
         .collect();
     let body = json!({ "resourceType": "Parameters", "parameter": identifying });
 
-    let mut request = reqwest::Client::new()
+    let mut request = http_client()
         .post(&target)
         .header("Content-Type", "application/fhir+json")
         .header("Prefer", "respond-async")
@@ -855,6 +855,49 @@ async fn status_kickoff(submission: &Submission, id: &str) -> Result<String, Str
         .and_then(|v| v.to_str().ok())
         .map(String::from)
         .ok_or_else(|| format!("status kick-off answered {status} without Content-Location"))
+}
+
+/// How long a status poll may take before it is abandoned. During a heavy
+/// ingest the recipient's status handler contends with the writers and is
+/// legitimately slow — measured at 8-13s against a local recipient under a
+/// bulk load, past the previous 10s cap — so the cap is generous rather
+/// than snappy: a slow status is expected under load, not an outage. A poll
+/// that still times out logs its cause and backs off instead of hammering
+/// (#957).
+const STATUS_POLL_TIMEOUT_SECS: u64 = 30;
+
+/// How long to hold polls after a transport failure. The error branch used to
+/// leave `next_poll_at` in the past, so every subsequent 5s htmx tick fired
+/// another poll — the exact hammering the recipient's rate limit (#790)
+/// rejects (#957).
+const STATUS_POLL_FAILURE_BACKOFF_SECS: u64 = 30;
+
+/// Shared HTTP client. A per-request `reqwest::Client::new()` rebuilds the
+/// connection pool and resolver every call, so every poll paid a fresh TCP
+/// connect and nothing was ever kept alive (#957).
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+/// Renders a poll transport failure with its cause. `reqwest::Error`'s
+/// `Display` stops at the URL and hides the reason in `source()`, which made
+/// a timeout, a refused connection, and a reset log byte-identically (#957).
+fn poll_failure_detail(e: &reqwest::Error) -> String {
+    if e.is_timeout() {
+        return format!(
+            "timed out after {STATUS_POLL_TIMEOUT_SECS}s — the recipient's status \
+             endpoint can be slow while it is ingesting"
+        );
+    }
+    let mut detail = e.to_string();
+    let mut src = std::error::Error::source(e);
+    while let Some(cause) = src {
+        detail.push_str(": ");
+        detail.push_str(&cause.to_string());
+        src = cause.source();
+    }
+    detail
 }
 
 /// Whether the recipient asked us to hold off: a stored `next_poll_at` still
@@ -887,16 +930,23 @@ fn retry_after_seconds(response: &reqwest::Response) -> Option<u64> {
 /// never turns into a poll the recipient would reject (#790).
 async fn poll_status(submission: &mut Submission) {
     let poll_url = submission.poll_url.clone();
-    let response = match reqwest::Client::new()
+    let response = match http_client()
         .get(&poll_url)
         .header("Accept", "application/json")
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(STATUS_POLL_TIMEOUT_SECS))
         .send()
         .await
     {
         Ok(r) => r,
         Err(e) => {
-            push_log(submission, format!("Status poll failed: {e}"));
+            push_log(
+                submission,
+                format!("Status poll failed: {}", poll_failure_detail(&e)),
+            );
+            // A failed poll honors a backoff too — without this,
+            // `next_poll_at` stays in the past and every 5s tick re-polls,
+            // sailing through the recipient's rate limit (#957).
+            hold_polls_for(submission, STATUS_POLL_FAILURE_BACKOFF_SECS);
             return;
         }
     };


### PR DESCRIPTION
Closes #957.

## Reproduction — the issue's timeout hypothesis, confirmed

Sampled the status endpoint's latency live while a 6.4M-entry import ran on stock main:

| resources ingested | poll latency |
|---|---|
| 228k | 0.1 s |
| 605k | 8.0 s |
| **737k** | **13.0 s — past the old 10 s cap** |

Exactly the failure mode in the issue's log (its failures began ~4.5M resources in). The handler's reads contend with the ingest writers and traverse a large WAL, so slow-under-load is an expected condition, not an outage.

## The four fixes, per the issue's suggested approach

1. **The log names the cause.** A timeout logs a human phrase ("timed out after 30s — the recipient's status endpoint can be slow while it is ingesting"); every other transport error prints its full `source()` chain instead of reqwest's URL-only `Display`. The next occurrence is self-diagnosing.
2. **A failed poll backs off.** The error branch now calls `hold_polls_for(30s)`; previously it left `next_poll_at` in the past, so every 5s htmx tick re-polled — the exact hammering the recipient's 10-per-60s rate limit (#790) exists to reject.
3. **Timeout raised to 30s**, with the measurement in the doc comment. Combined with (1) and (2), a poll that still exceeds it costs one legible log line and a 30s hold, not a hammer.
4. **One shared `reqwest::Client`** across the module's four call sites (each `Client::new()` built a fresh pool and resolver, forfeiting keep-alive). The editor's separate client is left for its own change, per the issue's scope.

## Tests

helios-ui lib (239) + `bulk_import_http` integration (29) — green. The existing tests that feed lowercase/foreign `X-Progress` strings and rate-limit behavior all pass unchanged.

Out of scope, per the issue: making the status handler itself faster under ingest load (the latency curve above is recorded on #957 for that follow-up).