### PR TITLE
fix(persistence): bound reindex job retention after bulk submit

### DIFF
--- a/crates/hfs/tests/bulk_submit/MEMORY_MEASUREMENT.md
+++ b/crates/hfs/tests/bulk_submit/MEMORY_MEASUREMENT.md
@@ -1,0 +1,115 @@
+# Bulk-submit memory investigation (#995)
+
+This experiment establishes a new baseline for the current source. The earlier
+raw/buffered measurements are historical context, not comparison arms. Production
+processing code is unchanged. Initial measurements are external RSS observations,
+not live-heap measurements or evidence of a leak.
+
+## Build and resource budget
+
+The initial host is macOS ARM64, 16 GiB RAM, eight logical CPUs. Docker shares
+the host with existing services. Build HFS natively and run only the dedicated
+benchmark PostgreSQL in Docker. Do not stop or reconfigure existing services.
+
+```sh
+CARGO_BUILD_JOBS=1 cargo build --locked --release \
+  -p helios-hfs --bin hfs --no-default-features --features R4,postgres
+```
+
+Retain the target directory and record the source revision, binary SHA-256,
+compiler, features, database image identity and effective runtime configuration.
+Never build while measuring. A single build job reduces parallel compiler memory;
+it does not cap one compiler process. Monitor host memory and swap during the build.
+
+Use one dedicated PostgreSQL container, initially limited to one CPU and 768 MiB,
+with swap disabled for that container. Use a disposable database per series and
+retain the evidence before removing benchmark-owned infrastructure. HFS starts
+with one submit worker, one file task and a small explicitly configured database
+pool. These are resource-constrained settings, not an assertion of default-server
+throughput. The current worker uses an effective batch of 100 regardless of the
+configured bulk-submit batch-size setting.
+
+## Stages
+
+1. Pilot: 1,000 deterministic Patient resources in four plaintext NDJSON files.
+2. First series: 12,000 resources, five consecutive submissions in one HFS process,
+   compared with five submissions with HFS restarted each time.
+3. Increase to 48,000 and 192,000 only if the smaller series leaves resource
+   headroom and further volume addresses an unresolved question.
+
+Reimports use identical resource IDs. The first job creates resources; subsequent
+jobs update them and grow history and submission bookkeeping. Match job ordinal
+and database state between process-lifetime arms. Do not call later reimports
+fresh jobs. A fresh-ID series is a separate experiment with growing current data.
+
+The first measurements use deferred indexing, the current runtime default. Record
+submit-terminal and actual reindex-terminal separately. Existing searchable data
+means a matching search count alone cannot prove a reimport's reindex finished.
+Then repeat with deferred indexing disabled if resources permit.
+
+These are quiescent consecutive jobs: each next submission waits for background
+indexing, idle observation and validation to finish. They do not measure the
+overlap possible when a client submits the next job immediately after a terminal
+submit response while the preceding reindex is still active.
+
+## Observation and validation
+
+- Sample HFS RSS separately from PostgreSQL/container memory. Docker VM residency
+  and host memory compression are not PostgreSQL process RSS.
+- The PostgreSQL stats collector runs separately from the RSS/watchdog thread.
+  Retain actual sample timestamps and report gaps instead of assuming the target
+  0.5-second cadence was achieved perfectly.
+- Retain wall-clock and monotonic timestamps, PIDs, external phase markers, host
+  swap/VM counters and all failed or interrupted attempts.
+- Observe startup, pre-kickoff, submit-terminal, reindex-terminal, and a fixed
+  60-second idle interval. External markers do not distinguish internal receipt
+  readback, serialization and writes; a later instrumentation pass is needed
+  for that attribution.
+- Validate resource content, versions/history, counts and receipt references.
+  Perform downloads and full validation after the idle window, labelling that
+  phase so it cannot be mistaken for ingestion or post-job retention. Such
+  validation still affects the next job's process/cache state; apply it equally
+  to both arms and record the next pre-kickoff baseline.
+- Keep the standard R4 search-parameter data available. Record the startup registry
+  count so a fallback registry cannot silently turn this into a smaller workload.
+- Treat sustained new swap activity or rising host memory pressure as a reason
+  to stop escalation. A pre-existing swap allocation alone is not a stop signal.
+  Container OOM, timeout and host-pressure interruptions remain reported attempts.
+
+## Interpretation
+
+RSS growth identifies a question, not its owner. Follow persistent growth with
+live-allocation evidence on the smallest reproducible series. Distinguish
+temporary receipts, application caches, reindex job metadata, driver buffers and
+allocator/OS residency. Do not infer allocator implementation from the absence of
+a Rust global-allocator override. No historical RSS median is a pre-job baseline.
+
+The initial campaign does not change receipt streaming, output buffering,
+indexing, batch-size propagation or job cleanup. Each confirmed defect needs its
+own scoped follow-up; receipt streaming remains coordinated with #982.
+
+## Running the controller
+
+Provision a dedicated PostgreSQL container/database before invoking the controller;
+it never creates, deletes or reconfigures the supplied database/container. The
+database must be fresh at series start. Reuse its state within the series even
+when `--mode restart` restarts HFS between jobs.
+
+```sh
+python3 crates/hfs/tests/bulk_submit/measure_memory.py \
+  --binary target/release/hfs --output-dir target/issue-995/new-series \
+  --resources 12000 --jobs 5 --mode consecutive --defer-indexing true \
+  --idle-seconds 60 --file-concurrency 1 \
+  --pg-container BENCHMARK_CONTAINER \
+  --database-url postgres://postgres@127.0.0.1:BENCHMARK_PORT/BENCHMARK_DATABASE
+
+python3 crates/hfs/tests/bulk_submit/summarize_memory.py \
+  target/issue-995/new-series
+```
+
+`--dry-run` prints configuration without launching anything. Each output directory
+must be new. `run.json`, phase/host/RSS/container CSV files, logs and validation
+results remain on failure. A root-managed local trust-auth database was used for
+the initial run; it contains only generated fixtures. HFS's URL-bearing startup
+info log is filtered with `RUST_LOG=info,hfs=warn`; persistence registry/reindex
+markers remain enabled. Other inherited `HFS_*` settings are removed.

--- a/crates/hfs/tests/bulk_submit/MEMORY_RESULTS.md
+++ b/crates/hfs/tests/bulk_submit/MEMORY_RESULTS.md
@@ -1,0 +1,142 @@
+# Issue #995: current-code measurements, 2026-09-10
+
+The four reference series completed 20/20 jobs in successful attempts. Production
+processing code is unchanged. A separate three-job allocation snapshot pass also completed all validations.
+
+## Baseline and build
+
+Source `1386c0ef4c2e8969a1d90b6256772bdc6db1a408`; native macOS ARM64,
+16 GiB RAM, eight logical CPUs. Release R4 + PostgreSQL, no default features,
+one Cargo build job. Rust 1.98.0. Binary SHA-256
+`ed8247ed85faf069c51aadb16502d49eeb92bba1cf4071566394aa90243153d8`.
+Build took 34m18s; maximum RSS reported by `/usr/bin/time -l` was
+3,936,436,224 bytes (3.67 GiB). No new host swapouts during the build.
+No builds overlapped ingestion measurements.
+
+Dedicated PostgreSQL 16.14 container: one CPU, 768 MiB RAM, no container swap,
+128 MiB shared buffers. Existing unrelated containers were left running.
+Exact image identity is retained in `target/issue-995/postgres-identity.json`.
+All corpora are synthetic. Each series starts with a fresh database; later jobs
+reimport identical IDs/content and grow versions/history. Restart arms preserve
+that database between HFS processes. One worker, one file task, four input files,
+PG pool four, effective ingestion batch 100. See [protocol](MEMORY_MEASUREMENT.md).
+
+## Validated initial observations
+
+Both indexing modes completed five-job continuous/restart pairs (20 jobs). Each submission contains
+12,000 Patients; receipt references, full current content, exact versions/history,
+index coverage and parameterized search passed; deferred runs also required a
+completed background reindex with exact totals and zero errors.
+Post-job observations wait for indexing and 60 seconds of idle; full downloads
+and validation follow that window.
+
+| Configuration | Post-idle RSS, jobs 1–5 (MiB) | Maximum sampled RSS (MiB) |
+| --- | --- | ---: |
+| Deferred, same HFS process | 60.1, 28.9, 31.3, 31.4, 31.4 | 60.2 |
+| Deferred, restart HFS per job | 58.2, 58.1, 58.0, 57.9, 57.9 | 59.8 |
+| Inline, same HFS process | 59.3, 59.6, 59.6, 58.1, 59.7 | 59.7 |
+| Inline, restart HFS per job | 58.3, 57.6, 57.6, 57.9, 57.8 | 58.3 |
+
+These runs do not show monotonically increasing resident memory. They do not
+prove the absence of retained allocations or establish a live-heap bound.
+In the continuous run, RSS fell by approximately 34 MiB during job 2 ingestion,
+with unchanged virtual size and increased host compression. The event occurred
+before submit completion, so it cannot be attributed to job-terminal cleanup.
+Host compression is system-wide evidence, not a measurement of compressed HFS
+pages. Clean-page reclamation, anonymous-page compression and allocation release
+remain possible explanations. Earlier Linux raw/buffered results are not direct
+comparison arms for this native macOS baseline.
+
+All four successful reference series kept host pressure at level 1 and had zero
+new host swapouts; maximum within-job sampling gap rounded to 0.6 seconds.
+
+## Attempts and evidence
+
+Raw evidence is local under `target/issue-995/` (ignored build directory):
+
+- `build.log`, `build-memory.jsonl`, `build.json`: successful constrained build.
+- `pilot-1000-a`: controller initialization failure before HFS startup.
+- `pilot-1000-b`: ingestion completed, reindex UUID parser failed; interrupted,
+  not a verified measurement.
+- `pilot-1000-c`: successful 1,000-resource pilot, all validation passed.
+- `12k-consecutive-deferred`, `12k-restart-deferred`: completed reference pair.
+- `reference-comparison.md`: all four series, per-job measurements and sampling quality.
+- `12k-consecutive-inline-v2`, `12k-restart-inline-v3`: completed inline pair.
+- `12k-restart-inline-v2`: aborted after the first submit. SQL showed 12,000
+  Patients and zero Patients without index rows, but the HTTP search check returned
+  no valid total after about 30 seconds. The original controller discarded HTTP
+  error details, so timeout source/cause is unconfirmed. A fresh repeat with the
+  same HFS settings and added HTTP evidence logging passed all five jobs. This
+  failed attempt remains excluded; it is not evidence of a wrong resource count.
+- `12k-consecutive-inline`: submit completed but controller coverage query hit
+  its 120-second timeout; series failed before full validation, excluded from
+  valid comparisons. A query was still active after the client timeout.
+- `measure_memory-reference-v1.py`: controller used for the deferred pair and
+  failed first inline attempt. Subsequent controller replaces correlated
+  `NOT EXISTS` coverage with equivalent filtered ID-set `EXCEPT`, and sets a
+  PostgreSQL statement timeout below the client timeout. This changes observation
+  overhead, not the HFS binary. Treat cross-indexing timing comparisons cautiously.
+- `task-inspection-preflight`: footprint/vmmap/heap succeeded on an owned temporary
+  sleep process; this is tool-access evidence, not HFS allocation evidence.
+
+## Supplemental allocation snapshots
+
+Same binary and deferred configuration, fresh database, three 12,000-resource
+jobs. Sequential footprint/vmmap/heap snapshots were taken before kickoff and
+after the idle marker, before validation. All 18 tool calls succeeded, each under
+1.25 seconds. Tools can fault pages into residency; these timings and RSS values
+are not pooled with the reference runs. Driver identity and source are retained
+in `target/issue-995/diagnostic-driver-identity.json` and `diagnostic_driver.py`.
+
+| Post-idle snapshot | malloc blocks | malloc bytes | Physical footprint reported by heap |
+| --- | ---: | ---: | ---: |
+| Job 1 | 56,034 | 5,091,328 | 19.2M |
+| Job 2 | 56,276 | 5,082,576 | 19.4M |
+| Job 3 | 56,360 | 5,106,752 | 19.4M |
+
+The initial pre-kickoff snapshot had 55,366 blocks / 5,153,680 malloc bytes.
+Post-idle bytes vary by approximately 24 KiB across the three jobs; block count
+increases modestly. This does not demonstrate linear retained-byte growth, and
+cannot assign those blocks to reindex metadata, caches or other owners. `heap`
+reports malloc-visible allocations, not every form of process memory. No allocation
+backtraces were enabled. The original ~34 MiB RSS fall did not recur, so these
+snapshots cannot resolve its cause retrospectively.
+
+Raw snapshots, timestamps, exit codes and parsed totals live under
+`target/issue-995/12k-diagnostic-deferred/diagnostic/`; the complete run passed
+with normal pressure and no new swapouts. The benchmark HFS processes and provider
+were shut down by the controller. The dedicated PostgreSQL container was stopped
+and auto-removed after evidence collection; its disposable databases are gone.
+Logs, generated fixtures, receipts and validation evidence remain on disk.
+
+Controller revisions are preserved as `measure_memory-reference-v1/v2/v3.py`.
+After the campaign, the reusable controller also gained server-side timeout
+protection for its streamed SQL validation and linear-time duplicate detection
+for receipts. Those final maintenance edits were syntax/help/dry-run checked;
+they were not used for the recorded campaign and did not change production code.
+
+## Scope still unresolved
+
+Whole-manifest receipt accumulation can create transient memory proportional to
+receipt count; streaming remains coordinated with #982. Static inspection also
+found retained reindex job/cancellation metadata with no cleanup caller. Neither
+owner is quantified by these RSS observations. Small repeated Patient imports,
+quiescent scheduling and five jobs cannot establish behavior for large/mixed
+resources, overlapping reindexes or long-running production workloads.
+
+
+## Decision and next experiment
+
+Keep #995 open. This is a current-code baseline under constrained, quiescent
+settings, not a finding that production retention is solved. Do not compare its
+absolute RSS with historical Linux measurements. No larger run was launched:
+48k/192k escalation was conditional, and more RSS-only volume would not settle
+ownership of retained allocations or the OS residency event.
+
+Next, use a separate instrumented experiment to measure receipt accumulation,
+serialization/output and release boundaries, coordinated with #982. For true
+cross-job retention, attribute allocations to owners and measure reindex job/map
+cardinality over more small consecutive jobs, with a restart control. Keep job
+counts and pending reindexes explicit. Investigate the intermittent post-submit
+search-check failure separately with retained HTTP error details and query plans;
+the first failure lacks those details and cannot support a root-cause claim.

--- a/crates/hfs/tests/bulk_submit/RETENTION_FIX_RESULTS.md
+++ b/crates/hfs/tests/bulk_submit/RETENTION_FIX_RESULTS.md
@@ -1,0 +1,136 @@
+# #995 reindex lifecycle correction
+
+The fix passed thirteen regression tests and a fresh pilot plus twenty consecutive
+bulk-submit jobs. Every post-idle inventory has zero cancellation channels.
+Baseline findings: RETENTION_RESULTS.md.
+
+## Intended behavior
+
+- Release the cancellation sender when the background task exits, including
+  normal completion, backend failure, panic/unwind and dropped kickoff futures.
+- Protect a cancellation that is already reported terminal while the worker is
+  still executing. Do not overwrite an existing terminal status in a racing
+  completion/failure/cancellation path.
+- Keep at most the most recent 1024 terminal states whose tasks have exited,
+  for up to 24 hours. Sweep expired states every minute, including during idle.
+  Tasks still executing are exempt. Evicted status endpoints return 404.
+- Start one cleanup task lazily at the first job; construction remains valid
+  without a Tokio runtime. The cleanup task holds weak map references while
+  sleeping and does not retain the manager after it is dropped.
+- Reclaim oversized map capacity after a burst subsides.
+
+The policy bounds terminal record count and age, not total process memory. Active
+jobs and each job's error details are not given new bounds in this change.
+
+## Regression cases
+
+Tests exercise the real ReindexOperation::start driver with a controlled source,
+including completion, failure, cancellation blocked in the source, a panicked
+task, an aborted kickoff blocked in audit, idle expiry using paused Tokio time,
+1025 successive completions and dropping the manager. Polling of recent terminal
+states and terminal cancellation idempotence remain checked.
+
+Evidence root: `target/issue-995-fix/`. Regression tests are run first against
+unchanged lifecycle code, then against the correction. Builds and workloads are
+serial, with one Cargo job and host-memory monitoring. No unrelated containers
+are stopped or reconfigured.
+
+
+## Regression validation
+
+The first test build with only R4/Postgres failed before running tests because
+existing bulk-submit lib tests import SQLite without feature gating. No unrelated
+source was changed; the test feature set was adjusted to R4,postgres,sqlite.
+This caused additional dependency compilation. All builds used one Cargo job.
+
+Against unchanged lifecycle code, the eight new tests executed: seven failed for
+the intended retention/lifecycle reasons and one (manager release) passed.
+After applying the fix, all thirteen tests under search::reindex passed,
+including the original progress/status/request/audit cases. The green incremental
+build plus tests took about 160 seconds; test execution itself took 0.10 seconds.
+
+```sh
+CARGO_BUILD_JOBS=1 cargo test --locked --release -p helios-persistence --lib \
+  --no-default-features --features R4,postgres,sqlite \
+  search::reindex:: -- --test-threads=1
+```
+
+Logs: `tests-red.log` (configuration failure), `tests-red-sqlite.log` (seven
+expected regressions), `tests-green.log` (13 passed). The tests use controlled
+sources and SQLite is enabled for compatibility with the existing lib test
+modules; no external database container is needed for these selected tests.
+
+## Repeated-job validation setup
+
+The fixed production binary and the temporary inventory binary were built
+serially with `CARGO_BUILD_JOBS=1`, release profile, R4/Postgres features.
+Their builds succeeded in about 161 and 156 seconds respectively. The temporary
+probe is the same probe used for the previous retention campaign. After the
+instrumented build, the clean fixed source and default release binary were
+restored before starting the workloads. SHA-256 hashes are in
+`target/issue-995-fix/provenance.json`; the reviewable production diff is in
+`target/issue-995-fix/fix.patch`.
+
+A dedicated PostgreSQL 16.14 container uses the same pinned image as the prior
+campaign, with one CPU, 768 MiB memory, no additional container swap, 128 MiB
+shared buffers and 20 connections. Image, version and limits are recorded in
+`target/issue-995-fix/postgres.json`. Each arm uses a fresh database.
+
+The pilot and continuous arm submit 1,000 Patient resources per job in four
+files, repeating the same IDs/content, with deferred indexing, one submit
+worker, file concurrency one, a four-connection pool and 30 seconds idle.
+The pilot runs one job; the main arm runs twenty jobs in the same HFS process.
+Inventories are captured after verified reindex and idle. Heap, vmmap and
+footprint are captured at startup and after jobs 1, 5, 10, 15 and 20. No build
+runs alongside these workloads. The earlier restart arm remains the control;
+it is not rerun here.
+
+## Measured result
+
+All 21 jobs passed all 336 hard checks, including stored content, IDs, version
+distribution, search and receipts. All 24 diagnostic tool calls succeeded
+(six in the pilot, eighteen in the continuous arm). Host pressure stayed at
+level 1 and additional swapouts were zero in both arms.
+
+| Post-idle observation | Previous continuous run | Fixed continuous run |
+| --- | ---: | ---: |
+| Finished states after job 20 | 20 | 20 |
+| Cancellation channels after job 20 | 20 (all closed) | 0 |
+| Jobs / channels map capacity after job 20 | 28 / 28 | 28 / 3 |
+| Accounted occupied entries + owned buffers after job 20 | 8,080 bytes | 6,720 bytes |
+| Malloc bytes after job 1 | 5,072,304 | 5,122,512 |
+| Malloc bytes after job 20 | 5,109,344 | 5,106,384 |
+| Malloc change, job 1 → 20 | +37,040 bytes | −16,128 bytes |
+| Malloc blocks change, job 1 → 20 | +584 | +530 |
+
+The fixed inventories show N finished states and zero channels at every ordinal
+N from 1 through 20. Status retrieval succeeds after idle. The pilot likewise
+retains one finished state and no channels. The 1024-state quota and idle expiry
+are exercised by regression tests, not by this twenty-job workload.
+
+The direct byte accounting excludes map buckets, channel internals and allocator
+overhead. Its reduction is 1,360 bytes at twenty jobs. Whole-process malloc
+measurements fluctuate: the fixed run falls to 5,079,648 bytes at job 5, then
+reaches 5,106,384 bytes at job 20. The final value is close to the earlier run;
+these observations do not establish a substantial reduction in total heap or
+solve peak memory during ingestion. The demonstrated result is removal of the
+per-job cancellation-channel retention and a tested bound on terminal metadata
+count/age. Active jobs and per-job error payloads remain outside that bound.
+
+Full inventories and heap checkpoints: `target/issue-995-fix/inventory-summary.md`.
+Raw jobs, checks, receipts, resource fixtures, process/host samples and tool output
+remain under `pilot/` and `consecutive-20/` in the same evidence directory.
+
+## Final workspace and cleanup
+
+The production fix remains in the workspace. Temporary inventory instrumentation
+is absent from production source, and `target/release/hfs` matches the clean
+fixed binary. The instrumented binary is preserved under its explicit diagnostic
+name. Both measurement HFS processes exited; the dedicated PostgreSQL container
+was stopped and removed. The 21 unrelated running containers were left untouched.
+Verification is recorded in `target/issue-995-fix/final-verification.json`.
+
+Python syntax checks passed for all four measurement/summary scripts, and
+`git diff --check` passed. No commit, push or issue comment was made. This closes
+the confirmed reindex metadata retention finding; #995's ingestion-peak
+investigation remains separate.

--- a/crates/hfs/tests/bulk_submit/RETENTION_FIX_RESULTS.md
+++ b/crates/hfs/tests/bulk_submit/RETENTION_FIX_RESULTS.md
@@ -134,3 +134,13 @@ Python syntax checks passed for all four measurement/summary scripts, and
 `git diff --check` passed. No commit, push or issue comment was made. This closes
 the confirmed reindex metadata retention finding; #995's ingestion-peak
 investigation remains separate.
+
+## PR branch validation after synchronization
+
+The PR branch was rebased onto origin/main at
+`5d738d3fb84d629870d35d5ac01dabe9fd9682c1`. All thirteen selected reindex
+tests passed again (0 failed; 0.09 seconds execution) with the same command
+and one Cargo build job. Build plus tests took about 176 seconds, with normal
+host pressure and no new swapouts. Evidence: `target/issue-995-fix/tests-rebased.*`.
+The workload measurements above predate this rebase and are not measurements
+of the updated base.

--- a/crates/hfs/tests/bulk_submit/RETENTION_MEASUREMENT.md
+++ b/crates/hfs/tests/bulk_submit/RETENTION_MEASUREMENT.md
@@ -1,0 +1,73 @@
+# #995: repeated-job retention follow-up
+
+Diagnostic experiment, not a production fix. Baseline source is
+`1386c0ef4c2e8969a1d90b6256772bdc6db1a408`. The earlier RSS campaign is documented
+in MEMORY_RESULTS.md. Its binary is retained separately.
+
+## Predictions
+
+1. Without cleanup, each successful deferred manifest adds one finished reindex
+   job and one closed cancellation sender to the process-owned manager maps.
+   Twenty jobs should leave twenty entries; restarting HFS should leave one.
+2. If additional owners grow, malloc-visible retained bytes may increase beyond
+   the directly accounted manager fields. Map inventory does not measure channel
+   internals, allocator overhead or HashMap bucket allocations.
+3. OS residence can change while malloc-visible bytes stay stable. Compare RSS,
+   physical footprint and heap separately, without claiming RSS is live memory.
+
+## Instrumentation
+
+A temporary environment-gated probe in ReindexOperation::get_progress emits
+`[DEBUG-995-retention]` inventory lines. It reports map lengths/capacities, finished
+jobs, closed senders, occupied inline entry bytes and owned String/Vec buffer
+capacities. It does not run cleanup. The last two byte counts are accounting of
+specific fields, NOT allocator measurements or a complete manager size.
+
+The patch and source are retained in `target/issue-995-retention/`. Build once,
+release R4/Postgres, CARGO_BUILD_JOBS=1, with host monitoring. Preserve the binary
+hash and restore the uninstrumented source after collecting evidence. Each arm
+uses the same instrumented binary and settings. Polling also emits inventory;
+the authoritative sample is a separate status request AFTER idle, correlated by
+job ID and log offset, before heap inspection and validation.
+
+## Arms and budget
+
+One pilot followed by two serial arms: twenty submissions of the same 1,000
+synthetic Patient IDs, four input files, deferred indexing, one worker, one file
+task, PG pool four. First job creates, later jobs replace and grow exact
+versions/history. Fresh database per arm; restart only HFS between jobs in the
+restart arm, preserving database state and job ordinal.
+
+After verified reindex completion, idle 30 seconds each job. This differs from
+the previous campaign's 60 seconds and is not pooled with it. Snapshot startup
+once, then post-idle at jobs 1, 5, 10, 15 and 20. Each snapshot uses footprint,
+vmmap summary and heap summary sequentially, with a 15-second tool timeout.
+Any inspection failure aborts; artifacts remain. No allocation stack logging.
+
+Use the same 1 CPU / 768 MiB / no-swap PostgreSQL container budget, dedicated
+loopback port and existing cached image as before. Never touch unrelated
+containers. No builds overlap a measurement. RSS and host watchdogs remain the
+same as measure_memory.py. Abort on failed data/index/receipt validation. The
+experiment does not include immediate-next-job/reindex overlap or injected errors.
+
+## Command
+
+Provision the dedicated fresh database first. The driver requires the temporary
+probe binary; an ordinary binary cannot produce the inventory and will fail.
+
+```sh
+python3 crates/hfs/tests/bulk_submit/measure_retention.py \
+  --binary target/issue-995-retention/hfs-instrumented \
+  --output-dir target/issue-995-retention/NEW_ARM \
+  --resources 1000 --jobs 20 --mode consecutive --defer-indexing true \
+  --idle-seconds 30 --file-concurrency 1 \
+  --hfs-env HFS_995_RETENTION_PROBE=1 \
+  --pg-container BENCHMARK_CONTAINER \
+  --database-url postgres://postgres@127.0.0.1:56810/FRESH_DATABASE
+```
+
+`retention-inventory.jsonl` holds post-idle manager samples. `retention/` holds
+raw snapshots, tool exit codes/timings and the diagnostic driver hash. Standard
+controller artifacts retain full validation and environmental evidence. Snapshot
+inspection can page memory in, and validation affects the next job; both arms
+apply the same ordinal schedule. Post-idle RSS is sampled before these probes.

--- a/crates/hfs/tests/bulk_submit/RETENTION_RESULTS.md
+++ b/crates/hfs/tests/bulk_submit/RETENTION_RESULTS.md
@@ -1,0 +1,148 @@
+# #995 retention ownership follow-up — 2026-09-10
+
+Completed: forty validated jobs plus one validated pilot. The process retains one
+finished reindex job and one closed cancellation sender per successful deferred
+manifest; the restart control stays at one of each. This confirms an ownership
+and cleanup issue, but does not explain large transient memory peaks.
+Protocol: [RETENTION_MEASUREMENT.md](RETENTION_MEASUREMENT.md).
+
+## Build and provenance
+
+Baseline source `1386c0ef4c2e8969a1d90b6256772bdc6db1a408`. Temporary observation
+patch adds manager inventory to get_progress, gated by HFS_995_RETENTION_PROBE=1.
+It does not remove entries, close senders or otherwise change ingestion semantics.
+
+Incremental release R4/Postgres build, one Cargo job: Cargo 2m42s; wrapper 166s.
+`time -l` maximum RSS: 1,301,331,968 bytes; sampled compiler-tree maximum: 1,400.7 MiB.
+These are different accounting methods. Host pressure stayed normal and no new
+swapouts occurred. No build overlapped a workload.
+
+Instrumented binary SHA-256:
+`7833c66fc4887da2e313a08805e62e935b64af0625c719c228173cd03dbf57a7`.
+Patch SHA-256:
+`129d969edc17e61d1281bd9173d313c534e90ccdb9d56be00d558a36bdf72b16`.
+Original binary and temporary patch are retained in `target/issue-995-retention/`.
+
+Dedicated PostgreSQL 16.14 (same immutable image as the first campaign), one CPU,
+768 MiB, no container swap. Its own databases are disposable. Existing unrelated
+services remain running. Full identity and resource settings: `postgres.json`.
+
+## Scope
+
+One validated pilot (1,000 Patients), then twenty 1,000-resource jobs per arm:
+continuous HFS process versus restart per job, preserving DB/history by ordinal.
+Every job waits for verified reindex completion and thirty seconds of idle, then
+records manager inventory. Malloc/footprint/vmmap snapshots at startup and after
+jobs 1, 5, 10, 15 and 20. All validations remain mandatory. The 30-second idle
+interval differs from the preceding campaign's 60 seconds.
+
+## What the byte counters mean
+
+On this build each retained entry contributes 232 bytes of occupied Rust tuple
+storage across the two maps and 172 bytes of owned String/Vec capacities in a
+successful, error-free job: 404 accounted bytes per job. This excludes actual
+HashMap bucket allocation, channel internals, allocator rounding and headers.
+It is neither a complete manager size nor an estimate of RSS. Closed senders show
+that receivers were dropped even though the manager still owns the sender.
+
+
+## Continuous process: completed observations
+
+All twenty submissions passed exact data/version/history/receipt validation,
+search coverage and completed reindex totals with zero errors. Every post-idle
+inventory matched `jobs_len = finished_jobs = channels_len = closed_channels =
+job ordinal`. Capacities stepped 3 → 7 → 14 → 28 and did not shrink.
+
+| Post-idle job | Jobs / closed senders | Accounted entry + buffer bytes | Malloc blocks | Malloc bytes | Footprint reported by heap |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | 1 / 1 | 404 | 56,023 | 5,072,304 | 23.2M |
+| 5 | 5 / 5 | 2,020 | 56,433 | 5,078,800 | 17.7M |
+| 10 | 10 / 10 | 4,040 | 56,509 | 5,095,488 | 17.7M |
+| 15 | 15 / 15 | 6,060 | 56,562 | 5,096,432 | 17.7M |
+| 20 | 20 / 20 | 8,080 | 56,607 | 5,109,344 | 17.7M |
+
+Post-idle malloc delta job 1 → 20: +37,040 bytes (+584 blocks). These aggregate
+snapshots do not identify the owners of the full delta. The map counts establish
+retention of specific objects; their partial byte accounting must not be subtracted
+from total malloc growth to claim an exact remainder for other owners.
+
+Raw evidence: `target/issue-995-retention/consecutive-20/`; per-job inventory/heap
+summary `consecutive-summary.md`; RSS summary `consecutive-rss.md`.
+
+
+## Restart control: completed observations
+
+All twenty jobs passed the same 320 hard checks as the continuous arm. Each
+post-idle inventory has one finished job, one closed sender, map capacities 3/3
+and 404 accounted bytes. Databases preserve versions/history between restarts.
+
+| Post-idle job | Malloc blocks | Malloc bytes | Footprint reported by heap |
+| --- | ---: | ---: | ---: |
+| 1 | 56,022 | 5,031,504 | 22.2M |
+| 5 | 54,968 | 4,765,696 | 20.7M |
+| 10 | 54,963 | 4,759,328 | 20.1M |
+| 15 | 54,963 | 4,763,488 | 16.3M |
+| 20 | 54,962 | 4,761,984 | 20.3M |
+
+Later restarted processes are lower than the first, which initialized the fresh
+database. Restart resets all process state, so neither the approximately 0.3 MB
+between-arm heap difference nor the first-to-last restart decrease can be assigned
+solely to reindex metadata. Across restart checkpoints 5–20, malloc bytes vary by
+6,368 bytes. Continuous checkpoints 5–20 increase by 30,544 bytes. These are
+aggregate observations with no allocation backtraces, not a measured leak rate.
+
+RSS after idle: continuous job 1 → 20 was 56.4 → 56.7 MiB; restart was
+55.4 → 54.6 MiB. A sharp RSS fall also occurred during restarted job 6, which
+had only one job's process state. This further demonstrates why RSS changes
+cannot by themselves identify retained manager objects. It does not identify
+the OS mechanism of that fall. Footprint values above retain the tool's units.
+
+## Conclusions and limits
+
+1. The retained owners are confirmed: ReindexOperation.jobs keeps terminal
+   ReindexProgress values, and cancel_channels keeps Senders after their receivers
+   close. In the current source, start inserts entries; terminal paths update
+   status but do not remove entries. cleanup_old_jobs is the sole removal path
+   and has no callers in the repository. There is no effective automatic bound
+   on this metadata accumulation in the examined path.
+2. The measured successful-job cost is small in this experiment. Twenty retained
+   records account for 8,080 bytes in the specifically measured fields; total
+   malloc-visible bytes grew by 37,040 bytes from the first post-idle snapshot.
+   These numbers are distinct observations. Do not extrapolate the aggregate
+   malloc delta as a per-job rate or claim it fully measures the manager.
+3. Error-free 1,000-resource imports do not exercise large retained error vectors,
+   overlapping reindexes, other resource shapes, or a long process lifetime.
+   No cleanup intervention or allocation-stack experiment was run, so attribution
+   of the entire heap delta remains unresolved. The original bulk-submit peaks
+   remain a separate question; #995 should remain open.
+
+A scoped lifecycle fix should consider releasing cancellation senders once the
+background task has actually returned, and bounding terminal status retention
+with an explicit policy. Removing status immediately would break polling; active
+jobs must survive any cleanup. That fix needs completion/failure/cancellation and
+status-retention tests plus a repeat of this inventory experiment. No such fix
+was applied in this campaign.
+
+The next peak-focused experiment should instrument receipt accumulation,
+serialization, output and release boundaries, coordinated with #982. Increasing
+volume without those boundaries would again leave phase ownership unresolved.
+
+## Evidence, verification and cleanup
+
+Raw campaign root: `target/issue-995-retention/` (local ignored artifacts).
+`comparison.md` contains all forty inventory rows and twelve allocation snapshots;
+`rss-comparison.md` contains phase RSS, sample gaps and environment observations.
+`audit.json` checks run status, all 656 hard checks across both arms and pilot,
+all 41 post-idle inventories, and all 42 successful inspection tool calls. No
+attempt failed in this campaign. Host pressure remained normal and no new
+swapouts occurred. `build.json`, `build-memory.jsonl`, `instrumentation.patch`,
+`reindex-instrumented.rs`, original source/binary and both driver hashes retain
+provenance; `postgres.json` records the dedicated database image and limits.
+
+The controller stopped its HFS processes and fixture providers. Only the dedicated
+PostgreSQL container was stopped and auto-removed; its disposable databases were
+removed with it. Fixtures, receipts, SQL validation results and snapshots remain.
+The exact uninstrumented reindex.rs and original target/release/hfs were restored
+and verified; `restoration.json` records the baseline binary hash. No production
+source change remains, and no commit, push or issue comment was made. The diagnostic
+scripts and reports remain in the workspace for review/reuse.

--- a/crates/hfs/tests/bulk_submit/measure_memory.py
+++ b/crates/hfs/tests/bulk_submit/measure_memory.py
@@ -1,0 +1,2501 @@
+#!/usr/bin/env python3
+"""Bulk-submit memory benchmark controller for issue #995 (current HEAD).
+
+Drives the release ``hfs`` binary natively on macOS against a dedicated
+PostgreSQL container the caller owns, and records **external** observations
+only: HFS RSS from ``ps`` every 0.5 s, host memory pressure/swap/compressor
+vitals every 5 s, PostgreSQL state through ``docker exec <container> psql``,
+and HTTP phase markers with the raw responses behind them.  The server is
+never instrumented and no internal phase is claimed; see
+``MEMORY_MEASUREMENT.md`` next to this file for the protocol.
+
+A successful attempt requires the deferred reindex to be positively verified:
+the ``deferred-index rebuild started job_id=...`` log line, ``$reindex-status``
+reporting ``completed`` with ``errorCount == 0`` and ``processed == total``,
+and a SQL coverage probe of zero unindexed Patients.  Anything less marks the
+attempt unverified, keeps its raw timings labelled incomplete, and stops the
+run instead of continuing to the next job.
+
+Safety: starts one HFS process in its own process group plus an in-process
+loopback provider, and stops exactly those.  The PostgreSQL container is
+inspected and queried, never stopped or reconfigured.  Credentials are never
+logged or written to the output directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import functools
+import hashlib
+import http.server
+import json
+import os
+import re
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional
+
+SCHEMA_VERSION = 1
+TENANT = "default"
+FAMILY = "Pilot995"
+MRN_SYSTEM = "http://helios.example/mrn"
+SUBMITTER_SYSTEM = "http://helios.example/bench"
+SUBMITTER_VALUE = "mem995"
+FIXTURE_FILE_COUNT = 4
+
+EXIT_OK, EXIT_ABORTED, EXIT_CONFIG, EXIT_VALIDATION, EXIT_PREFLIGHT = 0, 2, 3, 4, 5
+
+# Resource-constrained by design: this is not a default-server measurement.
+HFS_ENV_BASE = {
+    # hfs logs its database URL at info; persistence info still supplies the
+    # registry and deferred-reindex markers used by this controller.
+    "RUST_LOG": "info,hfs=warn",
+    "HFS_STORAGE_BACKEND": "postgres",
+    "HFS_DEFAULT_TENANT": TENANT,
+    "HFS_DEFAULT_FHIR_VERSION": "R4",
+    "HFS_BULK_SUBMIT_ENABLED": "true",
+    "HFS_BULK_SUBMIT_WORKER_CONCURRENCY": "1",
+    "HFS_BULK_SUBMIT_MAX_CONCURRENT_PER_TENANT": "1",
+    # Poll rate limit defaults to 10 hits / 60 s, which would quantise the
+    # terminal marker to 6 s; it throttles nothing on the ingest path.
+    "HFS_BULK_SUBMIT_POLL_RATE_LIMIT": "1000000",
+    "HFS_PG_MAX_CONNECTIONS": "4",
+    "HFS_MAX_PAGE_SIZE": "1000",
+    "HFS_AUTH_ENABLED": "false",
+    "HFS_AUDIT_BACKEND": "none",
+}
+
+
+# --------------------------------------------------------------------------
+# utilities
+# --------------------------------------------------------------------------
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def mono() -> float:
+    return time.monotonic()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def redact_db_url(url: str) -> str:
+    try:
+        parts = urllib.parse.urlsplit(url)
+    except Exception:
+        return "<unparsable database url>"
+    if not parts.hostname:
+        return "<redacted database url>"
+    user = parts.username or ""
+    auth = f"{urllib.parse.quote(user)}:REDACTED@" if user else ""
+    port = f":{parts.port}" if parts.port else ""
+    return f"{parts.scheme}://{auth}{parts.hostname}{port}{parts.path}"
+
+
+def db_url_parts(url: str) -> dict[str, Optional[str]]:
+    parts = urllib.parse.urlsplit(url)
+    user = urllib.parse.unquote(parts.username) if parts.username else "postgres"
+    return {
+        "user": user,
+        "db": (parts.path or "").lstrip("/") or user,
+        "host": parts.hostname,
+        "port": parts.port,
+    }
+
+
+def run_capture(cmd: Iterable[str], timeout: float = 60.0) -> subprocess.CompletedProcess:
+    return subprocess.run(list(cmd), capture_output=True, text=True, timeout=timeout, check=False)
+
+
+def pgrep_count(name: str) -> int:
+    try:
+        proc = run_capture(["pgrep", "-x", name], timeout=10)
+    except Exception:
+        return 0
+    return len([line for line in proc.stdout.splitlines() if line.strip().isdigit()])
+
+
+def port_is_free(host: str, port: int) -> bool:
+    """connect() first: a bind-only probe misreports an active listener."""
+    probe = socket.socket()
+    probe.settimeout(0.35)
+    try:
+        probe.connect((host, port))
+    except OSError:
+        pass
+    else:
+        return False
+    finally:
+        probe.close()
+    holder = socket.socket()
+    try:
+        holder.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        holder.bind((host, port))
+    except OSError:
+        return False
+    finally:
+        holder.close()
+    return True
+
+
+def pick_free_port(preferred: int, host: str = "127.0.0.1", span: int = 400) -> int:
+    if preferred and port_is_free(host, preferred):
+        return preferred
+    start = preferred or 19000
+    for candidate in range(start, start + span):
+        if port_is_free(host, candidate):
+            return candidate
+    raise RuntimeError(f"no free loopback port in {start}..{start + span}")
+
+
+def ps_sample(pid: int) -> Optional[dict[str, float]]:
+    try:
+        proc = run_capture(["ps", "-o", "rss=,vsz=,pcpu=", "-p", str(pid)], timeout=15)
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    fields = proc.stdout.split()
+    if len(fields) < 3:
+        return None
+    try:
+        return {
+            "rss_kib": float(fields[0]),
+            "vsz_kib": float(fields[1]),
+            "cpu_percent": float(fields[2]),
+        }
+    except ValueError:
+        return None
+
+
+def parse_vm_stat(text: str) -> dict[str, Any]:
+    page_size = 16384
+    match = re.search(r"page size of (\d+) bytes", text)
+    if match:
+        page_size = int(match.group(1))
+    pages: dict[str, int] = {}
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, _, rest = line.partition(":")
+        value = rest.strip().rstrip(".")
+        if value.isdigit():
+            pages[key.strip().strip('"')] = int(value)
+
+    def mib(name: str) -> Optional[float]:
+        value = pages.get(name)
+        return None if value is None else value * page_size / 1024 / 1024
+
+    free_spec = pages.get("Pages free", 0) + pages.get("Pages speculative", 0)
+    swapouts = pages.get("Swapouts")
+    return {
+        "page_size": page_size,
+        "free_pages": pages.get("Pages free"),
+        "speculative_pages": pages.get("Pages speculative"),
+        "free_spec_mib": free_spec * page_size / 1024 / 1024,
+        "active_mib": mib("Pages active"),
+        "inactive_mib": mib("Pages inactive"),
+        "wired_mib": mib("Pages wired down"),
+        "compressor_mib": mib("Pages occupied by compressor"),
+        "compressed_pages": pages.get("Pages stored in compressor"),
+        "swapouts_pages": swapouts,
+        "swapout_bytes": None if swapouts is None else swapouts * page_size,
+        "swapins_pages": pages.get("Swapins"),
+    }
+
+
+def parse_swapusage(text: str) -> dict[str, Optional[float]]:
+    def mib(label: str) -> Optional[float]:
+        match = re.search(rf"{label}\s*=\s*([0-9.]+)([MG])", text)
+        if not match:
+            return None
+        value = float(match.group(1))
+        return value * 1024 if match.group(2) == "G" else value
+
+    return {
+        "swap_total_mib": mib("total"),
+        "swap_used_mib": mib("used"),
+        "swap_free_mib": mib("free"),
+    }
+
+
+def host_vitals() -> dict[str, Any]:
+    sample: dict[str, Any] = {"wall": iso_now(), "mono": mono()}
+    sample.update(zip(("load1", "load5", "load15"), os.getloadavg()))
+    try:
+        sample.update(parse_vm_stat(run_capture(["vm_stat"], timeout=20).stdout))
+    except Exception as exc:
+        sample["vm_stat_error"] = str(exc)
+    try:
+        sample.update(parse_swapusage(run_capture(["sysctl", "-n", "vm.swapusage"], timeout=20).stdout))
+    except Exception as exc:
+        sample["swapusage_error"] = str(exc)
+    try:
+        level = run_capture(["sysctl", "-n", "kern.memorystatus_vm_pressure_level"], timeout=10).stdout.strip()
+        sample["pressure_level"] = int(level) if level.isdigit() else None
+    except Exception:
+        sample["pressure_level"] = None
+    return sample
+
+
+def _round(value: Any, digits: int = 1) -> Optional[float]:
+    return None if value is None else round(float(value), digits)
+
+
+def _mib(value: Any) -> Optional[float]:
+    return None if value in (None, 0) else round(int(value) / 1024 / 1024, 1)
+
+
+def _median(values: list[float]) -> Optional[float]:
+    if not values:
+        return None
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return _round(ordered[middle])
+    return _round((ordered[middle - 1] + ordered[middle]) / 2)
+
+
+def _json_array_length(path: Path) -> Optional[int]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if isinstance(payload, list):
+        return len(payload)
+    if isinstance(payload, dict) and isinstance(payload.get("entry"), list):
+        return len(payload["entry"])
+    return None
+
+
+# --------------------------------------------------------------------------
+# writers
+# --------------------------------------------------------------------------
+
+
+class CsvWriter:
+    def __init__(self, path: Path, columns: list[str]):
+        self.columns = columns
+        self._lock = threading.Lock()
+        self._handle = open(path, "w", encoding="utf-8", newline="")
+        self._writer = csv.DictWriter(self._handle, fieldnames=columns, extrasaction="ignore")
+        self._writer.writeheader()
+        self._handle.flush()
+
+    def write(self, row: dict[str, Any]) -> None:
+        with self._lock:
+            self._writer.writerow({key: ("" if row.get(key) is None else row.get(key)) for key in self.columns})
+            self._handle.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            self._handle.close()
+
+
+class JsonlWriter:
+    def __init__(self, path: Path):
+        self._lock = threading.Lock()
+        self._handle = open(path, "w", encoding="utf-8", buffering=1)
+
+    def write(self, record: dict[str, Any]) -> None:
+        with self._lock:
+            self._handle.write(json.dumps(record, default=str) + "\n")
+
+    def close(self) -> None:
+        with self._lock:
+            self._handle.close()
+
+
+def write_json_atomic(path: Path, payload: Any) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+class RunLog:
+    def __init__(self, path: Path, echo: bool = True):
+        self._lock = threading.Lock()
+        self._handle = open(path, "a", encoding="utf-8", buffering=1)
+        self.echo = echo
+
+    def line(self, event: str, **fields: Any) -> None:
+        record = {"wall": iso_now(), "mono": round(mono(), 3), "event": event}
+        record.update(fields)
+        with self._lock:
+            self._handle.write(json.dumps(record, default=str) + "\n")
+            self._handle.flush()
+            if self.echo:
+                detail = " ".join(f"{key}={value}" for key, value in fields.items())
+                print(f"[{record['wall']}] {event}{' ' + detail if detail else ''}", flush=True)
+
+    def close(self) -> None:
+        with self._lock:
+            self._handle.close()
+
+
+class Aborted(Exception):
+    """The measurement cannot produce a verified result; stop the run."""
+
+    def __init__(self, reason: str, detail: Optional[dict[str, Any]] = None):
+        super().__init__(reason)
+        self.reason = reason
+        self.detail = detail or {}
+
+
+class ConfigError(Exception):
+    pass
+
+
+class PgError(Exception):
+    pass
+
+
+# --------------------------------------------------------------------------
+# HFS log follower
+# --------------------------------------------------------------------------
+
+
+class LogFollower:
+    """Incremental reader over the HFS log file written by our own process."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.offset = 0
+        self._pending = b""
+
+    def seek_end(self) -> int:
+        try:
+            self.offset = self.path.stat().st_size
+        except OSError:
+            self.offset = 0
+        return self.offset
+
+    def read_new(self) -> list[str]:
+        try:
+            with open(self.path, "rb") as handle:
+                handle.seek(self.offset)
+                chunk = handle.read()
+                self.offset = handle.tell()
+        except OSError:
+            return []
+        if not chunk:
+            return []
+        data = self._pending + chunk
+        lines = data.split(b"\n")
+        self._pending = lines.pop()
+        return [line.decode("utf-8", errors="replace") for line in lines]
+
+    def tail(self, max_bytes: int = 6000) -> str:
+        try:
+            size = self.path.stat().st_size
+            with open(self.path, "rb") as handle:
+                handle.seek(max(0, size - max_bytes))
+                return handle.read().decode("utf-8", errors="replace")
+        except OSError:
+            return ""
+
+
+# --------------------------------------------------------------------------
+# PostgreSQL through the dedicated container (read-only probes)
+# --------------------------------------------------------------------------
+
+
+class PgClient:
+    TABLES = (
+        "resources",
+        "resource_history",
+        "search_index",
+        "resource_fts",
+        "bulk_submissions",
+        "bulk_manifests",
+        "bulk_entry_results",
+        "bulk_submission_changes",
+        "bulk_submit_files",
+    )
+    UNIT = "\x1f"
+
+    def __init__(self, container: str, user: str, database: str):
+        self.container = container
+        self.user = user
+        self.database = database
+
+    def psql(self, sql: str, timeout: float = 120.0) -> dict[str, Any]:
+        cmd = [
+            "docker", "exec", "-e", f"PGOPTIONS=-c statement_timeout={max(1, int((timeout - 5) * 1000))}", self.container, "psql",
+            "-U", self.user, "-d", self.database,
+            "-X", "-q", "-A", "-t", "-F", self.UNIT, "-v", "ON_ERROR_STOP=1", "-c", sql,
+        ]
+        try:
+            proc = run_capture(cmd, timeout=timeout)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc), "rows": [], "stderr": ""}
+        return {
+            "ok": proc.returncode == 0,
+            "error": None if proc.returncode == 0 else (proc.stderr.strip() or "psql failed"),
+            "rows": [line.split(self.UNIT) for line in proc.stdout.splitlines() if line.strip()],
+            "stderr": proc.stderr.strip(),
+        }
+
+    def require(self, sql: str) -> list[list[str]]:
+        result = self.psql(sql)
+        if not result["ok"]:
+            raise PgError(result["error"] or "psql probe failed")
+        return result["rows"]
+
+    def wait_ready(self, attempts: int = 15, interval: float = 2.0) -> bool:
+        for _ in range(attempts):
+            if self.psql("SELECT 1", timeout=30)["ok"]:
+                return True
+            time.sleep(interval)
+        return False
+
+    def stream_rows(self, sql: str, timeout: float = 1800.0):
+        """Stream rows instead of buffering the whole result set in one blob.
+
+        JSONB text output never contains a newline, so a line is a row.
+        """
+        cmd = [
+            "docker", "exec", "-e", f"PGOPTIONS=-c statement_timeout={max(1, int((timeout - 5) * 1000))}", self.container, "psql",
+            "-U", self.user, "-d", self.database,
+            "-X", "-q", "-A", "-t", "-F", self.UNIT, "-v", "ON_ERROR_STOP=1", "-c", sql,
+        ]
+        # Spool to disk so timeout covers the query and pipe consumption, while
+        # the controller never holds the entire result set in memory.
+        with tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as output:
+            process = subprocess.run(cmd, stdout=output, stderr=subprocess.PIPE,
+                                     text=True, timeout=timeout, check=False)
+            if process.returncode != 0:
+                raise PgError(process.stderr.strip() or "psql stream failed")
+            output.seek(0)
+            for line in output:
+                line = line.rstrip("\n")
+                if line:
+                    yield line.split(self.UNIT)
+
+    def existing_tables(self) -> set[str]:
+        listing = ", ".join(f"'{name}'" for name in self.TABLES)
+        sql = (
+            "SELECT table_name FROM information_schema.tables "
+            f"WHERE table_schema = 'public' AND table_name IN ({listing});"
+        )
+        return {row[0] for row in self.require(sql) if row}
+
+    def counts(self) -> dict[str, Any]:
+        """Counts and coverage.  Only tables that exist are named in SQL."""
+        tables = self.existing_tables()
+        parts: list[str] = []
+        for table in self.TABLES:
+            if table in tables:
+                parts.append(f"SELECT '{table}', count(*)::text FROM {table} WHERE tenant_id = '{TENANT}'")
+        if "resources" in tables:
+            parts.append(
+                f"SELECT 'resources_patient', count(*)::text FROM resources "
+                f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient'"
+            )
+            parts.append(
+                f"SELECT 'version:' || version_id, count(*)::text FROM resources "
+                f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient' GROUP BY 1"
+            )
+        if "resource_history" in tables:
+            parts.append(
+                f"SELECT 'history:' || version_id, count(*)::text FROM resource_history "
+                f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient' GROUP BY 1"
+            )
+        if "resources" in tables and "search_index" in tables:
+            # The #903 verdict: a Patient with no index rows is unsearchable.
+            parts.append(
+                "SELECT 'unindexed_patients', count(*)::text FROM ("
+                f"SELECT id FROM resources WHERE tenant_id = '{TENANT}' "
+                "AND resource_type = 'Patient' AND is_deleted = FALSE EXCEPT "
+                f"SELECT resource_id FROM search_index WHERE tenant_id = '{TENANT}' "
+                "AND resource_type = 'Patient') missing"
+            )
+            parts.append(
+                f"SELECT 'search_index_patient', count(*)::text FROM search_index "
+                f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient'"
+            )
+        rows = self.require("\nUNION ALL\n".join(parts) + ";") if parts else []
+        flat: dict[str, Any] = {}
+        version_spread: dict[str, int] = {}
+        history_spread: dict[str, int] = {}
+        for row in rows:
+            if len(row) < 2:
+                continue
+            key, value = row[0], row[1]
+            try:
+                number = int(value)
+            except ValueError:
+                continue
+            if key.startswith("version:"):
+                version_spread[key.split(":", 1)[1]] = number
+            elif key.startswith("history:"):
+                history_spread[key.split(":", 1)[1]] = number
+            else:
+                flat[key] = number
+        return {"counts": flat, "version_spread": version_spread, "history_spread": history_spread}
+
+    def detail(self, resource_ids: list[str], submission_id: str) -> dict[str, Any]:
+        """Versions, history and receipt bookkeeping.  Never SELECT * on changes."""
+        tables = self.existing_tables()
+        ids = ", ".join("'" + rid.replace("'", "") + "'" for rid in resource_ids)
+        sid = submission_id.replace("'", "")
+        queries: dict[str, str] = {
+            "resources": (
+                f"SELECT id, version_id, is_deleted, last_updated, fhir_version, data::text FROM resources "
+                f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient' AND id IN ({ids}) ORDER BY id;"
+            ),
+            "history": (
+                f"SELECT id, version_id, last_updated FROM resource_history "
+                f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient' AND id IN ({ids}) "
+                "ORDER BY id, last_updated, version_id;"
+            ),
+        }
+        if "bulk_submissions" in tables:
+            queries["submission"] = (
+                f"SELECT submission_id, status, created_at, updated_at, completed_at FROM bulk_submissions "
+                f"WHERE tenant_id = '{TENANT}' AND submission_id = '{sid}';"
+            )
+        if "bulk_manifests" in tables:
+            queries["manifests"] = (
+                f"SELECT manifest_id, status, total_entries, processed_entries, failed_entries FROM bulk_manifests "
+                f"WHERE tenant_id = '{TENANT}' AND submission_id = '{sid}' ORDER BY added_at;"
+            )
+        if "bulk_entry_results" in tables:
+            queries["entry_results"] = (
+                f"SELECT outcome, coalesce(created::text, 'null'), count(*) FROM bulk_entry_results "
+                f"WHERE tenant_id = '{TENANT}' AND submission_id = '{sid}' GROUP BY 1, 2 ORDER BY 1, 2;"
+            )
+        if "bulk_submission_changes" in tables:
+            queries["changes"] = (
+                f"SELECT change_type, coalesce(previous_version, 'null'), new_version, count(*) "
+                f"FROM bulk_submission_changes WHERE tenant_id = '{TENANT}' AND submission_id = '{sid}' "
+                "GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;"
+            )
+        if "bulk_submit_files" in tables:
+            queries["files"] = (
+                f"SELECT file_type, count(*) FROM bulk_submit_files "
+                f"WHERE tenant_id = '{TENANT}' AND submission_id = '{sid}' GROUP BY 1 ORDER BY 1;"
+            )
+        data: dict[str, list[list[str]]] = {}
+        for name, sql in queries.items():
+            data[name] = self.require(sql)
+        return {"tables": sorted(tables), "data": data}
+
+
+# --------------------------------------------------------------------------
+# loopback fixture provider
+# --------------------------------------------------------------------------
+
+
+class FixtureProvider:
+    def __init__(self, root: Path, preferred_port: int, log: RunLog, log_path: Path):
+        self.root = root
+        self.preferred_port = preferred_port
+        self.log = log
+        self.httpd: Optional[http.server.ThreadingHTTPServer] = None
+        self.port = 0
+        self._lock = threading.Lock()
+        self._handle = open(log_path, "a", encoding="utf-8", buffering=1)
+
+    def _factory(self) -> Callable[..., http.server.SimpleHTTPRequestHandler]:
+        provider = self
+
+        class Handler(http.server.SimpleHTTPRequestHandler):
+            def log_message(self, fmt: str, *args: Any) -> None:
+                provider._record(f"{self.address_string()} {fmt % args}")
+
+            def log_error(self, fmt: str, *args: Any) -> None:
+                provider._record(f"error {self.address_string()} {fmt % args}")
+
+        return functools.partial(Handler, directory=str(self.root))
+
+    def _record(self, message: str) -> None:
+        with self._lock:
+            self._handle.write(json.dumps({"wall": iso_now(), "message": message}) + "\n")
+
+    def start(self) -> str:
+        base = self.preferred_port or 19200
+        for candidate in range(base, base + 60):
+            if not port_is_free("127.0.0.1", candidate):
+                continue
+            try:
+                self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", candidate), self._factory())
+            except OSError:
+                continue
+            self.port = candidate
+            break
+        if self.httpd is None:
+            raise ConfigError("could not bind a loopback provider port")
+        self.httpd.daemon_threads = True
+        threading.Thread(target=self.httpd.serve_forever, name="provider", daemon=True).start()
+        url = f"http://127.0.0.1:{self.port}"
+        self.log.line("provider_started", base=url, root=str(self.root))
+        return url
+
+    def stop(self) -> None:
+        if self.httpd is not None:
+            try:
+                self.httpd.shutdown()
+                self.httpd.server_close()
+            except Exception:
+                pass
+        with self._lock:
+            self._handle.close()
+
+
+# --------------------------------------------------------------------------
+# HFS process
+# --------------------------------------------------------------------------
+
+
+class HfsProcess:
+    def __init__(self, argv: list[str], env: dict[str, str], cwd: Path, log_path: Path):
+        self.argv = argv
+        self.env = env
+        self.cwd = cwd
+        self.log_path = log_path
+        self.popen: Optional[subprocess.Popen] = None
+        self.pid: Optional[int] = None
+        self._handle = None
+
+    def start(self) -> int:
+        self._handle = open(self.log_path, "wb", buffering=0)
+        self.popen = subprocess.Popen(
+            self.argv, cwd=str(self.cwd), env=self.env,
+            stdout=self._handle, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        self.pid = self.popen.pid
+        return self.pid
+
+    def alive(self) -> bool:
+        return self.popen is not None and self.popen.poll() is None
+
+    def stop(self, grace_seconds: float = 10.0) -> dict[str, Any]:
+        """Terminate exactly this process group; never anything else."""
+        result: dict[str, Any] = {"pid": self.pid, "sigkill": False, "exit_code": None}
+        if self.popen is not None and self.popen.poll() is None and self.pid:
+            for signum, wait in ((signal.SIGTERM, grace_seconds), (signal.SIGKILL, 5.0)):
+                try:
+                    os.killpg(os.getpgid(self.pid), signum)
+                except (ProcessLookupError, PermissionError):
+                    break
+                result["sigkill"] = signum == signal.SIGKILL
+                try:
+                    self.popen.wait(timeout=wait)
+                    break
+                except subprocess.TimeoutExpired:
+                    continue
+        if self.popen is not None:
+            result["exit_code"] = self.popen.poll()
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+        return result
+
+
+def http_request(
+    method: str, url: str, body: Optional[bytes] = None, timeout: float = 60.0
+) -> dict[str, Any]:
+    request = urllib.request.Request(url, data=body, method=method)
+    request.add_header("Accept", "application/fhir+json, application/json")
+    if body is not None:
+        request.add_header("Content-Type", "application/fhir+json")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return {
+                "status": response.status,
+                "headers": {key.lower(): value for key, value in response.headers.items()},
+                "body": response.read(),
+                "error": None,
+            }
+    except urllib.error.HTTPError as exc:
+        payload = b""
+        try:
+            payload = exc.read()
+        except Exception:
+            pass
+        return {
+            "status": exc.code,
+            "headers": {key.lower(): value for key, value in (exc.headers or {}).items()},
+            "body": payload,
+            "error": f"HTTP {exc.code}",
+        }
+    except Exception as exc:
+        return {"status": 0, "headers": {}, "body": b"", "error": str(exc)}
+
+
+def http_json(method: str, url: str, payload: Any = None, timeout: float = 60.0) -> dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    result = http_request(method, url, body=body, timeout=timeout)
+    parsed = None
+    if result["body"]:
+        try:
+            parsed = json.loads(result["body"].decode("utf-8", errors="replace"))
+        except json.JSONDecodeError:
+            parsed = None
+    result["json"] = parsed
+    return result
+
+
+def parameters_map(payload: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for parameter in (payload or {}).get("parameter", []):
+        for key, value in parameter.items():
+            if key != "name":
+                values[parameter.get("name")] = value
+    return values
+
+
+# --------------------------------------------------------------------------
+# sampling thread
+# --------------------------------------------------------------------------
+
+
+class Sampler(threading.Thread):
+    def __init__(self, ctl: "Controller"):
+        super().__init__(name="sampler", daemon=True)
+        self.ctl = ctl
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def run(self) -> None:
+        next_host = 0.0
+        docker_thread = None
+        if self.ctl.args.docker_stats_interval > 0:
+            docker_thread = threading.Thread(target=self.sample_database, daemon=True)
+            docker_thread.start()
+        while not self._stop_event.is_set():
+            now = mono()
+            try:
+                self.ctl.sample_rss()
+                if now >= next_host:
+                    self.ctl.sample_host()
+                    next_host = now + self.ctl.args.host_interval
+                self.ctl.check_deadline()
+            except Exception as exc:
+                self.ctl.log.line("sampler_error", error=str(exc))
+            self._stop_event.wait(self.ctl.args.sample_interval)
+        if docker_thread is not None:
+            docker_thread.join(timeout=7)
+
+    def sample_database(self) -> None:
+        # Docker's stats call can take seconds. It must not block HFS RSS or
+        # the host-pressure watchdog.
+        while not self._stop_event.is_set():
+            try:
+                self.ctl.sample_docker_stats()
+            except Exception as exc:
+                self.ctl.log.line("database_sampler_error", error=str(exc))
+            self._stop_event.wait(self.ctl.args.docker_stats_interval)
+
+
+# --------------------------------------------------------------------------
+# controller
+# --------------------------------------------------------------------------
+
+
+RSS_COLUMNS = [
+    "wall_iso", "mono_s", "rel_s", "phase", "job", "pid",
+    "rss_kib", "rss_mib", "vsz_kib", "cpu_percent",
+]
+HOST_COLUMNS = [
+    "wall_iso", "mono_s", "rel_s", "phase", "job", "page_size", "free_pages",
+    "speculative_pages", "free_spec_mib", "active_mib", "inactive_mib", "wired_mib",
+    "compressor_mib", "compressed_pages", "swap_total_mib", "swap_used_mib",
+    "swap_free_mib", "pressure_level", "swapouts_pages_cum", "swapout_bytes_cum",
+    "swapout_bytes_since_start", "swapins_pages_cum", "load1", "load5", "load15",
+]
+PHASE_COLUMNS = [
+    "phase", "job", "wall_iso", "mono_s", "rel_s", "rss_mib", "host_free_spec_mib",
+    "host_swap_free_mib", "host_compressor_mib", "pressure_level",
+    "swapout_bytes_since_start", "uptime_seconds", "extra_json",
+]
+DOCKER_COLUMNS = [
+    "wall_iso", "mono_s", "rel_s", "phase", "job", "container", "mem_usage_mib",
+    "mem_limit_mib", "mem_percent", "cpu_percent", "pids", "block_io", "net_io",
+]
+
+
+class Controller:
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+        self.t0 = mono()
+        self.run_id = os.urandom(3).hex()
+        self.repo_root = (
+            Path(args.repo_root).expanduser().resolve()
+            if args.repo_root
+            else Path(__file__).resolve().parents[4]
+        )
+        self.out = Path(args.output_dir).expanduser().resolve()
+        self.binary = Path(args.binary).expanduser().resolve()
+        parts = db_url_parts(args.database_url)
+        self.pg = PgClient(
+            args.pg_container,
+            args.pg_user or str(parts["user"]),
+            args.pg_db or str(parts["db"]),
+        )
+
+        self.log: Optional[RunLog] = None
+        self.provider: Optional[FixtureProvider] = None
+        self.hfs: Optional[HfsProcess] = None
+        self.follower: Optional[LogFollower] = None
+        self.sampler: Optional[Sampler] = None
+        self.provider_base: Optional[str] = None
+        self.csv_rss: Optional[CsvWriter] = None
+        self.csv_host: Optional[CsvWriter] = None
+        self.csv_phase: Optional[CsvWriter] = None
+        self.csv_docker: Optional[CsvWriter] = None
+        self.jsonl_phase: Optional[JsonlWriter] = None
+        self.jsonl_pg: Optional[JsonlWriter] = None
+        self.jsonl_stops: Optional[JsonlWriter] = None
+
+        self.lock = threading.Lock()
+        self.phases: list[dict[str, Any]] = []
+        self.stops: list[dict[str, Any]] = []
+        self.checks: list[dict[str, Any]] = []
+        self.attempts: list[dict[str, Any]] = []
+        self.rss_rows: list[dict[str, Any]] = []
+        self.preflight_info: dict[str, Any] = {}
+        self.fixture_info: dict[str, Any] = {}
+        self.current_attempt: Optional[dict[str, Any]] = None
+        self.current_phase = "preflight"
+        self.current_job = 0
+        self.last_host: Optional[dict[str, Any]] = None
+        self.swapout_baseline_bytes: Optional[int] = None
+        self.rss_baseline_mib: Optional[float] = None
+        self.pressure_streak = 0
+        self.swap_growth_streak = 0
+        self.abort: Optional[dict[str, Any]] = None
+        self.signal_number: Optional[int] = None
+        self.deadline_mono = self.t0 + args.deadline
+
+    # -- paths / fixtures -------------------------------------------------
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.args.host}:{self.args.hfs_port}"
+
+    @property
+    def hfs_dir(self) -> Path:
+        return self.out / "hfs"
+
+    @property
+    def jobs_dir(self) -> Path:
+        return self.out / "jobs"
+
+    @property
+    def fixtures_dir(self) -> Path:
+        return self.out / "fixtures"
+
+    def patient_id(self, file_index: int, offset: int) -> str:
+        return f"p995-{file_index}-{offset}"
+
+    def patient_resource(self, file_index: int, offset: int) -> dict[str, Any]:
+        return {
+            "resourceType": "Patient",
+            "id": self.patient_id(file_index, offset),
+            "identifier": [
+                {
+                    "system": MRN_SYSTEM,
+                    "value": f"MRN-{file_index}-{offset}",
+                    "use": "official",
+                }
+            ],
+            "active": offset % 2 == 0,
+            "name": [{"family": FAMILY, "given": [f"File{file_index}", f"Index{offset}"]}],
+            "telecom": [
+                {"system": "phone", "value": f"555-{file_index:03d}-{offset:04d}", "use": "home"}
+            ],
+            "gender": "female" if offset % 2 == 0 else "male",
+            "birthDate": ["1970-01-01", "1975-05-05", "1980-09-09", "1985-12-12"][offset % 4],
+            "address": [
+                {
+                    "use": "home",
+                    "line": [f"{offset} Memory Way"],
+                    "city": "Springfield",
+                    "state": "IL",
+                    "postalCode": "62701",
+                }
+            ],
+        }
+
+    def file_offsets(self) -> list[list[int]]:
+        """Local offsets per file, so ids read `p995-<file>-<offset>`."""
+        total = self.args.resources
+        per_file = total // FIXTURE_FILE_COUNT
+        layout = [list(range(per_file)) for _ in range(FIXTURE_FILE_COUNT)]
+        remainder = total - per_file * FIXTURE_FILE_COUNT
+        if remainder:
+            layout[-1].extend(range(per_file, per_file + remainder))
+        return layout
+
+    def expected_ids(self, file_index: int) -> list[str]:
+        return [self.patient_id(file_index, offset) for offset in self.file_offsets()[file_index]]
+
+    def expected_total(self) -> int:
+        return self.args.resources
+
+    def expected_active(self) -> int:
+        return sum(1 for offsets in self.file_offsets() for offset in offsets if offset % 2 == 0)
+
+    def ensure_fixtures(self, job: int) -> str:
+        if not self.fixture_info:
+            files = []
+            for file_index, offsets in enumerate(self.file_offsets()):
+                path = self.fixtures_dir / f"patients-{file_index}.ndjson"
+                with open(path, "w", encoding="utf-8") as handle:
+                    for offset in offsets:
+                        handle.write(json.dumps(self.patient_resource(file_index, offset)) + "\n")
+                files.append(
+                    {
+                        "name": path.name,
+                        "count": len(offsets),
+                        "bytes": path.stat().st_size,
+                        "sha256": sha256_file(path),
+                        "ids": [self.patient_id(file_index, offset) for offset in offsets],
+                    }
+                )
+            self.fixture_info = {
+                "family": FAMILY,
+                "mrn_system": MRN_SYSTEM,
+                "files": files,
+                "total": sum(entry["count"] for entry in files),
+                "total_bytes": sum(entry["bytes"] for entry in files),
+                "scheme": "identical resources re-submitted with stable ids (reimports)",
+            }
+        manifest_path = self.fixtures_dir / f"manifest-{job:02d}.json"
+        manifest = {
+            "transactionTime": "2024-01-01T00:00:00Z",
+            "request": f"{self.provider_base}/{manifest_path.name}",
+            "requiresAccessToken": False,
+            "output": [
+                {
+                    "type": "Patient",
+                    "url": f"{self.provider_base}/{entry['name']}",
+                    "count": entry["count"],
+                }
+                for entry in self.fixture_info["files"]
+            ],
+            "error": [],
+            "deleted": [],
+        }
+        manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        return f"{self.provider_base}/{manifest_path.name}"
+
+    # -- outputs ----------------------------------------------------------
+
+    def prepare_outputs(self) -> None:
+        if self.out.exists():
+            raise ConfigError(f"output dir already exists: {self.out} (must be a new path)")
+        self.out.mkdir(parents=True)
+        for directory in (self.hfs_dir, self.jobs_dir, self.fixtures_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+        self.log = RunLog(self.out / "controller.log", echo=not self.args.quiet)
+        self.csv_rss = CsvWriter(self.out / "rss.csv", RSS_COLUMNS)
+        self.csv_host = CsvWriter(self.out / "host.csv", HOST_COLUMNS)
+        self.csv_phase = CsvWriter(self.out / "phases.csv", PHASE_COLUMNS)
+        self.csv_docker = CsvWriter(self.out / "docker_stats.csv", DOCKER_COLUMNS)
+        self.jsonl_phase = JsonlWriter(self.out / "phases.jsonl")
+        self.jsonl_pg = JsonlWriter(self.out / "pg_probes.jsonl")
+        self.jsonl_stops = JsonlWriter(self.out / "stops.jsonl")
+        self.log.line(
+            "run_start",
+            output_dir=str(self.out),
+            database=redact_db_url(self.args.database_url),
+            pg_container=self.args.pg_container,
+        )
+
+    def write_json(self, relative: str, payload: Any) -> None:
+        path = self.out / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_json_atomic(path, payload)
+
+    # -- phases / sampling ------------------------------------------------
+
+    def metrics_uptime(self) -> Optional[float]:
+        if not (self.hfs and self.hfs.alive()):
+            return None
+        result = http_request("GET", f"{self.base_url}/metrics", timeout=15)
+        if result["status"] != 200:
+            return None
+        match = re.search(r"uptime_seconds\s+([0-9.]+)", result["body"].decode("utf-8", "replace"))
+        return float(match.group(1)) if match else None
+
+    def phase(self, name: str, job: int, extra: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+        pid = self.hfs.pid if self.hfs else None
+        sample = ps_sample(pid) if pid else None
+        host = self.last_host or {}
+        swapout_growth = None
+        if host.get("swapout_bytes") is not None and self.swapout_baseline_bytes is not None:
+            swapout_growth = int(host["swapout_bytes"]) - self.swapout_baseline_bytes
+        record = {
+            "phase": name,
+            "job": job,
+            "wall_iso": iso_now(),
+            "mono_s": round(mono(), 3),
+            "rel_s": round(mono() - self.t0, 3),
+            "rss_mib": round(sample["rss_kib"] / 1024, 1) if sample else None,
+            "host_free_spec_mib": _round(host.get("free_spec_mib")),
+            "host_swap_free_mib": _round(host.get("swap_free_mib")),
+            "host_compressor_mib": _round(host.get("compressor_mib")),
+            "pressure_level": host.get("pressure_level"),
+            "swapout_bytes_since_start": swapout_growth,
+            "uptime_seconds": self.metrics_uptime(),
+            "extra": extra or {},
+        }
+        with self.lock:
+            self.phases.append(record)
+            self.current_phase = name
+            self.current_job = job
+        if self.csv_phase:
+            self.csv_phase.write(
+                {
+                    **{key: record[key] for key in PHASE_COLUMNS if key != "extra_json"},
+                    "extra_json": json.dumps(record["extra"], default=str),
+                }
+            )
+        if self.jsonl_phase:
+            self.jsonl_phase.write(record)
+        if self.log:
+            self.log.line(
+                "phase", phase=name, job=job, rss_mib=record["rss_mib"],
+                swap_free_mib=record["host_swap_free_mib"], pressure=record["pressure_level"],
+            )
+        return record
+
+    def sample_rss(self) -> None:
+        pid = self.hfs.pid if self.hfs else None
+        if not pid:
+            return
+        sample = ps_sample(pid)
+        if sample is None:
+            return
+        rss_mib = sample["rss_kib"] / 1024
+        row = {
+            "wall_iso": iso_now(),
+            "mono_s": round(mono(), 3),
+            "rel_s": round(mono() - self.t0, 3),
+            "phase": self.current_phase,
+            "job": self.current_job,
+            "pid": pid,
+            "rss_kib": int(sample["rss_kib"]),
+            "rss_mib": round(rss_mib, 3),
+            "vsz_kib": int(sample["vsz_kib"]),
+            "cpu_percent": sample["cpu_percent"],
+        }
+        with self.lock:
+            self.rss_rows.append(row)
+        if self.csv_rss:
+            self.csv_rss.write(row)
+        if rss_mib > self.args.operational_max_rss_mib:
+            self.request_stop(
+                {
+                    "rule": "rss_operational_max",
+                    "observed_mib": round(rss_mib, 1),
+                    "threshold_mib": self.args.operational_max_rss_mib,
+                }
+            )
+
+    def sample_host(self) -> None:
+        vitals = host_vitals()
+        self.last_host = vitals
+        if self.swapout_baseline_bytes is None and vitals.get("swapout_bytes") is not None:
+            self.swapout_baseline_bytes = int(vitals["swapout_bytes"])
+        growth = None
+        if vitals.get("swapout_bytes") is not None and self.swapout_baseline_bytes is not None:
+            growth = int(vitals["swapout_bytes"]) - self.swapout_baseline_bytes
+        row = {
+            "wall_iso": vitals["wall"],
+            "mono_s": round(vitals["mono"], 3),
+            "rel_s": round(vitals["mono"] - self.t0, 3),
+            "phase": self.current_phase,
+            "job": self.current_job,
+            "page_size": vitals.get("page_size"),
+            "free_pages": vitals.get("free_pages"),
+            "speculative_pages": vitals.get("speculative_pages"),
+            "free_spec_mib": _round(vitals.get("free_spec_mib")),
+            "active_mib": _round(vitals.get("active_mib")),
+            "inactive_mib": _round(vitals.get("inactive_mib")),
+            "wired_mib": _round(vitals.get("wired_mib")),
+            "compressor_mib": _round(vitals.get("compressor_mib")),
+            "compressed_pages": vitals.get("compressed_pages"),
+            "swap_total_mib": _round(vitals.get("swap_total_mib")),
+            "swap_used_mib": _round(vitals.get("swap_used_mib")),
+            "swap_free_mib": _round(vitals.get("swap_free_mib")),
+            "pressure_level": vitals.get("pressure_level"),
+            "swapouts_pages_cum": vitals.get("swapouts_pages"),
+            "swapout_bytes_cum": vitals.get("swapout_bytes"),
+            "swapout_bytes_since_start": growth,
+            "swapins_pages_cum": vitals.get("swapins_pages"),
+            "load1": vitals.get("load1"),
+            "load5": vitals.get("load5"),
+            "load15": vitals.get("load15"),
+        }
+        if self.csv_host:
+            self.csv_host.write(row)
+        pressure = vitals.get("pressure_level")
+        if pressure is not None:
+            self.pressure_streak = self.pressure_streak + 1 if pressure != 1 else 0
+            if self.pressure_streak >= self.args.pressure_samples:
+                self.request_stop(
+                    {
+                        "rule": "memory_pressure_sustained",
+                        "observed": pressure,
+                        "threshold_samples": self.args.pressure_samples,
+                        "sample": row,
+                    }
+                )
+                return
+        if growth is not None:
+            self.swap_growth_streak = (
+                self.swap_growth_streak + 1
+                if growth / 1024 / 1024 > self.args.swap_growth_mib
+                else 0
+            )
+            if self.swap_growth_streak >= self.args.swap_growth_samples:
+                self.request_stop(
+                    {
+                        "rule": "swapout_growth",
+                        "observed_mib": round(growth / 1024 / 1024, 1),
+                        "threshold_mib": self.args.swap_growth_mib,
+                        "sample": row,
+                    }
+                )
+
+    def sample_docker_stats(self) -> None:
+        result = run_capture(
+            ["docker", "stats", "--no-stream", "--format", "{{json .}}", self.args.pg_container],
+            timeout=5,
+        )
+        row = {
+            "wall_iso": iso_now(),
+            "mono_s": round(mono(), 3),
+            "rel_s": round(mono() - self.t0, 3),
+            "phase": self.current_phase,
+            "job": self.current_job,
+            "container": self.args.pg_container,
+        }
+        for line in result.stdout.splitlines():
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            usage, _, limit = (payload.get("MemUsage") or "").partition("/")
+            row.update(
+                {
+                    "mem_usage_mib": _usage_mib(usage),
+                    "mem_limit_mib": _usage_mib(limit),
+                    "mem_percent": payload.get("MemPerc"),
+                    "cpu_percent": payload.get("CPUPerc"),
+                    "pids": payload.get("PIDs"),
+                    "block_io": payload.get("BlockIO"),
+                    "net_io": payload.get("NetIO"),
+                }
+            )
+        if self.csv_docker:
+            self.csv_docker.write(row)
+
+    def check_deadline(self) -> None:
+        if self.args.deadline > 0 and mono() > self.deadline_mono:
+            self.request_stop(
+                {
+                    "rule": "deadline",
+                    "observed_s": round(mono() - self.t0, 1),
+                    "threshold_s": self.args.deadline,
+                }
+            )
+
+    def request_stop(self, event: dict[str, Any]) -> None:
+        with self.lock:
+            if self.abort is not None:
+                return
+            record = {
+                **event,
+                "wall_iso": iso_now(),
+                "mono_s": round(mono(), 3),
+                "rel_s": round(mono() - self.t0, 3),
+                "last_60s": self.rss_rows[-120:],
+            }
+            self.stops.append(record)
+            self.abort = {"reason": f"watchdog:{event['rule']}", "detail": record}
+        if self.jsonl_stops:
+            self.jsonl_stops.write(record)
+        if self.log:
+            self.log.line("stop_requested", rule=event["rule"], detail=json.dumps(event, default=str))
+        if self.hfs is not None:
+            stopped = self.hfs.stop(grace_seconds=5.0)
+            if self.log:
+                self.log.line("hfs_stopped_by_watchdog", **stopped)
+
+    def raise_if_aborted(self) -> None:
+        with self.lock:
+            abort = self.abort
+        if abort is not None:
+            raise Aborted(abort["reason"], abort.get("detail", {}))
+        if self.signal_number is not None:
+            raise Aborted(f"signal:{self.signal_number}")
+
+    # -- preflight --------------------------------------------------------
+
+    def preflight(self) -> dict[str, Any]:
+        if not self.binary.is_file():
+            raise ConfigError(f"binary not found: {self.binary}")
+        if not os.access(self.binary, os.X_OK):
+            raise ConfigError(f"binary is not executable: {self.binary}")
+        r4 = self.repo_root / "data" / "search-parameters-r4.json"
+        if not r4.is_file():
+            raise ConfigError(
+                f"missing {r4}: HFS would fall back to the embedded parameter set "
+                "(pass --repo-root if the checkout is elsewhere)"
+            )
+        info: dict[str, Any] = {
+            "binary": {
+                "path": str(self.binary),
+                "sha256": sha256_file(self.binary),
+                "size_bytes": self.binary.stat().st_size,
+                "mtime": datetime.fromtimestamp(self.binary.stat().st_mtime, timezone.utc)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "Z"),
+            },
+            "controller": {
+                "path": str(Path(__file__).resolve()),
+                "sha256": sha256_file(Path(__file__).resolve()),
+                "python": sys.version,
+            },
+            "git": {},
+            "host": {},
+            "search_parameters_file": {
+                "path": str(r4),
+                "sha256": sha256_file(r4),
+                "bytes": r4.stat().st_size,
+                "entries": _json_array_length(r4),
+            },
+            "foreign_processes": {
+                "hfs": pgrep_count("hfs"),
+                "rustc": pgrep_count("rustc"),
+                "cargo": pgrep_count("cargo"),
+            },
+        }
+        for key, cmd in (
+            ("head", ["git", "rev-parse", "HEAD"]),
+            ("branch", ["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+        ):
+            try:
+                info["git"][key] = run_capture(cmd, timeout=20).stdout.strip()
+            except Exception as exc:
+                info["git"][key] = f"error: {exc}"
+        try:
+            info["git"]["dirty"] = bool(run_capture(["git", "status", "--porcelain"], timeout=30).stdout.strip())
+        except Exception:
+            info["git"]["dirty"] = None
+        try:
+            info["host"] = {
+                "macos": run_capture(["sw_vers", "-productVersion"], timeout=20).stdout.strip(),
+                "build": run_capture(["sw_vers", "-buildVersion"], timeout=20).stdout.strip(),
+                "cpu": run_capture(["sysctl", "-n", "machdep.cpu.brand_string"], timeout=20).stdout.strip(),
+                "ncpu": run_capture(["sysctl", "-n", "hw.ncpu"], timeout=20).stdout.strip(),
+                "memsize_bytes": run_capture(["sysctl", "-n", "hw.memsize"], timeout=20).stdout.strip(),
+            }
+        except Exception as exc:
+            info["host"] = {"error": str(exc)}
+        info["postgres"] = self._docker_inspect()
+        info["postgres"]["psql_ready"] = self.pg.wait_ready()
+        if not info["postgres"]["psql_ready"]:
+            raise ConfigError(
+                f"psql is not usable inside container {self.args.pg_container!r}; "
+                "the deferred-reindex verdict requires SQL coverage probes"
+            )
+        info["db_before"] = self.pg.counts()
+
+        samples = []
+        for index in range(self.args.preflight_samples):
+            vitals = host_vitals()
+            samples.append(
+                {
+                    "wall_iso": vitals["wall"],
+                    "free_spec_mib": _round(vitals.get("free_spec_mib")),
+                    "swap_free_mib": _round(vitals.get("swap_free_mib")),
+                    "compressor_mib": _round(vitals.get("compressor_mib")),
+                    "pressure_level": vitals.get("pressure_level"),
+                }
+            )
+            if self.swapout_baseline_bytes is None and vitals.get("swapout_bytes") is not None:
+                self.swapout_baseline_bytes = int(vitals["swapout_bytes"])
+            if index + 1 < self.args.preflight_samples:
+                time.sleep(self.args.preflight_interval)
+        info["preflight_samples"] = samples
+        info["preflight_medians"] = {
+            key: _median([s[key] for s in samples if s.get(key) is not None])
+            for key in ("free_spec_mib", "swap_free_mib", "compressor_mib")
+        }
+
+        blocked: list[str] = []
+        counts = info["db_before"]["counts"]
+        stale = {
+            key: counts[key]
+            for key in ("resources", "resource_history", "bulk_submissions", "bulk_manifests")
+            if isinstance(counts.get(key), int) and counts[key] > 0
+        }
+        if stale and not self.args.allow_nonempty_db:
+            blocked.append("database is not fresh: " + ", ".join(f"{k}={v}" for k, v in stale.items()))
+        if info["foreign_processes"]["hfs"]:
+            blocked.append(f"another hfs process is running ({info['foreign_processes']['hfs']})")
+        if info["foreign_processes"]["rustc"]:
+            blocked.append(f"a rustc build is active ({info['foreign_processes']['rustc']} processes)")
+        recent = [s["pressure_level"] for s in samples[-3:]]
+        if recent and all(level is not None and level != 1 for level in recent):
+            blocked.append(f"memory pressure is not normal: {recent}")
+        info["blocked"] = bool(blocked)
+        info["block_reasons"] = blocked
+        self.preflight_info = info
+        for reason in blocked:
+            self.log.line("preflight_blocked", reason=reason)
+        if not blocked:
+            self.log.line(
+                "preflight_ok",
+                swap_free_mib=info["preflight_medians"]["swap_free_mib"],
+                free_spec_mib=info["preflight_medians"]["free_spec_mib"],
+                compressor_mib=info["preflight_medians"]["compressor_mib"],
+            )
+        return info
+
+    def _docker_inspect(self) -> dict[str, Any]:
+        result = run_capture(
+            ["docker", "inspect", "--format", "{{json .}}", self.args.pg_container], timeout=60
+        )
+        if result.returncode != 0:
+            raise ConfigError(
+                f"docker inspect {self.args.pg_container!r} failed: {result.stderr.strip()[:200]}"
+            )
+        payload = json.loads(result.stdout.strip().splitlines()[0])
+        host_config = payload.get("HostConfig") or {}
+        state = payload.get("State") or {}
+        return {
+            "container": self.args.pg_container,
+            "id": payload.get("Id"),
+            "image": (payload.get("Config") or {}).get("Image"),
+            "running": state.get("Running"),
+            "started_at": state.get("StartedAt"),
+            "memory_limit_mib": _mib(host_config.get("Memory")),
+            "memory_swap_mib": _mib(host_config.get("MemorySwap")),
+            "nano_cpus": host_config.get("NanoCpus"),
+            "user": self.pg.user,
+            "database": self.pg.database,
+        }
+
+    # -- HFS lifecycle ----------------------------------------------------
+
+    def effective_env(self) -> dict[str, str]:
+        env = dict(HFS_ENV_BASE)
+        env["HFS_BASE_URL"] = self.base_url
+        env["HFS_SERVER_HOST"] = self.args.host
+        env["HFS_SERVER_PORT"] = str(self.args.hfs_port)
+        env["HFS_LOG_LEVEL"] = self.args.hfs_log_level
+        env["HFS_BULK_SUBMIT_FILE_CONCURRENCY"] = str(self.args.file_concurrency)
+        env["HFS_BULK_SUBMIT_DEFER_INDEXING"] = "true" if self.args.defer_indexing else "false"
+        env["HFS_BULK_SUBMIT_OUTPUT_BACKEND"] = "local-fs"
+        env["HFS_BULK_SUBMIT_OUTPUT_DIR"] = str(self.out / "artifacts")
+        for item in self.args.hfs_env:
+            key, _, value = item.partition("=")
+            env[key.strip()] = value
+        return env
+
+    def start_hfs(self, job: int) -> None:
+        # An unrelated shell's HFS settings must not change this experiment.
+        env = {key: value for key, value in os.environ.items()
+               if not key.startswith("HFS_") and key != "HELIOS_OBS_MODE"}
+        overrides = self.effective_env()
+        env.update(overrides)
+        # Credentials travel in the environment, never in argv.
+        env["HFS_DATABASE_URL"] = self.args.database_url
+        argv = [
+            str(self.binary),
+            "--host", self.args.host,
+            "--port", str(self.args.hfs_port),
+            "--log-level", self.args.hfs_log_level,
+        ]
+        log_path = self.hfs_dir / f"job{job:02d}.log"
+        self.hfs = HfsProcess(argv, env, self.repo_root, log_path)
+        pid = self.hfs.start()
+        self.follower = LogFollower(log_path)
+        self.phase(
+            "server_start",
+            job,
+            {
+                "pid": pid,
+                "argv": argv,
+                "log": str(log_path),
+                "env": {
+                    key: (redact_db_url(value) if key == "HFS_DATABASE_URL" else value)
+                    for key, value in overrides.items()
+                },
+            },
+        )
+        deadline = mono() + self.args.startup_timeout
+        while True:
+            self.raise_if_aborted()
+            if not self.hfs.alive():
+                raise Aborted("hfs_exited_during_startup", {"log_tail": self.follower.tail()})
+            if http_request("GET", f"{self.base_url}/health", timeout=15)["status"] == 200:
+                break
+            if mono() > deadline:
+                raise Aborted("hfs_startup_timeout", {"log_tail": self.follower.tail()})
+            time.sleep(1.0)
+        sample = ps_sample(pid)
+        self.rss_baseline_mib = round(sample["rss_kib"] / 1024, 1) if sample else None
+        counts = self.pg.counts()
+        self.phase(
+            "startup_complete",
+            job,
+            {
+                "rss_baseline_mib": self.rss_baseline_mib,
+                "db_counts": counts["counts"],
+                "search_parameter_file_entries": self.preflight_info["search_parameters_file"]["entries"],
+                "search_parameter_log_lines": [
+                    line
+                    for line in self.follower.read_new()
+                    if "SearchParameter" in line
+                ][:5],
+            },
+        )
+
+    def stop_hfs(self, job: int, reason: str) -> None:
+        if self.hfs is None:
+            return
+        sample = ps_sample(self.hfs.pid) if self.hfs.pid else None
+        self.phase(
+            "server_stop",
+            job,
+            {"reason": reason, "rss_mib": round(sample["rss_kib"] / 1024, 1) if sample else None},
+        )
+        stopped = self.hfs.stop()
+        if self.log:
+            self.log.line("hfs_stopped", job=job, reason=reason, **stopped)
+        self.hfs = None
+        self.follower = None
+
+    # -- submit -----------------------------------------------------------
+
+    def search_count(self, query: str) -> Optional[int]:
+        """Parameterised searches go through the index; the bare one does not."""
+        suffix = f"?{query}&_summary=count&_count=1" if query else "?_summary=count&_count=1"
+        result = http_json("GET", f"{self.base_url}/Patient{suffix}")
+        with (self.out / "search-checks.jsonl").open("a") as evidence:
+            evidence.write(json.dumps({"wall_iso": iso_now(), "query": query,
+                "status": result["status"], "error": result["error"],
+                "json": result["json"]}) + "\n")
+        if result["status"] != 200 or not isinstance(result["json"], dict):
+            return None
+        total = result["json"].get("total")
+        return int(total) if isinstance(total, (int, float)) else None
+
+    def kickoff(self, submission_id: str, manifest_url: str) -> dict[str, Any]:
+        payload = {
+            "resourceType": "Parameters",
+            "parameter": [
+                {
+                    "name": "submitter",
+                    "valueIdentifier": {"system": SUBMITTER_SYSTEM, "value": SUBMITTER_VALUE},
+                },
+                {"name": "submissionId", "valueString": submission_id},
+                {"name": "manifestUrl", "valueUrl": manifest_url},
+                {"name": "fhirBaseUrl", "valueUrl": f"{self.provider_base}/fhir"},
+                {
+                    "name": "submissionStatus",
+                    "valueCoding": {
+                        "system": "http://hl7.org/fhir/event-status",
+                        "code": "completed",
+                    },
+                },
+            ],
+        }
+        return http_json(
+            "POST", f"{self.base_url}/$bulk-submit", payload=payload, timeout=self.args.request_timeout
+        )
+
+    def poll_terminal(
+        self, job: int, submission_id: str, kickoff_mono: float
+    ) -> dict[str, Any]:
+        status_payload = {
+            "resourceType": "Parameters",
+            "parameter": [
+                {
+                    "name": "submitter",
+                    "valueIdentifier": {"system": SUBMITTER_SYSTEM, "value": SUBMITTER_VALUE},
+                },
+                {"name": "submissionId", "valueString": submission_id},
+            ],
+        }
+        opened = http_json(
+            "POST", f"{self.base_url}/$bulk-submit-status", payload=status_payload, timeout=60
+        )
+        poll_url = opened["headers"].get("content-location")
+        if opened["status"] != 202 or not poll_url:
+            raise Aborted(
+                "submit_status_kickoff_failed",
+                {"status": opened["status"], "error": opened["error"]},
+            )
+        interval = max(0.25, self.args.endpoint_poll_interval)
+        deadline = mono() + self.args.terminal_timeout
+        polls: list[dict[str, Any]] = []
+        while True:
+            self.raise_if_aborted()
+            if mono() > deadline:
+                raise Aborted("submit_terminal_timeout", {"polls": polls[-20:]})
+            result = http_json("GET", poll_url, timeout=60)
+            polls.append(
+                {
+                    "elapsed_s": round(mono() - kickoff_mono, 3),
+                    "status": result["status"],
+                    "x_progress": result["headers"].get("x-progress"),
+                    "retry_after": result["headers"].get("retry-after"),
+                }
+            )
+            if result["status"] == 200:
+                manifest = result["json"] if isinstance(result["json"], dict) else {}
+                pages = [manifest]
+                guard = 0
+                while guard < 50:
+                    guard += 1
+                    nexts = [
+                        link
+                        for link in manifest.get("link", [])
+                        if link.get("relation") == "next" and link.get("url")
+                    ]
+                    if not nexts:
+                        break
+                    page = http_json("GET", nexts[0]["url"], timeout=60)
+                    if page["status"] != 200 or not isinstance(page["json"], dict):
+                        raise Aborted("submit_manifest_page_failed", {"url": nexts[0]["url"]})
+                    manifest = page["json"]
+                    pages.append(manifest)
+                return {
+                    "poll_url": poll_url,
+                    "polls": polls,
+                    "pages": len(pages),
+                    "manifest": pages[0],
+                    "output": [entry for page in pages for entry in page.get("output", [])],
+                    "outcome": [entry for page in pages for entry in page.get("outcome", [])],
+                    "deleted": [entry for page in pages for entry in page.get("deleted", [])],
+                    "terminal_s": round(mono() - kickoff_mono, 3),
+                    "job": job,
+                }
+            if result["status"] == 404:
+                raise Aborted("submit_poll_404", {"poll_url": poll_url, "polls": polls[-5:]})
+            if result["status"] == 429:
+                time.sleep(float(result["headers"].get("retry-after") or 6))
+            else:
+                time.sleep(interval)
+
+    def receipt_check(self, job: int, output: list[dict[str, Any]]) -> dict[str, Any]:
+        """Download every receipt artifact and require the exact aggregate id set.
+
+        The worker writes one receipt per resource *type*, not per input file, so
+        the four Patient files come back as a single combined artifact.  The
+        verdict is therefore on the union of all output entries.
+        """
+        expected = {
+            self.patient_id(file_index, offset)
+            for file_index, offsets in enumerate(self.file_offsets())
+            for offset in offsets
+        }
+        summaries = []
+        ids: list[str] = []
+        for entry in output:
+            url = entry.get("url")
+            fetched = http_request("GET", url, timeout=300) if url else {"status": 0, "body": b""}
+            lines = [line for line in fetched["body"].decode("utf-8", "replace").splitlines() if line.strip()]
+            unparsable = 0
+            bad_reference = 0
+            for line in lines:
+                try:
+                    reference = str(json.loads(line).get("reference", ""))
+                except json.JSONDecodeError:
+                    unparsable += 1
+                    continue
+                if reference.startswith("Patient/"):
+                    ids.append(reference.split("/", 1)[1])
+                else:
+                    bad_reference += 1
+            declared_count = entry.get("count")
+            declared_size = entry.get("fileSize")
+            summaries.append(
+                {
+                    "url": url,
+                    "type": entry.get("type"),
+                    "status": fetched["status"],
+                    "lines": len(lines),
+                    "bytes": len(fetched["body"]),
+                    "sha256": hashlib.sha256(fetched["body"]).hexdigest(),
+                    "declared_count": declared_count,
+                    "declared_file_size": declared_size,
+                    "declared_count_ok": declared_count is None or int(declared_count) == len(lines),
+                    "declared_file_size_ok": declared_size is None or int(declared_size) == len(fetched["body"]),
+                    "unparsable_lines": unparsable,
+                    "bad_reference_lines": bad_reference,
+                }
+            )
+        seen_ids: set[str] = set()
+        duplicate_ids: set[str] = set()
+        for identifier in ids:
+            if identifier in seen_ids:
+                duplicate_ids.add(identifier)
+            seen_ids.add(identifier)
+        duplicates = sorted(duplicate_ids)
+        result = {
+            "ok": (
+                len(summaries) >= 1
+                and all(item["status"] == 200 for item in summaries)
+                and all(item["unparsable_lines"] == 0 for item in summaries)
+                and all(item["bad_reference_lines"] == 0 for item in summaries)
+                and all(item["declared_count_ok"] for item in summaries)
+                and all(item["declared_file_size_ok"] for item in summaries)
+                and not duplicates
+                and len(ids) == self.expected_total()
+                and set(ids) == expected
+            ),
+            "output_entries": len(summaries),
+            "references": len(ids),
+            "unique_references": len(set(ids)),
+            "duplicates": duplicates[:5],
+            "expected_references": len(expected),
+            "artifacts": summaries,
+        }
+        self.write_json(f"jobs/job{job:02d}/receipts.json", result)
+        if not result["ok"]:
+            raise Aborted("receipt_mismatch", result)
+        return result
+
+    # -- reindex verification ---------------------------------------------
+
+    def verify_reindex(
+        self, job: int, submission_id: str, log_offset: int, kickoff_mono: float
+    ) -> dict[str, Any]:
+        """Positive verification or the attempt is unverified and the run stops."""
+        total = self.expected_total()
+        evidence: dict[str, Any] = {
+            "defer_indexing": bool(self.args.defer_indexing),
+            "log_offset_at_kickoff": log_offset,
+        }
+        if self.args.defer_indexing:
+            deadline = mono() + self.args.reindex_timeout
+            job_id = None
+            lines: list[str] = []
+            while job_id is None:
+                self.raise_if_aborted()
+                if mono() > deadline:
+                    raise Aborted(
+                        "reindex_job_id_not_found",
+                        {"log_tail": self.follower.tail(), "evidence": evidence},
+                    )
+                lines.extend(self.follower.read_new())
+                hooks = [
+                    line
+                    for line in lines
+                    if "bulk fast-load: rebuilding deferred search indexes" in line
+                    and submission_id in line
+                ]
+                started = [
+                    line for line in lines if "deferred-index rebuild started" in line
+                ]
+                ids = {
+                    match.group(1)
+                    for line in started
+                    for match in [re.search(r'job_id="?([0-9a-fA-F-]{36})"?', line)]
+                    if match
+                }
+                if ids:
+                    evidence["hook_lines"] = hooks[-3:]
+                    evidence["start_lines"] = started[-3:]
+                    if len(ids) > 1 or len(hooks) != 1:
+                        raise Aborted(
+                            "reindex_correlation_ambiguous",
+                            {"job_ids": sorted(ids), "hook_lines": hooks[-3:]},
+                        )
+                    job_id = ids.pop()
+                time.sleep(min(1.0, self.args.endpoint_poll_interval))
+            evidence["job_id"] = job_id
+            evidence["job_id_source"] = "hfs log line 'deferred-index rebuild started' after kickoff"
+            status_deadline = mono() + self.args.reindex_timeout
+            status_polls: list[dict[str, Any]] = []
+            while True:
+                self.raise_if_aborted()
+                result = http_json("GET", f"{self.base_url}/$reindex-status/{job_id}", timeout=60)
+                params = parameters_map(result["json"]) if result["status"] == 200 else {}
+                status_polls.append(
+                    {"status": result["status"], "reindex": params.get("status"), "at_s": round(mono() - kickoff_mono, 1)}
+                )
+                if params.get("status") in ("completed", "failed", "cancelled"):
+                    break
+                if mono() > status_deadline:
+                    raise Aborted(
+                        "reindex_timeout",
+                        {"polls": status_polls[-10:], "evidence": evidence},
+                    )
+                time.sleep(max(0.5, self.args.endpoint_poll_interval))
+            evidence["status_polls"] = status_polls[-10:]
+            evidence["status"] = params.get("status")
+            evidence["total"] = params.get("total")
+            evidence["processed"] = params.get("processed")
+            evidence["entries_created"] = params.get("entriesCreated")
+            evidence["error_count"] = params.get("errorCount")
+            if (
+                params.get("status") != "completed"
+                or params.get("errorCount") != 0
+                or params.get("processed") != params.get("total")
+                or params.get("total") != total
+            ):
+                raise Aborted("reindex_not_completed_cleanly", {"evidence": evidence})
+        else:
+            evidence["job_id_source"] = "not applicable: HFS_BULK_SUBMIT_DEFER_INDEXING=false"
+
+        counts = self.pg.counts()
+        evidence["db_counts"] = counts["counts"]
+        unindexed = counts["counts"].get("unindexed_patients")
+        indexed_total = self.search_count(f"family={FAMILY}")
+        evidence["search_total_family"] = indexed_total
+        evidence["unindexed_patients"] = unindexed
+        evidence["reindex_s"] = round(mono() - kickoff_mono, 3)
+        if unindexed != 0:
+            raise Aborted("reindex_coverage_incomplete", {"evidence": evidence})
+        if indexed_total != total:
+            raise Aborted("search_index_count_mismatch", {"evidence": evidence})
+        evidence["verified"] = True
+        self.jsonl_pg.write({"phase": "reindex_verified", "job": job, **evidence})
+        return evidence
+
+    # -- idle / validation ------------------------------------------------
+
+    def idle(self, job: int) -> float:
+        self.phase("idle_start", job, {"idle_seconds": self.args.idle_seconds})
+        end = mono() + self.args.idle_seconds
+        while mono() < end:
+            self.raise_if_aborted()
+            time.sleep(min(0.5, max(0.05, end - mono())))
+        return self.phase("idle_end", job)["mono_s"]
+
+    def validate_job(self, job: int, submission_id: str, output: list[dict[str, Any]]) -> dict[str, Any]:
+        """Exactness checks after the idle window; labelled as validation.
+
+        The receipt artifact is written per resource *type*, so the four Patient
+        files come back as one combined artifact and the verdict is on the union
+        of all output entries.
+        """
+        self.phase("validation_start", job, {"label": "post_idle_validation"})
+        started = mono()
+        total = self.expected_total()
+        layout = self.file_offsets()
+        sample_points = [
+            (0, layout[0][0]),
+            (FIXTURE_FILE_COUNT // 2, layout[FIXTURE_FILE_COUNT // 2][0]),
+            (FIXTURE_FILE_COUNT - 1, layout[-1][-1]),
+        ]
+        sampled = [self.patient_id(file_index, offset) for file_index, offset in sample_points]
+        expected = {
+            self.patient_id(file_index, offset): self.patient_resource(file_index, offset)
+            for file_index, offsets in enumerate(layout)
+            for offset in offsets
+        }
+        receipts = self.receipt_check(job, output)
+        detail = self.pg.detail(sampled, submission_id)
+        counts = self.pg.counts()
+        checks: list[dict[str, Any]] = []
+
+        def add(name: str, kind: str, ok: bool, expected: Any, actual: Any, note: str = "") -> None:
+            check = {
+                "job": job,
+                "name": name,
+                "kind": kind,
+                "ok": bool(ok),
+                "expected": expected,
+                "actual": actual,
+                "note": note,
+            }
+            checks.append(check)
+            self.checks.append(check)
+
+        # Exact current content, id set, version and history - streamed from SQL.
+        content_mismatches: list[dict[str, Any]] = []
+        seen_ids: set[str] = set()
+        version_distribution: Counter = Counter()
+        content_rows = 0
+        for row in self.pg.stream_rows(
+            "SELECT id, version_id, is_deleted, data::text FROM resources "
+            f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient' ORDER BY id"
+        ):
+            if len(row) < 4:
+                continue
+            content_rows += 1
+            resource_id, version_id, is_deleted, body = row[0], row[1], row[2], row[3]
+            seen_ids.add(resource_id)
+            version_distribution[version_id] += 1
+            wanted = expected.get(resource_id)
+            if wanted is None:
+                content_mismatches.append({"id": resource_id, "reason": "unexpected id"})
+                continue
+            if is_deleted == "t":
+                content_mismatches.append({"id": resource_id, "reason": "is_deleted"})
+                continue
+            try:
+                stored = json.loads(body)
+            except json.JSONDecodeError:
+                content_mismatches.append({"id": resource_id, "reason": "unparsable jsonb"})
+                continue
+            # `data` holds the submitted body only: server meta is merged on read.
+            diffs = [key for key, value in wanted.items() if stored.get(key) != value]
+            if set(stored) != set(wanted):
+                diffs.append("keys:" + ",".join(sorted(set(stored) ^ set(wanted))[:5]))
+            if diffs:
+                content_mismatches.append({"id": resource_id, "reason": "content", "diff": diffs[:5]})
+
+        add("pg_content_all", "hard", not content_mismatches and content_rows == total,
+            f"{total} stored bodies identical to the fixture",
+            {"rows": content_rows, "mismatches": len(content_mismatches),
+             "examples": content_mismatches[:5]})
+        add("pg_id_set", "hard", seen_ids == set(expected), f"{total} ids", {
+            "rows": len(seen_ids),
+            "missing": len(set(expected) - seen_ids),
+            "unexpected": len(seen_ids - set(expected)),
+        })
+        add("pg_version_distribution", "hard", dict(version_distribution) == {str(job): total},
+            {str(job): total}, dict(version_distribution))
+
+        history_counts: Counter = Counter()
+        history_keys: Counter = Counter()
+        for row in self.pg.stream_rows(
+            "SELECT id, version_id FROM resource_history "
+            f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient' ORDER BY id, version_id"
+        ):
+            if len(row) >= 2:
+                history_keys[(row[0], row[1])] += 1
+                history_counts[row[0]] += 1
+        expected_versions = {str(version) for version in range(1, job + 1)}
+        bad_history: dict[str, Any] = {}
+        for (resource_id, version_id), count in history_keys.items():
+            if version_id not in expected_versions or count != 1:
+                bad_history[resource_id] = f"{version_id}x{count}"
+        for resource_id in expected:
+            if history_counts.get(resource_id) != job:
+                bad_history.setdefault(resource_id, f"versions={history_counts.get(resource_id)}")
+        add("pg_history_exact", "hard", not bad_history and len(history_counts) == total,
+            {str(version): total for version in range(1, job + 1)},
+            {"ids": len(history_counts), "bad_ids": len(bad_history),
+             "examples": dict(list(bad_history.items())[:5])})
+
+        add("pg_patient_resources", "hard", counts["counts"].get("resources_patient") == total,
+            total, counts["counts"].get("resources_patient"))
+        add("pg_unindexed_patients", "hard", counts["counts"].get("unindexed_patients") == 0,
+            0, counts["counts"].get("unindexed_patients"))
+
+        # HTTP exactness (the bare count is storage-only; the family search is indexed)
+        add("http_storage_total", "hard", self.search_count("") == total, total, self.search_count(""))
+        family_total = self.search_count(f"family={FAMILY}")
+        add("http_family_search", "hard", family_total == total, total, family_total)
+        active_total = self.search_count("active=true")
+        add("http_active_search", "hard", active_total == self.expected_active(),
+            self.expected_active(), active_total)
+        middle_file, middle_offset = sample_points[1]
+        identifier_total = self.search_count(
+            "identifier="
+            + urllib.parse.quote(f"{MRN_SYSTEM}|MRN-{middle_file}-{middle_offset}", safe="")
+        )
+        add("http_identifier_search", "hard", identifier_total == 1, 1, identifier_total)
+
+        # Supplemental: three sampled resources over HTTP, including meta version.
+        for resource_id in sampled:
+            response = http_json("GET", f"{self.base_url}/Patient/{resource_id}")
+            stored = response["json"] if isinstance(response["json"], dict) else {}
+            wanted = self._expected_for_id(resource_id)
+            matches = bool(wanted) and all(stored.get(key) == value for key, value in wanted.items())
+            version = str((stored.get("meta") or {}).get("versionId", ""))
+            add(f"http_sample_{resource_id}", "hard",
+                response["status"] == 200 and matches and version == str(job),
+                {"content": "matches fixture", "version": job},
+                {"status": response["status"], "version": version})
+
+        entry_results = detail["data"].get("entry_results", [])
+        receipt_ok = (
+            len(entry_results) == 1
+            and entry_results[0][0] == "success"
+            and int(entry_results[0][2]) == total
+            and entry_results[0][1] == ("true" if job == 1 else "false")
+        )
+        add("pg_entry_results", "hard", receipt_ok,
+            {"outcome": "success", "created": job == 1, "count": total}, entry_results)
+        changes = detail["data"].get("changes", [])
+        if job == 1:
+            changes_ok = len(changes) == 1 and changes[0][0] == "create" and int(changes[0][3]) == total
+            expected_changes = {"change_type": "create", "count": total}
+        else:
+            changes_ok = (
+                len(changes) == 1
+                and changes[0][0] == "update"
+                and changes[0][1] == str(job - 1)
+                and changes[0][2] == str(job)
+                and int(changes[0][3]) == total
+            )
+            expected_changes = {
+                "change_type": "update",
+                "previous_version": job - 1,
+                "new_version": job,
+                "count": total,
+            }
+        add("pg_submission_changes", "hard", changes_ok, expected_changes, changes)
+        manifests = detail["data"].get("manifests", [])
+        add("pg_manifests_terminal", "hard",
+            bool(manifests) and all(row[1] == "completed" for row in manifests),
+            "every manifest completed", manifests)
+
+        result = {
+            "job": job,
+            "submission_id": submission_id,
+            "label": "post_idle_validation",
+            "duration_s": round(mono() - started, 3),
+            "checks": checks,
+            "receipts": receipts,
+            "pg_detail": detail,
+            "pg_counts": counts,
+            "sampled_ids": sampled,
+            "version_distribution": dict(version_distribution),
+            "history_ids": len(history_counts),
+        }
+        self.write_json(f"jobs/job{job:02d}/validation.json", result)
+        self.phase(
+            "validation_end",
+            job,
+            {
+                "checks": len(checks),
+                "failed_hard": len([c for c in checks if c["kind"] == "hard" and not c["ok"]]),
+                "failed_soft": len([c for c in checks if c["kind"] == "soft" and not c["ok"]]),
+                "duration_s": result["duration_s"],
+            },
+        )
+        return result
+
+    def _expected_for_id(self, resource_id: str) -> dict[str, Any]:
+        match = re.fullmatch(r"p995-(\d+)-(\d+)", resource_id)
+        if not match:
+            return {}
+        file_index, offset = int(match.group(1)), int(match.group(2))
+        return self.patient_resource(file_index, offset)
+
+    # -- job / run orchestration ------------------------------------------
+
+    def run_job(self, job: int) -> None:
+        submission_id = f"{SUBMITTER_VALUE}-{self.run_id}-j{job}"
+        total = self.expected_total()
+        attempt: dict[str, Any] = {
+            "ordinal": job,
+            "submission_id": submission_id,
+            "mode": self.args.mode,
+            "defer_indexing": bool(self.args.defer_indexing),
+            "status": "running",
+            "timings": {"label": "incomplete", "comparable": False},
+            "throughput_resources_per_s": None,
+        }
+        self.current_attempt = attempt
+        self.attempts.append(attempt)
+        if self.args.mode == "restart" or self.hfs is None:
+            self.start_hfs(job)
+        manifest_url = self.ensure_fixtures(job)
+        baseline = self.phase(
+            "prekickoff_baseline",
+            job,
+            {
+                "submission_id": submission_id,
+                "validation_effects": job > 1,
+                "manifest": str(Path(manifest_url).name),
+            },
+        )
+        log_offset = self.follower.seek_end()
+        self.phase("kickoff", job, {"submission_id": submission_id})
+        kickoff_mono = mono()
+        kickoff = self.kickoff(submission_id, manifest_url)
+        self.write_json(
+            f"jobs/job{job:02d}/kickoff.json",
+            {"submission_id": submission_id, "status": kickoff["status"], "body": kickoff["json"]},
+        )
+        if kickoff["status"] != 200:
+            raise Aborted(
+                "kickoff_failed",
+                {"status": kickoff["status"], "body": kickoff["json"], "error": kickoff["error"]},
+            )
+        self.phase("kickoff_accepted", job, {"submission_id": submission_id, "status": kickoff["status"]})
+        terminal = self.poll_terminal(job, submission_id, kickoff_mono)
+        attempt["timings"]["kickoff_to_terminal_s"] = terminal["terminal_s"]
+        declared = sum(int(entry.get("count") or 0) for entry in terminal["output"])
+        self.phase(
+            "submit_terminal",
+            job,
+            {
+                "submission_id": submission_id,
+                "terminal_s": terminal["terminal_s"],
+                "pages": terminal["pages"],
+                "declared_count": declared,
+                "outcome_entries": len(terminal["outcome"]),
+                "deleted_entries": len(terminal["deleted"]),
+            },
+        )
+        self.write_json(
+            f"jobs/job{job:02d}/submit-terminal.json",
+            {
+                "submission_id": submission_id,
+                "terminal_s": terminal["terminal_s"],
+                "polls": terminal["polls"],
+                "output": terminal["output"],
+                "outcome": terminal["outcome"],
+                "deleted": terminal["deleted"],
+            },
+        )
+        if declared != self.expected_total():
+            raise Aborted("manifest_count_mismatch", {"declared": declared, "expected": self.expected_total()})
+        if terminal["outcome"]:
+            raise Aborted("manifest_reports_outcome_entries", {"outcome": terminal["outcome"][:3]})
+        if terminal["deleted"]:
+            raise Aborted("manifest_reports_deleted_entries", {"deleted": terminal["deleted"][:3]})
+        attempt["manifest"] = {
+            "pages": terminal["pages"],
+            "declared_count": declared,
+            "output_entries": len(terminal["output"]),
+            "outcome_entries": len(terminal["outcome"]),
+            "deleted_entries": len(terminal["deleted"]),
+            "transaction_time": (terminal["manifest"] or {}).get("transactionTime"),
+            "requires_access_token": (terminal["manifest"] or {}).get("requiresAccessToken"),
+        }
+        reindex = self.verify_reindex(job, submission_id, log_offset, kickoff_mono)
+        self.phase("reindex_terminal", job, {
+            "job_id": reindex.get("job_id"), "verified": reindex["verified"],
+            "deferred": bool(self.args.defer_indexing),
+        })
+        attempt["reindex"] = reindex
+        attempt["timings"]["kickoff_to_reindex_s"] = reindex["reindex_s"]
+        self.write_json(f"jobs/job{job:02d}/reindex.json", reindex)
+        idle_end = self.idle(job)
+        validation = self.validate_job(job, submission_id, terminal["output"])
+        attempt["validation"] = {
+            "duration_s": validation["duration_s"],
+            "failed_hard": [c["name"] for c in validation["checks"] if c["kind"] == "hard" and not c["ok"]],
+            "failed_soft": [c["name"] for c in validation["checks"] if c["kind"] == "soft" and not c["ok"]],
+            "version_distribution": validation["version_distribution"],
+            "history_ids": validation["history_ids"],
+        }
+        attempt["receipts"] = {
+            "ok": validation["receipts"]["ok"],
+            "output_entries": validation["receipts"]["output_entries"],
+            "references": validation["receipts"]["references"],
+            "checked_after": "idle_end (validation phase)",
+        }
+        attempt["rss"] = self.rss_stats(job, kickoff_mono, idle_end, baseline["rss_mib"])
+        if self.args.mode == "restart":
+            self.stop_hfs(job, "job_complete")
+        self.write_summary()
+        # A failed validation stops the run: the next job would build on an
+        # unverified database state.
+        if attempt["validation"]["failed_hard"]:
+            attempt["status"] = "failed"
+            raise Aborted(
+                "hard_validation_failed",
+                {"job": job, "checks": attempt["validation"]["failed_hard"]},
+            )
+        attempt["timings"].update({"label": "complete", "comparable": True, "verified": True})
+        attempt["status"] = "verified"
+        attempt["throughput_resources_per_s"] = round(total / max(terminal["terminal_s"], 0.001), 3)
+
+    def rss_stats(self, job: int, start: float, end: float, baseline: Optional[float]) -> dict[str, Any]:
+        """Measured window is kickoff..idle_end; startup and validation are separate."""
+        rows = [row for row in self.rss_rows if row.get("job") == job]
+
+        def block(values: list[float], base: Optional[float] = None) -> dict[str, Any]:
+            if not values:
+                return {"samples": 0}
+            return {
+                "samples": len(values),
+                "first_mib": values[0],
+                "peak_mib": max(values),
+                "last_mib": values[-1],
+                "delta_peak_mib": None if base is None else round(max(values) - base, 1),
+            }
+
+        measured = [row["rss_mib"] for row in rows if start <= row["mono_s"] <= end]
+        return {
+            "measured_window": {
+                **block(measured, baseline),
+                "baseline_mib": baseline,
+                "window": "kickoff..idle_end",
+            },
+            "startup_window": block([row["rss_mib"] for row in rows if row["mono_s"] < start]),
+            "validation_window": block([row["rss_mib"] for row in rows if row["mono_s"] > end]),
+        }
+
+    def mark_attempt_incomplete(self, reason: str) -> None:
+        attempt = self.current_attempt
+        if not attempt or attempt.get("status") not in ("running",):
+            return
+        attempt["status"] = "unverified" if "reindex" in reason else "failed"
+        attempt["failure_reason"] = reason
+        attempt["timings"].update({"label": "incomplete", "comparable": False, "verified": False})
+        attempt["throughput_resources_per_s"] = None
+        attempt["rss"] = self.rss_stats(attempt["ordinal"], 0.0, float("inf"), None)
+
+    def hard_failures(self) -> list[dict[str, Any]]:
+        return [check for check in self.checks if check["kind"] == "hard" and not check["ok"]]
+
+    def write_summary(self) -> None:
+        write_json_atomic(
+            self.out / "summary.json",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "updated": iso_now(),
+                "attempts": self.attempts,
+                "phases": len(self.phases),
+                "stops": self.stops,
+                "hard_failures": [c["name"] for c in self.hard_failures()],
+            },
+        )
+
+    def cleanup(self) -> None:
+        if self.sampler is not None:
+            self.sampler.stop()
+            self.sampler.join(timeout=60)
+            self.sampler = None
+        if self.hfs is not None:
+            stopped = self.hfs.stop()
+            if self.log:
+                self.log.line("hfs_stopped", reason="cleanup", **stopped)
+            self.hfs = None
+        if self.provider is not None:
+            self.provider.stop()
+            self.provider = None
+        for writer in (
+            self.csv_rss, self.csv_host, self.csv_phase, self.csv_docker,
+            self.jsonl_phase, self.jsonl_pg, self.jsonl_stops,
+        ):
+            if writer is not None:
+                writer.close()
+        self.csv_rss = self.csv_host = self.csv_phase = self.csv_docker = None
+        self.jsonl_phase = self.jsonl_pg = self.jsonl_stops = None
+
+    def finish(self, status: str, exit_code: int, reason: Optional[str]) -> None:
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "status": status,
+            "exit_code": exit_code,
+            "reason": reason,
+            "controller": {"path": str(Path(__file__).resolve()), "python": sys.version},
+            "config": {
+                "binary": str(self.binary),
+                "output_dir": str(self.out),
+                "repo_root": str(self.repo_root),
+                "resources": self.args.resources,
+                "jobs": self.args.jobs,
+                "mode": self.args.mode,
+                "defer_indexing": bool(self.args.defer_indexing),
+                "idle_seconds": self.args.idle_seconds,
+                "file_concurrency": self.args.file_concurrency,
+                "pg_container": self.args.pg_container,
+                "database_url": redact_db_url(self.args.database_url),
+                "hfs_env": {
+                    key: (redact_db_url(value) if key == "HFS_DATABASE_URL" else value)
+                    for key, value in self.effective_env().items()
+                },
+                "watchdog": {
+                    "operational_max_rss_mib": self.args.operational_max_rss_mib,
+                    "pressure_samples": self.args.pressure_samples,
+                    "swap_growth_mib": self.args.swap_growth_mib,
+                    "swap_growth_samples": self.args.swap_growth_samples,
+                    "deadline_s": self.args.deadline,
+                },
+                "timers": {
+                    "startup_timeout_s": self.args.startup_timeout,
+                    "terminal_timeout_s": self.args.terminal_timeout,
+                    "reindex_timeout_s": self.args.reindex_timeout,
+                    "endpoint_poll_interval_s": self.args.endpoint_poll_interval,
+                    "sample_interval_s": self.args.sample_interval,
+                    "host_interval_s": self.args.host_interval,
+                    "docker_stats_interval_s": self.args.docker_stats_interval,
+                },
+            },
+            "preflight": self.preflight_info,
+            "fixture": {
+                key: value
+                for key, value in self.fixture_info.items()
+                if key != "files"
+            }
+            | {"files": [
+                {key: value for key, value in entry.items() if key != "ids"}
+                for entry in self.fixture_info.get("files", [])
+            ]},
+            "phases": self.phases,
+            "attempts": self.attempts,
+            "checks": self.checks,
+            "stops": self.stops,
+        }
+        write_json_atomic(self.out / "run.json", payload)
+        self.write_summary()
+        if self.log:
+            self.log.line("run_end", status=status, exit_code=exit_code, reason=reason)
+            self.log.close()
+
+    # -- top level --------------------------------------------------------
+
+    def install_signal_handlers(self) -> None:
+        def handler(signum: int, _frame: Any) -> None:
+            self.signal_number = signum
+            with self.lock:
+                if self.abort is None:
+                    self.abort = {"reason": f"signal:{signum}", "detail": {}}
+            if self.hfs is not None:
+                self.hfs.stop(grace_seconds=5.0)
+            if self.log:
+                self.log.line("signal_received", signal=signum)
+
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            try:
+                signal.signal(signum, handler)
+            except (ValueError, OSError):
+                pass
+
+    def run(self) -> int:
+        try:
+            self.prepare_outputs()
+        except ConfigError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return EXIT_CONFIG
+        self.install_signal_handlers()
+        status, exit_code, reason = "ok", EXIT_OK, None
+        try:
+            info = self.preflight()
+            if info["blocked"]:
+                raise Aborted("preflight_blocked", {"reasons": info["block_reasons"]})
+            fixture_plan = {
+                "files": [
+                    {"name": f"patients-{index}.ndjson", "count": len(offsets)}
+                    for index, offsets in enumerate(self.file_offsets())
+                ],
+                "total": self.expected_total(),
+            }
+            self.log.line("fixture_plan", plan=json.dumps(fixture_plan))
+            self.provider = FixtureProvider(
+                self.fixtures_dir, self.args.provider_port, self.log, self.out / "provider.log"
+            )
+            self.provider_base = self.provider.start()
+            self.sampler = Sampler(self)
+            self.sampler.start()
+            for job in range(1, self.args.jobs + 1):
+                self.run_job(job)
+        except Aborted as exc:
+            reason = exc.reason
+            self.mark_attempt_incomplete(exc.reason)
+            if exc.reason == "preflight_blocked":
+                status, exit_code = "preflight_blocked", EXIT_PREFLIGHT
+            elif exc.reason == "hard_validation_failed":
+                status, exit_code = "aborted", EXIT_VALIDATION
+            elif self.signal_number is not None:
+                status, exit_code = "interrupted", 128 + self.signal_number
+            else:
+                status, exit_code = "aborted", EXIT_ABORTED
+            if self.log:
+                self.log.line("run_aborted", reason=reason, detail=json.dumps(exc.detail, default=str))
+        except ConfigError as exc:
+            status, exit_code, reason = "config_error", EXIT_CONFIG, str(exc)
+            print(f"ERROR: {exc}", file=sys.stderr)
+        except KeyboardInterrupt:
+            status, exit_code, reason = "interrupted", 130, "keyboard interrupt"
+        except Exception as exc:
+            status, exit_code, reason = "failed", EXIT_CONFIG, f"{type(exc).__name__}: {exc}"
+            if self.log:
+                self.log.line("run_failed", error=reason)
+        finally:
+            self.phase("series_end", self.current_job, {"status": status, "reason": reason})
+            self.cleanup()
+        if status == "ok" and self.args.strict_validation and self.hard_failures():
+            failures = [check["name"] for check in self.hard_failures()]
+            status, exit_code = "validation_failed", EXIT_VALIDATION
+            reason = f"hard validation checks failed: {', '.join(failures)}"
+        self.finish(status, exit_code, reason)
+        verified = [attempt for attempt in self.attempts if attempt.get("status") == "verified"]
+        print(
+            f"\n{status}: {len(verified)}/{len(self.attempts)} attempt(s) verified; "
+            f"artifacts in {self.out}"
+        )
+        return exit_code
+
+
+def _usage_mib(value: str) -> Optional[float]:
+    match = re.match(r"\s*([0-9.]+)\s*([kKmMgG]?i?B)", value or "")
+    if not match:
+        return None
+    number = float(match.group(1))
+    unit = match.group(2).lower()
+    if unit.startswith("b"):
+        return round(number / 1024 / 1024, 1)
+    if unit.startswith("k"):
+        return round(number / 1024, 1)
+    if unit.startswith("g"):
+        return round(number * 1024, 1)
+    return round(number, 1)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def parse_bool(value: str) -> bool:
+    normalised = str(value).strip().lower()
+    if normalised in ("1", "true", "yes", "on"):
+        return True
+    if normalised in ("0", "false", "no", "off"):
+        return False
+    raise argparse.ArgumentTypeError(f"expected true or false, got {value!r}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Drive $bulk-submit imports of a deterministic Patient corpus against a "
+            "dedicated PostgreSQL container and record external RSS/pressure/DB evidence."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--binary", required=True, help="release hfs binary (R4+postgres)")
+    parser.add_argument("--output-dir", required=True, help="new, nonexistent output directory")
+    parser.add_argument("--resources", type=int, default=1000, help="Patients per submission")
+    parser.add_argument("--jobs", type=int, default=1, help="submissions in this run")
+    parser.add_argument("--mode", choices=("consecutive", "restart"), default="consecutive")
+    parser.add_argument(
+        "--defer-indexing", type=parse_bool, default=True,
+        help="HFS_BULK_SUBMIT_DEFER_INDEXING for the measured server",
+    )
+    parser.add_argument("--idle-seconds", type=float, default=60.0)
+    parser.add_argument("--file-concurrency", type=int, default=1)
+    parser.add_argument("--pg-container", required=True, help="dedicated PostgreSQL container")
+    parser.add_argument("--database-url", required=True, help="host-reachable PostgreSQL URL")
+    parser.add_argument("--pg-user", help="psql -U (default: from the URL)")
+    parser.add_argument("--pg-db", help="psql -d (default: from the URL)")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--hfs-port", type=int, default=0, help="0 picks a free loopback port")
+    parser.add_argument("--provider-port", type=int, default=0, help="0 starts at 19200")
+    parser.add_argument("--hfs-log-level", default="info")
+    parser.add_argument("--sample-interval", type=float, default=0.5, help="HFS RSS cadence, seconds")
+    parser.add_argument("--host-interval", type=float, default=5.0, help="host vitals cadence, seconds")
+    parser.add_argument("--docker-stats-interval", type=float, default=60.0, help="0 disables")
+    parser.add_argument("--endpoint-poll-interval", type=float, default=1.0)
+    parser.add_argument("--request-timeout", type=float, default=60.0)
+    parser.add_argument("--startup-timeout", type=float, default=180.0)
+    parser.add_argument("--terminal-timeout", type=float, default=3600.0)
+    parser.add_argument("--reindex-timeout", type=float, default=900.0)
+    parser.add_argument("--deadline", type=float, default=10800.0, help="whole-run watchdog, seconds")
+    parser.add_argument("--preflight-samples", type=int, default=5)
+    parser.add_argument("--preflight-interval", type=float, default=5.0, help="settle between preflight samples")
+    parser.add_argument("--operational-max-rss-mib", type=float, default=1536.0)
+    parser.add_argument("--pressure-samples", type=int, default=6, help="consecutive non-normal pressure samples")
+    parser.add_argument("--swap-growth-mib", type=float, default=256.0)
+    parser.add_argument("--swap-growth-samples", type=int, default=3)
+    parser.add_argument("--allow-nonempty-db", action="store_true", help="skip the fresh-database gate")
+    parser.add_argument("--strict-validation", dest="strict_validation", action="store_true", default=True)
+    parser.add_argument("--no-strict-validation", dest="strict_validation", action="store_false")
+    parser.add_argument("--repo-root", help="checkout root containing data/ (default: derived)")
+    parser.add_argument("--hfs-env", action="append", default=[], metavar="KEY=VALUE")
+    parser.add_argument("--dry-run", action="store_true", help="print the plan and exit")
+    parser.add_argument("--quiet", action="store_true", help="do not echo controller events to stdout")
+    return parser
+
+
+def dry_run_plan(args: argparse.Namespace) -> dict[str, Any]:
+    repo_root = (
+        Path(args.repo_root).expanduser().resolve()
+        if args.repo_root
+        else Path(__file__).resolve().parents[4]
+    )
+    per_file = args.resources // FIXTURE_FILE_COUNT
+    layout = [per_file] * FIXTURE_FILE_COUNT
+    for _ in range(per_file * FIXTURE_FILE_COUNT, args.resources):
+        layout[-1] += 1
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "dry_run": True,
+        "binary": str(Path(args.binary).expanduser().resolve()),
+        "output_dir": str(Path(args.output_dir).expanduser().resolve()),
+        "repo_root": str(repo_root),
+        "search_parameters_file": str(repo_root / "data" / "search-parameters-r4.json"),
+        "fixture": {
+            "files": [
+                {"name": f"patients-{index}.ndjson", "count": count, "ids": f"p995-{index}-0..{count - 1}"}
+                for index, count in enumerate(layout)
+            ],
+            "total": args.resources,
+            "family": FAMILY,
+            "mrn_system": MRN_SYSTEM,
+        },
+        "jobs": args.jobs,
+        "mode": args.mode,
+        "defer_indexing": bool(args.defer_indexing),
+        "database": redact_db_url(args.database_url),
+        "pg_container": args.pg_container,
+        "watchdog": {
+            "operational_max_rss_mib": args.operational_max_rss_mib,
+            "pressure_samples": args.pressure_samples,
+            "swap_growth_mib": args.swap_growth_mib,
+            "swap_growth_samples": args.swap_growth_samples,
+            "deadline_s": args.deadline,
+        },
+        "verification": [
+            "submit terminal 200 for every manifest page, outcome/deleted empty, declared counts match",
+            "receipt artifact download: exact aggregate Patient id set (one receipt per resource type)",
+            "deferred reindex job id from the hfs log line, $reindex-status completed with errorCount=0 and processed=total",
+            "SQL coverage: zero unindexed Patients, parameterised family search equals the expected total",
+            "post-idle: version/history spread, content, entry_results receipts, submission changes",
+        ],
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.resources < FIXTURE_FILE_COUNT:
+        parser.error(f"--resources must be >= {FIXTURE_FILE_COUNT}")
+    if args.jobs < 1:
+        parser.error("--jobs must be >= 1")
+    if args.file_concurrency < 1:
+        parser.error("--file-concurrency must be >= 1")
+    if args.sample_interval <= 0 or args.host_interval <= 0:
+        parser.error("--sample-interval and --host-interval must be > 0")
+    if args.pressure_samples < 1 or args.swap_growth_samples < 1:
+        parser.error("--pressure-samples and --swap-growth-samples must be >= 1")
+    if args.dry_run:
+        print(json.dumps(dry_run_plan(args), indent=2))
+        return EXIT_OK
+    try:
+        args.hfs_port = args.hfs_port or pick_free_port(18810, args.host)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
+    return Controller(args).run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/hfs/tests/bulk_submit/measure_retention.py
+++ b/crates/hfs/tests/bulk_submit/measure_retention.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""#995 diagnostic campaign: instrumented manager inventory and sparse malloc snapshots.
+
+Uses the same CLI as measure_memory.py. Requires its temporary Rust probe patch
+and HFS_995_RETENTION_PROBE=1. Does not enable cleanup or change ingestion.
+"""
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import measure_memory as m
+
+
+class RetentionController(m.Controller):
+    def snapshot(self, job, label):
+        out = self.out / "retention"
+        out.mkdir(exist_ok=True)
+        driver = Path(__file__).resolve()
+        self.write_json("retention/driver.json", {
+            "path": str(driver), "sha256": hashlib.sha256(driver.read_bytes()).hexdigest(),
+            "checkpoints": "startup job 1; postidle jobs 1, every 5, and final",
+            "timings_comparable_to_uninstrumented": False,
+        })
+        pid = self.hfs.pid
+        for name, command in [
+            ("footprint", ["/usr/bin/footprint", "-p", str(pid), "--swapped", "--noCategories"]),
+            ("vmmap", ["/usr/bin/vmmap", "-summary", str(pid)]),
+            ("heap", ["/usr/bin/heap", "-s", "--noContent", str(pid)]),
+        ]:
+            self.raise_if_aborted()
+            started = time.monotonic()
+            record = {"job": job, "label": label, "pid": pid, "command": command,
+                      "wall_iso": m.iso_now(), "mono_s": started}
+            raw = out / f"job{job:02d}-{label}-{name}.txt"
+            try:
+                with raw.open("w") as output:
+                    result = subprocess.run(command, stdout=output, stderr=subprocess.STDOUT, timeout=15)
+                record["returncode"] = result.returncode
+            except subprocess.TimeoutExpired:
+                record["timeout"] = True
+            except OSError as exc:
+                record["error"] = str(exc)
+            record.update(duration_s=time.monotonic() - started, raw=str(raw))
+            with (out / "snapshots.jsonl").open("a") as output:
+                output.write(json.dumps(record) + "\n")
+            if record.get("returncode") != 0:
+                raise m.Aborted("retention_snapshot_failed", record)
+
+    def inventory(self, job):
+        job_id = self.current_attempt["reindex"]["job_id"]
+        log_path = self.hfs.log_path
+        offset = log_path.stat().st_size
+        response = m.http_json("GET", f"{self.base_url}/$reindex-status/{job_id}")
+        params = m.parameters_map(response["json"]) if response["status"] == 200 else {}
+        if params.get("status") != "completed":
+            raise m.Aborted("retention_job_not_quiescent", {"status": response["status"], "parameters": params})
+        deadline = m.mono() + 5
+        matches = []
+        while m.mono() < deadline:
+            self.raise_if_aborted()
+            with log_path.open("rb") as log:
+                log.seek(offset)
+                lines = log.read().decode(errors="replace").splitlines()
+            matches = [line for line in lines if "[DEBUG-995-retention]" in line and job_id in line]
+            if matches:
+                break
+            time.sleep(0.05)
+        if len(matches) != 1:
+            raise m.Aborted("retention_inventory_missing_or_ambiguous", {"job": job, "matches": matches})
+        fields = {key: int(value) for key, value in re.findall(r"\b(\w+)=(\d+)\b", matches[0])}
+        required = {"jobs_len", "jobs_capacity", "finished_jobs", "channels_len", "channels_capacity",
+                    "closed_channels", "occupied_entry_bytes", "owned_buffer_capacity_bytes"}
+        if not required.issubset(fields):
+            raise m.Aborted("retention_inventory_parse_failed", {"raw": matches[0], "fields": fields})
+        record = {"job": job, "pid": self.hfs.pid, "mode": self.args.mode,
+                  "wall_iso": m.iso_now(), "mono_s": m.mono(), "job_id": job_id,
+                  "fields": fields, "raw": matches[0], "sample_point": "after idle before heap and validation"}
+        with (self.out / "retention-inventory.jsonl").open("a") as output:
+            output.write(json.dumps(record) + "\n")
+        self.log.line("retention_inventory", job=job, **fields)
+
+    def phase(self, name, job, extra=None):
+        result = super().phase(name, job, extra)
+        if name == "prekickoff_baseline" and job == 1:
+            self.snapshot(job, "startup")
+        return result
+
+    def idle(self, job):
+        result = super().idle(job)
+        self.inventory(job)
+        if job == 1 or job % 5 == 0 or job == self.args.jobs:
+            self.snapshot(job, "postidle")
+        return result
+
+
+if __name__ == "__main__":
+    m.Controller = RetentionController
+    sys.exit(m.main())

--- a/crates/hfs/tests/bulk_submit/summarize_memory.py
+++ b/crates/hfs/tests/bulk_submit/summarize_memory.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Render retained #995 series as Markdown, including unsuccessful attempts."""
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from statistics import mean
+
+
+def number(value):
+    return "—" if value is None else f"{value:.1f}"
+
+
+def summarize(directory):
+    run = json.loads((directory / "run.json").read_text())
+    with (directory / "rss.csv").open() as source:
+        samples = list(csv.DictReader(source))
+    with (directory / "host.csv").open() as source:
+        host = list(csv.DictReader(source))
+    config = run["config"]
+    print(f"### {directory.name}\n")
+    print(f"Result: **{run['status']}**. Mode: `{config['mode']}`; "
+          f"deferred indexing: `{config['defer_indexing']}`; "
+          f"resources per submission: {config['resources']:,}.\n")
+    print("| Job | Status | Pre-kickoff MiB | Sampled peak MiB | Post-idle MiB | "
+          "Last 10 s mean MiB | Validation peak MiB | Submit s | Reindex verified s |")
+    print("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    for attempt in run.get("attempts", []):
+        job = attempt["ordinal"]
+        phases = {p["phase"]: p for p in run.get("phases", []) if p["job"] == job}
+        idle = phases.get("idle_end", {})
+        end = idle.get("mono_s")
+        last = [float(row["rss_mib"]) for row in samples
+                if int(row["job"]) == job and end is not None
+                and end - 10 <= float(row["mono_s"]) <= end]
+        rss = attempt.get("rss", {})
+        measured = rss.get("measured_window", {})
+        times = attempt.get("timings", {})
+        values = [job, attempt["status"],
+                  number(phases.get("prekickoff_baseline", {}).get("rss_mib")),
+                  number(measured.get("peak_mib")), number(idle.get("rss_mib")),
+                  number(mean(last) if last else None),
+                  number(rss.get("validation_window", {}).get("peak_mib")),
+                  number(times.get("kickoff_to_terminal_s")),
+                  number(times.get("kickoff_to_reindex_s"))]
+        print("| " + " | ".join(map(str, values)) + " |")
+    intervals = [float(b["mono_s"]) - float(a["mono_s"])
+                 for a, b in zip(samples, samples[1:])
+                 if a["pid"] == b["pid"] and a["job"] == b["job"]]
+    swap = [float(row["swapout_bytes_since_start"]) / 1024**2
+            for row in host if row.get("swapout_bytes_since_start")]
+    pressure = sorted({row["pressure_level"] for row in host if row.get("pressure_level")})
+    failed = [c["name"] for c in run.get("checks", []) if not c["ok"]]
+    print(f"\nRSS samples: {len(samples)}; maximum within-job sampling gap: "
+          f"{number(max(intervals) if intervals else None)} s. "
+          f"Maximum new host swapouts: {number(max(swap) if swap else None)} MiB. "
+          f"Host pressure levels: {', '.join(pressure) or 'unavailable'}.\n")
+    print(f"Failed checks: {', '.join(failed) or 'none'}. "
+          f"Stop records: {len(run.get('stops', []))}.\n")
+    if run.get("reason"):
+        print(f"Reason: {run['reason']}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("series", nargs="+", type=Path)
+    args = parser.parse_args()
+    print("# Current-code bulk-submit memory observations\n")
+    print("RSS is resident memory, not a live-allocation measurement. "
+          "Peaks below are sampled lower bounds. Validation follows the idle "
+          "window and can affect the next job's baseline. Job 1 creates the "
+          "corpus; subsequent jobs reimport it and grow history. "
+          "Times are external observations, not internal stage durations.\n")
+    for directory in args.series:
+        summarize(directory)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/hfs/tests/bulk_submit/summarize_retention.py
+++ b/crates/hfs/tests/bulk_submit/summarize_retention.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Summarize #995 inventories and successful malloc snapshots, preserving units."""
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def report(path, released_channels=False):
+    run = json.loads((path / "run.json").read_text())
+    config = run["config"]
+    inventory_path = path / "retention-inventory.jsonl"
+    inventories = [json.loads(line) for line in inventory_path.read_text().splitlines()] if inventory_path.exists() else []
+    samples_path = path / "retention/snapshots.jsonl"
+    samples = [json.loads(line) for line in samples_path.read_text().splitlines()] if samples_path.exists() else []
+    verified = sum(attempt["status"] == "verified" for attempt in run["attempts"])
+    print(f"\n## {path.name}\n")
+    print(f"Run: **{run['status']}**; mode `{config['mode']}`; {config['resources']:,} resources/job; "
+          f"{verified}/{config['jobs']} verified; idle {config['idle_seconds']:g} seconds.\n")
+    print("| Job | PID | Jobs / finished | Channels / closed | Map capacities jobs / channels | Occupied entry bytes | Owned buffer capacity bytes |")
+    print("| --- | ---: | ---: | ---: | ---: | ---: | ---: |")
+    for row in inventories:
+        f = row["fields"]
+        print(f"| {row['job']} | {row['pid']} | {f['jobs_len']} / {f['finished_jobs']} | "
+              f"{f['channels_len']} / {f['closed_channels']} | {f['jobs_capacity']} / {f['channels_capacity']} | "
+              f"{f['occupied_entry_bytes']:,} | {f['owned_buffer_capacity_bytes']:,} |")
+    complete = run["status"] == "ok" and verified == config["jobs"] and len(inventories) == config["jobs"]
+    expected = lambda row: row["job"] if config["mode"] == "consecutive" else 1
+    signature = bool(inventories) and all(
+        row["fields"]["jobs_len"] == min(expected(row), 1024) if released_channels else row["fields"]["jobs_len"] == expected(row)
+        for row in inventories
+    ) and all(
+        row["fields"]["finished_jobs"] == row["fields"]["jobs_len"]
+        and row["fields"]["channels_len"] == (0 if released_channels else expected(row))
+        and row["fields"]["closed_channels"] == (0 if released_channels else expected(row))
+        for row in inventories
+    )
+    expectation = "retained polling status with no cancellation channels" if released_channels else (
+        "one retained entry per job" if config["mode"] == "consecutive" else "one entry after each restart")
+    print(f"\nComplete validated inventory: **{complete}**. "
+          f"Observed counts match {expectation}: **{signature}**.\n")
+    print("| Snapshot | Malloc blocks | Malloc bytes | Physical footprint reported by heap |")
+    print("| --- | ---: | ---: | ---: |")
+    failures = []
+    heap_rows = []
+    for sample in samples:
+        if sample.get("returncode") != 0 or sample.get("timeout"):
+            failures.append(sample)
+            continue
+        if Path(sample["command"][0]).name != "heap":
+            continue
+        raw = (path / "retention" / Path(sample["raw"]).name).read_text()
+        sizes = re.search(r"All zones: (\d+) nodes \((\d+) bytes\)", raw)
+        footprint = re.search(r"Physical footprint:\s*(\S+)", raw)
+        if not sizes or not footprint:
+            failures.append({"parse_failure": sample["raw"]})
+            continue
+        nodes, allocated = map(int, sizes.groups())
+        heap_rows.append((sample["job"], sample["label"], allocated, nodes))
+        print(f"| Job {sample['job']} {sample['label']} | {nodes:,} | {allocated:,} | {footprint[1]} |")
+    postidle = sorted(row for row in heap_rows if row[1] == "postidle")
+    if len(postidle) >= 2:
+        print(f"\nPost-idle malloc delta job {postidle[0][0]} → {postidle[-1][0]}: "
+              f"**{postidle[-1][2] - postidle[0][2]:+,} bytes**, "
+              f"**{postidle[-1][3] - postidle[0][3]:+,} blocks**.")
+    print(f"\nTool calls: {len(samples)}; failed calls/parses: {len(failures)}.")
+    if failures:
+        print("Failures: " + json.dumps(failures))
+
+
+if __name__ == "__main__":
+    print("# #995 repeated-job retention observations\n")
+    print("Inventories are sampled after verified reindex and idle, before heap inspection and validation. "
+          "Byte fields account for occupied inline entries and owned buffer capacities only; they exclude "
+          "HashMap bucket allocations, channel internals and allocator overhead. Malloc snapshots do not "
+          "cover every process allocation. RSS/footprint are separate metrics. This summarizer does not modify captured state.")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expect-released-channels", action="store_true",
+                        help="expect the fixed lifecycle: status retained, channels removed")
+    parser.add_argument("directories", nargs="+", type=Path)
+    args = parser.parse_args()
+    for directory in args.directories:
+        report(directory, args.expect_released_channels)

--- a/crates/persistence/src/search/reindex.rs
+++ b/crates/persistence/src/search/reindex.rs
@@ -5,6 +5,8 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use parking_lot::RwLock;
@@ -415,6 +417,97 @@ struct ReindexAudit {
     source_observer: String,
 }
 
+// Terminal status is a polling window, not a permanent in-memory job archive.
+const REINDEX_STATUS_RETENTION_SECONDS: i64 = 24 * 60 * 60;
+const MAX_RETAINED_REINDEX_STATUSES: usize = 1024;
+const REINDEX_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+
+type ReindexJobs = RwLock<HashMap<String, ReindexProgress>>;
+type ReindexChannels = RwLock<HashMap<String, mpsc::Sender<()>>>;
+
+/// Only tasks that have exited are eligible, including after cancellation was
+/// already reported to the client. All paths acquire jobs before channels and
+/// release their guards before awaiting or calling external code.
+fn cleanup_reindex_jobs(jobs: &ReindexJobs, channels: &ReindexChannels, max_age_seconds: i64) {
+    let cutoff = chrono::Utc::now() - chrono::Duration::seconds(max_age_seconds);
+    let mut jobs = jobs.write();
+    let channels = channels.read();
+    jobs.retain(|id, progress| {
+        channels.contains_key(id)
+            || !progress.status.is_finished()
+            || progress
+                .completed_at
+                .as_deref()
+                .and_then(|at| chrono::DateTime::parse_from_rfc3339(at).ok())
+                .is_none_or(|at| at >= cutoff)
+    });
+    let eligible = jobs
+        .iter()
+        .filter(|(id, p)| p.status.is_finished() && !channels.contains_key(*id))
+        .count();
+    if eligible > MAX_RETAINED_REINDEX_STATUSES {
+        let mut oldest: Vec<_> = jobs
+            .iter()
+            .filter(|(id, p)| p.status.is_finished() && !channels.contains_key(*id))
+            .map(|(id, p)| {
+                (
+                    p.completed_at
+                        .as_deref()
+                        .and_then(|at| chrono::DateTime::parse_from_rfc3339(at).ok())
+                        .map(|at| at.timestamp_micros())
+                        .unwrap_or(i64::MIN),
+                    id.clone(),
+                )
+            })
+            .collect();
+        oldest.sort_unstable();
+        for (_, id) in oldest
+            .into_iter()
+            .take(eligible - MAX_RETAINED_REINDEX_STATUSES)
+        {
+            jobs.remove(&id);
+        }
+    }
+    // A large burst of active jobs must not leave empty buckets resident forever.
+    if jobs.capacity()
+        > jobs
+            .len()
+            .saturating_mul(2)
+            .max(MAX_RETAINED_REINDEX_STATUSES)
+    {
+        jobs.shrink_to_fit();
+    }
+}
+
+/// Lives from insertion (before kickoff audit awaits) until the spawned task is
+/// dropped. Drop also runs when kickoff is aborted or the worker unwinds.
+struct ReindexJobGuard {
+    job_id: String,
+    jobs: Arc<ReindexJobs>,
+    channels: Arc<ReindexChannels>,
+}
+
+impl Drop for ReindexJobGuard {
+    fn drop(&mut self) {
+        {
+            let mut jobs = self.jobs.write();
+            let mut channels = self.channels.write();
+            if let Some(progress) = jobs.get_mut(&self.job_id)
+                && progress.status.is_running()
+            {
+                progress.status = ReindexStatus::Failed;
+                progress.error_message = Some("Reindex task ended before completing".to_string());
+                progress.completed_at = Some(chrono::Utc::now().to_rfc3339());
+            }
+            channels.remove(&self.job_id);
+            if channels.capacity() > channels.len().saturating_mul(2).max(16) {
+                channels.shrink_to_fit();
+            }
+        }
+        cleanup_reindex_jobs(&self.jobs, &self.channels, REINDEX_STATUS_RETENTION_SECONDS);
+    }
+}
+
 /// Manages reindex operations.
 ///
 /// Deliberately **not** generic over a storage type. A composite deployment
@@ -427,7 +520,10 @@ struct ReindexAudit {
 ///
 /// Jobs live in an in-memory map, so `$reindex-status` for a job started on one
 /// node is not visible from another. In a multi-node deployment, poll the node
-/// that accepted the kick-off.
+/// that accepted the kick-off. Terminal states are retained for up to 24 hours,
+/// subject to a limit of the most recent 1024 states whose tasks have exited.
+/// Expiration is swept every minute; an evicted status is no longer available.
+/// Active tasks (including cancellation still unwinding) are never evicted.
 pub struct ReindexOperation {
     /// Where resources are read from — the primary.
     source: Arc<dyn ReindexSource>,
@@ -436,10 +532,12 @@ pub struct ReindexOperation {
     /// The per-tenant search parameter registries; the extractor is built from
     /// the reindexed tenant's registry so a tenant's stored params are honored.
     registries: Arc<crate::search::TenantSearchRegistries>,
-    /// Active jobs.
+    /// Active and recently finished jobs.
     jobs: Arc<RwLock<HashMap<String, ReindexProgress>>>,
     /// Cancellation channels.
     cancel_channels: Arc<RwLock<HashMap<String, mpsc::Sender<()>>>>,
+    /// Lazily started by the first job, so construction needs no Tokio runtime.
+    cleanup_started: AtomicBool,
     /// Optional audit sink for reindex lifecycle events.
     audit: Option<ReindexAudit>,
 }
@@ -474,8 +572,28 @@ impl ReindexOperation {
             registries,
             jobs: Arc::new(RwLock::new(HashMap::new())),
             cancel_channels: Arc::new(RwLock::new(HashMap::new())),
+            cleanup_started: AtomicBool::new(false),
             audit: None,
         }
+    }
+
+    fn ensure_cleanup_task(&self) {
+        if self.cleanup_started.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let jobs = Arc::downgrade(&self.jobs);
+        let channels = Arc::downgrade(&self.cancel_channels);
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(REINDEX_CLEANUP_INTERVAL).await;
+                // Upgrades are dropped at the end of this iteration, before
+                // sleeping; an idle cleanup task does not keep the maps alive.
+                let (Some(jobs), Some(channels)) = (jobs.upgrade(), channels.upgrade()) else {
+                    break;
+                };
+                cleanup_reindex_jobs(&jobs, &channels, REINDEX_STATUS_RETENTION_SECONDS);
+            }
+        });
     }
 
     /// Emits a BALP `AuditEvent` at each reindex lifecycle transition.
@@ -512,6 +630,8 @@ impl ReindexOperation {
         request: ReindexRequest,
         agent: Option<String>,
     ) -> Result<String, ReindexError> {
+        self.ensure_cleanup_task();
+        self.cleanup_old_jobs(REINDEX_STATUS_RETENTION_SECONDS);
         let job_id = Uuid::new_v4().to_string();
         let progress = ReindexProgress::new(&job_id);
 
@@ -523,6 +643,12 @@ impl ReindexOperation {
         self.cancel_channels
             .write()
             .insert(job_id.clone(), cancel_tx);
+
+        let lifecycle = ReindexJobGuard {
+            job_id: job_id.clone(),
+            jobs: self.jobs.clone(),
+            channels: self.cancel_channels.clone(),
+        };
 
         let requested_types = request.resource_types.clone().unwrap_or_default();
 
@@ -552,6 +678,7 @@ impl ReindexOperation {
 
         // Spawn background task
         tokio::spawn(async move {
+            let _lifecycle = lifecycle;
             run_reindex(
                 job_id_clone.clone(),
                 tenant,
@@ -630,7 +757,9 @@ impl ReindexOperation {
         // Update status
         {
             let mut jobs = self.jobs.write();
-            if let Some(progress) = jobs.get_mut(job_id) {
+            if let Some(progress) = jobs.get_mut(job_id)
+                && progress.status.is_running()
+            {
                 progress.status = ReindexStatus::Cancelled;
                 progress.completed_at = Some(chrono::Utc::now().to_rfc3339());
             }
@@ -644,24 +773,11 @@ impl ReindexOperation {
         self.jobs.read().values().cloned().collect()
     }
 
-    /// Removes completed jobs older than the specified duration.
+    /// Removes terminal states older than the supplied age and limits retained
+    /// terminal states to 1024. A task still owning its cancellation sender is
+    /// protected even if cancellation has already marked its status terminal.
     pub fn cleanup_old_jobs(&self, max_age_seconds: i64) {
-        let cutoff = chrono::Utc::now() - chrono::Duration::seconds(max_age_seconds);
-
-        let mut jobs = self.jobs.write();
-        let mut channels = self.cancel_channels.write();
-
-        jobs.retain(|job_id, progress| {
-            if progress.status.is_finished()
-                && let Some(ref completed_at) = progress.completed_at
-                && let Ok(completed) = chrono::DateTime::parse_from_rfc3339(completed_at)
-                && completed.with_timezone(&chrono::Utc) < cutoff
-            {
-                channels.remove(job_id);
-                return false;
-            }
-            true
-        });
+        cleanup_reindex_jobs(&self.jobs, &self.cancel_channels, max_age_seconds);
     }
 }
 
@@ -677,7 +793,9 @@ impl std::fmt::Debug for ReindexOperation {
 /// Marks a job as failed.
 fn mark_failed(jobs: &Arc<RwLock<HashMap<String, ReindexProgress>>>, job_id: &str, error: String) {
     let mut jobs_guard = jobs.write();
-    if let Some(progress) = jobs_guard.get_mut(job_id) {
+    if let Some(progress) = jobs_guard.get_mut(job_id)
+        && progress.status.is_running()
+    {
         progress.status = ReindexStatus::Failed;
         progress.error_message = Some(error);
         progress.completed_at = Some(chrono::Utc::now().to_rfc3339());
@@ -687,7 +805,9 @@ fn mark_failed(jobs: &Arc<RwLock<HashMap<String, ReindexProgress>>>, job_id: &st
 /// Marks a job as cancelled.
 fn mark_cancelled(jobs: &Arc<RwLock<HashMap<String, ReindexProgress>>>, job_id: &str) {
     let mut jobs_guard = jobs.write();
-    if let Some(progress) = jobs_guard.get_mut(job_id) {
+    if let Some(progress) = jobs_guard.get_mut(job_id)
+        && progress.status.is_running()
+    {
         progress.status = ReindexStatus::Cancelled;
         progress.completed_at = Some(chrono::Utc::now().to_rfc3339());
     }
@@ -896,7 +1016,9 @@ async fn run_reindex(
     // Mark as completed
     {
         let mut jobs_guard = jobs.write();
-        if let Some(progress) = jobs_guard.get_mut(&job_id) {
+        if let Some(progress) = jobs_guard.get_mut(&job_id)
+            && progress.status.is_running()
+        {
             progress.status = ReindexStatus::Completed;
             progress.completed_at = Some(chrono::Utc::now().to_rfc3339());
             progress.current_resource_type = None;
@@ -946,6 +1068,304 @@ impl crate::core::DeferredReindexHook for ReindexOnFinish {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Default)]
+    struct LifecycleSource {
+        blocked: bool,
+        fail: bool,
+        panic: bool,
+        entered: tokio::sync::Notify,
+        release: tokio::sync::Notify,
+    }
+
+    #[async_trait]
+    impl ReindexSource for LifecycleSource {
+        async fn list_resource_types(&self, _: &TenantContext) -> StorageResult<Vec<String>> {
+            self.entered.notify_one();
+            if self.blocked {
+                self.release.notified().await;
+            }
+            assert!(!self.panic, "injected reindex task panic");
+            if self.fail {
+                return Err(crate::error::BackendError::Unavailable {
+                    backend_name: "test".into(),
+                    message: "injected failure".into(),
+                }
+                .into());
+            }
+            Ok(Vec::new())
+        }
+        async fn count_resources(&self, _: &TenantContext, _: &str) -> StorageResult<u64> {
+            unreachable!("empty source has no types")
+        }
+        async fn fetch_resources_page(
+            &self,
+            _: &TenantContext,
+            _: &str,
+            _: Option<&str>,
+            _: u32,
+        ) -> StorageResult<ResourcePage> {
+            unreachable!("empty source has no pages")
+        }
+    }
+
+    fn lifecycle_operation(source: Arc<LifecycleSource>) -> ReindexOperation {
+        ReindexOperation::with_parts(
+            source,
+            Vec::new(),
+            Arc::new(crate::search::TenantSearchRegistries::base_only()),
+        )
+    }
+
+    async fn start_lifecycle_job(op: &ReindexOperation) -> String {
+        op.start(TenantContext::system(), ReindexRequest::default(), None)
+            .await
+            .unwrap()
+    }
+
+    async fn await_terminal(op: &ReindexOperation, id: &str) -> ReindexProgress {
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+            if let Some(progress) = op
+                .jobs
+                .read()
+                .get(id)
+                .filter(|p| p.status.is_finished())
+                .cloned()
+            {
+                return progress;
+            }
+        }
+        panic!("job never reached terminal status");
+    }
+
+    #[tokio::test]
+    async fn test_retention_completed_jobs_release_channels_and_keep_status() {
+        let op = lifecycle_operation(Arc::new(LifecycleSource::default()));
+        for _ in 0..3 {
+            let id = start_lifecycle_job(&op).await;
+            assert_eq!(
+                await_terminal(&op, &id).await.status,
+                ReindexStatus::Completed
+            );
+            assert!(
+                !op.cancel_channels.read().contains_key(&id),
+                "finished job retained sender"
+            );
+            assert_eq!(
+                op.get_progress(&id).await.unwrap().status,
+                ReindexStatus::Completed
+            );
+            op.cancel(&id).await.unwrap(); // Terminal cancellation remains idempotent.
+            assert_eq!(
+                op.get_progress(&id).await.unwrap().status,
+                ReindexStatus::Completed
+            );
+        }
+        assert_eq!(op.list_jobs().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_retention_failed_job_releases_channel() {
+        let op = lifecycle_operation(Arc::new(LifecycleSource {
+            fail: true,
+            ..Default::default()
+        }));
+        let id = start_lifecycle_job(&op).await;
+        let progress = await_terminal(&op, &id).await;
+        assert_eq!(progress.status, ReindexStatus::Failed);
+        assert!(
+            progress
+                .error_message
+                .unwrap()
+                .contains("Failed to list resource types")
+        );
+        assert!(op.cancel_channels.read().is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_retention_cancelled_task_is_protected_until_it_returns() {
+        let source = Arc::new(LifecycleSource {
+            blocked: true,
+            ..Default::default()
+        });
+        let op = lifecycle_operation(source.clone());
+        let id = start_lifecycle_job(&op).await;
+        source.entered.notified().await;
+        op.cancel(&id).await.unwrap();
+        op.jobs.write().get_mut(&id).unwrap().completed_at =
+            Some((chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339());
+        op.cleanup_old_jobs(0);
+        assert!(
+            op.jobs.read().contains_key(&id),
+            "cleanup evicted a task still using its status"
+        );
+        assert!(op.cancel_channels.read().contains_key(&id));
+        tokio::time::advance(std::time::Duration::from_secs(61)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            op.jobs.read().contains_key(&id),
+            "periodic cleanup evicted a live cancelled task"
+        );
+        // Restore a recent timestamp before allowing the task to return, so
+        // the next assertion tests cancellation state rather than expiry.
+        op.jobs.write().get_mut(&id).unwrap().completed_at = Some(chrono::Utc::now().to_rfc3339());
+        source.release.notify_one();
+        for _ in 0..100 {
+            if op.cancel_channels.read().is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(op.cancel_channels.read().is_empty());
+        assert_eq!(
+            op.get_progress(&id).await.unwrap().status,
+            ReindexStatus::Cancelled
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retention_panicked_task_does_not_leave_active_metadata() {
+        let op = lifecycle_operation(Arc::new(LifecycleSource {
+            panic: true,
+            ..Default::default()
+        }));
+        let id = start_lifecycle_job(&op).await;
+        assert_eq!(await_terminal(&op, &id).await.status, ReindexStatus::Failed);
+        assert!(op.cancel_channels.read().is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_retention_idle_sweep_expires_status_without_api_calls() {
+        let op = lifecycle_operation(Arc::new(LifecycleSource::default()));
+        let id = start_lifecycle_job(&op).await;
+        await_terminal(&op, &id).await;
+        op.jobs.write().get_mut(&id).unwrap().completed_at =
+            Some((chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339());
+        tokio::time::advance(std::time::Duration::from_secs(61)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !op.jobs.read().contains_key(&id),
+            "idle manager retained expired status"
+        );
+        assert!(op.cancel_channels.read().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_retention_keeps_latest_1024_terminal_statuses() {
+        let source = Arc::new(LifecycleSource {
+            blocked: true,
+            ..Default::default()
+        });
+        let op = lifecycle_operation(source.clone());
+        let active = start_lifecycle_job(&op).await;
+        source.entered.notified().await;
+        // Empty explicit types let other jobs finish while this one is blocked.
+        let first = op
+            .start(
+                TenantContext::system(),
+                ReindexRequest::for_types(Vec::<String>::new()),
+                None,
+            )
+            .await
+            .unwrap();
+        await_terminal(&op, &first).await;
+        op.jobs.write().get_mut(&first).unwrap().completed_at =
+            Some((chrono::Utc::now() - chrono::Duration::minutes(1)).to_rfc3339());
+        let mut latest = first.clone();
+        for _ in 0..1024 {
+            latest = op
+                .start(
+                    TenantContext::system(),
+                    ReindexRequest::for_types(Vec::<String>::new()),
+                    None,
+                )
+                .await
+                .unwrap();
+            await_terminal(&op, &latest).await;
+        }
+        assert_eq!(op.jobs.read().len(), 1025); // 1024 terminal plus the active task.
+        assert!(op.get_progress(&first).await.is_none());
+        assert_eq!(
+            op.get_progress(&latest).await.unwrap().status,
+            ReindexStatus::Completed
+        );
+        assert_eq!(
+            op.get_progress(&active).await.unwrap().status,
+            ReindexStatus::InProgress
+        );
+        assert_eq!(op.cancel_channels.read().len(), 1);
+        op.cancel(&active).await.unwrap();
+        source.release.notify_one();
+        for _ in 0..100 {
+            if op.cancel_channels.read().is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(op.cancel_channels.read().is_empty());
+        assert_eq!(
+            op.get_progress(&active).await.unwrap().status,
+            ReindexStatus::Cancelled
+        );
+    }
+
+    #[cfg(feature = "R4")]
+    #[derive(Default)]
+    struct BlockingStartAudit {
+        entered: tokio::sync::Notify,
+    }
+
+    #[cfg(feature = "R4")]
+    #[async_trait]
+    impl helios_audit::AuditSink for BlockingStartAudit {
+        async fn record(&self, _: helios_fhir::r4::AuditEvent) {
+            self.entered.notify_one();
+            std::future::pending::<()>().await;
+        }
+        async fn flush(&self) {}
+        fn name(&self) -> &str {
+            "blocking-start-audit"
+        }
+    }
+
+    #[cfg(feature = "R4")]
+    #[tokio::test]
+    async fn test_retention_aborted_kickoff_does_not_leave_queued_metadata() {
+        let audit = Arc::new(BlockingStartAudit::default());
+        let op = Arc::new(
+            lifecycle_operation(Arc::new(LifecycleSource::default()))
+                .with_audit(audit.clone(), "Device/test"),
+        );
+        let kickoff = tokio::spawn({
+            let op = op.clone();
+            async move { start_lifecycle_job(&op).await }
+        });
+        audit.entered.notified().await;
+        assert_eq!(op.jobs.read().len(), 1);
+        kickoff.abort();
+        assert!(kickoff.await.unwrap_err().is_cancelled());
+        assert!(op.cancel_channels.read().is_empty());
+        assert!(
+            op.jobs
+                .read()
+                .values()
+                .all(|p| p.status == ReindexStatus::Failed && p.completed_at.is_some())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retention_sweeper_does_not_keep_manager_state_alive() {
+        let op = lifecycle_operation(Arc::new(LifecycleSource::default()));
+        let id = start_lifecycle_job(&op).await;
+        await_terminal(&op, &id).await;
+        let jobs = Arc::downgrade(&op.jobs);
+        let channels = Arc::downgrade(&op.cancel_channels);
+        drop(op);
+        tokio::task::yield_now().await;
+        assert!(jobs.upgrade().is_none());
+        assert!(channels.upgrade().is_none());
+    }
 
     #[test]
     fn test_reindex_request() {

--- a/crates/rest/README.md
+++ b/crates/rest/README.md
@@ -132,6 +132,11 @@ the background and is polled via `/$reindex-status/[job_id]`.
 - Job state is held **in memory on the node that accepted the kick-off**, so
   `/$reindex-status/[job_id]` returns `404` from any other node. In a multi-node
   deployment, poll the node you kicked off against.
+- Terminal status is retained for up to **24 hours**, subject to a limit of the
+  **most recent 1024 statuses** whose tasks have exited. Expiration is swept once
+  per minute. Under high job volume, the count limit can evict a status earlier;
+  an evicted status returns `404`. Tasks still executing, including cancellation
+  in progress, are protected. Cancellation channels are released when tasks exit.
 - The `s3` backend standalone has no search index of any kind, so `$reindex`
   there returns `501`. Every other backend and composite supports it.
 - The same applies after a **server upgrade that adds a parameter to the

--- a/crates/rest/src/handlers/reindex.rs
+++ b/crates/rest/src/handlers/reindex.rs
@@ -27,6 +27,11 @@
 //! multi-node deployment, poll the node you kicked off against. (Persisting job
 //! state across the cluster is tracked separately.)
 //!
+//! Terminal status is available for up to 24 hours, subject to a limit of the
+//! most recent 1024 statuses whose tasks have exited. Expiration is swept once
+//! per minute. Evicted statuses return 404; tasks still executing (including
+//! cancellation in progress) are protected from eviction.
+//!
 //! # Composite deployments
 //!
 //! The reindex driver writes to *every* search index — the primary's own index


### PR DESCRIPTION
[Visual explanation for reviewers](https://vanish.gordex.dev/s/cosmic-brook-79/) — available until September 15, 2026, 18:46 UTC.

Closes #995.

## Problem and change

Consecutive bulk-submit jobs with deferred indexing left a finished reindex status and a closed cancellation sender in the node-local manager for every job. Twenty repeated jobs retained twenty of each. The manager now releases the sender when its task exits and retains at most the most recent 1024 terminal statuses for up to 24 hours.

A lifecycle guard covers completion, backend failure, panic/unwind and aborted kickoff futures. Tasks still executing remain protected from eviction, including cancellation already reported to the client. Racing terminal transitions preserve the existing terminal status. A lazy cleanup task sweeps expired statuses every minute without keeping the manager alive; oversized map capacity is reclaimed after bursts.

Recent statuses remain pollable. Expired or count-evicted statuses return 404; high volume can shorten the 24-hour window. The REST documentation describes this behavior.

## Investigation outcome for #995

Current-code measurements include continuous/restart controls with inline and deferred indexing. They did not show sustained resident-memory growth in the measured workloads. Heap snapshots and ownership inventories then identified the concrete reindex retention defect fixed here.

This PR closes the investigation with a scoped correction and documented evidence. It does not claim to explain the historical high/low RSS distribution or eliminate ingestion peaks. macOS residency changes are not equivalent to live-allocation changes, and the new runs are not a paired reproduction of the historical Linux buffer experiment. Active-job counts and per-job error payloads remain unbounded by this policy. Receipt streaming remains separate work in #982 / #1045.

## Validation

- 13 reindex tests passed. Of eight new regression tests, seven failed against the previous lifecycle code and one passed. Cases include blocked cancellation, panic, aborted kickoff, idle expiry, 1025 completions with another task active, and manager release.
- Fresh pilot plus 20 consecutive jobs, 1,000 Patients/job, PostgreSQL 16.14, deferred indexing and 30-second idle: all 21 jobs, 336 correctness checks and 24 diagnostic calls passed.
- Every fixed post-idle inventory contained zero cancellation channels; all twenty terminal states remained available at the end. Before the fix, twenty closed senders remained.
- At job 20, partial entry/buffer accounting fell from 8,080 to 6,720 bytes. Final whole-process malloc totals were similar (~5.11 MB); this is not evidence of a substantial total-heap reduction.
- Serial release builds used one Cargo job on a 16 GiB Mac. The repeat measurement had no new host swapouts. Temporary instrumentation was removed from production source and the default binary.

```sh
CARGO_BUILD_JOBS=1 cargo test --locked --release -p helios-persistence --lib \
  --no-default-features --features R4,postgres,sqlite \
  search::reindex:: -- --test-threads=1
```

SQLite is enabled because existing unrelated lib tests import it unconditionally; the initial R4/Postgres-only test build failed before execution.

## Evidence

Reports under `crates/hfs/tests/bulk_submit/`: `MEMORY_RESULTS.md`, `RETENTION_RESULTS.md` and `RETENTION_FIX_RESULTS.md`, with measurement protocols and scripts. Raw logs, captures, binaries and temporary probe remain local under `target/issue-995*`; they are not GitHub attachments.

The branch is rebased onto `origin/main` at `5d738d3fb84d629870d35d5ac01dabe9fd9682c1`. All 13 reindex tests passed again on this base; the workload measurements above were collected before this rebase, on `1386c0ef4c2e8969a1d90b6256772bdc6db1a408` plus the fix.
