### PR TITLE
fix: ui: Bulk Import Submission Log never refreshes while the PROCESSING card polls — log entries are written but only reach the page on reload

### DIFF
--- a/crates/ui/e2e/pages/bulk-import.ts
+++ b/crates/ui/e2e/pages/bulk-import.ts
@@ -6,7 +6,8 @@ import type { APIRequestContext, Locator, Page } from "@playwright/test";
 export class BulkImportPage {
   constructor(readonly page: Page) {}
 
-  async seedAndGoto(request: APIRequestContext, name = "e2e-bulk-import-detail"): Promise<string> {
+  /** Creates a submission and returns its detail path, without navigating. */
+  async seed(request: APIRequestContext, name = "e2e-bulk-import-detail"): Promise<string> {
     const response = await request.post("/ui/bulk-import", {
       form: {
         name,
@@ -21,6 +22,11 @@ export class BulkImportPage {
         `seeding a bulk-import submission did not redirect to detail (got ${response.status()} ${location ?? "no Location"})`,
       );
     }
+    return location;
+  }
+
+  async seedAndGoto(request: APIRequestContext, name = "e2e-bulk-import-detail"): Promise<string> {
+    const location = await this.seed(request, name);
     await this.page.goto(location, { waitUntil: "networkidle" });
     return location;
   }
@@ -49,5 +55,23 @@ export class BulkImportPage {
 
   get logEmptyState(): Locator {
     return this.logCard.locator(".empty-state");
+  }
+
+  get statusCard(): Locator {
+    return this.page.locator("#bulk-status");
+  }
+
+  get statusCell(): Locator {
+    return this.page.locator("#submission-status");
+  }
+
+  /** The log's entries, newest first, as the browser currently renders them. */
+  async logLines(): Promise<string[]> {
+    const entries = this.logCard.locator("pre.detail__code");
+    if ((await entries.count()) === 0) return [];
+    return (await entries.innerText())
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
   }
 }

--- a/crates/ui/e2e/tests/bulk-import.spec.ts
+++ b/crates/ui/e2e/tests/bulk-import.spec.ts
@@ -267,3 +267,72 @@ test("Test authentication reports its outcome inside the dialog", async ({ page 
   await page.locator("button[formaction='/ui/bulk-import/test-auth']").click();
   await expect(page.locator("#test-auth-result .field__hint")).toBeVisible();
 });
+
+// #955: the status card polls every 5s, but the Submission Log below it used to
+// stay frozen at whatever the page was served with — the entries each poll
+// recorded only surfaced on a full reload. The status fragment now re-emits the
+// log out of band, so this drives the real browser: hold the load-triggered
+// poll, photograph the first paint, let the poll through, and require the DOM
+// to have been patched in place.
+//
+// The Rust ring already asserts the fragment's markup (bulk_import_http.rs);
+// what only a browser can prove is that htmx actually applies the swap, that it
+// lands on the page's own log rather than appending a second card, and that the
+// newest-first order survives it.
+test("the polled status fragment refreshes the Submission Log without a reload", async ({
+  page,
+  request,
+  bulkImport,
+}) => {
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route("**/ui/bulk-import/*/status", async (route) => {
+    await held;
+    await route.continue();
+  });
+
+  const detail = await bulkImport.seed(request, "e2e-955-oob-log");
+  await page.goto(detail, { waitUntil: "domcontentloaded" });
+
+  // First paint: the log is already populated (kick-off wrote to it) and the
+  // status card is still the empty shell waiting on its `load` trigger.
+  const before = await bulkImport.logLines();
+  expect(before.length).toBeGreaterThan(0);
+  // The page's own copy must not carry the out-of-band attribute, or htmx
+  // would treat the served markup itself as an orphan swap.
+  await expect(bulkImport.logCard).not.toHaveAttribute("hx-swap-oob", /.*/);
+  expect((await bulkImport.statusCard.innerHTML()).trim()).toBe("");
+
+  // A reload would refresh the log too, and would pass a naive assertion.
+  // Tag this document so only an in-place patch can satisfy the checks below.
+  await page.evaluate(() => {
+    (window as unknown as { __sameDocument: boolean }).__sameDocument = true;
+  });
+
+  release();
+
+  await expect
+    .poll(async () => (await bulkImport.logLines()).length, { timeout: 20_000 })
+    .toBeGreaterThan(before.length);
+  const after = await bulkImport.logLines();
+
+  expect(
+    await page.evaluate(
+      () => (window as unknown as { __sameDocument?: boolean }).__sameDocument === true,
+    ),
+  ).toBe(true);
+  // One log, patched — not a second card grafted onto the page.
+  await expect(page.locator("#submission-log")).toHaveCount(1);
+  // Newest first: the fresh entries are prepended and nothing already shown
+  // is reordered or dropped.
+  expect(after.slice(after.length - before.length)).toEqual(before);
+  const stamps = after.map((line) => line.split(/\s+/)[0]);
+  expect(stamps).toEqual([...stamps].sort().reverse());
+  // The same single response also refreshed the card and the STATUS cell, so
+  // no region of the page is left behind by the one that moved.
+  expect((await bulkImport.statusCard.innerHTML()).trim()).not.toBe("");
+  await expect(bulkImport.statusCell).toHaveCount(1);
+  await expect(bulkImport.statusCell).not.toBeEmpty();
+});

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -250,6 +250,29 @@ struct LogLine {
     message: String,
 }
 
+/// The submission's log as `partials/bulk_import_log.html` wants it:
+/// newest-first, so the detail page's first paint and the status fragment's
+/// out-of-band refresh agree on the order (#955).
+fn log_lines(submission: &Submission) -> Vec<LogLine> {
+    submission
+        .log
+        .iter()
+        .rev()
+        .map(|entry| LogLine {
+            at: entry
+                .get("at")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            message: entry
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+        })
+        .collect()
+}
+
 fn status_label(i18n: &I18n, status: &str) -> String {
     match status {
         "in-progress" => i18n.t("bulk-import-status-in-progress"),
@@ -288,6 +311,8 @@ struct BulkImportDetailPage {
     client_id: String,
     token_url: String,
     log: Vec<LogLine>,
+    /// The page paints the log in place, never out-of-band.
+    log_oob: bool,
     error: Option<String>,
     edit_open: bool,
 }
@@ -458,24 +483,7 @@ fn render_detail_page(
         .unwrap_or("")
         .to_string();
 
-    let log: Vec<LogLine> = s
-        .log
-        .iter()
-        .rev()
-        .map(|entry| LogLine {
-            at: entry
-                .get("at")
-                .and_then(Value::as_str)
-                .unwrap_or("")
-                .to_string(),
-            message: entry
-                .get("message")
-                .and_then(Value::as_str)
-                .unwrap_or("")
-                .to_string(),
-        })
-        .collect();
-
+    let log = log_lines(&s);
     let label = status_label(&i18n, &s.status);
     render(BulkImportDetailPage {
         status,
@@ -504,6 +512,7 @@ fn render_detail_page(
         client_id: s.client_id,
         token_url: s.token_url,
         log,
+        log_oob: false,
         error,
         edit_open,
     })
@@ -1145,6 +1154,10 @@ struct StatusCard {
     completed_at: String,
     /// Rides out-of-band into the summary card's STATUS cell.
     status_label: String,
+    /// Rides out-of-band into the Submission Log section, whose lines this
+    /// poll may have just written (#955).
+    log: Vec<LogLine>,
+    log_oob: bool,
 }
 
 /// `GET /ui/bulk-import/{id}/status` — at most one recipient poll, then the
@@ -1178,6 +1191,8 @@ pub async fn status_fragment(
         errors: s.result["errors"].as_u64().unwrap_or(0),
         completed_at: s.result["completedAt"].as_str().unwrap_or("").to_string(),
         status_label: label,
+        log: log_lines(&s),
+        log_oob: true,
         i18n,
     })
 }

--- a/crates/ui/templates/pages/bulk-import-detail.html
+++ b/crates/ui/templates/pages/bulk-import-detail.html
@@ -52,10 +52,5 @@
 
 <div id="bulk-status" hx-get="/ui/bulk-import/{{ id }}/status" hx-trigger="load" hx-swap="outerHTML"></div>
 
-<section class="card table-card">
-  <div class="toolbar"><h2 class="toolbar__title">{{ i18n.t("bulk-import-log") }}</h2></div>
-  {% if log.is_empty() %}<div class="empty-state">{{ i18n.t("bulk-import-log-empty") }}</div>
-  {% else %}<pre class="detail__code">{% for line in log %}{{ line.at }}  {{ line.message }}
-{% endfor %}</pre>{% endif %}
-</section>
+{% include "partials/bulk_import_log.html" %}
 {% endblock %}

--- a/crates/ui/templates/partials/bulk_import_log.html
+++ b/crates/ui/templates/partials/bulk_import_log.html
@@ -1,0 +1,11 @@
+{# The Submission Log. Included by the detail page's first paint and, with
+   `log_oob`, re-emitted out-of-band by the status fragment so an open page
+   never drifts behind the entries each 5s poll records (#955). `log` is
+   newest-first in both, and the whole block is replaced rather than appended
+   to, because `LOG_CAP` trimming can drop old lines server-side. #}
+<section id="submission-log" class="card table-card"{% if log_oob %} hx-swap-oob="true"{% endif %}>
+  <div class="toolbar"><h2 class="toolbar__title">{{ i18n.t("bulk-import-log") }}</h2></div>
+  {% if log.is_empty() %}<div class="empty-state">{{ i18n.t("bulk-import-log-empty") }}</div>
+  {% else %}<pre class="detail__code">{% for line in log %}{{ line.at }}  {{ line.message }}
+{% endfor %}</pre>{% endif %}
+</section>

--- a/crates/ui/templates/partials/bulk_import_status.html
+++ b/crates/ui/templates/partials/bulk_import_status.html
@@ -54,3 +54,6 @@
 {# The summary card's STATUS cell rides along out-of-band, so the page-level
    status never goes stale while the card polls (#765 follow-up). #}
 <div id="submission-status" hx-swap-oob="true">{{ status_label }}</div>
+{# So does the Submission Log, whose lines this same poll just recorded
+   (#955) — one response keeps both regions current. #}
+{% include "partials/bulk_import_log.html" %}

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -1237,6 +1237,52 @@ async fn status_polling_tracks_progress_and_lands_the_result() {
     assert!(detail.contains("got 200 OK"));
 }
 
+/// #955: the polled fragment writes log lines, so it must carry them back.
+/// Before this, an open page kept the log it was loaded with while the card
+/// advanced, and only a reload caught it up.
+#[tokio::test]
+async fn the_polled_status_fragment_refreshes_the_log_out_of_band() {
+    let (recipient_url, _) = mock_recipient_with_status().await;
+    let ctx = ctx(&recipient_url);
+    let detail_path = create_submission(&ctx).await;
+
+    // The page paints the log in place — same section, no out-of-band hook.
+    let (_, page) = get(&ctx, &detail_path).await;
+    assert!(
+        page.contains(r#"<section id="submission-log" class="card table-card">"#),
+        "{page}"
+    );
+    assert!(!page.contains("Status: processing 0% complete"));
+
+    // First poll: the fragment records a new line and ships the whole log
+    // back out-of-band, newest-first like the page renders it.
+    let (status, html) = get(&ctx, &format!("{detail_path}/status")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains(
+            r#"<section id="submission-log" class="card table-card" hx-swap-oob="true">"#
+        ),
+        "{html}"
+    );
+    assert!(html.contains("Status: processing 0% complete"), "{html}");
+    let newest = html.find("Status: processing 0% complete").unwrap();
+    let oldest = html.find("Bulk status kick-off request").unwrap();
+    assert!(newest < oldest, "log stays newest-first: {html}");
+
+    // Second poll completes the submission: polling stops, and the terminal
+    // response still carries the closing line so the log never trails the
+    // result card.
+    let (_, html) = get(&ctx, &format!("{detail_path}/status")).await;
+    assert!(!html.contains("every 5s"), "polling stopped: {html}");
+    assert!(
+        html.contains(
+            r#"<section id="submission-log" class="card table-card" hx-swap-oob="true">"#
+        ),
+        "{html}"
+    );
+    assert!(html.contains("processing finished cleanly"), "{html}");
+}
+
 /// The UI route became a permanent redirect to the server-level JWKS when
 /// `/.well-known/bulk-submit-jwks.json` landed; existing registrations keep
 /// working through it.


### PR DESCRIPTION
Closes #955

The Bulk Import submission detail page only polls the #bulk-status fragment, so the Submission Log below it never updates until a manual reload, even though poll_status writes and persists log entries on every poll. The fix adds a log field to the StatusCard view model and emits the rendered log out-of-band from the status partial, reusing the same hx-swap-oob pattern already used for the #submission-status cell, so a single 5s request refreshes both regions. Shared newest-first ordering and an always-present OOB target (including on the terminal, non-polling render) are the details to get right.

_PR auto-generated by claude-agent; fix implemented with Claude Code and validated with the Playwright e2e suite._