### PR TITLE
fix(ui): reuse the HTTP client on the bulk-export, lookup and expand paths

### DIFF
--- a/crates/ui/src/bulk_export.rs
+++ b/crates/ui/src/bulk_export.rs
@@ -378,12 +378,35 @@ fn public_api_url<'a>(
     )
 }
 
+/// The shared client for every UI call back into the FHIR API: the Bulk Export
+/// start/poll/retry/delete/download paths and the patient and Group lookups.
+///
+/// Built once. A per-call `Client::builder().build()` rebuilds the connection
+/// pool, the resolver and the TLS trust store every time, and that work does
+/// not scale across threads — measured here at 18.8ms on an idle machine
+/// against 716ms mean (781ms worst) with 32 builds in flight, a 38x
+/// degradation (#1019). Every card poll and every combobox keystroke paid it,
+/// and paid a fresh TCP connect on top because nothing was ever kept alive.
+///
+/// This is [`crate::bulk_import`]'s `http_client()` lesson (#957) applied to
+/// the paths that did not get it. Sharing is safe because the configuration
+/// below is the same at all ten call sites; the per-request timeouts that
+/// differ between them are set on the `RequestBuilder`, not here.
+///
+/// The `Result` is kept — rather than unwrapping into the `OnceLock` — so a
+/// build failure still degrades the page instead of taking the process down.
 pub(crate) fn no_redirect_client() -> Result<reqwest::Client, String> {
-    reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(std::time::Duration::from_secs(15))
-        .build()
-        .map_err(|e| e.to_string())
+    static CLIENT: std::sync::OnceLock<Result<reqwest::Client, String>> =
+        std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .connect_timeout(std::time::Duration::from_secs(15))
+                .build()
+                .map_err(|e| e.to_string())
+        })
+        .clone()
 }
 
 fn parse_url_without_credentials(raw: &str) -> Option<reqwest::Url> {

--- a/crates/ui/src/editor.rs
+++ b/crates/ui/src/editor.rs
@@ -1053,6 +1053,16 @@ pub struct ExpandQuery {
     pub filter: String,
 }
 
+/// Shared client for the `$expand` proxy below, for the reason spelled out on
+/// [`crate::bulk_export::no_redirect_client`] (#1019): building a client is
+/// ~19ms idle but ~716ms with 32 in flight, and this handler runs once per
+/// keystroke against a 2500ms budget — the build alone could consume a third
+/// of it before the terminology server was even contacted.
+fn terminology_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
 pub async fn expand(State(state): State<WebState>, Query(query): Query<ExpandQuery>) -> Response {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
@@ -1065,7 +1075,7 @@ pub async fn expand(State(state): State<WebState>, Query(query): Query<ExpandQue
     if !query.filter.is_empty() {
         params.push(("filter", query.filter.as_str()));
     }
-    let response = match reqwest::Client::new()
+    let response = match terminology_client()
         .get(&target)
         .query(&params)
         .header("Accept", "application/fhir+json")

--- a/crates/ui/tests/bulk_export_http.rs
+++ b/crates/ui/tests/bulk_export_http.rs
@@ -587,6 +587,30 @@ async fn inject_test_principal(
 
 /// Serves the mounted UI (over the mock FHIR app) on a real port; returns the
 /// base URL and the mock's state handles.
+/// The `data/` spec bundle, parsed once for the whole binary.
+///
+/// `from_data_dir` reads and parses `search-parameters-r4.json` (2.2 MB) plus
+/// the compartment definitions eagerly: 130ms measured, and `serve()` ran it
+/// per test, so 63 tests burned ~8.2s of CPU re-parsing identical bytes —
+/// about 43% of this binary's serial runtime (#1019). None of it lands inside
+/// a test's timeout window, but it is the background load that pushed the
+/// tight ones over on a many-core runner.
+///
+/// Sharing one `Arc` across tests is safe: `from_data_dir` builds a read-only
+/// source, and the interior-mutable recording fields a `StaticConformanceSource`
+/// also carries (`saved_resources`, `sql_run_calls`) are for tests that seed
+/// their own source and assert on it — no test in this file reads them.
+fn shared_conformance() -> Arc<dyn helios_ui::ConformanceSource> {
+    static SRC: std::sync::OnceLock<Arc<helios_ui::StaticConformanceSource>> =
+        std::sync::OnceLock::new();
+    SRC.get_or_init(|| {
+        Arc::new(helios_ui::StaticConformanceSource::from_data_dir(
+            std::path::Path::new("../../data"),
+        ))
+    })
+    .clone()
+}
+
 async fn serve_with_settings(settings_available: bool) -> (String, MockExport, Arc<SqliteBackend>) {
     let backend = Arc::new(SqliteBackend::in_memory().expect("in-memory sqlite"));
     backend.init_schema().expect("init schema");
@@ -605,9 +629,7 @@ async fn serve_with_settings(settings_available: bool) -> (String, MockExport, A
         None,
         settings,
         "default".to_string(),
-        Arc::new(helios_ui::StaticConformanceSource::from_data_dir(
-            std::path::Path::new("../../data"),
-        )),
+        shared_conformance(),
         FhirVersion::R4,
         None,
         base.clone(),
@@ -645,9 +667,7 @@ async fn serve_with_fhir_version(version: FhirVersion) -> (String, MockExport, A
         None,
         Some(backend.clone() as Arc<dyn SettingsStore>),
         "default".to_string(),
-        Arc::new(helios_ui::StaticConformanceSource::from_data_dir(
-            std::path::Path::new("../../data"),
-        )),
+        shared_conformance(),
         version,
         None,
         base.clone(),
@@ -677,9 +697,7 @@ async fn serve_with_runtime(
         None,
         Some(settings),
         "default".to_string(),
-        Arc::new(helios_ui::StaticConformanceSource::from_data_dir(
-            std::path::Path::new("../../data"),
-        )),
+        shared_conformance(),
         FhirVersion::R4,
         None,
         base.clone(),
@@ -2627,7 +2645,14 @@ async fn patient_parameter_searches_start_concurrently() {
         )
         .await
     });
-    tokio::time::timeout(std::time::Duration::from_secs(1), barrier.wait())
+    // 10s, not the 1s this used to allow (#1019). The assertion is *whether*
+    // the two searches overlap, never how fast they get there, so the budget
+    // only has to exceed the worst scheduling delay a loaded runner imposes —
+    // and it is the only wait in this file that was set below the 2s its
+    // siblings use. Instrumented under `--test-threads=32` on 32 cores it
+    // measures 430-560ms typically with 2.0s outliers, so 1s failed about one
+    // run in six even after the client fix above removed the real cost.
+    tokio::time::timeout(std::time::Duration::from_secs(10), barrier.wait())
         .await
         .expect("both searches must reach the backend together");
     let (status, _, _) = lookup.await.unwrap();


### PR DESCRIPTION
Fixes #1019.

## The bug

`no_redirect_client()` built a fresh `reqwest::Client` on every call — all eight bulk-export call sites (start, poll, retry, delete, download) and the two patient/Group lookups in `lookup.rs` — and `editor::expand` did the same with `Client::new()`.

Each build rebuilds the connection pool, the resolver and the TLS trust store, and that work does not scale across threads. Measured on this repo, 32 cores:

| | per `build()` |
|---|---|
| 1 thread | **18.8 ms** |
| 32 threads concurrently | **716 ms mean, 781 ms worst** |

A **38x** degradation. Every Bulk Export card poll and every patient-combobox keystroke paid it, plus a fresh TCP connect on top because nothing was ever kept alive.

`editor::expand` (`/ui/editor/expand`, the terminology autocomplete) is the worst placed of the three: it runs **once per keystroke** against a 2500 ms timeout, so under load the client build alone could consume a third of the budget before the terminology server was contacted. It was not in #1019's original scope — I found it while implementing.

## Not a regression

This is `bulk_import::http_client()`'s lesson (#957) applied to the paths that were never in its scope. #972, which fixed #957, touched only `crates/ui/src/bulk_import.rs` (+56/-6). `no_redirect_client` has had this shape since `d744469bf` and `OnceLock` has never appeared in `bulk_export.rs`. Two independent paths, same bug; one got fixed a week later, in a different file.

## Why sharing is safe

The configuration is identical at all ten `no_redirect_client()` call sites — they call it with no arguments — and the per-request timeouts that differ between them are set on the `RequestBuilder`, not the client. The `Result` is kept rather than unwrapped into the `OnceLock`, so a build failure still degrades the page instead of taking the process down.

## Test-side changes

The same contention was making `bulk_export_http` fail intermittently under parallel test load — a different subset each run, all passing in isolation, because the gates those tests wait on are budgeted at 1-2 s. The client fix alone took all the 2 s-budget gate tests green across 13 runs. Two changes finish it:

- **`patient_parameter_searches_start_concurrently` 1 s -> 10 s.** It allowed 1 s where every sibling in the file allows 2. Instrumented under `--test-threads=32` it measures 430-560 ms typically with 2.0 s outliers, and it still failed about one run in six after the client fix — alone among the 63 tests. The assertion is *whether* the two searches overlap, never how fast they get there, so the budget only has to clear the worst scheduling delay a loaded runner imposes.
- **`serve()`'s spec-bundle parse hoisted into a shared `OnceLock`.** `StaticConformanceSource::from_data_dir` eagerly parses `search-parameters-r4.json` (2.2 MB) plus the compartment definitions — 130 ms measured, run once per test, so 63 tests burned ~8.2 s of CPU re-parsing identical bytes, about 43% of this binary's serial runtime. None of it lands inside a timeout window, but it is the background load that pushed the tight ones over.

## Verification

`cargo test -p helios-ui --test bulk_export_http` on 32 cores:

- **6 consecutive clean runs** (63/63), where the unmodified tree failed on nearly every parallel run
- wall clock **11.3 s -> 6.2 s**

Full `cargo test -p helios-ui` green (15 binaries). `cargo clippy -p helios-ui --all-targets` with the CI flag set: clean. `cargo fmt --check`: clean.

For the record, the `--test-threads` sweep that located this on the unmodified tree — wall clock *regressing* from 16 to 32 threads on a 32-core box is the contention signature, not CPU saturation:

| threads | result | wall |
|---|---|---|
| 1 | ok, 63 passed | 19.25s |
| 8 | ok, 63 passed | 7.57s |
| 16 | ok, 63 passed | 7.28s |
| 32 | **FAILED, 2 failed** | 11.32s |

https://claude.ai/code/session_01TMrWc3HtwiynF89cxXxEYa
