### PR TITLE
Make bulk-submit artifact publication idempotent and lease-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,6 +3678,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -26,7 +26,7 @@ cassandra = ["dep:cdrs-tokio", "dep:cdrs-tokio-helpers-derive"]
 mongodb = ["dep:mongodb"]
 neo4j = ["dep:neo4rs"]
 elasticsearch = ["dep:elasticsearch"]
-s3 = ["dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:sha2"]
+s3 = ["dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types"]
 
 # Configuration advisor binary
 advisor = ["dep:axum", "dep:tower-http", "dep:tracing-subscriber"]
@@ -96,8 +96,8 @@ elasticsearch = { version = "8.15.0-alpha.1", optional = true }
 aws-sdk-s3 = { version = "1", optional = true, default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }
 aws-config = { version = "1", optional = true }
 aws-credential-types = { version = "1", optional = true }
-# Hashes the per-user settings key into an opaque, fixed-length S3 object name.
-sha2 = { version = "0.10", optional = true }
+# Hashes opaque keys and submit artifact scopes into fixed-length safe names.
+sha2 = { version = "0.10" }
 
 # Audit event integration.
 #

--- a/crates/persistence/src/backends/mongodb/bulk_submit.rs
+++ b/crates/persistence/src/backends/mongodb/bulk_submit.rs
@@ -51,6 +51,9 @@ use crate::core::bulk_submit::{
     StreamProcessingResult, StreamingBulkSubmitProvider, SubmissionChange, SubmissionId,
     SubmissionManifest, SubmissionStatus, SubmissionSummary, invalid_entry_result_page,
 };
+use crate::core::bulk_submit_publication::{
+    ManifestPublicationResult, ManifestPublicationStatus, canonical_publication_files,
+};
 use crate::core::bulk_submit_worker::{
     ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
     SubmitFileRecord, SubmitFileRow, SubmitWorkerStorage,
@@ -1469,6 +1472,7 @@ impl SubmitWorkerStorage for MongoBackend {
         // token, so a retried write replaces its own row rather than adding a
         // duplicate entry to the status manifest.
         let mut key = submission_filter(&lease.tenant, &lease.submission_id);
+        key.insert("manifest_id", &lease.manifest_id);
         key.insert("file_type", &file.file_type);
         key.insert("resource_type", file.resource_type.as_deref());
         key.insert("part_index", file.part_index as i64);
@@ -1493,6 +1497,28 @@ impl SubmitWorkerStorage for MongoBackend {
             .await
             .map_err(|e| LeaseError::Storage(internal_error(format!("record submit file: {e}"))))?;
         Ok(())
+    }
+
+    /// Publishes by canonical validation, then fenced per-row writes and the
+    /// fenced terminal update. Mongo provides no atomic full-set publication;
+    /// this intentionally preserves the existing non-atomic backend behavior.
+    async fn publish_manifest_artifacts(
+        &self,
+        lease: &ManifestLease,
+        files: &[SubmitFileRecord],
+        terminal: ManifestPublicationStatus,
+    ) -> Result<ManifestPublicationResult, LeaseError> {
+        let canonical = canonical_publication_files(files).map_err(LeaseError::Storage)?;
+        for file in &canonical {
+            self.record_submit_file(lease, file).await?;
+        }
+        match terminal {
+            ManifestPublicationStatus::Completed => self.finish_manifest(lease).await?,
+            ManifestPublicationStatus::Failed { error_message } => {
+                self.fail_manifest(lease, &error_message).await?
+            }
+        }
+        Ok(ManifestPublicationResult::Published)
     }
 
     async fn finish_manifest(&self, lease: &ManifestLease) -> Result<(), LeaseError> {
@@ -1725,6 +1751,8 @@ impl SubmitWorkerStorage for MongoBackend {
                 resource_type: opt_str(d, "resource_type"),
                 part_index: d.get_i64("part_index").unwrap_or(0).max(0) as u32,
                 fencing_token: d.get_i64("fencing_token").unwrap_or(0).max(0) as u64,
+                manifest_id: opt_str(d, "manifest_id"),
+                legacy_locator: opt_str(d, "manifest_id").is_none(),
                 file_path: d.get_str("file_path").unwrap_or_default().to_string(),
                 line_count: d.get_i64("line_count").unwrap_or(0).max(0) as u64,
                 byte_count: d.get_i64("byte_count").unwrap_or(0).max(0) as u64,

--- a/crates/persistence/src/backends/mongodb/schema.rs
+++ b/crates/persistence/src/backends/mongodb/schema.rs
@@ -13,8 +13,9 @@ use super::backend::MongoBackendConfig;
 
 /// Current MongoDB schema version.
 ///
-/// v7 adds the Bulk Data Submit collections and their indexes.
-pub const SCHEMA_VERSION: i32 = 7;
+/// v7 adds the Bulk Data Submit collections and their indexes. v8 moves the
+/// artifact identity under its owning manifest.
+pub const SCHEMA_VERSION: i32 = 8;
 
 /// Initialize MongoDB collections/indexes required by the backend.
 ///
@@ -392,13 +393,35 @@ async fn ensure_bulk_submit_indexes(database: &Database) -> StorageResult<()> {
 
     let files = database.collection::<Document>(SUBMIT_FILES_COLLECTION);
     let mut file_key = submission_key;
+    file_key.insert("manifest_id", 1_i32);
     file_key.insert("file_type", 1_i32);
     file_key.insert("resource_type", 1_i32);
     file_key.insert("part_index", 1_i32);
     file_key.insert("fencing_token", 1_i32);
-    create_index(&files, file_key, "idx_bulk_submit_files_part", true).await?;
+    create_index(&files, file_key, "idx_bulk_submit_files_manifest", true).await?;
+    drop_bulk_submit_file_legacy_index(&files).await?;
 
     Ok(())
+}
+
+/// Removes the pre-v8 submit-file identity index.
+///
+/// Reinitializing an already-updated database does not fail on its absence;
+/// command error 27 is the MongoDB server's documented `IndexNotFound`.
+async fn drop_bulk_submit_file_legacy_index(files: &Collection<Document>) -> StorageResult<()> {
+    use mongodb::error::ErrorKind;
+
+    match files.drop_index("idx_bulk_submit_files_part").await {
+        Ok(()) => Ok(()),
+        Err(error) if matches!(&*error.kind, ErrorKind::Command(command) if command.code == 27) => {
+            Ok(())
+        }
+        Err(error) => Err(StorageError::Backend(BackendError::Internal {
+            backend_name: "mongodb".to_string(),
+            message: format!("drop legacy submit-file index: {error}"),
+            source: None,
+        })),
+    }
 }
 
 async fn create_index(

--- a/crates/persistence/src/backends/postgres/backend.rs
+++ b/crates/persistence/src/backends/postgres/backend.rs
@@ -739,8 +739,8 @@ impl PostgresBackend {
 
     /// Initialize the database schema.
     pub async fn init_schema(&self) -> StorageResult<()> {
-        let client = self.get_client().await?;
-        super::schema::initialize_schema(&client).await?;
+        let mut client = self.get_client().await?;
+        super::schema::initialize_schema(&mut client).await?;
         let _ = self
             .index_layout
             .set(super::schema::read_index_layout(&client).await);

--- a/crates/persistence/src/backends/postgres/bulk_submit.rs
+++ b/crates/persistence/src/backends/postgres/bulk_submit.rs
@@ -19,6 +19,9 @@ use crate::core::bulk_submit::{
     SubmissionId, SubmissionManifest, SubmissionStatus, SubmissionSummary,
     invalid_entry_result_page,
 };
+use crate::core::bulk_submit_publication::{
+    ManifestPublicationResult, ManifestPublicationStatus, canonical_publication_files,
+};
 use crate::core::bulk_submit_worker::{
     ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
     SubmitFileRecord, SubmitFileRow, SubmitWorkerStorage,
@@ -41,6 +44,18 @@ fn lease_lost(lease: &ManifestLease) -> LeaseError {
     LeaseError::LeaseLost {
         job_id: ExportJobId::from_string(format!("{}/{}", lease.submission_id, lease.manifest_id)),
     }
+}
+
+#[derive(Debug)]
+struct ManifestPublicationState {
+    manifest_url: Option<String>,
+    status: String,
+    fencing_token: i64,
+    worker_id: Option<String>,
+    published_token: Option<i64>,
+    publication_status: Option<String>,
+    publication_error_message: Option<String>,
+    publication_worker_id: Option<String>,
 }
 
 /// Derives the ingest FHIR version from a stored `outputFormat` MIME string.
@@ -650,7 +665,8 @@ impl BulkSubmitProvider for PostgresBackend {
             client
                 .execute(
                     "UPDATE bulk_manifests SET status = 'processing'
-                     WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3 AND manifest_id = $4",
+                     WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
+                       AND manifest_id = $4 AND status <> 'replaced'",
                     &[
                         &tenant_id,
                         &submission_id.submitter.as_str(),
@@ -1518,7 +1534,8 @@ impl SubmitClaimStrategy for PostgresBackend {
             .execute(
                 "UPDATE bulk_manifests SET lease_expiry = $1
                  WHERE tenant_id = $2 AND submitter = $3 AND submission_id = $4
-                   AND manifest_id = $5 AND worker_id = $6 AND fencing_token = $7",
+                   AND manifest_id = $5 AND status = 'processing'
+                   AND worker_id = $6 AND fencing_token = $7",
                 &[
                     &new_expiry,
                     &lease.tenant.tenant_id().as_str(),
@@ -1574,9 +1591,10 @@ impl SubmitWorkerStorage for PostgresBackend {
                 "SELECT manifest_url, fhir_base_url, output_format, file_request_headers,
                         oauth_metadata_urls, file_encryption_key, last_processed_line,
                         import_directives, submission_metadata
-                 FROM bulk_manifests
-                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
-                   AND manifest_id = $4 AND worker_id = $5 AND fencing_token = $6",
+                FROM bulk_manifests
+                WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
+                  AND manifest_id = $4 AND status = 'processing'
+                  AND worker_id = $5 AND fencing_token = $6",
                 &[
                     &lease.tenant.tenant_id().as_str(),
                     &lease.submission_id.submitter,
@@ -1642,7 +1660,8 @@ impl SubmitWorkerStorage for PostgresBackend {
             .execute(
                 "UPDATE bulk_manifests SET status = 'processing'
                  WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
-                   AND manifest_id = $4 AND worker_id = $5 AND fencing_token = $6",
+                   AND manifest_id = $4 AND status = 'processing'
+                   AND worker_id = $5 AND fencing_token = $6",
                 &[
                     &lease.tenant.tenant_id().as_str(),
                     &lease.submission_id.submitter,
@@ -1778,112 +1797,82 @@ impl SubmitWorkerStorage for PostgresBackend {
         lease: &ManifestLease,
         file: &SubmitFileRecord,
     ) -> Result<(), LeaseError> {
-        let client = self.get_client().await.map_err(LeaseError::Storage)?;
-        // Fence: only record if we still hold the lease.
-        let holds = client
-            .query(
-                "SELECT 1 FROM bulk_manifests
-                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
-                   AND manifest_id = $4 AND worker_id = $5 AND fencing_token = $6",
-                &[
-                    &lease.tenant.tenant_id().as_str(),
-                    &lease.submission_id.submitter,
-                    &lease.submission_id.submission_id,
-                    &lease.manifest_id,
-                    &lease.worker_id.as_str(),
-                    &(lease.fencing_token as i64),
-                ],
-            )
+        let mut client = self.get_client().await.map_err(LeaseError::Storage)?;
+        let tx = client
+            .transaction()
             .await
-            .map_err(|e| LeaseError::Storage(internal_error(format!("fence check: {e}"))))?;
-        if holds.is_empty() {
+            .map_err(|e| LeaseError::Storage(internal_error(format!("begin staging: {e}"))))?;
+        let lease_token = i64::try_from(lease.fencing_token).map_err(|_| {
+            LeaseError::Storage(internal_error(
+                "lease fencing_token does not fit i64".to_string(),
+            ))
+        })?;
+        let Some(state) = manifest_publication_state(&tx, lease).await? else {
+            return Err(lease_lost(lease));
+        };
+        if state.status != "processing"
+            || state.fencing_token != lease_token
+            || state.worker_id.as_deref() != Some(lease.worker_id.as_str())
+        {
             return Err(lease_lost(lease));
         }
 
-        let count_severity = file
-            .count_severity
-            .as_ref()
-            .and_then(|v| serde_json::to_string(v).ok());
-        client
-            .execute(
-                "INSERT INTO bulk_submit_files
-                 (tenant_id, submitter, submission_id, manifest_url, file_type, resource_type,
-                  part_index, fencing_token, file_path, line_count, byte_count, count_severity,
-                  created_at)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
-                &[
-                    &lease.tenant.tenant_id().as_str(),
-                    &lease.submission_id.submitter,
-                    &lease.submission_id.submission_id,
-                    &file.manifest_url,
-                    &file.file_type,
-                    &file.resource_type,
-                    &(file.part_index as i32),
-                    &(lease.fencing_token as i64),
-                    &file.file_path,
-                    &(file.line_count as i64),
-                    &(file.byte_count as i64),
-                    &count_severity,
-                    &Utc::now(),
-                ],
+        let canonical =
+            canonical_publication_files(std::slice::from_ref(file)).map_err(LeaseError::Storage)?;
+        validate_publication_records(state.manifest_url.as_deref(), &canonical)
+            .map_err(LeaseError::Storage)?;
+        let staged = read_manifest_generation_records(&tx, lease, lease_token).await?;
+        let identity = |record: &SubmitFileRecord| {
+            (
+                record.file_type.clone(),
+                record.resource_type.clone(),
+                record.part_index,
             )
+        };
+        if let Some(existing) = staged
+            .iter()
+            .find(|record| identity(record) == identity(file))
+        {
+            if existing != file {
+                return Err(LeaseError::Storage(publication_conflict(
+                    "staged artifact identity has conflicting content",
+                )));
+            }
+        } else {
+            insert_publication_files(&tx, lease, lease_token, &canonical).await?;
+        }
+        tx.commit()
             .await
-            .map_err(|e| LeaseError::Storage(internal_error(format!("record submit file: {e}"))))?;
+            .map_err(|e| LeaseError::Storage(internal_error(format!("commit staging: {e}"))))?;
         Ok(())
     }
 
+    async fn publish_manifest_artifacts(
+        &self,
+        lease: &ManifestLease,
+        files: &[SubmitFileRecord],
+        terminal: ManifestPublicationStatus,
+    ) -> Result<ManifestPublicationResult, LeaseError> {
+        PostgresBackend::publish_manifest_artifacts(self, lease, files, terminal).await
+    }
+
     async fn finish_manifest(&self, lease: &ManifestLease) -> Result<(), LeaseError> {
-        let client = self.get_client().await.map_err(LeaseError::Storage)?;
-        let affected = client
-            .execute(
-                "UPDATE bulk_manifests SET status = 'completed', worker_id = NULL, lease_expiry = NULL
-                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
-                   AND manifest_id = $4 AND worker_id = $5 AND fencing_token = $6",
-                &[
-                    &lease.tenant.tenant_id().as_str(),
-                    &lease.submission_id.submitter,
-                    &lease.submission_id.submission_id,
-                    &lease.manifest_id,
-                    &lease.worker_id.as_str(),
-                    &(lease.fencing_token as i64),
-                ],
-            )
+        self.publish_current_manifest_generation(lease, ManifestPublicationStatus::Completed)
             .await
-            .map_err(|e| LeaseError::Storage(internal_error(format!("finish manifest: {e}"))))?;
-        if affected == 0 {
-            Err(lease_lost(lease))
-        } else {
-            Ok(())
-        }
     }
 
     async fn fail_manifest(
         &self,
         lease: &ManifestLease,
-        _error_message: &str,
+        error_message: &str,
     ) -> Result<(), LeaseError> {
-        let client = self.get_client().await.map_err(LeaseError::Storage)?;
-        let affected = client
-            .execute(
-                "UPDATE bulk_manifests SET status = 'failed', worker_id = NULL, lease_expiry = NULL
-                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
-                   AND manifest_id = $4 AND worker_id = $5 AND fencing_token = $6",
-                &[
-                    &lease.tenant.tenant_id().as_str(),
-                    &lease.submission_id.submitter,
-                    &lease.submission_id.submission_id,
-                    &lease.manifest_id,
-                    &lease.worker_id.as_str(),
-                    &(lease.fencing_token as i64),
-                ],
-            )
-            .await
-            .map_err(|e| LeaseError::Storage(internal_error(format!("fail manifest: {e}"))))?;
-        if affected == 0 {
-            Err(lease_lost(lease))
-        } else {
-            Ok(())
-        }
+        self.publish_current_manifest_generation(
+            lease,
+            ManifestPublicationStatus::Failed {
+                error_message: error_message.to_string(),
+            },
+        )
+        .await
     }
 
     async fn set_manifest_fetch_params(
@@ -2107,11 +2096,25 @@ impl SubmitWorkerStorage for PostgresBackend {
         let client = self.get_client().await?;
         let rows = client
             .query(
-                "SELECT manifest_url, file_type, resource_type, part_index, fencing_token,
-                        file_path, line_count, byte_count, count_severity
-                 FROM bulk_submit_files
-                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
-                 ORDER BY id",
+                "SELECT f.manifest_url, f.file_type, f.resource_type, f.part_index,
+                        f.fencing_token,
+                        file_path, line_count, byte_count, count_severity,
+                        f.manifest_id, m.publication_worker_id
+                 FROM bulk_submit_files AS f
+                 INNER JOIN bulk_manifests AS m
+                   ON m.tenant_id = f.tenant_id
+                      AND m.submitter = f.submitter
+                      AND m.submission_id = f.submission_id
+                      AND m.manifest_id = f.manifest_id
+                      AND m.published_token = f.fencing_token
+                 WHERE f.manifest_id IS NOT NULL
+                   AND f.tenant_id = $1
+                   AND f.submitter = $2
+                   AND f.submission_id = $3
+                   AND f.publication_excluded_reason IS NULL
+                   AND m.published_token IS NOT NULL
+                   AND m.publication_status IN ('completed', 'failed')
+                 ORDER BY f.id",
                 &[
                     &tenant.tenant_id().as_str(),
                     &id.submitter,
@@ -2120,25 +2123,34 @@ impl SubmitWorkerStorage for PostgresBackend {
             )
             .await
             .map_err(|e| internal_error(format!("list submit files: {e}")))?;
-        Ok(rows
-            .iter()
+        rows.iter()
             .map(|row| {
+                let manifest_url: Option<String> = row.get(0);
+                let file_type: String = row.get(1);
+                let resource_type: Option<String> = row.get(2);
+                let part_index: i32 = row.get(3);
+                let fencing_token: i64 = row.get(4);
+                let file_path: String = row.get(5);
+                let line_count: i64 = row.get(6);
+                let byte_count: i64 = row.get(7);
                 let count_severity: Option<String> = row.get(8);
-                SubmitFileRow {
-                    manifest_url: row.get(0),
-                    file_type: row.get(1),
-                    resource_type: row.get(2),
-                    part_index: row.get::<_, i32>(3) as u32,
-                    fencing_token: row.get::<_, i64>(4) as u64,
-                    file_path: row.get(5),
-                    line_count: row.get::<_, i64>(6) as u64,
-                    byte_count: row.get::<_, i64>(7) as u64,
-                    count_severity: count_severity
-                        .as_deref()
-                        .and_then(|s| serde_json::from_str(s).ok()),
-                }
+                let manifest_id: Option<String> = row.get(9);
+                let publication_worker_id: Option<String> = row.get(10);
+                publication_row_from_parts(
+                    manifest_url,
+                    file_type,
+                    resource_type,
+                    part_index,
+                    fencing_token,
+                    file_path,
+                    line_count,
+                    byte_count,
+                    count_severity,
+                    manifest_id,
+                    publication_worker_id.is_none(),
+                )
             })
-            .collect())
+            .collect::<StorageResult<Vec<_>>>()
     }
 
     async fn delete_submission_artifacts(
@@ -2146,19 +2158,51 @@ impl SubmitWorkerStorage for PostgresBackend {
         tenant: &TenantContext,
         id: &SubmissionId,
     ) -> StorageResult<()> {
-        let client = self.get_client().await?;
-        client
-            .execute(
-                "DELETE FROM bulk_submit_files
-                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3",
-                &[
-                    &tenant.tenant_id().as_str(),
-                    &id.submitter,
-                    &id.submission_id,
-                ],
-            )
+        let mut client = self.get_client().await?;
+        let tx = client
+            .transaction()
             .await
-            .map_err(|e| internal_error(format!("delete artifacts: {e}")))?;
+            .map_err(|e| internal_error(format!("begin artifact cleanup: {e}")))?;
+        tx.query(
+            "SELECT manifest_id FROM bulk_manifests
+             WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
+             ORDER BY added_at, manifest_id
+             FOR UPDATE",
+            &[
+                &tenant.tenant_id().as_str(),
+                &id.submitter,
+                &id.submission_id,
+            ],
+        )
+        .await
+        .map_err(|e| internal_error(format!("lock manifest rows: {e}")))?;
+        tx.execute(
+            "DELETE FROM bulk_submit_files
+                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3",
+            &[
+                &tenant.tenant_id().as_str(),
+                &id.submitter,
+                &id.submission_id,
+            ],
+        )
+        .await
+        .map_err(|e| internal_error(format!("delete artifacts: {e}")))?;
+        tx.execute(
+            "UPDATE bulk_manifests
+                 SET published_token = NULL, publication_status = NULL,
+                     publication_error_message = NULL, publication_worker_id = NULL
+                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3",
+            &[
+                &tenant.tenant_id().as_str(),
+                &id.submitter,
+                &id.submission_id,
+            ],
+        )
+        .await
+        .map_err(|e| internal_error(format!("clear publication markers: {e}")))?;
+        tx.commit()
+            .await
+            .map_err(|e| internal_error(format!("commit artifact cleanup: {e}")))?;
         Ok(())
     }
 
@@ -2217,4 +2261,459 @@ impl SubmitWorkerStorage for PostgresBackend {
             .map_err(|e| internal_error(format!("set transaction_time: {e}")))?;
         Ok(now)
     }
+}
+
+impl PostgresBackend {
+    /// Atomically replaces and publishes the complete artifact set for a lease.
+    ///
+    /// State selection, staged-row replacement, and the terminal fencing update
+    /// all run on one locked manifest row. A successful commit is the only point
+    /// at which the generation becomes visible to publication queries.
+    pub async fn publish_manifest_artifacts(
+        &self,
+        lease: &ManifestLease,
+        files: &[SubmitFileRecord],
+        terminal: ManifestPublicationStatus,
+    ) -> Result<ManifestPublicationResult, LeaseError> {
+        let canonical = canonical_publication_files(files).map_err(LeaseError::Storage)?;
+        let mut client = self.get_client().await.map_err(LeaseError::Storage)?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|e| LeaseError::Storage(internal_error(format!("begin publication: {e}"))))?;
+        let Some(outcome) =
+            publish_manifest_artifacts_in_tx(&tx, lease, &canonical, &terminal).await?
+        else {
+            return Err(lease_lost(lease));
+        };
+        tx.commit()
+            .await
+            .map_err(|e| LeaseError::Storage(internal_error(format!("commit publication: {e}"))))?;
+        Ok(outcome)
+    }
+
+    /// Publishes the generation already staged for `lease`. Terminal finish and
+    /// failure read the staged set inside the publication transaction, so a
+    /// concurrent staging write cannot be omitted from the atomic commit.
+    async fn publish_current_manifest_generation(
+        &self,
+        lease: &ManifestLease,
+        terminal: ManifestPublicationStatus,
+    ) -> Result<(), LeaseError> {
+        let mut client = self.get_client().await.map_err(LeaseError::Storage)?;
+        let tx = client.transaction().await.map_err(|e| {
+            LeaseError::Storage(internal_error(format!("begin finish publication: {e}")))
+        })?;
+        let lease_token = i64::try_from(lease.fencing_token).map_err(|_| {
+            LeaseError::Storage(internal_error(
+                "lease fencing_token does not fit i64".to_string(),
+            ))
+        })?;
+        let Some(state) = manifest_publication_state(&tx, lease).await? else {
+            return Err(lease_lost(lease));
+        };
+        if state.status == "replaced" || state.fencing_token != lease_token {
+            return Err(lease_lost(lease));
+        }
+
+        let staged = if state.status == "processing" {
+            if state.worker_id.as_deref() != Some(lease.worker_id.as_str()) {
+                return Err(lease_lost(lease));
+            }
+            read_manifest_generation_records(&tx, lease, lease_token).await?
+        } else {
+            let published_token_matches = state.published_token == Some(lease_token);
+            let publisher_matches =
+                state.publication_worker_id.as_deref() == Some(lease.worker_id.as_str());
+            if !published_token_matches || !publisher_matches {
+                return Err(lease_lost(lease));
+            }
+            let (terminal_status, terminal_error) = publication_status_parts(&terminal);
+            if state.status != terminal_status
+                || state.publication_status.as_deref() != Some(terminal_status)
+                || state.publication_error_message != terminal_error.map(str::to_string)
+            {
+                return Err(LeaseError::Storage(publication_conflict(
+                    "terminal state changed for the same publication",
+                )));
+            }
+            read_manifest_generation_records(&tx, lease, lease_token).await?
+        };
+        let staged = canonical_publication_files(&staged).map_err(LeaseError::Storage)?;
+        let Some(outcome) =
+            publish_manifest_artifacts_in_tx(&tx, lease, &staged, &terminal).await?
+        else {
+            return Err(lease_lost(lease));
+        };
+        let _ = outcome;
+        tx.commit().await.map_err(|e| {
+            LeaseError::Storage(internal_error(format!("commit finish publication: {e}")))
+        })?;
+        Ok(())
+    }
+}
+
+/// Reads the publication state with its manifest row locked. A missing identity
+/// means lease loss; every query error is a storage error.
+async fn manifest_publication_state(
+    tx: &tokio_postgres::Transaction<'_>,
+    lease: &ManifestLease,
+) -> StorageResult<Option<ManifestPublicationState>> {
+    let row = tx
+        .query_opt(
+            "SELECT manifest_url, status, fencing_token, worker_id,
+                    published_token, publication_status, publication_error_message,
+                    publication_worker_id
+             FROM bulk_manifests
+             WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
+               AND manifest_id = $4
+             FOR UPDATE",
+            &[
+                &lease.tenant.tenant_id().as_str(),
+                &lease.submission_id.submitter,
+                &lease.submission_id.submission_id,
+                &lease.manifest_id,
+            ],
+        )
+        .await
+        .map_err(|e| internal_error(format!("read publication state: {e}")))?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let manifest_url: Option<String> = row.get(0);
+    let status: String = row.get(1);
+    let fencing_token: i64 = row.get(2);
+    let worker_id: Option<String> = row.get(3);
+    let published_token: Option<i64> = row.get(4);
+    let publication_status: Option<String> = row.get(5);
+    let publication_error_message: Option<String> = row.get(6);
+    let publication_worker_id: Option<String> = row.get(7);
+    Ok(Some(ManifestPublicationState {
+        manifest_url,
+        status,
+        fencing_token,
+        worker_id,
+        published_token,
+        publication_status,
+        publication_error_message,
+        publication_worker_id,
+    }))
+}
+
+fn publication_conflict(message: impl Into<String>) -> StorageError {
+    internal_error(format!("manifest publication conflict: {}", message.into()))
+}
+
+fn publication_status_parts(terminal: &ManifestPublicationStatus) -> (&'static str, Option<&str>) {
+    match terminal {
+        ManifestPublicationStatus::Completed => ("completed", None),
+        ManifestPublicationStatus::Failed { error_message } => {
+            ("failed", Some(error_message.as_str()))
+        }
+    }
+}
+
+async fn read_manifest_generation_records(
+    tx: &tokio_postgres::Transaction<'_>,
+    lease: &ManifestLease,
+    fencing_token: i64,
+) -> StorageResult<Vec<SubmitFileRecord>> {
+    let rows = tx
+        .query(
+            "SELECT manifest_url, file_type, resource_type, part_index, file_path,
+                    line_count, byte_count, count_severity
+             FROM bulk_submit_files
+             WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
+               AND manifest_id = $4 AND fencing_token = $5
+               AND publication_excluded_reason IS NULL
+             ORDER BY id",
+            &[
+                &lease.tenant.tenant_id().as_str(),
+                &lease.submission_id.submitter,
+                &lease.submission_id.submission_id,
+                &lease.manifest_id,
+                &fencing_token,
+            ],
+        )
+        .await
+        .map_err(|e| internal_error(format!("read publication rows: {e}")))?;
+    let mut records = Vec::new();
+    for row in rows {
+        let manifest_url: Option<String> = row.get(0);
+        let file_type: String = row.get(1);
+        let resource_type: Option<String> = row.get(2);
+        let part_index: i32 = row.get(3);
+        let file_path: String = row.get(4);
+        let line_count: i64 = row.get(5);
+        let byte_count: i64 = row.get(6);
+        let count_severity: Option<String> = row.get(7);
+        records.push(publication_record_from_parts(
+            manifest_url,
+            file_type,
+            resource_type,
+            part_index,
+            fencing_token,
+            file_path,
+            line_count,
+            byte_count,
+            count_severity,
+        )?);
+    }
+    Ok(records)
+}
+
+fn validate_publication_records(
+    manifest_url: Option<&str>,
+    records: &[SubmitFileRecord],
+) -> StorageResult<()> {
+    for file in records {
+        if !matches!(file.file_type.as_str(), "output" | "error" | "deleted") {
+            return Err(publication_conflict(format!(
+                "invalid file_type: {}",
+                file.file_type
+            )));
+        }
+        match (&file.manifest_url, manifest_url) {
+            (Some(file_url), Some(manifest_url)) if file_url == manifest_url => {}
+            _ => {
+                return Err(publication_conflict(
+                    "artifact manifest_url does not match the leased manifest",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn publication_record_from_parts(
+    manifest_url: Option<String>,
+    file_type: String,
+    resource_type: Option<String>,
+    part_index: i32,
+    fencing_token: i64,
+    file_path: String,
+    line_count: i64,
+    byte_count: i64,
+    count_severity: Option<String>,
+) -> StorageResult<SubmitFileRecord> {
+    let count_severity = match count_severity {
+        Some(text) => Some(serde_json::from_str::<Value>(&text).map_err(|error| {
+            internal_error(format!("decode published count_severity: {error}"))
+        })?),
+        None => None,
+    };
+    let part_index = u32::try_from(part_index)
+        .map_err(|_| internal_error("published part_index is negative".to_string()))?;
+    if fencing_token < 0 {
+        return Err(internal_error(
+            "published fencing_token is negative".to_string(),
+        ));
+    }
+    let line_count = u64::try_from(line_count)
+        .map_err(|_| internal_error("published line_count is negative".to_string()))?;
+    let byte_count = u64::try_from(byte_count)
+        .map_err(|_| internal_error("published byte_count is negative".to_string()))?;
+    Ok(SubmitFileRecord {
+        manifest_url,
+        file_type,
+        resource_type,
+        part_index,
+        file_path,
+        line_count,
+        byte_count,
+        count_severity,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn publication_row_from_parts(
+    manifest_url: Option<String>,
+    file_type: String,
+    resource_type: Option<String>,
+    part_index: i32,
+    fencing_token: i64,
+    file_path: String,
+    line_count: i64,
+    byte_count: i64,
+    count_severity: Option<String>,
+    manifest_id: Option<String>,
+    legacy_locator: bool,
+) -> StorageResult<SubmitFileRow> {
+    let record = publication_record_from_parts(
+        manifest_url,
+        file_type,
+        resource_type,
+        part_index,
+        fencing_token,
+        file_path,
+        line_count,
+        byte_count,
+        count_severity,
+    )?;
+    Ok(SubmitFileRow {
+        manifest_url: record.manifest_url,
+        file_type: record.file_type,
+        resource_type: record.resource_type,
+        part_index: record.part_index,
+        fencing_token: fencing_token as u64,
+        manifest_id,
+        legacy_locator,
+        file_path: record.file_path,
+        line_count: record.line_count,
+        byte_count: record.byte_count,
+        count_severity: record.count_severity,
+    })
+}
+
+/// Returns `None` for lease loss and `Some` for a committed publication. All
+/// writes remain protected by the transaction's rollback-on-drop behavior.
+async fn publish_manifest_artifacts_in_tx(
+    tx: &tokio_postgres::Transaction<'_>,
+    lease: &ManifestLease,
+    canonical: &[SubmitFileRecord],
+    terminal: &ManifestPublicationStatus,
+) -> StorageResult<Option<ManifestPublicationResult>> {
+    let lease_token = i64::try_from(lease.fencing_token)
+        .map_err(|_| internal_error("lease fencing_token does not fit i64".to_string()))?;
+    let Some(state) = manifest_publication_state(tx, lease).await? else {
+        return Ok(None);
+    };
+    if state.status == "replaced" || state.fencing_token != lease_token {
+        return Ok(None);
+    }
+
+    let published_token_matches = state.published_token == Some(lease_token);
+    let publisher_matches =
+        state.publication_worker_id.as_deref() == Some(lease.worker_id.as_str());
+    if published_token_matches {
+        if !publisher_matches {
+            return Ok(None);
+        }
+        let (terminal_status, terminal_error) = publication_status_parts(terminal);
+        if state.publication_status.as_deref() != Some(terminal_status)
+            || state.status != terminal_status
+            || state.publication_error_message != terminal_error.map(str::to_string)
+        {
+            return Err(publication_conflict(
+                "terminal state changed for the same publication",
+            ));
+        }
+
+        let persisted = read_manifest_generation_records(tx, lease, lease_token).await?;
+        let persisted = canonical_publication_files(&persisted)?;
+        if persisted != canonical {
+            return Err(publication_conflict(
+                "artifact payload changed for the same publication",
+            ));
+        }
+        return Ok(Some(ManifestPublicationResult::AlreadyPublished));
+    }
+
+    // Fresh work must still be owned by this exact lease. An older publication
+    // marker is allowed and remains selected until this transaction replaces it.
+    if state.status != "processing" || state.worker_id.as_deref() != Some(lease.worker_id.as_str())
+    {
+        return Ok(None);
+    }
+
+    validate_publication_records(state.manifest_url.as_deref(), canonical)?;
+    delete_staged_publication_files(tx, lease, lease_token).await?;
+    insert_publication_files(tx, lease, lease_token, canonical).await?;
+
+    let (terminal_status, terminal_error) = publication_status_parts(terminal);
+    let affected = tx
+        .execute(
+            "UPDATE bulk_manifests
+             SET status = $5, published_token = $6, publication_status = $7,
+                 publication_error_message = $8, publication_worker_id = $9,
+                 worker_id = NULL, lease_expiry = NULL
+             WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
+               AND manifest_id = $4 AND status = 'processing'
+               AND worker_id = $10 AND fencing_token = $11",
+            &[
+                &lease.tenant.tenant_id().as_str(),
+                &lease.submission_id.submitter,
+                &lease.submission_id.submission_id,
+                &lease.manifest_id,
+                &terminal_status,
+                &lease_token,
+                &terminal_status,
+                &terminal_error,
+                &lease.worker_id.as_str(),
+                &lease.worker_id.as_str(),
+                &lease_token,
+            ],
+        )
+        .await
+        .map_err(|e| internal_error(format!("publish manifest: {e}")))?;
+    if affected != 1 {
+        return Ok(None);
+    }
+    Ok(Some(ManifestPublicationResult::Published))
+}
+
+async fn delete_staged_publication_files(
+    tx: &tokio_postgres::Transaction<'_>,
+    lease: &ManifestLease,
+    fencing_token: i64,
+) -> StorageResult<()> {
+    tx.execute(
+        "DELETE FROM bulk_submit_files
+         WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
+           AND manifest_id = $4 AND fencing_token = $5",
+        &[
+            &lease.tenant.tenant_id().as_str(),
+            &lease.submission_id.submitter,
+            &lease.submission_id.submission_id,
+            &lease.manifest_id,
+            &fencing_token,
+        ],
+    )
+    .await
+    .map_err(|e| internal_error(format!("delete staged files: {e}")))?;
+    Ok(())
+}
+
+async fn insert_publication_files(
+    tx: &tokio_postgres::Transaction<'_>,
+    lease: &ManifestLease,
+    fencing_token: i64,
+    files: &[SubmitFileRecord],
+) -> StorageResult<()> {
+    for file in files {
+        let count_severity = match &file.count_severity {
+            Some(value) => Some(
+                serde_json::to_string(value)
+                    .map_err(|error| internal_error(format!("encode count_severity: {error}")))?,
+            ),
+            None => None,
+        };
+        tx.execute(
+            "INSERT INTO bulk_submit_files
+             (tenant_id, submitter, submission_id, manifest_id, manifest_url, file_type,
+              resource_type, part_index, fencing_token, file_path, line_count, byte_count,
+              count_severity, created_at, publication_excluded_reason)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULL)",
+            &[
+                &lease.tenant.tenant_id().as_str(),
+                &lease.submission_id.submitter,
+                &lease.submission_id.submission_id,
+                &lease.manifest_id,
+                &file.manifest_url,
+                &file.file_type,
+                &file.resource_type,
+                &(file.part_index as i32),
+                &fencing_token,
+                &file.file_path,
+                &(file.line_count as i64),
+                &(file.byte_count as i64),
+                &count_severity,
+                &Utc::now(),
+            ],
+        )
+        .await
+        .map_err(|e| internal_error(format!("insert publication file: {e}")))?;
+    }
+    Ok(())
 }

--- a/crates/persistence/src/backends/postgres/schema.rs
+++ b/crates/persistence/src/backends/postgres/schema.rs
@@ -1,9 +1,15 @@
 //! PostgreSQL schema definitions and migrations.
 
+use deadpool_postgres::GenericClient;
+use serde_json::Value;
+
+use crate::core::bulk_submit_legacy::{
+    LegacyFile, LegacyManifest, LegacyPublicationAction, classify_legacy_publications,
+};
 use crate::error::{BackendError, StorageResult};
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 36;
+pub const SCHEMA_VERSION: i32 = 37;
 
 /// Advisory-lock key serializing schema migration across HFS instances sharing
 /// one database. Arbitrary but must stay stable across releases.
@@ -22,7 +28,7 @@ const MIGRATION_LOCK_KEY: i64 = 0x4846_5300_4d49_4752; // "HFS\0MIGR"
 ///
 /// The lock is session-scoped, so it is released even if the process is killed
 /// mid-migration.
-pub async fn initialize_schema(client: &deadpool_postgres::Client) -> StorageResult<()> {
+pub async fn initialize_schema(client: &mut deadpool_postgres::Client) -> StorageResult<()> {
     client
         .execute("SELECT pg_advisory_lock($1)", &[&MIGRATION_LOCK_KEY])
         .await
@@ -41,7 +47,7 @@ pub async fn initialize_schema(client: &deadpool_postgres::Client) -> StorageRes
     result
 }
 
-async fn run_migrations(client: &deadpool_postgres::Client) -> StorageResult<()> {
+async fn run_migrations(client: &mut deadpool_postgres::Client) -> StorageResult<()> {
     let current_version = get_schema_version(client).await?;
 
     if current_version == 0 {
@@ -76,7 +82,10 @@ async fn get_schema_version(client: &deadpool_postgres::Client) -> StorageResult
 }
 
 /// Set the schema version.
-async fn set_schema_version(client: &deadpool_postgres::Client, version: i32) -> StorageResult<()> {
+async fn set_schema_version<C>(client: &C, version: i32) -> StorageResult<()>
+where
+    C: GenericClient + ?Sized,
+{
     client
         .execute("DELETE FROM schema_version", &[])
         .await
@@ -314,7 +323,7 @@ async fn create_fts_tables(client: &deadpool_postgres::Client) -> StorageResult<
 
 /// Run schema migrations from current version to latest.
 async fn migrate_schema(
-    client: &deadpool_postgres::Client,
+    client: &mut deadpool_postgres::Client,
     from_version: i32,
 ) -> StorageResult<()> {
     let mut version = from_version;
@@ -356,6 +365,13 @@ async fn migrate_schema(
             33 => migrate_v33_to_v34(client).await?,
             34 => migrate_v34_to_v35(client).await?,
             35 => migrate_v35_to_v36(client).await?,
+            36 => {
+                // The helper commits the v37 marker inside its transaction, so
+                // the common loop must not stamp the same version again.
+                migrate_v36_to_v37(client).await?;
+                version += 1;
+                continue;
+            }
             _ => {
                 return Err(pg_error(format!("Unknown schema version: {}", version)));
             }
@@ -3327,6 +3343,286 @@ async fn migrate_v35_to_v36(client: &deadpool_postgres::Client) -> StorageResult
     Ok(())
 }
 
+/// v36 -> v37: manifest-scoped artifact publication.
+///
+/// Legacy artifact rows do not know which status manifest owned them and were
+/// not publication-sealed. Add the same columns and partial unique indexes as
+/// SQLite, then classify the rows with the shared legacy classifier. DDL,
+/// data classification, indexes, and the version marker all commit together.
+async fn migrate_v36_to_v37(client: &mut deadpool_postgres::Client) -> StorageResult<()> {
+    let tx = client
+        .transaction()
+        .await
+        .map_err(|e| pg_error(format!("begin v37 migration: {e}")))?;
+    let result = migrate_v36_to_v37_in_transaction(&tx).await;
+
+    // Errors and cancellation rely on the transaction's rollback-on-drop
+    // behavior; only a successful classification reaches this commit.
+    if result.is_err() {
+        return result;
+    }
+    tx.commit()
+        .await
+        .map_err(|e| pg_error(format!("commit v37 migration: {e}")))
+}
+
+async fn table_columns(
+    tx: &deadpool_postgres::Transaction<'_>,
+    table: &str,
+) -> StorageResult<Vec<String>> {
+    let rows = tx
+        .query(
+            "SELECT column_name FROM information_schema.columns
+             WHERE table_schema = current_schema() AND table_name = $1
+             ORDER BY ordinal_position",
+            &[&table],
+        )
+        .await
+        .map_err(|e| pg_error(format!("read {table} columns: {e}")))?;
+    Ok(rows.iter().map(|row| row.get::<_, String>(0)).collect())
+}
+
+#[allow(clippy::too_many_lines)]
+async fn migrate_v36_to_v37_in_transaction(
+    tx: &deadpool_postgres::Transaction<'_>,
+) -> StorageResult<()> {
+    // ALTERs would take these same ACCESS EXCLUSIVE locks, but acquire them
+    // before the all-column replay check so every initializer observes one
+    // frozen pre-v37 lease/file state. The locks release with the RAII
+    // transaction.
+    tx.batch_execute(
+        "LOCK TABLE bulk_manifests IN ACCESS EXCLUSIVE MODE;
+         LOCK TABLE bulk_submit_files IN ACCESS EXCLUSIVE MODE;",
+    )
+    .await
+    .map_err(|e| pg_error(format!("lock bulk tables for v37 migration: {e}")))?;
+
+    let manifest_columns = table_columns(tx, "bulk_manifests").await?;
+    let file_columns = table_columns(tx, "bulk_submit_files").await?;
+    if manifest_columns.is_empty() || file_columns.is_empty() {
+        return Err(pg_error(
+            "bulk_manifests and bulk_submit_files must exist before v37".to_string(),
+        ));
+    }
+
+    // Capture this before ALTER. Replaying an already committed v37 schema
+    // must not reclassify records or overwrite its publication markers.
+    let new_columns = [
+        ("bulk_manifests", "published_token"),
+        ("bulk_manifests", "publication_status"),
+        ("bulk_manifests", "publication_error_message"),
+        ("bulk_manifests", "publication_worker_id"),
+        ("bulk_submit_files", "manifest_id"),
+        ("bulk_submit_files", "publication_excluded_reason"),
+    ];
+    let classification_already_complete = new_columns.iter().all(|(table, column)| {
+        let columns = match *table {
+            "bulk_manifests" => &manifest_columns,
+            _ => &file_columns,
+        };
+        columns.iter().any(|existing| existing == column)
+    });
+
+    let ddl = [
+        "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS published_token BIGINT",
+        "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS publication_status TEXT",
+        "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS publication_error_message TEXT",
+        "ALTER TABLE bulk_manifests ADD COLUMN IF NOT EXISTS publication_worker_id TEXT",
+        "ALTER TABLE bulk_submit_files ADD COLUMN IF NOT EXISTS manifest_id TEXT",
+        "ALTER TABLE bulk_submit_files ADD COLUMN IF NOT EXISTS publication_excluded_reason TEXT",
+    ];
+    for sql in &ddl {
+        tx.execute(*sql, &[])
+            .await
+            .map_err(|e| pg_error(format!("Migration v36->v37 failed: {}", e)))?;
+    }
+
+    if !classification_already_complete {
+        let manifests = load_legacy_manifests(tx).await?;
+        let files = load_legacy_files(tx).await?;
+        for action in classify_legacy_publications(&manifests, &files) {
+            match action {
+                LegacyPublicationAction::Exclude { id, reason } => {
+                    set_row_reason(tx, id, reason).await?;
+                }
+                LegacyPublicationAction::Assign { id, manifest_id } => {
+                    set_manifest_file_identity(tx, id, &manifest_id).await?;
+                }
+                LegacyPublicationAction::Publish { manifest } => {
+                    mark_manifest_publication(tx, &manifest).await?;
+                }
+            }
+        }
+    }
+
+    let indexes = [
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_bulk_submit_files_artifact_null
+         ON bulk_submit_files(
+             tenant_id, submitter, submission_id, manifest_id, file_type,
+             part_index, fencing_token
+         )
+         WHERE manifest_id IS NOT NULL
+           AND publication_excluded_reason IS NULL
+           AND resource_type IS NULL",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_bulk_submit_files_artifact_not_null
+         ON bulk_submit_files(
+             tenant_id, submitter, submission_id, manifest_id, file_type,
+             resource_type, part_index, fencing_token
+         )
+         WHERE manifest_id IS NOT NULL
+           AND publication_excluded_reason IS NULL
+           AND resource_type IS NOT NULL",
+    ];
+    for sql in &indexes {
+        tx.execute(*sql, &[])
+            .await
+            .map_err(|e| pg_error(format!("create publication artifact index: {e}")))?;
+    }
+
+    set_schema_version(tx, 37).await?;
+    Ok(())
+}
+
+async fn load_legacy_manifests(
+    tx: &deadpool_postgres::Transaction<'_>,
+) -> StorageResult<Vec<LegacyManifest>> {
+    let rows = tx
+        .query(
+            "SELECT tenant_id, submitter, submission_id, manifest_id, manifest_url,
+                    status, fencing_token
+             FROM bulk_manifests
+             ORDER BY tenant_id, submitter, submission_id, added_at, manifest_id",
+            &[],
+        )
+        .await
+        .map_err(|e| pg_error(format!("read legacy manifests: {e}")))?;
+    rows.iter()
+        .map(|row| {
+            Ok(LegacyManifest {
+                tenant_id: row.get(0),
+                submitter: row.get(1),
+                submission_id: row.get(2),
+                manifest_id: row.get(3),
+                manifest_url: row.get(4),
+                status: row.get(5),
+                fencing_token: row.get(6),
+            })
+        })
+        .collect::<StorageResult<Vec<_>>>()
+}
+
+async fn load_legacy_files(
+    tx: &deadpool_postgres::Transaction<'_>,
+) -> StorageResult<Vec<LegacyFile>> {
+    let rows = tx
+        .query(
+            "SELECT id, tenant_id, submitter, submission_id, manifest_url, file_type,
+                    resource_type, part_index, fencing_token, file_path, line_count,
+                    byte_count, count_severity
+             FROM bulk_submit_files
+             WHERE manifest_id IS NULL AND publication_excluded_reason IS NULL
+             ORDER BY id",
+            &[],
+        )
+        .await
+        .map_err(|e| pg_error(format!("read legacy artifacts: {e}")))?;
+    rows.iter()
+        .map(|row| {
+            let count_severity: Option<String> = row.get::<_, Option<String>>(12);
+            let (count_severity, count_severity_invalid) = match count_severity {
+                Some(text) => match serde_json::from_str::<Value>(&text) {
+                    Ok(value) => (Some(value), false),
+                    Err(_) => (Some(Value::String(text)), true),
+                },
+                None => (None, false),
+            };
+            Ok(LegacyFile {
+                id: row.get(0),
+                tenant_id: row.get(1),
+                submitter: row.get(2),
+                submission_id: row.get(3),
+                metadata: crate::core::bulk_submit_legacy::LegacyArtifactMetadata {
+                    manifest_url: row.get(4),
+                    file_type: row.get(5),
+                    resource_type: row.get(6),
+                    part_index: i64::from(row.get::<_, i32>(7)),
+                    file_path: row.get(9),
+                    line_count: row.get(10),
+                    byte_count: row.get(11),
+                    count_severity,
+                    count_severity_invalid,
+                },
+                fencing_token: row.get(8),
+            })
+        })
+        .collect()
+}
+
+async fn set_row_reason(
+    tx: &deadpool_postgres::Transaction<'_>,
+    id: i64,
+    reason: &str,
+) -> StorageResult<()> {
+    tx.execute(
+        "UPDATE bulk_submit_files
+         SET manifest_id = NULL, publication_excluded_reason = $2
+         WHERE id = $1",
+        &[&id, &reason],
+    )
+    .await
+    .map_err(|e| pg_error(format!("classify artifact {id}: {e}")))?;
+    Ok(())
+}
+
+async fn set_manifest_file_identity(
+    tx: &deadpool_postgres::Transaction<'_>,
+    id: i64,
+    manifest_id: &str,
+) -> StorageResult<()> {
+    tx.execute(
+        "UPDATE bulk_submit_files
+         SET manifest_id = $2, publication_excluded_reason = NULL
+         WHERE id = $1",
+        &[&id, &manifest_id],
+    )
+    .await
+    .map_err(|e| pg_error(format!("assign artifact {id}: {e}")))?;
+    Ok(())
+}
+
+async fn mark_manifest_publication(
+    tx: &deadpool_postgres::Transaction<'_>,
+    manifest: &LegacyManifest,
+) -> StorageResult<()> {
+    // Failed legacy messages are unknowable, so publication_status is retained
+    // without inventing publication_error_message. The NULL worker leaves the
+    // marker unable to authorize a fresh publication replay.
+    tx.execute(
+        "UPDATE bulk_manifests
+         SET published_token = $5,
+             publication_status = $6,
+             publication_error_message = NULL,
+             publication_worker_id = NULL
+         WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3
+           AND manifest_id = $4
+           AND published_token IS NULL
+           AND publication_status IS NULL
+           AND publication_error_message IS NULL
+           AND publication_worker_id IS NULL",
+        &[
+            &manifest.tenant_id,
+            &manifest.submitter,
+            &manifest.submission_id,
+            &manifest.manifest_id,
+            &manifest.fencing_token,
+            &manifest.status,
+        ],
+    )
+    .await
+    .map_err(|e| pg_error(format!("mark legacy publication: {e}")))?;
+    Ok(())
+}
+
 /// v23 -> v24: drop `fk_search_resource`.
 ///
 /// `search_index` carried a composite FK to `resources` with `ON DELETE
@@ -3939,4 +4235,912 @@ fn pg_error(message: String) -> crate::error::StorageError {
         message,
         source: None,
     })
+}
+
+#[cfg(test)]
+mod postgres_integration_v37_migration {
+    use super::*;
+    use chrono::Utc;
+    use testcontainers::ImageExt;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+    use tokio::sync::{Mutex, OnceCell};
+    use tokio_postgres::NoTls;
+
+    use crate::backends::postgres::{PostgresBackend, PostgresConfig};
+    use crate::core::bulk_submit_legacy::{
+        LEGACY_REASON_CONFLICTING_DUPLICATE, LEGACY_REASON_EXACT_DUPLICATE,
+        LEGACY_REASON_INVALID_DOMAIN,
+    };
+    use crate::error::StorageResult;
+
+    struct SharedPg {
+        host: String,
+        port: u16,
+        /// Kept alive for the test binary; CI cleanup uses the run label.
+        _container: testcontainers::ContainerAsync<Postgres>,
+    }
+
+    static SHARED_PG: OnceCell<SharedPg> = OnceCell::const_new();
+    static POSTGRES_TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
+    async fn shared_pg() -> &'static SharedPg {
+        SHARED_PG
+            .get_or_init(|| async {
+                let run_id = std::env::var("GITHUB_RUN_ID").unwrap_or_default();
+                let container = Postgres::default()
+                    .with_tag("16-alpine")
+                    .with_label("github.run_id", &run_id)
+                    .start()
+                    .await
+                    .expect("start PostgreSQL container");
+                let host = container
+                    .get_host()
+                    .await
+                    .expect("get PostgreSQL host")
+                    .to_string();
+                let port = container
+                    .get_host_port_ipv4(5432)
+                    .await
+                    .expect("get PostgreSQL port");
+                SharedPg {
+                    host,
+                    port,
+                    _container: container,
+                }
+            })
+            .await
+    }
+
+    async fn create_database(pg: &SharedPg, name: &str) -> PostgresBackend {
+        let (admin, connection) = tokio_postgres::connect(
+            &format!(
+                "host={} port={} dbname=postgres user=postgres password=postgres",
+                pg.host, pg.port
+            ),
+            NoTls,
+        )
+        .await
+        .expect("connect to administrative PostgreSQL");
+        tokio::spawn(connection);
+        admin
+            .execute(&format!("CREATE DATABASE {name}"), &[])
+            .await
+            .expect("create migration database");
+        drop(admin);
+
+        PostgresBackend::new(PostgresConfig {
+            host: pg.host.clone(),
+            port: pg.port,
+            dbname: name.to_string(),
+            user: "postgres".to_string(),
+            password: Some("postgres".to_string()),
+            max_connections: 2,
+            ..Default::default()
+        })
+        .await
+        .expect("connect migration test backend")
+    }
+
+    async fn migrate_through_v36(client: &deadpool_postgres::Client) -> StorageResult<()> {
+        assert_eq!(get_schema_version(client).await?, 0);
+        create_schema_v1(client).await?;
+        set_schema_version(client, 1).await?;
+        migrate_v1_to_v2(client).await?;
+        set_schema_version(client, 2).await?;
+        migrate_v2_to_v3(client).await?;
+        set_schema_version(client, 3).await?;
+        migrate_v3_to_v4(client).await?;
+        set_schema_version(client, 4).await?;
+        migrate_v4_to_v5(client).await?;
+        set_schema_version(client, 5).await?;
+        migrate_v5_to_v6(client).await?;
+        set_schema_version(client, 6).await?;
+        migrate_v6_to_v7(client).await?;
+        set_schema_version(client, 7).await?;
+        migrate_v7_to_v8(client).await?;
+        set_schema_version(client, 8).await?;
+        migrate_v8_to_v9(client).await?;
+        set_schema_version(client, 9).await?;
+        migrate_v9_to_v10(client).await?;
+        set_schema_version(client, 10).await?;
+        migrate_v10_to_v11(client).await?;
+        set_schema_version(client, 11).await?;
+        migrate_v11_to_v12(client).await?;
+        set_schema_version(client, 12).await?;
+        migrate_v12_to_v13(client).await?;
+        set_schema_version(client, 13).await?;
+        migrate_v13_to_v14(client).await?;
+        set_schema_version(client, 14).await?;
+        migrate_v14_to_v15(client).await?;
+        set_schema_version(client, 15).await?;
+        migrate_v15_to_v16(client).await?;
+        set_schema_version(client, 16).await?;
+        migrate_v16_to_v17(client).await?;
+        set_schema_version(client, 17).await?;
+        migrate_v17_to_v18(client).await?;
+        set_schema_version(client, 18).await?;
+        migrate_v18_to_v19(client).await?;
+        set_schema_version(client, 19).await?;
+        migrate_v19_to_v20(client).await?;
+        set_schema_version(client, 20).await?;
+        migrate_v20_to_v21(client).await?;
+        set_schema_version(client, 21).await?;
+        migrate_v21_to_v22(client).await?;
+        set_schema_version(client, 22).await?;
+        migrate_v22_to_v23(client).await?;
+        set_schema_version(client, 23).await?;
+        migrate_v23_to_v24(client).await?;
+        set_schema_version(client, 24).await?;
+        migrate_v24_to_v25(client).await?;
+        set_schema_version(client, 25).await?;
+        migrate_v25_to_v26(client).await?;
+        set_schema_version(client, 26).await?;
+        migrate_v26_to_v27(client).await?;
+        set_schema_version(client, 27).await?;
+        migrate_v27_to_v28(client).await?;
+        set_schema_version(client, 28).await?;
+        migrate_v28_to_v29(client).await?;
+        set_schema_version(client, 29).await?;
+        migrate_v29_to_v30(client).await?;
+        set_schema_version(client, 30).await?;
+        migrate_v30_to_v31(client).await?;
+        set_schema_version(client, 31).await?;
+        migrate_v31_to_v32(client).await?;
+        set_schema_version(client, 32).await?;
+        migrate_v32_to_v33(client).await?;
+        set_schema_version(client, 33).await?;
+        migrate_v33_to_v34(client).await?;
+        set_schema_version(client, 34).await?;
+        migrate_v34_to_v35(client).await?;
+        set_schema_version(client, 35).await?;
+        migrate_v35_to_v36(client).await?;
+        set_schema_version(client, 36).await?;
+        assert_eq!(get_schema_version(client).await?, 36);
+        Ok(())
+    }
+
+    async fn seed_submission(
+        client: &deadpool_postgres::Client,
+        tenant: &str,
+        submitter: &str,
+        submission: &str,
+    ) {
+        client
+            .execute(
+                "INSERT INTO bulk_submissions
+                 (tenant_id, submitter, submission_id, status, created_at, updated_at)
+                 VALUES ($1, $2, $3, 'complete', $4, $4)",
+                &[&tenant, &submitter, &submission, &Utc::now()],
+            )
+            .await
+            .expect("seed submission");
+    }
+
+    #[allow(clippy::too_many_arguments)] // Explicit legacy-schema fixture columns.
+    async fn seed_manifest(
+        client: &deadpool_postgres::Client,
+        tenant: &str,
+        submitter: &str,
+        submission: &str,
+        manifest: &str,
+        url: Option<&str>,
+        status: &str,
+        fencing_token: i64,
+    ) {
+        client
+            .execute(
+                "INSERT INTO bulk_manifests
+                 (tenant_id, submitter, submission_id, manifest_id, manifest_url,
+                  status, added_at, fencing_token)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                &[
+                    &tenant,
+                    &submitter,
+                    &submission,
+                    &manifest,
+                    &url,
+                    &status,
+                    &Utc::now(),
+                    &fencing_token,
+                ],
+            )
+            .await
+            .expect("seed manifest");
+    }
+
+    #[allow(clippy::too_many_arguments)] // Explicit legacy-schema fixture columns.
+    async fn seed_file(
+        client: &deadpool_postgres::Client,
+        tenant: &str,
+        submitter: &str,
+        submission: &str,
+        url: Option<&str>,
+        file_type: &str,
+        resource_type: Option<&str>,
+        part_index: i32,
+        fencing_token: i64,
+        file_path: &str,
+        line_count: i64,
+        byte_count: i64,
+        count_severity: Option<&str>,
+    ) -> i64 {
+        client
+            .query_one(
+                "INSERT INTO bulk_submit_files
+                 (tenant_id, submitter, submission_id, manifest_url, file_type,
+                  resource_type, part_index, fencing_token, file_path, line_count,
+                  byte_count, count_severity, created_at)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                 RETURNING id",
+                &[
+                    &tenant,
+                    &submitter,
+                    &submission,
+                    &url,
+                    &file_type,
+                    &resource_type,
+                    &part_index,
+                    &fencing_token,
+                    &file_path,
+                    &line_count,
+                    &byte_count,
+                    &count_severity,
+                    &Utc::now(),
+                ],
+            )
+            .await
+            .expect("seed file")
+            .get::<_, i64>(0)
+    }
+
+    async fn classification(
+        client: &deadpool_postgres::Client,
+        id: i64,
+    ) -> (Option<String>, Option<String>) {
+        let row = client
+            .query_one(
+                "SELECT manifest_id, publication_excluded_reason
+                 FROM bulk_submit_files WHERE id = $1",
+                &[&id],
+            )
+            .await
+            .expect("read artifact classification");
+        (row.get(0), row.get(1))
+    }
+
+    async fn publication_marker(
+        client: &deadpool_postgres::Client,
+        tenant: &str,
+        submitter: &str,
+        submission: &str,
+        manifest: &str,
+    ) -> (Option<i64>, Option<String>, Option<String>, Option<String>) {
+        let row = client
+            .query_one(
+                "SELECT published_token, publication_status, publication_error_message,
+                        publication_worker_id
+                 FROM bulk_manifests
+                 WHERE tenant_id = $1 AND submitter = $2
+                   AND submission_id = $3 AND manifest_id = $4",
+                &[&tenant, &submitter, &submission, &manifest],
+            )
+            .await
+            .expect("read publication marker");
+        (row.get(0), row.get(1), row.get(2), row.get(3))
+    }
+
+    async fn index_count(client: &deadpool_postgres::Client) -> i64 {
+        client
+            .query_one(
+                "SELECT COUNT(*) FROM pg_indexes
+                 WHERE schemaname = current_schema()
+                   AND indexname IN (
+                       'idx_bulk_submit_files_artifact_null',
+                       'idx_bulk_submit_files_artifact_not_null'
+                   )",
+                &[],
+            )
+            .await
+            .expect("count publication indexes")
+            .get::<_, i64>(0)
+    }
+
+    async fn column_type(
+        client: &deadpool_postgres::Client,
+        table: &str,
+        column: &str,
+    ) -> Option<String> {
+        client
+            .query_opt(
+                "SELECT data_type FROM information_schema.columns
+                 WHERE table_schema = current_schema()
+                   AND table_name = $1 AND column_name = $2",
+                &[&table, &column],
+            )
+            .await
+            .expect("read column type")
+            .map(|row| row.get(0))
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_v36_to_v37_classifies_and_enforces_uniqueness() {
+        let _guard = POSTGRES_TEST_LOCK.lock().await;
+        let pg = shared_pg().await;
+        let backend = create_database(
+            pg,
+            &format!("hfs_v37_test_{}", uuid::Uuid::new_v4().simple()),
+        )
+        .await;
+        let client = backend.get_client().await.unwrap();
+        migrate_through_v36(&client).await.unwrap();
+
+        // Same submitter/submission/URL/token in two tenant scopes must both
+        // be assigned. This is a direct regression for cross-scope bleed.
+        let mut shared_rows = Vec::new();
+        for tenant in ["tenant-a", "tenant-b"] {
+            seed_submission(&client, tenant, "alice", "shared-submission").await;
+            seed_manifest(
+                &client,
+                tenant,
+                "alice",
+                "shared-submission",
+                "shared-manifest",
+                Some("https://provider/shared.json"),
+                "completed",
+                1,
+            )
+            .await;
+            let shared = seed_file(
+                &client,
+                tenant,
+                "alice",
+                "shared-submission",
+                Some("https://provider/shared.json"),
+                "output",
+                Some("Patient"),
+                0,
+                1,
+                "shared/path.ndjson",
+                1,
+                10,
+                None,
+            )
+            .await;
+            shared_rows.push(shared);
+        }
+
+        seed_submission(&client, "tenant-a", "alice", "terminal-submission").await;
+        seed_manifest(
+            &client,
+            "tenant-a",
+            "alice",
+            "terminal-submission",
+            "manifest-completed",
+            Some("https://provider/completed.json"),
+            "completed",
+            2,
+        )
+        .await;
+        seed_manifest(
+            &client,
+            "tenant-a",
+            "alice",
+            "terminal-submission",
+            "manifest-failed",
+            Some("https://provider/failed.json"),
+            "failed",
+            3,
+        )
+        .await;
+        let completed = seed_file(
+            &client,
+            "tenant-a",
+            "alice",
+            "terminal-submission",
+            Some("https://provider/completed.json"),
+            "output",
+            Some("Patient"),
+            0,
+            2,
+            "completed/output-0.ndjson",
+            1,
+            10,
+            None,
+        )
+        .await;
+        let failed = seed_file(
+            &client,
+            "tenant-a",
+            "alice",
+            "terminal-submission",
+            Some("https://provider/failed.json"),
+            "error",
+            Some("OperationOutcome"),
+            0,
+            3,
+            "failed/error-0.ndjson",
+            2,
+            20,
+            Some(r#"{"error":2,"warning":1}"#),
+        )
+        .await;
+        let exact_duplicate = seed_file(
+            &client,
+            "tenant-a",
+            "alice",
+            "terminal-submission",
+            Some("https://provider/completed.json"),
+            "output",
+            Some("Patient"),
+            0,
+            2,
+            "completed/output-0.ndjson",
+            1,
+            10,
+            None,
+        )
+        .await;
+
+        seed_submission(&client, "tenant-a", "alice", "typed-submission").await;
+        seed_manifest(
+            &client,
+            "tenant-a",
+            "alice",
+            "typed-submission",
+            "manifest-typed",
+            Some("https://provider/types.json"),
+            "completed",
+            4,
+        )
+        .await;
+        let null_type = seed_file(
+            &client,
+            "tenant-a",
+            "alice",
+            "typed-submission",
+            Some("https://provider/types.json"),
+            "output",
+            None,
+            0,
+            4,
+            "types/null.ndjson",
+            1,
+            10,
+            None,
+        )
+        .await;
+        let empty_type = seed_file(
+            &client,
+            "tenant-a",
+            "alice",
+            "typed-submission",
+            Some("https://provider/types.json"),
+            "output",
+            Some(""),
+            0,
+            4,
+            "types/empty.ndjson",
+            1,
+            10,
+            None,
+        )
+        .await;
+
+        let mut quarantined = Vec::new();
+        for (submission, malformed) in [("conflict", false), ("malformed", true)] {
+            seed_submission(&client, "tenant-a", "alice", submission).await;
+            seed_manifest(
+                &client,
+                "tenant-a",
+                "alice",
+                submission,
+                submission,
+                Some("https://provider/quarantine"),
+                "completed",
+                9,
+            )
+            .await;
+            let row = seed_file(
+                &client,
+                "tenant-a",
+                "alice",
+                submission,
+                Some("https://provider/quarantine"),
+                "error",
+                Some("OperationOutcome"),
+                0,
+                9,
+                "legacy-path",
+                1,
+                10,
+                if malformed { Some("{broken") } else { None },
+            )
+            .await;
+            quarantined.push((
+                row,
+                if malformed {
+                    LEGACY_REASON_INVALID_DOMAIN
+                } else {
+                    LEGACY_REASON_CONFLICTING_DUPLICATE
+                },
+            ));
+            if !malformed {
+                let duplicate = seed_file(
+                    &client,
+                    "tenant-a",
+                    "alice",
+                    submission,
+                    Some("https://provider/quarantine"),
+                    "error",
+                    Some("OperationOutcome"),
+                    0,
+                    9,
+                    "conflicting-path",
+                    1,
+                    10,
+                    None,
+                )
+                .await;
+                quarantined.push((duplicate, LEGACY_REASON_CONFLICTING_DUPLICATE));
+            }
+        }
+        let before_count: i64 = client
+            .query_one("SELECT COUNT(*) FROM bulk_submit_files", &[])
+            .await
+            .unwrap()
+            .get(0);
+        let mut migration_client = backend.get_client().await.unwrap();
+        initialize_schema(&mut migration_client)
+            .await
+            .expect("initialize v37");
+        for row in shared_rows {
+            assert_eq!(
+                classification(&client, row).await,
+                (Some("shared-manifest".into()), None)
+            );
+        }
+        for (row, reason) in quarantined {
+            assert_eq!(
+                classification(&client, row).await,
+                (None, Some(reason.into()))
+            );
+        }
+        let after_count: i64 = client
+            .query_one("SELECT COUNT(*) FROM bulk_submit_files", &[])
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(before_count, after_count);
+        let malformed: String = client
+            .query_one(
+                "SELECT count_severity FROM bulk_submit_files WHERE submission_id = 'malformed'",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(malformed, "{broken");
+
+        assert_eq!(get_schema_version(&client).await.unwrap(), 37);
+        assert_eq!(index_count(&client).await, 2);
+        assert_eq!(
+            column_type(&client, "bulk_manifests", "published_token").await,
+            Some("bigint".to_string())
+        );
+        assert_eq!(
+            column_type(&client, "bulk_manifests", "publication_status").await,
+            Some("text".to_string())
+        );
+        assert_eq!(
+            column_type(&client, "bulk_manifests", "publication_error_message").await,
+            Some("text".to_string())
+        );
+        assert_eq!(
+            column_type(&client, "bulk_manifests", "publication_worker_id").await,
+            Some("text".to_string())
+        );
+        assert_eq!(
+            column_type(&client, "bulk_submit_files", "manifest_id").await,
+            Some("text".to_string())
+        );
+        assert_eq!(
+            column_type(&client, "bulk_submit_files", "publication_excluded_reason").await,
+            Some("text".to_string())
+        );
+        assert_eq!(
+            classification(&client, completed).await,
+            (Some("manifest-completed".to_string()), None)
+        );
+        assert_eq!(
+            classification(&client, failed).await,
+            (Some("manifest-failed".to_string()), None)
+        );
+        assert_eq!(
+            classification(&client, exact_duplicate).await,
+            (None, Some(LEGACY_REASON_EXACT_DUPLICATE.to_string()))
+        );
+        assert_eq!(
+            classification(&client, null_type).await,
+            (Some("manifest-typed".to_string()), None)
+        );
+        assert_eq!(
+            classification(&client, empty_type).await,
+            (Some("manifest-typed".to_string()), None)
+        );
+        assert_eq!(
+            publication_marker(
+                &client,
+                "tenant-a",
+                "alice",
+                "terminal-submission",
+                "manifest-completed"
+            )
+            .await,
+            (Some(2), Some("completed".to_string()), None, None)
+        );
+        assert_eq!(
+            publication_marker(
+                &client,
+                "tenant-a",
+                "alice",
+                "terminal-submission",
+                "manifest-failed"
+            )
+            .await,
+            (Some(3), Some("failed".to_string()), None, None)
+        );
+
+        for resource_type in [None::<&str>, Some("")] {
+            let error = client
+                .execute(
+                    "INSERT INTO bulk_submit_files
+                     (tenant_id, submitter, submission_id, manifest_id, manifest_url,
+                      file_type, resource_type, part_index, fencing_token, file_path,
+                      line_count, byte_count, created_at)
+                     VALUES ('tenant-a', 'alice', 'typed-submission', 'manifest-typed',
+                             'https://provider/types.json', 'output', $1, 0, 4,
+                             'types/duplicate.ndjson', 1, 10, $2)",
+                    &[&resource_type, &Utc::now()],
+                )
+                .await
+                .expect_err("duplicate resource_type must violate the partial index");
+            assert_eq!(
+                error.code(),
+                Some(&tokio_postgres::error::SqlState::UNIQUE_VIOLATION)
+            );
+        }
+        let null_count = client
+            .query_one(
+                "SELECT COUNT(*) FROM bulk_submit_files
+                 WHERE manifest_id = 'manifest-typed'
+                   AND publication_excluded_reason IS NULL AND resource_type IS NULL",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        let empty_count = client
+            .query_one(
+                "SELECT COUNT(*) FROM bulk_submit_files
+                 WHERE manifest_id = 'manifest-typed'
+                   AND publication_excluded_reason IS NULL AND resource_type = ''",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(null_count, 1);
+        assert_eq!(empty_count, 1);
+        assert_eq!(index_count(&client).await, 2);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_v36_to_v37_rolls_back_trigger_failure_and_replays() {
+        let _guard = POSTGRES_TEST_LOCK.lock().await;
+        let pg = shared_pg().await;
+        let backend = create_database(
+            pg,
+            &format!("hfs_v37_test_{}", uuid::Uuid::new_v4().simple()),
+        )
+        .await;
+        let client = backend.get_client().await.unwrap();
+        migrate_through_v36(&client).await.unwrap();
+        seed_submission(&client, "tenant-a", "alice", "submission-rollback").await;
+        seed_manifest(
+            &client,
+            "tenant-a",
+            "alice",
+            "submission-rollback",
+            "manifest-rollback",
+            Some("https://provider/rollback.json"),
+            "completed",
+            5,
+        )
+        .await;
+        let output = seed_file(
+            &client,
+            "tenant-a",
+            "alice",
+            "submission-rollback",
+            Some("https://provider/rollback.json"),
+            "output",
+            Some("Patient"),
+            0,
+            5,
+            "rollback/output-0.ndjson",
+            1,
+            10,
+            None,
+        )
+        .await;
+        let before = client
+            .query_one(
+                "SELECT to_jsonb(f) FROM bulk_submit_files f WHERE id = $1",
+                &[&output],
+            )
+            .await
+            .unwrap();
+
+        client
+            .batch_execute(&format!(
+                "CREATE FUNCTION fail_v37_update() RETURNS trigger LANGUAGE plpgsql AS $$
+                 BEGIN RAISE EXCEPTION 'injected v37 publication failure'; END $$;
+                 CREATE TRIGGER fail_v37_classification BEFORE UPDATE ON bulk_submit_files
+                 FOR EACH ROW WHEN (OLD.id = {output})
+                 EXECUTE FUNCTION fail_v37_update();"
+            ))
+            .await
+            .expect("create failing trigger");
+        let mut migration_client = backend.get_client().await.unwrap();
+        let error = initialize_schema(&mut migration_client)
+            .await
+            .expect_err("rollback expected");
+        assert!(error.to_string().contains("assign artifact"), "{error}");
+
+        // Because all DDL, classification, indexes, and the version marker run
+        // in one transaction, none of them survive the trigger failure.
+        assert_eq!(get_schema_version(&client).await.unwrap(), 36);
+        for (table, column) in [
+            ("bulk_manifests", "published_token"),
+            ("bulk_manifests", "publication_status"),
+            ("bulk_manifests", "publication_error_message"),
+            ("bulk_manifests", "publication_worker_id"),
+            ("bulk_submit_files", "manifest_id"),
+            ("bulk_submit_files", "publication_excluded_reason"),
+        ] {
+            assert_eq!(
+                column_type(&client, table, column).await,
+                None,
+                "{table}.{column} must roll back"
+            );
+        }
+        assert_eq!(index_count(&client).await, 0);
+        let after = client
+            .query_one(
+                "SELECT to_jsonb(f) FROM bulk_submit_files f WHERE id = $1",
+                &[&output],
+            )
+            .await
+            .unwrap();
+        assert_eq!(after.get::<_, Value>(0), before.get::<_, Value>(0));
+
+        client
+            .batch_execute(
+                "DROP TRIGGER fail_v37_classification ON bulk_submit_files;
+                 DROP FUNCTION fail_v37_update();",
+            )
+            .await
+            .expect("drop failing trigger");
+        initialize_schema(&mut migration_client)
+            .await
+            .expect("retry v37");
+        assert_eq!(get_schema_version(&client).await.unwrap(), 37);
+        assert_eq!(
+            classification(&client, output).await,
+            (Some("manifest-rollback".to_string()), None)
+        );
+        assert_eq!(
+            publication_marker(
+                &client,
+                "tenant-a",
+                "alice",
+                "submission-rollback",
+                "manifest-rollback"
+            )
+            .await,
+            (Some(5), Some("completed".to_string()), None, None)
+        );
+        assert_eq!(index_count(&client).await, 2);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_v36_to_v37_replays_without_reclassification() {
+        let _guard = POSTGRES_TEST_LOCK.lock().await;
+        let pg = shared_pg().await;
+        let backend = create_database(
+            pg,
+            &format!("hfs_v37_test_{}", uuid::Uuid::new_v4().simple()),
+        )
+        .await;
+        let client = backend.get_client().await.unwrap();
+        migrate_through_v36(&client).await.unwrap();
+        seed_submission(&client, "tenant-a", "alice", "submission-replay").await;
+        seed_manifest(
+            &client,
+            "tenant-a",
+            "alice",
+            "submission-replay",
+            "manifest-replay",
+            Some("https://provider/replay.json"),
+            "completed",
+            6,
+        )
+        .await;
+        let output = seed_file(
+            &client,
+            "tenant-a",
+            "alice",
+            "submission-replay",
+            Some("https://provider/replay.json"),
+            "output",
+            Some("Patient"),
+            0,
+            6,
+            "replay/output-0.ndjson",
+            1,
+            10,
+            None,
+        )
+        .await;
+        let mut migration_client = backend.get_client().await.unwrap();
+        initialize_schema(&mut migration_client)
+            .await
+            .expect("initialize v37");
+        let first_marker = publication_marker(
+            &client,
+            "tenant-a",
+            "alice",
+            "submission-replay",
+            "manifest-replay",
+        )
+        .await;
+        let first_classification = classification(&client, output).await;
+        assert_eq!(
+            first_classification,
+            (Some("manifest-replay".to_string()), None)
+        );
+
+        // A current database must not re-run legacy classification and must
+        // preserve both the artifact assignment and publication marker.
+        client
+            .execute(
+                "UPDATE bulk_manifests SET publication_worker_id = 'preserved-publisher'",
+                &[],
+            )
+            .await
+            .unwrap();
+        migrate_v36_to_v37(&mut migration_client)
+            .await
+            .expect("replay current");
+        assert_eq!(get_schema_version(&client).await.unwrap(), 37);
+        assert_eq!(
+            publication_marker(
+                &client,
+                "tenant-a",
+                "alice",
+                "submission-replay",
+                "manifest-replay"
+            )
+            .await,
+            (
+                first_marker.0,
+                first_marker.1,
+                first_marker.2,
+                Some("preserved-publisher".into())
+            )
+        );
+        assert_eq!(classification(&client, output).await, first_classification);
+        assert_eq!(index_count(&client).await, 2);
+    }
 }

--- a/crates/persistence/src/backends/s3/keyspace.rs
+++ b/crates/persistence/src/backends/s3/keyspace.rs
@@ -338,15 +338,18 @@ impl S3Keyspace {
 
     /// Key for one finalized status-manifest artifact row of a submission.
     ///
-    /// The identity is `(file_type, resource_type, part_index, fencing_token)`,
-    /// matching the `bulk_submit_files` uniqueness the SQL backends carry. The
-    /// fencing token is in the key so a worker that re-writes an artifact after
-    /// reclaiming a manifest replaces its own row and never collides with the
-    /// row a *previous* lease holder left behind.
+    /// The identity is `(submitter, submission_id, manifest_id, file_type,
+    /// resource_type, part_index, fencing_token)`, matching the manifest-aware
+    /// `bulk_submit_files` uniqueness the SQL backends carry. The fencing token
+    /// is in the key so a worker that re-writes an artifact after reclaiming a
+    /// manifest replaces its own row and never collides with the row a
+    /// *previous* lease holder left behind.
+    #[allow(clippy::too_many_arguments)] // The complete persisted artifact identity.
     pub fn submit_file_key(
         &self,
         submitter: &str,
         submission_id: &str,
+        manifest_id: &str,
         file_type: &str,
         resource_type: Option<&str>,
         part_index: u32,
@@ -359,11 +362,16 @@ impl S3Keyspace {
             submission_id,
             "files",
             &format!(
-                "{}-{}-{}-{}.json",
-                sanitize(file_type),
-                sanitize(resource_type.unwrap_or("_")),
-                part_index,
-                fencing_token
+                "{}.json",
+                submit_file_object_id(
+                    submitter,
+                    submission_id,
+                    manifest_id,
+                    file_type,
+                    resource_type,
+                    part_index,
+                    fencing_token,
+                )
             ),
         ])
     }
@@ -517,6 +525,42 @@ impl S3Keyspace {
         }
         out
     }
+}
+
+const SUBMIT_FILE_KEY_VERSION: u8 = 1;
+
+/// Builds the opaque object id for one manifest-aware submit artifact row.
+///
+/// Raw ids and optional resource types are serialized as an injective typed
+/// JSON tuple — `None` and `Some("")` remain distinct — then SHA-256 digested.
+/// The digest is collision-resistant, not mathematically injective, but it keeps
+/// hostile slashes out of S3 paths while preserving the stable `files/` prefix.
+fn submit_file_object_id(
+    submitter: &str,
+    submission_id: &str,
+    manifest_id: &str,
+    file_type: &str,
+    resource_type: Option<&str>,
+    part_index: u32,
+    fencing_token: u64,
+) -> String {
+    let payload = serde_json::to_vec(&(
+        SUBMIT_FILE_KEY_VERSION,
+        submitter,
+        submission_id,
+        manifest_id,
+        file_type,
+        resource_type,
+        part_index,
+        fencing_token,
+    ))
+    .expect("canonical submit-file key payload must be valid JSON");
+    let digest = Sha256::digest(&payload);
+    format!("{SUBMIT_FILE_KEY_VERSION}-{}", hex_digest(&digest))
+}
+
+fn hex_digest(digest: &[u8]) -> String {
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 /// Replaces characters that are unsafe in S3 key path segments.
@@ -1178,6 +1222,20 @@ mod tests {
                 ks.legacy_tenant_registry_key(id),
                 "previously-colliding id {id:?} must move to a new key"
             );
+        }
+    }
+
+    #[test]
+    fn submit_file_keys_distinguish_manifest_and_nullable_resource() {
+        let ks = S3Keyspace::new(None);
+        let none = ks.submit_file_key("s", "job", "m-a", "output", None, 0, 1);
+        let empty = ks.submit_file_key("s", "job", "m-a", "output", Some(""), 0, 1);
+        let other_manifest = ks.submit_file_key("s", "job", "m-b", "output", None, 0, 1);
+
+        assert_ne!(none, empty);
+        assert_ne!(none, other_manifest);
+        for key in [none, empty, other_manifest] {
+            assert!(key.starts_with("bulk/submit/s/job/files/"));
         }
     }
 }

--- a/crates/persistence/src/backends/s3/submit_worker.rs
+++ b/crates/persistence/src/backends/s3/submit_worker.rs
@@ -56,6 +56,9 @@ use crate::core::bulk_submit::{
     BulkSubmitProvider, ManifestPhase, ManifestStatus, SubmissionId, SubmissionManifest,
     SubmissionStatus,
 };
+use crate::core::bulk_submit_publication::{
+    ManifestPublicationResult, ManifestPublicationStatus, canonical_publication_files,
+};
 use crate::core::bulk_submit_worker::{
     ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
     SubmitFileRecord, SubmitFileRow, SubmitWorkerStorage,
@@ -725,6 +728,8 @@ impl SubmitWorkerStorage for S3Backend {
             resource_type: file.resource_type.clone(),
             part_index: file.part_index,
             fencing_token: lease.fencing_token,
+            manifest_id: Some(lease.manifest_id.clone()),
+            legacy_locator: false,
             file_path: file.file_path.clone(),
             line_count: file.line_count,
             byte_count: file.byte_count,
@@ -733,6 +738,7 @@ impl SubmitWorkerStorage for S3Backend {
         let key = location.keyspace.submit_file_key(
             &lease.submission_id.submitter,
             &lease.submission_id.submission_id,
+            &lease.manifest_id,
             &file.file_type,
             file.resource_type.as_deref(),
             file.part_index,
@@ -747,6 +753,28 @@ impl SubmitWorkerStorage for S3Backend {
             .await
             .map_err(LeaseError::Storage)?;
         Ok(())
+    }
+
+    /// Publishes by canonical validation, then fenced per-row writes and the
+    /// fenced terminal update. S3 provides no cross-object transaction; this
+    /// intentionally preserves the existing non-atomic backend behavior.
+    async fn publish_manifest_artifacts(
+        &self,
+        lease: &ManifestLease,
+        files: &[SubmitFileRecord],
+        terminal: ManifestPublicationStatus,
+    ) -> Result<ManifestPublicationResult, LeaseError> {
+        let canonical = canonical_publication_files(files).map_err(LeaseError::Storage)?;
+        for file in &canonical {
+            self.record_submit_file(lease, file).await?;
+        }
+        match terminal {
+            ManifestPublicationStatus::Completed => self.finish_manifest(lease).await?,
+            ManifestPublicationStatus::Failed { error_message } => {
+                self.fail_manifest(lease, &error_message).await?
+            }
+        }
+        Ok(ManifestPublicationResult::Published)
     }
 
     async fn finish_manifest(&self, lease: &ManifestLease) -> Result<(), LeaseError> {
@@ -1145,6 +1173,8 @@ struct SubmitFileRowRecord {
     resource_type: Option<String>,
     part_index: u32,
     fencing_token: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    manifest_id: Option<String>,
     file_path: String,
     line_count: u64,
     byte_count: u64,
@@ -1159,6 +1189,7 @@ impl From<&SubmitFileRow> for SubmitFileRowRecord {
             resource_type: row.resource_type.clone(),
             part_index: row.part_index,
             fencing_token: row.fencing_token,
+            manifest_id: row.manifest_id.clone(),
             file_path: row.file_path.clone(),
             line_count: row.line_count,
             byte_count: row.byte_count,
@@ -1169,16 +1200,46 @@ impl From<&SubmitFileRow> for SubmitFileRowRecord {
 
 impl From<SubmitFileRowRecord> for SubmitFileRow {
     fn from(record: SubmitFileRowRecord) -> Self {
+        let legacy_locator = record.manifest_id.is_none();
         Self {
             manifest_url: record.manifest_url,
             file_type: record.file_type,
             resource_type: record.resource_type,
             part_index: record.part_index,
             fencing_token: record.fencing_token,
+            manifest_id: record.manifest_id,
+            legacy_locator,
             file_path: record.file_path,
             line_count: record.line_count,
             byte_count: record.byte_count,
             count_severity: record.count_severity,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_record_without_manifest_id_is_legacy_locator() {
+        let record: SubmitFileRowRecord = serde_json::from_str(
+            r#"{
+                "manifest_url": "http://provider/manifest.json",
+                "file_type": "output",
+                "resource_type": "Patient",
+                "part_index": 0,
+                "fencing_token": 1,
+                "file_path": "output.ndjson",
+                "line_count": 1,
+                "byte_count": 16,
+                "count_severity": null
+            }"#,
+        )
+        .unwrap();
+        let row = SubmitFileRow::from(record);
+
+        assert_eq!(row.manifest_id, None);
+        assert!(row.legacy_locator);
     }
 }

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use helios_fhir::FhirVersion;
-use rusqlite::params;
+use rusqlite::{TransactionBehavior, params};
 use serde_json::Value;
 use std::time::Duration as StdDuration;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt};
@@ -20,6 +20,9 @@ use crate::core::bulk_submit::{
     PagedEntryResult, StreamProcessingResult, StreamingBulkSubmitProvider, SubmissionChange,
     SubmissionId, SubmissionManifest, SubmissionStatus, SubmissionSummary,
     invalid_entry_result_page,
+};
+use crate::core::bulk_submit_publication::{
+    ManifestPublicationResult, ManifestPublicationStatus, canonical_publication_files,
 };
 use crate::core::bulk_submit_worker::{
     ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy,
@@ -756,7 +759,8 @@ impl BulkSubmitProvider for SqliteBackend {
         txn.with_connection(|conn| {
             conn.prepare_cached(
                 "UPDATE bulk_manifests SET status = 'processing'
-                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3 AND manifest_id = ?4",
+                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                   AND manifest_id = ?4 AND status <> 'replaced'",
             )
             .map_err(|e| internal_error(format!("prepare manifest status update: {e}")))?
             .execute(params![
@@ -1614,7 +1618,8 @@ impl SubmitClaimStrategy for SqliteBackend {
             conn.execute(
                 "UPDATE bulk_manifests SET lease_expiry = ?1
                  WHERE tenant_id = ?2 AND submitter = ?3 AND submission_id = ?4
-                   AND manifest_id = ?5 AND worker_id = ?6 AND fencing_token = ?7",
+                   AND manifest_id = ?5 AND status = 'processing'
+                   AND worker_id = ?6 AND fencing_token = ?7",
                 params![
                     new_expiry.to_rfc3339(),
                     lease.tenant.tenant_id().as_str(),
@@ -1682,7 +1687,8 @@ impl SubmitWorkerStorage for SqliteBackend {
                         import_directives, submission_metadata
                  FROM bulk_manifests
                  WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
-                   AND manifest_id = ?4 AND worker_id = ?5 AND fencing_token = ?6",
+                   AND manifest_id = ?4 AND status = 'processing'
+                   AND worker_id = ?5 AND fencing_token = ?6",
                 params![
                     lease.tenant.tenant_id().as_str(),
                     lease.submission_id.submitter,
@@ -1705,7 +1711,16 @@ impl SubmitWorkerStorage for SqliteBackend {
                     ))
                 },
             )
-            .map_err(|_| lease_lost(lease))?;
+            .map_err(|error| {
+                if matches!(error, rusqlite::Error::QueryReturnedNoRows) {
+                    lease_lost(lease)
+                } else {
+                    LeaseError::Storage(StorageError::Backend(classify_sqlite_error(
+                        "get manifest for worker",
+                        error,
+                    )))
+                }
+            })?;
 
         let (
             manifest_url,
@@ -1719,25 +1734,43 @@ impl SubmitWorkerStorage for SqliteBackend {
             metadata_json,
         ) = row;
 
-        let file_request_headers: Vec<(String, String)> = headers_json
-            .as_deref()
-            .and_then(|s| serde_json::from_str(s).ok())
-            .unwrap_or_default();
-        let oauth_metadata_urls: Vec<String> = oauth_json
-            .as_deref()
-            .and_then(|s| serde_json::from_str(s).ok())
-            .unwrap_or_default();
-        let file_encryption_key: Option<Value> = encryption_json
-            .as_deref()
-            .and_then(|s| serde_json::from_str(s).ok());
-        let import_directives: Vec<(String, String)> = import_json
-            .as_deref()
-            .and_then(|s| serde_json::from_str(s).ok())
-            .unwrap_or_default();
-        let metadata: Vec<(String, String)> = metadata_json
-            .as_deref()
-            .and_then(|s| serde_json::from_str(s).ok())
-            .unwrap_or_default();
+        let decode_json = |field: &str, json: Option<&str>| -> StorageResult<Value> {
+            match json {
+                Some(text) => serde_json::from_str(text)
+                    .map_err(|error| internal_error(format!("decode manifest {field}: {error}"))),
+                None => Ok(Value::Array(Vec::new())),
+            }
+        };
+        let file_request_headers: Vec<(String, String)> = serde_json::from_value(decode_json(
+            "file_request_headers",
+            headers_json.as_deref(),
+        )?)
+        .map_err(|error| {
+            internal_error(format!("invalid manifest file_request_headers: {error}"))
+        })?;
+        let oauth_metadata_urls: Vec<String> =
+            serde_json::from_value(decode_json("oauth_metadata_urls", oauth_json.as_deref())?)
+                .map_err(|error| {
+                    internal_error(format!("invalid manifest oauth_metadata_urls: {error}"))
+                })?;
+        let file_encryption_key: Option<Value> = match encryption_json.as_deref() {
+            Some(text) => Some(serde_json::from_str(text).map_err(|error| {
+                internal_error(format!("decode manifest file_encryption_key: {error}"))
+            })?),
+            None => None,
+        };
+        let import_directives: Vec<(String, String)> =
+            serde_json::from_value(decode_json("import_directives", import_json.as_deref())?)
+                .map_err(|error| {
+                    internal_error(format!("invalid manifest import_directives: {error}"))
+                })?;
+        let metadata: Vec<(String, String)> = serde_json::from_value(decode_json(
+            "submission_metadata",
+            metadata_json.as_deref(),
+        )?)
+        .map_err(|error| {
+            internal_error(format!("invalid manifest submission_metadata: {error}"))
+        })?;
         let fhir_version = fhir_version_from_output_format(output_format.as_deref());
 
         Ok(ManifestWorkerView {
@@ -1750,7 +1783,9 @@ impl SubmitWorkerStorage for SqliteBackend {
             file_encryption_key,
             import_directives,
             metadata,
-            last_processed_line: last_processed_line.max(0) as u64,
+            last_processed_line: u64::try_from(last_processed_line).map_err(|_| {
+                internal_error("manifest last_processed_line does not fit u64".to_string())
+            })?,
             fhir_version,
         })
     }
@@ -1766,7 +1801,8 @@ impl SubmitWorkerStorage for SqliteBackend {
                 conn.execute(
                     "UPDATE bulk_manifests SET status = 'processing'
                  WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
-                   AND manifest_id = ?4 AND worker_id = ?5 AND fencing_token = ?6",
+                   AND manifest_id = ?4 AND status = 'processing'
+                   AND worker_id = ?5 AND fencing_token = ?6",
                     params![
                         lease.tenant.tenant_id().as_str(),
                         lease.submission_id.submitter,
@@ -1926,138 +1962,124 @@ impl SubmitWorkerStorage for SqliteBackend {
         lease: &ManifestLease,
         file: &SubmitFileRecord,
     ) -> Result<(), LeaseError> {
-        let count_severity = file
-            .count_severity
-            .as_ref()
-            .and_then(|v| serde_json::to_string(v).ok());
-        // This row is what the status manifest lists a file from, so dropping
-        // it on a busy silently truncates the output (#942). The INSERT is a
-        // single statement: a busy one never took the write lock and applied
-        // nothing, so reissuing it cannot duplicate the row. The fence is
-        // re-read on every attempt so a lease lost while we were backing off
-        // still stops the write. `false` means the fence no longer matches.
-        let holds =
+        let staged =
             retry_bookkeeping_on_busy("record submit file", lease_retry_budget(lease), || {
-                let conn = self.get_connection()?;
-                let holds: bool = conn
-                    .query_row(
-                        "SELECT 1 FROM bulk_manifests
-                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
-                   AND manifest_id = ?4 AND worker_id = ?5 AND fencing_token = ?6",
-                        params![
-                            lease.tenant.tenant_id().as_str(),
-                            lease.submission_id.submitter,
-                            lease.submission_id.submission_id,
-                            lease.manifest_id,
-                            lease.worker_id.as_str(),
-                            lease.fencing_token as i64
-                        ],
-                        |_| Ok(true),
-                    )
-                    .unwrap_or(false);
-                if !holds {
-                    return Ok(false);
-                }
-                conn.execute(
-                    "INSERT INTO bulk_submit_files
-             (tenant_id, submitter, submission_id, manifest_url, file_type, resource_type,
-              part_index, fencing_token, file_path, line_count, byte_count, count_severity,
-              created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-                    params![
-                        lease.tenant.tenant_id().as_str(),
-                        lease.submission_id.submitter,
-                        lease.submission_id.submission_id,
-                        file.manifest_url,
-                        file.file_type,
-                        file.resource_type,
-                        file.part_index as i64,
-                        lease.fencing_token as i64,
-                        file.file_path,
-                        file.line_count as i64,
-                        file.byte_count as i64,
-                        count_severity,
-                        Utc::now().to_rfc3339()
-                    ],
-                )
-                .map_err(|e| {
-                    StorageError::Backend(classify_sqlite_error("record submit file", e))
+                let mut conn = self.get_connection()?;
+                let tx = conn
+                    .transaction_with_behavior(TransactionBehavior::Immediate)
+                    .map_err(|e| {
+                        StorageError::Backend(classify_sqlite_error("begin staging", e))
+                    })?;
+                let lease_token = i64::try_from(lease.fencing_token).map_err(|_| {
+                    internal_error("lease fencing_token does not fit i64".to_string())
                 })?;
-                Ok(true)
-            })
-            .await
-            .map_err(LeaseError::Storage)?;
-        if !holds {
-            return Err(lease_lost(lease));
-        }
-        Ok(())
-    }
+                let Some(state) = manifest_publication_state(&tx, lease)? else {
+                    return Ok(None);
+                };
+                if state.status == "replaced"
+                    || state.status != "processing"
+                    || state.fencing_token != lease_token
+                    || state.worker_id.as_deref() != Some(lease.worker_id.as_str())
+                {
+                    return Ok(None);
+                }
+                let canonical = canonical_publication_files(std::slice::from_ref(file))?;
+                validate_publication_records(&state, &canonical)?;
+                let staged = read_manifest_generation_records(&tx, lease, lease_token)?;
+                let identity = |record: &SubmitFileRecord| {
+                    (
+                        record.file_type.clone(),
+                        record.resource_type.clone(),
+                        record.part_index,
+                    )
+                };
+                if let Some(existing) = staged
+                    .iter()
+                    .find(|record| identity(record) == identity(file))
+                {
+                    if existing != file {
+                        return Err(publication_conflict(
+                            "staged artifact identity has conflicting content",
+                        ));
+                    }
+                    tx.commit()
+                        .map_err(|e| {
+                            StorageError::Backend(classify_sqlite_error("commit staged replay", e))
+                        })
+                        .map(|()| Some(()))?;
+                    return Ok(Some(()));
+                }
 
-    async fn finish_manifest(&self, lease: &ManifestLease) -> Result<(), LeaseError> {
-        // Losing this write to a busy would leave a fully ingested manifest
-        // stuck in 'processing' until its lease expires and a worker redoes it
-        // (#942). Guarded by worker_id + fencing_token, and it clears both, so
-        // only the first attempt to land can match.
-        let affected =
-            retry_bookkeeping_on_busy("finish manifest", lease_retry_budget(lease), || {
-                let conn = self.get_connection()?;
-                conn.execute(
-                    "UPDATE bulk_manifests SET status = 'completed', worker_id = NULL, lease_expiry = NULL
-                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
-                   AND manifest_id = ?4 AND worker_id = ?5 AND fencing_token = ?6",
+                let count_severity = match &file.count_severity {
+                    Some(value) => Some(serde_json::to_string(value).map_err(|error| {
+                        internal_error(format!("encode count_severity: {error}"))
+                    })?),
+                    None => None,
+                };
+                tx.execute(
+                    "INSERT INTO bulk_submit_files
+                     (tenant_id, submitter, submission_id, manifest_id, manifest_url, file_type,
+                      resource_type, part_index, fencing_token, file_path, line_count,
+                      byte_count, count_severity, created_at, publication_excluded_reason)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, NULL)",
                     params![
                         lease.tenant.tenant_id().as_str(),
                         lease.submission_id.submitter,
                         lease.submission_id.submission_id,
                         lease.manifest_id,
-                        lease.worker_id.as_str(),
-                        lease.fencing_token as i64
+                        file.manifest_url,
+                        file.file_type,
+                        file.resource_type,
+                        file.part_index,
+                        lease_token,
+                        file.file_path,
+                        file.line_count,
+                        file.byte_count,
+                        count_severity,
+                        Utc::now().to_rfc3339(),
                     ],
                 )
-                .map_err(|e| StorageError::Backend(classify_sqlite_error("finish manifest", e)))
+                .map_err(|e| {
+                    StorageError::Backend(classify_sqlite_error("stage submit file", e))
+                })?;
+                tx.commit()
+                    .map_err(|e| StorageError::Backend(classify_sqlite_error("commit staging", e)))
+                    .map(|()| Some(()))
             })
             .await
             .map_err(LeaseError::Storage)?;
-        if affected == 0 {
-            Err(lease_lost(lease))
-        } else {
-            Ok(())
+        if staged.is_none() {
+            return Err(lease_lost(lease));
         }
+        Ok(())
+    }
+
+    async fn publish_manifest_artifacts(
+        &self,
+        lease: &ManifestLease,
+        files: &[SubmitFileRecord],
+        terminal: ManifestPublicationStatus,
+    ) -> Result<ManifestPublicationResult, LeaseError> {
+        SqliteBackend::publish_manifest_artifacts(self, lease, files, terminal).await
+    }
+
+    async fn finish_manifest(&self, lease: &ManifestLease) -> Result<(), LeaseError> {
+        self.publish_current_manifest_generation(lease, ManifestPublicationStatus::Completed)
+            .await
     }
 
     async fn fail_manifest(
         &self,
         lease: &ManifestLease,
-        _error_message: &str,
+        error_message: &str,
     ) -> Result<(), LeaseError> {
-        // Same reasoning as `finish_manifest`: a busy here would hide the
-        // terminal state and leave the manifest to be retried on lease expiry
-        // (#942). Guarded and self-clearing, so the retry is idempotent.
-        let affected =
-            retry_bookkeeping_on_busy("fail manifest", lease_retry_budget(lease), || {
-                let conn = self.get_connection()?;
-                conn.execute(
-                "UPDATE bulk_manifests SET status = 'failed', worker_id = NULL, lease_expiry = NULL
-                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
-                   AND manifest_id = ?4 AND worker_id = ?5 AND fencing_token = ?6",
-                params![
-                    lease.tenant.tenant_id().as_str(),
-                    lease.submission_id.submitter,
-                    lease.submission_id.submission_id,
-                    lease.manifest_id,
-                    lease.worker_id.as_str(),
-                    lease.fencing_token as i64
-                ],
-            )
-            .map_err(|e| StorageError::Backend(classify_sqlite_error("fail manifest", e)))
-            })
-            .await
-            .map_err(LeaseError::Storage)?;
-        if affected == 0 {
-            Err(lease_lost(lease))
-        } else {
-            Ok(())
-        }
+        self.publish_current_manifest_generation(
+            lease,
+            ManifestPublicationStatus::Failed {
+                error_message: error_message.to_string(),
+            },
+        )
+        .await
     }
 
     async fn set_manifest_fetch_params(
@@ -2268,37 +2290,74 @@ impl SubmitWorkerStorage for SqliteBackend {
         let conn = self.get_connection()?;
         let mut stmt = conn
             .prepare(
-                "SELECT manifest_url, file_type, resource_type, part_index, fencing_token,
-                        file_path, line_count, byte_count, count_severity
-                 FROM bulk_submit_files
-                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
-                 ORDER BY id",
+                "SELECT f.manifest_url, f.file_type, f.resource_type, f.part_index, f.fencing_token,
+                        f.file_path, f.line_count, f.byte_count, f.count_severity,
+                        f.manifest_id, m.publication_worker_id
+                 FROM bulk_submit_files AS f
+                 INNER JOIN bulk_manifests AS m
+                   ON m.tenant_id = f.tenant_id
+                      AND m.submitter = f.submitter
+                      AND m.submission_id = f.submission_id
+                      AND m.manifest_id = f.manifest_id
+                      AND m.published_token = f.fencing_token
+                 WHERE f.manifest_id IS NOT NULL
+                   AND f.tenant_id = ?1
+                   AND f.submitter = ?2
+                   AND f.submission_id = ?3
+                   AND f.publication_excluded_reason IS NULL
+                   AND m.published_token IS NOT NULL
+                   AND m.publication_status IN ('completed', 'failed')
+                 ORDER BY f.id",
             )
             .map_err(|e| internal_error(format!("prepare list files: {e}")))?;
         let rows = stmt
             .query_map(
                 params![tenant.tenant_id().as_str(), id.submitter, id.submission_id],
                 |r| {
-                    let count_severity: Option<String> = r.get(8)?;
-                    Ok(SubmitFileRow {
-                        manifest_url: r.get(0)?,
-                        file_type: r.get(1)?,
-                        resource_type: r.get(2)?,
-                        part_index: r.get::<_, i64>(3)? as u32,
-                        fencing_token: r.get::<_, i64>(4)? as u64,
-                        file_path: r.get(5)?,
-                        line_count: r.get::<_, i64>(6)? as u64,
-                        byte_count: r.get::<_, i64>(7)? as u64,
-                        count_severity: count_severity
-                            .as_deref()
-                            .and_then(|s| serde_json::from_str(s).ok()),
-                    })
+                    Ok((
+                        r.get::<_, Option<String>>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, Option<String>>(2)?,
+                        r.get::<_, i64>(3)?,
+                        r.get::<_, i64>(4)?,
+                        r.get::<_, String>(5)?,
+                        r.get::<_, i64>(6)?,
+                        r.get::<_, i64>(7)?,
+                        r.get::<_, Option<String>>(8)?,
+                        r.get::<_, Option<String>>(9)?,
+                        r.get::<_, Option<String>>(10)?,
+                    ))
                 },
             )
             .map_err(|e| internal_error(format!("query list files: {e}")))?;
         let mut out = Vec::new();
         for row in rows {
-            out.push(row.map_err(|e| internal_error(format!("row list files: {e}")))?);
+            let (
+                manifest_url,
+                file_type,
+                resource_type,
+                part_index,
+                fencing_token,
+                file_path,
+                line_count,
+                byte_count,
+                count_severity,
+                manifest_id,
+                publication_worker_id,
+            ) = row.map_err(|e| internal_error(format!("row list files: {e}")))?;
+            out.push(publication_row_from_parts(
+                manifest_url,
+                file_type,
+                resource_type,
+                part_index,
+                fencing_token,
+                file_path,
+                line_count,
+                byte_count,
+                count_severity,
+                manifest_id,
+                publication_worker_id.is_none(),
+            )?);
         }
         Ok(out)
     }
@@ -2308,13 +2367,33 @@ impl SubmitWorkerStorage for SqliteBackend {
         tenant: &TenantContext,
         id: &SubmissionId,
     ) -> StorageResult<()> {
-        let conn = self.get_connection()?;
-        conn.execute(
+        let mut conn = self.get_connection()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| {
+                StorageError::Backend(classify_sqlite_error("begin artifact cleanup", e))
+            })?;
+        tx.execute(
             "DELETE FROM bulk_submit_files
              WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3",
             params![tenant.tenant_id().as_str(), id.submitter, id.submission_id],
         )
-        .map_err(|e| internal_error(format!("delete artifacts: {e}")))?;
+        .map_err(|e| {
+            StorageError::Backend(classify_sqlite_error("delete submission artifacts", e))
+        })?;
+        tx.execute(
+            "UPDATE bulk_manifests
+             SET published_token = NULL, publication_status = NULL,
+                 publication_error_message = NULL, publication_worker_id = NULL
+             WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3",
+            params![tenant.tenant_id().as_str(), id.submitter, id.submission_id],
+        )
+        .map_err(|e| {
+            StorageError::Backend(classify_sqlite_error("clear publication markers", e))
+        })?;
+        tx.commit().map_err(|e| {
+            StorageError::Backend(classify_sqlite_error("commit artifact cleanup", e))
+        })?;
         Ok(())
     }
 
@@ -2371,6 +2450,495 @@ impl SubmitWorkerStorage for SqliteBackend {
     }
 }
 
+impl SqliteBackend {
+    /// Atomically replaces and publishes the complete artifact set for a lease.
+    ///
+    /// The entire attempt—state selection, staged-row replacement, and
+    /// terminal fencing update—runs in one immediate transaction. A
+    /// successful commit is the only point at which a new generation becomes
+    /// visible to future publication queries.
+    pub async fn publish_manifest_artifacts(
+        &self,
+        lease: &ManifestLease,
+        files: &[SubmitFileRecord],
+        terminal: ManifestPublicationStatus,
+    ) -> Result<ManifestPublicationResult, LeaseError> {
+        let canonical = canonical_publication_files(files).map_err(LeaseError::Storage)?;
+        let outcome = retry_bookkeeping_on_busy(
+            "publish manifest artifacts",
+            lease_retry_budget(lease),
+            || {
+                let mut conn = self.get_connection()?;
+                let tx = conn
+                    .transaction_with_behavior(TransactionBehavior::Immediate)
+                    .map_err(|e| {
+                        StorageError::Backend(classify_sqlite_error("begin publication", e))
+                    })?;
+                let Some(outcome) =
+                    publish_manifest_artifacts_in_tx(&tx, lease, &canonical, &terminal)?
+                else {
+                    return Ok(None);
+                };
+                tx.commit()
+                    .map_err(|e| {
+                        StorageError::Backend(classify_sqlite_error("commit publication", e))
+                    })
+                    .map(|()| Some(outcome))
+            },
+        )
+        .await
+        .map_err(LeaseError::Storage)?;
+        outcome.ok_or_else(|| lease_lost(lease))
+    }
+
+    /// Publishes the generation already staged for `lease`. Terminal finish and
+    /// failure read the staged set inside the publication transaction, so a
+    /// concurrent staging write cannot be omitted from the atomic commit.
+    async fn publish_current_manifest_generation(
+        &self,
+        lease: &ManifestLease,
+        terminal: ManifestPublicationStatus,
+    ) -> Result<(), LeaseError> {
+        let outcome = retry_bookkeeping_on_busy(
+            "finish manifest publication",
+            lease_retry_budget(lease),
+            || {
+                let mut conn = self.get_connection()?;
+                let tx = conn
+                    .transaction_with_behavior(TransactionBehavior::Immediate)
+                    .map_err(|e| {
+                        StorageError::Backend(classify_sqlite_error("begin finish publication", e))
+                    })?;
+                let lease_token = i64::try_from(lease.fencing_token).map_err(|_| {
+                    internal_error("lease fencing_token does not fit i64".to_string())
+                })?;
+                let Some(state) = manifest_publication_state(&tx, lease)? else {
+                    return Ok(None);
+                };
+                if state.status == "replaced" || state.fencing_token != lease_token {
+                    return Ok(None);
+                }
+
+                let staged = if state.status == "processing" {
+                    if state.worker_id.as_deref() != Some(lease.worker_id.as_str()) {
+                        return Ok(None);
+                    }
+                    read_manifest_generation_records(&tx, lease, lease_token)?
+                } else {
+                    let published_token_matches = state.published_token == Some(lease_token);
+                    let publisher_matches =
+                        state.publication_worker_id.as_deref() == Some(lease.worker_id.as_str());
+                    if !published_token_matches || !publisher_matches {
+                        return Ok(None);
+                    }
+                    let (terminal_status, terminal_error) = publication_status_parts(&terminal);
+                    if state.status != terminal_status
+                        || state.publication_status.as_deref() != Some(terminal_status)
+                        || state.publication_error_message != terminal_error.map(str::to_string)
+                    {
+                        return Err(publication_conflict(
+                            "terminal state changed for the same publication",
+                        ));
+                    }
+                    read_manifest_generation_records(&tx, lease, lease_token)?
+                };
+                let staged = canonical_publication_files(&staged)?;
+                let Some(outcome) =
+                    publish_manifest_artifacts_in_tx(&tx, lease, &staged, &terminal)?
+                else {
+                    return Ok(None);
+                };
+                tx.commit()
+                    .map_err(|e| {
+                        StorageError::Backend(classify_sqlite_error("commit finish publication", e))
+                    })
+                    .map(|()| Some(outcome))
+            },
+        )
+        .await
+        .map_err(LeaseError::Storage)?;
+        outcome.map(|_| ()).ok_or_else(|| lease_lost(lease))
+    }
+}
+
+#[derive(Debug)]
+struct ManifestPublicationState {
+    manifest_url: Option<String>,
+    status: String,
+    fencing_token: i64,
+    worker_id: Option<String>,
+    published_token: Option<i64>,
+    publication_status: Option<String>,
+    publication_error_message: Option<String>,
+    publication_worker_id: Option<String>,
+}
+
+/// Reads the full tenant/submission/manifest publication identity. A missing
+/// identity is a lost lease; every SQLite failure is a storage error.
+fn manifest_publication_state(
+    tx: &rusqlite::Transaction<'_>,
+    lease: &ManifestLease,
+) -> StorageResult<Option<ManifestPublicationState>> {
+    let state = match tx.query_row(
+        "SELECT manifest_url, status, fencing_token, worker_id,
+                published_token, publication_status, publication_error_message,
+                publication_worker_id
+         FROM bulk_manifests
+         WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+           AND manifest_id = ?4",
+        params![
+            lease.tenant.tenant_id().as_str(),
+            lease.submission_id.submitter,
+            lease.submission_id.submission_id,
+            lease.manifest_id,
+        ],
+        |row| {
+            Ok(ManifestPublicationState {
+                manifest_url: row.get(0)?,
+                status: row.get(1)?,
+                fencing_token: row.get(2)?,
+                worker_id: row.get(3)?,
+                published_token: row.get(4)?,
+                publication_status: row.get(5)?,
+                publication_error_message: row.get(6)?,
+                publication_worker_id: row.get(7)?,
+            })
+        },
+    ) {
+        Ok(state) => state,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(error) => {
+            return Err(StorageError::Backend(classify_sqlite_error(
+                "read publication state",
+                error,
+            )));
+        }
+    };
+    Ok(Some(state))
+}
+
+fn publication_conflict(message: impl Into<String>) -> StorageError {
+    internal_error(format!("manifest publication conflict: {}", message.into()))
+}
+
+fn publication_status_parts(terminal: &ManifestPublicationStatus) -> (&'static str, Option<&str>) {
+    match terminal {
+        ManifestPublicationStatus::Completed => ("completed", None),
+        ManifestPublicationStatus::Failed { error_message } => {
+            ("failed", Some(error_message.as_str()))
+        }
+    }
+}
+
+/// Reads the artifact generation stored for one exact fencing token. The caller
+/// supplies the marker token for replay or the lease token for staged work.
+fn read_manifest_generation_records(
+    conn: &rusqlite::Connection,
+    lease: &ManifestLease,
+    fencing_token: i64,
+) -> StorageResult<Vec<SubmitFileRecord>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT manifest_url, file_type, resource_type, part_index, file_path,
+                    line_count, byte_count, count_severity
+             FROM bulk_submit_files
+             WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+               AND manifest_id = ?4 AND fencing_token = ?5
+               AND publication_excluded_reason IS NULL
+             ORDER BY id",
+        )
+        .map_err(|e| StorageError::Backend(classify_sqlite_error("prepare publication rows", e)))?;
+    let rows = stmt
+        .query_map(
+            params![
+                lease.tenant.tenant_id().as_str(),
+                lease.submission_id.submitter,
+                lease.submission_id.submission_id,
+                lease.manifest_id,
+                fencing_token,
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, i64>(6)?,
+                    row.get::<_, Option<String>>(7)?,
+                ))
+            },
+        )
+        .map_err(|e| StorageError::Backend(classify_sqlite_error("query publication rows", e)))?;
+    let mut records = Vec::new();
+    for row in rows {
+        let (
+            manifest_url,
+            file_type,
+            resource_type,
+            part_index,
+            file_path,
+            line_count,
+            byte_count,
+            count_severity,
+        ) = row
+            .map_err(|e| StorageError::Backend(classify_sqlite_error("read publication row", e)))?;
+        records.push(publication_record_from_parts(
+            manifest_url,
+            file_type,
+            resource_type,
+            part_index,
+            fencing_token,
+            file_path,
+            line_count,
+            byte_count,
+            count_severity,
+        )?);
+    }
+    Ok(records)
+}
+
+fn validate_publication_records(
+    state: &ManifestPublicationState,
+    records: &[SubmitFileRecord],
+) -> StorageResult<()> {
+    for file in records {
+        if !matches!(file.file_type.as_str(), "output" | "error" | "deleted") {
+            return Err(publication_conflict(format!(
+                "invalid file_type: {}",
+                file.file_type
+            )));
+        }
+        match (&file.manifest_url, &state.manifest_url) {
+            (Some(file_url), Some(manifest_url)) if file_url == manifest_url => {}
+            _ => {
+                return Err(publication_conflict(
+                    "artifact manifest_url does not match the leased manifest",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Converts a persisted publication row to the shared semantic value. Corrupt
+/// numeric columns and JSON are storage errors, never silently filtered rows.
+#[allow(clippy::too_many_arguments)]
+fn publication_record_from_parts(
+    manifest_url: Option<String>,
+    file_type: String,
+    resource_type: Option<String>,
+    part_index: i64,
+    fencing_token: i64,
+    file_path: String,
+    line_count: i64,
+    byte_count: i64,
+    count_severity: Option<String>,
+) -> StorageResult<SubmitFileRecord> {
+    let count_severity = match count_severity {
+        Some(text) => Some(serde_json::from_str::<Value>(&text).map_err(|error| {
+            internal_error(format!("decode published count_severity: {error}"))
+        })?),
+        None => None,
+    };
+    let part_index = u32::try_from(part_index)
+        .map_err(|_| internal_error("published part_index does not fit u32".to_string()))?;
+    if fencing_token < 0 {
+        return Err(internal_error(
+            "published fencing_token is negative".to_string(),
+        ));
+    }
+    let line_count = u64::try_from(line_count)
+        .map_err(|_| internal_error("published line_count does not fit u64".to_string()))?;
+    let byte_count = u64::try_from(byte_count)
+        .map_err(|_| internal_error("published byte_count does not fit u64".to_string()))?;
+    Ok(SubmitFileRecord {
+        manifest_url,
+        file_type,
+        resource_type,
+        part_index,
+        file_path,
+        line_count,
+        byte_count,
+        count_severity,
+    })
+}
+
+/// Converts a visible artifact row to the shared consumer value. All semantic
+/// decoding and range checks are shared with the publication reader.
+#[allow(clippy::too_many_arguments)]
+fn publication_row_from_parts(
+    manifest_url: Option<String>,
+    file_type: String,
+    resource_type: Option<String>,
+    part_index: i64,
+    fencing_token: i64,
+    file_path: String,
+    line_count: i64,
+    byte_count: i64,
+    count_severity: Option<String>,
+    manifest_id: Option<String>,
+    legacy_locator: bool,
+) -> StorageResult<SubmitFileRow> {
+    let record = publication_record_from_parts(
+        manifest_url,
+        file_type,
+        resource_type,
+        part_index,
+        fencing_token,
+        file_path,
+        line_count,
+        byte_count,
+        count_severity,
+    )?;
+    Ok(SubmitFileRow {
+        manifest_url: record.manifest_url,
+        file_type: record.file_type,
+        resource_type: record.resource_type,
+        part_index: record.part_index,
+        fencing_token: fencing_token as u64,
+        manifest_id,
+        legacy_locator,
+        file_path: record.file_path,
+        line_count: record.line_count,
+        byte_count: record.byte_count,
+        count_severity: record.count_severity,
+    })
+}
+
+/// Returns `None` for lease loss and `Some` for a committed publication. All
+/// writes remain protected by the transaction's rollback-on-drop behavior.
+fn publish_manifest_artifacts_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    lease: &ManifestLease,
+    canonical: &[SubmitFileRecord],
+    terminal: &ManifestPublicationStatus,
+) -> StorageResult<Option<ManifestPublicationResult>> {
+    let lease_token = i64::try_from(lease.fencing_token)
+        .map_err(|_| internal_error("lease fencing_token does not fit i64".to_string()))?;
+    let Some(state) = manifest_publication_state(tx, lease)? else {
+        return Ok(None);
+    };
+    if state.status == "replaced" || state.fencing_token != lease_token {
+        return Ok(None);
+    }
+
+    let published_token_matches = state.published_token == Some(lease_token);
+    let publisher_matches =
+        state.publication_worker_id.as_deref() == Some(lease.worker_id.as_str());
+    if published_token_matches {
+        if !publisher_matches {
+            return Ok(None);
+        }
+        let (terminal_status, terminal_error) = publication_status_parts(terminal);
+        if state.publication_status.as_deref() != Some(terminal_status)
+            || state.status != terminal_status
+            || state.publication_error_message != terminal_error.map(str::to_string)
+        {
+            return Err(publication_conflict(
+                "terminal state changed for the same publication",
+            ));
+        }
+
+        let persisted = read_manifest_generation_records(tx, lease, lease_token)?;
+        let persisted = canonical_publication_files(&persisted)?;
+        if persisted != canonical {
+            return Err(publication_conflict(
+                "artifact payload changed for the same publication",
+            ));
+        }
+        return Ok(Some(ManifestPublicationResult::AlreadyPublished));
+    }
+
+    // Fresh work must still be owned by this exact lease. An older publication
+    // marker is allowed and remains selected until this transaction replaces it.
+    if state.status != "processing" || state.worker_id.as_deref() != Some(lease.worker_id.as_str())
+    {
+        return Ok(None);
+    }
+
+    validate_publication_records(&state, canonical)?;
+
+    tx.execute(
+        "DELETE FROM bulk_submit_files
+         WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+           AND manifest_id = ?4 AND fencing_token = ?5",
+        params![
+            lease.tenant.tenant_id().as_str(),
+            lease.submission_id.submitter,
+            lease.submission_id.submission_id,
+            lease.manifest_id,
+            lease_token,
+        ],
+    )
+    .map_err(|e| StorageError::Backend(classify_sqlite_error("delete staged files", e)))?;
+
+    for file in canonical {
+        let count_severity = match &file.count_severity {
+            Some(value) => Some(
+                serde_json::to_string(value)
+                    .map_err(|error| internal_error(format!("encode count_severity: {error}")))?,
+            ),
+            None => None,
+        };
+        tx.execute(
+            "INSERT INTO bulk_submit_files
+             (tenant_id, submitter, submission_id, manifest_id, manifest_url, file_type,
+              resource_type, part_index, fencing_token, file_path, line_count, byte_count,
+              count_severity, created_at, publication_excluded_reason)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, NULL)",
+            params![
+                lease.tenant.tenant_id().as_str(),
+                lease.submission_id.submitter,
+                lease.submission_id.submission_id,
+                lease.manifest_id,
+                file.manifest_url,
+                file.file_type,
+                file.resource_type,
+                file.part_index,
+                lease_token,
+                file.file_path,
+                file.line_count,
+                file.byte_count,
+                count_severity,
+                Utc::now().to_rfc3339(),
+            ],
+        )
+        .map_err(|e| StorageError::Backend(classify_sqlite_error("insert publication file", e)))?;
+    }
+
+    let (terminal_status, terminal_error) = publication_status_parts(terminal);
+    let affected = tx
+        .execute(
+            "UPDATE bulk_manifests
+             SET status = ?5, published_token = ?6, publication_status = ?7,
+                 publication_error_message = ?8, publication_worker_id = ?9,
+                 worker_id = NULL, lease_expiry = NULL
+             WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+               AND manifest_id = ?4 AND status = 'processing'
+               AND worker_id = ?10 AND fencing_token = ?11",
+            params![
+                lease.tenant.tenant_id().as_str(),
+                lease.submission_id.submitter,
+                lease.submission_id.submission_id,
+                lease.manifest_id,
+                terminal_status,
+                lease_token,
+                terminal_status,
+                terminal_error,
+                lease.worker_id.as_str(),
+                lease.worker_id.as_str(),
+                lease_token,
+            ],
+        )
+        .map_err(|e| StorageError::Backend(classify_sqlite_error("publish manifest", e)))?;
+    if affected != 1 {
+        return Ok(None);
+    }
+    Ok(Some(ManifestPublicationResult::Published))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2391,6 +2959,1245 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             "/tests/bulk_submit/consumer_contract.rs"
         ));
+    }
+
+    mod publication {
+        use super::*;
+        use crate::core::bulk_submit_publication::ManifestPublicationResult;
+        use crate::core::bulk_submit_publication::ManifestPublicationStatus;
+
+        fn publication_file(
+            manifest_url: &str,
+            file_type: &str,
+            resource_type: Option<&str>,
+            part_index: u32,
+            file_path: &str,
+            count_severity: Option<Value>,
+        ) -> SubmitFileRecord {
+            SubmitFileRecord {
+                manifest_url: Some(manifest_url.to_string()),
+                file_type: file_type.to_string(),
+                resource_type: resource_type.map(str::to_string),
+                part_index,
+                file_path: file_path.to_string(),
+                line_count: 1,
+                byte_count: 16,
+                count_severity,
+            }
+        }
+
+        async fn claim(
+            backend: &SqliteBackend,
+            manifest_url: &str,
+        ) -> (TenantContext, SubmissionId, ManifestLease) {
+            let tenant = create_test_tenant();
+            let submission = SubmissionId::generate("publication");
+            backend
+                .create_submission(&tenant, &submission, None)
+                .await
+                .unwrap();
+            backend
+                .add_manifest(&tenant, &submission, Some(manifest_url), None)
+                .await
+                .unwrap();
+            let lease = backend
+                .claim_next_manifest(&WorkerId::new("publisher"), StdDuration::from_secs(60))
+                .await
+                .unwrap()
+                .unwrap();
+            (tenant, submission, lease)
+        }
+
+        pub(super) fn publication_row_count(
+            backend: &SqliteBackend,
+            tenant: &TenantContext,
+            submission: &SubmissionId,
+            manifest_id: &str,
+        ) -> i64 {
+            backend
+                .get_connection()
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM bulk_submit_files
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        tenant.tenant_id().as_str(),
+                        submission.submitter,
+                        submission.submission_id,
+                        manifest_id,
+                    ],
+                    |row| row.get(0),
+                )
+                .unwrap()
+        }
+
+        #[allow(clippy::type_complexity)] // Exact persisted columns for rollback assertions.
+        pub(super) fn publication_marker(
+            backend: &SqliteBackend,
+            tenant: &TenantContext,
+            submission: &SubmissionId,
+            manifest_id: &str,
+        ) -> (
+            String,
+            Option<i64>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) {
+            backend
+                .get_connection()
+                .unwrap()
+                .query_row(
+                    "SELECT status, published_token, publication_status,
+                            publication_error_message, publication_worker_id, worker_id
+                     FROM bulk_manifests
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        tenant.tenant_id().as_str(),
+                        submission.submitter,
+                        submission.submission_id,
+                        manifest_id,
+                    ],
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                            row.get(5)?,
+                        ))
+                    },
+                )
+                .unwrap()
+        }
+
+        #[tokio::test]
+        async fn complete_publication_replays_exactly_and_rejects_changes() {
+            let backend = create_test_backend();
+            let manifest_url = "http://provider/complete.json";
+            let (tenant, submission, lease) = claim(&backend, manifest_url).await;
+            let output = publication_file(
+                manifest_url,
+                "output",
+                Some("Patient"),
+                0,
+                "output/patient-0.ndjson",
+                None,
+            );
+            let error = publication_file(
+                manifest_url,
+                "error",
+                Some("OperationOutcome"),
+                0,
+                "error/outcome-0.ndjson",
+                Some(json!({"error": 1})),
+            );
+
+            assert_eq!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[output.clone(), error.clone()],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await
+                    .unwrap(),
+                ManifestPublicationResult::Published
+            );
+            let (
+                status,
+                published_token,
+                publication_status,
+                publication_error,
+                publication_worker,
+                worker,
+            ) = publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            assert_eq!(status, "completed");
+            assert_eq!(published_token, Some(lease.fencing_token as i64));
+            assert_eq!(publication_status.as_deref(), Some("completed"));
+            assert_eq!(publication_error, None);
+            assert_eq!(
+                publication_worker.as_deref(),
+                Some(lease.worker_id.as_str())
+            );
+            assert_eq!(worker, None);
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &lease.manifest_id),
+                2
+            );
+
+            assert_eq!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[error.clone(), output.clone()],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await
+                    .unwrap(),
+                ManifestPublicationResult::AlreadyPublished
+            );
+
+            let mut changed_payload = output.clone();
+            changed_payload.file_path = "output/patient-changed.ndjson".to_string();
+            assert!(matches!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[changed_payload, error.clone()],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await,
+                Err(LeaseError::Storage(_))
+            ));
+            let mut changed_status = error.clone();
+            changed_status.count_severity = Some(json!({"error": 2}));
+            assert!(matches!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[output.clone(), changed_status],
+                        ManifestPublicationStatus::Failed {
+                            error_message: "changed".to_string(),
+                        },
+                    )
+                    .await,
+                Err(LeaseError::Storage(_))
+            ));
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &lease.manifest_id),
+                2
+            );
+            let (status, _, publication_status, _, _, _) =
+                publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            assert_eq!(status, "completed");
+            assert_eq!(publication_status.as_deref(), Some("completed"));
+        }
+
+        #[tokio::test]
+        async fn replaced_manifest_process_entries_does_not_revive_publication() {
+            let backend = create_test_backend();
+            let tenant = create_test_tenant();
+            let submission = SubmissionId::generate("replacement-guard");
+            let manifest_url = "http://provider/replacement-guard.json";
+            backend
+                .create_submission(&tenant, &submission, None)
+                .await
+                .unwrap();
+            let manifest = backend
+                .add_manifest(&tenant, &submission, Some(manifest_url), None)
+                .await
+                .unwrap();
+            let lease = backend
+                .claim_next_manifest(&WorkerId::new("publisher"), StdDuration::from_secs(60))
+                .await
+                .unwrap()
+                .unwrap();
+            backend
+                .replace_manifest_by_url(&tenant, &submission, manifest_url)
+                .await
+                .unwrap();
+
+            backend
+                .process_entries(
+                    &tenant,
+                    &submission,
+                    &manifest.manifest_id,
+                    Vec::new(),
+                    &BulkProcessingOptions::new(),
+                )
+                .await
+                .unwrap();
+            let manifest = backend
+                .get_manifest(&tenant, &submission, &manifest.manifest_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                manifest.status,
+                ManifestStatus::Replaced,
+                "an empty ingest must not revive a replaced manifest"
+            );
+            assert!(
+                matches!(
+                    backend
+                        .publish_manifest_artifacts(
+                            &lease,
+                            &[],
+                            ManifestPublicationStatus::Completed,
+                        )
+                        .await,
+                    Err(LeaseError::LeaseLost { .. })
+                ),
+                "the old lease must lose publication after replacement"
+            );
+        }
+
+        #[tokio::test]
+        async fn empty_failed_publication_replays_exactly_and_rejects_new_message() {
+            let backend = create_test_backend();
+            let manifest_url = "http://provider/empty.json";
+            let (tenant, submission, lease) = claim(&backend, manifest_url).await;
+            assert_eq!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[],
+                        ManifestPublicationStatus::Failed {
+                            error_message: "remote manifest unavailable".to_string(),
+                        },
+                    )
+                    .await
+                    .unwrap(),
+                ManifestPublicationResult::Published
+            );
+            let (
+                status,
+                published_token,
+                publication_status,
+                publication_error,
+                publication_worker,
+                _,
+            ) = publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            assert_eq!(status, "failed");
+            assert_eq!(published_token, Some(lease.fencing_token as i64));
+            assert_eq!(publication_status.as_deref(), Some("failed"));
+            assert_eq!(
+                publication_error.as_deref(),
+                Some("remote manifest unavailable")
+            );
+            assert_eq!(
+                publication_worker.as_deref(),
+                Some(lease.worker_id.as_str())
+            );
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &lease.manifest_id),
+                0
+            );
+
+            assert_eq!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[],
+                        ManifestPublicationStatus::Failed {
+                            error_message: "remote manifest unavailable".to_string(),
+                        },
+                    )
+                    .await
+                    .unwrap(),
+                ManifestPublicationResult::AlreadyPublished
+            );
+            assert!(matches!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[],
+                        ManifestPublicationStatus::Failed {
+                            error_message: "changed".to_string(),
+                        },
+                    )
+                    .await,
+                Err(LeaseError::Storage(_))
+            ));
+            let (status, _, publication_status, publication_error, _, _) =
+                publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            assert_eq!(status, "failed");
+            assert_eq!(publication_status.as_deref(), Some("failed"));
+            assert_eq!(
+                publication_error.as_deref(),
+                Some("remote manifest unavailable")
+            );
+        }
+
+        #[tokio::test]
+        async fn stale_wrong_worker_and_replaced_leases_are_lost() {
+            let backend = create_test_backend();
+            let terminal = ManifestPublicationStatus::Completed;
+
+            let stale_url = "http://provider/stale.json";
+            let (_, _, stale) = claim(&backend, stale_url).await;
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "UPDATE bulk_manifests SET lease_expiry = '1970-01-01T00:00:00Z'
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        create_test_tenant().tenant_id().as_str(),
+                        stale.submission_id.submitter,
+                        stale.submission_id.submission_id,
+                        stale.manifest_id,
+                    ],
+                )
+                .unwrap();
+            let _fresh = backend
+                .claim_next_manifest(&WorkerId::new("takeover"), StdDuration::from_secs(60))
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(matches!(
+                backend
+                    .publish_manifest_artifacts(&stale, &[], terminal.clone())
+                    .await,
+                Err(LeaseError::LeaseLost { .. })
+            ));
+
+            let wrong_url = "http://provider/wrong-worker.json";
+            let (tenant, submission, lease) = claim(&backend, wrong_url).await;
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "UPDATE bulk_manifests SET worker_id = 'interloper'
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        tenant.tenant_id().as_str(),
+                        submission.submitter,
+                        submission.submission_id,
+                        lease.manifest_id,
+                    ],
+                )
+                .unwrap();
+            assert!(matches!(
+                backend
+                    .publish_manifest_artifacts(&lease, &[], terminal.clone())
+                    .await,
+                Err(LeaseError::LeaseLost { .. })
+            ));
+
+            let replaced_url = "http://provider/replaced.json";
+            let (tenant, submission, lease) = claim(&backend, replaced_url).await;
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "UPDATE bulk_manifests SET status = 'replaced'
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        tenant.tenant_id().as_str(),
+                        submission.submitter,
+                        submission.submission_id,
+                        lease.manifest_id,
+                    ],
+                )
+                .unwrap();
+            assert!(matches!(
+                backend
+                    .publish_manifest_artifacts(&lease, &[], terminal)
+                    .await,
+                Err(LeaseError::LeaseLost { .. })
+            ));
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &lease.manifest_id),
+                0
+            );
+        }
+
+        #[tokio::test]
+        async fn guard_change_after_insert_rolls_back_artifacts_and_marker() {
+            let backend = create_test_backend();
+            let manifest_url = "http://provider/injected.json";
+            let (tenant, submission, lease) = claim(&backend, manifest_url).await;
+            let file = publication_file(
+                manifest_url,
+                "output",
+                Some("Patient"),
+                0,
+                "output/patient-0.ndjson",
+                None,
+            );
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "CREATE TRIGGER publication_guard_change
+                     AFTER INSERT ON bulk_submit_files
+                     BEGIN
+                       UPDATE bulk_manifests
+                       SET worker_id = 'interloper', fencing_token = 999
+                       WHERE tenant_id = NEW.tenant_id
+                         AND submitter = NEW.submitter
+                         AND submission_id = NEW.submission_id
+                         AND manifest_id = NEW.manifest_id;
+                     END",
+                    [],
+                )
+                .unwrap();
+
+            assert!(matches!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[file],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await,
+                Err(LeaseError::LeaseLost { .. })
+            ));
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &lease.manifest_id),
+                0
+            );
+            let (
+                status,
+                published_token,
+                publication_status,
+                publication_error,
+                publication_worker,
+                worker,
+            ) = publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            assert_eq!(status, "processing");
+            assert_eq!(published_token, None);
+            assert_eq!(publication_status, None);
+            assert_eq!(publication_error, None);
+            assert_eq!(publication_worker, None);
+            assert_eq!(worker.as_deref(), Some(lease.worker_id.as_str()));
+        }
+
+        async fn stage_output(
+            backend: &SqliteBackend,
+            lease: &ManifestLease,
+            manifest_url: &str,
+            file_path: &str,
+        ) {
+            backend
+                .record_submit_file(
+                    lease,
+                    &publication_file(manifest_url, "output", Some("Patient"), 0, file_path, None),
+                )
+                .await
+                .unwrap();
+        }
+
+        fn visible_paths(rows: &[SubmitFileRow]) -> Vec<String> {
+            rows.iter().map(|row| row.file_path.clone()).collect()
+        }
+
+        #[tokio::test]
+        async fn visible_artifacts_are_scoped_by_manifest_tenant_and_marker() {
+            let backend = create_test_backend();
+            let first_tenant = TenantContext::new(
+                TenantId::new("scope-tenant-one"),
+                TenantPermissions::full_access(),
+            );
+            let second_tenant = TenantContext::new(
+                TenantId::new("scope-tenant-two"),
+                TenantPermissions::full_access(),
+            );
+            let submission = SubmissionId::new("scope-submitter", "shared-submission");
+            let manifest_id = "shared-manifest-id";
+
+            for tenant in [&first_tenant, &second_tenant] {
+                backend
+                    .create_submission(tenant, &submission, None)
+                    .await
+                    .unwrap();
+                let manifest = backend
+                    .add_manifest(
+                        tenant,
+                        &submission,
+                        Some("http://provider/shared.json"),
+                        None,
+                    )
+                    .await
+                    .unwrap();
+                backend
+                    .get_connection()
+                    .unwrap()
+                    .execute(
+                        "UPDATE bulk_manifests SET manifest_id = ?1, added_at = ?5
+                         WHERE tenant_id = ?2 AND submitter = ?3 AND submission_id = ?4",
+                        params![
+                            manifest_id,
+                            tenant.tenant_id().as_str(),
+                            submission.submitter,
+                            submission.submission_id,
+                            if tenant.tenant_id() == first_tenant.tenant_id() {
+                                "1970-01-01T00:00:00Z"
+                            } else {
+                                "2000-01-01T00:00:00Z"
+                            }
+                        ],
+                    )
+                    .unwrap();
+                if tenant.tenant_id() == second_tenant.tenant_id() {
+                    backend
+                        .get_connection()
+                        .unwrap()
+                        .execute(
+                            "UPDATE bulk_manifests SET added_at = '2000-01-01T00:00:00Z'
+                             WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3",
+                            params![
+                                tenant.tenant_id().as_str(),
+                                submission.submitter,
+                                submission.submission_id
+                            ],
+                        )
+                        .unwrap();
+                }
+                let _ = manifest;
+            }
+
+            let first = backend
+                .claim_next_manifest(&WorkerId::new("scope-first"), StdDuration::from_secs(60))
+                .await
+                .unwrap()
+                .unwrap();
+            let second = backend
+                .claim_next_manifest(&WorkerId::new("scope-second"), StdDuration::from_secs(60))
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(first.manifest_id, manifest_id);
+            assert_eq!(second.manifest_id, manifest_id);
+            assert_eq!(first.fencing_token, second.fencing_token);
+
+            stage_output(
+                &backend,
+                &first,
+                "http://provider/shared.json",
+                "tenant-one/output.ndjson",
+            )
+            .await;
+            assert!(
+                backend
+                    .list_submit_files(&first_tenant, &first.submission_id)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            assert!(
+                backend
+                    .list_submit_files(&second_tenant, &second.submission_id)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+
+            // A token without a complete publication marker is still invisible,
+            // even when the row itself has the expected manifest and fence.
+            stage_output(
+                &backend,
+                &second,
+                "http://provider/shared.json",
+                "tenant-two/output.ndjson",
+            )
+            .await;
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "UPDATE bulk_manifests SET published_token = 1
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        second_tenant.tenant_id().as_str(),
+                        second.submission_id.submitter,
+                        second.submission_id.submission_id,
+                        manifest_id
+                    ],
+                )
+                .unwrap();
+            assert!(
+                backend
+                    .list_submit_files(&second_tenant, &second.submission_id)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "UPDATE bulk_manifests SET published_token = NULL
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        second_tenant.tenant_id().as_str(),
+                        second.submission_id.submitter,
+                        second.submission_id.submission_id,
+                        manifest_id
+                    ],
+                )
+                .unwrap();
+
+            assert_eq!(
+                backend
+                    .publish_manifest_artifacts(
+                        &first,
+                        &[publication_file(
+                            "http://provider/shared.json",
+                            "output",
+                            Some("Patient"),
+                            0,
+                            "tenant-one/output.ndjson",
+                            None,
+                        )],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await
+                    .unwrap(),
+                ManifestPublicationResult::Published
+            );
+            assert_eq!(
+                visible_paths(
+                    &backend
+                        .list_submit_files(&first_tenant, &first.submission_id)
+                        .await
+                        .unwrap()
+                ),
+                ["tenant-one/output.ndjson"]
+            );
+            assert!(
+                backend
+                    .list_submit_files(&second_tenant, &second.submission_id)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+
+            assert_eq!(
+                backend
+                    .publish_manifest_artifacts(
+                        &second,
+                        &[publication_file(
+                            "http://provider/shared.json",
+                            "output",
+                            Some("Patient"),
+                            0,
+                            "tenant-two/output.ndjson",
+                            None,
+                        )],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await
+                    .unwrap(),
+                ManifestPublicationResult::Published
+            );
+            assert_eq!(
+                visible_paths(
+                    &backend
+                        .list_submit_files(&second_tenant, &second.submission_id)
+                        .await
+                        .unwrap()
+                ),
+                ["tenant-two/output.ndjson"]
+            );
+            assert_eq!(
+                visible_paths(
+                    &backend
+                        .list_submit_files(&first_tenant, &first.submission_id)
+                        .await
+                        .unwrap()
+                ),
+                ["tenant-one/output.ndjson"]
+            );
+        }
+
+        #[tokio::test]
+        async fn new_same_manifest_generation_hides_old_but_preserves_rows() {
+            let backend = create_test_backend();
+            let tenant = create_test_tenant();
+            let submission = SubmissionId::generate("generations");
+            backend
+                .create_submission(&tenant, &submission, None)
+                .await
+                .unwrap();
+            let manifest_url = "http://provider/generation.json";
+            backend
+                .add_manifest(&tenant, &submission, Some(manifest_url), None)
+                .await
+                .unwrap();
+
+            let old = backend
+                .claim_next_manifest(&WorkerId::new("generation-old"), StdDuration::from_secs(60))
+                .await
+                .unwrap()
+                .unwrap();
+            stage_output(&backend, &old, manifest_url, "generation/old.ndjson").await;
+            backend.finish_manifest(&old).await.unwrap();
+            assert_eq!(
+                visible_paths(
+                    &backend
+                        .list_submit_files(&tenant, &submission)
+                        .await
+                        .unwrap()
+                ),
+                ["generation/old.ndjson"]
+            );
+
+            // Simulate the same manifest becoming reclaimable while retaining
+            // the token-one publication marker. The marker continues to select
+            // generation one until generation two commits.
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "UPDATE bulk_manifests SET status = 'pending', worker_id = NULL,
+                            lease_expiry = NULL
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        tenant.tenant_id().as_str(),
+                        submission.submitter,
+                        submission.submission_id,
+                        old.manifest_id
+                    ],
+                )
+                .unwrap();
+            let new = backend
+                .claim_next_manifest(&WorkerId::new("generation-new"), StdDuration::from_secs(60))
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(new.manifest_id, old.manifest_id);
+            assert!(new.fencing_token > old.fencing_token);
+            stage_output(&backend, &new, manifest_url, "generation/new.ndjson").await;
+            assert_eq!(
+                visible_paths(
+                    &backend
+                        .list_submit_files(&tenant, &submission)
+                        .await
+                        .unwrap()
+                ),
+                ["generation/old.ndjson"]
+            );
+
+            backend.finish_manifest(&new).await.unwrap();
+            let rows = backend
+                .list_submit_files(&tenant, &submission)
+                .await
+                .unwrap();
+            assert_eq!(visible_paths(&rows), ["generation/new.ndjson"]);
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &new.manifest_id),
+                2
+            );
+        }
+
+        #[tokio::test]
+        async fn same_token_and_artifact_identity_are_independent_by_manifest() {
+            let backend = create_test_backend();
+            let tenant = create_test_tenant();
+            let submission = SubmissionId::generate("independent");
+            backend
+                .create_submission(&tenant, &submission, None)
+                .await
+                .unwrap();
+            let first_url = "http://provider/independent-one.json";
+            let second_url = "http://provider/independent-two.json";
+            backend
+                .add_manifest(&tenant, &submission, Some(first_url), None)
+                .await
+                .unwrap();
+            backend
+                .add_manifest(&tenant, &submission, Some(second_url), None)
+                .await
+                .unwrap();
+
+            let first = backend
+                .claim_next_manifest(
+                    &WorkerId::new("independent-one"),
+                    StdDuration::from_secs(60),
+                )
+                .await
+                .unwrap()
+                .unwrap();
+            stage_output(&backend, &first, first_url, "independent/first.ndjson").await;
+            backend.finish_manifest(&first).await.unwrap();
+
+            let second = backend
+                .claim_next_manifest(
+                    &WorkerId::new("independent-two"),
+                    StdDuration::from_secs(60),
+                )
+                .await
+                .unwrap()
+                .unwrap();
+            stage_output(&backend, &second, second_url, "independent/second.ndjson").await;
+            assert_eq!(
+                visible_paths(
+                    &backend
+                        .list_submit_files(&tenant, &submission)
+                        .await
+                        .unwrap()
+                ),
+                ["independent/first.ndjson"]
+            );
+
+            backend.finish_manifest(&second).await.unwrap();
+            let rows = backend
+                .list_submit_files(&tenant, &submission)
+                .await
+                .unwrap();
+            assert_eq!(
+                visible_paths(&rows),
+                ["independent/first.ndjson", "independent/second.ndjson"]
+            );
+            // Publication is per manifest. The same lease identity is valid
+            // independently under each manifest, and both published sets stay
+            // visible to the consumer.
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &first.manifest_id),
+                1
+            );
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &second.manifest_id),
+                1
+            );
+            assert!(rows.iter().all(|row| row.fencing_token == 1));
+            assert!(
+                rows.iter()
+                    .all(|row| row.resource_type.as_deref() == Some("Patient")
+                        && row.part_index == 0)
+            );
+        }
+
+        #[tokio::test]
+        async fn expired_lease_can_publish_when_not_reclaimed() {
+            let backend = create_test_backend();
+            let manifest_url = "http://provider/expired.json";
+            let (tenant, submission, lease) = claim(&backend, manifest_url).await;
+            stage_output(&backend, &lease, manifest_url, "expired/output.ndjson").await;
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "UPDATE bulk_manifests SET lease_expiry = '1970-01-01T00:00:00Z'
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        tenant.tenant_id().as_str(),
+                        submission.submitter,
+                        submission.submission_id,
+                        lease.manifest_id
+                    ],
+                )
+                .unwrap();
+
+            backend.finish_manifest(&lease).await.unwrap();
+            assert_eq!(
+                visible_paths(
+                    &backend
+                        .list_submit_files(&tenant, &submission)
+                        .await
+                        .unwrap()
+                ),
+                ["expired/output.ndjson"]
+            );
+        }
+
+        #[tokio::test]
+        async fn cleanup_blocks_exact_publication_replay() {
+            let backend = create_test_backend();
+            let manifest_url = "http://provider/cleanup-replay.json";
+            let (tenant, submission, lease) = claim(&backend, manifest_url).await;
+            stage_output(&backend, &lease, manifest_url, "cleanup/output.ndjson").await;
+            backend.finish_manifest(&lease).await.unwrap();
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &lease.manifest_id),
+                1
+            );
+
+            backend
+                .delete_submission_artifacts(&tenant, &submission)
+                .await
+                .unwrap();
+            assert!(
+                backend
+                    .list_submit_files(&tenant, &submission)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            let (
+                status,
+                published_token,
+                publication_status,
+                publication_error,
+                publication_worker,
+                _,
+            ) = publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            assert_eq!(status, "completed");
+            assert_eq!(published_token, None);
+            assert_eq!(publication_status, None);
+            assert_eq!(publication_error, None);
+            assert_eq!(publication_worker, None);
+
+            assert!(matches!(
+                backend.finish_manifest(&lease).await,
+                Err(LeaseError::LeaseLost { .. })
+            ));
+            assert!(
+                backend
+                    .list_submit_files(&tenant, &submission)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+        }
+
+        #[tokio::test]
+        async fn publication_busy_timeout_retry_and_concurrent_replay() {
+            use rusqlite::Connection;
+            use std::sync::mpsc::channel;
+
+            use crate::backends::sqlite::SqliteBackendConfig;
+
+            let dir = tempfile::tempdir().unwrap();
+            let config = SqliteBackendConfig {
+                max_connections: 2,
+                busy_timeout_ms: 20,
+                ..Default::default()
+            };
+            let backend =
+                SqliteBackend::with_config(dir.path().join("publication-busy.db"), config).unwrap();
+            backend.init_schema().unwrap();
+            let manifest_url = "http://provider/busy-publication.json";
+            let (tenant, submission, lease) = claim(&backend, manifest_url).await;
+            let output = publication_file(
+                manifest_url,
+                "output",
+                Some("Patient"),
+                0,
+                "output/patient-0.ndjson",
+                None,
+            );
+            let error = publication_file(
+                manifest_url,
+                "error",
+                Some("OperationOutcome"),
+                0,
+                "error/outcome-0.ndjson",
+                Some(json!({"error": 1})),
+            );
+            let set = [output.clone(), error.clone()];
+
+            let (held_tx, held_rx) = channel();
+            let lock_path = dir.path().join("publication-busy.db");
+            let lock = std::thread::spawn(move || {
+                let conn = Connection::open(lock_path).unwrap();
+                conn.execute_batch("BEGIN IMMEDIATE").unwrap();
+                held_tx.send(()).unwrap();
+                std::thread::sleep(std::time::Duration::from_millis(150));
+                conn.execute_batch("COMMIT").unwrap();
+            });
+            held_rx.recv().unwrap();
+
+            let started = std::time::Instant::now();
+            let (first, second) = tokio::join!(
+                backend.publish_manifest_artifacts(
+                    &lease,
+                    &set,
+                    ManifestPublicationStatus::Completed,
+                ),
+                backend.publish_manifest_artifacts(
+                    &lease,
+                    &set,
+                    ManifestPublicationStatus::Completed,
+                ),
+            );
+            let results = [first.unwrap(), second.unwrap()];
+            assert!(started.elapsed() >= std::time::Duration::from_millis(50));
+            assert_eq!(
+                results
+                    .iter()
+                    .filter(|result| **result == ManifestPublicationResult::Published)
+                    .count(),
+                1
+            );
+            assert_eq!(
+                results
+                    .iter()
+                    .filter(|result| **result == ManifestPublicationResult::AlreadyPublished)
+                    .count(),
+                1
+            );
+            lock.join().unwrap();
+            let (
+                status,
+                published_token,
+                publication_status,
+                publication_error,
+                publication_worker,
+                _,
+            ) = publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            assert_eq!(status, "completed");
+            assert_eq!(published_token, Some(lease.fencing_token as i64));
+            assert_eq!(publication_status.as_deref(), Some("completed"));
+            assert_eq!(publication_error, None);
+            assert_eq!(
+                publication_worker.as_deref(),
+                Some(lease.worker_id.as_str())
+            );
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &lease.manifest_id),
+                2
+            );
+            assert_eq!(
+                visible_paths(
+                    &backend
+                        .list_submit_files(&tenant, &submission)
+                        .await
+                        .unwrap()
+                ),
+                ["error/outcome-0.ndjson", "output/patient-0.ndjson"]
+            );
+        }
+
+        #[tokio::test]
+        async fn publication_cleanup_marker_fault_rolls_back_after_delete() {
+            let backend = create_test_backend();
+            let manifest_url = "http://provider/cleanup-fault.json";
+            let (tenant, submission, lease) = claim(&backend, manifest_url).await;
+            let output = publication_file(
+                manifest_url,
+                "output",
+                Some("Patient"),
+                0,
+                "output/patient-0.ndjson",
+                None,
+            );
+            let error = publication_file(
+                manifest_url,
+                "error",
+                Some("OperationOutcome"),
+                0,
+                "error/outcome-0.ndjson",
+                Some(json!({"error": 1})),
+            );
+            assert_eq!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[output.clone(), error.clone()],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await
+                    .unwrap(),
+                ManifestPublicationResult::Published
+            );
+            let marker_before =
+                publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "CREATE TRIGGER publication_cleanup_marker_fault
+                     BEFORE UPDATE OF published_token ON bulk_manifests
+                     WHEN (OLD.published_token IS NOT NULL AND NEW.published_token IS NULL)
+                     BEGIN
+                       SELECT RAISE(ABORT, 'cleanup marker fault');
+                     END",
+                    [],
+                )
+                .unwrap();
+
+            let cleanup_error = backend
+                .delete_submission_artifacts(&tenant, &submission)
+                .await
+                .unwrap_err();
+            assert!(
+                cleanup_error
+                    .to_string()
+                    .contains("clear publication markers"),
+                "cleanup must fail while clearing the marker, got {cleanup_error}"
+            );
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &lease.manifest_id),
+                2
+            );
+            let marker_after =
+                publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            assert_eq!(marker_before, marker_after);
+            assert_eq!(
+                visible_paths(
+                    &backend
+                        .list_submit_files(&tenant, &submission)
+                        .await
+                        .unwrap()
+                ),
+                ["error/outcome-0.ndjson", "output/patient-0.ndjson"]
+            );
+
+            backend
+                .get_connection()
+                .unwrap()
+                .execute("DROP TRIGGER publication_cleanup_marker_fault", [])
+                .unwrap();
+            backend
+                .delete_submission_artifacts(&tenant, &submission)
+                .await
+                .unwrap();
+            assert_eq!(
+                publication_row_count(&backend, &tenant, &submission, &lease.manifest_id),
+                0
+            );
+            assert!(
+                backend
+                    .list_submit_files(&tenant, &submission)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            assert!(matches!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[output, error],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await,
+                Err(LeaseError::LeaseLost { .. })
+            ));
+        }
+
+        #[tokio::test]
+        async fn replaced_manifest_cannot_preflight_or_revive_processing() {
+            let backend = create_test_backend();
+            let manifest_url = "http://provider/replaced-guard.json";
+            let (tenant, submission, lease) = claim(&backend, manifest_url).await;
+            backend
+                .get_connection()
+                .unwrap()
+                .execute(
+                    "UPDATE bulk_manifests SET status = 'replaced'
+                     WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                       AND manifest_id = ?4",
+                    params![
+                        tenant.tenant_id().as_str(),
+                        submission.submitter,
+                        submission.submission_id,
+                        lease.manifest_id
+                    ],
+                )
+                .unwrap();
+
+            assert!(matches!(
+                backend.heartbeat(&lease).await,
+                Err(LeaseError::LeaseLost { .. })
+            ));
+            assert!(matches!(
+                backend.get_manifest_for_worker(&lease).await,
+                Err(LeaseError::LeaseLost { .. })
+            ));
+            assert!(matches!(
+                backend.mark_manifest_processing(&lease).await,
+                Err(LeaseError::LeaseLost { .. })
+            ));
+            let (status, _, _, _, _, worker) =
+                publication_marker(&backend, &tenant, &submission, &lease.manifest_id);
+            assert_eq!(status, "replaced");
+            assert_eq!(worker.as_deref(), Some(lease.worker_id.as_str()));
+        }
     }
 
     #[tokio::test]
@@ -3153,23 +4960,42 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        backend
-            .record_submit_file(
-                &lease,
-                &SubmitFileRecord {
-                    manifest_url: Some("http://example.com/manifest.json".to_string()),
-                    file_type: "error".to_string(),
-                    resource_type: None,
-                    part_index: 0,
-                    file_path: "tenant/sub/error-0.ndjson".to_string(),
-                    line_count: 3,
-                    byte_count: 120,
-                    count_severity: Some(json!({"error": 3})),
-                },
-            )
+        let file = SubmitFileRecord {
+            manifest_url: Some("http://example.com/manifest.json".to_string()),
+            file_type: "error".to_string(),
+            resource_type: None,
+            part_index: 0,
+            file_path: "tenant/sub/error-0.ndjson".to_string(),
+            line_count: 3,
+            byte_count: 120,
+            count_severity: Some(json!({"error": 3})),
+        };
+        backend.record_submit_file(&lease, &file).await.unwrap();
+        backend.record_submit_file(&lease, &file).await.unwrap();
+
+        // Staged work is publication-private: only the generation marker selects it.
+        let files = backend
+            .list_submit_files(&tenant, &lease.submission_id)
             .await
             .unwrap();
+        assert!(files.is_empty());
+        let staged_count: i64 = backend
+            .get_connection()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM bulk_submit_files
+                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3",
+                params![
+                    tenant.tenant_id().as_str(),
+                    lease.submission_id.submitter,
+                    lease.submission_id.submission_id
+                ],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(staged_count, 1);
 
+        backend.finish_manifest(&lease).await.unwrap();
         let files = backend
             .list_submit_files(&tenant, &lease.submission_id)
             .await
@@ -3177,6 +5003,7 @@ mod tests {
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].file_type, "error");
         assert_eq!(files[0].line_count, 3);
+        assert_eq!(files[0].count_severity, Some(json!({"error": 3})));
 
         backend
             .delete_submission_artifacts(&tenant, &lease.submission_id)
@@ -3189,6 +5016,18 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+        let (status, published_token, publication_status, publication_error, publication_worker, _) =
+            publication::publication_marker(
+                &backend,
+                &tenant,
+                &lease.submission_id,
+                &lease.manifest_id,
+            );
+        assert_eq!(status, "completed");
+        assert_eq!(published_token, None);
+        assert_eq!(publication_status, None);
+        assert_eq!(publication_error, None);
+        assert_eq!(publication_worker, None);
     }
 
     fn sqlite_busy() -> StorageError {

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -1,11 +1,16 @@
 //! SQLite schema definitions and migrations.
 
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction, TransactionBehavior};
+use serde_json::Value;
 
+use crate::core::bulk_submit_legacy::{
+    LegacyArtifactMetadata, LegacyFile, LegacyManifest, LegacyPublicationAction,
+    classify_legacy_publications,
+};
 use crate::error::StorageResult;
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 25;
+pub const SCHEMA_VERSION: i32 = 26;
 
 /// Initialize the database schema.
 pub fn initialize_schema(conn: &Connection) -> StorageResult<()> {
@@ -321,6 +326,7 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> StorageResult<()> {
             22 => migrate_v22_to_v23(conn)?,
             23 => migrate_v23_to_v24(conn)?,
             24 => migrate_v24_to_v25(conn)?,
+            25 => migrate_v25_to_v26(conn)?,
             _ => {
                 return Err(crate::error::StorageError::Backend(
                     crate::error::BackendError::Internal {
@@ -1745,6 +1751,295 @@ fn migrate_v24_to_v25(conn: &Connection) -> StorageResult<()> {
     Ok(())
 }
 
+fn table_columns(conn: &Connection, table: &str) -> StorageResult<Vec<String>> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(|e| migration_err(format!("pragma {table}: {e}")))?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| migration_err(format!("pragma {table} rows: {e}")))?;
+    let mut columns = Vec::new();
+    for row in rows {
+        columns.push(row?);
+    }
+    Ok(columns)
+}
+
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    sql: &str,
+) -> StorageResult<()> {
+    if !table_columns(conn, table)?
+        .iter()
+        .any(|existing| existing == column)
+    {
+        conn.execute(sql, [])
+            .map_err(|e| migration_err(format!("add {table}.{column}: {e}")))?;
+    }
+    Ok(())
+}
+
+/// Migrate from schema version 25 to version 26: manifest-scoped publication.
+///
+/// Existing artifact rows predate manifest identity and idempotent publication.
+/// The upgrade classifies every legacy row without deleting it, then adds two
+/// partial unique indexes so future SQLite publication can distinguish `None`
+/// from `Some("")` resource types.
+fn migrate_v25_to_v26(conn: &Connection) -> StorageResult<()> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|e| migration_err(format!("begin v26 migration: {e}")))?;
+    let result = migrate_v25_to_v26_in_transaction(&tx);
+
+    match result {
+        Ok(()) => tx
+            .commit()
+            .map_err(|e| migration_err(format!("commit v26 migration: {e}"))),
+        Err(error) => Err(error),
+    }
+}
+
+fn migrate_v25_to_v26_in_transaction(tx: &Connection) -> StorageResult<()> {
+    let manifest_columns = table_columns(tx, "bulk_manifests")?;
+    let file_columns = table_columns(tx, "bulk_submit_files")?;
+    if manifest_columns.is_empty() || file_columns.is_empty() {
+        return Err(migration_err(
+            "bulk_manifests and bulk_submit_files must exist before v26".to_string(),
+        ));
+    }
+
+    // Capture this before any ALTER. A prior interrupted run may have committed
+    // all DDL and classification but failed before stamping v26. In that state
+    // legacy classification must not run again or overwrite generation markers.
+    let new_columns = [
+        ("bulk_manifests", "published_token"),
+        ("bulk_manifests", "publication_status"),
+        ("bulk_manifests", "publication_error_message"),
+        ("bulk_manifests", "publication_worker_id"),
+        ("bulk_submit_files", "manifest_id"),
+        ("bulk_submit_files", "publication_excluded_reason"),
+    ];
+    let classification_already_complete = new_columns.iter().all(|(table, column)| {
+        let columns = match *table {
+            "bulk_manifests" => &manifest_columns,
+            _ => &file_columns,
+        };
+        columns.iter().any(|existing| existing == column)
+    });
+
+    add_column_if_missing(
+        tx,
+        "bulk_manifests",
+        "published_token",
+        "ALTER TABLE bulk_manifests ADD COLUMN published_token INTEGER",
+    )?;
+    add_column_if_missing(
+        tx,
+        "bulk_manifests",
+        "publication_status",
+        "ALTER TABLE bulk_manifests ADD COLUMN publication_status TEXT",
+    )?;
+    add_column_if_missing(
+        tx,
+        "bulk_manifests",
+        "publication_error_message",
+        "ALTER TABLE bulk_manifests ADD COLUMN publication_error_message TEXT",
+    )?;
+    add_column_if_missing(
+        tx,
+        "bulk_manifests",
+        "publication_worker_id",
+        "ALTER TABLE bulk_manifests ADD COLUMN publication_worker_id TEXT",
+    )?;
+    add_column_if_missing(
+        tx,
+        "bulk_submit_files",
+        "manifest_id",
+        "ALTER TABLE bulk_submit_files ADD COLUMN manifest_id TEXT",
+    )?;
+    add_column_if_missing(
+        tx,
+        "bulk_submit_files",
+        "publication_excluded_reason",
+        "ALTER TABLE bulk_submit_files ADD COLUMN publication_excluded_reason TEXT",
+    )?;
+
+    if !classification_already_complete {
+        let manifests = load_legacy_manifests(tx)?;
+        let files = load_legacy_files(tx)?;
+        for action in classify_legacy_publications(&manifests, &files) {
+            match action {
+                LegacyPublicationAction::Exclude { id, reason } => {
+                    set_row_reason(tx, id, reason)?;
+                }
+                LegacyPublicationAction::Assign { id, manifest_id } => {
+                    set_manifest_file_identity(tx, id, &manifest_id)?;
+                }
+                LegacyPublicationAction::Publish { manifest } => {
+                    mark_manifest_publication(tx, &manifest)?;
+                }
+            }
+        }
+    }
+    create_publication_partial_indexes(tx)?;
+    Ok(())
+}
+
+fn load_legacy_manifests(conn: &Connection) -> StorageResult<Vec<LegacyManifest>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT tenant_id, submitter, submission_id, manifest_id, manifest_url,
+                    status, fencing_token
+             FROM bulk_manifests
+             ORDER BY tenant_id, submitter, submission_id, added_at, manifest_id",
+        )
+        .map_err(|e| migration_err(format!("read legacy manifests: {e}")))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(LegacyManifest {
+                tenant_id: row.get(0)?,
+                submitter: row.get(1)?,
+                submission_id: row.get(2)?,
+                manifest_id: row.get(3)?,
+                manifest_url: row.get(4)?,
+                status: row.get(5)?,
+                fencing_token: row.get(6)?,
+            })
+        })
+        .map_err(|e| migration_err(format!("read legacy manifests: {e}")))?;
+    let mut manifests = Vec::new();
+    for row in rows {
+        manifests.push(row.map_err(|e| migration_err(format!("read legacy manifests: {e}")))?);
+    }
+    Ok(manifests)
+}
+
+fn load_legacy_files(conn: &Connection) -> StorageResult<Vec<LegacyFile>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, tenant_id, submitter, submission_id, manifest_url, file_type,
+                    resource_type, part_index, fencing_token, file_path, line_count,
+                    byte_count, count_severity
+             FROM bulk_submit_files
+             WHERE manifest_id IS NULL AND publication_excluded_reason IS NULL
+             ORDER BY id",
+        )
+        .map_err(|e| migration_err(format!("read legacy artifacts: {e}")))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let count_severity: Option<String> = row.get(12)?;
+            let (count_severity, count_severity_invalid) = match count_severity {
+                Some(text) => match serde_json::from_str::<Value>(&text) {
+                    Ok(value) => (Some(value), false),
+                    Err(_) => (Some(Value::String(text)), true),
+                },
+                None => (None, false),
+            };
+            Ok(LegacyFile {
+                id: row.get(0)?,
+                tenant_id: row.get(1)?,
+                submitter: row.get(2)?,
+                submission_id: row.get(3)?,
+                metadata: LegacyArtifactMetadata {
+                    manifest_url: row.get(4)?,
+                    file_type: row.get(5)?,
+                    resource_type: row.get(6)?,
+                    part_index: row.get(7)?,
+                    file_path: row.get(9)?,
+                    line_count: row.get(10)?,
+                    byte_count: row.get(11)?,
+                    count_severity,
+                    count_severity_invalid,
+                },
+                fencing_token: row.get(8)?,
+            })
+        })
+        .map_err(|e| migration_err(format!("read legacy artifacts: {e}")))?;
+    let mut files = Vec::new();
+    for row in rows {
+        files.push(row.map_err(|e| migration_err(format!("read legacy artifacts: {e}")))?);
+    }
+    Ok(files)
+}
+
+fn set_row_reason(conn: &Connection, id: i64, reason: &str) -> StorageResult<()> {
+    conn.execute(
+        "UPDATE bulk_submit_files
+         SET manifest_id = NULL, publication_excluded_reason = ?2
+         WHERE id = ?1",
+        rusqlite::params![id, reason],
+    )
+    .map_err(|e| migration_err(format!("classify artifact {id}: {e}")))?;
+    Ok(())
+}
+
+fn set_manifest_file_identity(conn: &Connection, id: i64, manifest_id: &str) -> StorageResult<()> {
+    conn.execute(
+        "UPDATE bulk_submit_files
+         SET manifest_id = ?2, publication_excluded_reason = NULL
+         WHERE id = ?1",
+        rusqlite::params![id, manifest_id],
+    )
+    .map_err(|e| migration_err(format!("assign artifact {id}: {e}")))?;
+    Ok(())
+}
+
+fn mark_manifest_publication(conn: &Connection, manifest: &LegacyManifest) -> StorageResult<()> {
+    // Failed legacy messages are unknowable, so publication_status is retained
+    // without inventing publication_error_message. The NULL worker leaves the
+    // marker unable to authorize a fresh publication replay.
+    conn.execute(
+        "UPDATE bulk_manifests
+         SET published_token = ?5,
+             publication_status = ?6,
+             publication_error_message = NULL,
+             publication_worker_id = NULL
+         WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+           AND manifest_id = ?4
+           AND published_token IS NULL
+           AND publication_status IS NULL
+           AND publication_error_message IS NULL
+           AND publication_worker_id IS NULL",
+        rusqlite::params![
+            manifest.tenant_id,
+            manifest.submitter,
+            manifest.submission_id,
+            manifest.manifest_id,
+            manifest.fencing_token,
+            manifest.status,
+        ],
+    )
+    .map_err(|e| migration_err(format!("mark legacy publication: {e}")))?;
+    Ok(())
+}
+
+fn create_publication_partial_indexes(conn: &Connection) -> StorageResult<()> {
+    let indexes = [
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_bulk_submit_files_artifact_null
+         ON bulk_submit_files(
+             tenant_id, submitter, submission_id, manifest_id, file_type,
+             part_index, fencing_token
+         )
+         WHERE manifest_id IS NOT NULL
+           AND publication_excluded_reason IS NULL
+           AND resource_type IS NULL",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_bulk_submit_files_artifact_not_null
+         ON bulk_submit_files(
+             tenant_id, submitter, submission_id, manifest_id, file_type,
+             resource_type, part_index, fencing_token
+         )
+         WHERE manifest_id IS NOT NULL
+           AND publication_excluded_reason IS NULL
+           AND resource_type IS NOT NULL",
+    ];
+    for index in indexes {
+        conn.execute(index, [])
+            .map_err(|e| migration_err(format!("create publication artifact index: {e}")))?;
+    }
+    Ok(())
+}
+
 /// Drop all tables (for testing).
 #[cfg(test)]
 #[allow(dead_code)]
@@ -1801,6 +2096,242 @@ pub fn drop_all_tables(conn: &Connection) -> StorageResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::bulk_submit_legacy::{
+        LEGACY_REASON_AMBIGUOUS_URL, LEGACY_REASON_CONFLICTING_DUPLICATE,
+        LEGACY_REASON_EXACT_DUPLICATE, LEGACY_REASON_INCOMPLETE_GENERATION,
+        LEGACY_REASON_INVALID_DOMAIN, LEGACY_REASON_NONTERMINAL, LEGACY_REASON_NULL_URL,
+        LEGACY_REASON_TOKEN_MISMATCH,
+    };
+    use rusqlite::OptionalExtension;
+
+    /// Builds a genuine v25 database by walking every real migration once. This
+    /// avoids initializing to v26 and pretending to remove columns afterward.
+    fn migrate_through_v25(conn: &Connection) {
+        create_schema_v1(conn).unwrap();
+        let _ = get_schema_version(conn).unwrap();
+        migrate_v1_to_v2(conn).unwrap();
+        migrate_v2_to_v3(conn).unwrap();
+        migrate_v3_to_v4(conn).unwrap();
+        migrate_v4_to_v5(conn).unwrap();
+        migrate_v5_to_v6(conn).unwrap();
+        migrate_v6_to_v7(conn).unwrap();
+        migrate_v7_to_v8(conn).unwrap();
+        migrate_v8_to_v9(conn).unwrap();
+        migrate_v9_to_v10(conn).unwrap();
+        migrate_v10_to_v11(conn).unwrap();
+        migrate_v11_to_v12(conn).unwrap();
+        migrate_v12_to_v13(conn).unwrap();
+        migrate_v13_to_v14(conn).unwrap();
+        migrate_v14_to_v15(conn).unwrap();
+        migrate_v15_to_v16(conn).unwrap();
+        migrate_v16_to_v17(conn).unwrap();
+        migrate_v17_to_v18(conn).unwrap();
+        migrate_v18_to_v19(conn).unwrap();
+        migrate_v19_to_v20(conn).unwrap();
+        migrate_v20_to_v21(conn).unwrap();
+        migrate_v21_to_v22(conn).unwrap();
+        migrate_v22_to_v23(conn).unwrap();
+        migrate_v23_to_v24(conn).unwrap();
+        migrate_v24_to_v25(conn).unwrap();
+        set_schema_version(conn, 25).unwrap();
+    }
+
+    fn seed_v25_submission(conn: &Connection, tenant: &str, submitter: &str, submission: &str) {
+        conn.execute(
+            "INSERT INTO bulk_submissions
+             (tenant_id, submitter, submission_id, status, created_at, updated_at)
+             VALUES (?1, ?2, ?3, 'in-progress', '2026-01-01T00:00:00Z',
+                     '2026-01-01T00:00:00Z')",
+            rusqlite::params![tenant, submitter, submission],
+        )
+        .unwrap();
+    }
+
+    #[allow(clippy::too_many_arguments)] // Explicit legacy-schema fixture columns.
+    fn seed_v25_manifest(
+        conn: &Connection,
+        tenant: &str,
+        submitter: &str,
+        submission: &str,
+        manifest: &str,
+        url: Option<&str>,
+        status: &str,
+        fencing_token: i64,
+    ) {
+        conn.execute(
+            "INSERT INTO bulk_manifests
+             (tenant_id, submitter, submission_id, manifest_id, manifest_url, status,
+              added_at, fencing_token)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, '2026-01-01T00:00:00Z', ?7)",
+            rusqlite::params![
+                tenant,
+                submitter,
+                submission,
+                manifest,
+                url,
+                status,
+                fencing_token
+            ],
+        )
+        .unwrap();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn seed_v25_artifact(
+        conn: &Connection,
+        tenant: &str,
+        submitter: &str,
+        submission: &str,
+        url: Option<&str>,
+        file_type: &str,
+        resource_type: Option<&str>,
+        part_index: i64,
+        fencing_token: i64,
+        file_path: &str,
+        line_count: i64,
+        byte_count: i64,
+        count_severity: Option<&str>,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO bulk_submit_files
+             (tenant_id, submitter, submission_id, manifest_url, file_type, resource_type,
+              part_index, fencing_token, file_path, line_count, byte_count, count_severity,
+              created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                     '2026-01-01T00:00:00Z')",
+            rusqlite::params![
+                tenant,
+                submitter,
+                submission,
+                url,
+                file_type,
+                resource_type,
+                part_index,
+                fencing_token,
+                file_path,
+                line_count,
+                byte_count,
+                count_severity,
+            ],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn artifact_classification(conn: &Connection, id: i64) -> (Option<String>, Option<String>) {
+        conn.query_row(
+            "SELECT manifest_id, publication_excluded_reason
+             FROM bulk_submit_files WHERE id = ?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap()
+    }
+
+    #[allow(clippy::type_complexity)] // Exact persisted columns for migration assertions.
+    fn publication_marker(
+        conn: &Connection,
+        tenant: &str,
+        submitter: &str,
+        submission: &str,
+        manifest: &str,
+    ) -> Option<(Option<i64>, Option<String>, Option<String>, Option<String>)> {
+        conn.query_row(
+            "SELECT published_token, publication_status, publication_error_message,
+                    publication_worker_id
+             FROM bulk_manifests
+             WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+               AND manifest_id = ?4",
+            rusqlite::params![tenant, submitter, submission, manifest],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .optional()
+        .unwrap()
+    }
+
+    fn v26_column_names(conn: &Connection, table: &str) -> Vec<String> {
+        let wanted: &[&str] = if table == "bulk_manifests" {
+            &[
+                "published_token",
+                "publication_status",
+                "publication_error_message",
+                "publication_worker_id",
+            ]
+        } else {
+            &["manifest_id", "publication_excluded_reason"]
+        };
+        let existing = table_columns(conn, table).unwrap();
+        wanted
+            .iter()
+            .filter(|column| existing.iter().any(|name| name == *column))
+            .map(|column| (*column).to_string())
+            .collect()
+    }
+
+    fn publication_index_names(conn: &Connection) -> Vec<String> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT name FROM sqlite_master
+                 WHERE type='index' AND tbl_name='bulk_submit_files'
+                   AND name LIKE 'idx_bulk_submit_files_artifact_%'
+                 ORDER BY name",
+            )
+            .unwrap();
+        stmt.query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ArtifactSnapshotRow {
+        id: i64,
+        tenant_id: String,
+        submitter: String,
+        submission_id: String,
+        manifest_url: Option<String>,
+        file_type: String,
+        resource_type: Option<String>,
+        part_index: i64,
+        fencing_token: i64,
+        file_path: String,
+        line_count: i64,
+        byte_count: i64,
+        count_severity: Option<String>,
+    }
+
+    type ArtifactSnapshot = Vec<ArtifactSnapshotRow>;
+
+    fn artifact_snapshot(conn: &Connection) -> ArtifactSnapshot {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, tenant_id, submitter, submission_id, manifest_url, file_type,
+                        resource_type, part_index, fencing_token, file_path, line_count,
+                        byte_count, count_severity
+                 FROM bulk_submit_files ORDER BY id",
+            )
+            .unwrap();
+        stmt.query_map([], |row| {
+            Ok(ArtifactSnapshotRow {
+                id: row.get(0)?,
+                tenant_id: row.get(1)?,
+                submitter: row.get(2)?,
+                submission_id: row.get(3)?,
+                manifest_url: row.get(4)?,
+                file_type: row.get(5)?,
+                resource_type: row.get(6)?,
+                part_index: row.get(7)?,
+                fencing_token: row.get(8)?,
+                file_path: row.get(9)?,
+                line_count: row.get(10)?,
+                byte_count: row.get(11)?,
+                count_severity: row.get(12)?,
+            })
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+    }
 
     #[test]
     fn test_schema_initialization() {
@@ -2171,11 +2702,631 @@ mod tests {
         }
     }
 
-    /// Migrations must be re-runnable: a database already carrying the latest
-    /// columns can be replayed from any earlier recorded version (tests do this,
-    /// and so does a build that stamped a version before finishing its work).
-    /// SQLite has no `ADD COLUMN IF NOT EXISTS`, so every `ALTER TABLE ... ADD
-    /// COLUMN` step has to guard against the column already being there.
+    #[test]
+    fn publication_migration_preserves_clean_and_exact_duplicate_artifacts() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate_through_v25(&conn);
+        seed_v25_submission(&conn, "tenant-a", "alice", "submission-1");
+        seed_v25_manifest(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-1",
+            "manifest-clean",
+            Some("http://provider/clean.json"),
+            "completed",
+            7,
+        );
+        seed_v25_manifest(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-1",
+            "manifest-failed",
+            Some("http://provider/failed.json"),
+            "failed",
+            8,
+        );
+        let output = seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-1",
+            Some("http://provider/clean.json"),
+            "output",
+            Some("Patient"),
+            0,
+            7,
+            "tenant/submit/output-0.ndjson",
+            3,
+            120,
+            None,
+        );
+        let failed_error = seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-1",
+            Some("http://provider/failed.json"),
+            "error",
+            Some("OperationOutcome"),
+            0,
+            8,
+            "tenant/submit/error-0.ndjson",
+            2,
+            88,
+            Some(r#"{"warning":1,"error":2}"#),
+        );
+        let duplicate = seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-1",
+            Some("http://provider/clean.json"),
+            "output",
+            Some("Patient"),
+            0,
+            7,
+            "tenant/submit/output-0.ndjson",
+            3,
+            120,
+            None,
+        );
+
+        initialize_schema(&conn).unwrap();
+        assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+        assert_eq!(
+            artifact_classification(&conn, output),
+            (Some("manifest-clean".to_string()), None)
+        );
+        assert_eq!(
+            artifact_classification(&conn, failed_error),
+            (Some("manifest-failed".to_string()), None)
+        );
+        assert_eq!(
+            artifact_classification(&conn, duplicate),
+            (None, Some(LEGACY_REASON_EXACT_DUPLICATE.to_string()))
+        );
+        assert_eq!(
+            publication_marker(&conn, "tenant-a", "alice", "submission-1", "manifest-clean",),
+            Some((Some(7), Some("completed".to_string()), None, None))
+        );
+        assert_eq!(
+            publication_marker(
+                &conn,
+                "tenant-a",
+                "alice",
+                "submission-1",
+                "manifest-failed",
+            ),
+            Some((Some(8), Some("failed".to_string()), None, None))
+        );
+        assert_eq!(publication_index_names(&conn).len(), 2);
+    }
+
+    #[test]
+    fn publication_migration_quarantines_conflicting_or_incomplete_generations() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate_through_v25(&conn);
+        seed_v25_submission(&conn, "tenant-a", "alice", "submission-conflicts");
+        seed_v25_manifest(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-conflicts",
+            "manifest-conflicts",
+            Some("http://provider/conflicts.json"),
+            "completed",
+            9,
+        );
+        seed_v25_manifest(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-conflicts",
+            "manifest-incomplete",
+            Some("http://provider/incomplete.json"),
+            "completed",
+            10,
+        );
+        let conflicting_first = seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-conflicts",
+            Some("http://provider/conflicts.json"),
+            "output",
+            Some("Patient"),
+            0,
+            9,
+            "tenant/submit/first.ndjson",
+            1,
+            10,
+            None,
+        );
+        let conflicting_second = seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-conflicts",
+            Some("http://provider/conflicts.json"),
+            "output",
+            Some("Patient"),
+            0,
+            9,
+            "tenant/submit/second.ndjson",
+            2,
+            20,
+            None,
+        );
+        let unique_conflict_member = seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-conflicts",
+            Some("http://provider/conflicts.json"),
+            "output",
+            Some("Observation"),
+            0,
+            9,
+            "tenant/submit/observation.ndjson",
+            1,
+            11,
+            None,
+        );
+        let recognized_with_null = seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-conflicts",
+            Some("http://provider/incomplete.json"),
+            "output",
+            Some("Patient"),
+            0,
+            10,
+            "tenant/submit/recognized.ndjson",
+            1,
+            12,
+            None,
+        );
+        let null_url = seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-conflicts",
+            None,
+            "output",
+            Some("Patient"),
+            1,
+            10,
+            "tenant/submit/null-url.ndjson",
+            1,
+            13,
+            None,
+        );
+
+        initialize_schema(&conn).unwrap();
+        for id in [
+            conflicting_first,
+            conflicting_second,
+            unique_conflict_member,
+        ] {
+            assert_eq!(
+                artifact_classification(&conn, id),
+                (None, Some(LEGACY_REASON_CONFLICTING_DUPLICATE.to_string()))
+            );
+        }
+        assert_eq!(
+            artifact_classification(&conn, recognized_with_null),
+            (None, Some(LEGACY_REASON_INCOMPLETE_GENERATION.to_string()))
+        );
+        assert_eq!(
+            artifact_classification(&conn, null_url),
+            (None, Some(LEGACY_REASON_NULL_URL.to_string()))
+        );
+        assert_eq!(
+            publication_marker(
+                &conn,
+                "tenant-a",
+                "alice",
+                "submission-conflicts",
+                "manifest-conflicts",
+            ),
+            Some((None, None, None, None))
+        );
+        assert_eq!(
+            publication_marker(
+                &conn,
+                "tenant-a",
+                "alice",
+                "submission-conflicts",
+                "manifest-incomplete",
+            ),
+            Some((None, None, None, None))
+        );
+    }
+
+    #[test]
+    fn publication_unique_indexes_distinguish_none_and_empty_resource_type() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate_through_v25(&conn);
+        seed_v25_submission(&conn, "tenant-a", "alice", "submission-types");
+        seed_v25_manifest(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-types",
+            "manifest-types",
+            Some("http://provider/types.json"),
+            "completed",
+            3,
+        );
+        seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-types",
+            Some("http://provider/types.json"),
+            "output",
+            None,
+            0,
+            3,
+            "tenant/submit/none.ndjson",
+            1,
+            10,
+            None,
+        );
+        seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-types",
+            Some("http://provider/types.json"),
+            "output",
+            Some(""),
+            0,
+            3,
+            "tenant/submit/empty.ndjson",
+            1,
+            11,
+            None,
+        );
+
+        initialize_schema(&conn).unwrap();
+        initialize_schema(&conn).unwrap();
+        let count = |resource: Option<&str>| -> i64 {
+            conn.query_row(
+                "SELECT COUNT(*) FROM bulk_submit_files
+                 WHERE manifest_id = 'manifest-types'
+                   AND publication_excluded_reason IS NULL
+                   AND resource_type IS ?1",
+                rusqlite::params![resource],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(count(None), 1);
+        assert_eq!(count(Some("")), 1);
+
+        let duplicate = |resource: Option<&str>| {
+            conn.execute(
+                "INSERT INTO bulk_submit_files
+                 (tenant_id, submitter, submission_id, manifest_id, manifest_url, file_type,
+                  resource_type, part_index, fencing_token, file_path, line_count, byte_count,
+                  created_at)
+                 VALUES ('tenant-a', 'alice', 'submission-types', 'manifest-types',
+                         'http://provider/types.json', 'output', ?1, 0, 3,
+                         'tenant/submit/duplicate.ndjson', 1, 10,
+                         '2026-01-01T00:00:00Z')",
+                rusqlite::params![resource],
+            )
+        };
+        for resource in [None, Some("")] {
+            let error = duplicate(resource).unwrap_err();
+            assert_eq!(
+                error.sqlite_error().unwrap().extended_code,
+                rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE
+            );
+        }
+    }
+
+    #[test]
+    fn publication_migration_rolls_back_trigger_failure_and_replays() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate_through_v25(&conn);
+        seed_v25_submission(&conn, "tenant-a", "alice", "submission-rollback");
+        seed_v25_manifest(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-rollback",
+            "manifest-rollback",
+            Some("http://provider/rollback.json"),
+            "completed",
+            5,
+        );
+        let output = seed_v25_artifact(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-rollback",
+            Some("http://provider/rollback.json"),
+            "output",
+            Some("Patient"),
+            0,
+            5,
+            "tenant/submit/output.ndjson",
+            1,
+            10,
+            None,
+        );
+        let before = artifact_snapshot(&conn);
+        conn.execute(
+            &format!(
+                "CREATE TRIGGER fail_v26_publication BEFORE UPDATE ON bulk_submit_files
+                 WHEN old.id = {output}
+                 BEGIN SELECT RAISE(ABORT, 'injected v26 publication failure'); END"
+            ),
+            [],
+        )
+        .unwrap();
+
+        let error = initialize_schema(&conn).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("injected v26 publication failure")
+        );
+        assert_eq!(get_schema_version(&conn).unwrap(), 25);
+        assert!(v26_column_names(&conn, "bulk_manifests").is_empty());
+        assert!(v26_column_names(&conn, "bulk_submit_files").is_empty());
+        assert!(publication_index_names(&conn).is_empty());
+        assert_eq!(artifact_snapshot(&conn), before);
+
+        conn.execute("DROP TRIGGER fail_v26_publication", [])
+            .unwrap();
+        initialize_schema(&conn).unwrap();
+        assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+        assert_eq!(
+            artifact_classification(&conn, output),
+            (Some("manifest-rollback".to_string()), None)
+        );
+        assert_eq!(
+            publication_marker(
+                &conn,
+                "tenant-a",
+                "alice",
+                "submission-rollback",
+                "manifest-rollback",
+            ),
+            Some((Some(5), Some("completed".to_string()), None, None))
+        );
+
+        // Simulate a crash after the committed classification but before the
+        // version stamp. Replay must preserve the marker and classifications.
+        let classified = artifact_classification(&conn, output);
+        let marker = publication_marker(
+            &conn,
+            "tenant-a",
+            "alice",
+            "submission-rollback",
+            "manifest-rollback",
+        );
+        set_schema_version(&conn, 25).unwrap();
+        initialize_schema(&conn).unwrap();
+        assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+        assert_eq!(artifact_classification(&conn, output), classified);
+        assert_eq!(
+            publication_marker(
+                &conn,
+                "tenant-a",
+                "alice",
+                "submission-rollback",
+                "manifest-rollback",
+            ),
+            marker
+        );
+    }
+
+    #[test]
+    fn publication_migration_excludes_ambiguous_stale_and_malformed_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate_through_v25(&conn);
+        let cases = [
+            (
+                "ambiguous",
+                "completed",
+                7,
+                1,
+                None,
+                LEGACY_REASON_AMBIGUOUS_URL,
+            ),
+            (
+                "stale",
+                "completed",
+                6,
+                1,
+                None,
+                LEGACY_REASON_TOKEN_MISMATCH,
+            ),
+            (
+                "future",
+                "completed",
+                99,
+                1,
+                None,
+                LEGACY_REASON_TOKEN_MISMATCH,
+            ),
+            (
+                "processing",
+                "processing",
+                7,
+                1,
+                None,
+                LEGACY_REASON_NONTERMINAL,
+            ),
+            (
+                "replaced",
+                "replaced",
+                7,
+                1,
+                None,
+                LEGACY_REASON_NONTERMINAL,
+            ),
+            (
+                "negative",
+                "completed",
+                7,
+                -1,
+                None,
+                LEGACY_REASON_INVALID_DOMAIN,
+            ),
+            (
+                "invalid-json",
+                "completed",
+                7,
+                1,
+                Some("{"),
+                LEGACY_REASON_INVALID_DOMAIN,
+            ),
+            (
+                "scalar",
+                "completed",
+                7,
+                1,
+                Some("[]"),
+                LEGACY_REASON_INVALID_DOMAIN,
+            ),
+            (
+                "negative-severity",
+                "completed",
+                7,
+                1,
+                Some(r#"{"error":-1}"#),
+                LEGACY_REASON_INVALID_DOMAIN,
+            ),
+        ];
+        let mut expected = Vec::new();
+        for (submission, status, token, lines, severity, reason) in cases {
+            seed_v25_submission(&conn, "tenant-a", "alice", submission);
+            seed_v25_manifest(
+                &conn,
+                "tenant-a",
+                "alice",
+                submission,
+                "m",
+                Some("url"),
+                status,
+                7,
+            );
+            if submission == "ambiguous" {
+                seed_v25_manifest(
+                    &conn,
+                    "tenant-a",
+                    "alice",
+                    submission,
+                    "other",
+                    Some("url"),
+                    status,
+                    7,
+                );
+            }
+            let row = seed_v25_artifact(
+                &conn,
+                "tenant-a",
+                "alice",
+                submission,
+                Some("url"),
+                "error",
+                Some("OperationOutcome"),
+                0,
+                token,
+                "preserved-path",
+                lines,
+                10,
+                severity,
+            );
+            expected.push((row, reason));
+            if reason == LEGACY_REASON_INVALID_DOMAIN {
+                let sibling = seed_v25_artifact(
+                    &conn,
+                    "tenant-a",
+                    "alice",
+                    submission,
+                    Some("url"),
+                    "output",
+                    Some("Patient"),
+                    0,
+                    7,
+                    "valid-sibling",
+                    1,
+                    10,
+                    None,
+                );
+                expected.push((sibling, reason));
+            }
+        }
+        let before = artifact_snapshot(&conn);
+        initialize_schema(&conn).unwrap();
+        for (row, reason) in expected {
+            assert_eq!(
+                artifact_classification(&conn, row),
+                (None, Some(reason.to_string()))
+            );
+        }
+        assert_eq!(artifact_snapshot(&conn), before);
+    }
+
+    #[test]
+    fn publication_migration_associates_urls_within_the_complete_submission_scope() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate_through_v25(&conn);
+        let scopes = [
+            ("a", "alice", "one"),
+            ("b", "alice", "one"),
+            ("a", "bob", "one"),
+            ("a", "alice", "two"),
+        ];
+        let mut rows = Vec::new();
+        for (tenant, submitter, submission) in scopes {
+            seed_v25_submission(&conn, tenant, submitter, submission);
+            seed_v25_manifest(
+                &conn,
+                tenant,
+                submitter,
+                submission,
+                "shared-id",
+                Some("shared-url"),
+                "completed",
+                7,
+            );
+            rows.push(seed_v25_artifact(
+                &conn,
+                tenant,
+                submitter,
+                submission,
+                Some("shared-url"),
+                "output",
+                Some("Patient"),
+                0,
+                7,
+                "preserved-path",
+                1,
+                10,
+                None,
+            ));
+        }
+        initialize_schema(&conn).unwrap();
+        for row in rows {
+            assert_eq!(
+                artifact_classification(&conn, row),
+                (Some("shared-id".to_string()), None)
+            );
+        }
+    }
+
+    /// Replay migrations against an already current database, including a
+    /// retry after the schema transaction committed before its version stamp.
     #[test]
     fn test_migration_ladder_replays_on_a_current_database() {
         for from in 1..SCHEMA_VERSION {

--- a/crates/persistence/src/composite/bulk_submit.rs
+++ b/crates/persistence/src/composite/bulk_submit.rs
@@ -41,6 +41,7 @@ use crate::core::bulk_submit::{
     StreamingBulkSubmitProvider, SubmissionChange, SubmissionId, SubmissionManifest,
     SubmissionStatus, SubmissionSummary, entry_result_pages,
 };
+use crate::core::bulk_submit_publication::{ManifestPublicationResult, ManifestPublicationStatus};
 use crate::core::bulk_submit_worker::{
     BulkSubmitJobStore, ManifestFetchParams, ManifestLease, ManifestWorkerView, PollTokenTarget,
     SubmitClaimStrategy, SubmitFileRecord, SubmitFileRow, SubmitWorkerStorage,
@@ -69,6 +70,22 @@ impl CompositeSubmitJobs {
     /// Wraps the primary's job store with the composite's secondary sync.
     pub fn new(primary: Arc<dyn BulkSubmitJobStore>, composite: Arc<CompositeStorage>) -> Self {
         Self { primary, composite }
+    }
+
+    /// Preflights the primary lease before terminal publication.
+    ///
+    /// Sync is best-effort only for a lease the primary still authorizes. If the
+    /// lease has been lost, publication still delegates to the primary so it can
+    /// distinguish an already-committed replay from a stale token.
+    async fn preflight_for_publication(&self, lease: &ManifestLease) -> Result<(), LeaseError> {
+        match self.primary.get_manifest_for_worker(lease).await {
+            Ok(_) => {
+                self.sync_ingested(lease).await;
+                Ok(())
+            }
+            Err(LeaseError::LeaseLost { .. }) => Ok(()),
+            Err(LeaseError::Storage(error)) => Err(LeaseError::Storage(error)),
+        }
     }
 
     /// Pushes every successfully ingested entry of the leased manifest
@@ -694,11 +711,20 @@ impl SubmitWorkerStorage for CompositeSubmitJobs {
         self.primary.record_submit_file(lease, file).await
     }
 
+    async fn publish_manifest_artifacts(
+        &self,
+        lease: &ManifestLease,
+        files: &[SubmitFileRecord],
+        terminal: ManifestPublicationStatus,
+    ) -> Result<ManifestPublicationResult, LeaseError> {
+        self.preflight_for_publication(lease).await?;
+        self.primary
+            .publish_manifest_artifacts(lease, files, terminal)
+            .await
+    }
+
     async fn finish_manifest(&self, lease: &ManifestLease) -> Result<(), LeaseError> {
-        // Sync before finishing: once the manifest is terminal the lease is
-        // gone, and syncing under the live lease keeps a reclaim from racing
-        // a half-finished sweep with a second ingestion of the same files.
-        self.sync_ingested(lease).await;
+        self.preflight_for_publication(lease).await?;
         self.primary.finish_manifest(lease).await
     }
 
@@ -707,9 +733,7 @@ impl SubmitWorkerStorage for CompositeSubmitJobs {
         lease: &ManifestLease,
         error_message: &str,
     ) -> Result<(), LeaseError> {
-        // A failed manifest still committed its successful entries on the
-        // primary — search must agree with what reads will return.
-        self.sync_ingested(lease).await;
+        self.preflight_for_publication(lease).await?;
         self.primary.fail_manifest(lease, error_message).await
     }
 

--- a/crates/persistence/src/core/bulk_submit_legacy.rs
+++ b/crates/persistence/src/core/bulk_submit_legacy.rs
@@ -1,0 +1,376 @@
+//! Backend-independent classification of legacy bulk-submit publications.
+
+use serde_json::Value;
+
+pub(crate) const LEGACY_REASON_NULL_URL: &str = "legacy-null-url";
+pub(crate) const LEGACY_REASON_UNMATCHED_URL: &str = "legacy-unmatched-url";
+pub(crate) const LEGACY_REASON_AMBIGUOUS_URL: &str = "legacy-ambiguous-url";
+pub(crate) const LEGACY_REASON_TOKEN_MISMATCH: &str = "legacy-token-mismatch";
+pub(crate) const LEGACY_REASON_NONTERMINAL: &str = "legacy-nonterminal";
+pub(crate) const LEGACY_REASON_EXACT_DUPLICATE: &str = "legacy-exact-duplicate";
+pub(crate) const LEGACY_REASON_INCOMPLETE_GENERATION: &str = "legacy-incomplete-generation";
+pub(crate) const LEGACY_REASON_CONFLICTING_DUPLICATE: &str = "legacy-conflicting-duplicate";
+pub(crate) const LEGACY_REASON_INVALID_DOMAIN: &str = "legacy-invalid-domain";
+
+#[derive(Clone, Debug)]
+pub(crate) struct LegacyManifest {
+    pub(crate) tenant_id: String,
+    pub(crate) submitter: String,
+    pub(crate) submission_id: String,
+    pub(crate) manifest_id: String,
+    pub(crate) manifest_url: Option<String>,
+    pub(crate) status: String,
+    pub(crate) fencing_token: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct LegacyArtifactMetadata {
+    pub(crate) manifest_url: Option<String>,
+    pub(crate) file_type: String,
+    pub(crate) resource_type: Option<String>,
+    pub(crate) part_index: i64,
+    pub(crate) file_path: String,
+    pub(crate) line_count: i64,
+    pub(crate) byte_count: i64,
+    pub(crate) count_severity: Option<Value>,
+    pub(crate) count_severity_invalid: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LegacyFile {
+    pub(crate) id: i64,
+    pub(crate) tenant_id: String,
+    pub(crate) submitter: String,
+    pub(crate) submission_id: String,
+    pub(crate) metadata: LegacyArtifactMetadata,
+    pub(crate) fencing_token: i64,
+}
+
+impl LegacyFile {
+    fn submission_key(&self) -> (&str, &str, &str) {
+        (
+            self.tenant_id.as_str(),
+            self.submitter.as_str(),
+            self.submission_id.as_str(),
+        )
+    }
+
+    fn has_valid_domain_metadata(&self) -> bool {
+        let metadata = &self.metadata;
+        matches!(metadata.file_type.as_str(), "output" | "error" | "deleted")
+            && !metadata.file_path.is_empty()
+            && (0..=i32::MAX as i64).contains(&metadata.part_index)
+            && metadata.line_count >= 0
+            && metadata.byte_count >= 0
+            && self.fencing_token >= 0
+            && !metadata.count_severity_invalid
+            && metadata.count_severity.as_ref().is_none_or(|severity| {
+                severity
+                    .as_object()
+                    .is_some_and(|counts| counts.values().all(|count| count.as_u64().is_some()))
+            })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct LegacyManifestKey<'a> {
+    tenant_id: &'a str,
+    submitter: &'a str,
+    submission_id: &'a str,
+    manifest_id: &'a str,
+    fencing_token: i64,
+}
+
+impl<'a> From<&'a LegacyManifest> for LegacyManifestKey<'a> {
+    fn from(manifest: &'a LegacyManifest) -> Self {
+        Self {
+            tenant_id: manifest.tenant_id.as_str(),
+            submitter: manifest.submitter.as_str(),
+            submission_id: manifest.submission_id.as_str(),
+            manifest_id: manifest.manifest_id.as_str(),
+            fencing_token: manifest.fencing_token,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum LegacyPublicationAction {
+    Exclude { id: i64, reason: &'static str },
+    Assign { id: i64, manifest_id: String },
+    Publish { manifest: LegacyManifest },
+}
+
+fn url_matches(manifest: &LegacyManifest, url: Option<&str>) -> bool {
+    match (manifest.manifest_url.as_deref(), url) {
+        (Some(manifest_url), Some(file_url)) => manifest_url == file_url,
+        _ => false,
+    }
+}
+
+pub(crate) fn classify_legacy_publications(
+    manifests: &[LegacyManifest],
+    files: &[LegacyFile],
+) -> Vec<LegacyPublicationAction> {
+    let mut actions = Vec::new();
+
+    let mut manifests_by_submission: std::collections::HashMap<
+        (&str, &str, &str),
+        Vec<&LegacyManifest>,
+    > = std::collections::HashMap::new();
+    for manifest in manifests {
+        manifests_by_submission
+            .entry((
+                manifest.tenant_id.as_str(),
+                manifest.submitter.as_str(),
+                manifest.submission_id.as_str(),
+            ))
+            .or_default()
+            .push(manifest);
+    }
+
+    let row_reasons: std::collections::HashMap<i64, &'static str> = files
+        .iter()
+        .map(|file| {
+            let exact_matches = file
+                .metadata
+                .manifest_url
+                .as_deref()
+                .map(|file_url| {
+                    manifests_by_submission
+                        .get(&file.submission_key())
+                        .map(|manifests| {
+                            manifests
+                                .iter()
+                                .filter(|manifest| url_matches(manifest, Some(file_url)))
+                                .count()
+                        })
+                        .unwrap_or_default()
+                })
+                .unwrap_or_default();
+            let same_token_matches = file
+                .metadata
+                .manifest_url
+                .as_deref()
+                .map(|file_url| {
+                    manifests_by_submission
+                        .get(&file.submission_key())
+                        .map(|manifests| {
+                            manifests
+                                .iter()
+                                .filter(|manifest| {
+                                    url_matches(manifest, Some(file_url))
+                                        && file.fencing_token == manifest.fencing_token
+                                })
+                                .count()
+                        })
+                        .unwrap_or_default()
+                })
+                .unwrap_or_default();
+            (
+                file.id,
+                base_reason(file, exact_matches, same_token_matches),
+            )
+        })
+        .collect();
+    let mut candidate_rows: std::collections::HashMap<LegacyManifestKey<'_>, Vec<&LegacyFile>> =
+        std::collections::HashMap::new();
+
+    for file in files {
+        let candidates_for_token =
+            |manifest: &LegacyManifest| file.fencing_token == manifest.fencing_token;
+
+        let associations: Vec<&LegacyManifest> = match file.metadata.manifest_url.as_deref() {
+            Some(file_url) => manifests_by_submission
+                .get(&file.submission_key())
+                .map(|manifests| {
+                    manifests
+                        .iter()
+                        .copied()
+                        .filter(|manifest| url_matches(manifest, Some(file_url)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            None => Vec::new(),
+        };
+
+        match associations.as_slice() {
+            [] => {
+                // An explicit URL that matches no manifest is not proof that it
+                // belonged to another manifest; conservatively make it a
+                // possible member of every same-token generation in its
+                // submission. A NULL URL gets the same treatment.
+                for manifest in manifests_by_submission
+                    .get(&file.submission_key())
+                    .map(Vec::as_slice)
+                    .unwrap_or_default()
+                    .iter()
+                    .copied()
+                    .filter(|manifest| candidates_for_token(manifest))
+                {
+                    candidate_rows
+                        .entry(manifest.into())
+                        .or_default()
+                        .push(file);
+                }
+            }
+            [manifest] if candidates_for_token(manifest) => {
+                candidate_rows
+                    .entry((*manifest).into())
+                    .or_default()
+                    .push(file);
+            }
+            _ => {
+                for manifest in associations
+                    .iter()
+                    .copied()
+                    .filter(|manifest| candidates_for_token(manifest))
+                {
+                    candidate_rows
+                        .entry(manifest.into())
+                        .or_default()
+                        .push(file);
+                }
+            }
+        }
+    }
+
+    let mut candidate_ids = std::collections::HashSet::new();
+    for rows in candidate_rows.values() {
+        for row in rows {
+            candidate_ids.insert(row.id);
+        }
+    }
+    for file in files {
+        if !candidate_ids.contains(&file.id) {
+            let reason = row_reasons
+                .get(&file.id)
+                .copied()
+                .expect("base reason for every candidate");
+            actions.push(LegacyPublicationAction::Exclude {
+                id: file.id,
+                reason,
+            });
+        }
+    }
+
+    for manifest in manifests {
+        let rows = candidate_rows
+            .get(&LegacyManifestKey::from(manifest))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let terminal = matches!(manifest.status.as_str(), "completed" | "failed");
+
+        if rows.is_empty() {
+            // Legacy rows have no publication seal. An absent artifact set
+            // cannot establish that an empty publication was committed.
+            continue;
+        }
+
+        let incomplete = rows.iter().any(|row| {
+            let url = row.metadata.manifest_url.as_deref();
+            let exact_matches = manifests_by_submission
+                .get(&row.submission_key())
+                .map(|manifests| {
+                    manifests
+                        .iter()
+                        .filter(|candidate| url_matches(candidate, url))
+                        .count()
+                })
+                .unwrap_or(0);
+            url.is_none() || exact_matches != 1
+        });
+        let invalid = rows.iter().any(|row| !row.has_valid_domain_metadata());
+        if invalid || !terminal {
+            let reason = if invalid {
+                LEGACY_REASON_INVALID_DOMAIN
+            } else {
+                LEGACY_REASON_NONTERMINAL
+            };
+            for row in rows {
+                actions.push(LegacyPublicationAction::Exclude { id: row.id, reason });
+            }
+            continue;
+        }
+
+        let mut grouped: std::collections::HashMap<
+            (String, Option<String>, i64),
+            Vec<&LegacyFile>,
+        > = std::collections::HashMap::new();
+        for row in rows {
+            grouped
+                .entry((
+                    row.metadata.file_type.clone(),
+                    row.metadata.resource_type.clone(),
+                    row.metadata.part_index,
+                ))
+                .or_default()
+                .push(row);
+        }
+
+        let mut conflicting = false;
+        let mut representatives: Vec<&LegacyFile> = Vec::new();
+        let mut exact_duplicates: Vec<&LegacyFile> = Vec::new();
+        for mut group in grouped.into_values() {
+            group.sort_by_key(|row| row.id);
+            if group.len() == 1 {
+                representatives.push(group[0]);
+            } else if group
+                .windows(2)
+                .all(|pair| pair[0].metadata == pair[1].metadata)
+            {
+                representatives.push(group[0]);
+                exact_duplicates.extend(&group[1..]);
+            } else {
+                conflicting = true;
+                break;
+            }
+        }
+
+        if incomplete || conflicting {
+            for row in rows {
+                let reason = if conflicting {
+                    LEGACY_REASON_CONFLICTING_DUPLICATE
+                } else if row_reasons.get(&row.id).copied() == Some(LEGACY_REASON_NONTERMINAL) {
+                    unreachable!("terminal manifest rows cannot be nonterminal");
+                } else if row_reasons.get(&row.id).copied() == Some(LEGACY_REASON_NULL_URL)
+                    || row_reasons.get(&row.id).copied() == Some(LEGACY_REASON_UNMATCHED_URL)
+                    || row_reasons.get(&row.id).copied() == Some(LEGACY_REASON_AMBIGUOUS_URL)
+                {
+                    row_reasons.get(&row.id).copied().expect("base reason")
+                } else {
+                    LEGACY_REASON_INCOMPLETE_GENERATION
+                };
+                actions.push(LegacyPublicationAction::Exclude { id: row.id, reason });
+            }
+            continue;
+        }
+
+        for row in &exact_duplicates {
+            actions.push(LegacyPublicationAction::Exclude {
+                id: row.id,
+                reason: LEGACY_REASON_EXACT_DUPLICATE,
+            });
+        }
+        for row in representatives {
+            actions.push(LegacyPublicationAction::Assign {
+                id: row.id,
+                manifest_id: manifest.manifest_id.clone(),
+            });
+        }
+        actions.push(LegacyPublicationAction::Publish {
+            manifest: manifest.clone(),
+        });
+    }
+
+    actions
+}
+
+fn base_reason(file: &LegacyFile, exact_matches: usize, same_token_matches: usize) -> &'static str {
+    match file.metadata.manifest_url.as_deref() {
+        None => LEGACY_REASON_NULL_URL,
+        Some(_) if exact_matches == 0 => LEGACY_REASON_UNMATCHED_URL,
+        Some(_) if exact_matches > 1 => LEGACY_REASON_AMBIGUOUS_URL,
+        Some(_) if same_token_matches == 1 => LEGACY_REASON_INCOMPLETE_GENERATION,
+        Some(_) => LEGACY_REASON_TOKEN_MISMATCH,
+    }
+}

--- a/crates/persistence/src/core/bulk_submit_output.rs
+++ b/crates/persistence/src/core/bulk_submit_output.rs
@@ -1,0 +1,192 @@
+//! Stable, submit-only artifact locators for output-store keys.
+//!
+//! The locator is a bounded SHA-256 digest of the complete artifact scope. It
+//! is stored in the internal `ExportPartKey::resource_type` field only; the
+//! worker continues to keep the protocol kind and resource type in database
+//! rows. The submission-level `job_id` is unchanged so cleanup remains grouped
+//! by submission.
+
+use sha2::{Digest, Sha256};
+
+use crate::core::bulk_export_output::ExportPartKey;
+use crate::core::bulk_submit::SubmissionId;
+use crate::core::bulk_submit_input::submission_output_job_id;
+use crate::tenant::TenantContext;
+
+const LOCATOR_PREFIX: &str = "submit-v1-";
+const LOCATOR_VERSION: u8 = 1;
+
+/// Builds a stable route locator for one submit artifact.
+///
+/// The tuple includes the tenant, submitter, submission ID, manifest ID,
+/// protocol file type, optional resource type, part index, and fencing token.
+/// JSON makes `None` and an empty resource type distinct while preserving the
+/// order of every identity field.
+pub fn submit_artifact_locator(
+    tenant: &TenantContext,
+    id: &SubmissionId,
+    manifest_id: &str,
+    file_type: &str,
+    resource_type: Option<&str>,
+    part_index: u32,
+    fencing_token: u64,
+) -> String {
+    let payload = serde_json::to_vec(&(
+        LOCATOR_VERSION,
+        tenant.tenant_id().as_str(),
+        id.submitter.as_str(),
+        id.submission_id.as_str(),
+        manifest_id,
+        file_type,
+        resource_type,
+        part_index,
+        fencing_token,
+    ))
+    .expect("canonical submit locator payload must be valid JSON");
+
+    let digest = Sha256::digest(&payload);
+    let mut locator = String::with_capacity(LOCATOR_PREFIX.len() + 64);
+    locator.push_str(LOCATOR_PREFIX);
+    for byte in digest.iter() {
+        locator.push_str(&format!("{byte:02x}"));
+    }
+    locator
+}
+
+/// Builds the internal output-store key for a submit artifact.
+///
+/// The locator binds the complete artifact identity. The key keeps the real
+/// protocol kind and the submission-level job ID, while using the locator as a
+/// bounded internal resource-type component safe for filesystem and S3 scratch
+/// names.
+pub fn submit_artifact_key(
+    tenant: &TenantContext,
+    id: &SubmissionId,
+    manifest_id: &str,
+    file_type: &str,
+    resource_type: Option<&str>,
+    part_index: u32,
+    fencing_token: u64,
+) -> ExportPartKey {
+    let locator = submit_artifact_locator(
+        tenant,
+        id,
+        manifest_id,
+        file_type,
+        resource_type,
+        part_index,
+        fencing_token,
+    );
+
+    ExportPartKey {
+        tenant_id: tenant.tenant_id().as_str().to_owned(),
+        job_id: submission_output_job_id(id),
+        resource_type: locator,
+        file_type: file_type.to_owned(),
+        part_index,
+        fencing_token,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tenant::{TenantId, TenantPermissions};
+
+    fn tenant(value: &str) -> TenantContext {
+        TenantContext::new(TenantId::new(value), TenantPermissions::full_access())
+    }
+
+    #[test]
+    fn every_identity_component_changes_the_locator() {
+        let base_tenant = tenant("tenant-a");
+        let id = SubmissionId::new("submitter-a", "submission-a");
+        let manifest = "manifest-a";
+        let kind = "output";
+        let resource = Some("Patient");
+        let part = 2;
+        let token = 7;
+        let base =
+            submit_artifact_locator(&base_tenant, &id, manifest, kind, resource, part, token);
+        // The v1 encoding is persistent: changing it would change stored keys.
+        assert_eq!(
+            base,
+            "submit-v1-2eb5ff8b2cef4a178ee29a131e69c1fdf258a2ddd05eec7edf5b9590048ad44a"
+        );
+
+        let changed_submitter = SubmissionId::new("submitter-b", "submission-a");
+        let changed_submission = SubmissionId::new("submitter-a", "submission-b");
+        let variants = [
+            submit_artifact_locator(
+                &tenant("tenant-b"),
+                &id,
+                manifest,
+                kind,
+                resource,
+                part,
+                token,
+            ),
+            submit_artifact_locator(
+                &base_tenant,
+                &changed_submitter,
+                manifest,
+                kind,
+                resource,
+                part,
+                token,
+            ),
+            submit_artifact_locator(
+                &base_tenant,
+                &changed_submission,
+                manifest,
+                kind,
+                resource,
+                part,
+                token,
+            ),
+            submit_artifact_locator(&base_tenant, &id, "manifest-b", kind, resource, part, token),
+            submit_artifact_locator(&base_tenant, &id, manifest, "error", resource, part, token),
+            submit_artifact_locator(&base_tenant, &id, manifest, kind, None, part, token),
+            submit_artifact_locator(&base_tenant, &id, manifest, kind, Some(""), part, token),
+            submit_artifact_locator(&base_tenant, &id, manifest, kind, resource, 3, token),
+            submit_artifact_locator(&base_tenant, &id, manifest, kind, resource, part, 8),
+        ];
+
+        let unique: std::collections::HashSet<_> = variants.iter().collect();
+        assert_eq!(
+            unique.len(),
+            variants.len(),
+            "including None versus Some(\"\")"
+        );
+        for variant in variants {
+            assert_ne!(base, variant);
+        }
+    }
+
+    #[test]
+    fn arbitrary_ids_produce_a_bounded_safe_internal_component() {
+        let safe_tenant = tenant("tenant-safe");
+        let long = "s".repeat(4096);
+        let id = SubmissionId::new(&long, "../../unsafe-submission");
+        let manifest = "../../unsafe-manifest";
+        let resource = Some("Patient/../Patient");
+        let locator =
+            submit_artifact_locator(&safe_tenant, &id, manifest, "output", resource, 1, 2);
+
+        assert_eq!(locator.len(), LOCATOR_PREFIX.len() + 64);
+        assert!(locator.starts_with(LOCATOR_PREFIX));
+        assert!(
+            locator[LOCATOR_PREFIX.len()..].bytes().all(|byte| {
+                byte.is_ascii_hexdigit() && matches!(byte, b'0'..=b'9' | b'a'..=b'f')
+            })
+        );
+
+        let key = submit_artifact_key(&safe_tenant, &id, manifest, "output", resource, 1, 2);
+        assert_eq!(key.tenant_id, "tenant-safe");
+        assert_eq!(key.job_id.as_str(), submission_output_job_id(&id).as_str());
+        assert_eq!(key.resource_type, locator);
+        assert_eq!(key.file_type, "output");
+        assert_eq!(key.part_index, 1);
+        assert_eq!(key.fencing_token, 2);
+    }
+}

--- a/crates/persistence/src/core/bulk_submit_publication.rs
+++ b/crates/persistence/src/core/bulk_submit_publication.rs
@@ -1,0 +1,263 @@
+//! Canonical validation for an atomic manifest artifact publication.
+//!
+//! A publication is a complete, self-consistent set of `SubmitFileRecord`
+//! values, not a stream of independent writes. These helpers give every
+//! backend the same view of logical file identity, deterministic order, and
+//! value ranges before rows are made visible.
+
+use crate::core::bulk_submit_worker::SubmitFileRecord;
+use crate::error::{StorageError, StorageResult};
+
+/// Terminal state written together with the complete artifact set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManifestPublicationStatus {
+    /// Publish the artifacts as successful output.
+    Completed,
+    /// Record the manifest as failed while preserving its error artifacts.
+    Failed {
+        /// Terminal message retained with the manifest.
+        error_message: String,
+    },
+}
+
+/// Outcome of publishing a manifest's artifacts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestPublicationResult {
+    /// A previously unpublished manifest/generation was published.
+    Published,
+    /// The publication had already been committed with the same identity.
+    AlreadyPublished,
+}
+
+fn invalid_publication(message: impl Into<String>) -> StorageError {
+    StorageError::Validation(crate::error::ValidationError::InvalidResource {
+        message: message.into(),
+        details: Vec::new(),
+    })
+}
+
+/// Sorts publication records by their logical identity and validates their
+/// storage-representable ranges.
+///
+/// Two records have the same logical identity when they have the same
+/// `file_type`, optional `resource_type`, and `part_index`. `manifest_url` and
+/// the other content fields are intentionally excluded from that identity: a
+/// publication may not silently resolve a disagreement about which generation
+/// owns a file. This function returns cloned, deterministic records so callers
+/// can compare and insert the exact canonical set.
+pub(crate) fn canonical_publication_files(
+    files: &[SubmitFileRecord],
+) -> StorageResult<Vec<SubmitFileRecord>> {
+    let mut seen = std::collections::HashSet::with_capacity(files.len());
+    for file in files {
+        if !matches!(file.file_type.as_str(), "output" | "error" | "deleted") {
+            return Err(invalid_publication(format!(
+                "unsupported publication file type: {:?}",
+                file.file_type
+            )));
+        }
+        if file.file_path.trim().is_empty() {
+            return Err(invalid_publication(
+                "publication file_path must not be empty",
+            ));
+        }
+        if let Some(count_severity) = &file.count_severity {
+            let Some(counts) = count_severity.as_object() else {
+                return Err(invalid_publication(
+                    "publication count_severity must be an object",
+                ));
+            };
+            for value in counts.values() {
+                if value.as_u64().is_none() {
+                    return Err(invalid_publication(
+                        "publication count_severity values must be nonnegative integers",
+                    ));
+                }
+            }
+        }
+        if file.part_index > i32::MAX as u32 {
+            return Err(invalid_publication(format!(
+                "publication part_index exceeds i32::MAX: {}",
+                file.part_index
+            )));
+        }
+        if file.line_count > i64::MAX as u64 {
+            return Err(invalid_publication(
+                "publication line_count exceeds i64::MAX",
+            ));
+        }
+        if file.byte_count > i64::MAX as u64 {
+            return Err(invalid_publication(
+                "publication byte_count exceeds i64::MAX",
+            ));
+        }
+        let identity = (
+            file.file_type.as_str(),
+            file.resource_type.as_deref(),
+            file.part_index,
+        );
+        if !seen.insert(identity) {
+            return Err(invalid_publication(format!(
+                "duplicate publication file identity: type={:?}, resource_type={:?}, part_index={}",
+                file.file_type, file.resource_type, file.part_index
+            )));
+        }
+    }
+
+    let mut sorted = files.to_vec();
+    sorted.sort_by_key(|file| {
+        (
+            file.file_type.clone(),
+            file.resource_type.clone(),
+            file.part_index,
+        )
+    });
+    Ok(sorted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    fn record(
+        file_type: &str,
+        resource_type: Option<&str>,
+        part_index: u32,
+        manifest_url: Option<&str>,
+        count_severity: Option<Value>,
+    ) -> SubmitFileRecord {
+        SubmitFileRecord {
+            manifest_url: manifest_url.map(str::to_string),
+            file_type: file_type.to_string(),
+            resource_type: resource_type.map(str::to_string),
+            part_index,
+            file_path: format!("{file_type}/part-{part_index}"),
+            line_count: 1,
+            byte_count: 1,
+            count_severity,
+        }
+    }
+
+    #[test]
+    fn reordered_records_have_the_same_canonical_order_and_values() {
+        let first = record(
+            "error",
+            Some("OperationOutcome"),
+            0,
+            Some("u"),
+            Some(json!({"a": 1, "b": 2})),
+        );
+        let second = record("output", Some("Patient"), 0, Some("u"), None);
+        let reversed = vec![second.clone(), first.clone()];
+        let expected = vec![first, second];
+
+        assert_eq!(canonical_publication_files(&reversed).unwrap(), expected);
+    }
+
+    #[test]
+    fn none_and_empty_resource_type_are_distinct_identities() {
+        let files = vec![
+            record("output", None, 0, Some("u"), None),
+            record("output", Some(""), 0, Some("u"), None),
+        ];
+
+        let canonical = canonical_publication_files(&files).unwrap();
+        assert_eq!(canonical.len(), 2);
+        assert_eq!(canonical[0].resource_type, None);
+        assert_eq!(canonical[1].resource_type, Some(String::new()));
+    }
+
+    #[test]
+    fn duplicate_logical_identity_is_rejected_even_when_exact() {
+        let file = record("error", Some("OperationOutcome"), 0, Some("u"), None);
+        let identical = vec![file.clone(), file];
+
+        let error = canonical_publication_files(&identical).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate publication file identity")
+        );
+    }
+
+    #[test]
+    fn changed_metadata_and_severity_are_retained_as_inequal() {
+        let unchanged = record(
+            "error",
+            Some("OperationOutcome"),
+            0,
+            Some("u"),
+            Some(json!({"error": 1})),
+        );
+        let mut changed = unchanged.clone();
+        changed.manifest_url = Some("u-2".to_string());
+        changed.count_severity = Some(json!({"error": 2}));
+
+        assert_ne!(unchanged, changed);
+        let canonical = canonical_publication_files(std::slice::from_ref(&changed)).unwrap();
+        assert_eq!(canonical[0].manifest_url, Some("u-2".to_string()));
+        assert_eq!(canonical[0].count_severity, Some(json!({"error": 2})));
+    }
+
+    #[test]
+    fn invalid_kind_path_and_severity_are_rejected() {
+        let bad_kind = record("failure", Some("Patient"), 0, Some("u"), None);
+        assert!(
+            canonical_publication_files(&[bad_kind])
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported publication file type")
+        );
+
+        let mut empty_path = record("output", Some("Patient"), 0, Some("u"), None);
+        empty_path.file_path = "   ".to_string();
+        assert!(
+            canonical_publication_files(&[empty_path])
+                .unwrap_err()
+                .to_string()
+                .contains("file_path must not be empty")
+        );
+
+        for severity in [
+            json!("error"),
+            json!({"error": -1}),
+            json!({"error": 1.5}),
+            json!({"error": null}),
+        ] {
+            let bad_severity = record(
+                "error",
+                Some("OperationOutcome"),
+                0,
+                Some("u"),
+                Some(severity),
+            );
+            assert!(
+                canonical_publication_files(&[bad_severity])
+                    .unwrap_err()
+                    .to_string()
+                    .contains("count_severity")
+            );
+        }
+    }
+
+    #[test]
+    fn values_that_do_not_fit_signed_sql_columns_are_rejected() {
+        let mut too_many_lines = record("output", Some("Patient"), 0, Some("u"), None);
+        too_many_lines.line_count = (i64::MAX as u64) + 1;
+        assert!(canonical_publication_files(&[too_many_lines]).is_err());
+
+        let mut too_many_bytes = record("output", Some("Patient"), 0, Some("u"), None);
+        too_many_bytes.byte_count = (i64::MAX as u64) + 1;
+        assert!(canonical_publication_files(&[too_many_bytes]).is_err());
+
+        let too_large_index = record(
+            "output",
+            Some("Patient"),
+            (i32::MAX as u32) + 1,
+            Some("u"),
+            None,
+        );
+        assert!(canonical_publication_files(&[too_large_index]).is_err());
+    }
+}

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -27,9 +27,13 @@ use crate::core::bulk_submit::{
     ByteProgress, EntryResultPage, ImportMode, ManifestPhase, StreamingBulkSubmitProvider,
     SubmissionId, entry_result_pages,
 };
-use crate::core::bulk_submit_input::{SubmitInputFetcher, submission_output_job_id};
+use crate::core::bulk_submit_input::{RemoteFile, SubmitInputFetcher};
+use crate::core::bulk_submit_output::submit_artifact_key;
+use crate::core::bulk_submit_publication::{ManifestPublicationResult, ManifestPublicationStatus};
 use crate::error::{StorageError, StorageResult};
 use crate::tenant::TenantContext;
+
+const MANIFEST_FETCH_ERROR_PART_INDEX: u32 = 1;
 
 /// A lease over a single pending manifest, held by exactly one worker at a time.
 ///
@@ -129,7 +133,7 @@ pub struct ManifestFetchParams<'a> {
 }
 
 /// A finalized status-manifest artifact (output / error / deleted NDJSON part) to record.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubmitFileRecord {
     /// The submitted manifest this artifact relates to (for `output[].manifestUrl`).
     pub manifest_url: Option<String>,
@@ -137,7 +141,8 @@ pub struct SubmitFileRecord {
     pub file_type: String,
     /// FHIR resource type (for `output` entries).
     pub resource_type: Option<String>,
-    /// 0-based part index within (submission, file_type, resource_type).
+    /// 0-based part index within one manifest generation, file type, and
+    /// optional resource type.
     pub part_index: u32,
     /// Encoded storage key / path in the output store.
     pub file_path: String,
@@ -162,6 +167,16 @@ pub struct SubmitFileRow {
     pub part_index: u32,
     /// Fencing token of the worker that wrote it.
     pub fencing_token: u64,
+    /// Exact owning manifest when the persisted row is manifest-aware.
+    ///
+    /// Non-SQL rows that predate manifest-aware identities decode as `None`.
+    /// SQL migration may backfill `Some` for a legacy row.
+    pub manifest_id: Option<String>,
+    /// True when the row uses the legacy pre-manifest identity/location.
+    ///
+    /// SQL backends identify migrated legacy rows by their absent publication
+    /// worker; non-SQL backends identify them by an absent manifest ID.
+    pub legacy_locator: bool,
     /// Encoded storage key / path in the output store.
     pub file_path: String,
     /// Number of NDJSON lines in the artifact.
@@ -272,11 +287,32 @@ pub trait SubmitWorkerStorage: Send + Sync {
     ) -> Result<(), LeaseError>;
 
     /// Idempotent upsert of a finalized status-manifest artifact row. Fenced.
+    ///
+    /// SQL adapters stage the row and keep it hidden until publication; the
+    /// `finish`/`fail` publication transaction makes the full generation visible.
     async fn record_submit_file(
         &self,
         lease: &ManifestLease,
         file: &SubmitFileRecord,
     ) -> Result<(), LeaseError>;
+
+    /// Publishes the complete artifact set with the manifest's terminal state.
+    ///
+    /// SQL adapters perform canonical validation, full-set replacement, and the
+    /// fenced terminal-state update in one transaction. A same-token replay must
+    /// return [`ManifestPublicationResult::AlreadyPublished`] only when the exact
+    /// artifact set and terminal state match; a stale lease is `LeaseLost`.
+    ///
+    /// MongoDB and S3 retain the existing fenced, non-atomic sequencing: validate
+    /// the canonical set, record each artifact in turn, then write the terminal
+    /// state. Those adapters do not provide atomic full-set publication or
+    /// same-token replay markers.
+    async fn publish_manifest_artifacts(
+        &self,
+        lease: &ManifestLease,
+        files: &[SubmitFileRecord],
+        terminal: ManifestPublicationStatus,
+    ) -> Result<ManifestPublicationResult, LeaseError>;
 
     /// Marks the manifest `completed`. Fenced.
     async fn finish_manifest(&self, lease: &ManifestLease) -> Result<(), LeaseError>;
@@ -720,13 +756,28 @@ where
             Err(LeaseError::LeaseLost { .. }) => return Ok(()),
             Err(LeaseError::Storage(e)) => return Err(e),
         };
-        if let Err(LeaseError::Storage(e)) = self.jobs.mark_manifest_processing(&lease).await {
-            return Err(e);
+        match self.jobs.mark_manifest_processing(&lease).await {
+            Ok(()) => {}
+            Err(LeaseError::LeaseLost { .. }) => return Ok(()),
+            Err(LeaseError::Storage(e)) => return Err(e),
         }
 
         let Some(manifest_url) = view.manifest_url.clone() else {
-            // Nothing to fetch (status-only submission) — treat as done.
-            let _ = self.jobs.finish_manifest(&lease).await;
+            // Nothing to fetch (status-only submission). Publish its empty
+            // terminal generation with the live lease.
+            let keeper = LeaseKeeper::spawn(
+                Arc::new(JobStoreRenewal(Arc::clone(&self.jobs))),
+                lease.clone(),
+                ByteProgress::default(),
+            );
+            let _ = self
+                .publish_collected_artifacts(
+                    &lease,
+                    keeper,
+                    Vec::new(),
+                    ManifestPublicationStatus::Completed,
+                )
+                .await?;
             return Ok(());
         };
 
@@ -762,16 +813,25 @@ where
         {
             Ok(m) => m,
             Err(e) => {
-                self.record_manifest_error(
-                    &lease,
-                    &manifest_url,
-                    &format!("failed to fetch manifest: {e}"),
-                )
-                .await?;
-                // Stop renewing before the manifest goes terminal, so no
-                // heartbeat lands on a row this task has already failed.
-                drop(keeper);
-                let _ = self.jobs.fail_manifest(&lease, &e.to_string()).await;
+                let failure_message = e.to_string();
+                let fetch_error = self
+                    .write_manifest_error(
+                        &lease,
+                        &manifest_url,
+                        MANIFEST_FETCH_ERROR_PART_INDEX,
+                        &format!("failed to fetch manifest: {failure_message}"),
+                    )
+                    .await?;
+                let _ = self
+                    .publish_collected_artifacts(
+                        &lease,
+                        keeper,
+                        vec![fetch_error],
+                        ManifestPublicationStatus::Failed {
+                            error_message: failure_message,
+                        },
+                    )
+                    .await?;
                 return Ok(());
             }
         };
@@ -793,6 +853,27 @@ where
             .with_defer_indexing(self.defer_indexing)
             .with_byte_progress(progress.clone());
         let file_count = manifest.output.len() as u64;
+        // Reserve 0 for the aggregated entry-error artifact and 1 for the
+        // manifest-fetch failure. Per-file output/deleted indexes follow their
+        // input ordinal so concurrent completion order cannot renumber them.
+        let output_len = u64::try_from(manifest.output.len()).ok();
+        let deleted_len = u64::try_from(manifest.deleted.len()).ok();
+        let artifact_count = output_len
+            .and_then(|output| deleted_len.and_then(|deleted| output.checked_add(deleted)))
+            .and_then(|files| files.checked_add(u64::from(MANIFEST_FETCH_ERROR_PART_INDEX + 1)));
+        match artifact_count {
+            Some(count) if count <= i32::MAX as u64 => {}
+            Some(count) => {
+                return Err(internal_error(format!(
+                    "bulk submit manifest has too many artifacts: {count}"
+                )));
+            }
+            None => {
+                return Err(internal_error(
+                    "bulk submit manifest has too many artifacts".to_string(),
+                ));
+            }
+        }
         // Pre-size the byte denominator: every output file's advertised size
         // up front, so the percentage never recomputes against a partial
         // total — learned lazily per file, each newly opened file yanked the
@@ -888,6 +969,10 @@ where
         // manifest's persisted counters are cumulative across runs and belong
         // to the ingestion engine's per-batch bookkeeping (#969).
         let failed_at = AtomicU64::new(0);
+        // File-level fetch/ingest failures write their own finalized artifacts.
+        // No staged row exists; all finalized records are collected and handed
+        // to one publication call after the whole run.
+        let error_records = Arc::new(tokio::sync::Mutex::new(Vec::<SubmitFileRecord>::new()));
         // Shared borrows for the concurrent per-file futures. Iterating by
         // index keeps the map closure's argument owned (a `usize`), so the
         // future it returns can borrow `manifest.output[i]` for the manifest's
@@ -902,6 +987,7 @@ where
         let lease_ref = &lease;
         let manifest_ref = &manifest;
         let manifest_url_ref = &manifest_url;
+        let error_records_ref = &error_records;
 
         let mut ingest = futures::stream::iter(0..manifest.output.len())
             .map(|i| async move {
@@ -932,12 +1018,15 @@ where
                 {
                     Ok(s) => s,
                     Err(e) => {
-                        self.record_manifest_error(
-                            lease_ref,
-                            manifest_url_ref,
-                            &format!("failed to fetch file {}: {e}", file.url),
-                        )
-                        .await?;
+                        let file_error = self
+                            .write_manifest_error(
+                                lease_ref,
+                                manifest_url_ref,
+                                i as u32 + 2,
+                                &format!("failed to fetch file {}: {e}", file.url),
+                            )
+                            .await?;
+                        error_records_ref.lock().await.push(file_error);
                         failed_ref.fetch_add(1, Ordering::Relaxed);
                         // No batch ran for a file that never opened, so this
                         // failure is the worker's to add.
@@ -1002,12 +1091,15 @@ where
                         }
                     }
                     Err(e) => {
-                        self.record_manifest_error(
-                            lease_ref,
-                            manifest_url_ref,
-                            &format!("failed to ingest file {}: {e}", file.url),
-                        )
-                        .await?;
+                        let file_error = self
+                            .write_manifest_error(
+                                lease_ref,
+                                manifest_url_ref,
+                                i as u32 + 2,
+                                &format!("failed to ingest file {}: {e}", file.url),
+                            )
+                            .await?;
+                        error_records_ref.lock().await.push(file_error);
                         failed_ref.fetch_add(1, Ordering::Relaxed);
                         // Every entry this file did commit was already counted
                         // by its own batch; the file-level failure was not.
@@ -1062,9 +1154,13 @@ where
         }
         let failed = failed_at.load(Ordering::Relaxed);
 
-        // 2b. Process `deleted` files — transaction Bundles / resource refs to remove.
-        let mut deleted_refs: Vec<String> = Vec::new();
-        for file in &manifest.deleted {
+        // 2b. Process `deleted` files — transaction Bundles / resource refs to
+        // remove. Successful deletions across every deleted file share one
+        // part-0 receipt; a deleted-file fetch failure gets a source-ordinal
+        // error artifact and does not abort the remaining files.
+        let mut records = error_records.lock().await.clone();
+        let mut deleted_refs = Vec::new();
+        for (input_index, file) in manifest.deleted.iter().enumerate() {
             if keeper.lease_lost() {
                 return Ok(());
             }
@@ -1084,62 +1180,51 @@ where
                         .await;
                 }
                 Err(e) => {
-                    self.record_manifest_error(
-                        &lease,
-                        &manifest_url,
-                        &format!("failed to fetch deleted file {}: {e}", file.url),
-                    )
-                    .await?;
+                    let deleted_error = self
+                        .write_manifest_error(
+                            &lease,
+                            &manifest_url,
+                            manifest.output.len() as u32 + input_index as u32 + 2,
+                            &format!("failed to fetch deleted file {}: {e}", file.url),
+                        )
+                        .await?;
+                    records.push(deleted_error);
                 }
             }
         }
         if !deleted_refs.is_empty() {
-            self.write_deleted_artifact(&lease, &manifest_url, &deleted_refs)
+            let deleted_record = self
+                .write_deleted_artifact(&lease, &manifest_url, &deleted_refs)
                 .await?;
+            records.push(deleted_record);
         }
 
         // 3. Emit per-type `output` receipts and an aggregated `error` artifact.
         if keeper.lease_lost() {
             return Ok(());
         }
-        self.write_result_artifacts(&lease, &manifest_url, view.fhir_version, failed)
-            .await?;
+        records.extend(
+            self.write_result_artifacts(&lease, &manifest_url, view.fhir_version, failed)
+                .await?,
+        );
 
-        // 4. Mark the manifest complete.
-        if let Err(LeaseError::Storage(e)) = self.jobs.finish_manifest(&lease).await {
-            return Err(e);
-        }
+        // 4. Publish all finalized artifacts and the terminal state together
+        // where the storage engine supports it.
+        let published = self
+            .publish_collected_artifacts(
+                &lease,
+                keeper,
+                records,
+                ManifestPublicationStatus::Completed,
+            )
+            .await?;
 
         // 5. Fast-load (#903): the manifest ingested without search indexing —
         // rebuild the indexes for its resource types now. Fire-and-forget:
         // the manifest is already terminal, and the hook drives the same
         // machinery $reindex does.
-        if self.defer_indexing {
-            let mut types: Vec<String> = manifest
-                .output
-                .iter()
-                .filter_map(|f| f.resource_type.clone())
-                .collect();
-            types.sort();
-            types.dedup();
-            match (&self.reindex_hook, types.is_empty()) {
-                (Some(hook), false) => {
-                    tracing::info!(
-                        submission = %lease.submission_id,
-                        manifest = %lease.manifest_id,
-                        types = ?types,
-                        "bulk fast-load: rebuilding deferred search indexes"
-                    );
-                    hook.reindex_types(&lease.tenant, types).await;
-                }
-                _ => {
-                    tracing::warn!(
-                        submission = %lease.submission_id,
-                        manifest = %lease.manifest_id,
-                        "bulk fast-load ingested without indexing and no reindex \n                         hook is wired — run $reindex to make the data searchable"
-                    );
-                }
-            }
+        if published {
+            self.reindex_deferred(&lease, &manifest.output).await;
         }
         Ok(())
     }
@@ -1152,7 +1237,7 @@ where
         manifest_url: &str,
         _fhir_version: FhirVersion,
         failed_count: u64,
-    ) -> StorageResult<()> {
+    ) -> StorageResult<Vec<SubmitFileRecord>> {
         let pages = entry_result_pages(|continuation| async move {
             self.jobs
                 .get_entry_results_page(
@@ -1175,10 +1260,8 @@ where
         manifest_url: &str,
         failed_count: u64,
         pages: impl futures::Stream<Item = StorageResult<EntryResultPage>>,
-    ) -> StorageResult<()> {
+    ) -> StorageResult<Vec<SubmitFileRecord>> {
         use futures::TryStreamExt;
-        let job_id = submission_output_job_id(&lease.submission_id);
-        let tenant_id = lease.tenant.tenant_id().as_str().to_string();
         let mut all = Vec::new();
         futures::pin_mut!(pages);
         while let Some(page) = pages.try_next().await? {
@@ -1238,40 +1321,40 @@ where
             error_lines.push(oo.to_string());
         }
 
+        let mut records = Vec::new();
+
         // Write one `output` part per resource type.
         for (idx, (resource_type, lines)) in by_type.iter().enumerate() {
-            let key = ExportPartKey::output(
-                tenant_id.clone(),
-                job_id.clone(),
-                resource_type.clone(),
+            let key = submit_artifact_key(
+                &lease.tenant,
+                &lease.submission_id,
+                &lease.manifest_id,
+                "output",
+                Some(resource_type.as_str()),
                 idx as u32,
                 lease.fencing_token,
             );
             let part = self.write_part(&key, lines).await?;
-            self.jobs
-                .record_submit_file(
-                    lease,
-                    &SubmitFileRecord {
-                        manifest_url: Some(manifest_url.to_string()),
-                        file_type: "output".to_string(),
-                        resource_type: Some(resource_type.clone()),
-                        part_index: idx as u32,
-                        file_path: key.part_segment(),
-                        line_count: part.0,
-                        byte_count: part.1,
-                        count_severity: None,
-                    },
-                )
-                .await
-                .map_err(lease_err_to_storage)?;
+            records.push(SubmitFileRecord {
+                manifest_url: Some(manifest_url.to_string()),
+                file_type: "output".to_string(),
+                resource_type: Some(resource_type.clone()),
+                part_index: idx as u32,
+                file_path: key.resource_type,
+                line_count: part.0,
+                byte_count: part.1,
+                count_severity: None,
+            });
         }
 
         // Write a single aggregated `error` part (if any).
         if !error_lines.is_empty() {
-            let key = ExportPartKey::error(
-                tenant_id.clone(),
-                job_id.clone(),
-                "OperationOutcome",
+            let key = submit_artifact_key(
+                &lease.tenant,
+                &lease.submission_id,
+                &lease.manifest_id,
+                "error",
+                Some("OperationOutcome"),
                 0,
                 lease.fencing_token,
             );
@@ -1282,24 +1365,18 @@ where
                     .map(|(k, v)| (k, Value::from(v)))
                     .collect(),
             );
-            self.jobs
-                .record_submit_file(
-                    lease,
-                    &SubmitFileRecord {
-                        manifest_url: Some(manifest_url.to_string()),
-                        file_type: "error".to_string(),
-                        resource_type: Some("OperationOutcome".to_string()),
-                        part_index: 0,
-                        file_path: key.part_segment(),
-                        line_count: part.0,
-                        byte_count: part.1,
-                        count_severity: Some(count_severity),
-                    },
-                )
-                .await
-                .map_err(lease_err_to_storage)?;
+            records.push(SubmitFileRecord {
+                manifest_url: Some(manifest_url.to_string()),
+                file_type: "error".to_string(),
+                resource_type: Some("OperationOutcome".to_string()),
+                part_index: 0,
+                file_path: key.resource_type,
+                line_count: part.0,
+                byte_count: part.1,
+                count_severity: Some(count_severity),
+            });
         }
-        Ok(())
+        Ok(records)
     }
 
     /// Applies deletions from a `deleted` NDJSON stream (transaction Bundles or
@@ -1353,39 +1430,31 @@ where
         lease: &ManifestLease,
         manifest_url: &str,
         refs: &[String],
-    ) -> StorageResult<()> {
-        let job_id = submission_output_job_id(&lease.submission_id);
-        let tenant_id = lease.tenant.tenant_id().as_str().to_string();
+    ) -> StorageResult<SubmitFileRecord> {
         let lines: Vec<String> = refs
             .iter()
             .map(|r| json!({ "reference": r }).to_string())
             .collect();
-        let key = ExportPartKey {
-            tenant_id,
-            job_id,
-            resource_type: "Bundle".to_string(),
-            file_type: "deleted".to_string(),
-            part_index: 0,
-            fencing_token: lease.fencing_token,
-        };
+        let key = submit_artifact_key(
+            &lease.tenant,
+            &lease.submission_id,
+            &lease.manifest_id,
+            "deleted",
+            Some("Bundle"),
+            0,
+            lease.fencing_token,
+        );
         let (line_count, byte_count) = self.write_part(&key, &lines).await?;
-        self.jobs
-            .record_submit_file(
-                lease,
-                &SubmitFileRecord {
-                    manifest_url: Some(manifest_url.to_string()),
-                    file_type: "deleted".to_string(),
-                    resource_type: Some("Bundle".to_string()),
-                    part_index: 0,
-                    file_path: key.part_segment(),
-                    line_count,
-                    byte_count,
-                    count_severity: None,
-                },
-            )
-            .await
-            .map_err(lease_err_to_storage)?;
-        Ok(())
+        Ok(SubmitFileRecord {
+            manifest_url: Some(manifest_url.to_string()),
+            file_type: "deleted".to_string(),
+            resource_type: Some("Bundle".to_string()),
+            part_index: 0,
+            file_path: key.resource_type,
+            line_count,
+            byte_count,
+            count_severity: None,
+        })
     }
 
     /// Publishes the coarse pre-ingest phase for the status endpoint (#953).
@@ -1418,15 +1487,14 @@ where
         }
     }
 
-    /// Records a single manifest-level `error` OperationOutcome artifact.
-    async fn record_manifest_error(
+    /// Writes a single manifest-level `error` OperationOutcome artifact.
+    async fn write_manifest_error(
         &self,
         lease: &ManifestLease,
         manifest_url: &str,
+        part_index: u32,
         message: &str,
-    ) -> StorageResult<()> {
-        let job_id = submission_output_job_id(&lease.submission_id);
-        let tenant_id = lease.tenant.tenant_id().as_str().to_string();
+    ) -> StorageResult<SubmitFileRecord> {
         let oo = json!({
             "resourceType": "OperationOutcome",
             "issue": [{
@@ -1436,33 +1504,26 @@ where
             }]
         })
         .to_string();
-        // Use a high part index space for manifest-level errors to avoid clashing
-        // with per-result error parts (which use index 0).
-        let key = ExportPartKey::error(
-            tenant_id,
-            job_id,
-            "OperationOutcome",
-            1_000_000 + (manifest_url.len() as u32 % 1000),
+        let key = submit_artifact_key(
+            &lease.tenant,
+            &lease.submission_id,
+            &lease.manifest_id,
+            "error",
+            Some("OperationOutcome"),
+            part_index,
             lease.fencing_token,
         );
         let part = self.write_part(&key, std::slice::from_ref(&oo)).await?;
-        self.jobs
-            .record_submit_file(
-                lease,
-                &SubmitFileRecord {
-                    manifest_url: Some(manifest_url.to_string()),
-                    file_type: "error".to_string(),
-                    resource_type: Some("OperationOutcome".to_string()),
-                    part_index: key.part_index,
-                    file_path: key.part_segment(),
-                    line_count: part.0,
-                    byte_count: part.1,
-                    count_severity: Some(json!({"error": 1})),
-                },
-            )
-            .await
-            .map_err(lease_err_to_storage)?;
-        Ok(())
+        Ok(SubmitFileRecord {
+            manifest_url: Some(manifest_url.to_string()),
+            file_type: "error".to_string(),
+            resource_type: Some("OperationOutcome".to_string()),
+            part_index,
+            file_path: key.resource_type,
+            line_count: part.0,
+            byte_count: part.1,
+            count_severity: Some(json!({"error": 1})),
+        })
     }
 
     /// Writes NDJSON `lines` to a new output-store part, returning `(line_count, byte_count)`.
@@ -1480,18 +1541,62 @@ where
         let finalized = self.output.finalize_part(key, writer).await?;
         Ok((finalized.line_count, finalized.size_bytes))
     }
-}
 
-/// Converts a fenced [`LeaseError`] into a plain storage error for non-fatal paths.
-fn lease_err_to_storage(e: LeaseError) -> crate::error::StorageError {
-    match e {
-        LeaseError::Storage(s) => s,
-        LeaseError::LeaseLost { job_id } => {
-            crate::error::StorageError::Backend(crate::error::BackendError::Internal {
-                backend_name: "bulk-submit".to_string(),
-                message: format!("lease lost for {job_id}"),
-                source: None,
-            })
+    /// Publishes all collected finalized artifacts with the live lease.
+    ///
+    /// The keeper owns the heartbeat until publication has returned, then is
+    /// dropped before any deferred indexing. A publication already committed
+    /// by this same generation is quiet and does not trigger reindexing.
+    async fn publish_collected_artifacts(
+        &self,
+        lease: &ManifestLease,
+        keeper: LeaseKeeper,
+        files: Vec<SubmitFileRecord>,
+        terminal: ManifestPublicationStatus,
+    ) -> StorageResult<bool> {
+        let outcome = self
+            .jobs
+            .publish_manifest_artifacts(lease, &files, terminal)
+            .await;
+        drop(keeper);
+        match outcome {
+            Ok(ManifestPublicationResult::Published) => Ok(true),
+            Ok(ManifestPublicationResult::AlreadyPublished) => Ok(false),
+            Err(LeaseError::Storage(e)) => Err(e),
+            Err(LeaseError::LeaseLost { .. }) => Ok(false),
+        }
+    }
+
+    /// Rebuilds search indexes for the manifest's resource types after
+    /// deferred ingestion. Fire-and-forget: only publication storage errors
+    /// may affect the run.
+    async fn reindex_deferred(&self, lease: &ManifestLease, output_files: &[RemoteFile]) {
+        if !self.defer_indexing {
+            return;
+        }
+        let mut types: Vec<String> = output_files
+            .iter()
+            .filter_map(|file| file.resource_type.clone())
+            .collect();
+        types.sort();
+        types.dedup();
+        match (&self.reindex_hook, types.is_empty()) {
+            (Some(hook), false) => {
+                tracing::info!(
+                    submission = %lease.submission_id,
+                    manifest = %lease.manifest_id,
+                    types = ?types,
+                    "bulk fast-load: rebuilding deferred search indexes"
+                );
+                hook.reindex_types(&lease.tenant, types).await;
+            }
+            _ => {
+                tracing::warn!(
+                    submission = %lease.submission_id,
+                    manifest = %lease.manifest_id,
+                    "bulk fast-load ingested without indexing and no reindex hook is wired — run $reindex to make the data searchable"
+                );
+            }
         }
     }
 }
@@ -1509,6 +1614,14 @@ fn fenced_write_outcome(keeper: &LeaseKeeper, e: LeaseError) -> StorageResult<()
             Ok(())
         }
     }
+}
+
+fn internal_error(message: impl Into<String>) -> StorageError {
+    StorageError::Backend(crate::error::BackendError::Internal {
+        backend_name: "bulk-submit".to_string(),
+        message: message.into(),
+        source: None,
+    })
 }
 
 /// Builds a fallback OperationOutcome when an entry result lacks one.
@@ -1546,10 +1659,12 @@ mod tests {
     use super::*;
     use crate::backends::local_fs::LocalFsOutputStore;
     use crate::backends::sqlite::SqliteBackend;
+    use crate::core::ManifestStatus;
     use crate::core::bulk_submit::BulkSubmitProvider;
-    use crate::core::bulk_submit_input::{RemoteFile, RemoteManifest};
+    use crate::core::bulk_submit_input::{RemoteFile, RemoteManifest, submission_output_job_id};
     use crate::core::storage::ResourceStorage;
     use crate::tenant::{TenantContext, TenantId, TenantPermissions};
+    use rusqlite::params;
     use std::time::Duration as StdDuration;
 
     mod scripted_pages {
@@ -1591,11 +1706,20 @@ mod tests {
             WorkerId::new("scripted"),
         );
         let (pages, calls) = scripted_pages::pages();
-        worker
+        let records = worker
             .write_result_artifact_pages(&lease, "http://provider/m.json", 0, pages)
             .await
             .unwrap();
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 3);
+        assert_eq!(records.len(), 1);
+        backend
+            .publish_manifest_artifacts(
+                &lease,
+                &records,
+                crate::core::bulk_submit_publication::ManifestPublicationStatus::Completed,
+            )
+            .await
+            .unwrap();
         let rows = backend.list_submit_files(&tenant, &sub).await.unwrap();
         assert_eq!(rows.len(), 1);
         let row = &rows[0];
@@ -1603,7 +1727,7 @@ mod tests {
         let key = ExportPartKey {
             tenant_id: tenant.tenant_id().as_str().to_string(),
             job_id: submission_output_job_id(&sub),
-            resource_type: row.resource_type.clone().unwrap(),
+            resource_type: row.file_path.clone(),
             file_type: row.file_type.clone(),
             part_index: row.part_index,
             fencing_token: row.fencing_token,
@@ -1681,6 +1805,171 @@ mod tests {
             _oauth: &[String],
         ) -> StorageResult<Option<u64>> {
             Ok(self.files.get(url).map(|d| d.len() as u64))
+        }
+    }
+
+    /// The archived baseline wrapper, narrowed to the second-finalize fault.
+    struct FailSecondFinalize {
+        inner: Arc<LocalFsOutputStore>,
+        finalized: std::sync::atomic::AtomicU32,
+    }
+
+    #[async_trait]
+    impl ExportOutputStore for FailSecondFinalize {
+        async fn open_writer(
+            &self,
+            key: &ExportPartKey,
+        ) -> StorageResult<crate::core::bulk_export_output::ExportPartWriter> {
+            self.inner.open_writer(key).await
+        }
+
+        async fn finalize_part(
+            &self,
+            key: &ExportPartKey,
+            writer: crate::core::bulk_export_output::ExportPartWriter,
+        ) -> StorageResult<crate::core::bulk_export_output::FinalizedPart> {
+            let ordinal = self
+                .finalized
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if ordinal == 1 {
+                return Err(StorageError::Backend(
+                    crate::error::BackendError::Internal {
+                        backend_name: "bulk-submit-worker-test".to_string(),
+                        message: "second finalize forced failure".to_string(),
+                        source: None,
+                    },
+                ));
+            }
+            self.inner.finalize_part(key, writer).await
+        }
+
+        async fn download_url(
+            &self,
+            key: &ExportPartKey,
+            ttl: Duration,
+        ) -> StorageResult<crate::core::bulk_export_output::DownloadUrl> {
+            self.inner.download_url(key, ttl).await
+        }
+
+        async fn open_reader(
+            &self,
+            key: &ExportPartKey,
+        ) -> StorageResult<std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send>>> {
+            self.inner.open_reader(key).await
+        }
+
+        async fn delete_job_outputs(
+            &self,
+            tenant: &TenantContext,
+            job_id: &crate::core::ExportJobId,
+        ) -> StorageResult<()> {
+            self.inner.delete_job_outputs(tenant, job_id).await
+        }
+    }
+
+    /// Deliberately fails a compact set of input URLs while the manifest still
+    /// fetches normally, so source-ordinal error receipts can be checked.
+    struct SelectiveFailureFetcher {
+        inner: MockFetcher,
+        failing_urls: std::collections::BTreeSet<String>,
+    }
+
+    #[async_trait]
+    impl SubmitInputFetcher for SelectiveFailureFetcher {
+        async fn fetch_manifest(
+            &self,
+            url: &str,
+            headers: &[(String, String)],
+            oauth: &[String],
+            encryption_key: Option<&Value>,
+        ) -> StorageResult<RemoteManifest> {
+            self.inner
+                .fetch_manifest(url, headers, oauth, encryption_key)
+                .await
+        }
+
+        async fn open_file_stream(
+            &self,
+            url: &str,
+            headers: &[(String, String)],
+            requires_access_token: bool,
+            oauth: &[String],
+            encryption_key: Option<&Value>,
+        ) -> StorageResult<(Box<dyn tokio::io::AsyncBufRead + Send + Unpin>, Option<u64>)> {
+            if self.failing_urls.contains(url) {
+                return Err(StorageError::Backend(
+                    crate::error::BackendError::Internal {
+                        backend_name: "bulk-submit-worker-test".to_string(),
+                        message: "unavailable input".to_string(),
+                        source: None,
+                    },
+                ));
+            }
+            self.inner
+                .open_file_stream(url, headers, requires_access_token, oauth, encryption_key)
+                .await
+        }
+
+        async fn file_size(
+            &self,
+            url: &str,
+            headers: &[(String, String)],
+            requires_access_token: bool,
+            oauth: &[String],
+        ) -> StorageResult<Option<u64>> {
+            self.inner
+                .file_size(url, headers, requires_access_token, oauth)
+                .await
+        }
+    }
+
+    /// Slows only artifact finalization, exercising the worker's live keeper.
+    struct SlowFinalize {
+        inner: Arc<LocalFsOutputStore>,
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl ExportOutputStore for SlowFinalize {
+        async fn open_writer(
+            &self,
+            key: &ExportPartKey,
+        ) -> StorageResult<crate::core::bulk_export_output::ExportPartWriter> {
+            self.inner.open_writer(key).await
+        }
+
+        async fn finalize_part(
+            &self,
+            key: &ExportPartKey,
+            writer: crate::core::bulk_export_output::ExportPartWriter,
+        ) -> StorageResult<crate::core::bulk_export_output::FinalizedPart> {
+            self.entered.notify_one();
+            self.release.notified().await;
+            self.inner.finalize_part(key, writer).await
+        }
+
+        async fn download_url(
+            &self,
+            key: &ExportPartKey,
+            ttl: Duration,
+        ) -> StorageResult<crate::core::bulk_export_output::DownloadUrl> {
+            self.inner.download_url(key, ttl).await
+        }
+
+        async fn open_reader(
+            &self,
+            key: &ExportPartKey,
+        ) -> StorageResult<std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send>>> {
+            self.inner.open_reader(key).await
+        }
+
+        async fn delete_job_outputs(
+            &self,
+            tenant: &TenantContext,
+            job_id: &crate::core::ExportJobId,
+        ) -> StorageResult<()> {
+            self.inner.delete_job_outputs(tenant, job_id).await
         }
     }
 
@@ -2730,6 +3019,647 @@ mod tests {
             "the re-walked entry must add to the earlier run's total, not replace it"
         );
         assert_eq!(manifests[0].failed_entries, 7);
+    }
+
+    #[tokio::test]
+    async fn concurrent_file_errors_use_deterministic_source_indexes() {
+        use tokio::io::AsyncReadExt;
+
+        let backend = Arc::new(SqliteBackend::in_memory().unwrap());
+        backend.init_schema().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let tenant = tenant();
+        let sub_id = SubmissionId::generate("concurrent-errors");
+        backend
+            .create_submission(&tenant, &sub_id, None)
+            .await
+            .unwrap();
+        let _manifest = backend
+            .add_manifest(
+                &tenant,
+                &sub_id,
+                Some("http://provider/concurrent-errors.json"),
+                None,
+            )
+            .await
+            .unwrap();
+        let lease = backend
+            .claim_next_manifest(
+                &WorkerId::new("concurrent-errors-worker"),
+                StdDuration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let mut failing_urls = std::collections::BTreeSet::new();
+        let mut output_files = Vec::new();
+        for index in 0..3 {
+            let url = format!("http://provider/fail-{index}.ndjson");
+            output_files.push(RemoteFile {
+                resource_type: Some("Patient".to_string()),
+                url: url.clone(),
+                count: Some(1),
+            });
+            failing_urls.insert(url);
+        }
+        let deleted_url = "http://provider/deleted.ndjson".to_string();
+        failing_urls.insert(deleted_url.clone());
+        let fetcher = Arc::new(SelectiveFailureFetcher {
+            inner: MockFetcher {
+                files: std::collections::HashMap::new(),
+                manifest: RemoteManifest {
+                    requires_access_token: false,
+                    output: output_files,
+                    deleted: vec![RemoteFile {
+                        resource_type: Some("Bundle".to_string()),
+                        url: deleted_url.clone(),
+                        count: Some(1),
+                    }],
+                },
+            },
+            failing_urls,
+        });
+        let output = Arc::new(LocalFsOutputStore::new(
+            tmp.path().join("objects"),
+            "http://localhost",
+        ));
+        let worker = DefaultSubmitWorker::new(
+            backend.clone(),
+            fetcher,
+            output.clone(),
+            WorkerId::new("concurrent-errors-worker"),
+        )
+        .with_file_concurrency(3);
+        worker.run_job(lease.clone()).await.unwrap();
+
+        let manifests = backend.list_manifests(&tenant, &sub_id).await.unwrap();
+        assert_eq!(manifests[0].status, ManifestStatus::Completed);
+        let errors = backend
+            .list_submit_files(&tenant, &sub_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect::<Vec<_>>();
+        assert_eq!(errors.len(), 5);
+        assert!(errors.iter().all(|row| row.file_type == "error"
+            && row.resource_type.as_deref() == Some("OperationOutcome")
+            && row.line_count == 1));
+        let part_indexes = errors
+            .iter()
+            .map(|row| row.part_index)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            part_indexes.into_iter().collect::<Vec<_>>(),
+            vec![0, 2, 3, 4, 5]
+        );
+        let locators = errors
+            .iter()
+            .map(|row| row.file_path.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(locators.len(), 5);
+
+        for row in errors {
+            let expected_url = match row.part_index {
+                0 => "",
+                2 => "http://provider/fail-0.ndjson",
+                3 => "http://provider/fail-1.ndjson",
+                4 => "http://provider/fail-2.ndjson",
+                5 => deleted_url.as_str(),
+                _ => panic!("unexpected error part {}", row.part_index),
+            };
+            assert_eq!(row.count_severity, Some(json!({"error": 1})));
+
+            let key = ExportPartKey {
+                tenant_id: tenant.tenant_id().as_str().to_string(),
+                job_id: submission_output_job_id(&sub_id),
+                resource_type: row.file_path.clone(),
+                file_type: row.file_type.clone(),
+                part_index: row.part_index,
+                fencing_token: row.fencing_token,
+            };
+            let mut reader = output.open_reader(&key).await.unwrap();
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).await.unwrap();
+            assert_eq!(row.byte_count, bytes.len() as u64);
+            let outcome: Value =
+                serde_json::from_str(std::str::from_utf8(&bytes).unwrap()).unwrap();
+            let diagnostic = outcome["issue"][0]["diagnostics"].as_str().unwrap();
+            if row.part_index == 0 {
+                assert!(diagnostic.contains("3 submitted resource(s)"));
+                assert!(diagnostic.contains("could not be parsed"));
+            } else {
+                assert!(diagnostic.contains(expected_url));
+                assert!(diagnostic.contains("unavailable input"));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn already_published_helper_replays_return_false() {
+        let backend = Arc::new(SqliteBackend::in_memory().unwrap());
+        backend.init_schema().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let tenant = tenant();
+        let _sub_id = seed(&backend, &tenant).await;
+        let lease = backend
+            .claim_next_manifest(
+                &WorkerId::new("already-published"),
+                StdDuration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let worker = DefaultSubmitWorker::new(
+            backend.clone(),
+            patient_fetcher(""),
+            Arc::new(LocalFsOutputStore::new(
+                tmp.path().to_path_buf(),
+                "http://localhost",
+            )),
+            WorkerId::new("already-published"),
+        );
+
+        let keeper = LeaseKeeper::spawn(
+            Arc::new(JobStoreRenewal(Arc::clone(&backend))),
+            lease.clone(),
+            ByteProgress::default(),
+        );
+        let first = worker
+            .publish_collected_artifacts(
+                &lease,
+                keeper,
+                Vec::new(),
+                ManifestPublicationStatus::Completed,
+            )
+            .await;
+        assert!(first.unwrap());
+
+        let keeper = LeaseKeeper::spawn(
+            Arc::new(JobStoreRenewal(Arc::clone(&backend))),
+            lease.clone(),
+            ByteProgress::default(),
+        );
+        let second = worker
+            .publish_collected_artifacts(
+                &lease,
+                keeper,
+                Vec::new(),
+                ManifestPublicationStatus::Completed,
+            )
+            .await;
+        assert!(!second.unwrap());
+    }
+
+    #[tokio::test]
+    async fn slow_finalize_keeps_lease_alive_for_reclaimer() {
+        use tokio::io::AsyncReadExt;
+
+        let backend = Arc::new(SqliteBackend::in_memory().unwrap());
+        backend.init_schema().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let tenant = tenant();
+        let sub_id = SubmissionId::generate("slow-finalize");
+        backend
+            .create_submission(&tenant, &sub_id, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(
+                &tenant,
+                &sub_id,
+                Some("http://provider/slow-finalize.json"),
+                None,
+            )
+            .await
+            .unwrap();
+        let lease = backend
+            .claim_next_manifest(&WorkerId::new("slow-finalize"), StdDuration::from_secs(2))
+            .await
+            .unwrap()
+            .unwrap();
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let output = Arc::new(SlowFinalize {
+            inner: Arc::new(LocalFsOutputStore::new(
+                tmp.path().join("objects"),
+                "http://localhost",
+            )),
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+        });
+        let worker = DefaultSubmitWorker::new(
+            backend.clone(),
+            patient_fetcher("{\"resourceType\":\"Patient\",\"id\":\"slow-finalize\"}\n"),
+            output.clone(),
+            WorkerId::new("slow-finalize"),
+        );
+        let run = {
+            let lease = lease.clone();
+            tokio::spawn(async move { worker.run_job(lease).await })
+        };
+        tokio::time::timeout(StdDuration::from_secs(10), entered.notified())
+            .await
+            .unwrap();
+        tokio::time::sleep(StdDuration::from_millis(2200)).await;
+        assert_eq!(
+            backend.list_manifests(&tenant, &sub_id).await.unwrap()[0].status,
+            ManifestStatus::Processing
+        );
+        assert!(
+            backend
+                .claim_next_manifest(
+                    &WorkerId::new("slow-finalize-reclaimer"),
+                    StdDuration::from_secs(2),
+                )
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        release.notify_one();
+
+        let result = tokio::time::timeout(StdDuration::from_secs(10), run)
+            .await
+            .unwrap()
+            .unwrap();
+        result.unwrap();
+        let manifests = backend.list_manifests(&tenant, &sub_id).await.unwrap();
+        assert_eq!(manifests[0].status, ManifestStatus::Completed);
+        let rows = backend.list_submit_files(&tenant, &sub_id).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(
+            (
+                row.file_type.as_str(),
+                row.resource_type.as_deref(),
+                row.part_index,
+                row.fencing_token
+            ),
+            ("output", Some("Patient"), 0, lease.fencing_token)
+        );
+        let expected_key = submit_artifact_key(
+            &tenant,
+            &sub_id,
+            &manifest.manifest_id,
+            "output",
+            Some("Patient"),
+            0,
+            lease.fencing_token,
+        );
+        assert_eq!(row.file_path, expected_key.resource_type);
+        let key = ExportPartKey {
+            tenant_id: tenant.tenant_id().as_str().to_string(),
+            job_id: submission_output_job_id(&sub_id),
+            resource_type: row.file_path.clone(),
+            file_type: row.file_type.clone(),
+            part_index: row.part_index,
+            fencing_token: row.fencing_token,
+        };
+        let mut reader = output.open_reader(&key).await.unwrap();
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await.unwrap();
+        assert_eq!(row.line_count, 1);
+        assert_eq!(row.byte_count, bytes.len() as u64);
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"reference\":\"Patient/slow-finalize\"}\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn second_finalize_failure_hides_the_set_until_live_recovery() {
+        use tokio::io::AsyncReadExt;
+
+        let backend = Arc::new(SqliteBackend::in_memory().unwrap());
+        backend.init_schema().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let tenant = tenant();
+        let sub_id = SubmissionId::generate("finalize-failure");
+        backend
+            .create_submission(&tenant, &sub_id, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(
+                &tenant,
+                &sub_id,
+                Some("http://provider/finalize-failure.json"),
+                None,
+            )
+            .await
+            .unwrap();
+        let old = backend
+            .claim_next_manifest(
+                &WorkerId::new("finalize-failure-old"),
+                StdDuration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let mut files = std::collections::HashMap::new();
+        let mut output_files = Vec::new();
+        for resource_type in ["Condition", "Patient"] {
+            let url = format!("http://provider/{resource_type}.ndjson");
+            files.insert(
+                url.clone(),
+                format!("{{\"resourceType\":\"{resource_type}\",\"id\":\"one\"}}\n").into_bytes(),
+            );
+            output_files.push(RemoteFile {
+                resource_type: Some(resource_type.to_string()),
+                url,
+                count: Some(1),
+            });
+        }
+        let fetcher = Arc::new(MockFetcher {
+            files,
+            manifest: RemoteManifest {
+                requires_access_token: false,
+                output: output_files,
+                deleted: vec![],
+            },
+        });
+        let output = Arc::new(LocalFsOutputStore::new(
+            tmp.path().join("objects"),
+            "http://localhost",
+        ));
+        let failing_output = Arc::new(FailSecondFinalize {
+            inner: Arc::clone(&output),
+            finalized: std::sync::atomic::AtomicU32::new(0),
+        });
+        let failing_worker = DefaultSubmitWorker::new(
+            backend.clone(),
+            fetcher.clone(),
+            failing_output,
+            WorkerId::new("finalize-failure-old"),
+        );
+        let failed_result = failing_worker.run_job(old.clone()).await;
+        match failed_result {
+            Err(StorageError::Backend(crate::error::BackendError::Internal {
+                backend_name,
+                message,
+                source: None,
+            })) => {
+                assert_eq!(backend_name, "bulk-submit-worker-test");
+                assert_eq!(message, "second finalize forced failure");
+            }
+            other => panic!("expected exact second-finalize error, got {other:?}"),
+        }
+        assert!(
+            backend
+                .list_submit_files(&tenant, &sub_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        backend
+            .get_connection()
+            .unwrap()
+            .execute(
+                "UPDATE bulk_manifests SET lease_expiry = '1970-01-01T00:00:00Z'
+                 WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3
+                   AND manifest_id = ?4",
+                params![
+                    tenant.tenant_id().as_str(),
+                    sub_id.submitter,
+                    sub_id.submission_id,
+                    manifest.manifest_id,
+                ],
+            )
+            .unwrap();
+        let replacement = backend
+            .claim_next_manifest(
+                &WorkerId::new("finalize-failure-live"),
+                StdDuration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(replacement.manifest_id, manifest.manifest_id);
+        assert!(replacement.fencing_token > old.fencing_token);
+
+        let live_worker = DefaultSubmitWorker::new(
+            backend.clone(),
+            fetcher,
+            Arc::clone(&output),
+            WorkerId::new("finalize-failure-live"),
+        );
+        live_worker.run_job(replacement.clone()).await.unwrap();
+
+        let manifests = backend.list_manifests(&tenant, &sub_id).await.unwrap();
+        assert_eq!(manifests[0].status, ManifestStatus::Completed);
+        let mut outputs = backend
+            .list_submit_files(&tenant, &sub_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| {
+                (
+                    row.resource_type.clone().unwrap(),
+                    row.part_index,
+                    row.fencing_token,
+                    row.file_path,
+                    row.line_count,
+                    row.byte_count,
+                )
+            })
+            .collect::<Vec<_>>();
+        outputs.sort_by_key(|row| (row.0.clone(), row.1));
+        let expected_outputs = ["Condition", "Patient"]
+            .into_iter()
+            .enumerate()
+            .map(|(part_index, resource_type)| {
+                let key = submit_artifact_key(
+                    &tenant,
+                    &sub_id,
+                    &manifest.manifest_id,
+                    "output",
+                    Some(resource_type),
+                    part_index as u32,
+                    replacement.fencing_token,
+                );
+                (
+                    resource_type.to_string(),
+                    part_index as u32,
+                    replacement.fencing_token,
+                    key.resource_type,
+                    1,
+                    format!("{{\"reference\":\"{resource_type}/one\"}}\n").len() as u64,
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(outputs, expected_outputs);
+        for (resource_type, part_index, fencing_token, file_path, line_count, byte_count) in outputs
+        {
+            let key = ExportPartKey {
+                tenant_id: tenant.tenant_id().as_str().to_string(),
+                job_id: submission_output_job_id(&sub_id),
+                resource_type: file_path,
+                file_type: "output".to_string(),
+                part_index,
+                fencing_token,
+            };
+            let mut reader = output.open_reader(&key).await.unwrap();
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).await.unwrap();
+            let expected_bytes = format!("{{\"reference\":\"{resource_type}/one\"}}\n");
+            assert_eq!(line_count, 1);
+            assert_eq!(byte_count, expected_bytes.len() as u64);
+            assert_eq!(std::str::from_utf8(&bytes).unwrap(), expected_bytes);
+            let references = std::str::from_utf8(&bytes)
+                .unwrap()
+                .lines()
+                .map(|line| serde_json::from_str::<Value>(line).unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                references,
+                vec![json!({"reference": format!("{resource_type}/one")})]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn publication_takeover_is_quiet_then_original_lease_retry_reindexes() {
+        use tokio::io::AsyncReadExt;
+
+        let backend = Arc::new(SqliteBackend::in_memory().unwrap());
+        backend.init_schema().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let tenant = tenant();
+        let sub_id = SubmissionId::generate("publication-takeover");
+        backend
+            .create_submission(&tenant, &sub_id, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(
+                &tenant,
+                &sub_id,
+                Some("http://provider/publication-takeover.json"),
+                None,
+            )
+            .await
+            .unwrap();
+        let lease = backend
+            .claim_next_manifest(
+                &WorkerId::new("publication-takeover"),
+                StdDuration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let hook = Arc::new(MockReindexHook {
+            calls: std::sync::Mutex::new(Vec::new()),
+        });
+        let output = Arc::new(LocalFsOutputStore::new(
+            tmp.path().join("objects"),
+            "http://localhost",
+        ));
+        let guarded_worker = DefaultSubmitWorker::new(
+            backend.clone(),
+            patient_fetcher("{\"resourceType\":\"Patient\",\"id\":\"guarded\"}\n"),
+            Arc::clone(&output),
+            WorkerId::new("publication-takeover"),
+        )
+        .with_deferred_indexing(true, Some(hook.clone()));
+
+        backend
+            .get_connection()
+            .unwrap()
+            .execute(
+                "CREATE TRIGGER lose_lease_after_output
+                 AFTER INSERT ON bulk_submit_files
+                 BEGIN
+                   UPDATE bulk_manifests
+                   SET worker_id = 'interloper', fencing_token = 999
+                   WHERE tenant_id = NEW.tenant_id
+                     AND submitter = NEW.submitter
+                     AND submission_id = NEW.submission_id
+                     AND manifest_id = NEW.manifest_id;
+                 END",
+                [],
+            )
+            .unwrap();
+        guarded_worker.run_job(lease.clone()).await.unwrap();
+        assert_eq!(
+            backend.list_manifests(&tenant, &sub_id).await.unwrap()[0].status,
+            ManifestStatus::Processing
+        );
+        assert!(
+            backend
+                .list_submit_files(&tenant, &sub_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            hook.calls.lock().unwrap().is_empty(),
+            "lease lost publication must not fire reindex"
+        );
+
+        backend
+            .get_connection()
+            .unwrap()
+            .execute("DROP TRIGGER lose_lease_after_output", [])
+            .unwrap();
+        let retry_worker = DefaultSubmitWorker::new(
+            backend.clone(),
+            patient_fetcher("{\"resourceType\":\"Patient\",\"id\":\"guarded\"}\n"),
+            Arc::clone(&output),
+            WorkerId::new("publication-takeover"),
+        )
+        .with_deferred_indexing(true, Some(hook.clone()));
+        retry_worker.run_job(lease.clone()).await.unwrap();
+
+        let manifests = backend.list_manifests(&tenant, &sub_id).await.unwrap();
+        assert_eq!(manifests[0].status, ManifestStatus::Completed);
+        assert_eq!(
+            hook.calls.lock().unwrap().clone(),
+            vec![vec!["Patient".to_string()]]
+        );
+        let rows = backend.list_submit_files(&tenant, &sub_id).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(
+            (
+                row.file_type.as_str(),
+                row.resource_type.as_deref(),
+                row.part_index,
+                row.fencing_token
+            ),
+            ("output", Some("Patient"), 0, lease.fencing_token)
+        );
+        let expected_key = submit_artifact_key(
+            &tenant,
+            &sub_id,
+            &manifest.manifest_id,
+            "output",
+            Some("Patient"),
+            0,
+            lease.fencing_token,
+        );
+        assert_eq!(row.file_path, expected_key.resource_type);
+        let key = ExportPartKey {
+            tenant_id: tenant.tenant_id().as_str().to_string(),
+            job_id: submission_output_job_id(&sub_id),
+            resource_type: row.file_path.clone(),
+            file_type: "output".to_string(),
+            part_index: row.part_index,
+            fencing_token: row.fencing_token,
+        };
+        let mut reader = output.open_reader(&key).await.unwrap();
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await.unwrap();
+        assert_eq!(row.line_count, 1);
+        assert_eq!(row.byte_count, bytes.len() as u64);
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"reference\":\"Patient/guarded\"}\n"
+        );
     }
 
     /// How a stubbed heartbeat behaves, for the [`LeaseKeeper`] tests.

--- a/crates/persistence/src/core/mod.rs
+++ b/crates/persistence/src/core/mod.rs
@@ -96,6 +96,10 @@ pub mod bulk_export_worker;
 pub mod bulk_provider;
 pub mod bulk_submit;
 pub mod bulk_submit_input;
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+pub(crate) mod bulk_submit_legacy;
+pub mod bulk_submit_output;
+pub mod bulk_submit_publication;
 pub mod bulk_submit_worker;
 pub mod capabilities;
 pub mod history;
@@ -134,6 +138,8 @@ pub use bulk_submit::{
 pub use bulk_submit_input::{
     FileTokenProvider, RemoteFile, RemoteManifest, SubmitInputFetcher, submission_output_job_id,
 };
+pub use bulk_submit_output::{submit_artifact_key, submit_artifact_locator};
+pub use bulk_submit_publication::{ManifestPublicationResult, ManifestPublicationStatus};
 pub use bulk_submit_worker::{
     BulkSubmitJobStore, DefaultSubmitWorker, DeferredReindexHook, ManifestFetchParams,
     ManifestLease, ManifestWorkerView, PollTokenTarget, SubmitClaimStrategy, SubmitFileRecord,

--- a/crates/persistence/tests/bulk_submit/consumer_contract.rs
+++ b/crates/persistence/tests/bulk_submit/consumer_contract.rs
@@ -236,7 +236,7 @@ pub async fn worker_receipts<B: BulkSubmitJobStore + 'static>(
         let key = ExportPartKey {
             tenant_id: tenant.tenant_id().as_str().to_string(),
             job_id: submission_output_job_id(&submission),
-            resource_type: row.resource_type.clone().unwrap(),
+            resource_type: row.file_path.clone(),
             file_type: row.file_type.clone(),
             part_index: row.part_index,
             fencing_token: row.fencing_token,

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -4013,10 +4013,10 @@ mod bulk_submit {
 
     use helios_persistence::core::{
         BulkProcessingOptions, BulkSubmitProvider, BulkSubmitRollbackProvider, ChangeType,
-        DefaultSubmitWorker, IMPORT_MODE_PARAMETER_URL, ManifestFetchParams, ManifestStatus,
-        NdjsonEntry, RemoteFile, RemoteManifest, StreamingBulkSubmitProvider, SubmissionId,
-        SubmissionStatus, SubmitClaimStrategy, SubmitFileRecord, SubmitInputFetcher,
-        SubmitWorkerStorage, WorkerId,
+        DefaultSubmitWorker, IMPORT_MODE_PARAMETER_URL, ManifestFetchParams,
+        ManifestPublicationStatus, ManifestStatus, NdjsonEntry, RemoteFile, RemoteManifest,
+        StreamingBulkSubmitProvider, SubmissionId, SubmissionStatus, SubmitClaimStrategy,
+        SubmitFileRecord, SubmitInputFetcher, SubmitWorkerStorage, WorkerId,
     };
     use helios_persistence::error::StorageResult;
     use std::collections::HashMap;
@@ -4759,6 +4759,268 @@ mod bulk_submit {
                 .is_none(),
             "a line of the wrong type must not be stored"
         );
+    }
+
+    /// Reconstructs the pre-v8 Mongo artifact shape, migrates it through the
+    /// public backend migration, and verifies manifest-aware v8 identity for
+    /// two generations under one submission.
+    #[tokio::test]
+    async fn test_v7_to_v8_manifest_aware_submit_file_identity() {
+        use futures::TryStreamExt;
+
+        let Some(backend) = create_backend("submit_v7_to_v8_manifest_identity").await else {
+            eprintln!("skipping: no MongoDB container available");
+            return;
+        };
+        let tenant = create_tenant("submit-v7");
+        let submission_id = SubmissionId::new("v7-provider", "legacy-generation");
+        let db = backend.get_database().await.unwrap();
+        let files = db.collection::<Document>("bulk_submit_files");
+
+        files
+            .drop_index("idx_bulk_submit_files_manifest")
+            .await
+            .unwrap();
+        files
+            .create_index(
+                mongodb::IndexModel::builder()
+                    .keys(doc! {
+                        "tenant_id": 1_i32,
+                        "submitter": 1_i32,
+                        "submission_id": 1_i32,
+                        "file_type": 1_i32,
+                        "resource_type": 1_i32,
+                        "part_index": 1_i32,
+                        "fencing_token": 1_i32,
+                    })
+                    .options(
+                        mongodb::options::IndexOptions::builder()
+                            .name(Some("idx_bulk_submit_files_part".to_string()))
+                            .unique(Some(true))
+                            .build(),
+                    )
+                    .build(),
+            )
+            .await
+            .unwrap();
+        db.collection::<Document>("schema_version")
+            .update_one(
+                doc! { "_id": "schema_version" },
+                doc! { "$set": { "version": 7_i32 } },
+            )
+            .await
+            .unwrap();
+        files
+            .insert_one(doc! {
+                "tenant_id": tenant.tenant_id().as_str(),
+                "submitter": &submission_id.submitter,
+                "submission_id": &submission_id.submission_id,
+                "manifest_url": "https://provider.example/legacy.json",
+                "file_type": "output",
+                "resource_type": "Patient",
+                "part_index": 0_i64,
+                "fencing_token": 1_i64,
+                "file_path": "legacy/output/Patient-0.ndjson",
+                "line_count": 2_i64,
+                "byte_count": 19_i64,
+                "created_at": mongodb::bson::DateTime::from_millis(
+                    chrono::Utc::now().timestamp_millis(),
+                ),
+            })
+            .await
+            .unwrap();
+
+        backend.migrate().await.unwrap();
+        let schema_version = db
+            .collection::<Document>("schema_version")
+            .find_one(doc! { "_id": "schema_version" })
+            .await
+            .unwrap()
+            .expect("schema version document");
+        assert_eq!(schema_version.get_i32("version").unwrap(), 8_i32);
+
+        let indexes = files
+            .list_indexes()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let manifest_index = indexes
+            .iter()
+            .find(|index| {
+                index
+                    .options
+                    .as_ref()
+                    .and_then(|options| options.name.as_deref())
+                    == Some("idx_bulk_submit_files_manifest")
+            })
+            .expect("v8 submit-file identity index");
+        assert_eq!(
+            manifest_index.keys,
+            doc! {
+                "tenant_id": 1_i32,
+                "submitter": 1_i32,
+                "submission_id": 1_i32,
+                "manifest_id": 1_i32,
+                "file_type": 1_i32,
+                "resource_type": 1_i32,
+                "part_index": 1_i32,
+                "fencing_token": 1_i32,
+            }
+        );
+        assert_eq!(manifest_index.options.as_ref().unwrap().unique, Some(true));
+        assert!(
+            indexes.iter().all(|index| index
+                .options
+                .as_ref()
+                .and_then(|options| options.name.as_deref())
+                != Some("idx_bulk_submit_files_part")),
+            "legacy submit-file index must be dropped, got {indexes:?}"
+        );
+
+        // A second pass on the already-migrated database is a no-op.
+        backend.migrate().await.unwrap();
+        let legacy_rows = backend
+            .list_submit_files(&tenant, &submission_id)
+            .await
+            .unwrap();
+        assert_eq!(legacy_rows.len(), 1);
+        assert!(legacy_rows[0].manifest_id.is_none());
+        assert!(legacy_rows[0].legacy_locator);
+        assert_eq!(legacy_rows[0].line_count, 2);
+        assert_eq!(legacy_rows[0].byte_count, 19);
+
+        let new_submission_id = SubmissionId::new("v8-provider", "manifest-aware-generation");
+        backend
+            .create_submission(&tenant, &new_submission_id, None)
+            .await
+            .unwrap();
+        let first = backend
+            .add_manifest(
+                &tenant,
+                &new_submission_id,
+                Some("https://provider.example/first.json"),
+                None,
+            )
+            .await
+            .unwrap();
+        let second = backend
+            .add_manifest(
+                &tenant,
+                &new_submission_id,
+                Some("https://provider.example/second.json"),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_ne!(first.manifest_id, second.manifest_id);
+
+        let worker_id = WorkerId::new("v8-identity-worker");
+        let first_lease = backend
+            .claim_next_manifest(&worker_id, lease_duration())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first_lease.submission_id, new_submission_id);
+        assert_eq!(first_lease.manifest_id, first.manifest_id);
+        assert_eq!(first_lease.fencing_token, 1);
+        let record = SubmitFileRecord {
+            manifest_url: Some("https://provider.example/first.json".to_string()),
+            file_type: "output".to_string(),
+            resource_type: Some("Patient".to_string()),
+            part_index: 0,
+            file_path: "legacy/output/Patient-0.ndjson".to_string(),
+            line_count: 2,
+            byte_count: 19,
+            count_severity: None,
+        };
+        backend
+            .record_submit_file(&first_lease, &record)
+            .await
+            .unwrap();
+        backend
+            .record_submit_file(&first_lease, &record)
+            .await
+            .unwrap();
+        backend
+            .publish_manifest_artifacts(
+                &first_lease,
+                std::slice::from_ref(&record),
+                ManifestPublicationStatus::Completed,
+            )
+            .await
+            .unwrap();
+
+        let second_lease = backend
+            .claim_next_manifest(&worker_id, lease_duration())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(second_lease.submission_id, new_submission_id);
+        assert_eq!(second_lease.manifest_id, second.manifest_id);
+        assert_eq!(second_lease.fencing_token, 1);
+        let second_record = SubmitFileRecord {
+            manifest_url: Some("https://provider.example/second.json".to_string()),
+            ..record.clone()
+        };
+        backend
+            .record_submit_file(&second_lease, &second_record)
+            .await
+            .unwrap();
+        backend
+            .publish_manifest_artifacts(
+                &second_lease,
+                &[second_record],
+                ManifestPublicationStatus::Completed,
+            )
+            .await
+            .unwrap();
+
+        let rows = backend
+            .list_submit_files(&tenant, &new_submission_id)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|row| !row.legacy_locator));
+        let mut actual_manifest_ids: Vec<_> = rows
+            .iter()
+            .map(|row| row.manifest_id.as_deref().unwrap())
+            .collect();
+        actual_manifest_ids.sort_unstable();
+        let mut expected_manifest_ids =
+            vec![first.manifest_id.as_str(), second.manifest_id.as_str()];
+        expected_manifest_ids.sort_unstable();
+        assert_eq!(actual_manifest_ids, expected_manifest_ids);
+        assert!(rows.iter().all(|row| row.file_type == "output"));
+        assert!(
+            rows.iter()
+                .all(|row| row.resource_type.as_deref() == Some("Patient"))
+        );
+        assert!(rows.iter().all(|row| row.part_index == 0));
+        assert!(rows.iter().all(|row| row.line_count == 2));
+        assert!(rows.iter().all(|row| row.byte_count == 19));
+        assert!(
+            rows.iter()
+                .all(|row| row.file_path == "legacy/output/Patient-0.ndjson")
+        );
+        let manifests = backend
+            .list_manifests(&tenant, &new_submission_id)
+            .await
+            .unwrap();
+        assert_eq!(manifests.len(), 2);
+        assert_ne!(manifests[0].manifest_id, manifests[1].manifest_id);
+        assert!(manifests.iter().all(|manifest| {
+            manifest.manifest_id == first.manifest_id || manifest.manifest_id == second.manifest_id
+        }));
+
+        let preserved_legacy_rows = backend
+            .list_submit_files(&tenant, &submission_id)
+            .await
+            .unwrap();
+        assert_eq!(preserved_legacy_rows.len(), 1);
+        assert!(preserved_legacy_rows[0].manifest_id.is_none());
+        assert!(preserved_legacy_rows[0].legacy_locator);
     }
 }
 

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -816,6 +816,1013 @@ mod postgres_integration {
     use testcontainers_modules::postgres::Postgres;
     use tokio::sync::{Mutex, OnceCell};
 
+    #[tokio::test]
+    async fn postgres_publication_exact_contract() {
+        use helios_persistence::core::{
+            BulkSubmitProvider, LeaseError, ManifestPublicationResult, ManifestPublicationStatus,
+            ManifestStatus, SubmissionId, SubmitFileRecord, SubmitWorkerStorage,
+        };
+
+        let _guard = BULK_SUBMIT_TEST_LOCK.lock().await;
+        let backend = create_backend().await;
+        let tenant = create_tenant("publication-exact-contract");
+        let submission = SubmissionId::generate("publication-exact-contract");
+        let manifest_url = "https://provider/publication-exact-contract.json";
+        backend
+            .create_submission(&tenant, &submission, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(&tenant, &submission, Some(manifest_url), None)
+            .await
+            .unwrap();
+        let lease = claim_specific_manifest(
+            &backend,
+            &helios_persistence::core::WorkerId::new(format!(
+                "publication-contract-worker-{}",
+                uuid::Uuid::new_v4().simple()
+            )),
+            &submission,
+            &manifest.manifest_id,
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+        let output = SubmitFileRecord {
+            manifest_url: Some(manifest_url.to_string()),
+            file_type: "output".to_string(),
+            resource_type: Some("Patient".to_string()),
+            part_index: 0,
+            file_path: "output/patient-0.ndjson".to_string(),
+            line_count: 3,
+            byte_count: 128,
+            count_severity: None,
+        };
+        let error = SubmitFileRecord {
+            manifest_url: Some(manifest_url.to_string()),
+            file_type: "error".to_string(),
+            resource_type: Some("OperationOutcome".to_string()),
+            part_index: 0,
+            file_path: "error/outcome-0.ndjson".to_string(),
+            line_count: 1,
+            byte_count: 96,
+            count_severity: Some(serde_json::json!({"error": 2})),
+        };
+
+        backend.record_submit_file(&lease, &output).await.unwrap();
+        backend.record_submit_file(&lease, &output).await.unwrap();
+        assert!(
+            backend
+                .list_submit_files(&tenant, &submission)
+                .await
+                .unwrap()
+                .is_empty(),
+            "staged artifacts are not publication-visible"
+        );
+
+        let mut conflicting = output.clone();
+        conflicting.byte_count = 127;
+        assert!(
+            matches!(
+                backend.record_submit_file(&lease, &conflicting).await,
+                Err(LeaseError::Storage(_))
+            ),
+            "the same artifact identity cannot change staged byte_count"
+        );
+
+        assert_eq!(
+            backend
+                .publish_manifest_artifacts(
+                    &lease,
+                    &[output.clone(), error.clone()],
+                    ManifestPublicationStatus::Completed,
+                )
+                .await
+                .unwrap(),
+            ManifestPublicationResult::Published
+        );
+        let manifest = backend
+            .get_manifest(&tenant, &submission, &lease.manifest_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(manifest.status, ManifestStatus::Completed);
+        let rows = backend
+            .list_submit_files(&tenant, &submission)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        let row = rows
+            .iter()
+            .find(|row| row.file_type == "output")
+            .expect("published output row");
+        assert_eq!(row.manifest_url.as_deref(), Some(manifest_url));
+        assert_eq!(row.resource_type.as_deref(), Some("Patient"));
+        assert_eq!(row.part_index, 0);
+        assert_eq!(row.fencing_token, lease.fencing_token);
+        assert_eq!(row.file_path, "output/patient-0.ndjson");
+        assert_eq!(row.line_count, 3);
+        assert_eq!(row.byte_count, 128);
+        assert_eq!(row.count_severity, None);
+        let row = rows
+            .iter()
+            .find(|row| row.file_type == "error")
+            .expect("published error row");
+        assert_eq!(row.manifest_url.as_deref(), Some(manifest_url));
+        assert_eq!(row.resource_type.as_deref(), Some("OperationOutcome"));
+        assert_eq!(row.part_index, 0);
+        assert_eq!(row.fencing_token, lease.fencing_token);
+        assert_eq!(row.file_path, "error/outcome-0.ndjson");
+        assert_eq!(row.line_count, 1);
+        assert_eq!(row.byte_count, 96);
+        assert_eq!(row.count_severity, Some(serde_json::json!({"error": 2})));
+
+        assert_eq!(
+            backend
+                .publish_manifest_artifacts(
+                    &lease,
+                    &[error.clone(), output.clone()],
+                    ManifestPublicationStatus::Completed,
+                )
+                .await
+                .unwrap(),
+            ManifestPublicationResult::AlreadyPublished
+        );
+
+        let mut altered = output.clone();
+        altered.byte_count = 127;
+        assert!(
+            matches!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[altered, error.clone()],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await,
+                Err(LeaseError::Storage(_))
+            ),
+            "published byte_count cannot change on replay"
+        );
+        assert!(
+            matches!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[output.clone(), error.clone()],
+                        ManifestPublicationStatus::Failed {
+                            error_message: "changed terminal".to_string(),
+                        },
+                    )
+                    .await,
+                Err(LeaseError::Storage(_))
+            ),
+            "published terminal status cannot change on replay"
+        );
+
+        assert!(
+            matches!(
+                backend
+                    .publish_manifest_artifacts(
+                        &helios_persistence::core::ManifestLease {
+                            worker_id: helios_persistence::core::WorkerId::new(
+                                "interloper".to_string()
+                            ),
+                            ..lease.clone()
+                        },
+                        &[output.clone(), error.clone()],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await,
+                Err(LeaseError::LeaseLost { .. })
+            ),
+            "the same publication cannot be replayed by another worker"
+        );
+
+        assert_eq!(
+            backend
+                .publish_manifest_artifacts(
+                    &lease,
+                    &[output.clone(), error.clone()],
+                    ManifestPublicationStatus::Completed,
+                )
+                .await
+                .unwrap(),
+            ManifestPublicationResult::AlreadyPublished
+        );
+        assert_eq!(
+            backend
+                .list_submit_files(&tenant, &submission)
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn postgres_publication_fault_rollback_and_retry() {
+        use helios_persistence::core::{
+            BulkSubmitProvider, LeaseError, ManifestPublicationResult, ManifestPublicationStatus,
+            ManifestStatus, SubmissionId, SubmitFileRecord, SubmitWorkerStorage,
+        };
+
+        let _guard = BULK_SUBMIT_TEST_LOCK.lock().await;
+        let backend = create_backend().await;
+        let tenant = create_tenant("publication-fault-rollback");
+        let submission = SubmissionId::generate("publication-fault-rollback");
+        let manifest_url = "https://provider/publication-fault-rollback.json";
+        backend
+            .create_submission(&tenant, &submission, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(&tenant, &submission, Some(manifest_url), None)
+            .await
+            .unwrap();
+        let lease = claim_specific_manifest(
+            &backend,
+            &helios_persistence::core::WorkerId::new(format!(
+                "publication-fault-worker-{}",
+                uuid::Uuid::new_v4().simple()
+            )),
+            &submission,
+            &manifest.manifest_id,
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+        let output = SubmitFileRecord {
+            manifest_url: Some(manifest_url.to_string()),
+            file_type: "output".to_string(),
+            resource_type: Some("Patient".to_string()),
+            part_index: 0,
+            file_path: "output/patient-0.ndjson".to_string(),
+            line_count: 3,
+            byte_count: 128,
+            count_severity: None,
+        };
+        let error = SubmitFileRecord {
+            manifest_url: Some(manifest_url.to_string()),
+            file_type: "error".to_string(),
+            resource_type: Some("OperationOutcome".to_string()),
+            part_index: 0,
+            file_path: "error/outcome-0.ndjson".to_string(),
+            line_count: 1,
+            byte_count: 96,
+            count_severity: Some(serde_json::json!({"error": 2})),
+        };
+
+        let client = backend.get_client().await.unwrap();
+        let identity_where = "tenant_id = $1 AND submitter = $2 AND submission_id = $3 \
+                              AND manifest_id = $4";
+        let tenant_id = lease.tenant.tenant_id().as_str();
+        let identity: [&(dyn tokio_postgres::types::ToSql + Sync); 4] = [
+            &tenant_id,
+            &lease.submission_id.submitter,
+            &lease.submission_id.submission_id,
+            &lease.manifest_id,
+        ];
+        let fault_worker = format!("publication-fault-{}", uuid::Uuid::new_v4().simple());
+        let insert_fn = format!(
+            "publication_fault_insert_fn_{}",
+            uuid::Uuid::new_v4().simple()
+        );
+        let insert_trigger = format!(
+            "publication_fault_insert_trigger_{}",
+            uuid::Uuid::new_v4().simple()
+        );
+        client
+            .batch_execute(&format!(
+                r#"
+                CREATE FUNCTION public.{insert_fn}() RETURNS trigger LANGUAGE plpgsql AS $body$
+                BEGIN
+                    UPDATE bulk_manifests
+                    SET worker_id = '{fault_worker}', fencing_token = fencing_token + 1
+                    WHERE tenant_id = NEW.tenant_id AND submitter = NEW.submitter
+                      AND submission_id = NEW.submission_id AND manifest_id = NEW.manifest_id;
+                    RETURN NEW;
+                END;
+                $body$;
+                CREATE TRIGGER {insert_trigger} AFTER INSERT ON bulk_submit_files
+                FOR EACH ROW
+                WHEN (NEW.tenant_id = '{tenant}' AND NEW.submitter = '{submitter}'
+                      AND NEW.submission_id = '{submission}' AND NEW.manifest_id = '{manifest_id}')
+                EXECUTE FUNCTION public.{insert_fn}();
+                "#,
+                tenant = lease.tenant.tenant_id(),
+                submitter = lease.submission_id.submitter,
+                submission = lease.submission_id.submission_id,
+                manifest_id = lease.manifest_id,
+            ))
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(
+                backend
+                    .publish_manifest_artifacts(
+                        &lease,
+                        &[output.clone(), error.clone()],
+                        ManifestPublicationStatus::Completed,
+                    )
+                    .await,
+                Err(LeaseError::LeaseLost { .. })
+            ),
+            "the active lease must no longer match the injected worker/token"
+        );
+        let raw_count = client
+            .query_one(
+                &format!("SELECT count(*) FROM bulk_submit_files WHERE {identity_where}"),
+                &identity,
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(raw_count, 0);
+        let marker = client
+            .query_one(
+                &format!(
+                    "SELECT worker_id, fencing_token, published_token, publication_status, \
+                     publication_error_message FROM bulk_manifests WHERE {identity_where}"
+                ),
+                &identity,
+            )
+            .await
+            .unwrap();
+        assert_eq!(marker.get::<_, String>(0), lease.worker_id.as_str());
+        assert_eq!(marker.get::<_, i64>(1), lease.fencing_token as i64);
+        assert_eq!(marker.get::<_, Option<i64>>(2), None);
+        assert_eq!(marker.get::<_, Option<String>>(3), None);
+        assert_eq!(marker.get::<_, Option<String>>(4), None);
+        client
+            .batch_execute(&format!(
+                "DROP TRIGGER IF EXISTS {insert_trigger} ON bulk_submit_files; \
+                 DROP FUNCTION IF EXISTS public.{insert_fn}();"
+            ))
+            .await
+            .unwrap();
+
+        let update_fn = format!(
+            "publication_fault_update_fn_{}",
+            uuid::Uuid::new_v4().simple()
+        );
+        let update_trigger = format!(
+            "publication_fault_update_trigger_{}",
+            uuid::Uuid::new_v4().simple()
+        );
+        client
+            .batch_execute(&format!(
+                r#"
+                CREATE FUNCTION public.{update_fn}() RETURNS trigger LANGUAGE plpgsql AS $body$
+                BEGIN
+                    IF NEW.published_token IS NOT NULL AND NEW.tenant_id = '{tenant}'
+                       AND NEW.submitter = '{submitter}' AND NEW.submission_id = '{submission}'
+                       AND NEW.manifest_id = '{manifest_id}' THEN
+                        RAISE EXCEPTION 'publication injected terminal failure';
+                    END IF;
+                    RETURN NEW;
+                END;
+                $body$;
+                CREATE TRIGGER {update_trigger} BEFORE UPDATE ON bulk_manifests
+                FOR EACH ROW EXECUTE FUNCTION public.{update_fn}();
+                "#,
+                tenant = lease.tenant.tenant_id(),
+                submitter = lease.submission_id.submitter,
+                submission = lease.submission_id.submission_id,
+                manifest_id = lease.manifest_id,
+            ))
+            .await
+            .unwrap();
+        let Err(LeaseError::Storage(storage_error)) = backend
+            .publish_manifest_artifacts(
+                &lease,
+                &[output.clone(), error.clone()],
+                ManifestPublicationStatus::Completed,
+            )
+            .await
+        else {
+            panic!("the BEFORE UPDATE fault must surface as a storage error");
+        };
+        assert!(matches!(
+            storage_error,
+            helios_persistence::error::StorageError::Backend(
+                helios_persistence::error::BackendError::Internal { .. }
+            )
+        ));
+        assert!(storage_error.to_string().contains("publish manifest:"));
+        let raw_count = client
+            .query_one(
+                &format!("SELECT count(*) FROM bulk_submit_files WHERE {identity_where}"),
+                &identity,
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(raw_count, 0);
+        let marker = client
+            .query_one(
+                &format!(
+                    "SELECT worker_id, fencing_token, published_token, publication_status, \
+                     publication_error_message FROM bulk_manifests WHERE {identity_where}"
+                ),
+                &identity,
+            )
+            .await
+            .unwrap();
+        assert_eq!(marker.get::<_, String>(0), lease.worker_id.as_str());
+        assert_eq!(marker.get::<_, i64>(1), lease.fencing_token as i64);
+        assert_eq!(marker.get::<_, Option<i64>>(2), None);
+        assert_eq!(marker.get::<_, Option<String>>(3), None);
+        assert_eq!(marker.get::<_, Option<String>>(4), None);
+        client
+            .batch_execute(&format!(
+                "DROP TRIGGER IF EXISTS {update_trigger} ON bulk_manifests; \
+                 DROP FUNCTION IF EXISTS public.{update_fn}();"
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            backend
+                .publish_manifest_artifacts(
+                    &lease,
+                    &[output.clone(), error.clone()],
+                    ManifestPublicationStatus::Completed,
+                )
+                .await
+                .unwrap(),
+            ManifestPublicationResult::Published
+        );
+        let rows = backend
+            .list_submit_files(&tenant, &submission)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        for expected in [&output, &error] {
+            let row = rows
+                .iter()
+                .find(|row| row.file_type == expected.file_type)
+                .expect("published row");
+            assert_eq!(row.file_path, expected.file_path);
+            assert_eq!(row.fencing_token, lease.fencing_token);
+        }
+        let manifest = backend
+            .get_manifest(&tenant, &submission, &lease.manifest_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(manifest.status, ManifestStatus::Completed);
+        assert_eq!(
+            backend
+                .publish_manifest_artifacts(
+                    &lease,
+                    &[error.clone(), output],
+                    ManifestPublicationStatus::Completed,
+                )
+                .await
+                .unwrap(),
+            ManifestPublicationResult::AlreadyPublished
+        );
+    }
+
+    #[tokio::test]
+    async fn postgres_publication_expiry_reclaim_scope_and_replay() {
+        use helios_persistence::core::{
+            BulkSubmitProvider, LeaseError, ManifestPublicationResult, ManifestPublicationStatus,
+            ManifestStatus, SubmissionId, SubmitFileRecord, SubmitWorkerStorage,
+        };
+
+        let _guard = BULK_SUBMIT_TEST_LOCK.lock().await;
+        let backend = create_backend().await;
+        let tenant = create_tenant("publication-expiry-scope");
+        let submission = SubmissionId::generate("publication-expiry-scope");
+        backend
+            .create_submission(&tenant, &submission, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(
+                &tenant,
+                &submission,
+                Some("https://provider/publication-expiry-scope.json"),
+                None,
+            )
+            .await
+            .unwrap();
+        let expired_unreclaimed = claim_specific_manifest(
+            &backend,
+            &helios_persistence::core::WorkerId::new(format!(
+                "publication-expiry-worker-{}",
+                uuid::Uuid::new_v4().simple()
+            )),
+            &submission,
+            &manifest.manifest_id,
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+        let client = backend.get_client().await.unwrap();
+        let expired_tenant_id = expired_unreclaimed.tenant.tenant_id().as_str();
+        client
+            .execute(
+                "UPDATE bulk_manifests SET lease_expiry = NOW() - INTERVAL '1 second' \
+                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3 \
+                   AND manifest_id = $4",
+                &[
+                    &expired_tenant_id as &(dyn tokio_postgres::types::ToSql + Sync),
+                    &expired_unreclaimed.submission_id.submitter,
+                    &expired_unreclaimed.submission_id.submission_id,
+                    &expired_unreclaimed.manifest_id,
+                ],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            backend
+                .publish_manifest_artifacts(
+                    &expired_unreclaimed,
+                    &[],
+                    ManifestPublicationStatus::Completed,
+                )
+                .await
+                .unwrap(),
+            ManifestPublicationResult::Published,
+            "expiry alone does not fence an unreclaimed live lease"
+        );
+
+        let stale_url = "https://provider/publication-expiry-scope-stale.json";
+        let reclaim_seed = backend
+            .add_manifest(&tenant, &submission, Some(stale_url), None)
+            .await
+            .unwrap();
+        let stale = claim_specific_manifest(
+            &backend,
+            &helios_persistence::core::WorkerId::new(format!(
+                "publication-stale-worker-{}",
+                uuid::Uuid::new_v4().simple()
+            )),
+            &submission,
+            &reclaim_seed.manifest_id,
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+        let stale_tenant_id = stale.tenant.tenant_id().as_str();
+        client
+            .execute(
+                "UPDATE bulk_manifests SET lease_expiry = NOW() - INTERVAL '1 second' \
+                 WHERE tenant_id = $1 AND submitter = $2 AND submission_id = $3 \
+                   AND manifest_id = $4",
+                &[
+                    &stale_tenant_id as &(dyn tokio_postgres::types::ToSql + Sync),
+                    &stale.submission_id.submitter,
+                    &stale.submission_id.submission_id,
+                    &stale.manifest_id,
+                ],
+            )
+            .await
+            .unwrap();
+        let lease = claim_specific_manifest(
+            &backend,
+            &helios_persistence::core::WorkerId::new(format!(
+                "publication-live-worker-{}",
+                uuid::Uuid::new_v4().simple()
+            )),
+            &submission,
+            &reclaim_seed.manifest_id,
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+        assert!(lease.fencing_token > stale.fencing_token);
+        let error = SubmitFileRecord {
+            manifest_url: Some(stale_url.to_string()),
+            file_type: "error".to_string(),
+            resource_type: Some("OperationOutcome".to_string()),
+            part_index: 0,
+            file_path: format!("error/{}.ndjson", lease.manifest_id),
+            line_count: 2,
+            byte_count: 128,
+            count_severity: Some(serde_json::json!({"error": 2})),
+        };
+        let failure_message = format!("reclaimed publication {}", lease.fencing_token);
+        assert!(matches!(
+            backend
+                .publish_manifest_artifacts(
+                    &stale,
+                    std::slice::from_ref(&error),
+                    ManifestPublicationStatus::Failed {
+                        error_message: failure_message.clone(),
+                    },
+                )
+                .await,
+            Err(LeaseError::LeaseLost { .. })
+        ));
+        assert!(
+            backend
+                .list_submit_files(&tenant, &submission)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the stale publication must not expose its rejected set"
+        );
+        assert_eq!(
+            backend
+                .publish_manifest_artifacts(
+                    &lease,
+                    std::slice::from_ref(&error),
+                    ManifestPublicationStatus::Failed {
+                        error_message: failure_message.clone(),
+                    },
+                )
+                .await
+                .unwrap(),
+            ManifestPublicationResult::Published
+        );
+        let live_manifest = backend
+            .get_manifest(&tenant, &submission, &lease.manifest_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(live_manifest.status, ManifestStatus::Failed);
+        let rows = backend
+            .list_submit_files(&tenant, &submission)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.file_type, "error");
+        assert_eq!(row.resource_type.as_deref(), Some("OperationOutcome"));
+        assert_eq!(row.part_index, 0);
+        assert_eq!(row.fencing_token, lease.fencing_token);
+        assert_eq!(row.file_path, error.file_path);
+        assert_eq!(row.line_count, 2);
+        assert_eq!(row.byte_count, 128);
+        assert_eq!(row.count_severity, Some(serde_json::json!({"error": 2})));
+        assert_eq!(
+            backend
+                .publish_manifest_artifacts(
+                    &lease,
+                    std::slice::from_ref(&error),
+                    ManifestPublicationStatus::Failed {
+                        error_message: failure_message.clone(),
+                    },
+                )
+                .await
+                .unwrap(),
+            ManifestPublicationResult::AlreadyPublished
+        );
+        assert!(matches!(
+            backend
+                .publish_manifest_artifacts(
+                    &lease,
+                    std::slice::from_ref(&error),
+                    ManifestPublicationStatus::Failed {
+                        error_message: "different terminal message".to_string(),
+                    },
+                )
+                .await,
+            Err(LeaseError::Storage(_))
+        ));
+
+        let coexist_url = "https://provider/publication-expiry-scope-coexist.json";
+        let coexist_manifest = backend
+            .add_manifest(&tenant, &submission, Some(coexist_url), None)
+            .await
+            .unwrap();
+        let coexist_lease = claim_specific_manifest(
+            &backend,
+            &helios_persistence::core::WorkerId::new(format!(
+                "publication-coexist-worker-{}",
+                uuid::Uuid::new_v4().simple()
+            )),
+            &submission,
+            &coexist_manifest.manifest_id,
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+        let mut coexist_lease = coexist_lease;
+        coexist_lease.fencing_token = lease.fencing_token;
+        client
+            .execute(
+                "UPDATE bulk_manifests SET fencing_token = $1 \
+                 WHERE tenant_id = $2 AND submitter = $3 AND submission_id = $4 \
+                   AND manifest_id = $5",
+                &[
+                    &(coexist_lease.fencing_token as i64),
+                    &coexist_lease.tenant.tenant_id().as_str(),
+                    &coexist_lease.submission_id.submitter,
+                    &coexist_lease.submission_id.submission_id,
+                    &coexist_lease.manifest_id,
+                ],
+            )
+            .await
+            .unwrap();
+        let coexist = SubmitFileRecord {
+            manifest_url: Some(coexist_url.to_string()),
+            file_path: format!("error/{}.ndjson", coexist_lease.manifest_id),
+            ..error.clone()
+        };
+        backend
+            .record_submit_file(&coexist_lease, &coexist)
+            .await
+            .unwrap();
+        assert_eq!(
+            backend
+                .publish_manifest_artifacts(
+                    &coexist_lease,
+                    std::slice::from_ref(&coexist),
+                    ManifestPublicationStatus::Completed,
+                )
+                .await
+                .unwrap(),
+            ManifestPublicationResult::Published
+        );
+        let rows = backend
+            .list_submit_files(&tenant, &submission)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|row| row.file_type == "error"
+            && row.resource_type.as_deref() == Some("OperationOutcome")
+            && row.part_index == 0
+            && row.fencing_token == lease.fencing_token));
+        assert_eq!(
+            rows.iter()
+                .map(|row| row.manifest_id.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some(lease.manifest_id.as_str()),
+                Some(coexist_lease.manifest_id.as_str())
+            ]
+        );
+        let other_tenant = create_tenant("publication-scope-other");
+        assert!(
+            backend
+                .list_submit_files(&other_tenant, &submission)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            backend
+                .list_submit_files(&tenant, &SubmissionId::generate("publication-scope-other"))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let _ = client;
+    }
+
+    #[tokio::test]
+    async fn postgres_publication_concurrency_and_cleanup_rollback() {
+        use helios_persistence::core::{
+            BulkSubmitProvider, LeaseError, ManifestPublicationResult, ManifestPublicationStatus,
+            SubmissionId, SubmitFileRecord, SubmitWorkerStorage,
+        };
+
+        let _guard = BULK_SUBMIT_TEST_LOCK.lock().await;
+        let backend = create_backend().await;
+        let tenant = create_tenant("publication-cleanup");
+        let submission = SubmissionId::generate("publication-cleanup");
+        let manifest_url = "https://provider/publication-cleanup.json";
+        backend
+            .create_submission(&tenant, &submission, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(&tenant, &submission, Some(manifest_url), None)
+            .await
+            .unwrap();
+        let lease = claim_specific_manifest(
+            &backend,
+            &helios_persistence::core::WorkerId::new(format!(
+                "publication-cleanup-worker-{}",
+                uuid::Uuid::new_v4().simple()
+            )),
+            &submission,
+            &manifest.manifest_id,
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+        let output = SubmitFileRecord {
+            manifest_url: Some(manifest_url.to_string()),
+            file_type: "output".to_string(),
+            resource_type: Some("Patient".to_string()),
+            part_index: 0,
+            file_path: "output/patient-0.ndjson".to_string(),
+            line_count: 3,
+            byte_count: 128,
+            count_severity: None,
+        };
+        let error = SubmitFileRecord {
+            manifest_url: Some(manifest_url.to_string()),
+            file_type: "error".to_string(),
+            resource_type: Some("OperationOutcome".to_string()),
+            part_index: 0,
+            file_path: "error/outcome-0.ndjson".to_string(),
+            line_count: 1,
+            byte_count: 96,
+            count_severity: Some(serde_json::json!({"error": 2})),
+        };
+        backend.record_submit_file(&lease, &output).await.unwrap();
+        backend.record_submit_file(&lease, &error).await.unwrap();
+        let set = [output.clone(), error.clone()];
+        let (first, second) = tokio::join!(
+            backend.publish_manifest_artifacts(&lease, &set, ManifestPublicationStatus::Completed,),
+            backend.publish_manifest_artifacts(&lease, &set, ManifestPublicationStatus::Completed,),
+        );
+        let results = [first.unwrap(), second.unwrap()];
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| **result == ManifestPublicationResult::Published)
+                .count(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| **result == ManifestPublicationResult::AlreadyPublished)
+                .count(),
+            1
+        );
+
+        let client = backend.get_client().await.unwrap();
+        let tenant_id = lease.tenant.tenant_id().as_str();
+        let where_clause = "tenant_id = $1 AND submitter = $2 AND submission_id = $3";
+        let identity: [&(dyn tokio_postgres::types::ToSql + Sync); 3] = [
+            &tenant_id,
+            &lease.submission_id.submitter,
+            &lease.submission_id.submission_id,
+        ];
+        let cleanup_fn = format!("publication_cleanup_fn_{}", uuid::Uuid::new_v4().simple());
+        let cleanup_trigger = format!(
+            "publication_cleanup_trigger_{}",
+            uuid::Uuid::new_v4().simple()
+        );
+        client
+            .batch_execute(&format!(
+                r#"
+                CREATE FUNCTION public.{cleanup_fn}() RETURNS trigger LANGUAGE plpgsql AS $body$
+                BEGIN
+                    RAISE EXCEPTION 'cleanup injected terminal failure';
+                END;
+                $body$;
+                CREATE TRIGGER {cleanup_trigger} BEFORE UPDATE OF published_token ON bulk_manifests
+                FOR EACH ROW
+                WHEN (OLD.published_token IS NOT NULL AND NEW.published_token IS NULL
+                      AND NEW.tenant_id = '{tenant_id}'
+                      AND NEW.submitter = '{submitter}'
+                      AND NEW.submission_id = '{submission_id}')
+                EXECUTE FUNCTION public.{cleanup_fn}();
+                "#,
+                tenant_id = lease.tenant.tenant_id(),
+                submitter = lease.submission_id.submitter,
+                submission_id = lease.submission_id.submission_id,
+            ))
+            .await
+            .unwrap();
+        let Err(storage_error) = backend
+            .delete_submission_artifacts(&tenant, &submission)
+            .await
+        else {
+            panic!("cleanup marker reset must fail while the trigger is installed");
+        };
+        assert!(
+            storage_error
+                .to_string()
+                .contains("clear publication markers:"),
+            "PG Display must retain the backend stage context, got {storage_error}"
+        );
+        let raw_count = client
+            .query_one(
+                &format!("SELECT count(*) FROM bulk_submit_files WHERE {where_clause}"),
+                &identity,
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(raw_count, 2);
+        let marker = client
+            .query_one(
+                &format!(
+                    "SELECT published_token, publication_status, publication_error_message, \
+                     publication_worker_id FROM bulk_manifests WHERE {where_clause}"
+                ),
+                &identity,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            marker.get::<_, Option<i64>>(0),
+            Some(lease.fencing_token as i64)
+        );
+        assert_eq!(
+            marker.get::<_, Option<String>>(1),
+            Some("completed".to_string())
+        );
+        assert_eq!(marker.get::<_, Option<String>>(2), None);
+        assert_eq!(
+            marker.get::<_, Option<String>>(3),
+            Some(lease.worker_id.as_str().to_string())
+        );
+        client
+            .batch_execute(&format!(
+                "DROP TRIGGER IF EXISTS {cleanup_trigger} ON bulk_manifests; \
+                 DROP FUNCTION IF EXISTS public.{cleanup_fn}();"
+            ))
+            .await
+            .unwrap();
+        backend
+            .delete_submission_artifacts(&tenant, &submission)
+            .await
+            .unwrap();
+        let raw_count = client
+            .query_one(
+                &format!("SELECT count(*) FROM bulk_submit_files WHERE {where_clause}"),
+                &identity,
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(raw_count, 0);
+        assert!(matches!(
+            backend
+                .publish_manifest_artifacts(
+                    &lease,
+                    &[output, error],
+                    ManifestPublicationStatus::Completed,
+                )
+                .await,
+            Err(LeaseError::LeaseLost { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn postgres_replaced_manifest_process_entries_does_not_revive_publication() {
+        use helios_persistence::core::LeaseError;
+        use helios_persistence::core::{
+            BulkSubmitProvider, ManifestPublicationStatus, ManifestStatus, SubmissionId,
+            SubmitWorkerStorage,
+        };
+
+        let _guard = BULK_SUBMIT_TEST_LOCK.lock().await;
+        let backend = create_backend().await;
+        let tenant = create_tenant("replacement-guard");
+        let submission = SubmissionId::generate("replacement-guard");
+        let manifest_url = "https://provider/replacement-guard.json";
+        backend
+            .create_submission(&tenant, &submission, None)
+            .await
+            .unwrap();
+        let manifest = backend
+            .add_manifest(&tenant, &submission, Some(manifest_url), None)
+            .await
+            .unwrap();
+        let lease = claim_specific_manifest(
+            &backend,
+            &helios_persistence::core::WorkerId::new(format!(
+                "replacement-guard-worker-{}",
+                uuid::Uuid::new_v4().simple()
+            )),
+            &submission,
+            &manifest.manifest_id,
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+        backend
+            .replace_manifest_by_url(&tenant, &submission, manifest_url)
+            .await
+            .unwrap();
+
+        backend
+            .process_entries(
+                &tenant,
+                &submission,
+                &manifest.manifest_id,
+                Vec::new(),
+                &helios_persistence::core::BulkProcessingOptions::new(),
+            )
+            .await
+            .unwrap();
+        let manifest = backend
+            .get_manifest(&tenant, &submission, &manifest.manifest_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            manifest.status,
+            ManifestStatus::Replaced,
+            "an empty ingest must not revive a replaced manifest"
+        );
+        assert!(
+            matches!(
+                backend
+                    .publish_manifest_artifacts(&lease, &[], ManifestPublicationStatus::Completed,)
+                    .await,
+                Err(LeaseError::LeaseLost { .. })
+            ),
+            "the old lease must lose publication after replacement"
+        );
+    }
+
     mod receipt_paging_contract {
         use helios_persistence as persistence;
         include!(concat!(

--- a/crates/rest/Cargo.toml
+++ b/crates/rest/Cargo.toml
@@ -145,6 +145,10 @@ rand = "0.8"
 # registry through `helios-persistence` and never names the lock type.
 parking_lot = "0.12"
 
+# Direct SQLite fixture access for legacy-row REST tests. Bounded to the version
+# already used by helios-persistence; no new backend code is exposed.
+rusqlite = { version = "0.33", features = ["bundled", "serde_json", "functions"] }
+
 # Temp files
 tempfile = "3"
 

--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -9,6 +9,7 @@
 //! Implements the FHIR Bulk Data Access **Submit** operation:
 //! <https://build.fhir.org/ig/HL7/bulk-data/en/submit.html>.
 
+use std::collections::HashSet;
 use std::net::IpAddr;
 use std::time::Duration;
 
@@ -19,10 +20,11 @@ use axum::{
     response::Response,
 };
 use helios_auth::Principal;
+use helios_persistence::TenantContext;
 use helios_persistence::core::{
     DownloadUrl, ExportPartKey, IMPORT_MODE_PARAMETER_URL, ImportMode, ManifestFetchParams,
-    ManifestPhase, ManifestStatus, ResourceStorage, SubmissionId, SubmissionStatus,
-    submission_output_job_id,
+    ManifestPhase, ManifestStatus, ResourceStorage, SubmissionId, SubmissionStatus, SubmitFileRow,
+    submission_output_job_id, submit_artifact_key,
 };
 use serde_json::{Value, json};
 
@@ -79,6 +81,123 @@ fn bad_request(msg: impl Into<String>) -> RestError {
     RestError::BadRequest {
         message: msg.into(),
     }
+}
+
+/// One artifact resolved to the exact output-store key and REST route part.
+#[derive(Debug)]
+struct ResolvedSubmitArtifact<'a> {
+    key: ExportPartKey,
+    route_part: String,
+    row: &'a SubmitFileRow,
+}
+
+/// Reconstructs a legacy artifact's resource-part route and key.
+///
+/// Only `SubmitFileRow::legacy_locator == true` authorizes this fallback. The
+/// flag itself, rather than the shape of `file_path`, is the compatibility
+/// decision, so a malformed new row can never be silently treated as legacy.
+fn legacy_submit_artifact_route_part(row: &SubmitFileRow) -> String {
+    let resource_type = row
+        .resource_type
+        .clone()
+        .unwrap_or_else(|| "OperationOutcome".into());
+    format!("{resource_type}-{}", row.part_index)
+}
+
+/// Resolves one recorded artifact to its exact key and route.
+///
+/// New rows must carry an owning manifest ID and their exact v1 locator.
+/// Legacy rows use the pre-manifest resource-part route only because their
+/// explicit flag says so. Callers that expose the whole set must first reject
+/// duplicate route parts.
+fn resolve_submit_artifacts<'a>(
+    tenant: &TenantContext,
+    submission_id: &SubmissionId,
+    files: &'a [SubmitFileRow],
+) -> RestResult<Vec<ResolvedSubmitArtifact<'a>>> {
+    files
+        .iter()
+        .map(|row| {
+            if row.legacy_locator {
+                let resource_type = row
+                    .resource_type
+                    .clone()
+                    .unwrap_or_else(|| "OperationOutcome".into());
+                let route_part = legacy_submit_artifact_route_part(row);
+                let key = ExportPartKey {
+                    tenant_id: tenant.tenant_id().as_str().to_string(),
+                    job_id: submission_output_job_id(submission_id),
+                    resource_type,
+                    file_type: row.file_type.clone(),
+                    part_index: row.part_index,
+                    fencing_token: row.fencing_token,
+                };
+                return Ok(ResolvedSubmitArtifact {
+                    key,
+                    route_part,
+                    row,
+                });
+            }
+
+            let manifest_id =
+                row.manifest_id
+                    .as_deref()
+                    .ok_or_else(|| RestError::InternalError {
+                        message: format!(
+                            "manifest-aware bulk-submit artifact is missing manifest_id: {}",
+                            row.file_path
+                        ),
+                    })?;
+            let key = submit_artifact_key(
+                tenant,
+                submission_id,
+                manifest_id,
+                &row.file_type,
+                row.resource_type.as_deref(),
+                row.part_index,
+                row.fencing_token,
+            );
+            if row.file_path != key.resource_type {
+                return Err(RestError::InternalError {
+                    message: format!(
+                        "stored submit artifact locator does not match its manifest identity: {}",
+                        row.file_path
+                    ),
+                });
+            }
+            Ok(ResolvedSubmitArtifact {
+                route_part: key.resource_type.clone(),
+                key,
+                row,
+            })
+        })
+        .collect()
+}
+
+/// Resolves the complete visible artifact set and rejects ambiguous routes.
+///
+/// A legacy collision across `file_type` or manifest generations yields the
+/// same REST route for two artifacts. Rejecting before slicing keeps every
+/// page deterministic and prevents a valid-looking route from silently
+/// selecting the first collision.
+fn resolve_visible_submit_artifacts<'a>(
+    tenant: &TenantContext,
+    submission_id: &SubmissionId,
+    files: &'a [SubmitFileRow],
+) -> RestResult<Vec<ResolvedSubmitArtifact<'a>>> {
+    let resolved_files = resolve_submit_artifacts(tenant, submission_id, files)?;
+    let mut route_parts = HashSet::with_capacity(resolved_files.len());
+    for artifact in &resolved_files {
+        if !route_parts.insert(artifact.route_part.as_str()) {
+            return Err(RestError::InternalError {
+                message: format!(
+                    "ambiguous bulk-submit artifact route: {}",
+                    artifact.route_part
+                ),
+            });
+        }
+    }
+    Ok(resolved_files)
 }
 
 /// Enforces the `system/bulk-submit` operation scope when auth is enabled.
@@ -917,8 +1036,11 @@ where
         .list_submit_files(ctx, sub_id)
         .await
         .map_err(RestError::from)?;
-    let job_id = submission_output_job_id(sub_id);
     let ttl = Duration::from_secs(cfg.file_url_ttl_secs);
+
+    // Resolve and validate the complete visible set before slicing so a route
+    // collision cannot make pagination non-deterministic.
+    let resolved_files = resolve_visible_submit_artifacts(ctx, sub_id, &files)?;
 
     // Slice the artifact rows into the requested page. Backends return them in a
     // stable order (`ORDER BY id`) and rows are append-only until the whole
@@ -935,11 +1057,15 @@ where
             id: format!("{token}?{PAGE_PARAM}={page}"),
         });
     }
-    let page_files = if page_size == 0 {
-        &files[..]
+    let start = if page_size == 0 {
+        0
     } else {
-        let start = (page - 1) * page_size;
-        &files[start..(start + page_size).min(files.len())]
+        (page - 1) * page_size
+    };
+    let page_artifacts = if page_size == 0 {
+        &resolved_files[..]
+    } else {
+        &resolved_files[start..(start + page_size).min(resolved_files.len())]
     };
 
     let mut output_arr = Vec::new();
@@ -952,21 +1078,10 @@ where
     // stays identical on every page even though each page sees a different slice.
     let mut requires_token = cfg.requires_access_token == "true";
 
-    for f in page_files {
-        let resource_type = f
-            .resource_type
-            .clone()
-            .unwrap_or_else(|| "OperationOutcome".into());
-        let key = ExportPartKey {
-            tenant_id: ctx.tenant_id().as_str().to_string(),
-            job_id: job_id.clone(),
-            resource_type: resource_type.clone(),
-            file_type: f.file_type.clone(),
-            part_index: f.part_index,
-            fencing_token: f.fencing_token,
-        };
+    for artifact in page_artifacts {
+        let f = artifact.row;
         let dl = output
-            .download_url(&key, ttl)
+            .download_url(&artifact.key, ttl)
             .await
             .map_err(RestError::from)?;
         // HFS-served artifacts (local-fs) MUST be advertised on the
@@ -975,10 +1090,13 @@ where
         // Pre-signed URLs (S3) are capability URLs and are used as-is.
         requires_token |= dl.requires_access_token;
         let url = advertised_download_url(&dl, || {
-            let part = format!("{resource_type}-{}", f.part_index);
             state.public_url_for_request(
                 &tenant,
-                ["bulk-submit-file", token.as_str(), part.as_str()],
+                [
+                    "bulk-submit-file",
+                    token.as_str(),
+                    artifact.route_part.as_str(),
+                ],
             )
         });
         let url = serde_json::Value::String(url);
@@ -1184,36 +1302,31 @@ where
     let ctx = &target.tenant;
     let sub_id = &target.submission_id;
 
-    // Resolve the part to a recorded artifact (part = "{resource_type}-{part_index}").
+    // Resolve the requested route exactly once. A duplicate route is an
+    // ambiguous stored artifact, so it is reported as missing rather than
+    // allowing first-row ordering to choose a file.
     let files = jobs
         .list_submit_files(ctx, sub_id)
         .await
         .map_err(RestError::from)?;
-    let job_id = submission_output_job_id(sub_id);
-    let matched = files.into_iter().find(|f| {
-        let rt = f
-            .resource_type
-            .clone()
-            .unwrap_or_else(|| "OperationOutcome".into());
-        format!("{}-{}", rt, f.part_index) == part
-    });
-    let f = matched.ok_or_else(|| RestError::NotFound {
+    let resolved_files = resolve_submit_artifacts(ctx, sub_id, &files)?;
+    let mut matches = resolved_files
+        .into_iter()
+        .filter(|artifact| artifact.route_part == part);
+    let matched = matches.next().ok_or_else(|| RestError::NotFound {
         resource_type: "bulk-submit-file".to_string(),
         id: format!("{token}/{part}"),
     })?;
-    let key = ExportPartKey {
-        tenant_id: ctx.tenant_id().as_str().to_string(),
-        job_id,
-        resource_type: f
-            .resource_type
-            .clone()
-            .unwrap_or_else(|| "OperationOutcome".into()),
-        file_type: f.file_type.clone(),
-        part_index: f.part_index,
-        fencing_token: f.fencing_token,
-    };
-
-    let mut reader = output.open_reader(&key).await.map_err(RestError::from)?;
+    if matches.next().is_some() {
+        return Err(RestError::NotFound {
+            resource_type: "bulk-submit-file".to_string(),
+            id: format!("{token}/{part}"),
+        });
+    }
+    let mut reader = output
+        .open_reader(&matched.key)
+        .await
+        .map_err(RestError::from)?;
     let mut bytes = Vec::new();
     tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut bytes)
         .await
@@ -1233,6 +1346,98 @@ where
 mod tests {
     use super::*;
     use serde_json::json;
+
+    use helios_persistence::tenant::{TenantId, TenantPermissions};
+
+    fn submit_file_row(
+        file_type: &str,
+        resource_type: Option<&str>,
+        manifest_id: Option<&str>,
+        legacy_locator: bool,
+        file_path: &str,
+    ) -> SubmitFileRow {
+        SubmitFileRow {
+            manifest_url: Some("https://provider/manifest.json".to_string()),
+            file_type: file_type.to_string(),
+            resource_type: resource_type.map(str::to_string),
+            part_index: 0,
+            fencing_token: 1,
+            manifest_id: manifest_id.map(str::to_string),
+            legacy_locator,
+            file_path: file_path.to_string(),
+            line_count: 1,
+            byte_count: 1,
+            count_severity: None,
+        }
+    }
+
+    fn test_tenant() -> TenantContext {
+        TenantContext::new(
+            TenantId::new("test-tenant"),
+            TenantPermissions::full_access(),
+        )
+    }
+
+    #[test]
+    fn legacy_routes_reject_ambiguous_resource_parts() {
+        let tenant = test_tenant();
+        let submission_id = SubmissionId::new("http://ehr|ehr-1", "it-1");
+        let rows = vec![
+            submit_file_row(
+                "output",
+                Some("OperationOutcome"),
+                None,
+                true,
+                "legacy-output",
+            ),
+            submit_file_row(
+                "error",
+                Some("OperationOutcome"),
+                None,
+                true,
+                "legacy-error",
+            ),
+        ];
+        let result = resolve_visible_submit_artifacts(&tenant, &submission_id, &rows);
+        assert!(matches!(result, Err(RestError::InternalError { .. })));
+    }
+
+    #[test]
+    fn one_unambiguous_legacy_row_resolves_to_the_legacy_route() {
+        let tenant = test_tenant();
+        let submission_id = SubmissionId::new("http://ehr|ehr-1", "it-1");
+        let rows = vec![submit_file_row(
+            "output",
+            Some("OperationOutcome"),
+            None,
+            true,
+            "legacy-output",
+        )];
+
+        let resolved = resolve_visible_submit_artifacts(&tenant, &submission_id, &rows)
+            .expect("unambiguous legacy row");
+
+        assert_eq!(resolved[0].route_part, "OperationOutcome-0");
+        assert_eq!(
+            resolved[0].key.job_id.as_str(),
+            submission_output_job_id(&submission_id).as_str()
+        );
+    }
+
+    #[test]
+    fn malformed_new_rows_do_not_use_legacy_fallback() {
+        let tenant = test_tenant();
+        let submission_id = SubmissionId::new("http://ehr|ehr-1", "it-1");
+        let rows = vec![submit_file_row(
+            "output",
+            Some("OperationOutcome"),
+            Some("manifest-a"),
+            false,
+            "not-a-submit-v1-locator",
+        )];
+        let result = resolve_submit_artifacts(&tenant, &submission_id, &rows);
+        assert!(matches!(result, Err(RestError::InternalError { .. })));
+    }
 
     #[test]
     fn group_thousands_groups_digits_from_the_right() {

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -4,7 +4,7 @@
 //! through the real Axum router, plus the validation SHALLs and the
 //! poll/cancel → 404 contract.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -14,11 +14,13 @@ use axum_test::TestServer;
 use helios_persistence::backends::local_fs::LocalFsOutputStore;
 use helios_persistence::backends::sqlite::{SqliteBackend, SqliteBackendConfig};
 use helios_persistence::core::{
-    BulkSubmitJobStore, BulkSubmitProvider, DefaultSubmitWorker, ExportOutputStore, ManifestPhase,
-    RemoteFile, RemoteManifest, ResourceStorage, SubmitClaimStrategy, SubmitInputFetcher,
-    SubmitWorkerStorage, WorkerId,
+    BulkSubmitJobStore, BulkSubmitProvider, DefaultSubmitWorker, ExportOutputStore, ExportPartKey,
+    ManifestPhase, ManifestPublicationStatus, RemoteFile, RemoteManifest, ResourceStorage,
+    SubmissionId, SubmitClaimStrategy, SubmitFileRecord, SubmitInputFetcher, SubmitWorkerStorage,
+    WorkerId, submission_output_job_id,
 };
 use helios_persistence::error::StorageResult;
+use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
 use helios_rest::ServerConfig;
 use helios_rest::bulk_export_auth::BearerScopeAuth;
 use helios_rest::config::{BulkSubmitConfig, MultitenancyConfig, TenantRoutingMode};
@@ -28,6 +30,7 @@ use serde_json::{Value, json};
 struct MockFetcher {
     files: std::collections::HashMap<String, Vec<u8>>,
     manifest: RemoteManifest,
+    manifests: std::collections::HashMap<String, RemoteManifest>,
 }
 
 #[async_trait]
@@ -39,6 +42,14 @@ impl SubmitInputFetcher for MockFetcher {
         _oauth: &[String],
         _encryption_key: Option<&Value>,
     ) -> StorageResult<RemoteManifest> {
+        if let Some(manifest) = self.manifests.get(_url) {
+            return Ok(RemoteManifest {
+                requires_access_token: manifest.requires_access_token,
+                output: manifest.output.clone(),
+                deleted: manifest.deleted.clone(),
+            });
+        }
+
         Ok(RemoteManifest {
             requires_access_token: self.manifest.requires_access_token,
             output: self.manifest.output.clone(),
@@ -84,6 +95,7 @@ fn mock_fetcher() -> Arc<MockFetcher> {
             }],
             deleted: vec![],
         },
+        manifests: std::collections::HashMap::new(),
     })
 }
 
@@ -121,7 +133,123 @@ fn multi_artifact_fetcher() -> Arc<MockFetcher> {
                 count: Some(1),
             }],
         },
+        manifests: std::collections::HashMap::new(),
     })
+}
+
+/// A fetcher whose output receipt declares `OperationOutcome` but whose second
+/// NDJSON line is another resource type, producing one valid output artifact and
+/// one aggregated error artifact with the same resource type but different
+/// protocol kind.
+fn operation_outcome_fetcher() -> Arc<MockFetcher> {
+    let mut files = std::collections::HashMap::new();
+    files.insert(
+        "https://provider/operation-outcome.ndjson".to_string(),
+        concat!(
+            "{\"resourceType\":\"OperationOutcome\",\"id\":\"oo-out-1\"}\n",
+            "{\"resourceType\":\"Patient\",\"id\":\"oo-wrong-type\"}\n",
+        )
+        .as_bytes()
+        .to_vec(),
+    );
+    Arc::new(MockFetcher {
+        files,
+        manifest: RemoteManifest {
+            requires_access_token: false,
+            output: vec![RemoteFile {
+                resource_type: Some("OperationOutcome".to_string()),
+                url: "https://provider/operation-outcome.ndjson".to_string(),
+                count: Some(1),
+            }],
+            deleted: vec![],
+        },
+        manifests: std::collections::HashMap::new(),
+    })
+}
+
+/// Serves distinct Patient manifests for the same submitter/submission ID.
+fn two_manifest_fetcher() -> Arc<MockFetcher> {
+    let mut files = std::collections::HashMap::new();
+    files.insert(
+        "https://provider/mm-a.ndjson".to_string(),
+        b"{\"resourceType\":\"Patient\",\"id\":\"mm-a-1\"}\n".to_vec(),
+    );
+    files.insert(
+        "https://provider/mm-b.ndjson".to_string(),
+        b"{\"resourceType\":\"Patient\",\"id\":\"mm-b-1\"}\n".to_vec(),
+    );
+
+    let mut manifests = std::collections::HashMap::new();
+    for (manifest_name, patient_id) in [("manifest-a", "mm-a"), ("manifest-b", "mm-b")] {
+        manifests.insert(
+            format!("https://provider/{manifest_name}.json"),
+            RemoteManifest {
+                requires_access_token: false,
+                output: vec![RemoteFile {
+                    resource_type: Some("Patient".to_string()),
+                    url: format!("https://provider/{patient_id}.ndjson"),
+                    count: Some(1),
+                }],
+                deleted: vec![],
+            },
+        );
+    }
+
+    Arc::new(MockFetcher {
+        files,
+        manifest: manifests["https://provider/manifest-a.json"].clone(),
+        manifests,
+    })
+}
+
+async fn create_file_submit_server(
+    bulk_submit: BulkSubmitConfig,
+) -> (
+    TestServer,
+    Arc<SqliteBackend>,
+    Arc<LocalFsOutputStore>,
+    PathBuf,
+    tempfile::TempDir,
+) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("legacy.db");
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("data"))
+        .unwrap_or_else(|| PathBuf::from("data"));
+    let backend = Arc::new(
+        SqliteBackend::with_config(
+            &db_path,
+            SqliteBackendConfig {
+                data_dir: Some(data_dir),
+                ..Default::default()
+            },
+        )
+        .expect("create file-backed SQLite backend"),
+    );
+    backend.init_schema().expect("init schema");
+
+    let output_dir = tmp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("create legacy output dir");
+    let output = Arc::new(LocalFsOutputStore::new(
+        &output_dir,
+        "https://wrong-internal.example",
+    ));
+
+    let config = ServerConfig {
+        bulk_submit,
+        ..ServerConfig::for_testing()
+    };
+    let state = helios_rest::AppState::new(Arc::clone(&backend), config).with_bulk_submit(
+        backend.clone() as Arc<dyn BulkSubmitJobStore>,
+        mock_fetcher() as Arc<dyn SubmitInputFetcher>,
+        output.clone() as Arc<dyn ExportOutputStore>,
+        Arc::new(BearerScopeAuth),
+    );
+    let app = helios_rest::routing::fhir_routes::create_routes(state);
+    let server = TestServer::new(app).expect("create test server");
+    (server, backend, output, db_path, tmp)
 }
 
 async fn create_submit_server() -> (
@@ -233,6 +361,134 @@ async fn drain_submit(
     }
 }
 
+const LEGACY_OUTPUT_BYTES: &str = "{\"reference\":\"OperationOutcome/legacy-1\"}\n";
+const LEGACY_DELETED_BYTES: &str = "{\"reference\":\"Bundle/legacy-deleted\"}\n";
+const LEGACY_ERROR_BYTES: &str = "{\"legacy\":\"collides\"}\n";
+
+#[derive(Debug)]
+struct LegacyArtifact {
+    file_type: &'static str,
+    resource_type: &'static str,
+    body: &'static str,
+}
+
+impl LegacyArtifact {
+    fn new(file_type: &'static str, resource_type: &'static str, body: &'static str) -> Self {
+        Self {
+            file_type,
+            resource_type,
+            body,
+        }
+    }
+}
+
+async fn write_legacy_artifact(
+    output: &Arc<LocalFsOutputStore>,
+    tenant: &TenantContext,
+    submission_id: &SubmissionId,
+    artifact: &LegacyArtifact,
+    fencing_token: u64,
+) -> (u64, u64) {
+    let key = ExportPartKey {
+        tenant_id: tenant.tenant_id().as_str().to_owned(),
+        job_id: submission_output_job_id(submission_id),
+        resource_type: artifact.resource_type.to_owned(),
+        file_type: artifact.file_type.to_owned(),
+        part_index: 0,
+        fencing_token,
+    };
+    let mut writer = output.open_writer(&key).await.expect("open legacy writer");
+    let line = artifact.body.trim_end_matches('\n');
+    writer.write_line(line).await.expect("write legacy line");
+    let finalized = output
+        .finalize_part(&key, writer)
+        .await
+        .expect("finalize legacy part");
+    (finalized.line_count, finalized.size_bytes)
+}
+
+async fn publish_legacy_manifest(
+    backend: &Arc<SqliteBackend>,
+    output: &Arc<LocalFsOutputStore>,
+    tenant: &TenantContext,
+    submission_id: &SubmissionId,
+    manifest_url: &str,
+    artifacts: &[LegacyArtifact],
+) {
+    let manifest = backend
+        .list_manifests(tenant, submission_id)
+        .await
+        .expect("list legacy manifests")
+        .into_iter()
+        .find(|m| m.manifest_url.as_deref() == Some(manifest_url))
+        .expect("legacy manifest");
+    let worker_id = WorkerId::new("legacy-fixture-worker");
+    let lease = backend
+        .claim_next_manifest(&worker_id, Duration::from_secs(60))
+        .await
+        .expect("claim legacy manifest")
+        .expect("a pending legacy manifest");
+    assert_eq!(lease.manifest_id, manifest.manifest_id);
+    backend
+        .mark_manifest_processing(&lease)
+        .await
+        .expect("mark legacy manifest processing");
+
+    let mut records = Vec::with_capacity(artifacts.len());
+    for artifact in artifacts {
+        let (line_count, byte_count) =
+            write_legacy_artifact(output, tenant, submission_id, artifact, lease.fencing_token)
+                .await;
+        let record = SubmitFileRecord {
+            manifest_url: Some(manifest_url.to_string()),
+            file_type: artifact.file_type.to_owned(),
+            resource_type: Some(artifact.resource_type.to_owned()),
+            part_index: 0,
+            file_path: format!("{}-0", artifact.resource_type),
+            line_count,
+            byte_count,
+            count_severity: None,
+        };
+        records.push(record.clone());
+        backend
+            .record_submit_file(&lease, &record)
+            .await
+            .expect("stage legacy artifact");
+    }
+
+    backend
+        .publish_manifest_artifacts(&lease, &records, ManifestPublicationStatus::Completed)
+        .await
+        .expect("publish legacy manifest");
+}
+
+fn clear_legacy_publication_worker(
+    db_path: &Path,
+    tenant: &TenantContext,
+    submission_id: &SubmissionId,
+) {
+    let connection = rusqlite::Connection::open(db_path).expect("open legacy SQLite database");
+    connection
+        .execute(
+            "UPDATE bulk_manifests
+             SET publication_worker_id = NULL
+             WHERE tenant_id = ?1 AND submitter = ?2 AND submission_id = ?3",
+            rusqlite::params![
+                tenant.tenant_id().as_str(),
+                submission_id.submitter,
+                submission_id.submission_id,
+            ],
+        )
+        .expect("clear legacy publication marker");
+}
+
+fn legacy_test_tenant() -> TenantContext {
+    TenantContext::new(
+        TenantId::new("test-tenant"),
+        TenantPermissions::full_access(),
+    )
+}
+
 fn kickoff_body() -> Value {
     json!({
         "resourceType": "Parameters",
@@ -240,6 +496,19 @@ fn kickoff_body() -> Value {
             {"name": "submitter", "valueIdentifier": {"system": "http://ehr", "value": "ehr-1"}},
             {"name": "submissionId", "valueString": "it-1"},
             {"name": "manifestUrl", "valueUrl": "https://provider/manifest.json"},
+            {"name": "fhirBaseUrl", "valueUrl": "https://provider/fhir"}
+        ]
+    })
+}
+
+/// A kickoff with the same submitter/submission identity but another manifest URL.
+fn kickoff_body_at(manifest_url: &str) -> Value {
+    json!({
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "submitter", "valueIdentifier": {"system": "http://ehr", "value": "ehr-1"}},
+            {"name": "submissionId", "valueString": "it-1"},
+            {"name": "manifestUrl", "valueUrl": manifest_url},
             {"name": "fhirBaseUrl", "valueUrl": "https://provider/fhir"}
         ]
     })
@@ -591,6 +860,258 @@ async fn run_to_completion(
         .to_string();
     drain_submit(backend, fetcher, output).await;
     poll_path
+}
+
+/// Trims the configured public origin from an advertised URL for local GETs.
+fn local_file_path(url: &str) -> &str {
+    url.trim_start_matches("http://localhost:8080")
+}
+
+/// A migrated SQLite generation keeps manifest IDs but uses the old
+/// `{resource_type}-{part}` route. Two different file kinds sharing
+/// `OperationOutcome-0` are ambiguous and fail the whole visible status set;
+/// a distinct `Bundle-0` route remains readable.
+#[tokio::test]
+async fn legacy_routes_reject_duplicate_operation_outcomes() {
+    let (server, backend, output, db_path, _tmp) = create_file_submit_server(BulkSubmitConfig {
+        manifest_page_size: 1,
+        ..Default::default()
+    })
+    .await;
+    let tenant = legacy_test_tenant();
+    let submission_id = SubmissionId::new("http://ehr|ehr-1", "it-1");
+
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_at("https://provider/legacy-a.json"))
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+    let token = backend
+        .ensure_poll_token(&tenant, &submission_id)
+        .await
+        .expect("mint legacy poll token");
+    let poll_path = format!("/bulk-submit-status/{token}");
+    publish_legacy_manifest(
+        &backend,
+        &output,
+        &tenant,
+        &submission_id,
+        "https://provider/legacy-a.json",
+        &[
+            LegacyArtifact::new("output", "OperationOutcome", LEGACY_OUTPUT_BYTES),
+            LegacyArtifact::new("deleted", "Bundle", LEGACY_DELETED_BYTES),
+        ],
+    )
+    .await;
+    clear_legacy_publication_worker(&db_path, &tenant, &submission_id);
+    let files = backend
+        .list_submit_files(&tenant, &submission_id)
+        .await
+        .expect("list migrated legacy files");
+    assert_eq!(files.len(), 2);
+    assert!(
+        files
+            .iter()
+            .all(|row| row.manifest_id.is_some() && row.legacy_locator)
+    );
+
+    // Canonical publication order puts `deleted` before `output`; page 1 is
+    // therefore the deleted receipt, and page 2 advertises the legacy output.
+    let manifest: Value = server.get(&format!("{poll_path}?page=2")).await.json();
+    let output_entries = manifest["output"].as_array().expect("legacy output array");
+    assert_eq!(output_entries.len(), 1);
+    assert_eq!(output_entries[0]["count"], 1);
+    assert_eq!(
+        output_entries[0]["fileSize"],
+        LEGACY_OUTPUT_BYTES.len() as u64
+    );
+    let output_url = output_entries[0]["url"].as_str().expect("output url");
+    assert!(output_url.ends_with(&format!("/bulk-submit-file/{token}/OperationOutcome-0")));
+    assert_eq!(
+        server.get(local_file_path(output_url)).await.text(),
+        LEGACY_OUTPUT_BYTES
+    );
+
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_at("https://provider/legacy-b.json"))
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+    publish_legacy_manifest(
+        &backend,
+        &output,
+        &tenant,
+        &submission_id,
+        "https://provider/legacy-b.json",
+        &[LegacyArtifact::new(
+            "error",
+            "OperationOutcome",
+            LEGACY_ERROR_BYTES,
+        )],
+    )
+    .await;
+    clear_legacy_publication_worker(&db_path, &tenant, &submission_id);
+    let files = backend
+        .list_submit_files(&tenant, &submission_id)
+        .await
+        .expect("list colliding legacy files");
+    assert_eq!(files.len(), 3);
+    assert!(
+        files
+            .iter()
+            .all(|row| row.manifest_id.is_some() && row.legacy_locator)
+    );
+
+    let status = server.get(&poll_path).await;
+    assert_eq!(status.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+    let status_outcome: Value = status.json();
+    assert_eq!(status_outcome["issue"][0]["code"], "exception");
+
+    let duplicate = server
+        .get(&format!("/bulk-submit-file/{token}/OperationOutcome-0"))
+        .await;
+    assert_eq!(duplicate.status_code(), StatusCode::NOT_FOUND);
+    let duplicate_outcome: Value = duplicate.json();
+    assert_eq!(duplicate_outcome["issue"][0]["code"], "not-found");
+
+    let independent = server
+        .get(&format!("/bulk-submit-file/{token}/Bundle-0"))
+        .await;
+    assert_eq!(independent.status_code(), StatusCode::OK);
+    assert_eq!(independent.text(), LEGACY_DELETED_BYTES);
+}
+
+/// The old `{type}-{part}` route could collapse an `output` and an `error`
+/// OperationOutcome with the same part index. Manifest-aware v1 routes bind the
+/// protocol file kind too, so both artifacts remain addressable and downloadable.
+#[tokio::test]
+async fn operation_outcome_output_and_error_routes_are_distinct() {
+    let (server, backend, fetcher, output, _tmp) =
+        create_submit_server_with(operation_outcome_fetcher(), BulkSubmitConfig::default()).await;
+    let poll_path = run_to_completion(&server, &backend, &fetcher, &output).await;
+
+    let manifest: Value = server.get(&poll_path).await.json();
+    let output = manifest["output"].as_array().expect("output array");
+    let outcome = manifest["outcome"].as_array().expect("outcome array");
+    assert_eq!(output.len(), 1);
+    assert_eq!(outcome.len(), 1);
+
+    let output_url = output[0]["url"].as_str().expect("output url");
+    let outcome_url = outcome[0]["url"].as_str().expect("outcome url");
+    assert_eq!(output[0]["count"], 1);
+    assert_eq!(output[0]["fileSize"], 42);
+    assert_ne!(output_url, outcome_url);
+    for url in [output_url, outcome_url] {
+        assert!(
+            url.contains("submit-v1-"),
+            "v1 locator must include its route hash: {url}"
+        );
+        let resp = server.get(local_file_path(url)).await;
+        assert_eq!(resp.status_code(), StatusCode::OK, "{url}");
+    }
+
+    let output_bytes = server.get(local_file_path(output_url)).await.text();
+    assert_eq!(
+        output_bytes,
+        "{\"reference\":\"OperationOutcome/oo-out-1\"}\n"
+    );
+
+    let outcome_bytes = server.get(local_file_path(outcome_url)).await.text();
+    assert_eq!(
+        outcome_bytes,
+        concat!(
+            "{\"resourceType\":\"OperationOutcome\",\"issue\":[{",
+            "\"severity\":\"error\",\"code\":\"processing\",",
+            "\"diagnostics\":\"1 submitted resource(s) could not be parsed ",
+            "or did not match the declared resource type\"}]}\n"
+        )
+    );
+    assert_eq!(outcome[0]["count"], 1);
+    assert_eq!(outcome[0]["fileSize"], 191);
+    assert_eq!(
+        outcome[0]["countSeverity"],
+        json!([{"code": "error", "count": 1}])
+    );
+}
+
+/// Two manifests under one submitter/submission ID are separate generations.
+/// Their part-0 Patient outputs must use distinct manifest-aware routes, and each
+/// route must return its own exact receipt.
+#[tokio::test]
+async fn manifest_generations_use_distinct_v1_routes() {
+    let (server, backend, fetcher, output, _tmp) =
+        create_submit_server_with(two_manifest_fetcher(), BulkSubmitConfig::default()).await;
+
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_at("https://provider/manifest-a.json"))
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        server
+            .post("/$bulk-submit")
+            .json(&kickoff_body_at("https://provider/manifest-b.json"))
+            .await
+            .status_code(),
+        StatusCode::OK
+    );
+    let status = server
+        .post("/$bulk-submit-status")
+        .json(&status_body())
+        .await;
+    assert_eq!(status.status_code(), StatusCode::ACCEPTED);
+    let poll_path = status
+        .headers()
+        .get("content-location")
+        .expect("Content-Location")
+        .to_str()
+        .unwrap()
+        .trim_start_matches("http://localhost:8080")
+        .to_string();
+    drain_submit(&backend, &fetcher, &output).await;
+
+    let manifest: Value = server.get(&poll_path).await.json();
+    let outputs = manifest["output"].as_array().expect("output array");
+    assert_eq!(outputs.len(), 2);
+    let manifest_urls = outputs
+        .iter()
+        .map(|entry| entry["manifestUrl"].as_str().expect("manifest url"))
+        .collect::<Vec<_>>();
+    assert!(manifest_urls.contains(&"https://provider/manifest-a.json"));
+    assert!(manifest_urls.contains(&"https://provider/manifest-b.json"));
+
+    let mut routes = Vec::new();
+    for (manifest_url, url) in outputs.iter().map(|entry| {
+        (
+            entry["manifestUrl"].as_str().expect("manifest url"),
+            entry["url"].as_str().expect("output url"),
+        )
+    }) {
+        let route = url
+            .rsplit('/')
+            .next()
+            .expect("URL always has a path component");
+        assert!(route.starts_with("submit-v1-"));
+        routes.push(route.to_string());
+        assert_eq!(
+            server.get(local_file_path(url)).await.text(),
+            match manifest_url {
+                "https://provider/manifest-a.json" => "{\"reference\":\"Patient/mm-a-1\"}\n",
+                "https://provider/manifest-b.json" => "{\"reference\":\"Patient/mm-b-1\"}\n",
+                unexpected => unreachable!("unexpected manifestUrl: {unexpected}"),
+            }
+        );
+    }
+    assert_ne!(routes[0], routes[1]);
 }
 
 /// Spec (submit.html): when the status manifest is returned incrementally, `link`


### PR DESCRIPTION
Bulk-submit could register duplicate or partial artifact sets, and a worker that lost its lease during completion could still start deferred reindexing. SQLite and PostgreSQL now publish the complete artifact set and its completed or failed state in one fenced transaction. An identical committed retry returns `AlreadyPublished`; changed retries and stale owners cannot overwrite the publication. Status reads select the committed generation, and deferred reindexing starts only after a fresh successful publication.

Artifacts now carry manifest identity and use scoped versioned locators, so separate manifests and output/error files cannot share a download route accidentally. The worker keeps renewing its lease through finalization and composite synchronization. SQL migrations retain legacy records, deduplicate exact matches and exclude ambiguous or incomplete generations. Unambiguous legacy downloads remain supported; ambiguous routes fail closed. MongoDB and S3 adapters retain their documented sequential behavior with manifest-aware identities.

Validation covers the original failing recovery scenarios, injected finalization and transaction failures, exact replay, lease expiry/reclaim, concurrent publication, cleanup rollback, existing-schema migrations, receipt counts and bytes, and legacy downloads. Focused and broader persistence/REST tests pass, including real PostgreSQL and MongoDB tests, S3 mock contracts and the existing lease-concurrency suite. Clippy and the HFS build pass. HTTP QA against both SQL backends verifies distinct artifact URLs, exact downloads, pagination, tenant isolation, failed-manifest publication and cleanup. Review found no unresolved blocking defect.

The atomic guarantee applies to SQLite and PostgreSQL. Finalized bytes can remain orphaned after lease loss; durable exactly-once reindexing is outside scope. Composite secondary synchronization retains its existing best-effort behavior.

Depends on #996 for the sequential branch stack.

Closes #980.
