### PR TITLE
rest(batch): emit subscription events for batch/transaction writes (#1023)

### DIFF
--- a/crates/rest/src/handlers/batch.rs
+++ b/crates/rest/src/handlers/batch.rs
@@ -651,6 +651,18 @@ where
                 }
             }
 
+            // Announce each committed write to subscribers (#1023). The batch
+            // arm emits per-entry as it writes; the transaction path commits
+            // atomically in the persistence layer and returns results, so its
+            // emission happens here, once the bundle has committed, against
+            // those results. `indexed_entries` and `bundle_result.entries`
+            // share an order (the writes, sorted the same way).
+            #[cfg(feature = "subscriptions")]
+            for ((_, entry, _), result) in indexed_entries.iter().zip(bundle_result.entries.iter())
+            {
+                emit_transaction_entry_event(state, &tenant, fhir_version, entry, result);
+            }
+
             // GET searches run against the committed state (see above). A
             // failure here cannot roll the transaction back, so it surfaces
             // as that entry's own error outcome rather than a misleading
@@ -804,6 +816,137 @@ where
     };
 
     bundle_if_match_gate(if_match, current.as_ref().map(|r| r.version_id()))
+}
+
+/// Emits a create/update subscription event for a Bundle-driven write, the
+/// same announcement the single-resource handlers make (#1023). A write
+/// performed through a batch or transaction Bundle must reach subscribers just
+/// as a direct `POST`/`PUT` does; this is the seam the batch arms call so a
+/// Bundle write is never silent.
+#[cfg(feature = "subscriptions")]
+fn emit_bundle_write_event<S>(
+    state: &AppState<S>,
+    tenant: &TenantExtractor,
+    fhir_version: FhirVersion,
+    stored: &helios_persistence::types::StoredResource,
+    event_type: helios_subscriptions::ResourceEventType,
+) where
+    S: ResourceStorage,
+{
+    if let Some(engine) = state.subscription_engine() {
+        super::subscription_event::emit_subscription_event(
+            engine,
+            tenant.context(),
+            stored,
+            fhir_version,
+            event_type,
+        );
+    }
+}
+
+/// Emits a delete subscription event for a Bundle-driven delete (#1023).
+#[cfg(feature = "subscriptions")]
+fn emit_bundle_delete_event<S>(
+    state: &AppState<S>,
+    tenant: &TenantExtractor,
+    fhir_version: FhirVersion,
+    resource_type: &str,
+    resource_id: &str,
+    previous_resource: Option<serde_json::Value>,
+) where
+    S: ResourceStorage,
+{
+    if let Some(engine) = state.subscription_engine() {
+        super::subscription_event::emit_delete_event(
+            engine,
+            tenant.context(),
+            resource_type,
+            resource_id,
+            fhir_version,
+            previous_resource,
+        );
+    }
+}
+
+/// The create/update event a committed transaction write announces, or `None`
+/// when the entry is not an announcing write (a non-2xx result, or a method
+/// other than POST/PUT). A create answers 201, an update — a conditional PUT
+/// that matched an existing resource — answers 200. DELETE is handled apart
+/// from this: it carries no body, so its event is built from the URL instead.
+#[cfg(feature = "subscriptions")]
+fn transaction_write_event_type(
+    method: BundleMethod,
+    status: u16,
+) -> Option<helios_subscriptions::ResourceEventType> {
+    use helios_subscriptions::ResourceEventType;
+    if !(200..300).contains(&status) {
+        return None;
+    }
+    match method {
+        BundleMethod::Post | BundleMethod::Put => Some(if status == 201 {
+            ResourceEventType::Create
+        } else {
+            ResourceEventType::Update
+        }),
+        _ => None,
+    }
+}
+
+/// Emits a subscription event for one committed transaction entry (#1023).
+///
+/// The atomic transaction path returns `BundleEntryResult`s rather than
+/// `StoredResource`s, so the event is built from the entry's method and the
+/// result's stored JSON instead of going through the `StoredResource` helpers
+/// the batch arm uses. Only 2xx write entries announce; a POST or a PUT that
+/// created answers 201 (Create), an update answers 200 (Update).
+#[cfg(feature = "subscriptions")]
+fn emit_transaction_entry_event<S>(
+    state: &AppState<S>,
+    tenant: &TenantExtractor,
+    fhir_version: FhirVersion,
+    entry: &BundleEntry,
+    result: &BundleEntryResult,
+) where
+    S: ResourceStorage,
+{
+    let Some(engine) = state.subscription_engine() else {
+        return;
+    };
+    match entry.method {
+        BundleMethod::Post | BundleMethod::Put => {
+            let (Some(event_type), Some(resource)) = (
+                transaction_write_event_type(entry.method, result.status),
+                &result.resource,
+            ) else {
+                return;
+            };
+            super::subscription_event::emit_subscription_event_from_json(
+                engine,
+                tenant.context(),
+                resource,
+                fhir_version,
+                event_type,
+            );
+        }
+        BundleMethod::Delete if (200..300).contains(&result.status) => {
+            // A 2xx delete carries no body; take type/id from the entry URL.
+            // A conditional delete that resolved to no id has nothing to
+            // announce.
+            if let Ok((resource_type, id)) = parse_request_url(&entry.url)
+                && !id.is_empty()
+            {
+                super::subscription_event::emit_delete_event(
+                    engine,
+                    tenant.context(),
+                    &resource_type,
+                    &id,
+                    fhir_version,
+                    None,
+                );
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Processes a single batch entry, returning a structured BundleEntryResult.
@@ -1038,6 +1181,14 @@ where
             {
                 Ok(stored) => {
                     record_stored_profile(state, tenant, fhir_version, &stored);
+                    #[cfg(feature = "subscriptions")]
+                    emit_bundle_write_event(
+                        state,
+                        tenant,
+                        fhir_version,
+                        &stored,
+                        helios_subscriptions::ResourceEventType::Create,
+                    );
                     BundleEntryResult::created(stored)
                 }
                 Err(e) => {
@@ -1158,6 +1309,18 @@ where
             {
                 Ok((stored, created)) => {
                     record_stored_profile(state, tenant, fhir_version, &stored);
+                    #[cfg(feature = "subscriptions")]
+                    emit_bundle_write_event(
+                        state,
+                        tenant,
+                        fhir_version,
+                        &stored,
+                        if created {
+                            helios_subscriptions::ResourceEventType::Create
+                        } else {
+                            helios_subscriptions::ResourceEventType::Update
+                        },
+                    );
                     if created {
                         BundleEntryResult::created(stored)
                     } else {
@@ -1229,7 +1392,18 @@ where
                 .delete(tenant.context(), &resource_type, &id)
                 .await
             {
-                Ok(()) => BundleEntryResult::deleted(),
+                Ok(()) => {
+                    #[cfg(feature = "subscriptions")]
+                    emit_bundle_delete_event(
+                        state,
+                        tenant,
+                        fhir_version,
+                        &resource_type,
+                        &id,
+                        None,
+                    );
+                    BundleEntryResult::deleted()
+                }
                 Err(e) => {
                     let (status, message) = entry_error(e);
                     create_error_result(status, &message)
@@ -3407,6 +3581,39 @@ mod tests {
         for url in ["", "/", "?identifier=x"] {
             assert!(parse_request_url(url).is_err(), "url: {url}");
         }
+    }
+
+    /// The event a committed transaction write announces (#1023). A POST or a
+    /// PUT that created answers 201 (Create); a PUT that matched answers 200
+    /// (Update). DELETE and non-2xx entries announce nothing here — DELETE is
+    /// emitted from its URL, and a failed entry never committed.
+    #[cfg(feature = "subscriptions")]
+    #[test]
+    fn transaction_write_event_type_maps_status_to_the_right_event() {
+        use helios_subscriptions::ResourceEventType;
+        assert_eq!(
+            transaction_write_event_type(BundleMethod::Post, 201),
+            Some(ResourceEventType::Create)
+        );
+        assert_eq!(
+            transaction_write_event_type(BundleMethod::Put, 201),
+            Some(ResourceEventType::Create)
+        );
+        // A conditional PUT that matched an existing resource updates it.
+        assert_eq!(
+            transaction_write_event_type(BundleMethod::Put, 200),
+            Some(ResourceEventType::Update)
+        );
+        // DELETE carries no body; its event is built from the URL, not here.
+        assert_eq!(
+            transaction_write_event_type(BundleMethod::Delete, 200),
+            None
+        );
+        // A GET entry is a read, never an announcing write.
+        assert_eq!(transaction_write_event_type(BundleMethod::Get, 200), None);
+        // A non-2xx entry never committed, so it announces nothing.
+        assert_eq!(transaction_write_event_type(BundleMethod::Post, 409), None);
+        assert_eq!(transaction_write_event_type(BundleMethod::Put, 412), None);
     }
 
     #[test]

--- a/crates/rest/src/handlers/subscription_event.rs
+++ b/crates/rest/src/handlers/subscription_event.rs
@@ -49,6 +49,61 @@ pub fn emit_subscription_event(
     });
 }
 
+/// Emits a create/update subscription event from an already-serialized
+/// resource.
+///
+/// The atomic transaction path returns each committed entry as JSON
+/// (`content_with_meta`) rather than a [`StoredResource`], so this builds the
+/// event from the resource's own `resourceType` / `id` / `meta.versionId`.
+/// It is a no-op if any of those are absent.
+pub fn emit_subscription_event_from_json(
+    engine: &Arc<SubscriptionEngine>,
+    tenant: &TenantContext,
+    resource: &serde_json::Value,
+    fhir_version: FhirVersion,
+    event_type: ResourceEventType,
+) {
+    let (Some(resource_type), Some(resource_id)) = (
+        resource
+            .get("resourceType")
+            .and_then(serde_json::Value::as_str),
+        resource.get("id").and_then(serde_json::Value::as_str),
+    ) else {
+        return;
+    };
+    let version_id = resource
+        .get("meta")
+        .and_then(|m| m.get("versionId"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    let event = ResourceEvent {
+        tenant_id: tenant.tenant_id().clone(),
+        fhir_version,
+        resource_type: resource_type.to_string(),
+        resource_id: resource_id.to_string(),
+        version_id,
+        event_type,
+        resource: Some(resource.clone()),
+        previous_resource: None,
+        timestamp: chrono::Utc::now(),
+    };
+
+    let engine = Arc::clone(engine);
+
+    debug!(
+        resource_type = %event.resource_type,
+        resource_id = %event.resource_id,
+        event_type = %event.event_type,
+        "Emitting subscription event (transaction)"
+    );
+
+    tokio::spawn(async move {
+        engine.on_resource_event(event).await;
+    });
+}
+
 /// Emits a subscription event for a resource delete.
 ///
 /// Delete events carry the resource type and ID but no resource content.


### PR DESCRIPTION
Fixes #1023.

## Problem

A resource written through a **batch or transaction** Bundle emitted no subscription event, so rest-hook (and every other channel) subscribers silently missed every create/update/delete performed via `POST /` Bundle. A direct `POST /[type]` announced normally. `batch.rs` wrote each entry by calling `storage.create` / `create_or_update` / `delete` directly, bypassing the emit the single-resource handlers do. FHIR batch/transaction is a very common write path (bulk clients, Synthea-style loads), so this was a significant gap.

## Fix

Both write paths now announce through the same seam the unconditional handlers use:

- **Batch** (`process_batch_entry`): the POST / PUT / DELETE arms emit on success — a POST and a PUT that created announce `Create`, a PUT that matched announces `Update`, a delete announces `Delete`. These use the `StoredResource` the arm already holds (`emit_bundle_write_event` / `emit_bundle_delete_event`).
- **Transaction** (`process_transaction`): the atomic path commits in the persistence layer and returns `BundleEntryResult`s, not `StoredResource`s, so emission runs once **after commit** over `bundle_result.entries`, built from each entry's method and its stored JSON via a new `emit_subscription_event_from_json` helper. A create answers 201 (`Create`), a conditional PUT that matched answers 200 (`Update`); DELETE carries no body, so its event is built from the entry URL.

The status→event decision is factored into the pure `transaction_write_event_type` (201→Create, 200→Update, non-2xx and non-write→None) with a unit test. Everything is gated behind the existing `subscriptions` feature, so the **default build is unchanged**.

## Verification

Matches the §12.3 expectation in `MANUAL_TESTING_MATRIX.md`: a batch of 3 POST Encounters against an active topic now delivers **3** notifications where it delivered **zero**.

- `cargo test -p helios-rest --features subscriptions --lib batch::` — 33 passed (incl. new `transaction_write_event_type_maps_status_to_the_right_event`).
- `cargo clippy -p helios-rest --features subscriptions --lib` — clean (no new warnings in the changed files).
- `cargo check -p helios-rest --lib` (default, no subscriptions) — clean.

## Relationship to #862

Same class of gap as #862 (the *conditional* single-resource handlers emit no events), but a **different code path**. #862 remains open; worth fixing next in the same spirit.