### PR TITLE
perf(sqlite): checkpoint the WAL at each bulk-submit file boundary

### DIFF
--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -1967,6 +1967,25 @@ impl SubmitWorkerStorage for SqliteBackend {
         Ok(())
     }
 
+    async fn checkpoint_after_file(&self) {
+        // Fold the WAL back into the database at a file boundary (#978). The
+        // passive auto-checkpoint yields to the back-to-back batch writers and
+        // lets the WAL grow into the multi-gigabyte range over a long ingest,
+        // which slows every read and doubles disk use; a TRUNCATE checkpoint
+        // between files reclaims it while no batch holds the write lock. A
+        // busy return (a reader still in a WAL frame) is fine — the next file
+        // boundary tries again — so this is best-effort and never fails the
+        // ingest. Runs on a blocking thread so the checkpoint's I/O does not
+        // stall an async worker.
+        let backend = self.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            if let Ok(conn) = backend.get_connection() {
+                let _ = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);");
+            }
+        })
+        .await;
+    }
+
     async fn finish_manifest(&self, lease: &ManifestLease) -> Result<(), LeaseError> {
         // Losing this write to a busy would leave a fully ingested manifest
         // stuck in 'processing' until its lease expires and a worker redoes it
@@ -3156,5 +3175,47 @@ mod tests {
             Err(StorageError::Backend(BackendError::Internal { .. }))
         ));
         assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    /// #978: `checkpoint_after_file` truncates the WAL back into the database.
+    /// A file-backed WAL grows with each write until a checkpoint folds it in;
+    /// after the call the `-wal` file is reclaimed (0 bytes on TRUNCATE).
+    #[tokio::test]
+    async fn checkpoint_after_file_truncates_the_wal() {
+        use crate::core::bulk_submit_worker::SubmitWorkerStorage;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("wal-test.db");
+        let backend = SqliteBackend::open(&db_path).unwrap();
+        backend.init_schema().unwrap();
+        let tenant = create_test_tenant();
+
+        // Write enough resources to grow the WAL past its initial size.
+        for i in 0..500 {
+            backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({"resourceType": "Patient", "id": format!("wal-{i}")}),
+                    FhirVersion::default_enabled(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let wal_path = db_path.with_extension("db-wal");
+        let before = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+        assert!(
+            before > 0,
+            "the WAL should have grown before the checkpoint"
+        );
+
+        backend.checkpoint_after_file().await;
+
+        let after = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+        assert!(
+            after < before,
+            "TRUNCATE checkpoint should reclaim the WAL: before={before} after={after}"
+        );
     }
 }

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -280,6 +280,16 @@ pub trait SubmitWorkerStorage: Send + Sync {
     /// Marks the manifest `completed`. Fenced.
     async fn finish_manifest(&self, lease: &ManifestLease) -> Result<(), LeaseError>;
 
+    /// Reclaims write-ahead-log space at a file boundary, when the backend
+    /// keeps one (#978). SQLite's WAL grows without bound under a long ingest
+    /// because its passive auto-checkpoint keeps yielding to the back-to-back
+    /// batch writers; a multi-gigabyte WAL then slows every read (the status
+    /// poll included) and doubles disk use. The worker calls this once per
+    /// output file — a point where no batch holds the write lock — so the WAL
+    /// is folded back into the database between files. Backends without a
+    /// SQLite-style WAL (PostgreSQL, MongoDB, S3) leave the default no-op.
+    async fn checkpoint_after_file(&self) {}
+
     /// Marks the manifest `failed` with a message. Fenced.
     async fn fail_manifest(
         &self,
@@ -1015,6 +1025,10 @@ where
                         }
                     }
                 }
+
+                // File boundary: no batch holds the write lock here, so fold
+                // the WAL back into the database before the next file (#978).
+                self.jobs.checkpoint_after_file().await;
 
                 let total = progress_ref.total.load(Ordering::Relaxed);
                 if total > 0 {


### PR DESCRIPTION
Closes #978.

## The problem

Under a long bulk-submit ingest, SQLite's passive WAL auto-checkpoint keeps yielding to the back-to-back batch writers, so the WAL grows without bound — **measured at 7.3 GB mid-import on the real corpus** (the `-wal` file, vs the ~200 MB the `wal_autocheckpoint = 50000` threshold implies). A multi-gigabyte WAL slows every read — including the `$bulk-submit-status` poll, which is what surfaced as the poll timeouts in #957 — and doubles disk use for the duration.

## The fix

The submit worker folds the WAL back into the database at **each output-file boundary** — a point where no batch holds the write lock — via a new `SubmitWorkerStorage::checkpoint_after_file` hook:

- **SQLite** runs `PRAGMA wal_checkpoint(TRUNCATE)` on a `spawn_blocking` thread. A busy return (a reader still in a WAL frame) is fine — the next file boundary retries — so it is **best-effort and never fails the ingest**.
- **PostgreSQL, MongoDB, S3** keep the default no-op (no SQLite-style WAL).

No configuration — automatic and backend-aware, in the same spirit as the existing write-path pragmas. It does not change *how much* gets checkpointed over the run, only *when*: bounded pauses at file boundaries instead of an unbounded WAL.

## Tests

- New: a file-backed backend grows its WAL over 500 writes; `checkpoint_after_file` reclaims it (TRUNCATE → smaller `-wal`).
- The existing fan-out multi-file ingest suite stays green with the hook active (60 bulk_submit tests pass). clippy clean, fmt clean.

## Note on the follow-up validation

This was diagnosed live during a full 18.9M-resource import (the WAL growth and the ingest-rate decay it causes). An end-to-end before/after on the same corpus is the natural confirmation and can be posted on #978 once run.