### PR TITLE
fix(mongodb): advertise :missing/:not exactly where the modifier gate allows them

### DIFF
--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -693,21 +693,46 @@ use crate::types::{
 
 impl MongoBackend {
     /// Returns the search modifiers the MongoDB backend actually honors for a
-    /// parameter type. Unlike the SQL backends, the Mongo search implementation
-    /// does not implement `:missing`, token `:not`/`:of-type`, reference
-    /// `:identifier`, or uri `:above`/`:below`; advertising only what
-    /// `search_impl` accepts keeps the CapabilityStatement honest.
+    /// parameter type.
+    ///
+    /// `:missing` (true and false) and token `:not` ARE implemented (#881):
+    /// both are resolved generically in `search_impl::matching_resource_ids`
+    /// from search-index-entry presence/absence and positive-filter
+    /// complement respectively, *before* any type-specific value parsing
+    /// runs — which is why `:missing` is safe to advertise on date/number/
+    /// quantity even though a literal `"true"`/`"false"` value would fail
+    /// their parsers. They are advertised on exactly the types
+    /// `SearchModifier::is_valid_for` permits (the same gate
+    /// `search_query_builder` uses to reject a modifier before it reaches any
+    /// backend): `:missing` on every index-backed type (string, token, date,
+    /// number, quantity, reference, uri), `:not` on token only. Composite and
+    /// special params stay unadvertised for both — they are never indexed by
+    /// value, so `:missing` there would answer from an empty index rather
+    /// than a real absence check.
+    ///
+    /// One known-imprecise case, not fixed here: `matching_resource_ids`
+    /// skips `_id`/`_lastUpdated` by name and never evaluates their modifiers
+    /// at all, but this function is keyed on parameter type only, so the
+    /// common-param loop in `resource_search_capabilities` will still
+    /// advertise `:missing` on `_lastUpdated` (and `:not`/`:missing` on
+    /// `_id`, via its Token fallback type) even though the Mongo index path
+    /// silently ignores those modifiers there.
+    ///
+    /// Still unimplemented and therefore still unadvertised: `:above`/
+    /// `:below`/`:in`/`:not-in` (rejected outright by `validate_query_support`
+    /// for every type), token `:of-type`/`:text-advanced`, and reference
+    /// `:identifier`/`:above`/`:below`/`:text-advanced` — each still hits an
+    /// `UnsupportedModifier` catch-all in its type-specific builder.
     pub(super) fn modifiers_for_type(param_type: SearchParamType) -> Vec<&'static str> {
         match param_type {
-            SearchParamType::String => vec!["exact", "contains", "text"],
-            SearchParamType::Token => vec!["text", "code-text"],
-            SearchParamType::Reference => vec!["contains", "text", "code-text"],
-            SearchParamType::Uri => vec!["exact", "contains"],
-            SearchParamType::Date
-            | SearchParamType::Number
-            | SearchParamType::Quantity
-            | SearchParamType::Composite
-            | SearchParamType::Special => vec![],
+            SearchParamType::String => vec!["exact", "contains", "text", "missing"],
+            SearchParamType::Token => vec!["text", "code-text", "not", "missing"],
+            SearchParamType::Reference => vec!["contains", "text", "code-text", "missing"],
+            SearchParamType::Uri => vec!["exact", "contains", "missing"],
+            SearchParamType::Date | SearchParamType::Number | SearchParamType::Quantity => {
+                vec!["missing"]
+            }
+            SearchParamType::Composite | SearchParamType::Special => vec![],
         }
     }
 }
@@ -775,32 +800,184 @@ impl SearchCapabilityProvider for MongoBackend {
 #[cfg(test)]
 mod capability_tests {
     use super::*;
+    use crate::types::{SearchModifier, SearchParameter, SearchValue};
 
     #[test]
     fn test_modifiers_for_type_reflects_mongo_support() {
-        // String honors exact/contains/text but not :missing.
+        // String honors exact/contains/text, and :missing (#881, presence-only).
         let s = MongoBackend::modifiers_for_type(SearchParamType::String);
         assert!(s.contains(&"exact"));
         assert!(s.contains(&"text"));
-        assert!(!s.contains(&"missing"));
+        assert!(s.contains(&"missing"));
 
-        // Token honors text/code-text but not the non-spec :code, nor :not / :of-type.
+        // Token honors text/code-text but not the non-spec :code; :not and
+        // :missing ARE honored (#881, generically in `matching_resource_ids`),
+        // but :of-type is still rejected by `build_token_filter`.
         let t = MongoBackend::modifiers_for_type(SearchParamType::Token);
         assert!(!t.contains(&"code"));
         assert!(t.contains(&"code-text"));
-        assert!(!t.contains(&"not"));
+        assert!(t.contains(&"not"));
+        assert!(t.contains(&"missing"));
         assert!(!t.contains(&"of-type"));
 
-        // Reference honors contains/text/code-text but not :identifier.
+        // Reference honors contains/text/code-text/missing but not :identifier.
         let r = MongoBackend::modifiers_for_type(SearchParamType::Reference);
         assert!(r.contains(&"contains"));
         assert!(r.contains(&"text"));
+        assert!(r.contains(&"missing"));
         assert!(!r.contains(&"identifier"));
 
-        // Uri honors exact/contains but not :above/:below.
+        // Uri honors exact/contains/missing but not :above/:below.
         let u = MongoBackend::modifiers_for_type(SearchParamType::Uri);
         assert!(u.contains(&"contains"));
+        assert!(u.contains(&"missing"));
         assert!(!u.contains(&"above"));
         assert!(!u.contains(&"below"));
+    }
+
+    /// Every `SearchParamType` variant paired with a value `matching_resource_ids`
+    /// (`search_impl.rs`) can build a *positive* index filter from. Written as
+    /// an exhaustive match with no wildcard arm: adding a new `SearchParamType`
+    /// variant makes this fail to compile, which is the point — it forces the
+    /// author to also decide what `modifiers_for_type` should advertise for it,
+    /// rather than silently skipping it in these tests.
+    fn sample_value_for(param_type: SearchParamType) -> &'static str {
+        match param_type {
+            SearchParamType::String => "smith",
+            SearchParamType::Uri => "http://example.org/x",
+            SearchParamType::Number => "5",
+            SearchParamType::Date => "2020-01-01",
+            SearchParamType::Quantity => "5|http://unitsofmeasure.org|mg",
+            SearchParamType::Token => "http://loinc.org|1234-5",
+            SearchParamType::Reference => "Patient/123",
+            SearchParamType::Composite => "unused-composite-has-no-single-value",
+            SearchParamType::Special => "unused-special-has-no-single-value",
+        }
+    }
+
+    /// All nine `SearchParamType` variants, built through `sample_value_for` so
+    /// the exhaustiveness guarantee above actually applies to this list.
+    fn all_param_types() -> Vec<SearchParamType> {
+        [
+            SearchParamType::String,
+            SearchParamType::Uri,
+            SearchParamType::Number,
+            SearchParamType::Date,
+            SearchParamType::Quantity,
+            SearchParamType::Token,
+            SearchParamType::Reference,
+            SearchParamType::Composite,
+            SearchParamType::Special,
+        ]
+        .into_iter()
+        .inspect(|t| {
+            let _ = sample_value_for(*t);
+        })
+        .collect()
+    }
+
+    /// #1054: the CapabilityStatement must advertise `:missing`/`:not` on
+    /// exactly the parameter types where a client is actually allowed to send
+    /// them. `SearchModifier::is_valid_for` is that gate in production — it is
+    /// what `crates/rest/src/extractors/search_query_builder.rs` calls to 400 a
+    /// modifier before it ever reaches a backend — so the expected answer is
+    /// derived from it rather than hardcoded here. Both modifiers are resolved
+    /// generically (type-agnostically) in
+    /// `MongoBackend::matching_resource_ids` (`search_impl.rs`, #881): `:missing`
+    /// from search-index-entry presence/absence, `:not` from the positive
+    /// filter's complement. Neither reaches type-specific value parsing, which
+    /// is why `:missing` is safe on date/number/quantity (see
+    /// `query_support_tests::missing_is_supported_without_type_specific_value_parsing`
+    /// in search_impl.rs) and is not gated here on anything Mongo-specific.
+    #[test]
+    fn missing_and_not_are_advertised_wherever_the_gate_allows_them() {
+        for param_type in all_param_types() {
+            let advertised = MongoBackend::modifiers_for_type(param_type);
+
+            assert_eq!(
+                advertised.contains(&"missing"),
+                SearchModifier::Missing.is_valid_for(param_type),
+                "advertised `missing` for {param_type} disagrees with \
+                 SearchModifier::Missing::is_valid_for"
+            );
+            assert_eq!(
+                advertised.contains(&"not"),
+                SearchModifier::Not.is_valid_for(param_type),
+                "advertised `not` for {param_type} disagrees with \
+                 SearchModifier::Not::is_valid_for"
+            );
+        }
+    }
+
+    /// Companion guard to the test above: for every modifier `modifiers_for_type`
+    /// actually advertises for a type, the Mongo index-filter path must be able
+    /// to build a filter from it (never advertise something the query builders
+    /// reject), the string must round-trip through `SearchModifier::parse` (no
+    /// stray/typo'd modifier spellings), and it must never be one of the four
+    /// modifiers `MongoBackend::validate_query_support` (`search_impl.rs`,
+    /// private to that module) hard-rejects for every type regardless of
+    /// per-type support. This is the closest hermetic stand-in for a literal
+    /// cross-check against `validate_query_support`: that method is private to
+    /// `search_impl`, which is off-limits for edits this wave, so it cannot be
+    /// called directly from here.
+    #[test]
+    fn advertised_modifiers_are_honored_by_the_mongo_index_path() {
+        let backend = MongoBackend::new(MongoBackendConfig::default()).unwrap();
+
+        for param_type in all_param_types() {
+            for &modifier_str in &MongoBackend::modifiers_for_type(param_type) {
+                // `validate_query_support` (search_impl.rs) rejects these four
+                // outright for every parameter type; advertising any of them
+                // would be a straightforward regression back to over-promising.
+                assert!(
+                    !matches!(modifier_str, "above" | "below" | "in" | "not-in"),
+                    "{param_type} advertises `{modifier_str}`, which \
+                     validate_query_support rejects unconditionally"
+                );
+
+                // The advertised string must be a real, round-trippable
+                // modifier spelling, not a typo or a legacy alias.
+                let parsed = SearchModifier::parse(modifier_str).unwrap_or_else(|| {
+                    panic!(
+                        "{param_type} advertises `{modifier_str}`, which \
+                         SearchModifier::parse does not recognize"
+                    )
+                });
+                assert_eq!(
+                    parsed.to_string(),
+                    modifier_str,
+                    "{param_type}'s advertised `{modifier_str}` does not round-trip \
+                     through SearchModifier::parse/Display"
+                );
+
+                // `:missing` and `:not` are resolved generically in
+                // `matching_resource_ids` *before* any type-specific value
+                // filter is built (#881: presence-only / positive-complement),
+                // so the faithful probe for them clears the modifier rather
+                // than setting it — setting it would wrongly fail (e.g. token's
+                // `build_token_filter` has no `Missing`/`Not` arm and would hit
+                // its `Some(other) => Err(UnsupportedModifier)` catch-all).
+                let probe_modifier = match modifier_str {
+                    "missing" | "not" => None,
+                    other => Some(SearchModifier::parse(other).unwrap()),
+                };
+
+                let param = SearchParameter {
+                    name: "test_param".to_string(),
+                    param_type,
+                    modifier: probe_modifier,
+                    values: vec![SearchValue::eq(sample_value_for(param_type))],
+                    ..Default::default()
+                };
+
+                let result = backend.build_search_index_filter("t1", "Patient", &param);
+                assert!(
+                    result.is_ok(),
+                    "{param_type} advertises `{modifier_str}` but the Mongo index \
+                     filter path rejected it: {:?}",
+                    result.err()
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1054.

## What was wrong

`MongoBackend::modifiers_for_type` omitted `missing` and `not` from every parameter type, and its doc comment asserted the backend "does not implement `:missing`, token `:not`/`:of-type`…". That was true before #881 and has been false since: `matching_resource_ids` implements both in full, `validate_query_support` deliberately admits them, and `mongodb_tests.rs` exercises them end to end.

Because `modifiers_for_type` feeds the published CapabilityStatement via `SearchParamFullCapability::with_modifiers`, a conformance client reading it would never attempt either modifier.

## What changed

One file, `crates/persistence/src/backends/mongodb/backend.rs`:

- `missing` is advertised exactly where `SearchModifier::Missing.is_valid_for` allows it (string, token, date, number, quantity, reference, uri), and `not` on token only.
- Nothing `validate_query_support` rejects — `above`, `below`, `in`, `not-in` — is newly advertised.
- The `Date | Number | Quantity` arm is split out of the `Composite | Special => vec![]` arm, since the first three now advertise `missing` and the last two still advertise nothing.
- The doc comment is rewritten to state the truth, including the `_id`/`_lastUpdated` exception described below.

Both modifiers resolve generically in `matching_resource_ids` *before* type-specific value parsing, which is why `:missing` is safe on date, number and quantity parameters — there is no value to misparse.

## Tests

`capability_tests::missing_and_not_are_advertised_wherever_the_gate_allows_them` cross-checks the advertised set against `SearchModifier::is_valid_for` rather than a hardcoded list, so the two cannot drift apart again. A companion test asserts no advertised modifier is one of the four `validate_query_support` rejects, and round-trips every advertised string through `SearchModifier::parse`.

Verified with Docker actually running, not skipped:

```
cargo test -p helios-persistence --features mongodb --test mongodb_tests
test result: ok. 100 passed; 0 failed; 0 ignored
```

`cargo test -p helios-rest capabilities` also run to confirm no REST-side fallout. `cargo fmt --all -- --check` and clippy with CI's allowlist both pass.

## Known gaps deliberately left unfixed

Three adjacent defects were found and **not** fixed here, because the fix for each lives in `search_impl.rs`, which is reserved for other in-flight work:

1. The `_contained` search path does not honor these modifiers — `matching_contained` passes the modifier through to `build_token_filter`, which errors on the catch-all. So `Patient?_contained=true&gender:missing=true` will fail while the CapabilityStatement now says it is supported. Pre-existing and niche; needs its own issue.
2. `_id` and `_lastUpdated` now advertise `missing` (and `not` on `_id`), but `matching_resource_ids` skips them by name and never evaluates their modifiers, so `_lastUpdated:missing=true` silently matches everything. This is the same root cause as #1055 and is now documented in the doc comment.
3. Uri `exact` remains over-advertised — `SearchModifier::Exact.is_valid_for` is String-only, so `url:exact` 400s at the REST layer. Pre-existing, untouched by this diff, worth its own issue.

Found while researching #1040 / #999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECbBsNhgXwBo4dQtFyVBXv
