### PR TITLE
fix(hfs): make headless a runtime switch so --all-features keeps the web UI

### DIFF
--- a/.claude/skills/run-hfs-server/SKILL.md
+++ b/.claude/skills/run-hfs-server/SKILL.md
@@ -36,6 +36,7 @@ HFS_SERVER_PORT=3000 HFS_LOG_LEVEL=debug cargo run --bin hfs
 | `HFS_BASE_URL` | `http://localhost:8080` | Base URL for Location headers and Bundle links |
 | `HFS_DATA_DIR` | `./data` | FHIR data directory, including search parameters |
 | `HFS_SEARCH_PARAM_CACHE_TTL` | `3600` | Seconds between refreshes of the in-memory SearchParameter registry from storage; a param POSTed to one cluster node becomes visible to others within this interval. `0` disables the refresh. |
+| `HFS_UI_ENABLED` | `true` | Serve the web UI at `/ui`. `false` = headless (`/ui` returns 404 + OperationOutcome). Replaces the removed `headless` build feature (#975) |
 
 ## Limits
 

--- a/.claude/skills/work-with-ui/SKILL.md
+++ b/.claude/skills/work-with-ui/SKILL.md
@@ -37,12 +37,12 @@ Handlers return a **full page** on a hard navigation and an **HTML fragment** on
 cargo run -p helios-hfs            # then open http://127.0.0.1:8080/ui
 cargo run -p helios-hfs --features ui
 
-# Headless deployments: `headless` wins over `ui`.
-cargo run -p helios-hfs --features headless
+# Headless deployments: a runtime switch, not a build feature.
+HFS_UI_ENABLED=false cargo run -p helios-hfs
 ```
 
-The mount is `#[cfg(all(feature = "ui", not(feature = "headless")))]` in
-`crates/hfs/src/main.rs`. FHIR version features forward through
+The mount is `#[cfg(feature = "ui")]` plus the runtime `config.ui_enabled` check
+in `attach_ui` (`crates/hfs/src/main.rs`). FHIR version features forward through
 `helios-ui?/R4|R4B|R5|R6`, so the UI's viewers cover exactly the versions the
 server was built with.
 
@@ -316,5 +316,11 @@ across every storage backend.
   being on this router — don't hand-roll the header.
 - `/ui/search` does not exist when NL search is disabled; a test that navigates
   there unconditionally will 404.
-- The `headless` feature is checked as `not(feature = "headless")`, so enabling
-  both `ui` and `headless` yields **no UI**.
+- Headless operation is `HFS_UI_ENABLED=false`, **not** a Cargo feature. The old
+  `headless` feature was gated as `not(feature = "headless")` and so was switched
+  on — killing the UI — by `--all-features`, the selection that builds the
+  released binaries (#975). Never add a negative feature here.
+- When the UI is not served (feature off, or `HFS_UI_ENABLED=false`), `/ui`
+  returns **404 + OperationOutcome** from `ui_absent_routes`. It must never fall
+  through to the FHIR router, which reads `ui` as a resource type and answers
+  `200` with an empty searchset.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,12 +3482,14 @@ dependencies = [
  "helios-sof",
  "helios-subscriptions",
  "helios-ui",
+ "http-body-util",
  "openssl",
  "parking_lot",
  "reqwest",
  "serde_json",
  "sqlparser",
  "tokio",
+ "tower",
  "tracing",
 ]
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ AWS_REGION=us-east-1 \
 | `HFS_SEARCH_PARAM_CACHE_TTL` | `3600` | Seconds between refreshes of the in-memory SearchParameter registry from storage; a param POSTed to one cluster node becomes visible to others within this interval. `0` disables the refresh. |
 | `HFS_DEFAULT_FHIR_VERSION` | `R4` | FHIR version (R4, R4B, R5, R6) |
 | `HFS_LOG_LEVEL` | `info` | Log level (error, warn, info, debug, trace) |
+| `HFS_UI_ENABLED` | `true` | Serve the web UI at `/ui`. Set `false` for headless deployments; `/ui` then returns `404` + OperationOutcome. Has no effect on a binary built without the `ui` feature. |
 
 Set `HFS_BASE_URL` to the URL clients use, including any reverse-proxy path
 prefix, for example `https://fhir.example.com/fhir`. HFS accepts only absolute

--- a/crates/hfs/Cargo.toml
+++ b/crates/hfs/Cargo.toml
@@ -28,7 +28,11 @@ R6 = ["helios-fhir/R6", "helios-rest/R6", "helios-audit/R6", "helios-ui?/R6"]
 # Build options
 skip-r6-download = []
 ui = ["dep:helios-ui"]
-headless = []
+# NOTE: headless operation is a *runtime* switch (`HFS_UI_ENABLED=false`), not a
+# feature. The former `headless` feature was gated as `not(feature = "headless")`
+# and so was enabled — turning the UI off — by `--all-features`, the selection
+# `ci.yml` uses to build the uploaded release artifacts (#975). Never add a
+# negative feature here: `--all-features` cannot express mutual exclusion.
 
 # Database backends
 sqlite = ["helios-rest/sqlite"]
@@ -91,6 +95,12 @@ async-trait = "0.1"
 # Time (used by the bulk-export cleanup task)
 chrono = "0.4"
 serde_json = "1"
+
+[dev-dependencies]
+# Drive the assembled router end-to-end (`oneshot`) so the UI-mount tests
+# assert what the binary actually serves, not what a `cfg` says.
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
 
 # Vendor OpenSSL when cross-compiling for Linux ARM64 (the macOS runner
 # doesn't have target-platform OpenSSL dev libs).  Cargo feature unification

--- a/crates/hfs/README.md
+++ b/crates/hfs/README.md
@@ -81,6 +81,7 @@ Options:
 | `HFS_SERVER_HOST` | 127.0.0.1 | Host to bind |
 | `HFS_BASE_URL` | http://localhost:8080 | Public HTTP(S) base for response links and `Location` headers |
 | `HFS_LOG_LEVEL` | info | Log level (error, warn, info, debug, trace) |
+| `HFS_UI_ENABLED` | true | Serve the web UI at `/ui`; `false` for headless deployments (`/ui` then returns 404 + OperationOutcome) |
 | `DATABASE_URL` | fhir.db | Database connection string |
 | `HFS_DATA_DIR` | ./data | Path to FHIR data directory (search parameters) |
 | `HFS_SEARCH_PARAM_CACHE_TTL` | 3600 | Seconds between refreshes of the in-memory SearchParameter registry from storage; a param POSTed to one cluster node becomes visible to others within this interval. `0` disables the refresh. |

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -672,57 +672,7 @@ async fn serve(
     ui_settings: Option<Arc<dyn SettingsStore>>,
     ui_bulk_provider: Option<Arc<dyn BulkProviderStore>>,
 ) -> anyhow::Result<()> {
-    #[cfg(all(feature = "ui", not(feature = "headless")))]
-    let app = {
-        // The UI reads SearchParameter/CompartmentDefinition from the server's
-        // own FHIR API over HTTP. It calls itself on the loopback address, with
-        // the configured outbound service token (HFS_OUTBOUND_BEARER_TOKEN) when
-        // set, or no credentials when auth is disabled.
-        //
-        // TODO(service-token): when auth is enabled, this relies on an operator
-        // provisioning a valid, non-expiring bearer via HFS_OUTBOUND_BEARER_TOKEN;
-        // without one the self-call is rejected and the conformance pages degrade
-        // to a warning. The follow-up is to mint a short-lived, auto-refreshed
-        // `system/SearchParameter.rs system/CompartmentDefinition.rs` token via
-        // the planned `JwtAssertionOutboundAuthProvider` (SMART Backend Services
-        // client_credentials + private_key_jwt; see crates/auth/src/outbound.rs)
-        // configured from HFS_UI_* client credentials. The `$sql-export`
-        // self-calls (#833) are the exception: they already carry the
-        // browser's own `Authorization` when it sent one (the `Caller` seam
-        // in `crates/ui/src/conformance.rs`), falling back to this service
-        // token only when the request had none.
-        let self_base_url = format!("http://127.0.0.1:{}", config.port);
-        let outbound_auth = AuthConfig::from_env().outbound_provider();
-        let patient_name_search = patient_name_search_support(
-            config
-                .storage_backend_mode()
-                .expect("storage backend was validated before server startup"),
-        );
-        helios_ui::mount_with_body_limit_and_tenant_routing(
-            app,
-            env!("CARGO_PKG_VERSION"),
-            config.data_dir.clone(),
-            helios_ui::NlSearch {
-                enabled: config.nl_search_enabled,
-                configured: config.nl_search_api_key.is_some(),
-                model: config.nl_search_model.clone(),
-            },
-            ui_tenants.clone(),
-            ui_settings.clone(),
-            config.default_tenant.clone(),
-            self_base_url,
-            outbound_auth,
-            config.default_fhir_version,
-            config.terminology_server.clone(),
-            config.base_url.clone(),
-            config.max_body_size,
-            config.multitenancy.routing_mode.supports_url_path(),
-            ui_bulk_provider.clone(),
-            patient_name_search,
-        )
-    };
-    #[cfg(not(all(feature = "ui", not(feature = "headless"))))]
-    let _ = (&ui_tenants, &ui_settings, &ui_bulk_provider);
+    let app = attach_ui(app, config, ui_tenants, ui_settings, ui_bulk_provider);
 
     let addr = config.socket_addr();
     info!(address = %addr, "Server listening");
@@ -758,7 +708,129 @@ async fn serve(
     Ok(())
 }
 
-#[cfg(all(feature = "ui", not(feature = "headless")))]
+/// Attaches the web UI surface to the FHIR router.
+///
+/// The UI is served when it is compiled in (the `ui` feature) **and** enabled at
+/// runtime (`HFS_UI_ENABLED`, default `true`). Otherwise `/ui` answers `404`
+/// with an OperationOutcome rather than falling through to the FHIR router,
+/// which reads `ui` as a resource type and replies `200` with an empty
+/// searchset — a missing UI must not present as success.
+///
+/// Headless operation is a *runtime* switch on purpose. It used to be a Cargo
+/// feature gated negatively (`not(feature = "headless")`). Because
+/// `--all-features` — the selection `ci.yml` uses to build the uploaded release
+/// artifacts — turns every feature on, it turned the UI off in every published
+/// binary, silently (#975). Negative Cargo features cannot express mutual
+/// exclusion; don't reintroduce one here.
+fn attach_ui(
+    app: axum::Router,
+    config: &ServerConfig,
+    ui_tenants: Option<Arc<dyn ResourceStorage>>,
+    ui_settings: Option<Arc<dyn SettingsStore>>,
+    ui_bulk_provider: Option<Arc<dyn BulkProviderStore>>,
+) -> axum::Router {
+    #[cfg(feature = "ui")]
+    {
+        if config.ui_enabled {
+            return mount_ui(app, config, ui_tenants, ui_settings, ui_bulk_provider);
+        }
+        info!("Web UI is DISABLED (HFS_UI_ENABLED=false)");
+    }
+    #[cfg(not(feature = "ui"))]
+    {
+        let _ = (config, &ui_tenants, &ui_settings, &ui_bulk_provider);
+    }
+    ui_absent_routes(app)
+}
+
+/// Answers `/ui` with `404` + OperationOutcome when the UI is not served.
+///
+/// Without this the path falls through to the FHIR router, which treats `ui` as
+/// an unknown resource type and returns `200` with an empty searchset — the
+/// reason the #975 regression looked like a healthy server.
+fn ui_absent_routes(app: axum::Router) -> axum::Router {
+    async fn not_found() -> impl axum::response::IntoResponse {
+        (
+            axum::http::StatusCode::NOT_FOUND,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/fhir+json; charset=utf-8",
+            )],
+            axum::Json(serde_json::json!({
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "error",
+                    "code": "not-found",
+                    "diagnostics": "The web UI is not available on this server: it is \
+            either not compiled in (the `ui` build feature is off) or disabled at runtime \
+            (HFS_UI_ENABLED=false)."
+                }]
+            })),
+        )
+    }
+
+    app.route("/ui", axum::routing::any(not_found))
+        .route("/ui/", axum::routing::any(not_found))
+}
+
+/// Builds the UI router and merges it onto the FHIR app.
+#[cfg(feature = "ui")]
+fn mount_ui(
+    app: axum::Router,
+    config: &ServerConfig,
+    ui_tenants: Option<Arc<dyn ResourceStorage>>,
+    ui_settings: Option<Arc<dyn SettingsStore>>,
+    ui_bulk_provider: Option<Arc<dyn BulkProviderStore>>,
+) -> axum::Router {
+    // The UI reads SearchParameter/CompartmentDefinition from the server's
+    // own FHIR API over HTTP. It calls itself on the loopback address, with
+    // the configured outbound service token (HFS_OUTBOUND_BEARER_TOKEN) when
+    // set, or no credentials when auth is disabled.
+    //
+    // TODO(service-token): when auth is enabled, this relies on an operator
+    // provisioning a valid, non-expiring bearer via HFS_OUTBOUND_BEARER_TOKEN;
+    // without one the self-call is rejected and the conformance pages degrade
+    // to a warning. The follow-up is to mint a short-lived, auto-refreshed
+    // `system/SearchParameter.rs system/CompartmentDefinition.rs` token via
+    // the planned `JwtAssertionOutboundAuthProvider` (SMART Backend Services
+    // client_credentials + private_key_jwt; see crates/auth/src/outbound.rs)
+    // configured from HFS_UI_* client credentials. The `$sql-export`
+    // self-calls (#833) are the exception: they already carry the
+    // browser's own `Authorization` when it sent one (the `Caller` seam
+    // in `crates/ui/src/conformance.rs`), falling back to this service
+    // token only when the request had none.
+    let self_base_url = format!("http://127.0.0.1:{}", config.port);
+    let outbound_auth = AuthConfig::from_env().outbound_provider();
+    let patient_name_search = patient_name_search_support(
+        config
+            .storage_backend_mode()
+            .expect("storage backend was validated before server startup"),
+    );
+    helios_ui::mount_with_body_limit_and_tenant_routing(
+        app,
+        env!("CARGO_PKG_VERSION"),
+        config.data_dir.clone(),
+        helios_ui::NlSearch {
+            enabled: config.nl_search_enabled,
+            configured: config.nl_search_api_key.is_some(),
+            model: config.nl_search_model.clone(),
+        },
+        ui_tenants,
+        ui_settings,
+        config.default_tenant.clone(),
+        self_base_url,
+        outbound_auth,
+        config.default_fhir_version,
+        config.terminology_server.clone(),
+        config.base_url.clone(),
+        config.max_body_size,
+        config.multitenancy.routing_mode.supports_url_path(),
+        ui_bulk_provider,
+        patient_name_search,
+    )
+}
+
+#[cfg(feature = "ui")]
 fn patient_name_search_support(mode: StorageBackendMode) -> helios_ui::PatientNameSearchSupport {
     match mode {
         StorageBackendMode::S3 => helios_ui::PatientNameSearchSupport::IdOnly,
@@ -3157,7 +3229,7 @@ mod tests {
         );
     }
 
-    #[cfg(all(feature = "ui", not(feature = "headless")))]
+    #[cfg(feature = "ui")]
     #[test]
     fn test_patient_name_search_support_matches_storage_capability() {
         for (mode, expected) in [
@@ -3241,5 +3313,74 @@ mod tests {
             shared_file.is_ok(),
             "shared SQLite file path must be accepted"
         );
+    }
+
+    /// The regression guard for #975: whatever feature selection this test
+    /// binary was built with — `--all-features` in `ci.yml`'s `test-rust` job,
+    /// the same selection the release job uses for the uploaded artifacts —
+    /// the assembled router must actually serve the UI at `/ui`.
+    ///
+    /// Asserting on the served response rather than on a `cfg!` is the point:
+    /// the old bug was a *negative* feature (`not(feature = "headless")`) that
+    /// `--all-features` tripped, and no `cfg` assertion downstream of the mount
+    /// would have caught it.
+    #[cfg(feature = "ui")]
+    #[tokio::test]
+    async fn ui_is_served_under_this_builds_feature_selection() {
+        use http_body_util::BodyExt;
+        use tower::ServiceExt;
+
+        let config = ServerConfig::default();
+        assert!(config.ui_enabled, "the UI must default to on");
+
+        let response = attach_ui(axum::Router::new(), &config, None, None, None)
+            .oneshot(
+                axum::http::Request::get("/ui")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::OK,
+            "GET /ui must be served by the UI router"
+        );
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let html = String::from_utf8_lossy(&body);
+        assert!(
+            html.contains("<html") || html.contains("<!DOCTYPE"),
+            "GET /ui must return HTML, got: {}",
+            &html[..html.len().min(200)]
+        );
+    }
+
+    /// Headless deployments turn the UI off at runtime, and `/ui` must then say
+    /// so with a 404 + OperationOutcome. Without the explicit stub the path
+    /// falls through to the FHIR router, which reads `ui` as a resource type
+    /// and answers `200` with an empty searchset (#975).
+    #[tokio::test]
+    async fn ui_disabled_at_runtime_answers_404_not_an_empty_searchset() {
+        use http_body_util::BodyExt;
+        use tower::ServiceExt;
+
+        let mut config = ServerConfig::default();
+        config.ui_enabled = false;
+
+        let response = attach_ui(axum::Router::new(), &config, None, None, None)
+            .oneshot(
+                axum::http::Request::get("/ui")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let outcome: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(outcome["resourceType"], "OperationOutcome");
+        assert_eq!(outcome["issue"][0]["code"], "not-found");
     }
 }

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -1040,6 +1040,21 @@ pub struct ServerConfig {
     #[arg(long, env = "HFS_SOF_ENABLED", default_value = "true")]
     pub sof_enabled: bool,
 
+    /// Mount the web UI at `/ui`.
+    ///
+    /// On by default. Headless deployments (behind an API gateway, or anywhere
+    /// an HTML surface should not listen at all) opt out with
+    /// `HFS_UI_ENABLED=false`; `/ui` and everything under it then answer
+    /// `404` + OperationOutcome rather than falling through to the FHIR
+    /// router. This replaces the former `headless` *build* feature, which was
+    /// a negative Cargo feature and so was tripped accidentally by
+    /// `--all-features` (see issue #975).
+    ///
+    /// Has no effect on a binary built without the `ui` feature — there the UI
+    /// is not compiled in at all and `/ui` always answers `404`.
+    #[arg(long, env = "HFS_UI_ENABLED", default_value = "true")]
+    pub ui_enabled: bool,
+
     /// Natural-language search master switch. When false the feature is
     /// completely off: the endpoint 404s and the UI renders nothing.
     #[arg(long, env = "HFS_NL_SEARCH_ENABLED", default_value = "true")]
@@ -1255,6 +1270,7 @@ impl Default for ServerConfig {
             elasticsearch_refresh_interval: "1s".to_string(),
             elasticsearch_write_refresh: "false".to_string(),
             sof_enabled: true,
+            ui_enabled: true,
             nl_search_enabled: true,
             nl_search_api_key: None,
             nl_search_model: "claude-opus-4-8".to_string(),
@@ -1477,6 +1493,7 @@ impl ServerConfig {
             elasticsearch_refresh_interval: "1s".to_string(),
             elasticsearch_write_refresh: "false".to_string(),
             sof_enabled: true,
+            ui_enabled: true,
             nl_search_enabled: true,
             nl_search_api_key: None,
             nl_search_model: "claude-opus-4-8".to_string(),

--- a/crates/ui/README.md
+++ b/crates/ui/README.md
@@ -47,8 +47,9 @@ Why, over a SPA + JSON API:
   [Locality of Behaviour](https://htmx.org/essays/locality-of-behaviour/).
 
 Keeping the UI in a **separate crate** from `helios-rest` preserves the clean
-FHIR REST surface and lets the UI be feature-gated off (`--no-default-features`
-or the `headless` feature on `hfs`) for headless deployments.
+FHIR REST surface and lets the UI be compiled out (`--no-default-features`, i.e.
+no `ui` feature) or switched off at runtime (`HFS_UI_ENABLED=false`) for headless
+deployments.
 
 ---
 
@@ -927,10 +928,11 @@ inline-validation, and infinite-scroll fragment recipes we'll standardize on.
 
 ## Pages & routes
 
-Mounted under `/ui` when running `hfs` (the `ui` feature is on by default; the
-`headless` feature disables it — the mount is
-`cfg(all(feature = "ui", not(feature = "headless")))`, so enabling both yields
-no UI).
+Mounted under `/ui` when running `hfs` (the `ui` feature is on by default).
+Headless deployments set `HFS_UI_ENABLED=false`; `/ui` then answers 404 +
+OperationOutcome. Headless is deliberately a *runtime* switch — the former
+`headless` Cargo feature was gated as `not(feature = "headless")` and was
+therefore enabled, silently removing the UI, by `--all-features` (#975).
 
 ```bash
 cargo run -p helios-hfs   # then open http://127.0.0.1:8080/ui


### PR DESCRIPTION
Fixes #975.

## The bug

`cargo build --workspace --all-features --release` — the selection `ci.yml:1526`
uses to produce the uploaded release artifacts — compiled the web UI **out** of
the `hfs` binary.

The mount was gated `#[cfg(all(feature = "ui", not(feature = "headless")))]`.
`--all-features` enables *every* feature, so it enabled `ui` **and** `headless`;
because the gate requires `not(headless)`, turning everything on turned the UI
off. Every published Windows / macOS / Linux / ARM64 binary shipped without
`/ui`, and the failure was silent: `GET /ui` still returned `200` with a FHIR
searchset Bundle, because with the UI router absent the path falls through to the
FHIR router, which reads `ui` as a resource type and answers with an empty
searchset.

## The fix

**1. The `headless` Cargo feature is gone.** Negative features cannot express
mutual exclusion under `--all-features` — that is the whole defect — so the
feature is removed rather than kept as a no-op. `crates/hfs/Cargo.toml` now
carries a note not to add one back. A build that still passes `--features
headless` fails loudly with cargo's unknown-feature error rather than silently
losing the UI. Nothing in the repo set it: it appeared only in the four `cfg`
gates, in no workflow, Dockerfile or script.

**2. Headless is a runtime switch: `HFS_UI_ENABLED` (default `true`).** This
mirrors `HTS_UI_ENABLED`, which the terminology server already has, so the two
servers now configure the same way. The mount is gated on `feature = "ui"` alone,
inside a new `attach_ui`; the mount body moved unchanged into `mount_ui`.

**3. An absent UI no longer presents as success.** When the UI is not served —
feature off, or `HFS_UI_ENABLED=false` — `/ui` answers `404` +
OperationOutcome instead of falling through to the FHIR router. Without this the
new runtime switch would reproduce the same misleading `200` the issue describes.

**4. A guard that runs on every PR, not only on tags.**
`ui_is_served_under_this_builds_feature_selection` builds the assembled router
and asserts `GET /ui` returns `200 text/html`. It runs under `cargo test
--workspace --all-features` in `ci.yml`'s `test-rust` job — the same selection
that produced the bug, and a `needs` of the release job — so a future feature
that cancels the UI fails CI before anything is uploaded. Asserting on the served
response rather than on a `cfg!` is deliberate: no `cfg` assertion downstream of
the mount would have caught the original bug. This is preferred over the issue's
suggestion of a release-job-only assertion, which would only fire on a tag.

## Verification

Local, `--all-features` debug binary (the reproduction from the issue):

```console
$ curl -s -o /dev/null -w '%{http_code} %{content_type}\n' localhost:8099/ui
200 text/html; charset=utf-8
$ curl -s -o /dev/null -w '%{http_code}\n' localhost:8099/ui/tenants
200
$ strings target/debug/hfs | grep -c htmx
1984          # was 0
```

With the switch off:

```console
$ HFS_UI_ENABLED=false hfs
INFO hfs: Web UI is DISABLED (HFS_UI_ENABLED=false)
$ curl -s -w '\nHTTP %{http_code} %{content_type}\n' localhost:8098/ui
{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"not-found",
 "diagnostics":"The web UI is not available on this server: ..."}]}
HTTP 404 application/fhir+json; charset=utf-8
$ curl -s -o /dev/null -w '%{http_code}\n' localhost:8098/metadata
200
```

Builds and tests run locally:

- `cargo test -p helios-hfs --bin hfs --all-features` — 14 passed
- `cargo test -p helios-hfs --bin hfs` (default features) — 11 passed
- `cargo check -p helios-hfs --no-default-features --features R4,sqlite` — the
  UI-absent path compiles
- `cargo clippy -p helios-hfs -p helios-rest --all-targets --all-features` — no
  new warnings

## Effect on the manual test passes #936–#941

Their T0 mandates `--all-features`, which is why 5 of 9 UI cells were
unreachable. With this change that build serves the UI, so T0 needs no
correction — the third suggestion in the issue is moot once this lands.

## Docs

`README.md`, `crates/hfs/README.md`, `crates/ui/README.md` and the
`run-hfs-server` / `work-with-ui` skills now document `HFS_UI_ENABLED` and the
reason headless is not a feature.

## Follow-up, not fixed here

The issue also notes that an unknown resource type returns `200` with an empty
searchset rather than `404` + OperationOutcome (`GET /Nonsense123`), which is
what let this regression look healthy. That is a separate defect on the FHIR
routing surface and is deliberately out of scope; `/ui` specifically is now
explicit. Worth deciding on separately — a client that misspells a resource type
currently gets a successful empty response.
