### PR TITLE
fix contentReference cardinality not inherited from target

### DIFF
--- a/crates/fhir-validator/src/engine/walk.rs
+++ b/crates/fhir-validator/src/engine/walk.rs
@@ -233,7 +233,10 @@ pub(super) fn add_schemas_to_set(
     if let Some(segments) = schema.element_reference.clone() {
         let ref_key = segments.join(".");
         match resolve_element_reference(ctx.resolver, &segments) {
-            Some(target) => add_schemas_to_set(ctx, set, target, &ref_key),
+            Some(target) => {
+                let stripped = Arc::new(target.without_cardinality());
+                add_schemas_to_set(ctx, set, stripped, &ref_key);
+            }
             None => ctx.error(
                 ErrorKind::UnknownSchema,
                 errors::msg_unknown_schema(&ref_key),

--- a/crates/fhir-validator/src/schema.rs
+++ b/crates/fhir-validator/src/schema.rs
@@ -179,6 +179,21 @@ impl FhirSchema {
     pub fn is_primitive(&self) -> bool {
         self.kind.as_deref() == Some(kind::PRIMITIVE_TYPE)
     }
+
+    /// Return a clone with all cardinality fields cleared.
+    ///
+    /// Used when merging an `elementReference` target into a schema set: the
+    /// target contributes structure (elements, type, constraints) but never
+    /// its own array/min/max, which belong to the referring element.
+    pub fn without_cardinality(&self) -> Self {
+        Self {
+            array: None,
+            scalar: None,
+            min: None,
+            max: None,
+            ..self.clone()
+        }
+    }
 }
 
 /// Terminology binding: the ValueSet a coded value must belong to.

--- a/crates/fhir-validator/tests/extended.rs
+++ b/crates/fhir-validator/tests/extended.rs
@@ -53,3 +53,8 @@ fn extended_element_reference() {
 fn extended_primitives() {
     run_extended("primitives.json");
 }
+
+#[test]
+fn extended_content_reference_cardinality() {
+    run_extended("content_reference_cardinality.json");
+}

--- a/crates/fhir-validator/tests/fixtures/extended/content_reference_cardinality.json
+++ b/crates/fhir-validator/tests/fixtures/extended/content_reference_cardinality.json
@@ -1,0 +1,78 @@
+{
+  "desc": "contentReference cardinality — elementReference target's array/min/max must not override the referring element's own cardinality (#487)",
+  "schemas": {
+    "string": { "kind": "primitive-type" },
+    "Example": {
+      "elements": {
+        "resourceType": { "type": "string" },
+        "items": {
+          "array": true,
+          "elements": {
+            "id": { "type": "string" }
+          }
+        },
+        "single": {
+          "elementReference": ["Example", "elements", "items"]
+        }
+      }
+    }
+  },
+  "tests": [
+    {
+      "desc": "single object accepted when referring element is max=1",
+      "data": {
+        "resourceType": "Example",
+        "single": { "id": "x" }
+      }
+    },
+    {
+      "desc": "array rejected when referring element is max=1",
+      "data": {
+        "resourceType": "Example",
+        "single": [{ "id": "x" }]
+      },
+      "errors": [
+        {
+          "type": "not-singular",
+          "path": "Example.single",
+          "message": "single is not singular"
+        }
+      ]
+    },
+    {
+      "desc": "target structure is still validated through the reference",
+      "data": {
+        "resourceType": "Example",
+        "single": { "id": "x", "bogus": true }
+      },
+      "errors": [
+        {
+          "type": "unknown-element",
+          "path": "Example.single.bogus",
+          "message": "bogus is unknown"
+        }
+      ]
+    },
+    {
+      "desc": "array element preserves its own max=* cardinality unchanged",
+      "data": {
+        "resourceType": "Example",
+        "items": [{ "id": "a" }, { "id": "b" }]
+      }
+    },
+    {
+      "desc": "array element still rejects a non-array",
+      "data": {
+        "resourceType": "Example",
+        "items": { "id": "a" }
+      },
+      "errors": [
+        {
+          "type": "not-array",
+          "path": "Example.items",
+          "message": "items is not array"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/fhir-validator/tests/fixtures/spec-examples/known-failures-r4.json
+++ b/crates/fhir-validator/tests/fixtures/spec-examples/known-failures-r4.json
@@ -601,14 +601,6 @@
       "reason": "Genuine defect in the published example, not an engine bug: the nested `Questionnaire.item` really omits the required `linkId` (verified in the corpus)."
     },
     {
-      "file": "examplescenario-example.json",
-      "issues": 4,
-      "kinds": [
-        "not-array"
-      ],
-      "reason": "Engine bug #487: `contentReference` is lowered to `elementReference` and the target element's schema is merged wholesale, inheriting its `max=*`. E.g. `ExampleScenario.process.step.operation.request` is `max=1` but references `ExampleScenario.instance.containedInstance` (`max=*`), so a single object is reported as not-array."
-    },
-    {
       "file": "examplescenario-questionnaire.json",
       "issues": 88,
       "kinds": [

--- a/crates/fhir-validator/tests/fixtures/spec-examples/known-failures-r4b.json
+++ b/crates/fhir-validator/tests/fixtures/spec-examples/known-failures-r4b.json
@@ -1305,14 +1305,6 @@
       "reason": "Genuine defect in the published example, not an engine bug: it declares `meta.profile` `shareablecodesystem`/`shareablevalueset` and omits an element that profile requires (a few also omit base-required `status`)."
     },
     {
-      "file": "examplescenario-example.json",
-      "issues": 4,
-      "kinds": [
-        "not-array"
-      ],
-      "reason": "Engine bug #487: `contentReference` is lowered to `elementReference` and the target element's schema is merged wholesale, inheriting its `max=*`. E.g. `ExampleScenario.process.step.operation.request` is `max=1` but references `ExampleScenario.instance.containedInstance` (`max=*`), so a single object is reported as not-array."
-    },
-    {
       "file": "observation-example-bloodpressure-cancel.json",
       "issues": 1,
       "kinds": [

--- a/crates/fhir-validator/tests/fixtures/spec-examples/known-failures-r5.json
+++ b/crates/fhir-validator/tests/fixtures/spec-examples/known-failures-r5.json
@@ -3145,22 +3145,6 @@
       "reason": "Documented gap: core extension StructureDefinitions (`extension-definitions.json`) are not in the vendored spec bundles, so these extension canonicals cannot be resolved."
     },
     {
-      "file": "examplescenario-example-laborder.json",
-      "issues": 21,
-      "kinds": [
-        "not-array"
-      ],
-      "reason": "Engine bug #487: `contentReference` is lowered to `elementReference` and the target element's schema is merged wholesale, inheriting its `max=*`. E.g. `ExampleScenario.process.step.operation.request` is `max=1` but references `ExampleScenario.instance.containedInstance` (`max=*`), so a single object is reported as not-array."
-    },
-    {
-      "file": "examplescenario-example.json",
-      "issues": 4,
-      "kinds": [
-        "not-array"
-      ],
-      "reason": "Engine bug #487: `contentReference` is lowered to `elementReference` and the target element's schema is merged wholesale, inheriting its `max=*`. E.g. `ExampleScenario.process.step.operation.request` is `max=1` but references `ExampleScenario.instance.containedInstance` (`max=*`), so a single object is reported as not-array."
-    },
-    {
       "file": "observation-example-bloodpressure-cancel.json",
       "issues": 1,
       "kinds": [


### PR DESCRIPTION
Fix validator incorrectly inheriting contentReference target cardinality, causing valid single-object fields to be rejected and invalid arrays to be silently accepted closes #487.