### PR TITLE
fix(ci): unblock Linting — simplify a double-negated assert clippy 1.9x rejects

### DIFF
--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
@@ -293,9 +293,9 @@ mod tests {
         assert!(versioned >= base && versioned < upper.as_str());
         // excluded (a different id sharing the "123" prefix):
         let sibling = "Patient/1234";
-        assert!(!(sibling < upper.as_str()));
+        assert!(sibling >= upper.as_str());
         let sibling0 = "Patient/1230";
-        assert!(!(sibling0 < upper.as_str()));
+        assert!(sibling0 >= upper.as_str());
     }
 
     #[test]


### PR DESCRIPTION
## Problem\n\n`main` is red: the CI **Linting** gate (`cargo clippy --all-targets --all-features -- -D warnings`) fails under the runners' newer clippy (1.9x). Two range-bound assertions in the reference-handler tests are written as `assert!(!(x < upper))`, and `clippy::nonminimal_bool` (not in the CI allow-list) now rejects the double negation. This blocks the Linting check on **every** open PR.\n\n## Fix\n\nRewrite the two asserts as the equivalent `assert!(x >= upper)`. Test-only, behavior unchanged.\n\n## Verification\n\n`cargo clippy -p helios-persistence --all-targets --all-features -- -D warnings <CI allow-list>` — clean.