### PR TITLE
fix(persistence): batch MongoDB $reindex search-index writes per page

### DIFF
--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -4259,7 +4259,8 @@ impl ReindexTarget for MongoBackend {
         // SEARCH_INDEX_INSERT_CHUNK, tracking which resource each document
         // belongs to so an unordered write error attributes back to just
         // that resource instead of failing the whole page.
-        let mut owners: Vec<usize> = Vec::with_capacity(prepared.iter().map(|p| p.docs.len()).sum());
+        let mut owners: Vec<usize> =
+            Vec::with_capacity(prepared.iter().map(|p| p.docs.len()).sum());
         let mut all_docs: Vec<Document> = Vec::with_capacity(owners.capacity());
         for (i, p) in prepared.iter().enumerate() {
             for d in &p.docs {

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -8,7 +8,7 @@ use helios_fhir::FhirVersion;
 use mongodb::{
     ClientSession, Collection, Cursor, SessionCursor,
     bson::{self, Bson, DateTime as BsonDateTime, Document, doc},
-    error::Error as MongoError,
+    error::{Error as MongoError, ErrorKind as MongoErrorKind},
     options::FindOptions,
 };
 use serde_json::Value;
@@ -1895,16 +1895,44 @@ impl MongoBackend {
         resource_id: &str,
         resource: &Value,
     ) -> Vec<Document> {
-        let mut index_docs = match self
+        self.search_index_documents_checked(tenant_id, resource_type, resource_id, resource)
+            .0
+    }
+
+    /// [`Self::search_index_documents`], plus the extraction failure message
+    /// (if any) that made this resource fall back to minimal index rows.
+    ///
+    /// Used by [`ReindexTarget::write_search_entries_page`] so a page can
+    /// still write every resource's fallback rows (matching what
+    /// [`Self::index_resource`] already does for a single resource) while
+    /// still reporting that resource as failed — the way the old, per-resource
+    /// `write_search_entries` always did — instead of a batched rewrite
+    /// silently turning a corrupt resource into a quiet `Ok`.
+    pub(super) fn search_index_documents_checked(
+        &self,
+        tenant_id: &str,
+        resource_type: &str,
+        resource_id: &str,
+        resource: &Value,
+    ) -> (Vec<Document>, Option<String>) {
+        let (mut index_docs, failure) = match self
             .tenant_extractor(tenant_id)
             .extract(resource, resource_type)
         {
-            Ok(values) => values
-                .iter()
-                .filter_map(|value| {
-                    self.build_search_index_document(tenant_id, resource_type, resource_id, value)
-                })
-                .collect::<Vec<_>>(),
+            Ok(values) => (
+                values
+                    .iter()
+                    .filter_map(|value| {
+                        self.build_search_index_document(
+                            tenant_id,
+                            resource_type,
+                            resource_id,
+                            value,
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                None,
+            ),
             Err(e) => {
                 tracing::warn!(
                     "Search extraction failed for {}/{}: {}. Using minimal fallback index values.",
@@ -1912,11 +1940,14 @@ impl MongoBackend {
                     resource_id,
                     e
                 );
-                self.index_minimal_fallback_documents(
-                    tenant_id,
-                    resource_type,
-                    resource_id,
-                    resource,
+                (
+                    self.index_minimal_fallback_documents(
+                        tenant_id,
+                        resource_type,
+                        resource_id,
+                        resource,
+                    ),
+                    Some(format!("Search parameter extraction failed: {e}")),
                 )
             }
         };
@@ -1941,7 +1972,7 @@ impl MongoBackend {
             }
         }
 
-        index_docs
+        (index_docs, failure)
     }
 
     pub(crate) async fn index_resource(
@@ -4078,31 +4109,15 @@ impl ReindexTarget for MongoBackend {
         tenant: &TenantContext,
         resource: &StoredResource,
     ) -> StorageResult<usize> {
-        if self.is_search_offloaded() {
-            return Ok(0);
-        }
-
-        let db = self.get_database().await?;
-        let mut no_session: Option<ClientSession> = None;
-
-        // Reuses the CRUD indexing path, so contained resources are indexed the
-        // same way here as they are on create/update.
-        self.index_resource(
-            &db,
-            tenant.tenant_id().as_str(),
-            resource.resource_type(),
-            resource.id(),
-            resource.content(),
-            &mut no_session,
-        )
-        .await?;
-
-        let values = self
-            .tenant_extractor(tenant.tenant_id().as_str())
-            .extract(resource.content(), resource.resource_type())
-            .map_err(|e| internal_error(format!("Search parameter extraction failed: {e}")))?;
-
-        Ok(values.len())
+        // Delegates to the page method (a slice of one) so the single-resource
+        // and batched-reindex paths write and count identically by
+        // construction, and so this no longer pays a redundant second
+        // `extract()` purely to compute a count (#1064) — a count that also
+        // omitted any `_contained` rows the write itself inserted.
+        self.write_search_entries_page(tenant, std::slice::from_ref(resource))
+            .await
+            .pop()
+            .unwrap_or(Ok(0))
     }
 
     async fn clear_search_index(&self, tenant: &TenantContext) -> StorageResult<u64> {
@@ -4119,7 +4134,196 @@ impl ReindexTarget for MongoBackend {
 
         Ok(result.deleted_count)
     }
+
+    /// Rebuilds a whole page in one `delete_many` plus one (possibly chunked)
+    /// `insert_many`, instead of the default's two `delete_many` plus one
+    /// `insert_many` PER RESOURCE — `delete_search_entries` above, then
+    /// `write_search_entries` -> `index_resource`'s own delete-then-insert
+    /// (#1064). For a 100-resource page that was 300 sequential round trips;
+    /// this is two (three only if a page mixes resource types, which no
+    /// production caller does — see the precondition below).
+    ///
+    /// Building every resource's documents through
+    /// [`Self::search_index_documents_checked`] keeps a rebuild and the CRUD
+    /// path (`index_resource`) indexing identically by construction, and
+    /// lets one resource's bad content fall back to minimal rows (as
+    /// `index_resource` already does) while still reporting that resource as
+    /// failed — mirroring what the old, per-resource `write_search_entries`
+    /// did, and what SQLite's `write_search_entries_on` and Elasticsearch's
+    /// override still do for the same case.
+    ///
+    /// The count each `Ok` reports is the number of documents actually
+    /// written for that resource, which — unlike the old
+    /// `write_search_entries`'s `extract(..).len()` — includes any
+    /// `_contained` rows. `$reindex-status.entries_created` will read higher
+    /// for corpora with `contained` resources as a result; this is a more
+    /// truthful count of what was written, and matches SQLite's
+    /// `write_search_entries_on` (which also adds `index_contained_resources`'
+    /// count).
+    ///
+    /// Precondition: `resources` must hold each `(resource_type, id)` at most
+    /// once. The one production caller, `fetch_resources_page`, reads the
+    /// current-resources collection keyset-ordered by `(last_updated, id)`
+    /// and cannot produce a duplicate; unlike Elasticsearch's `_id`-keyed
+    /// upsert, a repeated id here would double-insert, because the delete for
+    /// the whole page runs once, up front, rather than once per resource.
+    ///
+    /// A page-level failure — getting the database handle, the grouped
+    /// delete, or an insert error the driver does not attribute to a specific
+    /// document — fans out to every resource as the same `Err`, because in
+    /// that case nothing was written for anybody (mirroring SQLite's
+    /// BEGIN/COMMIT fan-out and Elasticsearch's `ensure_index` fan-out for the
+    /// same reason). An unordered `insert_many` write error IS attributed to
+    /// just the document(s) it names, via the same per-op index mapping the
+    /// batched bulk-submit ingest uses (`bulk_ingest.rs`'s create-batch path)
+    /// and that Elasticsearch's `send_bulk_index` uses for the same purpose.
+    async fn write_search_entries_page(
+        &self,
+        tenant: &TenantContext,
+        resources: &[StoredResource],
+    ) -> Vec<StorageResult<usize>> {
+        if resources.is_empty() {
+            return Vec::new();
+        }
+
+        // Honors `is_search_offloaded()`, matching the guards in
+        // `delete_search_entries` and `write_search_entries`/`clear_search_index`
+        // above: a search-offloaded backend keeps no index of its own and must
+        // issue no commands here.
+        if self.is_search_offloaded() {
+            return resources.iter().map(|_| Ok(0)).collect();
+        }
+
+        let db = match self.get_database().await {
+            Ok(db) => db,
+            Err(e) => {
+                let msg = e.to_string();
+                return resources
+                    .iter()
+                    .map(|_| Err(internal_error(msg.clone())))
+                    .collect();
+            }
+        };
+
+        let tenant_id = tenant.tenant_id().as_str();
+
+        struct Prepared {
+            docs: Vec<Document>,
+            failure: Option<String>,
+        }
+        let prepared: Vec<Prepared> = resources
+            .iter()
+            .map(|resource| {
+                let (docs, failure) = self.search_index_documents_checked(
+                    tenant_id,
+                    resource.resource_type(),
+                    resource.id(),
+                    resource.content(),
+                );
+                Prepared { docs, failure }
+            })
+            .collect();
+
+        let collection = db.collection::<Document>(MongoBackend::SEARCH_INDEX_COLLECTION);
+
+        // ONE delete per distinct resource_type in the page (a production
+        // page is single-type — `fetch_resources_page` filters on one type —
+        // so this is one command; grouping keeps a hypothetical
+        // heterogeneous slice correct too). A failure here means stale rows
+        // may remain for the whole page, so it fans out to every resource.
+        let mut ids_by_type: HashMap<&str, Vec<Bson>> = HashMap::new();
+        for resource in resources {
+            ids_by_type
+                .entry(resource.resource_type())
+                .or_default()
+                .push(Bson::from(resource.id()));
+        }
+        for (resource_type, ids) in ids_by_type {
+            if let Err(e) = collection
+                .delete_many(doc! {
+                    "tenant_id": tenant_id,
+                    "resource_type": resource_type,
+                    "resource_id": { "$in": ids },
+                })
+                .await
+            {
+                let msg = format!("Failed to delete search entries: {e}");
+                return resources
+                    .iter()
+                    .map(|_| Err(internal_error(msg.clone())))
+                    .collect();
+            }
+        }
+
+        // Flatten every resource's documents into one insert, chunked at
+        // SEARCH_INDEX_INSERT_CHUNK, tracking which resource each document
+        // belongs to so an unordered write error attributes back to just
+        // that resource instead of failing the whole page.
+        let mut owners: Vec<usize> = Vec::with_capacity(prepared.iter().map(|p| p.docs.len()).sum());
+        let mut all_docs: Vec<Document> = Vec::with_capacity(owners.capacity());
+        for (i, p) in prepared.iter().enumerate() {
+            for d in &p.docs {
+                owners.push(i);
+                all_docs.push(d.clone());
+            }
+        }
+
+        let mut insert_failures: HashMap<usize, String> = HashMap::new();
+        let mut offset = 0usize;
+        for chunk in all_docs.chunks(SEARCH_INDEX_INSERT_CHUNK) {
+            match collection.insert_many(chunk).ordered(false).await {
+                Ok(_) => {}
+                Err(e) => match e.kind.as_ref() {
+                    MongoErrorKind::InsertMany(insert_many) => {
+                        let Some(write_errors) = insert_many.write_errors.as_ref() else {
+                            let msg = format!("Failed to insert search index entries: {e}");
+                            return resources
+                                .iter()
+                                .map(|_| Err(internal_error(msg.clone())))
+                                .collect();
+                        };
+                        for write_error in write_errors {
+                            let owner = owners[offset + write_error.index];
+                            insert_failures
+                                .entry(owner)
+                                .or_insert_with(|| write_error.message.clone());
+                        }
+                    }
+                    _ => {
+                        let msg = format!("Failed to insert search index entries: {e}");
+                        return resources
+                            .iter()
+                            .map(|_| Err(internal_error(msg.clone())))
+                            .collect();
+                    }
+                },
+            }
+            offset += chunk.len();
+        }
+
+        prepared
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| match p.failure {
+                Some(msg) => Err(internal_error(msg)),
+                None => match insert_failures.remove(&i) {
+                    Some(msg) => Err(internal_error(format!(
+                        "Failed to insert search index entries: {msg}"
+                    ))),
+                    None => Ok(p.docs.len()),
+                },
+            })
+            .collect()
+    }
 }
+
+/// Documents per `insert_many` when [`MongoBackend`]'s
+/// [`ReindexTarget::write_search_entries_page`] flattens a page's index
+/// documents into one insert. Mirrors `bulk_ingest.rs`'s
+/// `INSERT_DOCS_PER_COMMAND` (same value, same rationale: bound how much the
+/// driver serializes per command) without depending on that module, since a
+/// page's `search_index` documents are built the same way a batch's are.
+const SEARCH_INDEX_INSERT_CHUNK: usize = 5_000;
 
 /// Parses a `{rfc3339}|{id}` keyset-pagination cursor for the reindex source.
 fn parse_reindex_cursor(cursor: &str) -> Option<(DateTime<Utc>, String)> {

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -3486,6 +3486,296 @@ async fn mongodb_integration_standalone_search_writes_search_index() {
     );
 }
 
+/// #1064: `MongoBackend` had no `write_search_entries_page` override, so
+/// `$reindex` fell through to `ReindexTarget`'s default loop — per resource,
+/// one `delete_many` (`delete_search_entries`) followed by ANOTHER
+/// `delete_many` plus one `insert_many` (`write_search_entries` ->
+/// `index_resource`). An 8-resource page issued 16 deletes and 8 inserts
+/// instead of 1 and 1, strictly sequential.
+///
+/// MongoDB's per-database profiler is the seam that proves the command
+/// count: every test here gets a unique database
+/// (`build_test_database_name`), so `system.profile` is immune to the other
+/// integration tests running in parallel against the shared container — the
+/// reason a `serverStatus` counter would not work here.
+#[tokio::test]
+async fn mongodb_integration_reindex_page_batches_index_writes() {
+    use futures::stream::TryStreamExt;
+    use helios_persistence::search::ReindexTarget;
+    use helios_persistence::types::StoredResource;
+
+    let Some(backend) = create_backend("reindex_page_batches").await else {
+        eprintln!(
+            "Skipping mongodb_integration_reindex_page_batches_index_writes (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let tenant = create_tenant("reindex-page-tenant");
+
+    let make_patient = |n: usize| {
+        StoredResource::from_storage(
+            "Patient",
+            format!("page-{n}"),
+            "1",
+            tenant.tenant_id().clone(),
+            json!({
+                "resourceType": "Patient",
+                "id": format!("page-{n}"),
+                "name": [{"family": format!("Paged{n}")}]
+            }),
+            chrono::Utc::now(),
+            chrono::Utc::now(),
+            None,
+            FhirVersion::default(),
+        )
+    };
+
+    let page: Vec<StoredResource> = (0..8).map(make_patient).collect();
+    let untouched = make_patient(8);
+
+    // Seed: every resource — the page plus one that will NOT be reindexed —
+    // already has search_index rows, as a prior write or reindex would leave
+    // them. This also runs the override once before the profiled window, so
+    // that window measures only the second rebuild below.
+    let mut seed = page.clone();
+    seed.push(untouched.clone());
+    let seed_outcomes = backend.write_search_entries_page(&tenant, &seed).await;
+    assert!(
+        seed_outcomes.iter().all(|o| o.is_ok()),
+        "seeding failed: {seed_outcomes:?}"
+    );
+
+    let mut before_counts = Vec::with_capacity(page.len());
+    for resource in &page {
+        let count = search_index_entry_count(&backend, &tenant, "Patient", resource.id()).await;
+        assert!(count > 0, "resource {} should already be indexed", resource.id());
+        before_counts.push(count);
+    }
+    let untouched_before =
+        search_index_entry_count(&backend, &tenant, "Patient", untouched.id()).await;
+    assert!(untouched_before > 0);
+
+    let db = backend.get_database().await.unwrap();
+    let profiling_enabled = db.run_command(doc! { "profile": 2_i32 }).await.is_ok();
+    if !profiling_enabled {
+        eprintln!(
+            "mongodb_integration_reindex_page_batches_index_writes: server refused \
+             {{profile: 2}} (likely a managed/shared HFS_TEST_MONGODB_URL); skipping the \
+             command-count assertions and running the contract assertions only"
+        );
+    }
+
+    let outcomes = backend.write_search_entries_page(&tenant, &page).await;
+
+    if profiling_enabled {
+        db.run_command(doc! { "profile": 0_i32 })
+            .await
+            .expect("failed to disable profiling");
+
+        let ns = format!("{}.search_index", db.name());
+        let entries: Vec<Document> = db
+            .collection::<Document>("system.profile")
+            .find(doc! { "ns": ns.as_str() })
+            .await
+            .expect("failed to read system.profile")
+            .try_collect()
+            .await
+            .expect("failed to collect system.profile");
+
+        assert!(
+            !entries.is_empty(),
+            "profiler produced no entries for {ns} — the assertions below would be vacuous"
+        );
+
+        let removes = entries
+            .iter()
+            .filter(|e| e.get_str("op").ok() == Some("remove"))
+            .count();
+        let inserts = entries
+            .iter()
+            .filter(|e| e.get_str("op").ok() == Some("insert"))
+            .count();
+
+        assert!(
+            removes <= 1,
+            "a reindex page must issue at most one delete_many, got {removes}: {entries:?}"
+        );
+        assert!(
+            inserts <= 1,
+            "a reindex page must issue at most one insert_many, got {inserts}: {entries:?}"
+        );
+        assert!(
+            entries.len() <= 2,
+            "a reindex page must issue at most 2 write commands total, got {}: {entries:?}",
+            entries.len()
+        );
+    }
+
+    // Contract, checked whether or not profiling was available: one outcome
+    // per resource, in order, each reporting the rows actually present, and
+    // the rewrite left the row count for each resource unchanged (a
+    // delete-then-rewrite of identical content).
+    assert_eq!(outcomes.len(), page.len());
+    for (i, (outcome, resource)) in outcomes.iter().zip(&page).enumerate() {
+        let count = outcome
+            .as_ref()
+            .unwrap_or_else(|e| panic!("resource {i} failed: {e:?}"));
+        let actual = search_index_entry_count(&backend, &tenant, "Patient", resource.id()).await;
+        assert_eq!(
+            *count as u64, actual,
+            "resource {i} reported count must match rows actually present"
+        );
+        assert_eq!(
+            actual, before_counts[i],
+            "resource {i} row count drifted across the rebuild"
+        );
+    }
+
+    // Scoping: the ninth Patient, not in the page, must be untouched — proves
+    // the single grouped `delete_many` is scoped by the page's resource ids
+    // and did not wipe the tenant's other rows.
+    let untouched_after =
+        search_index_entry_count(&backend, &tenant, "Patient", untouched.id()).await;
+    assert_eq!(
+        untouched_after, untouched_before,
+        "the page's delete_many must not touch resources outside the page"
+    );
+}
+
+/// #1064: `write_search_entries` used to report `extract(..).len()` — the
+/// container's own extracted values — even though `index_resource` (and,
+/// after the fix, `write_search_entries_page`) also inserts `_contained`
+/// rows for anything nested under `contained`. The reported count therefore
+/// undercounted whenever a resource has `contained` entries. Uses the full
+/// registry so both the Observation's own parameters and the contained
+/// Patient's `name` are guaranteed to extract, not just whichever handful
+/// ship in the embedded default registry.
+#[tokio::test]
+async fn mongodb_integration_reindex_page_counts_contained_entries() {
+    use helios_persistence::search::ReindexTarget;
+    use helios_persistence::types::StoredResource;
+
+    let Some(backend) = create_backend_with_full_registry("reindex_page_contained").await else {
+        eprintln!(
+            "Skipping mongodb_integration_reindex_page_counts_contained_entries (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let tenant = create_tenant("reindex-contained-tenant");
+
+    let with_contained = StoredResource::from_storage(
+        "Observation",
+        "obs-contained",
+        "1",
+        tenant.tenant_id().clone(),
+        json!({
+            "resourceType": "Observation",
+            "id": "obs-contained",
+            "status": "final",
+            "contained": [{
+                "resourceType": "Patient",
+                "id": "inner",
+                "name": [{"family": "Contained"}]
+            }],
+            "subject": {"reference": "#inner"},
+            "code": {"coding": [{"system": "http://loinc.org", "code": "1234-5"}]}
+        }),
+        chrono::Utc::now(),
+        chrono::Utc::now(),
+        None,
+        FhirVersion::default(),
+    );
+
+    let outcomes = backend
+        .write_search_entries_page(&tenant, std::slice::from_ref(&with_contained))
+        .await;
+    assert_eq!(outcomes.len(), 1, "one outcome per resource, not per document");
+    let reported = outcomes[0]
+        .as_ref()
+        .unwrap_or_else(|e| panic!("reindex failed: {e:?}"));
+
+    let actual = search_index_entry_count(&backend, &tenant, "Observation", "obs-contained").await;
+    assert_eq!(
+        *reported as u64, actual,
+        "reported entry count must match rows actually written, including _contained rows"
+    );
+
+    let client = raw_test_client(&backend.config().connection_string)
+        .await
+        .expect("failed to connect MongoDB client for search_index assertions");
+    let database = client.database(&backend.config().database_name);
+    let contained_rows = database
+        .collection::<Document>("search_index")
+        .count_documents(doc! {
+            "tenant_id": tenant.tenant_id().as_str(),
+            "resource_type": "Observation",
+            "resource_id": "obs-contained",
+            "is_contained": true,
+        })
+        .await
+        .expect("failed to count contained search_index rows");
+    assert!(
+        contained_rows > 0,
+        "the contained Patient's values must be indexed alongside the container"
+    );
+}
+
+/// Guard for the `is_search_offloaded()` short-circuit the batched override
+/// needs. The default loop honors the flag via `delete_search_entries` and
+/// `write_search_entries`'s own guards; the page override has to reproduce
+/// it directly rather than issuing commands a search-offloaded backend must
+/// never run. Passes both before and after #1064 — it pins the guard, not
+/// the defect.
+#[tokio::test]
+async fn mongodb_integration_reindex_page_is_a_no_op_when_search_offloaded() {
+    use helios_persistence::search::ReindexTarget;
+    use helios_persistence::types::StoredResource;
+
+    let Some(backend) =
+        create_backend_with_search_offloaded("reindex_page_offloaded", true).await
+    else {
+        eprintln!(
+            "Skipping mongodb_integration_reindex_page_is_a_no_op_when_search_offloaded (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let tenant = create_tenant("reindex-offloaded-tenant");
+
+    let resources: Vec<StoredResource> = (0..2)
+        .map(|n| {
+            StoredResource::from_storage(
+                "Patient",
+                format!("offloaded-{n}"),
+                "1",
+                tenant.tenant_id().clone(),
+                json!({
+                    "resourceType": "Patient",
+                    "id": format!("offloaded-{n}"),
+                    "name": [{"family": format!("Offloaded{n}")}]
+                }),
+                chrono::Utc::now(),
+                chrono::Utc::now(),
+                None,
+                FhirVersion::default(),
+            )
+        })
+        .collect();
+
+    let outcomes = backend.write_search_entries_page(&tenant, &resources).await;
+    assert_eq!(outcomes.len(), 2);
+    for outcome in &outcomes {
+        assert_eq!(*outcome.as_ref().unwrap(), 0usize);
+    }
+
+    for resource in &resources {
+        let count = search_index_entry_count(&backend, &tenant, "Patient", resource.id()).await;
+        assert_eq!(count, 0, "search-offloaded backend must write nothing");
+    }
+}
+
 #[tokio::test]
 async fn mongodb_integration_search_parameter_registry_updates_when_offloaded() {
     let Some(backend) =

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -3549,7 +3549,11 @@ async fn mongodb_integration_reindex_page_batches_index_writes() {
     let mut before_counts = Vec::with_capacity(page.len());
     for resource in &page {
         let count = search_index_entry_count(&backend, &tenant, "Patient", resource.id()).await;
-        assert!(count > 0, "resource {} should already be indexed", resource.id());
+        assert!(
+            count > 0,
+            "resource {} should already be indexed",
+            resource.id()
+        );
         before_counts.push(count);
     }
     let untouched_before =
@@ -3691,7 +3695,11 @@ async fn mongodb_integration_reindex_page_counts_contained_entries() {
     let outcomes = backend
         .write_search_entries_page(&tenant, std::slice::from_ref(&with_contained))
         .await;
-    assert_eq!(outcomes.len(), 1, "one outcome per resource, not per document");
+    assert_eq!(
+        outcomes.len(),
+        1,
+        "one outcome per resource, not per document"
+    );
     let reported = outcomes[0]
         .as_ref()
         .unwrap_or_else(|e| panic!("reindex failed: {e:?}"));
@@ -3733,8 +3741,7 @@ async fn mongodb_integration_reindex_page_is_a_no_op_when_search_offloaded() {
     use helios_persistence::search::ReindexTarget;
     use helios_persistence::types::StoredResource;
 
-    let Some(backend) =
-        create_backend_with_search_offloaded("reindex_page_offloaded", true).await
+    let Some(backend) = create_backend_with_search_offloaded("reindex_page_offloaded", true).await
     else {
         eprintln!(
             "Skipping mongodb_integration_reindex_page_is_a_no_op_when_search_offloaded (requires Docker or HFS_TEST_MONGODB_URL)"


### PR DESCRIPTION
Fixes #1064.

## What was wrong

`MongoBackend` did not override `write_search_entries_page`, so `$reindex` inherited the per-resource default in `crates/persistence/src/search/reindex.rs:184-200`: for each resource, one `delete_many` from `delete_search_entries`, then `write_search_entries` → `index_resource`, which issued **another** `delete_many` plus one `insert_many`. Two `delete_many` and one `insert_many` per resource, strictly sequential. Elasticsearch and SQLite both override it; MongoDB did not.

`search_index_documents` was factored out of `index_resource` for exactly this purpose (see its doc comment) and the reindex path never called it.

## What changed

`crates/persistence/src/backends/mongodb/storage.rs` only — no cross-file edits:

- `write_search_entries_page` is overridden: build the whole page's documents, issue **one** grouped `delete_many` scoped to the page's resource ids, then chunked `.ordered(false)` `insert_many`.
- `write_search_entries` (single-resource) now delegates via `slice::from_ref`, so both paths index identically by construction.
- The redundant second `extract()` that re-ran extraction purely to return a count is gone.
- Short-circuits for `is_search_offloaded()` and an empty slice, matching the surrounding methods.

**The per-resource result contract is preserved.** The method still returns one `StorageResult<usize>` per resource, in order. Insert-many write errors are mapped back to the owning resource via `IndexedWriteError.index` — mirroring the existing `bulk_ingest.rs` create-batch path and Elasticsearch's `send_bulk_index` — so a partial insert failure never fails the whole page. Only the grouped delete, `get_database`, and non-per-op insert errors fan out page-wide. A new `search_index_documents_checked` reports `Err` for a resource whose extraction failed while still writing its minimal fallback rows, matching today's Mongo behaviour and both SQL backends rather than silently returning `Ok`.

## Tests

Three integration tests in `crates/persistence/tests/mongodb_tests.rs`:

- `mongodb_integration_reindex_page_batches_index_writes` — the command-count assertion, via MongoDB profiling
- `mongodb_integration_reindex_page_counts_contained_entries`
- `mongodb_integration_reindex_page_is_a_no_op_when_search_offloaded`

Verified with Docker actually running, not skipped:

```
cargo test -p helios-persistence --features mongodb --test mongodb_tests
test result: ok. 103 passed; 0 failed; 0 ignored
```

`cargo fmt --all -- --check` and clippy with CI's allowlist both pass.

## Behaviour change worth noting on review

`$reindex-status.entries_created` now reports **documents written** — including `_contained` rows, and excluding values `build_search_index_document` drops — rather than `extract(..).len()`. On a corpus with contained resources this reads higher than before. It is documented in the `write_search_entries_page` doc comment, and the runner takes `max()` across writers, but anyone comparing that number across runs will see it move. Elasticsearch still reports extract-length, so the two backends do not agree on this figure.

Also: for a single resource, `insert_many` with `ordered(false)` changes which documents survive when one fails — others still land, where previously an ordered insert stopped at the first failure. Both cases report `Err` for that resource, so reindex-runner behaviour is unchanged.

## Why this matters beyond the numbers

Any future change to the `search_index` document shape requires reindexing the whole corpus, and at the old per-resource cost that window is the dominant cost of such a change — it is the main reason a denormalized `search_index` layout was rejected while researching #1040 / #999. Postgres still inherits the un-overridden default and may want the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECbBsNhgXwBo4dQtFyVBXv
