### PR TITLE
fix(hfs): gate composite_submit_jobs on elasticsearch to silence dead_code warning

### DIFF
--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -1658,20 +1658,6 @@ fn spawn_export_workers<Dp>(
     );
 }
 
-/// Builds the bulk-submit subsystem (input fetcher + output store + file auth +
-/// worker pool) from a caller-supplied job store. Returns `None` when bulk submit
-/// is disabled. The job store is the same backend instance that holds the FHIR
-/// resources (so ingestion writes go to the primary store).
-///
-/// Unlike bulk *export*, every backend that can run `$bulk-submit` hosts its own
-/// job state — MongoDB in its own collections, S3 in the same objects its
-/// ingestion engine already writes — so there is no sidecar variant here.
-#[cfg(any(
-    feature = "sqlite",
-    feature = "postgres",
-    feature = "mongodb",
-    feature = "s3"
-))]
 /// Picks the `$bulk-submit` job store for a primary + Elasticsearch composite.
 ///
 /// The raw primary never feeds Elasticsearch, so by default the store is
@@ -1683,6 +1669,10 @@ fn spawn_export_workers<Dp>(
 /// the wrapper, otherwise the data never reaches Elasticsearch.
 ///
 /// [`CompositeSubmitJobs`]: helios_persistence::composite::CompositeSubmitJobs
+#[cfg(all(
+    feature = "elasticsearch",
+    any(feature = "sqlite", feature = "postgres")
+))]
 fn composite_submit_jobs(
     primary: Arc<dyn BulkSubmitJobStore>,
     composite: Arc<helios_persistence::composite::CompositeStorage>,
@@ -1698,6 +1688,20 @@ fn composite_submit_jobs(
     }
 }
 
+/// Builds the bulk-submit subsystem (input fetcher + output store + file auth +
+/// worker pool) from a caller-supplied job store. Returns `None` when bulk submit
+/// is disabled. The job store is the same backend instance that holds the FHIR
+/// resources (so ingestion writes go to the primary store).
+///
+/// Unlike bulk *export*, every backend that can run `$bulk-submit` hosts its own
+/// job state — MongoDB in its own collections, S3 in the same objects its
+/// ingestion engine already writes — so there is no sidecar variant here.
+#[cfg(any(
+    feature = "sqlite",
+    feature = "postgres",
+    feature = "mongodb",
+    feature = "s3"
+))]
 async fn build_bulk_submit(
     config: &ServerConfig,
     jobs: Arc<dyn BulkSubmitJobStore>,


### PR DESCRIPTION
## Summary

`cargo build` (default features) warned:

```
warning: function `composite_submit_jobs` is never used
    --> crates/hfs/src/main.rs:1686:4
```

A merge (af6030636, from `perf/903-bulk-fast-load`) put `composite_submit_jobs` between `build_bulk_submit`'s doc comment/`#[cfg(...)]` and its signature. As a result:

- `composite_submit_jobs` picked up the broad `sqlite`/`postgres`/`mongodb`/`s3` gate, so the default `sqlite` build compiled it. Its only callers are in `start_sqlite_elasticsearch` and `start_postgres_elasticsearch`, so without Elasticsearch it was never called and was flagged as dead code.
- `build_bulk_submit` lost its doc comment and cfg gate.

## Changes

- `composite_submit_jobs` is now gated on `all(feature = "elasticsearch", any(feature = "sqlite", feature = "postgres"))`, which matches its callers.
- `build_bulk_submit` has its doc comment and `#[cfg(...)]` back.

No behavior change.

## Testing

- `cargo check -p helios-hfs`: no warnings
- `cargo check -p helios-hfs --features sqlite,postgres,elasticsearch`: no warnings

https://claude.ai/code/session_017k4wPL2k6f1yKWD8RPCkW5