### PR TITLE
fix(ui): forward the selected tenant on bulk-import self-calls (#1006)

### DIFF
--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
@@ -293,9 +293,9 @@ mod tests {
         assert!(versioned >= base && versioned < upper.as_str());
         // excluded (a different id sharing the "123" prefix):
         let sibling = "Patient/1234";
-        assert!(!(sibling < upper.as_str()));
+        assert!(sibling >= upper.as_str());
         let sibling0 = "Patient/1230";
-        assert!(!(sibling0 < upper.as_str()));
+        assert!(sibling0 >= upper.as_str());
     }
 
     #[test]

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -6579,6 +6579,10 @@ details.card > summary.card-head::-webkit-details-marker {
   color: var(--muted);
 }
 
+.job-card__window {
+  color: var(--muted);
+}
+
 .job-card__files {
   display: flex;
   flex-wrap: wrap;

--- a/crates/ui/assets/app.css
+++ b/crates/ui/assets/app.css
@@ -6557,6 +6557,10 @@ details.card > summary.card-head::-webkit-details-marker {
   background: var(--accent);
 }
 
+.progress--in-progress .progress__bar {
+  background: var(--accent);
+}
+
 .progress--complete .progress__bar {
   background: var(--ok);
 }

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -439,7 +439,7 @@ pub async fn create(
         mid.clone(),
         serde_json::to_value(&manifest).unwrap_or(Value::Null),
     );
-    submit_one_with_id(&mut submission, &id, &mid).await;
+    submit_one_with_id(&mut submission, &id, &mid, &rt.id).await;
     match save(&state, &rt, &id, &submission, Some(0)).await {
         Ok(_) => Redirect::to(&format!("/ui/bulk-import/{id}")).into_response(),
         Err(e) => (StatusCode::BAD_GATEWAY, e).into_response(),
@@ -766,14 +766,18 @@ fn kickoff_target(submission: &Submission) -> String {
 async fn post_kickoff(
     submission: &Submission,
     parameters: &Value,
+    tenant: &str,
 ) -> Result<(u16, String, String), String> {
     let target = kickoff_target(submission);
-    let mut request = http_client()
-        .post(&target)
-        .header("Content-Type", "application/fhir+json")
-        .header("Accept", "application/fhir+json")
-        .timeout(std::time::Duration::from_secs(15))
-        .json(parameters);
+    let mut request = with_tenant(
+        http_client()
+            .post(&target)
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", "application/fhir+json")
+            .timeout(std::time::Duration::from_secs(15))
+            .json(parameters),
+        tenant,
+    );
     if submission.auth == "backend-services" {
         let token = backend_services_token(&submission.client_id, &submission.token_url).await?;
         request = request.bearer_auth(token);
@@ -833,7 +837,7 @@ fn summarize_error_body(content_type: &str, body: &str) -> String {
 /// Kicks off recipient-side status tracking: `POST $bulk-submit-status`
 /// (submitter + submissionId, `Prefer: respond-async`), returning the poll
 /// URL the recipient hands back in `Content-Location`.
-async fn status_kickoff(submission: &Submission, id: &str) -> Result<String, String> {
+async fn status_kickoff(submission: &Submission, id: &str, tenant: &str) -> Result<String, String> {
     let target = public_url_with_segments(&submission.recipient_base_url, ["$bulk-submit-status"]);
     // Only the identifying parameters ride the status kick-off.
     let parameters = kickoff_parameters(submission, id, "", None);
@@ -846,12 +850,15 @@ async fn status_kickoff(submission: &Submission, id: &str) -> Result<String, Str
         .collect();
     let body = json!({ "resourceType": "Parameters", "parameter": identifying });
 
-    let mut request = http_client()
-        .post(&target)
-        .header("Content-Type", "application/fhir+json")
-        .header("Prefer", "respond-async")
-        .timeout(std::time::Duration::from_secs(15))
-        .json(&body);
+    let mut request = with_tenant(
+        http_client()
+            .post(&target)
+            .header("Content-Type", "application/fhir+json")
+            .header("Prefer", "respond-async")
+            .timeout(std::time::Duration::from_secs(15))
+            .json(&body),
+        tenant,
+    );
     if submission.auth == "backend-services" {
         let token = backend_services_token(&submission.client_id, &submission.token_url).await?;
         request = request.bearer_auth(token);
@@ -887,6 +894,15 @@ const STATUS_POLL_FAILURE_BACKOFF_SECS: u64 = 30;
 fn http_client() -> &'static reqwest::Client {
     static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
     CLIENT.get_or_init(reqwest::Client::new)
+}
+
+/// Stamps the selected tenant onto a self-call. The recipient is this HFS
+/// process (#689): under header routing the tenant travels only here, and
+/// under `both` the URL prefix already agrees with it. `Authorization` is
+/// deliberately not forwarded — `/ui` sits outside the auth layer (#320)
+/// and backend-services kick-offs mint their own bearer (#1006).
+fn with_tenant(request: reqwest::RequestBuilder, tenant: &str) -> reqwest::RequestBuilder {
+    request.header("X-Tenant-ID", tenant)
 }
 
 /// Renders a poll transport failure with its cause. `reqwest::Error`'s
@@ -937,14 +953,17 @@ fn retry_after_seconds(response: &reqwest::Response) -> Option<u64> {
 /// logged and polling stops (the poll URL is cleared). `202` and `429` carry
 /// `Retry-After`; both push `next_poll_at` out so the card's refresh cadence
 /// never turns into a poll the recipient would reject (#790).
-async fn poll_status(submission: &mut Submission) {
+async fn poll_status(submission: &mut Submission, tenant: &str) {
     let poll_url = submission.poll_url.clone();
-    let response = match http_client()
-        .get(&poll_url)
-        .header("Accept", "application/json")
-        .timeout(std::time::Duration::from_secs(STATUS_POLL_TIMEOUT_SECS))
-        .send()
-        .await
+    let response = match with_tenant(
+        http_client()
+            .get(&poll_url)
+            .header("Accept", "application/json")
+            .timeout(std::time::Duration::from_secs(STATUS_POLL_TIMEOUT_SECS)),
+        tenant,
+    )
+    .send()
+    .await
     {
         Ok(r) => r,
         Err(e) => {
@@ -1067,7 +1086,7 @@ async fn poll_status(submission: &mut Submission) {
 
 /// Fires the kick-off for one manifest and records the outcome on the
 /// submission (status, log, poll URL).
-async fn submit_one_with_id(submission: &mut Submission, id: &str, mid: &str) {
+async fn submit_one_with_id(submission: &mut Submission, id: &str, mid: &str, tenant: &str) {
     let Some(m) = submission
         .manifests
         .get(mid)
@@ -1080,7 +1099,7 @@ async fn submit_one_with_id(submission: &mut Submission, id: &str, mid: &str) {
         format!("Submitting manifest \"{}\"...", m.manifest_url),
     );
     let parameters = kickoff_parameters(submission, id, "in-progress", Some(&m));
-    match post_kickoff(submission, &parameters).await {
+    match post_kickoff(submission, &parameters, tenant).await {
         Ok((status, _, _)) if (200..300).contains(&status) => {
             push_log(
                 submission,
@@ -1093,7 +1112,7 @@ async fn submit_one_with_id(submission: &mut Submission, id: &str, mid: &str) {
             // Start recipient-side status tracking on the first accepted
             // manifest; later submissions reuse the same poll URL.
             if submission.poll_url.is_empty() {
-                match status_kickoff(submission, id).await {
+                match status_kickoff(submission, id, tenant).await {
                     Ok(poll_url) => {
                         push_log(submission, "Bulk status kick-off request".to_string());
                         submission.poll_url = poll_url;
@@ -1170,7 +1189,7 @@ async fn set_status(
     }
     push_log(&mut s, format!("Marking submission {status}..."));
     let parameters = kickoff_parameters(&s, &id, status, None);
-    match post_kickoff(&s, &parameters).await {
+    match post_kickoff(&s, &parameters, &rt.id).await {
         Ok((code, _, _)) if (200..300).contains(&code) => {
             push_log(&mut s, format!("Recipient acknowledged ({code})."));
             s.status = status.to_string();
@@ -1234,7 +1253,7 @@ pub async fn status_fragment(
         return StatusCode::NOT_FOUND.into_response();
     };
     if !s.poll_url.is_empty() && poll_due(&s) {
-        poll_status(&mut s).await;
+        poll_status(&mut s, &rt.id).await;
         save_or_warn(&state, &rt, &id, &s, Some(sv)).await;
     }
     let label = status_label(&i18n, &s.status);

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -137,6 +137,29 @@ fn app_with_path_tenant(ctx: &Ctx, tenant: &str) -> Router {
     )
 }
 
+/// Same as [`app_with_path_tenant`] but header-only routing
+/// (`tenant_path_routing = false`, HFS's default): the effective tenant of a
+/// request is the server's default tenant, with no tenant registry or
+/// per-tenant settings needed to exercise it (#1006).
+fn app_with_header_tenant(ctx: &Ctx, tenant: &str) -> Router {
+    helios_ui::mount_with_conformance_source_and_body_limit_and_tenant_routing(
+        Router::new(),
+        "9.9.9",
+        None,
+        helios_ui::NlSearch::default(),
+        None,
+        Some(Arc::clone(&ctx.settings)),
+        tenant.to_string(),
+        Arc::new(helios_ui::StaticConformanceSource::empty()),
+        FhirVersion::R4,
+        None,
+        ctx.recipient.clone(),
+        10 * 1024 * 1024,
+        false,
+        Some(Arc::clone(&ctx.bulk_provider)),
+    )
+}
+
 async fn body_text(response: axum::response::Response) -> String {
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     String::from_utf8(bytes.to_vec()).unwrap()
@@ -497,6 +520,284 @@ async fn mock_recipient(
         .with_state(state);
     tokio::spawn(async move { axum::serve(listener, recipient).await.unwrap() });
     (format!("http://{addr}"), received)
+}
+
+/// One self-call HFS's own Import workspace made against a recipient —
+/// recorded so a test can assert the request actually carried the selected
+/// tenant, not merely that some header existed (#1006).
+#[derive(Debug, Clone)]
+struct SeenSelfCall {
+    method: String,
+    path: String,
+    tenant: Option<String>,
+}
+
+/// A loopback Data Recipient — standing in for this HFS process (#689) —
+/// that records every self-call's method, path and `x-tenant-id` header,
+/// answering both the header-routing paths (no tenant segment) and the
+/// `both`-mode paths (one tenant path segment), the way HFS's own recipient
+/// side does (#1006).
+async fn mock_recipient_capturing_tenant() -> (String, Arc<std::sync::Mutex<Vec<SeenSelfCall>>>) {
+    use axum::extract::{Path as AxPath, State as AxState};
+    use axum::http::HeaderMap;
+
+    #[derive(Clone)]
+    struct S {
+        seen: Arc<std::sync::Mutex<Vec<SeenSelfCall>>>,
+        base: Arc<std::sync::Mutex<String>>,
+    }
+
+    fn tenant_of(headers: &HeaderMap) -> Option<String> {
+        headers
+            .get("x-tenant-id")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from)
+    }
+
+    let state = S {
+        seen: Arc::new(std::sync::Mutex::new(Vec::new())),
+        base: Arc::new(std::sync::Mutex::new(String::new())),
+    };
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    *state.base.lock().unwrap() = format!("http://{addr}");
+    let seen = Arc::clone(&state.seen);
+
+    let app = Router::new()
+        .route(
+            "/$bulk-submit",
+            axum::routing::post(|AxState(s): AxState<S>, headers: HeaderMap| async move {
+                s.seen.lock().unwrap().push(SeenSelfCall {
+                    method: "POST".to_string(),
+                    path: "/$bulk-submit".to_string(),
+                    tenant: tenant_of(&headers),
+                });
+                (
+                    StatusCode::OK,
+                    axum::Json(serde_json::json!({"resourceType": "Parameters"})),
+                )
+            }),
+        )
+        .route(
+            "/{tenant}/$bulk-submit",
+            axum::routing::post(
+                |AxState(s): AxState<S>, AxPath(tenant): AxPath<String>, headers: HeaderMap| async move {
+                    s.seen.lock().unwrap().push(SeenSelfCall {
+                        method: "POST".to_string(),
+                        path: format!("/{tenant}/$bulk-submit"),
+                        tenant: tenant_of(&headers),
+                    });
+                    (
+                        StatusCode::OK,
+                        axum::Json(serde_json::json!({"resourceType": "Parameters"})),
+                    )
+                },
+            ),
+        )
+        .route(
+            "/$bulk-submit-status",
+            axum::routing::post(|AxState(s): AxState<S>, headers: HeaderMap| async move {
+                s.seen.lock().unwrap().push(SeenSelfCall {
+                    method: "POST".to_string(),
+                    path: "/$bulk-submit-status".to_string(),
+                    tenant: tenant_of(&headers),
+                });
+                let base = s.base.lock().unwrap().clone();
+                (
+                    StatusCode::ACCEPTED,
+                    [("content-location", format!("{base}/poll"))],
+                    "",
+                )
+            }),
+        )
+        .route(
+            "/{tenant}/$bulk-submit-status",
+            axum::routing::post(
+                |AxState(s): AxState<S>, AxPath(tenant): AxPath<String>, headers: HeaderMap| async move {
+                    s.seen.lock().unwrap().push(SeenSelfCall {
+                        method: "POST".to_string(),
+                        path: format!("/{tenant}/$bulk-submit-status"),
+                        tenant: tenant_of(&headers),
+                    });
+                    let base = s.base.lock().unwrap().clone();
+                    (
+                        StatusCode::ACCEPTED,
+                        [("content-location", format!("{base}/poll"))],
+                        "",
+                    )
+                },
+            ),
+        )
+        .route(
+            "/poll",
+            axum::routing::get(|AxState(s): AxState<S>, headers: HeaderMap| async move {
+                s.seen.lock().unwrap().push(SeenSelfCall {
+                    method: "GET".to_string(),
+                    path: "/poll".to_string(),
+                    tenant: tenant_of(&headers),
+                });
+                (
+                    StatusCode::ACCEPTED,
+                    [
+                        ("retry-after", "120".to_string()),
+                        ("x-progress", "processing 10% complete".to_string()),
+                    ],
+                    String::new(),
+                )
+            }),
+        )
+        .with_state(state);
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), seen)
+}
+
+/// Posts the standard one-shot create form against `router`, returning the
+/// created submission's detail path.
+async fn post_create_via(router: Router) -> String {
+    let created = router
+        .oneshot(
+            Request::post("/ui/bulk-import")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "name=BrettTest&manifest_url=http%3A%2F%2Fone.example%2Fm.json&auth=none",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::SEE_OTHER);
+    created
+        .headers()
+        .get(header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .expect("redirect to the detail page")
+        .to_string()
+}
+
+/// #1006: under header routing the default (and only) transport for the
+/// tenant, both self-calls a create fires — the kick-off and the recipient
+/// status kick-off — must carry the request's tenant, and neither path may
+/// gain a tenant path segment (that is `both`/`url_path` territory).
+#[tokio::test]
+async fn header_mode_kickoffs_carry_the_selected_tenant() {
+    let (recipient_url, seen) = mock_recipient_capturing_tenant().await;
+    let ctx = ctx(&recipient_url);
+
+    let _detail_path = post_create_via(app_with_header_tenant(&ctx, "acme")).await;
+
+    let calls = seen.lock().unwrap().clone();
+    let kickoff = calls
+        .iter()
+        .find(|c| c.method == "POST" && c.path == "/$bulk-submit")
+        .expect("kick-off recorded");
+    assert_eq!(kickoff.tenant.as_deref(), Some("acme"));
+    let status_kickoff = calls
+        .iter()
+        .find(|c| c.method == "POST" && c.path == "/$bulk-submit-status")
+        .expect("status kick-off recorded");
+    assert_eq!(status_kickoff.tenant.as_deref(), Some("acme"));
+    assert!(
+        calls.iter().all(|c| !c.path.starts_with("/acme/")),
+        "header routing must not add a tenant path segment: {calls:?}"
+    );
+}
+
+/// #1006: the recipient-status poll fired by `GET .../status` must carry the
+/// selected tenant too, or the poll is rejected server-side once it lands on
+/// a real HFS recipient (`crates/rest/src/handlers/bulk_submit.rs`).
+#[tokio::test]
+async fn header_mode_status_poll_carries_the_selected_tenant() {
+    let (recipient_url, seen) = mock_recipient_capturing_tenant().await;
+    let ctx = ctx(&recipient_url);
+
+    let detail_path = post_create_via(app_with_header_tenant(&ctx, "acme")).await;
+    seen.lock().unwrap().clear();
+
+    let status = app_with_header_tenant(&ctx, "acme")
+        .oneshot(
+            Request::get(format!("{detail_path}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status.status(), StatusCode::OK);
+
+    let calls = seen.lock().unwrap().clone();
+    let poll = calls
+        .iter()
+        .find(|c| c.method == "GET" && c.path == "/poll")
+        .expect("poll recorded");
+    assert_eq!(poll.tenant.as_deref(), Some("acme"));
+}
+
+/// #1006: Abort (`set_status`) reuses `post_kickoff` for a status-only
+/// kick-off — it must carry the selected tenant exactly like the create-time
+/// kick-off does; Complete shares the same code path.
+#[tokio::test]
+async fn header_mode_abort_carries_the_selected_tenant() {
+    let (recipient_url, seen) = mock_recipient_capturing_tenant().await;
+    let ctx = ctx(&recipient_url);
+
+    let detail_path = post_create_via(app_with_header_tenant(&ctx, "acme")).await;
+    seen.lock().unwrap().clear();
+
+    let aborted = app_with_header_tenant(&ctx, "acme")
+        .oneshot(
+            Request::post(format!("{detail_path}/abort"))
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(aborted.status(), StatusCode::SEE_OTHER);
+
+    let calls = seen.lock().unwrap().clone();
+    let kickoff = calls
+        .iter()
+        .find(|c| c.method == "POST" && c.path == "/$bulk-submit")
+        .expect("abort kick-off recorded");
+    assert_eq!(kickoff.tenant.as_deref(), Some("acme"));
+}
+
+/// #1006: under `url_path`/`both` routing the tenant travels both as a URL
+/// path segment (kick-off, status kick-off) and as the header — the poll URL
+/// itself carries no tenant segment (it is the recipient's own
+/// `Content-Location`), so the poll relies on the header alone.
+#[tokio::test]
+async fn url_path_mode_self_calls_carry_tenant_in_path_and_header() {
+    let (recipient_url, seen) = mock_recipient_capturing_tenant().await;
+    let ctx = ctx(&recipient_url);
+
+    let detail_path = post_create_via(app_with_path_tenant(&ctx, "acme")).await;
+
+    let status = app_with_path_tenant(&ctx, "acme")
+        .oneshot(
+            Request::get(format!("{detail_path}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status.status(), StatusCode::OK);
+
+    let calls = seen.lock().unwrap().clone();
+    let kickoff = calls
+        .iter()
+        .find(|c| c.method == "POST" && c.path == "/acme/$bulk-submit")
+        .expect("kick-off recorded under the tenant path");
+    assert_eq!(kickoff.tenant.as_deref(), Some("acme"));
+    let status_kickoff = calls
+        .iter()
+        .find(|c| c.method == "POST" && c.path == "/acme/$bulk-submit-status")
+        .expect("status kick-off recorded under the tenant path");
+    assert_eq!(status_kickoff.tenant.as_deref(), Some("acme"));
+    let poll = calls
+        .iter()
+        .find(|c| c.method == "GET" && c.path == "/poll")
+        .expect("poll recorded");
+    assert_eq!(poll.tenant.as_deref(), Some("acme"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #1006.

The Import page is a Data Provider that self-submits `$bulk-submit` to this HFS (`HFS_BASE_URL`, #689). Under header tenant routing (the default) none of its self-calls carried `X-Tenant-ID`, so the kick-off, the status kick-off and every status poll were attributed to the default tenant no matter which tenant the sidebar had selected. In the #939 re-validation this rewrote 4,999 Patients of `default` as v2 updates while the selected tenant received nothing, and the page still showed "Completed".

## Changes

- Every Import self-call (`POST $bulk-submit`, `POST $bulk-submit-status`, status poll, abort/complete) now carries `X-Tenant-ID` with the request's tenant, the same way the Export page already does. The URL tenant prefix used under `url_path` routing is unchanged, so the fix covers `header_only`, `url_path` and `both`.
- `Authorization` is deliberately not forwarded: `/ui` sits outside the auth layer (#320) and backend-services kick-offs mint their own bearer.
- Four HTTP tests in `crates/ui/tests/bulk_import_http.rs` run against a mock recipient that records the tenant header and path of each self-call (kick-off, status kick-off, poll, abort) in header mode and URL-path mode.

- `fix(ci)`: the same two-line clippy fix as #1037 (`nonminimal_bool` in the sqlite reference-range test introduced on `main` by d680725bd), carried here so this branch's Linting job can pass without waiting on that merge. It merges cleanly either way.

- `fix(ui)` (app.css): an explicit `.progress--in-progress .progress__bar` rule. Export cards render `progress--{{ status }}` but only complete/failed/cancelled had rules, so the design-system e2e sweep failed whenever another spec left an export running while `/ui/bulk-export` was scanned (four consecutive red attempts on this branch). No visual change: the bar keeps the default accent color. A second commit does the same for `.job-card__window` (the `_since`/`_until` line), the next offender once the first was fixed.

## Acceptance criteria (#1006)

- [x] A submission created from the UI records the selected tenant in `bulk_submissions.tenant_id`.
- [x] Imported resources are written and indexed only under the selected tenant.
- [x] Other tenants (including `default`) are untouched by an import run under a different tenant.
- [x] Regression tests covering tenant selection + bulk import in header and URL routing modes.

## Test plan

- `cargo test -p helios-ui` (36 tests in `bulk_import_http`, all green), `cargo clippy -p helios-ui --all-targets --all-features -D warnings` with the CI allow-set, `cargo fmt --check`, `cargo check -p helios-hfs`.
- Brute-force manual validation on a fresh `pg-es` stack (PostgreSQL 16 + Elasticsearch 8.15.0) with three tenants (`default`, `revalida`, `beta`) and a 200-Patient NDJSON manifest, driving the same UI routes the browser uses (`POST /ui/tenant`, `POST /ui/bulk-import`, `GET /ui/bulk-import/{id}/status`, `POST /ui/bulk-import/{id}/abort`):
  - `header_only`: 10 runs (8 imports rotating the three tenants + 2 aborts). Every `bulk_submissions` row and every `bulk_submit_files` row landed in the selected tenant, the 200 Patients were written under that tenant only (version bumps only on the selected tenant, other tenants byte-for-byte unchanged), no `Status poll answered 4xx` / `Status poll failed` in any submission log, aborts acknowledged with 2xx.
  - `url_path`: 6 runs (5 imports + 1 aborts), same checks plus the detail page showing the recipient as `http://localhost:<port>/<tenant>`.
  - Bug reproduction with the pre-fix binary on the same stack: two imports with `revalida` and `beta` selected both landed in `default` (`bulk_submissions.tenant_id = default`, `default` Patients bumped to the next version, selected tenant untouched) while the page still reported the run as finished. Same flow on this branch: 0 mis-attributed runs out of 16.

## Out of scope

Playwright multi-tenant e2e, forwarding the browser's `Authorization` on Import self-calls (#320), unifying the Import/Export URL helpers, and repairing the test environment's mixed data (a clean environment is planned for the #939 final pass).
