### PR TITLE
fix(sof): SQL View / SQL Query subjects no longer hang $sql-export and $sql-run

### DIFF
--- a/crates/rest/src/export/in_memory.rs
+++ b/crates/rest/src/export/in_memory.rs
@@ -1113,6 +1113,118 @@ mod tests {
         panic!("job did not reach Completed after both subjects finished");
     }
 
+    /// A `SofRunner` whose `run_view` streams 1,000 rows through a bounded
+    /// `tokio::sync::mpsc` channel fed from `spawn_blocking`, mirroring how
+    /// the real per-backend runners (e.g.
+    /// `crates/persistence/src/sof/sqlite.rs`) produce their row streams.
+    /// `helios-rest` does not depend on `tokio-stream`, so the receiver is
+    /// adapted into a [`RowStream`] with `futures::stream::poll_fn` instead
+    /// of `ReceiverStream`.
+    struct ChannelRunner;
+
+    #[async_trait]
+    impl SofRunner for ChannelRunner {
+        async fn run_view(
+            &self,
+            _tenant: &TenantContext,
+            _view_definition: serde_json::Value,
+            _filters: ViewFilters,
+        ) -> Result<RowStream, SofError> {
+            let (tx, mut rx) =
+                tokio::sync::mpsc::channel::<Result<serde_json::Value, SofError>>(256);
+            tokio::task::spawn_blocking(move || {
+                for i in 0..1000i64 {
+                    let row = serde_json::json!({"id": format!("p{i}")});
+                    if tx.blocking_send(Ok(row)).is_err() {
+                        break;
+                    }
+                }
+            });
+            Ok(Box::pin(futures::stream::poll_fn(move |cx| {
+                rx.poll_recv(cx)
+            })))
+        }
+
+        fn runner_name(&self) -> &'static str {
+            "channel-test-runner"
+        }
+    }
+
+    /// Regression test for the export-side hang this ticket fixes: the
+    /// SQLQuery subject's only dependency streams past tokio's 128-item
+    /// cooperative-poll budget via an `mpsc` channel fed from
+    /// `spawn_blocking`, exactly like a real backend runner. Before the fix,
+    /// `execute_plan`'s call into `insert_rows` never returned once the
+    /// stream crossed that budget, so the export job stayed `Running`
+    /// forever; with the fix it reaches `Completed` with every row written.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sqlquery_export_completes_when_dependency_streams_past_coop_budget() {
+        let runner = Arc::new(ChannelRunner);
+        let controller =
+            InMemoryController::new(runner, InMemorySink::new("http://localhost"), None);
+
+        let tenant = TenantContext::new(TenantId::new("t1"), TenantPermissions::full_access());
+        let leaf_view = serde_json::json!({
+            "resourceType": "ViewDefinition",
+            "resource": "Patient",
+            "status": "active",
+            "select": [{"column": [{"name": "id", "path": "id"}]}]
+        });
+        let query_plan = crate::handlers::sof::graph::GraphPlan {
+            nodes: vec![crate::handlers::sof::graph::PlanNode::Leaf {
+                internal_name: "vd_0".to_string(),
+                view: leaf_view,
+            }],
+            subject_edges: Vec::new(),
+        };
+
+        let job_id = controller.submit(ExportTask {
+            work: ExportWork {
+                views: vec![],
+                queries: vec![NamedSqlQuery {
+                    name: "families".to_string(),
+                    sql: "SELECT * FROM vd_0".to_string(),
+                    plan: query_plan,
+                    bindings: Vec::new(),
+                }],
+                limits: SqlExportLimits {
+                    max_source_rows_per_vd: 10_000,
+                    max_rows: 10_000,
+                    timeout_secs: 5,
+                },
+            },
+            tenant,
+            filters: ViewFilters::default(),
+            format: "ndjson".to_string(),
+            header: true,
+            client_tracking_id: None,
+        });
+
+        let status = tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                match controller.get_status("t1", &job_id) {
+                    Some(status @ JobStatus::Completed { .. })
+                    | Some(status @ JobStatus::Failed { .. }) => return status,
+                    _ => tokio::time::sleep(Duration::from_millis(20)).await,
+                }
+            }
+        })
+        .await
+        .expect("export job must reach a terminal state before the timeout");
+
+        match status {
+            JobStatus::Completed { files, .. } => {
+                assert_eq!(
+                    files.len(),
+                    1,
+                    "expected exactly one output file, got {files:?}"
+                );
+                assert_eq!(files[0].row_count, 1000);
+            }
+            other => panic!("expected Completed, got {other:?}"),
+        }
+    }
+
     /// The cleanup reaper deletes terminal jobs older than the TTL (output +
     /// bookkeeping) while leaving running jobs untouched.
     #[test]

--- a/crates/rest/src/export/in_memory.rs
+++ b/crates/rest/src/export/in_memory.rs
@@ -661,7 +661,7 @@ async fn execute_sql_query(
         exec_limits,
     )
     .await
-    .map_err(ExportError::Runner)?;
+    .map_err(|e| ExportError::Runner(e.to_string()))?;
 
     Ok(result)
 }
@@ -1222,6 +1222,109 @@ mod tests {
                 assert_eq!(files[0].row_count, 1000);
             }
             other => panic!("expected Completed, got {other:?}"),
+        }
+    }
+
+    /// A `SofRunner` whose `run_view` streams 200 rows and then fails with a
+    /// backend error, simulating a Postgres `statement_timeout` or a lost
+    /// connection partway through materializing a dependency.
+    struct FailingRunner;
+
+    #[async_trait]
+    impl SofRunner for FailingRunner {
+        async fn run_view(
+            &self,
+            _tenant: &TenantContext,
+            _view_definition: serde_json::Value,
+            _filters: ViewFilters,
+        ) -> Result<RowStream, SofError> {
+            let ok_rows = (0..200).map(|i| Ok(serde_json::json!({"id": format!("p{i}")})));
+            let failure = std::iter::once(Err(SofError::Backend(
+                "canceling statement due to statement timeout".to_string(),
+            )));
+            Ok(Box::pin(futures::stream::iter(ok_rows.chain(failure))))
+        }
+
+        fn runner_name(&self) -> &'static str {
+            "failing-test-runner"
+        }
+    }
+
+    /// A storage failure mid-materialization of a SQLQuery dependency must
+    /// fail the export job with a diagnostic that names the real cause (a
+    /// backend statement timeout), not one that blames the client's Library
+    /// as malformed.
+    #[tokio::test]
+    async fn sqlquery_export_fails_with_diagnostic_when_dependency_stream_errors() {
+        let runner = Arc::new(FailingRunner);
+        let controller =
+            InMemoryController::new(runner, InMemorySink::new("http://localhost"), None);
+
+        let tenant = TenantContext::new(TenantId::new("t1"), TenantPermissions::full_access());
+        let leaf_view = serde_json::json!({
+            "resourceType": "ViewDefinition",
+            "resource": "Patient",
+            "status": "active",
+            "select": [{"column": [{"name": "id", "path": "id"}]}]
+        });
+        let query_plan = crate::handlers::sof::graph::GraphPlan {
+            nodes: vec![crate::handlers::sof::graph::PlanNode::Leaf {
+                internal_name: "vd_0".to_string(),
+                view: leaf_view,
+            }],
+            subject_edges: Vec::new(),
+        };
+
+        let job_id = controller.submit(ExportTask {
+            work: ExportWork {
+                views: vec![],
+                queries: vec![NamedSqlQuery {
+                    name: "families".to_string(),
+                    sql: "SELECT * FROM vd_0".to_string(),
+                    plan: query_plan,
+                    bindings: Vec::new(),
+                }],
+                limits: SqlExportLimits {
+                    max_source_rows_per_vd: 10_000,
+                    max_rows: 10_000,
+                    timeout_secs: 5,
+                },
+            },
+            tenant,
+            filters: ViewFilters::default(),
+            format: "ndjson".to_string(),
+            header: true,
+            client_tracking_id: None,
+        });
+
+        let status = tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                match controller.get_status("t1", &job_id) {
+                    Some(status @ JobStatus::Completed { .. })
+                    | Some(status @ JobStatus::Failed { .. }) => return status,
+                    _ => tokio::time::sleep(Duration::from_millis(20)).await,
+                }
+            }
+        })
+        .await
+        .expect("export job must reach a terminal state before the timeout");
+
+        match status {
+            JobStatus::Failed { message, .. } => {
+                assert!(
+                    message.contains("dependency source failed"),
+                    "unexpected message: {message}"
+                );
+                assert!(
+                    message.contains("statement timeout"),
+                    "unexpected message: {message}"
+                );
+                assert!(
+                    !message.contains("malformed"),
+                    "a source failure must not be blamed on a malformed Library: {message}"
+                );
+            }
+            other => panic!("expected Failed, got {other:?}"),
         }
     }
 

--- a/crates/rest/src/handlers/sof/graph.rs
+++ b/crates/rest/src/handlers/sof/graph.rs
@@ -645,7 +645,7 @@ pub(crate) async fn execute_plan(
                     .await
                     .map_err(|e| format!("dependency failed to materialize: {e}"))?;
                 let row_stream = adapt_row_stream(row_stream);
-                engine
+                let (returned_engine, _inserted) = engine
                     .insert_rows(
                         internal_name,
                         &schema,
@@ -654,6 +654,7 @@ pub(crate) async fn execute_plan(
                     )
                     .await
                     .map_err(|e| e.to_string())?;
+                engine = returned_engine;
                 leaf_schemas.push(schema);
                 engine = materialize_labels(
                     engine,
@@ -780,7 +781,7 @@ fn schema_from_query_result(result: &QueryResult) -> TableSchema {
 /// Materializes a [`QueryResult`] into a fresh physical table named
 /// `table_name`.
 async fn materialize_query_result(
-    mut engine: InMemorySqlEngine,
+    engine: InMemorySqlEngine,
     table_name: &str,
     result: &QueryResult,
 ) -> Result<InMemorySqlEngine, String> {
@@ -802,11 +803,11 @@ async fn materialize_query_result(
         .collect();
     let cap = result.rows.len();
     let stream = futures::stream::iter(rows);
-    engine
+    let (returned_engine, _inserted) = engine
         .insert_rows(table_name, &schema, Box::pin(stream), cap)
         .await
         .map_err(|e| e.to_string())?;
-    Ok(engine)
+    Ok(returned_engine)
 }
 
 /// Runs one SELECT statement on a blocking thread under a watchdog timeout

--- a/crates/rest/src/handlers/sof/graph.rs
+++ b/crates/rest/src/handlers/sof/graph.rs
@@ -45,9 +45,10 @@ use helios_persistence::core::sof_runner::{RowStream, SofRunner, ViewFilters};
 use helios_persistence::tenant::TenantContext;
 use helios_sof::sqlquery::engine::ColumnSchema;
 use helios_sof::sqlquery::{
-    BoundParam, DependsOnView, InMemorySqlEngine, QueryResult, TableSchema,
+    BoundParam, DependsOnView, InMemorySqlEngine, QueryResult, SqlQueryError, TableSchema,
 };
 use serde_json::{Value, json};
+use tracing::{debug, warn};
 
 use super::references::{canonical_matches, resolve_resource_canonical_or_relative};
 use super::sqlquery::{sqlquery_err_to_rest, validate_select_only};
@@ -616,6 +617,13 @@ pub(crate) struct ExecLimits {
 /// once; each label is a physical copy of that one result, so it is
 /// addressable at every point where a consumer's SQL selects from it. Phase
 /// 1 guarantees every label maps to exactly one node.
+///
+/// Returns a typed [`SqlQueryError`]. In particular, a
+/// [`SqlQueryError::SourceStream`] means the *source* failed — a storage
+/// error, a backend statement timeout, or a lost connection while streaming
+/// a leaf ViewDefinition's rows — never that the Library or its
+/// ViewDefinitions were malformed; callers must not treat it as a client
+/// error.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_plan(
     mut engine: InMemorySqlEngine,
@@ -626,7 +634,7 @@ pub(crate) async fn execute_plan(
     subject_sql: &str,
     subject_bindings: &[BoundParam],
     limits: ExecLimits,
-) -> Result<(QueryResult, Vec<TableSchema>), String> {
+) -> Result<(QueryResult, Vec<TableSchema>), SqlQueryError> {
     let labels_by_target = labels_by_target(plan);
     let mut leaf_schemas: Vec<TableSchema> = Vec::new();
 
@@ -637,15 +645,26 @@ pub(crate) async fn execute_plan(
                 view,
             } => {
                 let schema = TableSchema::from_view_definition(view);
-                engine
-                    .create_table(internal_name, &schema)
-                    .map_err(|e| e.to_string())?;
-                let row_stream = runner
-                    .run_view(tenant, view.clone(), filters.clone())
-                    .await
-                    .map_err(|e| format!("dependency failed to materialize: {e}"))?;
+                engine.create_table(internal_name, &schema)?;
+                let view_label = leaf_view_label(view, internal_name);
+                let start = std::time::Instant::now();
+                let row_stream = match runner.run_view(tenant, view.clone(), filters.clone()).await
+                {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!(
+                            table = %internal_name,
+                            view = %view_label,
+                            error = %e,
+                            "SQL query dependency failed to materialize"
+                        );
+                        return Err(SqlQueryError::SourceStream(format!(
+                            "dependency failed to materialize: {e}"
+                        )));
+                    }
+                };
                 let row_stream = adapt_row_stream(row_stream);
-                let (returned_engine, _inserted) = engine
+                let (returned_engine, inserted) = match engine
                     .insert_rows(
                         internal_name,
                         &schema,
@@ -653,8 +672,27 @@ pub(crate) async fn execute_plan(
                         limits.max_source_rows_per_vd,
                     )
                     .await
-                    .map_err(|e| e.to_string())?;
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        warn!(
+                            table = %internal_name,
+                            view = %view_label,
+                            error = %e,
+                            "SQL query dependency failed to materialize"
+                        );
+                        return Err(e);
+                    }
+                };
                 engine = returned_engine;
+                let elapsed_ms = start.elapsed().as_millis();
+                debug!(
+                    table = %internal_name,
+                    view = %view_label,
+                    rows = inserted,
+                    elapsed_ms,
+                    "materialized SQL query dependency"
+                );
                 leaf_schemas.push(schema);
                 engine = materialize_labels(
                     engine,
@@ -667,6 +705,7 @@ pub(crate) async fn execute_plan(
             PlanNode::SqlView {
                 internal_name, sql, ..
             } => {
+                let start = std::time::Instant::now();
                 let (returned_engine, result) = run_select_with_timeout(
                     engine,
                     sql.clone(),
@@ -677,12 +716,19 @@ pub(crate) async fn execute_plan(
                 .await?;
                 engine = returned_engine;
                 if result.rows.len() > limits.max_source_rows_per_vd {
-                    return Err(format!(
-                        "SQLView result exceeds the {}-row source limit",
-                        limits.max_source_rows_per_vd
-                    ));
+                    return Err(SqlQueryError::RowCapExceeded {
+                        max: limits.max_source_rows_per_vd,
+                    });
                 }
+                let rows = result.rows.len();
                 engine = materialize_query_result(engine, internal_name, &result).await?;
+                let elapsed_ms = start.elapsed().as_millis();
+                debug!(
+                    table = %internal_name,
+                    rows,
+                    elapsed_ms,
+                    "materialized SQL view node"
+                );
                 engine = materialize_labels(
                     engine,
                     internal_name,
@@ -704,6 +750,17 @@ pub(crate) async fn execute_plan(
     .await?;
 
     Ok((result, leaf_schemas))
+}
+
+/// Picks a human-readable label for a leaf ViewDefinition's log lines:
+/// `view.name` if it is a string, else `view.url` if it is a string, else
+/// `internal_name` (the plan's internal table name), which is always
+/// present.
+fn leaf_view_label<'a>(view: &'a Value, internal_name: &'a str) -> &'a str {
+    view.get("name")
+        .and_then(|v| v.as_str())
+        .or_else(|| view.get("url").and_then(|v| v.as_str()))
+        .unwrap_or(internal_name)
 }
 
 /// Groups every distinct label used anywhere in the plan by the internal
@@ -747,15 +804,13 @@ async fn materialize_labels(
     internal_name: &str,
     labels_by_target: &HashMap<String, Vec<String>>,
     max_rows: usize,
-) -> Result<InMemorySqlEngine, String> {
+) -> Result<InMemorySqlEngine, SqlQueryError> {
     let Some(labels) = labels_by_target.get(internal_name) else {
         return Ok(engine);
     };
     for label in labels {
         let copy_sql = format!("SELECT * FROM \"{internal_name}\"");
-        let result = engine
-            .execute_select(&copy_sql, &[], max_rows.saturating_add(1))
-            .map_err(|e| e.to_string())?;
+        let result = engine.execute_select(&copy_sql, &[], max_rows.saturating_add(1))?;
         engine = materialize_query_result(engine, label, &result).await?;
     }
     Ok(engine)
@@ -784,11 +839,9 @@ async fn materialize_query_result(
     engine: InMemorySqlEngine,
     table_name: &str,
     result: &QueryResult,
-) -> Result<InMemorySqlEngine, String> {
+) -> Result<InMemorySqlEngine, SqlQueryError> {
     let schema = schema_from_query_result(result);
-    engine
-        .create_table(table_name, &schema)
-        .map_err(|e| e.to_string())?;
+    engine.create_table(table_name, &schema)?;
     let rows: Vec<Result<Value, String>> = result
         .rows
         .iter()
@@ -805,8 +858,7 @@ async fn materialize_query_result(
     let stream = futures::stream::iter(rows);
     let (returned_engine, _inserted) = engine
         .insert_rows(table_name, &schema, Box::pin(stream), cap)
-        .await
-        .map_err(|e| e.to_string())?;
+        .await?;
     Ok(returned_engine)
 }
 
@@ -820,7 +872,7 @@ async fn run_select_with_timeout(
     bindings: Vec<BoundParam>,
     max_rows: usize,
     timeout_secs: u64,
-) -> Result<(InMemorySqlEngine, QueryResult), String> {
+) -> Result<(InMemorySqlEngine, QueryResult), SqlQueryError> {
     let interrupt = engine.interrupt_handle();
     let watchdog = tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(timeout_secs)).await;
@@ -831,14 +883,14 @@ async fn run_select_with_timeout(
         (engine, r)
     })
     .await
-    .map_err(|e| format!("sqlquery worker panicked: {e}"))?;
+    .map_err(|e| SqlQueryError::Internal(format!("sqlquery worker panicked: {e}")))?;
     watchdog.abort();
     match exec_result {
         Ok(r) => Ok((engine, r)),
         Err(e) if e.to_string().contains("interrupted") => {
-            Err(format!("query exceeded {timeout_secs}s timeout"))
+            Err(SqlQueryError::Timeout { secs: timeout_secs })
         }
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(e),
     }
 }
 

--- a/crates/rest/src/handlers/sof/sqlquery.rs
+++ b/crates/rest/src/handlers/sof/sqlquery.rs
@@ -524,5 +524,6 @@ pub(crate) fn sqlquery_err_to_rest(e: SqlQueryError) -> RestError {
                 message: format!("SQLite error: {err}"),
             }
         }
+        SqlQueryError::Internal(message) => RestError::InternalError { message },
     }
 }

--- a/crates/rest/src/handlers/sof/sqlquery.rs
+++ b/crates/rest/src/handlers/sof/sqlquery.rs
@@ -216,7 +216,7 @@ where
         limits,
     )
     .await
-    .map_err(|e| RestError::UnprocessableEntity { message: e })?;
+    .map_err(sqlquery_err_to_rest)?;
 
     // SoF v2 PR #353: apply caller-supplied `_limit` as a soft cap on the
     // final result set, AFTER SQL evaluation (including any in-query LIMIT).
@@ -525,5 +525,36 @@ pub(crate) fn sqlquery_err_to_rest(e: SqlQueryError) -> RestError {
             }
         }
         SqlQueryError::Internal(message) => RestError::InternalError { message },
+        SqlQueryError::SourceStream(msg) => RestError::InternalError {
+            message: format!("dependency source failed: {msg}"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_stream_and_internal_errors_map_to_500() {
+        let source_stream = sqlquery_err_to_rest(SqlQueryError::SourceStream("x".into()));
+        assert_eq!(
+            source_stream.client_response().0,
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        let internal = sqlquery_err_to_rest(SqlQueryError::Internal("y".into()));
+        assert_eq!(
+            internal.client_response().0,
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        // A source failure must never be reported as if the client sent a
+        // malformed request: row-cap violations still answer 422.
+        let row_cap = sqlquery_err_to_rest(SqlQueryError::RowCapExceeded { max: 5 });
+        assert_eq!(
+            row_cap.client_response().0,
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
     }
 }

--- a/crates/sof/src/sqlquery/engine.rs
+++ b/crates/sof/src/sqlquery/engine.rs
@@ -196,14 +196,60 @@ impl InMemorySqlEngine {
         Ok(())
     }
 
-    /// Stream `rows` into `label`. Each row is a flat JSON object whose keys
-    /// match column names; missing or null keys become SQL NULL.
+    /// Streams `rows` into `label` on a dedicated blocking thread, then
+    /// hands the engine back to the caller.
+    ///
+    /// The engine (and the `rusqlite::Statement` the insert loop prepares)
+    /// is not `Send` across an `.await` point, and the row stream is
+    /// typically a `tokio::sync::mpsc` channel whose `recv` spends the
+    /// polling task's cooperative budget on every item — draining more than
+    /// 128 rows in an ordinary async task therefore starves the waker and
+    /// hangs forever. Moving the whole operation into
+    /// `tokio::task::spawn_blocking` sidesteps both problems: the engine
+    /// crosses into a blocking-pool thread by value, the stream is driven
+    /// with `Handle::block_on` (which resets the cooperative budget on every
+    /// poll and is safe to use exactly because there is no scheduler to
+    /// starve on that thread), and the engine is returned to the caller once
+    /// the whole insert has completed.
+    ///
+    /// Returns `Ok((engine, n))` on success, where `n` is the number of rows
+    /// inserted and the transaction has been committed. On `Err`, the
+    /// transaction has already been rolled back and the engine is dropped;
+    /// callers are expected to abort the current plan rather than keep using
+    /// a half-populated database.
     pub async fn insert_rows<S>(
+        self,
+        label: &str,
+        schema: &TableSchema,
+        rows: Pin<Box<S>>,
+        max_rows: usize,
+    ) -> Result<(Self, usize), SqlQueryError>
+    where
+        S: Stream<Item = Result<Value, String>> + Send + 'static + ?Sized,
+    {
+        let label = label.to_string();
+        let schema = schema.clone();
+        tokio::task::spawn_blocking(move || {
+            let handle = tokio::runtime::Handle::current();
+            let mut engine = self;
+            let inserted = engine.insert_rows_blocking(&label, &schema, rows, max_rows, &handle)?;
+            Ok((engine, inserted))
+        })
+        .await
+        .map_err(|e| SqlQueryError::Internal(format!("sqlquery worker panicked: {e}")))?
+    }
+
+    /// Synchronous body of [`Self::insert_rows`]. Runs entirely on the
+    /// blocking thread `insert_rows` spawned; every `rows.next()` call
+    /// (including the no-columns fast path) goes through `handle.block_on`
+    /// instead of `.await`, since this function is not itself async.
+    fn insert_rows_blocking<S>(
         &mut self,
         label: &str,
         schema: &TableSchema,
         mut rows: Pin<Box<S>>,
         max_rows: usize,
+        handle: &tokio::runtime::Handle,
     ) -> Result<usize, SqlQueryError>
     where
         S: Stream<Item = Result<Value, String>> + Send + ?Sized,
@@ -215,7 +261,7 @@ impl InMemorySqlEngine {
         if schema.columns.is_empty() {
             // Drain the stream without inserting; nothing to persist.
             let mut n = 0usize;
-            while let Some(item) = rows.next().await {
+            while let Some(item) = handle.block_on(rows.next()) {
                 item.map_err(SqlQueryError::MalformedLibrary)?;
                 n += 1;
                 if n > max_rows {
@@ -240,7 +286,7 @@ impl InMemorySqlEngine {
         let mut inserted = 0usize;
         let result: Result<usize, SqlQueryError> = (|| {
             let mut stmt = self.conn.prepare(&insert_sql)?;
-            while let Some(item) = futures::executor::block_on(rows.next()) {
+            while let Some(item) = handle.block_on(rows.next()) {
                 let row = item.map_err(SqlQueryError::MalformedLibrary)?;
                 inserted += 1;
                 if inserted > max_rows {
@@ -416,7 +462,7 @@ mod tests {
 
     #[tokio::test]
     async fn round_trip_basic() {
-        let mut engine = InMemorySqlEngine::open().unwrap();
+        let engine = InMemorySqlEngine::open().unwrap();
         let s = schema(&[
             ("id", ColumnFhirType::String("id".into())),
             ("n", ColumnFhirType::Integer),
@@ -426,7 +472,7 @@ mod tests {
             Ok(json!({"id": "a", "n": 1})),
             Ok(json!({"id": "b", "n": 2})),
         ]);
-        let inserted = engine
+        let (engine, inserted) = engine
             .insert_rows("patients", &s, Box::pin(rows), 10)
             .await
             .unwrap();
@@ -442,14 +488,14 @@ mod tests {
 
     #[tokio::test]
     async fn null_handling() {
-        let mut engine = InMemorySqlEngine::open().unwrap();
+        let engine = InMemorySqlEngine::open().unwrap();
         let s = schema(&[
             ("id", ColumnFhirType::String("id".into())),
             ("age", ColumnFhirType::Integer),
         ]);
         engine.create_table("t", &s).unwrap();
         let rows = stream::iter(vec![Ok(json!({"id": "a"}))]); // age missing
-        engine
+        let (engine, _inserted) = engine
             .insert_rows("t", &s, Box::pin(rows), 10)
             .await
             .unwrap();
@@ -461,14 +507,17 @@ mod tests {
 
     #[tokio::test]
     async fn row_cap_exceeded() {
-        let mut engine = InMemorySqlEngine::open().unwrap();
+        let engine = InMemorySqlEngine::open().unwrap();
         let s = schema(&[("n", ColumnFhirType::Integer)]);
         engine.create_table("t", &s).unwrap();
         let rows = stream::iter((0..10).map(|i| Ok(json!({"n": i}))));
-        let err = engine
-            .insert_rows("t", &s, Box::pin(rows), 3)
-            .await
-            .unwrap_err();
+        // `Result<(InMemorySqlEngine, usize), _>` doesn't implement `Debug`
+        // (the engine wraps a `rusqlite::Connection`, which doesn't), so
+        // `unwrap_err()` isn't available here; match instead.
+        let err = match engine.insert_rows("t", &s, Box::pin(rows), 3).await {
+            Ok(_) => panic!("expected RowCapExceeded"),
+            Err(e) => e,
+        };
         assert!(matches!(err, SqlQueryError::RowCapExceeded { max: 3 }));
     }
 
@@ -476,11 +525,11 @@ mod tests {
     async fn execute_select_silently_truncates_at_max_rows() {
         // SoF v2 PR #353: the server's hard cap silently truncates the
         // result set; it must not error.
-        let mut engine = InMemorySqlEngine::open().unwrap();
+        let engine = InMemorySqlEngine::open().unwrap();
         let s = schema(&[("n", ColumnFhirType::Integer)]);
         engine.create_table("t", &s).unwrap();
         let rows = stream::iter((1..=10).map(|i| Ok(json!({"n": i}))));
-        engine
+        let (engine, _inserted) = engine
             .insert_rows("t", &s, Box::pin(rows), 100)
             .await
             .unwrap();
@@ -502,11 +551,11 @@ mod tests {
 
     #[tokio::test]
     async fn named_bindings_filter() {
-        let mut engine = InMemorySqlEngine::open().unwrap();
+        let engine = InMemorySqlEngine::open().unwrap();
         let s = schema(&[("n", ColumnFhirType::Integer)]);
         engine.create_table("t", &s).unwrap();
         let rows = stream::iter((1..=5).map(|i| Ok(json!({"n": i}))));
-        engine
+        let (engine, _inserted) = engine
             .insert_rows("t", &s, Box::pin(rows), 100)
             .await
             .unwrap();
@@ -518,6 +567,62 @@ mod tests {
             .execute_select("SELECT n FROM t WHERE n >= :min ORDER BY n", &bindings, 100)
             .unwrap();
         assert_eq!(result.rows.len(), 3);
+    }
+
+    /// Regression test for the hang this ticket fixes. A real runner (see
+    /// `crates/persistence/src/sof/sqlite.rs`) feeds `insert_rows` through a
+    /// `tokio::sync::mpsc` channel from a `spawn_blocking` producer. Each
+    /// `recv` on that channel spends one unit of the polling task's
+    /// cooperative budget (128 per poll, tokio's `coop` module); once it ran
+    /// out at row 129, the old executor-blocking implementation (draining
+    /// the stream via the `futures` crate's synchronous executor) never woke
+    /// up again. 1,000 rows is comfortably past
+    /// that threshold — `futures::stream::iter` would not reproduce this,
+    /// since it never touches the cooperative budget.
+    ///
+    /// The consumer runs inside `tokio::spawn` (not directly `.await`ed) and
+    /// the `JoinHandle` is wrapped in `tokio::time::timeout`: on a
+    /// single-threaded runtime (`main`, the pre-fix binary) this test would
+    /// otherwise hang forever instead of failing.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn insert_rows_drains_tokio_mpsc_stream_past_coop_budget() {
+        const ROW_COUNT: i64 = 1000;
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<Value, String>>(256);
+
+        tokio::task::spawn_blocking(move || {
+            for i in 0..ROW_COUNT {
+                let row = json!({"id": format!("p{i}"), "n": i});
+                if tx.blocking_send(Ok(row)).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let consumer = tokio::spawn(async move {
+            let engine = InMemorySqlEngine::open().unwrap();
+            let s = schema(&[
+                ("id", ColumnFhirType::String("id".into())),
+                ("n", ColumnFhirType::Integer),
+            ]);
+            engine.create_table("t", &s).unwrap();
+            let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+            let (engine, inserted) = engine
+                .insert_rows("t", &s, Box::pin(stream), 10_000)
+                .await
+                .unwrap();
+            let count = engine
+                .execute_select("SELECT COUNT(*) AS c FROM t", &[], 10)
+                .unwrap();
+            (inserted, count)
+        });
+
+        let (inserted, count) = tokio::time::timeout(std::time::Duration::from_secs(10), consumer)
+            .await
+            .expect("insert_rows must not hang past the cooperative budget")
+            .expect("consumer task must not panic");
+
+        assert_eq!(inserted, ROW_COUNT as usize);
+        assert_eq!(count.rows[0][0], Some(Value::Number(ROW_COUNT.into())));
     }
 
     #[test]

--- a/crates/sof/src/sqlquery/engine.rs
+++ b/crates/sof/src/sqlquery/engine.rs
@@ -262,7 +262,7 @@ impl InMemorySqlEngine {
             // Drain the stream without inserting; nothing to persist.
             let mut n = 0usize;
             while let Some(item) = handle.block_on(rows.next()) {
-                item.map_err(SqlQueryError::MalformedLibrary)?;
+                item.map_err(SqlQueryError::SourceStream)?;
                 n += 1;
                 if n > max_rows {
                     return Err(SqlQueryError::RowCapExceeded { max: max_rows });
@@ -287,7 +287,7 @@ impl InMemorySqlEngine {
         let result: Result<usize, SqlQueryError> = (|| {
             let mut stmt = self.conn.prepare(&insert_sql)?;
             while let Some(item) = handle.block_on(rows.next()) {
-                let row = item.map_err(SqlQueryError::MalformedLibrary)?;
+                let row = item.map_err(SqlQueryError::SourceStream)?;
                 inserted += 1;
                 if inserted > max_rows {
                     return Err(SqlQueryError::RowCapExceeded { max: max_rows });
@@ -519,6 +519,36 @@ mod tests {
             Err(e) => e,
         };
         assert!(matches!(err, SqlQueryError::RowCapExceeded { max: 3 }));
+    }
+
+    #[tokio::test]
+    async fn insert_rows_reports_stream_error_as_source_stream() {
+        // A `SofRunner`'s row stream fails mid-materialization (storage
+        // error, backend statement timeout, lost connection). This must be
+        // reported as `SourceStream`, not folded into `MalformedLibrary` —
+        // the Library and its ViewDefinitions are perfectly well-formed.
+        let engine = InMemorySqlEngine::open().unwrap();
+        let s = schema(&[("id", ColumnFhirType::String("id".into()))]);
+        engine.create_table("t", &s).unwrap();
+        let ok_rows = (0..200).map(|i| Ok(json!({"id": format!("p{i}")})));
+        let rows = stream::iter(
+            ok_rows.chain(std::iter::once(Err("connection reset by peer".to_string()))),
+        );
+        let err = match engine.insert_rows("t", &s, Box::pin(rows), 10_000).await {
+            Ok(_) => panic!("expected SourceStream"),
+            Err(e) => e,
+        };
+        let SqlQueryError::SourceStream(msg) = &err else {
+            panic!("expected SourceStream, got {err:?}");
+        };
+        assert!(
+            msg.contains("connection reset by peer"),
+            "unexpected message: {msg}"
+        );
+        assert!(
+            format!("{err}").starts_with("dependency source failed: "),
+            "unexpected display: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/sof/src/sqlquery/mod.rs
+++ b/crates/sof/src/sqlquery/mod.rs
@@ -64,4 +64,12 @@ pub enum SqlQueryError {
 
     #[error("composite SQL value for column '{0}' cannot be represented as a FHIR scalar")]
     UnsupportedFhirValue(String),
+
+    /// A failure in the server's own execution machinery rather than in the
+    /// client's request — e.g. the blocking worker that materializes a
+    /// depends-on ViewDefinition's row stream panicked. This is never
+    /// caused by malformed client input and should be surfaced as a 500,
+    /// not as a validation error.
+    #[error("internal error: {0}")]
+    Internal(String),
 }

--- a/crates/sof/src/sqlquery/mod.rs
+++ b/crates/sof/src/sqlquery/mod.rs
@@ -65,6 +65,15 @@ pub enum SqlQueryError {
     #[error("composite SQL value for column '{0}' cannot be represented as a FHIR scalar")]
     UnsupportedFhirValue(String),
 
+    /// The `SofRunner` stream feeding a `depends-on` dependency table
+    /// yielded an error — a storage failure, a backend statement timeout,
+    /// or a lost connection. The dependency was not materialized. This is
+    /// never the client's fault (the Library and its ViewDefinitions may be
+    /// perfectly well-formed) and must be surfaced as a server error, not
+    /// folded into [`SqlQueryError::MalformedLibrary`].
+    #[error("dependency source failed: {0}")]
+    SourceStream(String),
+
     /// A failure in the server's own execution machinery rather than in the
     /// client's request — e.g. the blocking worker that materializes a
     /// depends-on ViewDefinition's row stream panicked. This is never


### PR DESCRIPTION
## Summary

Closes #1008.

`$sql-export` and `$sql-run` (the UI's SQL View / SQL Query preview) hung forever whenever a subject depended on a ViewDefinition with more than 128 rows, on every backend. `InMemorySqlEngine::insert_rows` drained the dependency's row stream with `futures::executor::block_on` on a tokio worker; the stream is a tokio mpsc channel whose `recv` spends the task's cooperative budget (128 per poll), and once it ran out tokio deferred the wake-up to a scheduler that the blocked worker never returned to. The same blocked worker starved unrelated requests, which is what made the composite mark PostgreSQL unhealthy, truncated "Download all" ZIPs and stalled rest-hook retries while an export was stuck.

## Changes

- **Dependency materialization runs on a blocking thread** (`spawn_blocking` + `Handle::block_on`), the pattern `run_select_with_timeout` already used for the plan's SQL statements, so no SQLite work runs on async workers. Same transaction and row caps. (`728301468`)
- **`execute_plan` returns typed `SqlQueryError`s.** A storage failure while feeding a dependency is `SourceStream`: `$sql-run` answers 500 with the detail in the server log (it used to be 422 "malformed Library"), and `$sql-export` marks the job `Failed` with the backend's diagnostic. No consumer-side timeout was added: PostgreSQL's `statement_timeout`, the pool wait timeout and the SQL watchdog already bound every wait, and their errors now surface correctly. (`6dbe8e733`)
- **Per-dependency logs.** Each materialized dependency logs table, view, row count and elapsed time at debug level; a failed one logs at warn.
- **Regression tests.** A 1,000-row mpsc-fed stream through `insert_rows` and through a full export job (both time out on `main`), a mid-stream error surfacing as `Failed` with the diagnostic, and the 500 mapping.

## Acceptance criteria (#1008)

- [x] SQL View subjects complete on pg-es in all four output formats.
- [x] Any runner failure surfaces as a `Failed` job with diagnostics and a server log line (unit-tested; `SourceStream` → 500 / `Failed`).
- [x] No blocking call on async workers in the sqlquery engine (`futures::executor::block_on` is gone from `crates/sof`).
- [x] The server stays responsive while an export runs.

## Testing

- Unit: `cargo test -p helios-sof sqlquery`, `cargo test -p helios-rest --features sqlite sof export::in_memory`; clippy with the CI allow-set on both crates.
- Brute-force reproduction on `postgres-elasticsearch` with the #939 dataset (11,705 Patients, `female_patients` SQL View → `patient_demographics`):
  - `main` binary: 3/3 `$sql-run` previews timed out at 45 s and 2/2 `$sql-export` jobs stayed `in-progress` until cancelled (the hang; unrelated requests still answered).
  - this branch: 30/30 sequential previews (0.7–2.2 s), 16/16 concurrent previews in two bursts of 6 and 10 (5,814 rows each, ≤2.1 s per burst), 20/20 exports across ndjson/csv/json/parquet (≈1.1 s each, `Patient?_count=1` answering 200 during every job); 66 `materialized SQL query dependency` log lines with `rows=11705`, zero `unhealthy`/panic entries. Failure path, live: with `HFS_PG_STATEMENT_TIMEOUT_MS=500`/`600` the dependency query is cancelled mid-stream and `$sql-run` answers 500 `exception` while the log shows `WARN … SQL query dependency failed to materialize … error=dependency source failed: backend error: row error: db error` plus `ERROR … error.detail=dependency source failed: …`; 2 of 6 `$sql-export` jobs ended `Failed` with `export job failed … error=query 'female_patients': view runner error: dependency source failed: backend error: row error: db error` (never `malformed Library`, never 422). With PostgreSQL paused, preview and export answer 500 with the connection error in the log.

## Follow-ups

- #1028 — a `SofRunner` producer that panics mid-stream is reported as a complete result (silent truncation).
- #1029 — `materialize_labels` copies label tables synchronously on the async worker.
- Preview latency with large dependencies (issue #1008, comment 2): after the fix the SQL View preview takes 0.7–2.2 s and the export ≈1.1 s on the same dataset; not reproduced, no issue opened.
- Systemic symptoms (backend marked unhealthy, truncated ZIPs, stalled rest-hook retries): the server stayed responsive during every export and the log has no `unhealthy` entry; treated as consequences of the blocked worker.
