### PR TITLE
fix(sqlite): Type/id reference range must not match sibling ids containing - or .

### DIFF
--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
@@ -111,23 +111,26 @@ impl ReferenceHandler {
         let base = strip_reference_version(ref_value);
 
         if base.contains('/') {
-            // Type/id (or absolute URL): match the base reference and any
-            // `_history`-versioned form of it, as a single **indexable range**
-            // rather than `= ? OR value_reference LIKE '…/_history/%'`. The OR
-            // and the leading-anchored LIKE both defeat the index, so the old
-            // form scanned every reference row of the type; a plain range uses
-            // `idx_search_reference` (#1017).
+            // Type/id (or absolute URL): match the base reference exactly, plus
+            // any `_history`-versioned form of it as an **indexable range**,
+            // rather than `= ? OR value_reference LIKE '…/_history/%'`. The
+            // leading-anchored LIKE defeats the index, so the old form scanned
+            // every reference row of the type; an equality plus a plain range
+            // on the same column lets the planner take two `idx_search_reference`
+            // probes (MULTI-INDEX OR) instead (#1017).
             //
-            // `[base, base || '0')` is exactly `<base>` plus `<base>/_history/…`:
-            // a stored reference is either `<base>` itself or `<base>/_history/<v>`
-            // (`strip_reference_version` removed any version from `base`), and
-            // `'/'` (0x2F) sorts just below `'0'` (0x30), so `<base>/…` falls
-            // inside the range while a different id that merely shares the
-            // prefix (`<base>4`, `<base>0`) sorts at or above the `'0'` bound and
-            // is excluded.
+            // The range `[base || '/_history/', base || '/_history0')` is exactly
+            // `<base>/_history/<anything>`: `'/'` (0x2F) is immediately below
+            // `'0'` (0x30). It must be anchored on the `/_history/` suffix rather
+            // than on `<base>` alone: FHIR ids may contain `-` (0x2D) and `.`
+            // (0x2E), which sort *below* `'/'`, so a bare `[base, base || '0')`
+            // range would also capture a different resource whose id merely
+            // extends this one (`<base>-4`, `<base>.5`) (#1030 review).
             SqlFragment::with_params(
                 format!(
-                    "(value_reference >= ?{p} AND value_reference < ?{p} || '0')",
+                    "(value_reference = ?{p} \
+                      OR (value_reference >= ?{p} || '/_history/' \
+                          AND value_reference < ?{p} || '/_history0'))",
                     p = param_num
                 ),
                 vec![SqlParam::string(base)],
@@ -257,10 +260,11 @@ mod tests {
         let value = SearchValue::new(SearchPrefix::Eq, "Patient/123");
         let frag = ReferenceHandler::build_sql(&value, None, 0);
 
-        // Version-agnostic via a single indexable range (#1017): the base and
-        // any `_history` version, bound once as `?1`.
-        assert!(frag.sql.contains("value_reference >= ?1"));
-        assert!(frag.sql.contains("value_reference < ?1 || '0'"));
+        // Version-agnostic via an equality plus an indexable `_history` range
+        // (#1017), bound once as `?1`.
+        assert!(frag.sql.contains("value_reference = ?1"));
+        assert!(frag.sql.contains("value_reference >= ?1 || '/_history/'"));
+        assert!(frag.sql.contains("value_reference < ?1 || '/_history0'"));
         assert!(
             !frag.sql.contains("LIKE"),
             "the range must not fall back to LIKE"
@@ -282,20 +286,32 @@ mod tests {
 
     #[test]
     fn test_reference_range_bounds_match_base_and_versions_only() {
-        // The `[base, base||'0')` range must include the base and every
-        // `_history` version, and exclude a different id that merely shares the
-        // prefix. `'/'` (0x2F) < `'0'` (0x30) is what makes this hold (#1017).
+        // The predicate is `= base OR [base/_history/, base/_history0)`. It
+        // must include the base and every `_history` version, and exclude a
+        // different id that merely extends this one — including with `-` and
+        // `.`, which are legal FHIR id characters that sort *below* `'/'` and
+        // `'0'` (#1030 review). Mirrors SQLite's BINARY (bytewise) collation.
         let base = "Patient/123";
-        let upper = format!("{base}0");
+        let lower = format!("{base}/_history/");
+        let upper = format!("{base}/_history0");
+        let matches = |s: &str| s == base || (s >= lower.as_str() && s < upper.as_str());
+
         // included:
-        assert!(base >= base && base < upper.as_str());
-        let versioned = "Patient/123/_history/2";
-        assert!(versioned >= base && versioned < upper.as_str());
-        // excluded (a different id sharing the "123" prefix):
-        let sibling = "Patient/1234";
-        assert!(sibling >= upper.as_str());
-        let sibling0 = "Patient/1230";
-        assert!(sibling0 >= upper.as_str());
+        assert!(matches("Patient/123"));
+        assert!(matches("Patient/123/_history/1"));
+        assert!(matches("Patient/123/_history/27"));
+        assert!(matches("Patient/123/_history/abc-1.2"));
+
+        // excluded (a different resource whose id extends "123"):
+        assert!(!matches("Patient/1234"));
+        assert!(!matches("Patient/1230"));
+        assert!(!matches("Patient/123-4"));
+        assert!(!matches("Patient/123.5"));
+        assert!(!matches("Patient/123-4/_history/1"));
+        assert!(!matches("Patient/123.5/_history/1"));
+        // excluded (a shorter id, or a different type):
+        assert!(!matches("Patient/12"));
+        assert!(!matches("Group/123"));
     }
 
     #[test]
@@ -328,9 +344,10 @@ mod tests {
         );
 
         // `:Patient` normalizes the bare id to `Patient/123`, which then uses
-        // the indexable range like any Type/id reference (#1017).
-        assert!(frag.sql.contains("value_reference >= ?1"));
-        assert!(frag.sql.contains("value_reference < ?1 || '0'"));
+        // the equality + `_history` range like any Type/id reference (#1017).
+        assert!(frag.sql.contains("value_reference = ?1"));
+        assert!(frag.sql.contains("value_reference >= ?1 || '/_history/'"));
+        assert!(frag.sql.contains("value_reference < ?1 || '/_history0'"));
         let dbg = format!("{:?}", frag.params);
         assert!(dbg.contains("Patient/123"));
     }

--- a/crates/persistence/tests/sqlite_tests.rs
+++ b/crates/persistence/tests/sqlite_tests.rs
@@ -1980,6 +1980,87 @@ async fn test_search_reference_subject() {
     assert!(ids.contains(&"obs-2"));
 }
 
+/// A `Type/id` reference search must not match a *different* resource whose
+/// id merely extends the searched id. FHIR ids may contain `-` and `.`, which
+/// sort below `'/'` and `'0'` in SQLite's BINARY collation, so a naive
+/// `[base, base || '0')` index range (PR #1030) wrongly captured `Patient/123-4`
+/// and `Patient/123.5` for `subject=Patient/123`. The predicate must still be
+/// version-agnostic (match `Patient/123/_history/<v>`).
+#[tokio::test]
+async fn test_search_by_reference_does_not_match_extended_sibling_ids() {
+    let backend = create_backend();
+    let tenant = create_tenant("test-tenant");
+
+    // Every stored reference shares the "Patient/123" prefix; only the first
+    // two are the same resource.
+    let refs = [
+        ("obs-base", "Patient/123"),
+        ("obs-versioned", "Patient/123/_history/2"),
+        ("obs-dash", "Patient/123-4"),
+        ("obs-dot", "Patient/123.5"),
+        ("obs-digit", "Patient/1234"),
+        ("obs-zero", "Patient/1230"),
+        ("obs-dash-versioned", "Patient/123-4/_history/1"),
+        ("obs-short", "Patient/12"),
+    ];
+    for (id, reference) in refs {
+        backend
+            .create(
+                &tenant,
+                "Observation",
+                json!({
+                    "resourceType": "Observation",
+                    "id": id,
+                    "status": "final",
+                    "subject": {"reference": reference},
+                    "code": {"coding": [{"code": "8867-4"}]}
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+    }
+
+    let search = |value: &str| {
+        SearchQuery::new("Observation").with_parameter(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::eq(value)],
+            chain: vec![],
+            components: vec![],
+        })
+    };
+
+    let result = backend
+        .search(&tenant, &search("Patient/123"))
+        .await
+        .unwrap();
+    let mut ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+    ids.sort_unstable();
+    assert_eq!(
+        ids,
+        vec!["obs-base", "obs-versioned"],
+        "subject=Patient/123 must match only Patient/123 and its _history versions"
+    );
+
+    // The siblings are themselves searchable, exactly.
+    let result = backend
+        .search(&tenant, &search("Patient/123-4"))
+        .await
+        .unwrap();
+    let mut ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec!["obs-dash", "obs-dash-versioned"]);
+
+    let result = backend
+        .search(&tenant, &search("Patient/123.5"))
+        .await
+        .unwrap();
+    let ids: Vec<&str> = result.resources.items.iter().map(|r| r.id()).collect();
+    assert_eq!(ids, vec!["obs-dot"]);
+}
+
 #[tokio::test]
 async fn test_patient_compartment_export_observation_without_since() {
     let backend = create_backend();


### PR DESCRIPTION
Follow-up to #1030, addressing the review finding in https://github.com/HeliosSoftware/hfs/pull/1030#issuecomment-5608517581.

## The bug

#1030 replaced the non-sargable `= ? OR LIKE '…/_history/%'` predicate with the index range `[base, base || '0')`, on the claim that `/` (0x2F) is the only continuation byte below `'0'` (0x30). It is not: FHIR ids may contain `-` (0x2D) and `.` (0x2E), both of which sort below `/`. So `subject=Patient/123` also returned references to **different resources** `Patient/123-4` and `Patient/123.5`.

Reproduced in sqlite3 with the real `idx_search_reference` definition:

```
--- OLD predicate rows:
o1|Patient/123
o2|Patient/123/_history/2
o3|Patient/123-4        <- wrong
o4|Patient/123.5        <- wrong
```

## The fix

Equality for the base, plus a range anchored on the `_history` suffix (as suggested in the review):

```sql
(value_reference = ?
 OR (value_reference >= ? || '/_history/' AND value_reference < ? || '/_history0'))
```

`[base/_history/, base/_history0)` is exactly `base/_history/<anything>`, and no longer depends on which id characters sort below `'0'`. Still one bound parameter.

## Still sargable

SQLite plans it as a MULTI-INDEX OR with both arms probing `idx_search_reference`, so the #1017 speedup is preserved:

```
MULTI-INDEX OR
|--INDEX 1: SEARCH search_index USING INDEX idx_search_reference (tenant_id=? AND resource_type=? AND param_name=? AND value_reference=?)
`--INDEX 2: SEARCH search_index USING INDEX idx_search_reference (tenant_id=? AND resource_type=? AND param_name=? AND value_reference>? AND value_reference<?)
```

## Tests

- `test_reference_range_bounds_match_base_and_versions_only` now exercises `-` and `.` continuations (the previous version only checked digits, which is the subset where the old invariant happened to hold).
- New `test_search_by_reference_does_not_match_extended_sibling_ids` in `sqlite_tests.rs` stores `Patient/123`, its `_history` form, and every prefix-sharing sibling (`-4`, `.5`, `4`, `0`, `-4/_history/1`, shorter id), then asserts `subject=Patient/123` returns only the first two and that each sibling is still searchable exactly. Verified it **fails on main** (returns 5 rows) and passes here.
- `helios-persistence` sqlite lib (918) and `sqlite_tests` (85) green; clippy with the CI flag set and `cargo fmt --check` clean.

https://claude.ai/code/session_01RbzKzT21pULnRqWvqw6hv3
