### PR TITLE
perf(bulk-submit): replace SQL receipt OFFSET pagination with keyset cursors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1344,7 +1344,7 @@ jobs:
                   ? `  ${t.group}/${t.name}: FAILED - ${t.msg}`
                   : `  ${t.group}/${t.name}: DID NOT EXECUTE (no recorded result)`).join('\n');
                 const txNote = remaining.some(t => t.mode === 'tx')
-                  ? `\n\nThe HTS pre-flight probe was healthy (3/3), so terminology infrastructure is NOT the cause of the tx test(s) above -- this is the evaluator.`
+                  ? `\n\nThe HTS pre-flight probe was healthy (3/3), but this does not rule out a later terminology outage. Check the errors above for HTS/proxy failures as well as evaluator regressions.`
                   : '';
                 core.error(`[COVERAGE-LOST] ${remaining.length} test(s) declared in tests-fhir-r5.xml did not pass and are not listed in known-test-failures.json:\n${detail}${txNote}\n\nA test marked DID NOT EXECUTE was downgraded to inconclusive by the runner, or never ran at all; neither affects the runner's exit code, which is the silent skip this gate exists to catch. Fix the defect, or add an entry to known-test-failures.json with a reason and a linked issue. Do not delete the test to get green.`);
                 codes.push('COVERAGE-LOST');

--- a/crates/fhirpath/src/terminology_client.rs
+++ b/crates/fhirpath/src/terminology_client.rs
@@ -4,7 +4,7 @@
 //! It implements the standard FHIR terminology operations including expand, lookup,
 //! validate-code, subsumes, and translate.
 
-use reqwest::Client;
+use reqwest::{Client, RequestBuilder, Response, StatusCode};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -20,6 +20,13 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Environment variable overriding [`DEFAULT_REQUEST_TIMEOUT`], in whole seconds.
 const REQUEST_TIMEOUT_ENV: &str = "FHIRPATH_TERMINOLOGY_TIMEOUT";
+
+/// Three retries after the initial request, with 1s, 2s and 4s backoff.
+const GATEWAY_RETRY_DELAYS: [Duration; 3] = [
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(4),
+];
 
 /// Resolves the request timeout from [`REQUEST_TIMEOUT_ENV`].
 ///
@@ -53,6 +60,40 @@ pub struct TerminologyClient {
 }
 
 impl TerminologyClient {
+    /// These terminology operations only read data, including those sent as POST.
+    /// Retry transient gateway/service failures, but preserve transport, parsing and
+    /// other HTTP errors. Each attempt retains the configured HTTP client timeout.
+    async fn send_with_retry(
+        &self,
+        request: impl Fn() -> RequestBuilder,
+    ) -> FhirPathResult<Response> {
+        let mut delays = GATEWAY_RETRY_DELAYS.into_iter();
+        loop {
+            let response = request()
+                .send()
+                .await
+                .map_err(|e| FhirPathError::NetworkError(e.to_string()))?;
+            if !matches!(
+                response.status(),
+                StatusCode::BAD_GATEWAY
+                    | StatusCode::SERVICE_UNAVAILABLE
+                    | StatusCode::GATEWAY_TIMEOUT
+            ) {
+                return Ok(response);
+            }
+            let Some(delay) = delays.next() else {
+                return Ok(response);
+            };
+            tracing::warn!(
+                status = %response.status(),
+                delay_ms = delay.as_millis(),
+                "Retrying terminology request after a transient HTTP failure"
+            );
+            drop(response);
+            tokio::time::sleep(delay).await;
+        }
+    }
+
     /// Creates a new terminology client
     ///
     /// # Arguments
@@ -62,6 +103,7 @@ impl TerminologyClient {
     ///
     /// The request timeout defaults to 30s and can be overridden with
     /// `FHIRPATH_TERMINOLOGY_TIMEOUT` (whole seconds; `0` disables it).
+    /// HTTP 502, 503 and 504 responses are retried up to three times with backoff.
     pub fn new(base_url: String, fhir_version: FhirVersion) -> Self {
         let mut builder = Client::builder();
         if let Some(timeout) = request_timeout() {
@@ -117,18 +159,18 @@ impl TerminologyClient {
         }
 
         let response = self
-            .client
-            .get(&url)
-            .query(
-                &query_params
-                    .iter()
-                    .map(|(k, v)| (k.as_str(), v.as_str()))
-                    .collect::<Vec<_>>(),
-            )
-            .header("Accept", "application/fhir+json")
-            .send()
-            .await
-            .map_err(|e| FhirPathError::NetworkError(e.to_string()))?;
+            .send_with_retry(|| {
+                self.client
+                    .get(&url)
+                    .query(
+                        &query_params
+                            .iter()
+                            .map(|(k, v)| (k.as_str(), v.as_str()))
+                            .collect::<Vec<_>>(),
+                    )
+                    .header("Accept", "application/fhir+json")
+            })
+            .await?;
 
         if response.status().is_success() {
             response
@@ -187,14 +229,14 @@ impl TerminologyClient {
         }
 
         let response = self
-            .client
-            .post(&url)
-            .json(&body)
-            .header("Content-Type", "application/fhir+json")
-            .header("Accept", "application/fhir+json")
-            .send()
-            .await
-            .map_err(|e| FhirPathError::NetworkError(e.to_string()))?;
+            .send_with_retry(|| {
+                self.client
+                    .post(&url)
+                    .json(&body)
+                    .header("Content-Type", "application/fhir+json")
+                    .header("Accept", "application/fhir+json")
+            })
+            .await?;
 
         if response.status().is_success() {
             response
@@ -283,14 +325,14 @@ impl TerminologyClient {
         });
 
         let response = self
-            .client
-            .post(&url)
-            .json(&body)
-            .header("Content-Type", "application/fhir+json")
-            .header("Accept", "application/fhir+json")
-            .send()
-            .await
-            .map_err(|e| FhirPathError::NetworkError(e.to_string()))?;
+            .send_with_retry(|| {
+                self.client
+                    .post(&url)
+                    .json(&body)
+                    .header("Content-Type", "application/fhir+json")
+                    .header("Accept", "application/fhir+json")
+            })
+            .await?;
 
         if response.status().is_success() {
             let result: Value = response
@@ -360,14 +402,14 @@ impl TerminologyClient {
         });
 
         let response = self
-            .client
-            .post(&url)
-            .json(&body)
-            .header("Content-Type", "application/fhir+json")
-            .header("Accept", "application/fhir+json")
-            .send()
-            .await
-            .map_err(|e| FhirPathError::NetworkError(e.to_string()))?;
+            .send_with_retry(|| {
+                self.client
+                    .post(&url)
+                    .json(&body)
+                    .header("Content-Type", "application/fhir+json")
+                    .header("Accept", "application/fhir+json")
+            })
+            .await?;
 
         if response.status().is_success() {
             response
@@ -432,14 +474,14 @@ impl TerminologyClient {
         });
 
         let response = self
-            .client
-            .post(&url)
-            .json(&body)
-            .header("Content-Type", "application/fhir+json")
-            .header("Accept", "application/fhir+json")
-            .send()
-            .await
-            .map_err(|e| FhirPathError::NetworkError(e.to_string()))?;
+            .send_with_retry(|| {
+                self.client
+                    .post(&url)
+                    .json(&body)
+                    .header("Content-Type", "application/fhir+json")
+                    .header("Accept", "application/fhir+json")
+            })
+            .await?;
 
         if response.status().is_success() {
             response
@@ -478,14 +520,14 @@ impl TerminologyClient {
         let body = build_translate_body(concept_map_url, system, code, target_system, params);
 
         let response = self
-            .client
-            .post(&url)
-            .json(&body)
-            .header("Content-Type", "application/fhir+json")
-            .header("Accept", "application/fhir+json")
-            .send()
-            .await
-            .map_err(|e| FhirPathError::NetworkError(e.to_string()))?;
+            .send_with_retry(|| {
+                self.client
+                    .post(&url)
+                    .json(&body)
+                    .header("Content-Type", "application/fhir+json")
+                    .header("Accept", "application/fhir+json")
+            })
+            .await?;
 
         if response.status().is_success() {
             let result: Value = response
@@ -574,6 +616,128 @@ fn build_translate_body(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    async fn call_operation(client: &TerminologyClient, operation: &str) -> FhirPathResult<Value> {
+        match operation {
+            "expand" => client.expand("http://example.org/vs", None).await,
+            "lookup" => client.lookup("http://example.org/cs", "x", None).await,
+            "validate_vs" => {
+                client
+                    .validate_vs("http://example.org/vs", None, "x", None, None)
+                    .await
+            }
+            "validate_cs" => {
+                client
+                    .validate_cs("http://example.org/cs", "x", None, None)
+                    .await
+            }
+            "subsumes" => {
+                client
+                    .subsumes("http://example.org/cs", "x", "y", None)
+                    .await
+            }
+            "translate" => {
+                client
+                    .translate(
+                        "http://example.org/cm",
+                        "http://example.org/cs",
+                        "x",
+                        None,
+                        None,
+                    )
+                    .await
+            }
+            _ => panic!("unknown test operation: {operation}"),
+        }
+    }
+
+    async fn stub_responses(statuses: Vec<u16>, body: &str) -> wiremock::MockServer {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let calls = AtomicUsize::new(0);
+        let body = body.to_owned();
+        Mock::given(|_: &Request| true)
+            .respond_with(move |_: &Request| {
+                let index = calls.fetch_add(1, Ordering::SeqCst).min(statuses.len() - 1);
+                ResponseTemplate::new(statuses[index]).set_body_string(body.clone())
+            })
+            .mount(&server)
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn terminology_retries_transient_gateway_errors_for_all_operations() {
+        for operation in [
+            "expand",
+            "lookup",
+            "validate_vs",
+            "validate_cs",
+            "subsumes",
+            "translate",
+        ] {
+            let body = json!({"resourceType": "Parameters", "parameter": []});
+            let server = stub_responses(vec![502, 503, 504, 200], &body.to_string()).await;
+            let client = TerminologyClient::new(server.uri(), FhirVersion::R4);
+
+            assert_eq!(
+                call_operation(&client, operation).await.unwrap(),
+                body,
+                "{operation}"
+            );
+            let requests = server.received_requests().await.unwrap();
+            assert_eq!(requests.len(), 4, "{operation}");
+            for request in &requests[1..] {
+                assert_eq!(request.method, requests[0].method);
+                assert_eq!(request.url, requests[0].url);
+                assert_eq!(request.body, requests[0].body);
+                assert_eq!(request.headers, requests[0].headers);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn terminology_retry_limit_preserves_final_error() {
+        let server = stub_responses(vec![502, 503, 502, 504], "gateway unavailable").await;
+        let client = TerminologyClient::new(server.uri(), FhirVersion::R4);
+        let error = client
+            .expand("http://example.org/vs", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(&error, FhirPathError::TerminologyError(message)
+            if message.contains("504 Gateway Timeout") && message.contains("gateway unavailable")));
+        assert_eq!(server.received_requests().await.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn terminology_does_not_retry_other_http_errors() {
+        for status in [400, 401, 403, 404, 422, 429, 500] {
+            let server = stub_responses(vec![status, 200], "operation failed").await;
+            let client = TerminologyClient::new(server.uri(), FhirVersion::R4);
+            assert!(matches!(
+                client.expand("http://example.org/vs", None).await,
+                Err(FhirPathError::TerminologyError(_))
+            ));
+            assert_eq!(
+                server.received_requests().await.unwrap().len(),
+                1,
+                "HTTP {status}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn terminology_does_not_retry_invalid_success_body() {
+        let server = stub_responses(vec![200], "invalid JSON").await;
+        let client = TerminologyClient::new(server.uri(), FhirVersion::R4);
+        assert!(matches!(
+            client.expand("http://example.org/vs", None).await,
+            Err(FhirPathError::ParseError(_))
+        ));
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
 
     /// Names of the `Parameters.parameter` entries, in order.
     fn param_names(body: &Value) -> Vec<&str> {

--- a/crates/fhirpath/src/terminology_client.rs
+++ b/crates/fhirpath/src/terminology_client.rs
@@ -4,7 +4,7 @@
 //! It implements the standard FHIR terminology operations including expand, lookup,
 //! validate-code, subsumes, and translate.
 
-use reqwest::{Client, RequestBuilder, Response, StatusCode};
+use reqwest::{Client, RequestBuilder, Response};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -73,12 +73,9 @@ impl TerminologyClient {
                 .send()
                 .await
                 .map_err(|e| FhirPathError::NetworkError(e.to_string()))?;
-            if !matches!(
-                response.status(),
-                StatusCode::BAD_GATEWAY
-                    | StatusCode::SERVICE_UNAVAILABLE
-                    | StatusCode::GATEWAY_TIMEOUT
-            ) {
+            // Cloudflare uses HTTP 530 for tunnel failures, including error 1033
+            // when no healthy cloudflared instance can receive the request.
+            if !matches!(response.status().as_u16(), 502 | 503 | 504 | 530) {
                 return Ok(response);
             }
             let Some(delay) = delays.next() else {
@@ -103,7 +100,7 @@ impl TerminologyClient {
     ///
     /// The request timeout defaults to 30s and can be overridden with
     /// `FHIRPATH_TERMINOLOGY_TIMEOUT` (whole seconds; `0` disables it).
-    /// HTTP 502, 503 and 504 responses are retried up to three times with backoff.
+    /// HTTP 502, 503, 504 and 530 responses are retried up to three times with backoff.
     pub fn new(base_url: String, fhir_version: FhirVersion) -> Self {
         let mut builder = Client::builder();
         if let Some(timeout) = request_timeout() {
@@ -696,6 +693,48 @@ mod tests {
                 assert_eq!(request.headers, requests[0].headers);
             }
         }
+    }
+
+    #[tokio::test]
+    async fn terminology_retries_cloudflare_tunnel_errors_for_all_operations() {
+        for operation in [
+            "expand",
+            "lookup",
+            "validate_vs",
+            "validate_cs",
+            "subsumes",
+            "translate",
+        ] {
+            let body = json!({"resourceType": "Parameters", "parameter": []});
+            let server = stub_responses(vec![530, 200], &body.to_string()).await;
+            let client = TerminologyClient::new(server.uri(), FhirVersion::R4);
+
+            assert_eq!(
+                call_operation(&client, operation).await.unwrap(),
+                body,
+                "{operation}"
+            );
+            let requests = server.received_requests().await.unwrap();
+            assert_eq!(requests.len(), 2, "{operation}");
+            assert_eq!(requests[1].method, requests[0].method);
+            assert_eq!(requests[1].url, requests[0].url);
+            assert_eq!(requests[1].body, requests[0].body);
+            assert_eq!(requests[1].headers, requests[0].headers);
+        }
+    }
+
+    #[tokio::test]
+    async fn terminology_cloudflare_retry_limit_preserves_final_error() {
+        let body = "<html><h1>Error 1033</h1><h2>Cloudflare Tunnel error</h2></html>";
+        let server = stub_responses(vec![530], body).await;
+        let client = TerminologyClient::new(server.uri(), FhirVersion::R4);
+        let error = client
+            .expand("http://example.org/vs", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(&error, FhirPathError::TerminologyError(message)
+            if message.contains("530") && message.contains(body)));
+        assert_eq!(server.received_requests().await.unwrap().len(), 4);
     }
 
     #[tokio::test]

--- a/crates/persistence/src/backends/mongodb/bulk_submit.rs
+++ b/crates/persistence/src/backends/mongodb/bulk_submit.rs
@@ -46,9 +46,10 @@ use crate::core::bulk_export::ExportJobId;
 use crate::core::bulk_export_worker::{LeaseError, WorkerId};
 use crate::core::bulk_submit::{
     BulkEntryOutcome, BulkEntryResult, BulkProcessingOptions, BulkSubmitProvider,
-    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, ManifestStatus, NdjsonEntry,
-    StreamProcessingResult, StreamingBulkSubmitProvider, SubmissionChange, SubmissionId,
-    SubmissionManifest, SubmissionStatus, SubmissionSummary,
+    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, EntryResultContinuation,
+    EntryResultPage, ManifestStatus, NdjsonEntry, PagedEntryResult, StreamProcessingResult,
+    StreamingBulkSubmitProvider, SubmissionChange, SubmissionId, SubmissionManifest,
+    SubmissionStatus, SubmissionSummary, invalid_entry_result_page,
 };
 use crate::core::bulk_submit_worker::{
     ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
@@ -932,15 +933,29 @@ impl BulkSubmitProvider for MongoBackend {
         Ok(results)
     }
 
-    async fn get_entry_results(
+    async fn get_entry_results_page(
         &self,
         tenant: &TenantContext,
         submission_id: &SubmissionId,
         manifest_id: &str,
         outcome_filter: Option<BulkEntryOutcome>,
         limit: u32,
-        offset: u32,
-    ) -> StorageResult<Vec<BulkEntryResult>> {
+        continuation: Option<&EntryResultContinuation>,
+    ) -> StorageResult<EntryResultPage> {
+        if limit == 0 {
+            return Err(invalid_entry_result_page(
+                "Receipt page limit must be greater than zero",
+            ));
+        }
+        let offset = match continuation {
+            None => 0,
+            Some(EntryResultContinuation::Offset(offset)) => *offset,
+            Some(EntryResultContinuation::Keyset(_)) => {
+                return Err(invalid_entry_result_page(
+                    "mongodb receipt pages require an offset continuation",
+                ));
+            }
+        };
         let mut filter = manifest_filter(tenant, submission_id, manifest_id);
         if let Some(outcome) = outcome_filter {
             filter.insert("outcome", outcome.to_string());
@@ -957,11 +972,30 @@ impl BulkSubmitProvider for MongoBackend {
             .with_options(options)
             .await
             .map_err(|e| internal_error(format!("query entry results: {e}")))?;
-        Ok(collect(cursor)
+        let results: Vec<_> = collect(cursor)
             .await?
             .iter()
             .map(decode_entry_result)
-            .collect())
+            .collect();
+        let next = if results.len() == limit as usize {
+            Some(EntryResultContinuation::Offset(
+                offset
+                    .checked_add(limit)
+                    .ok_or_else(|| invalid_entry_result_page("Receipt offset exceeds u32 range"))?,
+            ))
+        } else {
+            None
+        };
+        Ok(EntryResultPage {
+            entries: results
+                .into_iter()
+                .map(|result| PagedEntryResult {
+                    result,
+                    stored_identity: None,
+                })
+                .collect(),
+            next,
+        })
     }
 
     async fn get_entry_counts(

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -13,9 +13,10 @@ use crate::core::bulk_export::ExportJobId;
 use crate::core::bulk_export_worker::{LeaseError, WorkerId};
 use crate::core::bulk_submit::{
     BulkEntryOutcome, BulkEntryResult, BulkProcessingOptions, BulkSubmitProvider,
-    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, ManifestStatus, NdjsonEntry,
+    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, EntryResultContinuation,
+    EntryResultCursor, EntryResultPage, ManifestStatus, NdjsonEntry, PagedEntryResult,
     StreamProcessingResult, StreamingBulkSubmitProvider, SubmissionChange, SubmissionId,
-    SubmissionManifest, SubmissionStatus, SubmissionSummary,
+    SubmissionManifest, SubmissionStatus, SubmissionSummary, invalid_entry_result_page,
 };
 use crate::core::bulk_submit_worker::{
     ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
@@ -799,77 +800,115 @@ impl BulkSubmitProvider for PostgresBackend {
         Ok(results)
     }
 
-    async fn get_entry_results(
+    async fn get_entry_results_page(
         &self,
         tenant: &TenantContext,
         submission_id: &SubmissionId,
         manifest_id: &str,
         outcome_filter: Option<BulkEntryOutcome>,
         limit: u32,
-        offset: u32,
-    ) -> StorageResult<Vec<BulkEntryResult>> {
+        continuation: Option<&EntryResultContinuation>,
+    ) -> StorageResult<EntryResultPage> {
+        if limit == 0 {
+            return Err(invalid_entry_result_page(
+                "Receipt page limit must be greater than zero",
+            ));
+        }
+        let after = match continuation {
+            None => None,
+            Some(EntryResultContinuation::Keyset(cursor)) => Some((
+                cursor.file_url.as_str(),
+                i32::try_from(cursor.line_number).map_err(|_| {
+                    invalid_entry_result_page(
+                        "Receipt cursor line exceeds PostgreSQL INTEGER range",
+                    )
+                })?,
+            )),
+            Some(EntryResultContinuation::Offset(_)) => {
+                return Err(invalid_entry_result_page(
+                    "PostgreSQL receipt pages require a keyset continuation",
+                ));
+            }
+        };
         let client = self.get_client().await?;
-        let tenant_id = tenant.tenant_id().as_str();
-
-        let mut sql =
-            "SELECT line_number, resource_type, resource_id, created, outcome, operation_outcome
+        let mut sql = "SELECT file_url, line_number, resource_type, resource_id, created, outcome, operation_outcome
              FROM bulk_entry_results
-             WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3 AND manifest_id = $4"
-                .to_string();
-
+             WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3 AND manifest_id = $4".to_string();
         let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = vec![
-            Box::new(tenant_id.to_string()),
+            Box::new(tenant.tenant_id().as_str().to_string()),
             Box::new(submission_id.submitter.clone()),
             Box::new(submission_id.submission_id.clone()),
             Box::new(manifest_id.to_string()),
         ];
-
         if let Some(outcome) = outcome_filter {
-            sql.push_str(" AND outcome = $5");
+            sql.push_str(&format!(" AND outcome = ${}", params.len() + 1));
             params.push(Box::new(outcome.to_string()));
         }
-
+        if let Some((file, line)) = after {
+            sql.push_str(&format!(
+                " AND (file_url, line_number) > (${}, ${})",
+                params.len() + 1,
+                params.len() + 2
+            ));
+            params.push(Box::new(file.to_string()));
+            params.push(Box::new(line));
+        }
         sql.push_str(&format!(
-            " ORDER BY line_number LIMIT {} OFFSET {}",
-            limit, offset
+            " ORDER BY file_url, line_number LIMIT ${}",
+            params.len() + 1
         ));
-
+        params.push(Box::new(i64::from(limit)));
         let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
             .iter()
             .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
             .collect();
-
         let rows = client
             .query(&sql, &param_refs)
             .await
-            .map_err(|e| internal_error(format!("Failed to query results: {}", e)))?;
-
-        let results: Vec<BulkEntryResult> = rows
+            .map_err(|e| internal_error(format!("Failed to query receipt page: {e}")))?;
+        let entries: Vec<PagedEntryResult> = rows
             .iter()
-            .map(|row| {
-                let line_number: i32 = row.get(0);
-                let resource_type: String = row.get(1);
-                let resource_id: Option<String> = row.get(2);
-                let created: Option<bool> = row.get(3);
-                let outcome_str: String = row.get(4);
-                let operation_outcome: Option<Value> = row.get(5);
-
-                let outcome: BulkEntryOutcome = outcome_str
+            .map(|row| -> StorageResult<_> {
+                let decode = |e| internal_error(format!("Failed to decode receipt page: {e}"));
+                let file_url: String = row.try_get(0).map_err(decode)?;
+                let line: i32 = row.try_get(1).map_err(decode)?;
+                let line_number = u64::try_from(line).map_err(|_| {
+                    internal_error("Negative stored receipt line number".to_string())
+                })?;
+                let resource_type = row.try_get(2).map_err(decode)?;
+                let resource_id = row.try_get(3).map_err(decode)?;
+                let created: Option<bool> = row.try_get(4).map_err(decode)?;
+                let outcome_str: String = row.try_get(5).map_err(decode)?;
+                let operation_outcome = row.try_get(6).map_err(decode)?;
+                // Preserve the existing interpretation of unknown outcome labels.
+                let outcome = outcome_str
                     .parse()
                     .unwrap_or(BulkEntryOutcome::ProcessingError);
-
-                BulkEntryResult {
-                    line_number: line_number as u64,
-                    resource_type,
-                    resource_id,
-                    created: created.unwrap_or(false),
-                    outcome,
-                    operation_outcome,
-                }
+                Ok(PagedEntryResult {
+                    stored_identity: Some(EntryResultCursor {
+                        file_url,
+                        line_number,
+                    }),
+                    result: BulkEntryResult {
+                        line_number,
+                        resource_type,
+                        resource_id,
+                        created: created.unwrap_or(false),
+                        outcome,
+                        operation_outcome,
+                    },
+                })
             })
-            .collect();
-
-        Ok(results)
+            .collect::<StorageResult<_>>()?;
+        let next = if entries.len() == limit as usize {
+            entries
+                .last()
+                .and_then(|entry| entry.stored_identity.clone())
+                .map(EntryResultContinuation::Keyset)
+        } else {
+            None
+        };
+        Ok(EntryResultPage { entries, next })
     }
 
     async fn get_entry_counts(

--- a/crates/persistence/src/backends/s3/bulk_submit.rs
+++ b/crates/persistence/src/backends/s3/bulk_submit.rs
@@ -15,9 +15,10 @@ use crate::core::ResourceStorage;
 use crate::core::VersionedStorage;
 use crate::core::bulk_submit::{
     BulkEntryOutcome, BulkEntryResult, BulkProcessingOptions, BulkSubmitProvider,
-    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, ManifestStatus, NdjsonEntry,
-    StreamProcessingResult, StreamingBulkSubmitProvider, SubmissionChange, SubmissionId,
-    SubmissionManifest, SubmissionStatus, SubmissionSummary,
+    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, EntryResultContinuation,
+    EntryResultPage, ManifestStatus, NdjsonEntry, PagedEntryResult, StreamProcessingResult,
+    StreamingBulkSubmitProvider, SubmissionChange, SubmissionId, SubmissionManifest,
+    SubmissionStatus, SubmissionSummary, invalid_entry_result_page,
 };
 use crate::error::{BulkSubmitError, ResourceError, StorageError, StorageResult};
 use crate::tenant::TenantContext;
@@ -434,15 +435,29 @@ impl BulkSubmitProvider for S3Backend {
         Ok(results)
     }
 
-    async fn get_entry_results(
+    async fn get_entry_results_page(
         &self,
         tenant: &TenantContext,
         submission_id: &SubmissionId,
         manifest_id: &str,
         outcome_filter: Option<BulkEntryOutcome>,
         limit: u32,
-        offset: u32,
-    ) -> StorageResult<Vec<BulkEntryResult>> {
+        continuation: Option<&EntryResultContinuation>,
+    ) -> StorageResult<EntryResultPage> {
+        if limit == 0 {
+            return Err(invalid_entry_result_page(
+                "Receipt page limit must be greater than zero",
+            ));
+        }
+        let offset = match continuation {
+            None => 0,
+            Some(EntryResultContinuation::Offset(offset)) => *offset,
+            Some(EntryResultContinuation::Keyset(_)) => {
+                return Err(invalid_entry_result_page(
+                    "s3 receipt pages require an offset continuation",
+                ));
+            }
+        };
         let location = self.tenant_location(tenant)?;
         let mut results = self
             .load_entry_results(&location, submission_id, manifest_id)
@@ -456,7 +471,27 @@ impl BulkSubmitProvider for S3Backend {
 
         let start = (offset as usize).min(results.len());
         let end = start.saturating_add(limit as usize).min(results.len());
-        Ok(results[start..end].to_vec())
+        let page = &results[start..end];
+        let next = if page.len() == limit as usize {
+            Some(EntryResultContinuation::Offset(
+                offset
+                    .checked_add(limit)
+                    .ok_or_else(|| invalid_entry_result_page("Receipt offset exceeds u32 range"))?,
+            ))
+        } else {
+            None
+        };
+        Ok(EntryResultPage {
+            entries: page
+                .iter()
+                .cloned()
+                .map(|result| PagedEntryResult {
+                    result,
+                    stored_identity: None,
+                })
+                .collect(),
+            next,
+        })
     }
 
     async fn get_entry_counts(

--- a/crates/persistence/src/backends/s3/tests.rs
+++ b/crates/persistence/src/backends/s3/tests.rs
@@ -998,10 +998,125 @@ async fn bulk_submit_entry_results_are_keyed_by_their_output_file() {
     assert_eq!(counts.success, 2, "one stored entry result per file");
 
     let stored = backend
-        .get_entry_results(&tenant, &submission_id, &manifest.manifest_id, None, 10, 0)
+        .get_entry_results_page(
+            &tenant,
+            &submission_id,
+            &manifest.manifest_id,
+            None,
+            10,
+            None,
+        )
         .await
         .unwrap();
-    assert_eq!(stored.len(), 2, "both files' line 1 must survive");
+    assert_eq!(stored.entries.len(), 2, "both files' line 1 must survive");
+    let mut expected: Vec<_> = stored
+        .entries
+        .iter()
+        .map(|entry| entry.result.resource_id.clone())
+        .collect();
+    expected.sort();
+    let mut next = None;
+    let mut actual = Vec::new();
+    for page_index in 0..3 {
+        let page = backend
+            .get_entry_results_page(
+                &tenant,
+                &submission_id,
+                &manifest.manifest_id,
+                None,
+                1,
+                next.as_ref(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            page.entries
+                .iter()
+                .all(|entry| entry.stored_identity.is_none())
+        );
+        actual.extend(
+            page.entries
+                .into_iter()
+                .map(|entry| entry.result.resource_id),
+        );
+        next = page.next;
+        if page_index < 2 {
+            assert_eq!(
+                next,
+                Some(crate::core::EntryResultContinuation::Offset(page_index + 1))
+            );
+        } else {
+            assert!(
+                next.is_none(),
+                "exact multiple terminates with an empty final page"
+            );
+        }
+    }
+    actual.sort();
+    assert_eq!(actual, expected);
+    assert!(
+        backend
+            .get_entry_results_page(
+                &tenant,
+                &submission_id,
+                &manifest.manifest_id,
+                None,
+                0,
+                None
+            )
+            .await
+            .is_err()
+    );
+    assert!(
+        backend
+            .get_entry_results_page(
+                &tenant,
+                &submission_id,
+                &manifest.manifest_id,
+                None,
+                1,
+                Some(&crate::core::EntryResultContinuation::Keyset(
+                    crate::core::EntryResultCursor {
+                        file_url: String::new(),
+                        line_number: 0,
+                    }
+                ))
+            )
+            .await
+            .is_err()
+    );
+    let primary = Arc::new(backend);
+    let config = crate::composite::config::CompositeConfig::builder()
+        .primary("s3", crate::core::BackendKind::S3)
+        .build()
+        .unwrap();
+    let storage = Arc::new(
+        crate::composite::storage::CompositeStorage::new(
+            config,
+            std::collections::HashMap::from([(
+                "s3".to_string(),
+                primary.clone() as crate::composite::storage::DynStorage,
+            )]),
+        )
+        .unwrap(),
+    );
+    let jobs = crate::composite::bulk_submit::CompositeSubmitJobs::new(primary, storage);
+    let delegated = jobs
+        .get_entry_results_page(
+            &tenant,
+            &submission_id,
+            &manifest.manifest_id,
+            None,
+            1,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(delegated.entries[0].stored_identity.is_none());
+    assert_eq!(
+        delegated.next,
+        Some(crate::core::EntryResultContinuation::Offset(1))
+    );
 
     // The raw NDJSON archive is discriminated too, so the auditable copy of the
     // first file's payload is not replaced by the second's.

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -15,9 +15,10 @@ use crate::core::bulk_export::ExportJobId;
 use crate::core::bulk_export_worker::{LeaseError, WorkerId};
 use crate::core::bulk_submit::{
     BulkEntryOutcome, BulkEntryResult, BulkProcessingOptions, BulkSubmitProvider,
-    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, ManifestStatus, NdjsonEntry,
+    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, EntryResultContinuation,
+    EntryResultCursor, EntryResultPage, ManifestStatus, NdjsonEntry, PagedEntryResult,
     StreamProcessingResult, StreamingBulkSubmitProvider, SubmissionChange, SubmissionId,
-    SubmissionManifest, SubmissionStatus, SubmissionSummary,
+    SubmissionManifest, SubmissionStatus, SubmissionSummary, invalid_entry_result_page,
 };
 use crate::core::bulk_submit_worker::{
     ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
@@ -815,76 +816,100 @@ impl BulkSubmitProvider for SqliteBackend {
         Ok(results)
     }
 
-    async fn get_entry_results(
+    async fn get_entry_results_page(
         &self,
         tenant: &TenantContext,
         submission_id: &SubmissionId,
         manifest_id: &str,
         outcome_filter: Option<BulkEntryOutcome>,
         limit: u32,
-        offset: u32,
-    ) -> StorageResult<Vec<BulkEntryResult>> {
+        continuation: Option<&EntryResultContinuation>,
+    ) -> StorageResult<EntryResultPage> {
+        if limit == 0 {
+            return Err(invalid_entry_result_page(
+                "Receipt page limit must be greater than zero",
+            ));
+        }
+        let after = match continuation {
+            None => None,
+            Some(EntryResultContinuation::Keyset(cursor)) => Some((
+                cursor.file_url.as_str(),
+                i64::try_from(cursor.line_number).map_err(|_| {
+                    invalid_entry_result_page("Receipt cursor line exceeds SQLite INTEGER range")
+                })?,
+            )),
+            Some(EntryResultContinuation::Offset(_)) => {
+                return Err(invalid_entry_result_page(
+                    "SQLite receipt pages require a keyset continuation",
+                ));
+            }
+        };
         let conn = self.get_connection()?;
-        let tenant_id = tenant.tenant_id().as_str();
-
-        let mut query =
-            "SELECT line_number, resource_type, resource_id, created, outcome, operation_outcome
+        let mut query = "SELECT file_url, line_number, resource_type, resource_id, created, outcome, operation_outcome
              FROM bulk_entry_results
-             WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3 AND manifest_id = ?4"
-                .to_string();
-
+             WHERE tenant_id = ? AND submitter = ? AND submission_id = ? AND manifest_id = ?".to_string();
         let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = vec![
-            Box::new(tenant_id.to_string()),
+            Box::new(tenant.tenant_id().as_str().to_string()),
             Box::new(submission_id.submitter.clone()),
             Box::new(submission_id.submission_id.clone()),
             Box::new(manifest_id.to_string()),
         ];
-
         if let Some(outcome) = outcome_filter {
             query.push_str(" AND outcome = ?");
             params_vec.push(Box::new(outcome.to_string()));
         }
-
-        query.push_str(" ORDER BY line_number");
-        query.push_str(&format!(" LIMIT {} OFFSET {}", limit, offset));
-
+        if let Some((file, line)) = after {
+            query.push_str(" AND (file_url, line_number) > (?, ?)");
+            params_vec.push(Box::new(file.to_string()));
+            params_vec.push(Box::new(line));
+        }
+        query.push_str(" ORDER BY file_url, line_number LIMIT ?");
+        params_vec.push(Box::new(i64::from(limit)));
         let params_slice: Vec<&dyn rusqlite::ToSql> =
             params_vec.iter().map(|p| p.as_ref()).collect();
-
-        let mut stmt = conn
-            .prepare(&query)
-            .map_err(|e| internal_error(format!("Failed to prepare results query: {}", e)))?;
-
-        let results: Vec<BulkEntryResult> = stmt
-            .query_map(params_slice.as_slice(), |row| {
-                let line_number: i64 = row.get(0)?;
-                let resource_type: String = row.get(1)?;
-                let resource_id: Option<String> = row.get(2)?;
-                let created: Option<i32> = row.get(3)?;
-                let outcome_str: String = row.get(4)?;
-                let operation_outcome_bytes: Option<Vec<u8>> = row.get(5)?;
-
-                let outcome: BulkEntryOutcome = outcome_str
-                    .parse()
-                    .unwrap_or(BulkEntryOutcome::ProcessingError);
-
-                let operation_outcome =
-                    operation_outcome_bytes.and_then(|b| serde_json::from_slice(&b).ok());
-
-                Ok(BulkEntryResult {
-                    line_number: line_number as u64,
+        let mut stmt = conn.prepare(&query)?;
+        let mut rows = stmt.query(params_slice.as_slice())?;
+        let mut entries = Vec::new();
+        while let Some(row) = rows.next()? {
+            let file_url: String = row.get(0)?;
+            let line: i64 = row.get(1)?;
+            let line_number = u64::try_from(line)
+                .map_err(|_| internal_error("Negative stored receipt line number".to_string()))?;
+            let resource_type = row.get(2)?;
+            let resource_id = row.get(3)?;
+            let created: Option<i32> = row.get(4)?;
+            let outcome_str: String = row.get(5)?;
+            let operation_outcome_bytes: Option<Vec<u8>> = row.get(6)?;
+            let operation_outcome = operation_outcome_bytes
+                .map(|b| serde_json::from_slice(&b))
+                .transpose()?;
+            let outcome = outcome_str
+                .parse()
+                .unwrap_or(BulkEntryOutcome::ProcessingError);
+            entries.push(PagedEntryResult {
+                stored_identity: Some(EntryResultCursor {
+                    file_url,
+                    line_number,
+                }),
+                result: BulkEntryResult {
+                    line_number,
                     resource_type,
                     resource_id,
-                    created: created.map(|c| c != 0).unwrap_or(false),
+                    created: created.is_some_and(|value| value != 0),
                     outcome,
                     operation_outcome,
-                })
-            })
-            .map_err(|e| internal_error(format!("Failed to query results: {}", e)))?
-            .filter_map(|r| r.ok())
-            .collect();
-
-        Ok(results)
+                },
+            });
+        }
+        let next = if entries.len() == limit as usize {
+            entries
+                .last()
+                .and_then(|entry| entry.stored_identity.clone())
+                .map(EntryResultContinuation::Keyset)
+        } else {
+            None
+        };
+        Ok(EntryResultPage { entries, next })
     }
 
     async fn get_entry_counts(
@@ -2117,6 +2142,114 @@ mod tests {
     use super::*;
     use crate::tenant::{TenantId, TenantPermissions};
     use serde_json::json;
+
+    mod paging_contract {
+        use crate as persistence;
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/bulk_submit/paging_contract.rs"
+        ));
+    }
+
+    mod consumer_contract {
+        use crate as persistence;
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/bulk_submit/consumer_contract.rs"
+        ));
+    }
+
+    #[tokio::test]
+    async fn bulk_submit_worker_exact_artifacts_across_pages() {
+        consumer_contract::worker_receipts(
+            std::sync::Arc::new(create_test_backend()),
+            &create_test_tenant(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn bulk_submit_composite_deduplicates_all_pages_on_finish_and_failure() {
+        for (fail, secondary_failure) in
+            [(false, false), (true, false), (false, true), (true, true)]
+        {
+            consumer_contract::composite_receipts(
+                std::sync::Arc::new(create_test_backend()),
+                &create_test_tenant(),
+                crate::core::BackendKind::Sqlite,
+                fail,
+                secondary_failure,
+            )
+            .await;
+        }
+    }
+
+    #[async_trait]
+    impl paging_contract::ReceiptFixture for SqliteBackend {
+        async fn seed_receipts(
+            &self,
+            tenant: &TenantContext,
+            submission: &SubmissionId,
+            manifest: &str,
+            rows: &[paging_contract::ReceiptRow],
+        ) {
+            let conn = self.get_connection().unwrap();
+            let tid = tenant.tenant_id().as_str();
+            conn.execute("INSERT OR IGNORE INTO bulk_submissions (tenant_id,submitter,submission_id,status,created_at,updated_at) VALUES (?1,?2,?3,'complete',datetime('now'),datetime('now'))", params![tid, submission.submitter, submission.submission_id]).unwrap();
+            conn.execute("INSERT OR IGNORE INTO bulk_manifests (tenant_id,submitter,submission_id,manifest_id,status,added_at) VALUES (?1,?2,?3,?4,'completed',datetime('now'))", params![tid, submission.submitter, submission.submission_id, manifest]).unwrap();
+            for row in rows {
+                conn.execute("INSERT INTO bulk_entry_results (tenant_id,submitter,submission_id,manifest_id,file_url,line_number,resource_type,resource_id,outcome) VALUES (?1,?2,?3,?4,?5,?6,'Patient',?7,?8)", params![tid, submission.submitter, submission.submission_id, manifest, row.file, row.line, row.id, row.outcome]).unwrap();
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn bulk_submit_exact_keyset_pages() {
+        paging_contract::exact_sql_pages(&create_test_backend(), &create_test_tenant(), i64::MAX)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn bulk_submit_corrupt_receipt_is_an_error_not_a_short_page() {
+        use paging_contract::ReceiptFixture;
+        let backend = create_test_backend();
+        let tenant = create_test_tenant();
+        let sub = SubmissionId::generate("corrupt-receipt");
+        backend
+            .seed_receipts(
+                &tenant,
+                &sub,
+                "manifest",
+                &[paging_contract::ReceiptRow {
+                    file: String::new(),
+                    line: 0,
+                    id: "p".to_string(),
+                    outcome: "processing-error",
+                }],
+            )
+            .await;
+        backend
+            .get_connection()
+            .unwrap()
+            .execute(
+                "UPDATE bulk_entry_results SET operation_outcome = ?1",
+                params![b"not-json".to_vec()],
+            )
+            .unwrap();
+        assert!(
+            backend
+                .get_entry_results_page(&tenant, &sub, "manifest", None, 10, None)
+                .await
+                .is_err()
+        );
+        backend.get_connection().unwrap().execute("UPDATE bulk_entry_results SET operation_outcome = NULL, line_number = 'not-a-number'", []).unwrap();
+        assert!(
+            backend
+                .get_entry_results_page(&tenant, &sub, "manifest", None, 10, None)
+                .await
+                .is_err()
+        );
+    }
 
     fn create_test_backend() -> SqliteBackend {
         let backend = SqliteBackend::in_memory().unwrap();

--- a/crates/persistence/src/composite/bulk_submit.rs
+++ b/crates/persistence/src/composite/bulk_submit.rs
@@ -36,9 +36,10 @@ use tracing::warn;
 use crate::core::bulk_export_worker::{LeaseError, WorkerId};
 use crate::core::bulk_submit::{
     BulkEntryOutcome, BulkEntryResult, BulkProcessingOptions, BulkSubmitProvider,
-    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, NdjsonEntry, StreamProcessingResult,
-    StreamingBulkSubmitProvider, SubmissionChange, SubmissionId, SubmissionManifest,
-    SubmissionStatus, SubmissionSummary,
+    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, EntryResultContinuation,
+    EntryResultPage, NdjsonEntry, StreamProcessingResult, StreamingBulkSubmitProvider,
+    SubmissionChange, SubmissionId, SubmissionManifest, SubmissionStatus, SubmissionSummary,
+    entry_result_pages,
 };
 use crate::core::bulk_submit_worker::{
     BulkSubmitJobStore, ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget,
@@ -79,23 +80,32 @@ impl CompositeSubmitJobs {
     /// not be blocked by a search-index hiccup. Distinct resources are
     /// synced once even when a manifest touched them on several lines.
     async fn sync_ingested(&self, lease: &ManifestLease) {
-        let mut seen: std::collections::HashSet<(String, String)> =
-            std::collections::HashSet::new();
-        let limit = 1000u32;
-        let mut offset = 0u32;
-        loop {
-            let batch = match self
-                .primary
-                .get_entry_results(
+        let pages = entry_result_pages(|continuation| async move {
+            self.primary
+                .get_entry_results_page(
                     &lease.tenant,
                     &lease.submission_id,
                     &lease.manifest_id,
                     Some(BulkEntryOutcome::Success),
-                    limit,
-                    offset,
+                    1000,
+                    continuation.as_ref(),
                 )
                 .await
-            {
+        });
+        self.sync_ingested_pages(lease, pages).await;
+    }
+
+    async fn sync_ingested_pages(
+        &self,
+        lease: &ManifestLease,
+        pages: impl futures::Stream<Item = StorageResult<EntryResultPage>>,
+    ) {
+        use futures::StreamExt;
+        let mut seen: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        futures::pin_mut!(pages);
+        while let Some(page) = pages.next().await {
+            let page = match page {
                 Ok(b) => b,
                 Err(e) => {
                     warn!(
@@ -108,13 +118,12 @@ impl CompositeSubmitJobs {
                     return;
                 }
             };
-            let n = batch.len() as u32;
             // One batch per (type, FHIR version) per page, so the secondary
             // takes a page of ingested resources as one write rather than one
             // synchronous event each — under Elasticsearch `refresh=wait_for`
             // that is one refresh wait per page instead of per resource.
             let mut by_type: Vec<SyncGroup> = Vec::new();
-            for entry in batch {
+            for entry in page.entries.into_iter().map(|entry| entry.result) {
                 let Some(resource_id) = entry.resource_id else {
                     continue;
                 };
@@ -147,10 +156,6 @@ impl CompositeSubmitJobs {
                     )
                     .await;
             }
-            if n < limit {
-                return;
-            }
-            offset += limit;
         }
     }
 
@@ -478,23 +483,23 @@ impl BulkSubmitProvider for CompositeSubmitJobs {
             .await
     }
 
-    async fn get_entry_results(
+    async fn get_entry_results_page(
         &self,
         tenant: &TenantContext,
         submission_id: &SubmissionId,
         manifest_id: &str,
         outcome_filter: Option<BulkEntryOutcome>,
         limit: u32,
-        offset: u32,
-    ) -> StorageResult<Vec<BulkEntryResult>> {
+        continuation: Option<&EntryResultContinuation>,
+    ) -> StorageResult<EntryResultPage> {
         self.primary
-            .get_entry_results(
+            .get_entry_results_page(
                 tenant,
                 submission_id,
                 manifest_id,
                 outcome_filter,
                 limit,
-                offset,
+                continuation,
             )
             .await
     }
@@ -955,6 +960,56 @@ mod tests {
         let jobs =
             CompositeSubmitJobs::new(sqlite.clone() as Arc<dyn BulkSubmitJobStore>, composite);
         (sqlite, jobs, events)
+    }
+
+    mod scripted_pages {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/bulk_submit/scripted_pages.rs"
+        ));
+    }
+
+    #[tokio::test]
+    async fn sync_consumer_reads_beyond_an_empty_page_with_continuation() {
+        let (sqlite, jobs, events) = harness();
+        let tenant = tenant();
+        let sub = SubmissionId::generate("scripted-sync");
+        sqlite.create_submission(&tenant, &sub, None).await.unwrap();
+        sqlite
+            .add_manifest(&tenant, &sub, Some("http://provider/m.json"), None)
+            .await
+            .unwrap();
+        let lease = sqlite
+            .claim_next_manifest(
+                &WorkerId::new("scripted"),
+                std::time::Duration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        for id in ["after-empty", "exclusive-late"] {
+            sqlite
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({"resourceType":"Patient", "id":id}),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+        let (pages, calls) = scripted_pages::pages();
+        jobs.sync_ingested_pages(&lease, pages).await;
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 3);
+        let mut actual = events.lock().clone();
+        actual.sort();
+        assert_eq!(
+            actual,
+            vec![
+                "create Patient/after-empty",
+                "create Patient/exclusive-late"
+            ]
+        );
     }
 
     /// #882: a finished manifest pushes every ingested resource into the

--- a/crates/persistence/src/core/bulk_submit.rs
+++ b/crates/persistence/src/core/bulk_submit.rs
@@ -56,7 +56,7 @@ use tokio::io::AsyncBufRead;
 use uuid::Uuid;
 
 use crate::core::storage::ResourceStorage;
-use crate::error::StorageResult;
+use crate::error::{StorageError, StorageResult};
 use crate::tenant::TenantContext;
 
 /// Audit event helpers for bulk submit operations.
@@ -469,6 +469,79 @@ impl BulkEntryResult {
             BulkEntryOutcome::ValidationError | BulkEntryOutcome::ProcessingError
         )
     }
+}
+
+/// Stored receipt identity within one tenant, submission and manifest.
+/// SQL backends compare this pair using the database's ordering, not Rust's
+/// string ordering. Empty file URLs and line zero are valid stored values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntryResultCursor {
+    /// Original input file URL, as stored by the ingestion engine.
+    pub file_url: String,
+    /// Line number in that file.
+    pub line_number: u64,
+}
+
+/// Backend continuation for receipt traversal. Callers pass this back unchanged
+/// to the same provider with the same scope, outcome filter and page limit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntryResultContinuation {
+    /// PostgreSQL and SQLite continue strictly after this stored identity.
+    Keyset(EntryResultCursor),
+    /// MongoDB and S3 retain their existing offset-based traversal internally.
+    /// SQL providers reject this variant, including offset zero.
+    Offset(u32),
+}
+
+/// One receipt and, when available, its original persisted identity.
+#[derive(Debug, Clone)]
+pub struct PagedEntryResult {
+    /// The unchanged ingestion result, also used by persisted S3 objects.
+    pub result: BulkEntryResult,
+    /// Always present for PostgreSQL and SQLite. Other adapters may omit this:
+    /// old S3 receipt objects do not retain a recoverable original file URL.
+    pub stored_identity: Option<EntryResultCursor>,
+}
+
+/// A bounded receipt page. Only `next == None` means traversal is complete;
+/// an empty page may still carry a continuation.
+#[derive(Debug, Clone)]
+pub struct EntryResultPage {
+    /// At most the requested page limit of receipts, already outcome-filtered.
+    pub entries: Vec<PagedEntryResult>,
+    /// Continuation to pass unchanged to the next request.
+    pub next: Option<EntryResultContinuation>,
+}
+
+pub(crate) fn invalid_entry_result_page(message: impl Into<String>) -> StorageError {
+    crate::error::ValidationError::InvalidResource {
+        message: message.into(),
+        details: Vec::new(),
+    }
+    .into()
+}
+
+/// Traverse opaque backend continuations without treating an empty page as EOF.
+/// Consumers retain page boundaries for batching and choose their error policy.
+pub(crate) fn entry_result_pages<F, Fut>(
+    fetch: F,
+) -> impl futures::Stream<Item = StorageResult<EntryResultPage>>
+where
+    F: FnMut(Option<EntryResultContinuation>) -> Fut,
+    Fut: std::future::Future<Output = StorageResult<EntryResultPage>>,
+{
+    futures::stream::try_unfold(
+        (fetch, None, false),
+        |(mut fetch, continuation, finished)| async move {
+            if finished {
+                return Ok(None);
+            }
+            let page = fetch(continuation).await?;
+            let next = page.next.clone();
+            let finished = next.is_none();
+            Ok(Some((page, (fetch, next, finished))))
+        },
+    )
 }
 
 /// Summary of a submission's status.
@@ -1221,29 +1294,29 @@ pub trait BulkSubmitProvider: ResourceStorage {
         options: &BulkProcessingOptions,
     ) -> StorageResult<Vec<BulkEntryResult>>;
 
-    /// Gets entry results for a manifest.
+    /// Reads one bounded page of persisted receipts for a fixed scope and filter.
     ///
-    /// # Arguments
+    /// Start with `continuation = None`, then pass each page's `next` unchanged
+    /// until it is `None`. Keep tenant, submission, manifest, outcome filter and
+    /// nonzero limit unchanged throughout that traversal. Filtering happens
+    /// before limiting; a full last page may require a final empty request.
     ///
-    /// * `tenant` - The tenant context
-    /// * `submission_id` - The submission identifier
-    /// * `manifest_id` - The manifest identifier
-    /// * `outcome_filter` - Optional filter by outcome
-    /// * `limit` - Maximum number of results
-    /// * `offset` - Offset for pagination
+    /// SQL providers use native keyset pagination and return every stored
+    /// identity. MongoDB/S3 encapsulate their existing offset mechanism. A
+    /// continuation of the wrong kind is an error, never a fallback request.
     ///
-    /// # Returns
-    ///
-    /// List of entry results.
-    async fn get_entry_results(
+    /// This replaces the former `get_entry_results` offset method and is a
+    /// source-incompatible change to the Rust provider API. It does not change
+    /// the bulk-submit HTTP protocol or serialized `BulkEntryResult` objects.
+    async fn get_entry_results_page(
         &self,
         tenant: &TenantContext,
         submission_id: &SubmissionId,
         manifest_id: &str,
         outcome_filter: Option<BulkEntryOutcome>,
         limit: u32,
-        offset: u32,
-    ) -> StorageResult<Vec<BulkEntryResult>>;
+        continuation: Option<&EntryResultContinuation>,
+    ) -> StorageResult<EntryResultPage>;
 
     /// Gets entry counts for a manifest.
     ///
@@ -1360,6 +1433,21 @@ pub trait BulkSubmitRollbackProvider: BulkSubmitProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn receipt_page_errors_end_traversal_without_retry() {
+        use futures::StreamExt;
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let observed = calls.clone();
+        let pages = entry_result_pages(move |_| {
+            observed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            std::future::ready(Err(invalid_entry_result_page("scripted read failure")))
+        });
+        futures::pin_mut!(pages);
+        assert!(pages.next().await.unwrap().is_err());
+        assert!(pages.next().await.is_none());
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
 
     #[test]
     fn test_submission_id() {

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -24,7 +24,8 @@ use crate::core::bulk_export_output::{ExportOutputStore, ExportPartKey};
 use crate::core::bulk_export_worker::{LeaseError, WorkerId};
 use crate::core::bulk_submit::{
     BulkEntryOutcome, BulkProcessingOptions, BulkSubmitProvider, BulkSubmitRollbackProvider,
-    ByteProgress, ImportMode, StreamingBulkSubmitProvider, SubmissionId,
+    ByteProgress, EntryResultPage, ImportMode, StreamingBulkSubmitProvider, SubmissionId,
+    entry_result_pages,
 };
 use crate::core::bulk_submit_input::{SubmitInputFetcher, submission_output_job_id};
 use crate::error::{StorageError, StorageResult};
@@ -922,31 +923,36 @@ where
         _fhir_version: FhirVersion,
         failed_count: u64,
     ) -> StorageResult<()> {
-        let job_id = submission_output_job_id(&lease.submission_id);
-        let tenant_id = lease.tenant.tenant_id().as_str().to_string();
-
-        // Page through all entry results for this manifest.
-        let mut all = Vec::new();
-        let limit = 1000u32;
-        let mut offset = 0u32;
-        loop {
-            let batch = self
-                .jobs
-                .get_entry_results(
+        let pages = entry_result_pages(|continuation| async move {
+            self.jobs
+                .get_entry_results_page(
                     &lease.tenant,
                     &lease.submission_id,
                     &lease.manifest_id,
                     None,
-                    limit,
-                    offset,
+                    1000,
+                    continuation.as_ref(),
                 )
-                .await?;
-            let n = batch.len() as u32;
-            all.extend(batch);
-            if n < limit {
-                break;
-            }
-            offset += limit;
+                .await
+        });
+        self.write_result_artifact_pages(lease, manifest_url, failed_count, pages)
+            .await
+    }
+
+    async fn write_result_artifact_pages(
+        &self,
+        lease: &ManifestLease,
+        manifest_url: &str,
+        failed_count: u64,
+        pages: impl futures::Stream<Item = StorageResult<EntryResultPage>>,
+    ) -> StorageResult<()> {
+        use futures::TryStreamExt;
+        let job_id = submission_output_job_id(&lease.submission_id);
+        let tenant_id = lease.tenant.tenant_id().as_str().to_string();
+        let mut all = Vec::new();
+        futures::pin_mut!(pages);
+        while let Some(page) = pages.try_next().await? {
+            all.extend(page.entries.into_iter().map(|entry| entry.result));
         }
 
         // Partition successes (by type) and errors.
@@ -1270,6 +1276,81 @@ mod tests {
     use crate::core::storage::ResourceStorage;
     use crate::tenant::{TenantContext, TenantId, TenantPermissions};
     use std::time::Duration as StdDuration;
+
+    mod scripted_pages {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/bulk_submit/scripted_pages.rs"
+        ));
+    }
+
+    #[tokio::test]
+    async fn artifact_consumer_reads_beyond_an_empty_page_with_continuation() {
+        use tokio::io::AsyncReadExt;
+        let backend = Arc::new(SqliteBackend::in_memory().unwrap());
+        backend.init_schema().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let output = Arc::new(LocalFsOutputStore::new(
+            tmp.path().to_path_buf(),
+            "http://localhost",
+        ));
+        let tenant = tenant();
+        let sub = SubmissionId::generate("scripted-artifacts");
+        backend
+            .create_submission(&tenant, &sub, None)
+            .await
+            .unwrap();
+        backend
+            .add_manifest(&tenant, &sub, Some("http://provider/m.json"), None)
+            .await
+            .unwrap();
+        let lease = backend
+            .claim_next_manifest(&WorkerId::new("scripted"), StdDuration::from_secs(60))
+            .await
+            .unwrap()
+            .unwrap();
+        let worker = DefaultSubmitWorker::new(
+            backend.clone(),
+            patient_fetcher(""),
+            output.clone(),
+            WorkerId::new("scripted"),
+        );
+        let (pages, calls) = scripted_pages::pages();
+        worker
+            .write_result_artifact_pages(&lease, "http://provider/m.json", 0, pages)
+            .await
+            .unwrap();
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 3);
+        let rows = backend.list_submit_files(&tenant, &sub).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.line_count, 3);
+        let key = ExportPartKey {
+            tenant_id: tenant.tenant_id().as_str().to_string(),
+            job_id: submission_output_job_id(&sub),
+            resource_type: row.resource_type.clone().unwrap(),
+            file_type: row.file_type.clone(),
+            part_index: row.part_index,
+            fencing_token: row.fencing_token,
+        };
+        let mut reader = output.open_reader(&key).await.unwrap();
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await.unwrap();
+        assert_eq!(row.byte_count, bytes.len() as u64);
+        let references: Vec<Value> = std::str::from_utf8(&bytes)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(
+            references,
+            vec![
+                json!({"reference":"Patient/after-empty"}),
+                json!({"reference":"Patient/after-empty"}),
+                json!({"reference":"Patient/exclusive-late"}),
+            ]
+        );
+    }
 
     /// Captures the deferred-reindex callbacks the worker fires.
     struct MockReindexHook {

--- a/crates/persistence/src/core/mod.rs
+++ b/crates/persistence/src/core/mod.rs
@@ -125,8 +125,9 @@ pub use bulk_export_worker::{
 pub use bulk_provider::{BulkProviderStore, StoredProviderSubmission};
 pub use bulk_submit::{
     BulkEntryOutcome, BulkEntryResult, BulkProcessingOptions, BulkSubmitProvider,
-    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, IMPORT_MODE_PARAMETER_URL,
-    ImportMode, ManifestStatus, NdjsonEntry, StreamProcessingResult, StreamingBulkSubmitProvider,
+    BulkSubmitRollbackProvider, ChangeType, EntryCountSummary, EntryResultContinuation,
+    EntryResultCursor, EntryResultPage, IMPORT_MODE_PARAMETER_URL, ImportMode, ManifestStatus,
+    NdjsonEntry, PagedEntryResult, StreamProcessingResult, StreamingBulkSubmitProvider,
     SubmissionChange, SubmissionId, SubmissionManifest, SubmissionStatus, SubmissionSummary,
     merge_resource,
 };

--- a/crates/persistence/tests/bulk_submit/consumer_contract.rs
+++ b/crates/persistence/tests/bulk_submit/consumer_contract.rs
@@ -1,0 +1,517 @@
+// Shared real-SQL consumer regressions. The including module aliases the library
+// as `persistence`; no network provider or background worker service is needed.
+use async_trait::async_trait;
+use helios_fhir::FhirVersion;
+use persistence::backends::local_fs::LocalFsOutputStore;
+use persistence::composite::bulk_submit::CompositeSubmitJobs;
+use persistence::composite::config::{CompositeConfig, SyncMode};
+use persistence::composite::storage::{CompositeStorage, DynStorage};
+use persistence::core::bulk_export_output::{ExportOutputStore, ExportPartKey};
+use persistence::core::bulk_submit::{
+    BulkEntryOutcome, BulkProcessingOptions, ManifestStatus, NdjsonEntry, SubmissionId,
+};
+use persistence::core::bulk_submit_input::{
+    RemoteFile, RemoteManifest, SubmitInputFetcher, submission_output_job_id,
+};
+use persistence::core::bulk_submit_worker::{
+    BulkSubmitJobStore, DefaultSubmitWorker, ManifestLease, SubmitWorkerStorage,
+};
+use persistence::core::{BackendKind, ResourceStorage, WorkerId};
+use persistence::error::StorageResult;
+use persistence::tenant::TenantContext;
+use persistence::types::StoredResource;
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
+
+struct MemoryFetcher {
+    files: HashMap<String, Vec<u8>>,
+    manifest: RemoteManifest,
+}
+
+#[async_trait]
+impl SubmitInputFetcher for MemoryFetcher {
+    async fn fetch_manifest(
+        &self,
+        _: &str,
+        _: &[(String, String)],
+        _: &[String],
+        _: Option<&Value>,
+    ) -> StorageResult<RemoteManifest> {
+        Ok(self.manifest.clone())
+    }
+
+    async fn open_file_stream(
+        &self,
+        url: &str,
+        _: &[(String, String)],
+        _: bool,
+        _: &[String],
+        _: Option<&Value>,
+    ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
+        let bytes = self
+            .files
+            .get(url)
+            .expect("manifest references a fixture file")
+            .clone();
+        let length = bytes.len() as u64;
+        Ok((
+            Box::new(tokio::io::BufReader::new(std::io::Cursor::new(bytes))),
+            Some(length),
+        ))
+    }
+
+    async fn file_size(
+        &self,
+        url: &str,
+        _: &[(String, String)],
+        _: bool,
+        _: &[String],
+    ) -> StorageResult<Option<u64>> {
+        Ok(Some(self.files[url].len() as u64))
+    }
+}
+
+async fn claim<B: BulkSubmitJobStore>(
+    backend: &B,
+    submission: &SubmissionId,
+    manifest: &str,
+) -> ManifestLease {
+    let worker = WorkerId::new(format!("receipt-contract-{}", uuid::Uuid::new_v4()));
+    let mut held = Vec::new();
+    let mut found = None;
+    for _ in 0..256 {
+        match backend
+            .claim_next_manifest(&worker, Duration::from_secs(300))
+            .await
+            .unwrap()
+        {
+            Some(lease) if lease.submission_id == *submission && lease.manifest_id == manifest => {
+                found = Some(lease);
+                break;
+            }
+            Some(lease) => held.push(lease),
+            None => panic!("expected a claimable receipt fixture"),
+        }
+    }
+    for lease in held {
+        persistence::core::SubmitClaimStrategy::release(backend, lease)
+            .await
+            .unwrap();
+    }
+    found.expect("fixture manifest was not reached")
+}
+
+pub async fn worker_receipts<B: BulkSubmitJobStore + 'static>(
+    backend: Arc<B>,
+    tenant: &TenantContext,
+) {
+    let submission = SubmissionId::generate("worker-receipt-contract");
+    backend
+        .create_submission(tenant, &submission, None)
+        .await
+        .unwrap();
+    let manifest = backend
+        .add_manifest(
+            tenant,
+            &submission,
+            Some("http://provider/manifest.json"),
+            None,
+        )
+        .await
+        .unwrap();
+    backend
+        .create(
+            tenant,
+            "Patient",
+            json!({"resourceType":"Patient", "id":"gone"}),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+    backend.delete(tenant, "Patient", "gone").await.unwrap();
+    let mut files = HashMap::new();
+    let mut remote_files = Vec::new();
+    let mut expected = BTreeMap::<String, usize>::new();
+    for file in 0..3 {
+        let url = format!("http://provider/part-{file}.ndjson");
+        let mut bytes = Vec::new();
+        for line in 0..1100 {
+            let id = format!("p-{}", line % 1001);
+            *expected.entry(format!("Patient/{id}")).or_default() += 1;
+            bytes.extend_from_slice(
+                json!({"resourceType":"Patient", "id":id})
+                    .to_string()
+                    .as_bytes(),
+            );
+            bytes.push(b'\n');
+        }
+        bytes.extend_from_slice(b"{\"resourceType\":\"Patient\",\"id\":\"gone\"}\nnot-json\n");
+        files.insert(url.clone(), bytes);
+        remote_files.push(RemoteFile {
+            resource_type: Some("Patient".to_string()),
+            url,
+            count: Some(1102),
+        });
+    }
+    let expected_bytes = files.values().map(|bytes| bytes.len() as u64).sum::<u64>();
+    let fetcher = Arc::new(MemoryFetcher {
+        files,
+        manifest: RemoteManifest {
+            requires_access_token: false,
+            output: remote_files,
+            deleted: Vec::new(),
+        },
+    });
+    let temp = tempfile::tempdir().unwrap();
+    let output = Arc::new(LocalFsOutputStore::new(
+        temp.path().to_path_buf(),
+        "http://localhost",
+    ));
+    let lease = claim(backend.as_ref(), &submission, &manifest.manifest_id).await;
+    let worker = DefaultSubmitWorker::new(
+        backend.clone(),
+        fetcher,
+        output.clone(),
+        lease.worker_id.clone(),
+    );
+    worker.run_job(lease).await.unwrap();
+
+    let current = backend
+        .list_manifests(tenant, &submission)
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(current.status, ManifestStatus::Completed);
+    assert_eq!(current.processed_entries, 3300);
+    assert_eq!(current.failed_entries, 6);
+    assert_eq!(
+        current.total_entries, 3303,
+        "parse failures have no persisted entry result"
+    );
+    assert_eq!(current.bytes_processed, expected_bytes);
+    assert_eq!(current.bytes_total, expected_bytes);
+    let counts = backend
+        .get_entry_counts(tenant, &submission, &manifest.manifest_id)
+        .await
+        .unwrap();
+    assert_eq!(counts.success, 3300);
+    assert_eq!(counts.total, 3303);
+    assert_eq!(counts.processing_error, 3);
+    assert_eq!(counts.skipped, 0);
+    assert_eq!(backend.count(tenant, Some("Patient")).await.unwrap(), 1001);
+
+    // Persisted errors must survive unchanged; parse failures get the existing
+    // single summary OperationOutcome, whose severity is counted once.
+    let stored_errors = backend
+        .get_entry_results_page(
+            tenant,
+            &submission,
+            &manifest.manifest_id,
+            Some(BulkEntryOutcome::ProcessingError),
+            10,
+            None,
+        )
+        .await
+        .unwrap();
+    let mut expected_errors: Vec<_> = stored_errors
+        .entries
+        .into_iter()
+        .map(|entry| entry.result.operation_outcome.unwrap())
+        .collect();
+    expected_errors.push(json!({"resourceType":"OperationOutcome", "issue":[{
+        "severity":"error", "code":"processing", "diagnostics":"3 submitted resource(s) could not be parsed or did not match the declared resource type"
+    }]}));
+    let mut references = BTreeMap::<String, usize>::new();
+    let mut errors = Vec::new();
+    let rows = backend
+        .list_submit_files(tenant, &submission)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    for row in rows {
+        let key = ExportPartKey {
+            tenant_id: tenant.tenant_id().as_str().to_string(),
+            job_id: submission_output_job_id(&submission),
+            resource_type: row.resource_type.clone().unwrap(),
+            file_type: row.file_type.clone(),
+            part_index: row.part_index,
+            fencing_token: row.fencing_token,
+        };
+        let mut reader = output.open_reader(&key).await.unwrap();
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await.unwrap();
+        assert_eq!(row.byte_count, bytes.len() as u64);
+        let lines: Vec<Value> = std::str::from_utf8(&bytes)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(row.line_count, lines.len() as u64);
+        match row.file_type.as_str() {
+            "output" => {
+                for line in lines {
+                    *references
+                        .entry(line["reference"].as_str().unwrap().to_string())
+                        .or_default() += 1;
+                }
+            }
+            "error" => {
+                assert_eq!(row.count_severity, Some(json!({"error":4})));
+                errors.extend(lines);
+            }
+            other => panic!("unexpected artifact kind {other}"),
+        }
+    }
+    assert_eq!(references, expected);
+    errors.sort_by_key(Value::to_string);
+    expected_errors.sort_by_key(Value::to_string);
+    assert_eq!(errors, expected_errors);
+}
+
+struct RecordingSecondary {
+    events: Arc<Mutex<Vec<String>>>,
+    fail_on: Option<String>,
+    failures: Arc<Mutex<usize>>,
+}
+
+#[async_trait]
+impl ResourceStorage for RecordingSecondary {
+    fn backend_name(&self) -> &'static str {
+        "receipt-secondary"
+    }
+    async fn create(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        resource: Value,
+        version: FhirVersion,
+    ) -> StorageResult<StoredResource> {
+        let id = resource["id"].as_str().unwrap().to_string();
+        if self.fail_on.as_deref() == Some(&id) {
+            *self.failures.lock().unwrap() += 1;
+            return Err(persistence::error::ValidationError::InvalidResource {
+                message: "intentional secondary failure after earlier receipt pages".to_string(),
+                details: Vec::new(),
+            }
+            .into());
+        }
+        self.events
+            .lock()
+            .unwrap()
+            .push(format!("{resource_type}/{id}"));
+        Ok(StoredResource::new(
+            resource_type,
+            id,
+            tenant.tenant_id().clone(),
+            resource,
+            version,
+        ))
+    }
+    async fn create_or_update(
+        &self,
+        tenant: &TenantContext,
+        resource_type: &str,
+        id: &str,
+        mut resource: Value,
+        version: FhirVersion,
+    ) -> StorageResult<(StoredResource, bool)> {
+        resource["id"] = Value::String(id.to_string());
+        Ok((
+            self.create(tenant, resource_type, resource, version)
+                .await?,
+            true,
+        ))
+    }
+    async fn read(
+        &self,
+        _: &TenantContext,
+        _: &str,
+        _: &str,
+    ) -> StorageResult<Option<StoredResource>> {
+        Ok(None)
+    }
+    async fn update(
+        &self,
+        _: &TenantContext,
+        _: &StoredResource,
+        _: Value,
+    ) -> StorageResult<StoredResource> {
+        panic!("unexpected secondary update")
+    }
+    async fn delete(&self, _: &TenantContext, _: &str, _: &str) -> StorageResult<()> {
+        panic!("unexpected secondary delete")
+    }
+    async fn count(&self, _: &TenantContext, _: Option<&str>) -> StorageResult<u64> {
+        Ok(self.events.lock().unwrap().len() as u64)
+    }
+}
+
+pub async fn composite_receipts<B: BulkSubmitJobStore + 'static>(
+    backend: Arc<B>,
+    tenant: &TenantContext,
+    kind: BackendKind,
+    fail: bool,
+    secondary_failure: bool,
+) {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let failures = Arc::new(Mutex::new(0));
+    let config = CompositeConfig::builder()
+        .primary("primary", kind)
+        .search_backend("secondary", BackendKind::Elasticsearch)
+        .sync_mode(SyncMode::Synchronous)
+        .build()
+        .unwrap();
+    let storage = Arc::new(
+        CompositeStorage::new(
+            config,
+            HashMap::from([
+                ("primary".to_string(), backend.clone() as DynStorage),
+                (
+                    "secondary".to_string(),
+                    Arc::new(RecordingSecondary {
+                        events: events.clone(),
+                        fail_on: secondary_failure.then(|| "late-2-1000".to_string()),
+                        failures: failures.clone(),
+                    }) as DynStorage,
+                ),
+            ]),
+        )
+        .unwrap(),
+    );
+    let jobs = CompositeSubmitJobs::new(backend.clone(), storage);
+    let submission = SubmissionId::generate("composite-receipt-contract");
+    backend
+        .create_submission(tenant, &submission, None)
+        .await
+        .unwrap();
+    let manifest = backend
+        .add_manifest(
+            tenant,
+            &submission,
+            Some("http://provider/composite.json"),
+            None,
+        )
+        .await
+        .unwrap();
+    let lease = claim(backend.as_ref(), &submission, &manifest.manifest_id).await;
+    backend
+        .create(
+            tenant,
+            "Patient",
+            json!({"resourceType":"Patient", "id":"gone"}),
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+    backend.delete(tenant, "Patient", "gone").await.unwrap();
+    let mut expected = BTreeSet::new();
+    for file in 0..3 {
+        let mut entries: Vec<_> = (0..1100)
+            .map(|line| {
+                // Each later page contains both repeated IDs and resources that
+                // cannot be synchronized by stopping after an earlier page.
+                let id = if line >= 1000 {
+                    format!("late-{file}-{line}")
+                } else {
+                    format!("p-{}", line % 701)
+                };
+                expected.insert(format!("Patient/{id}"));
+                NdjsonEntry::new(
+                    line + 1,
+                    "Patient",
+                    json!({"resourceType":"Patient", "id":id}),
+                )
+            })
+            .collect();
+        entries.push(NdjsonEntry::new(
+            1101,
+            "Patient",
+            json!({"resourceType":"Patient", "id":"gone"}),
+        ));
+        entries.push(NdjsonEntry::new(
+            1102,
+            "Patient",
+            json!({"resourceType":"Patient", "id":"must-be-skipped"}),
+        ));
+        let mut options =
+            BulkProcessingOptions::new().with_file_url(format!("http://provider/{file}.ndjson"));
+        options.max_errors = 1;
+        let results = backend
+            .process_entries(
+                tenant,
+                &submission,
+                &manifest.manifest_id,
+                entries,
+                &options,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            results
+                .iter()
+                .filter(|r| r.outcome == BulkEntryOutcome::Success)
+                .count(),
+            1100
+        );
+        assert_eq!(results.last().unwrap().outcome, BulkEntryOutcome::Skipped);
+    }
+    assert!(events.lock().unwrap().is_empty());
+    // The worker reaches receipts through Composite's delegation too.
+    let delegated = persistence::core::BulkSubmitProvider::get_entry_results_page(
+        &jobs,
+        tenant,
+        &submission,
+        &manifest.manifest_id,
+        Some(BulkEntryOutcome::Success),
+        1,
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(delegated.entries[0].stored_identity.is_some());
+    assert!(matches!(
+        delegated.next,
+        Some(persistence::core::EntryResultContinuation::Keyset(_))
+    ));
+    if fail {
+        jobs.fail_manifest(&lease, "intentional partial failure")
+            .await
+            .unwrap();
+    } else {
+        jobs.finish_manifest(&lease).await.unwrap();
+    }
+    let mut actual = events.lock().unwrap().clone();
+    actual.sort();
+    if secondary_failure {
+        assert!(
+            *failures.lock().unwrap() > 0,
+            "the secondary must actually reject the late resource"
+        );
+        expected.remove("Patient/late-2-1000");
+    } else {
+        assert_eq!(*failures.lock().unwrap(), 0);
+    }
+    let expected: Vec<_> = expected.into_iter().collect();
+    assert_eq!(
+        actual, expected,
+        "every available resource syncs exactly once across all pages, including resources after a secondary error"
+    );
+    let current = backend
+        .list_manifests(tenant, &submission)
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(
+        current.status,
+        if fail {
+            ManifestStatus::Failed
+        } else {
+            ManifestStatus::Completed
+        }
+    );
+}

--- a/crates/persistence/tests/bulk_submit/paging_contract.rs
+++ b/crates/persistence/tests/bulk_submit/paging_contract.rs
@@ -1,0 +1,270 @@
+// Included by the SQLite unit tests and PostgreSQL integration tests.
+// The including module supplies `persistence` as an alias for the library.
+use persistence::core::bulk_submit::{
+    BulkEntryOutcome, BulkSubmitProvider, EntryResultContinuation, EntryResultCursor,
+    PagedEntryResult, SubmissionId,
+};
+use persistence::tenant::{TenantContext, TenantId, TenantPermissions};
+
+pub struct ReceiptRow {
+    pub file: String,
+    pub line: i64,
+    pub id: String,
+    pub outcome: &'static str,
+}
+
+#[async_trait::async_trait]
+pub trait ReceiptFixture: BulkSubmitProvider {
+    /// Insert the supplied scope verbatim, including an identical manifest id
+    /// in different scopes, so each scope predicate is independently tested.
+    async fn seed_receipts(
+        &self,
+        tenant: &TenantContext,
+        submission: &SubmissionId,
+        manifest: &str,
+        rows: &[ReceiptRow],
+    );
+}
+
+async fn collect_pages<B: BulkSubmitProvider>(
+    backend: &B,
+    tenant: &TenantContext,
+    submission: &SubmissionId,
+    manifest: &str,
+    filter: Option<BulkEntryOutcome>,
+    limit: u32,
+) -> Vec<PagedEntryResult> {
+    let mut next = None;
+    let mut all = Vec::new();
+    // A bound makes a repeated token fail instead of hanging a test forever.
+    for _ in 0..100 {
+        let page = backend
+            .get_entry_results_page(tenant, submission, manifest, filter, limit, next.as_ref())
+            .await
+            .unwrap();
+        assert!(page.entries.len() <= limit as usize);
+        if let Some(token) = &page.next {
+            let EntryResultContinuation::Keyset(cursor) = token else {
+                panic!("SQL returned an OFFSET continuation");
+            };
+            assert_eq!(
+                Some(cursor),
+                page.entries.last().unwrap().stored_identity.as_ref()
+            );
+            assert_ne!(Some(token), next.as_ref(), "continuation must advance");
+        }
+        for entry in &page.entries {
+            assert_eq!(
+                entry.stored_identity.as_ref().unwrap().line_number,
+                entry.result.line_number
+            );
+        }
+        all.extend(page.entries);
+        next = page.next;
+        if next.is_none() {
+            return all;
+        }
+    }
+    panic!("receipt traversal did not terminate");
+}
+
+pub async fn exact_sql_pages<B: ReceiptFixture>(
+    backend: &B,
+    tenant: &TenantContext,
+    max_line: i64,
+) {
+    let submission = SubmissionId::generate("receipt-paging");
+    let manifest = "same-manifest";
+    let rows: Vec<_> = ["", "a.ndjson", "b.ndjson", "c.ndjson", "d.ndjson"]
+        .into_iter()
+        .flat_map(|file| {
+            (0..7).map(move |line| ReceiptRow {
+                file: file.to_string(),
+                line,
+                id: format!("repeated-{}", line % 2),
+                outcome: match line {
+                    0 | 6 => "success",
+                    1 | 2 => "skipped",
+                    3 | 4 => "validation-error",
+                    _ => "processing-error",
+                },
+            })
+        })
+        .collect();
+    backend
+        .seed_receipts(tenant, &submission, manifest, &rows)
+        .await;
+
+    // Only one scope component differs in each distractor. Reusing identical
+    // stored identities exposes a missing predicate even when counts look right.
+    let other_tenant = TenantContext::new(
+        TenantId::new(format!("{}-other", tenant.tenant_id().as_str())),
+        TenantPermissions::full_access(),
+    );
+    let other_submitter = SubmissionId::new("other-submitter", &submission.submission_id);
+    let other_submission = SubmissionId::new(&submission.submitter, "other-submission");
+    let distractors = [ReceiptRow {
+        file: "a.ndjson".to_string(),
+        line: 0,
+        id: "scope-leak".to_string(),
+        outcome: "success",
+    }];
+    for (scope_tenant, scope_submission, scope_manifest) in [
+        (&other_tenant, &submission, manifest),
+        (tenant, &other_submitter, manifest),
+        (tenant, &other_submission, manifest),
+        (tenant, &submission, "other-manifest"),
+    ] {
+        backend
+            .seed_receipts(scope_tenant, scope_submission, scope_manifest, &distractors)
+            .await;
+    }
+
+    for filter in [
+        None,
+        Some(BulkEntryOutcome::Success),
+        Some(BulkEntryOutcome::Skipped),
+        Some(BulkEntryOutcome::ValidationError),
+        Some(BulkEntryOutcome::ProcessingError),
+    ] {
+        let expected: Vec<_> = rows
+            .iter()
+            .filter(|row| filter.is_none_or(|f| f.to_string() == row.outcome))
+            .collect();
+        // One row, tied boundaries, exact multiples, >2 pages, and a single page.
+        for limit in [1, 2, 5, 7, 35, 100] {
+            let actual = collect_pages(backend, tenant, &submission, manifest, filter, limit).await;
+            let identities: Vec<_> = actual
+                .iter()
+                .map(|entry| {
+                    let identity = entry.stored_identity.as_ref().unwrap();
+                    (identity.file_url.as_str(), identity.line_number)
+                })
+                .collect();
+            assert_eq!(
+                identities,
+                expected
+                    .iter()
+                    .map(|row| (row.file.as_str(), row.line as u64))
+                    .collect::<Vec<_>>()
+            );
+            let mut references: Vec<_> = actual
+                .iter()
+                .map(|entry| {
+                    assert_eq!(
+                        entry.result.created, false,
+                        "NULL created retains its existing meaning"
+                    );
+                    format!(
+                        "{}/{}",
+                        entry.result.resource_type,
+                        entry.result.resource_id.as_ref().unwrap()
+                    )
+                })
+                .collect();
+            references.sort();
+            let mut expected_refs: Vec<_> = expected
+                .iter()
+                .map(|row| format!("Patient/{}", row.id))
+                .collect();
+            expected_refs.sort();
+            assert_eq!(
+                references, expected_refs,
+                "receipt multiplicity must survive pagination"
+            );
+        }
+    }
+
+    let empty = collect_pages(backend, tenant, &submission, "empty-manifest", None, 5).await;
+    assert!(empty.is_empty());
+    assert!(
+        backend
+            .get_entry_results_page(tenant, &submission, manifest, None, 0, None)
+            .await
+            .is_err()
+    );
+    assert!(
+        backend
+            .get_entry_results_page(
+                tenant,
+                &submission,
+                manifest,
+                None,
+                1,
+                Some(&EntryResultContinuation::Offset(0))
+            )
+            .await
+            .is_err()
+    );
+    assert!(
+        backend
+            .get_entry_results_page(
+                tenant,
+                &submission,
+                manifest,
+                None,
+                1,
+                Some(&EntryResultContinuation::Keyset(EntryResultCursor {
+                    file_url: String::new(),
+                    line_number: u64::MAX
+                }))
+            )
+            .await
+            .is_err()
+    );
+
+    backend
+        .seed_receipts(
+            tenant,
+            &submission,
+            "maximum-line",
+            &[ReceiptRow {
+                file: String::new(),
+                line: max_line,
+                id: "maximum".to_string(),
+                outcome: "success",
+            }],
+        )
+        .await;
+    let maximum = collect_pages(backend, tenant, &submission, "maximum-line", None, 1).await;
+    assert_eq!(
+        maximum[0].stored_identity.as_ref().unwrap().line_number,
+        max_line as u64
+    );
+    assert!(
+        backend
+            .get_entry_results_page(
+                tenant,
+                &submission,
+                manifest,
+                None,
+                1,
+                Some(&EntryResultContinuation::Keyset(EntryResultCursor {
+                    file_url: String::new(),
+                    line_number: max_line as u64 + 1
+                }))
+            )
+            .await
+            .is_err()
+    );
+
+    backend
+        .seed_receipts(
+            tenant,
+            &submission,
+            "negative-line",
+            &[ReceiptRow {
+                file: "bad.ndjson".to_string(),
+                line: -1,
+                id: "negative".to_string(),
+                outcome: "success",
+            }],
+        )
+        .await;
+    assert!(
+        backend
+            .get_entry_results_page(tenant, &submission, "negative-line", None, 10, None)
+            .await
+            .is_err()
+    );
+}

--- a/crates/persistence/tests/bulk_submit/paging_contract.rs
+++ b/crates/persistence/tests/bulk_submit/paging_contract.rs
@@ -151,8 +151,8 @@ pub async fn exact_sql_pages<B: ReceiptFixture>(
             let mut references: Vec<_> = actual
                 .iter()
                 .map(|entry| {
-                    assert_eq!(
-                        entry.result.created, false,
+                    assert!(
+                        !entry.result.created,
                         "NULL created retains its existing meaning"
                     );
                     format!(

--- a/crates/persistence/tests/bulk_submit/scripted_pages.rs
+++ b/crates/persistence/tests/bulk_submit/scripted_pages.rs
@@ -1,0 +1,58 @@
+// Shared scripted paging source for the real private consumer boundaries.
+use crate::core::bulk_submit::{
+    BulkEntryResult, EntryResultContinuation, EntryResultPage, PagedEntryResult, entry_result_pages,
+};
+use crate::error::StorageResult;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+pub fn pages() -> (
+    impl futures::Stream<Item = StorageResult<EntryResultPage>>,
+    Arc<AtomicUsize>,
+) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let observed = calls.clone();
+    let script = [
+        (
+            None,
+            EntryResultPage {
+                entries: Vec::new(),
+                next: Some(EntryResultContinuation::Offset(17)),
+            },
+        ),
+        (
+            Some(EntryResultContinuation::Offset(17)),
+            EntryResultPage {
+                entries: ["after-empty", "after-empty", "exclusive-late"]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(line, id)| PagedEntryResult {
+                        result: BulkEntryResult::success(line as u64, "Patient", id, true),
+                        stored_identity: None,
+                    })
+                    .collect(),
+                next: Some(EntryResultContinuation::Offset(91)),
+            },
+        ),
+        (
+            Some(EntryResultContinuation::Offset(91)),
+            EntryResultPage {
+                entries: Vec::new(),
+                next: None,
+            },
+        ),
+    ];
+    let mut script = std::collections::VecDeque::from(script);
+    let pages = entry_result_pages(move |continuation| {
+        let (expected, page) = script.pop_front().expect("must not fetch after EOF");
+        assert_eq!(
+            continuation, expected,
+            "consumer passes the opaque token unchanged"
+        );
+        observed.fetch_add(1, Ordering::SeqCst);
+        std::future::ready(Ok(page))
+    });
+    (pages, calls)
+}

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -4186,6 +4186,87 @@ mod bulk_submit {
             counts.total, 2,
             "both files' line 1 must survive as separate results"
         );
+        let mut next = None;
+        let mut ids = Vec::new();
+        for page_index in 0..3 {
+            let page = backend
+                .get_entry_results_page(&tenant, &id, &manifest_id, None, 1, next.as_ref())
+                .await
+                .unwrap();
+            assert!(
+                page.entries
+                    .iter()
+                    .all(|entry| entry.stored_identity.is_none())
+            );
+            ids.extend(
+                page.entries
+                    .into_iter()
+                    .map(|entry| entry.result.resource_id.unwrap()),
+            );
+            next = page.next;
+            if page_index < 2 {
+                assert_eq!(
+                    next,
+                    Some(helios_persistence::core::EntryResultContinuation::Offset(
+                        page_index + 1
+                    ))
+                );
+            } else {
+                assert!(next.is_none(), "exact multiple must terminate");
+            }
+        }
+        assert_eq!(ids, ["pa", "pb"]);
+        assert!(
+            backend
+                .get_entry_results_page(&tenant, &id, &manifest_id, None, 0, None)
+                .await
+                .is_err()
+        );
+        assert!(
+            backend
+                .get_entry_results_page(
+                    &tenant,
+                    &id,
+                    &manifest_id,
+                    None,
+                    1,
+                    Some(&helios_persistence::core::EntryResultContinuation::Keyset(
+                        helios_persistence::core::EntryResultCursor {
+                            file_url: String::new(),
+                            line_number: 0,
+                        }
+                    ))
+                )
+                .await
+                .is_err()
+        );
+        let primary = Arc::new(backend);
+        let config = helios_persistence::composite::config::CompositeConfig::builder()
+            .primary("mongo", BackendKind::MongoDB)
+            .build()
+            .unwrap();
+        let storage = Arc::new(
+            helios_persistence::composite::storage::CompositeStorage::new(
+                config,
+                std::collections::HashMap::from([(
+                    "mongo".to_string(),
+                    primary.clone() as helios_persistence::composite::storage::DynStorage,
+                )]),
+            )
+            .unwrap(),
+        );
+        let jobs =
+            helios_persistence::composite::bulk_submit::CompositeSubmitJobs::new(primary, storage);
+        let delegated = jobs
+            .get_entry_results_page(&tenant, &id, &manifest_id, None, 1, None)
+            .await
+            .unwrap();
+        assert!(delegated.entries[0].stored_identity.is_none());
+        assert_eq!(
+            delegated.next,
+            Some(helios_persistence::core::EntryResultContinuation::Offset(1))
+        );
+        eprintln!("Verified MongoDB bulk-submit receipt pagination and Composite delegation");
     }
 
     #[tokio::test]

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -816,6 +816,79 @@ mod postgres_integration {
     use testcontainers_modules::postgres::Postgres;
     use tokio::sync::{Mutex, OnceCell};
 
+    mod receipt_paging_contract {
+        use helios_persistence as persistence;
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/bulk_submit/paging_contract.rs"
+        ));
+    }
+
+    mod receipt_consumer_contract {
+        use helios_persistence as persistence;
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/bulk_submit/consumer_contract.rs"
+        ));
+    }
+
+    #[tokio::test]
+    async fn postgres_bulk_submit_worker_exact_artifacts_across_pages() {
+        let _guard = BULK_SUBMIT_TEST_LOCK.lock().await;
+        receipt_consumer_contract::worker_receipts(
+            std::sync::Arc::new(create_backend().await),
+            &create_tenant("receipt-worker"),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn postgres_bulk_submit_composite_deduplicates_all_pages_on_finish_and_failure() {
+        let _guard = BULK_SUBMIT_TEST_LOCK.lock().await;
+        for (fail, secondary_failure) in
+            [(false, false), (true, false), (false, true), (true, true)]
+        {
+            receipt_consumer_contract::composite_receipts(
+                std::sync::Arc::new(create_backend().await),
+                &create_tenant("receipt-composite"),
+                BackendKind::Postgres,
+                fail,
+                secondary_failure,
+            )
+            .await;
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl receipt_paging_contract::ReceiptFixture for PostgresBackend {
+        async fn seed_receipts(
+            &self,
+            tenant: &TenantContext,
+            submission: &helios_persistence::core::SubmissionId,
+            manifest: &str,
+            rows: &[receipt_paging_contract::ReceiptRow],
+        ) {
+            let client = self.get_client().await.unwrap();
+            let tid = tenant.tenant_id().as_str();
+            client.execute("INSERT INTO bulk_submissions (tenant_id,submitter,submission_id,status,created_at,updated_at) VALUES ($1,$2,$3,'complete',NOW(),NOW()) ON CONFLICT DO NOTHING", &[&tid, &submission.submitter, &submission.submission_id]).await.unwrap();
+            client.execute("INSERT INTO bulk_manifests (tenant_id,submitter,submission_id,manifest_id,status,added_at) VALUES ($1,$2,$3,$4,'completed',NOW()) ON CONFLICT DO NOTHING", &[&tid, &submission.submitter, &submission.submission_id, &manifest]).await.unwrap();
+            for row in rows {
+                let line = i32::try_from(row.line).unwrap();
+                client.execute("INSERT INTO bulk_entry_results (tenant_id,submitter,submission_id,manifest_id,file_url,line_number,resource_type,resource_id,outcome) VALUES ($1,$2,$3,$4,$5,$6,'Patient',$7,$8)", &[&tid, &submission.submitter, &submission.submission_id, &manifest, &row.file, &line, &row.id, &row.outcome]).await.unwrap();
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn postgres_bulk_submit_exact_keyset_pages() {
+        receipt_paging_contract::exact_sql_pages(
+            &create_backend().await,
+            &create_tenant("receipt-pages"),
+            i64::from(i32::MAX),
+        )
+        .await;
+    }
+
     /// Shared PostgreSQL container reused across all tests in this module.
     struct SharedPg {
         host: String,


### PR DESCRIPTION
Bulk-submit receipt finalization repeatedly scanned earlier rows through OFFSET pagination, while ordering by line number alone did not uniquely order receipts across input files. PostgreSQL and SQLite now traverse the stored `(file_url, line_number)` identity with bound keyset predicates and matching ordering.

The shared provider API returns pages with opaque continuations. SQL providers validate cursor bounds and propagate malformed stored rows. Worker and Composite consumers follow continuations through empty pages, preserving receipt references, artifact counts, resource deduplication and best-effort synchronization. MongoDB and S3 retain their existing traversal and persisted formats.

**Rust API migration:** `BulkSubmitProvider::get_entry_results` is replaced by `get_entry_results_page`. Implementations and callers must return or consume `EntryResultPage` and `EntryResultContinuation`. This is source-incompatible. The bulk-submit HTTP protocol and serialized receipt format remain unchanged.

Validation covers both SQL engines, real worker artifacts, Composite finish/fail behavior, late-page resources, secondary failures, scope isolation, filters, continuation boundaries and malformed data. The final focused suites passed: 54 SQL library tests, 5 PostgreSQL integration tests, 6 SQLite concurrency tests, 75 S3-enabled library tests and 12 live MongoDB integration tests. All four separate minimal provider builds and formatting checks passed. The suites overlap. Three independent code reviews and the performance-report review have no outstanding findings.

New before/after measurements used identical corpora and configuration, retained starting-state snapshots and exact result reconciliation. The matrix includes 36 PostgreSQL HTTP runs, 11 separate diagnostic runs and 54 SQLite traversals.

| Measurement at 192,000 resources | Before | After |
|---|---:|---:|
| PostgreSQL diagnostic receipt read | 12.727 s | 0.529 s |
| PostgreSQL diagnostic finalization | 16.725 s | 4.902 s |
| SQLite unfiltered isolated SQL read, median of three | 11.270 s | 0.101 s |

These are receipt-stage improvements, not whole-import speedup factors. SQLite uses isolated production SQL and decoding; full consumer correctness is tested separately. PostgreSQL HTTP completion at 192,000 resources had medians of 176.710 and 171.033 seconds, with overlapping ranges.

**Performance limits:** the original 48,000-resource reimport HTTP median increased 8.67%. Three additional matched-restore pairs changed by -3.47%, -0.88% and +7.76%; their after median remained 6.18% higher, with overlapping ranges. Those controls neither establish a global improvement nor exclude a regression. PostgreSQL 12k diagnostic reads and SQLite 12k sparse traversal also increased slightly in absolute time. Three-trial results are descriptive, and logical restores do not preserve physical layout or planner statistics.

Whole-manifest accumulation remains, so this change does not promise bounded worker memory. No ingestion settings, schema, indexes or dependencies change.

Closes #973
