### PR TITLE
Drop "of bytes" from bulk-submit progress and capitalize Resources

### DIFF
--- a/crates/rest/src/handlers/bulk_submit.rs
+++ b/crates/rest/src/handlers/bulk_submit.rs
@@ -977,11 +977,11 @@ where
             // the number #969 exists to show was invisible exactly when it had
             // something to say.
             format!(
-                "Processing {pct}% of bytes - {} resources written",
+                "Processing {pct}% - {} Resources written",
                 group_thousands(entries)
             )
         } else if pct > 0 {
-            format!("Processing {pct}% of bytes")
+            format!("Processing {pct}%")
         } else if !manifests.is_empty()
             && manifests
                 .iter()
@@ -1015,7 +1015,7 @@ where
                     )),
                     _ => None,
                 })
-                .unwrap_or_else(|| format!("Processing {pct}% of bytes"))
+                .unwrap_or_else(|| format!("Processing {pct}%"))
         };
         return Response::builder()
             .status(StatusCode::ACCEPTED)

--- a/crates/rest/tests/bulk_submit.rs
+++ b/crates/rest/tests/bulk_submit.rs
@@ -1695,7 +1695,7 @@ async fn test_poll_percentage_tracks_ingested_bytes() {
         .unwrap()
         .to_string();
     assert!(
-        progress.contains("Processing 35% of bytes"),
+        progress.contains("Processing 35%"),
         "the percentage must follow ingested bytes, got: {progress}"
     );
 }
@@ -1739,7 +1739,7 @@ async fn test_poll_progress_header_is_ascii_readable_with_a_resource_count() {
         .to_str()
         .unwrap_or_else(|e| panic!("X-Progress must be ASCII a client can read: {e}"));
     assert_eq!(
-        progress, "Processing 35% of bytes - 1,234 resources written",
+        progress, "Processing 35% - 1,234 Resources written",
         "the poll must report both the byte percentage and the resource count"
     );
 }
@@ -1929,7 +1929,7 @@ async fn test_poll_falls_back_when_the_phase_has_no_file_total() {
 
     let progress = poll_progress(&server, &poll_path).await;
     assert_eq!(
-        progress, "Processing 0% of bytes",
+        progress, "Processing 0%",
         "an unknown file total must not render as 'of 0', got: {progress}"
     );
 }
@@ -1962,7 +1962,7 @@ async fn test_moving_bytes_outrank_a_stale_phase() {
 
     let progress = poll_progress(&server, &poll_path).await;
     assert!(
-        progress.contains("Processing 35% of bytes"),
+        progress.contains("Processing 35%"),
         "a real percentage must take over from the pre-ingest phase, got: {progress}"
     );
 }
@@ -2014,7 +2014,7 @@ async fn test_progress_header_stays_ascii_in_every_branch() {
         "X-Progress must be US-ASCII; a conservative client discards it otherwise. Got: {text}"
     );
     assert!(
-        text.contains("609,191 resources written"),
+        text.contains("609,191 Resources written"),
         "the count branch must still be the one under test, got: {text}"
     );
 }

--- a/crates/ui/e2e/pages/bulk-import.ts
+++ b/crates/ui/e2e/pages/bulk-import.ts
@@ -123,7 +123,7 @@ export class BulkImportPage {
   }
 
   /** The recipient's own progress sentence, e.g.
-   * "Processing 42% of bytes - 1,300 resources written". */
+   * "Processing 42% - 1,300 Resources written". */
   get progressText(): Locator {
     return this.statusCard.locator(".detail__field--wide > div").last();
   }
@@ -143,7 +143,7 @@ export class BulkImportPage {
   async resourcesWritten(): Promise<number | null> {
     if ((await this.progressText.count()) === 0) return null;
     const text = await this.progressText.innerText();
-    const match = /([\d,]+)\s+resources written/.exec(text);
+    const match = /([\d,]+)\s+Resources written/.exec(text);
     return match ? Number(match[1].replace(/,/g, "")) : null;
   }
 }

--- a/crates/ui/e2e/tests/bulk-import-progress.spec.ts
+++ b/crates/ui/e2e/tests/bulk-import-progress.spec.ts
@@ -24,7 +24,7 @@ const FILE_DELAY_MS = 2_500;
 
 const PRE_INGEST =
   /^(waiting for a worker|reading manifest|sizing \d+ of \d+ files|downloading file \d+ of \d+)$/;
-const INGEST = /^Processing (\d+)% of bytes/;
+const INGEST = /^Processing (\d+)%/;
 
 /** Two Patients per file, so the ingest phase reports several percentages. */
 function ndjson(index: number): string {
@@ -257,7 +257,7 @@ test("X-Progress names the phase instead of reporting 0% for the whole pre-inges
   expect(progress.some((p) => INGEST.test(p)), `ingest never reported:\n${seen}`).toBe(true);
   // The old handler's answer for the entire pre-ingest window: a bare 0% byte
   // reading, with no phase and no resource count to qualify it.
-  expect(progress, `a bare "0% of bytes" is the pre-#953 reading`).not.toContain(
-    "Processing 0% of bytes",
+  expect(progress, `a bare "0%" is the pre-#953 reading`).not.toContain(
+    "Processing 0%",
   );
 });

--- a/crates/ui/e2e/tests/bulk-submit-ingest.spec.ts
+++ b/crates/ui/e2e/tests/bulk-submit-ingest.spec.ts
@@ -56,7 +56,7 @@ function progressReports(lines: string[]): { pct: number; written: number }[] {
   return lines
     .slice()
     .reverse() // the log renders newest first
-    .map((line) => /Processing (\d+)% of bytes - ([\d,]+) resources written/.exec(line))
+    .map((line) => /Processing (\d+)% - ([\d,]+) Resources written/.exec(line))
     .filter((match): match is RegExpExecArray => match !== null)
     .map((match) => ({ pct: Number(match[1]), written: Number(match[2].replace(/,/g, "")) }));
 }
@@ -139,7 +139,7 @@ test("a manifest submitted from the Import page ingests, and its counters only e
       // lost on the way in.
       await expect(bulkImport.progressBar).toHaveAttribute("aria-valuenow", /^\d+$/);
       await expect(bulkImport.progressText).toHaveText(
-        /Processing \d+% of bytes - [\d,]+ resources written/,
+        /Processing \d+% - [\d,]+ Resources written/,
       );
 
       // HFS fetched both fixture files itself, server-to-server — and sized the

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -1291,7 +1291,7 @@ pub async fn status_fragment(
 /// 412 files`) would be mis-parsed as a percentage. The recipient owns the
 /// vocabulary; this parser only claims the one prefix.
 fn progress_percent(progress: &str) -> Option<u8> {
-    // Case-insensitive: HFS capitalizes the line ("Processing 3% of bytes -
+    // Case-insensitive: HFS capitalizes the line ("Processing 3% -
     // …", #954), older HFS versions and foreign recipients may send lowercase
     // "processing 3% complete …". Either way the digits follow the prefix.
     let rest = progress
@@ -1357,14 +1357,14 @@ mod tests {
         // Current HFS wording (#954, ASCII-only since the sentence travels in
         // a header).
         assert_eq!(
-            progress_percent("Processing 3% of bytes - 609,191 resources written"),
+            progress_percent("Processing 3% - 609,191 Resources written"),
             Some(3)
         );
-        assert_eq!(progress_percent("Processing 0% of bytes"), Some(0));
+        assert_eq!(progress_percent("Processing 0%"), Some(0));
         // A recipient that does use non-ASCII still gets its percentage read:
         // the header is decoded from bytes, so the sentence arrives intact.
         assert_eq!(
-            progress_percent("Processing 3% of bytes — 609,191 resources written"),
+            progress_percent("Processing 3% — 609,191 Resources written"),
             Some(3)
         );
         // Pre-#954 HFS and lowercase foreign recipients.

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -1912,14 +1912,14 @@ async fn pre_ingest_phases_show_their_text_on_an_indeterminate_bar() {
 #[tokio::test]
 async fn a_non_ascii_progress_report_still_reaches_the_operator() {
     let recipient =
-        mock_recipient_reporting(&["Processing 35% of bytes — 1,024 resources written"]).await;
+        mock_recipient_reporting(&["Processing 35% — 1,024 Resources written"]).await;
     let ctx = ctx(&recipient);
     let detail_path = create_submission(&ctx).await;
 
     let (status, html) = get(&ctx, &format!("{detail_path}/status")).await;
     assert_eq!(status, StatusCode::OK);
     assert!(
-        html.contains("1,024 resources written"),
+        html.contains("1,024 Resources written"),
         "the report must survive its non-ASCII byte: {html}"
     );
     assert!(

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -1911,8 +1911,7 @@ async fn pre_ingest_phases_show_their_text_on_an_indeterminate_bar() {
 /// reintroduced by an encoding detail. Decoding lossily keeps the report.
 #[tokio::test]
 async fn a_non_ascii_progress_report_still_reaches_the_operator() {
-    let recipient =
-        mock_recipient_reporting(&["Processing 35% — 1,024 Resources written"]).await;
+    let recipient = mock_recipient_reporting(&["Processing 35% — 1,024 Resources written"]).await;
     let ctx = ctx(&recipient);
     let detail_path = create_submission(&ctx).await;
 


### PR DESCRIPTION
## Summary
- The bulk-submit `X-Progress` header (shown on the UI Import page) read `Processing 2% of bytes - 476,491 resources written`. It now reads `Processing 2% - 476,491 Resources written`; the bare form is `Processing 2%`.
- Updated the REST tests, UI unit/HTTP tests, and Playwright regexes that matched the old wording.
- The UI percentage parser keys only off the `Processing N%` prefix, so no parser change was needed.

## Test plan
- [x] `cargo test -p helios-rest --test bulk_submit` (33 passed)
- [x] `cargo test -p helios-ui bulk_import` and `--test bulk_import_http` (all passed)
- [ ] Playwright specs updated but not run locally (need a live server + browser); CI covers them