### PR TITLE
fix(persistence): bound mongodb history_type/history_system to the requested page

### DIFF
--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -300,7 +300,7 @@ fn system_history_cursor_or(params: &HistoryParams) -> Option<Vec<Document>> {
     let bson_ts = chrono_to_bson(ts);
     Some(vec![
         doc! { "last_updated": { "$lt": bson_ts } },
-        doc! { "last_updated": bson_ts.clone(), "resource_type": { "$lt": &resource_type } },
+        doc! { "last_updated": bson_ts, "resource_type": { "$lt": &resource_type } },
         doc! {
             "last_updated": bson_ts,
             "resource_type": &resource_type,
@@ -4286,8 +4286,7 @@ mod history_query_tests {
             "system",
         );
 
-        let or_branches =
-            system_history_cursor_or(&params).expect("expected a cursor predicate");
+        let or_branches = system_history_cursor_or(&params).expect("expected a cursor predicate");
         let expected_ts = chrono_to_bson(ts);
         assert_eq!(
             or_branches,
@@ -4393,7 +4392,10 @@ mod history_query_tests {
     #[test]
     fn sorts_match_the_serving_index_key_order() {
         // idx_history_type_updated = {tenant_id, resource_type, last_updated: -1, id: -1}
-        assert_eq!(type_history_sort(), doc! { "last_updated": -1_i32, "id": -1_i32 });
+        assert_eq!(
+            type_history_sort(),
+            doc! { "last_updated": -1_i32, "id": -1_i32 }
+        );
         // idx_history_system_updated = {tenant_id, last_updated: -1, resource_type: -1, id: -1}
         assert_eq!(
             system_history_sort(),

--- a/crates/persistence/src/backends/mongodb/storage.rs
+++ b/crates/persistence/src/backends/mongodb/storage.rs
@@ -277,6 +277,57 @@ fn parse_system_history_cursor(params: &HistoryParams) -> Option<(DateTime<Utc>,
     Some((timestamp, resource_type, id))
 }
 
+/// Server-side keyset predicate for a `history_type` cursor page: matches the
+/// same `last_updated < ts OR (last_updated == ts AND id < cursor_id)` shape
+/// already used by the Rust-side comparison here and by the SQLite/Postgres
+/// backends, but as a MongoDB `$or` so the index — not a full scan — can
+/// serve it. `None` when there is no cursor (first page), an absent/malformed
+/// cursor, or offset-mode pagination — in every such case the caller adds no
+/// `$or` and the query is simply the first page.
+fn type_history_cursor_or(params: &HistoryParams) -> Option<Vec<Document>> {
+    let (ts, id) = parse_type_history_cursor(params)?;
+    let bson_ts = chrono_to_bson(ts);
+    Some(vec![
+        doc! { "last_updated": { "$lt": bson_ts } },
+        doc! { "last_updated": bson_ts, "id": { "$lt": id } },
+    ])
+}
+
+/// Same as [`type_history_cursor_or`] but for `history_system`'s 3-key sort
+/// (`last_updated`, `resource_type`, `id`).
+fn system_history_cursor_or(params: &HistoryParams) -> Option<Vec<Document>> {
+    let (ts, resource_type, id) = parse_system_history_cursor(params)?;
+    let bson_ts = chrono_to_bson(ts);
+    Some(vec![
+        doc! { "last_updated": { "$lt": bson_ts } },
+        doc! { "last_updated": bson_ts.clone(), "resource_type": { "$lt": &resource_type } },
+        doc! {
+            "last_updated": bson_ts,
+            "resource_type": &resource_type,
+            "id": { "$lt": id },
+        },
+    ])
+}
+
+/// Sort matching `idx_history_type_updated`'s key order after its two
+/// equality-filtered prefix fields (`tenant_id`, `resource_type`).
+fn type_history_sort() -> Document {
+    doc! { "last_updated": -1_i32, "id": -1_i32 }
+}
+
+/// Sort matching `idx_history_system_updated`'s key order after its
+/// equality-filtered prefix field (`tenant_id`).
+fn system_history_sort() -> Document {
+    doc! { "last_updated": -1_i32, "resource_type": -1_i32, "id": -1_i32 }
+}
+
+/// Documents to fetch for a history page: `count + 1` so the caller can
+/// detect `has_next` by truncating back to `count`. Never 0 — MongoDB reads
+/// `limit(0)` as "unlimited", which would silently undo the bound.
+fn history_fetch_limit(count: u32) -> i64 {
+    i64::from(count.saturating_add(1))
+}
+
 #[derive(Debug, Clone)]
 struct ParsedHistoryRow {
     resource_type: String,
@@ -2444,9 +2495,25 @@ impl TypeHistoryProvider for MongoBackend {
             "resource_type": resource_type,
         };
         apply_history_params_filter(&mut filter, params);
+        if let Some(or_branches) = type_history_cursor_or(params) {
+            // A distinct top-level key from the `last_updated` range that
+            // `apply_history_params_filter` may have just inserted, so the
+            // two AND together implicitly rather than colliding.
+            filter.insert("$or", or_branches);
+        }
+
+        let opts = FindOptions::builder()
+            .sort(type_history_sort())
+            .limit(history_fetch_limit(params.pagination.count))
+            // Exclusion-style on the only two fields parse_history_row never
+            // reads: an inclusion projection risks silently substituting a
+            // default for a field it does read (e.g. fhir_version).
+            .projection(doc! { "_id": 0, "created_at": 0 })
+            .build();
 
         let cursor = history
             .find(filter)
+            .with_options(opts)
             .await
             .or_query_error("Failed to query type history")?;
 
@@ -2456,19 +2523,25 @@ impl TypeHistoryProvider for MongoBackend {
             .map(|doc| parse_history_row(doc, Some(resource_type), None))
             .collect::<StorageResult<Vec<_>>>()?;
 
+        // The server-side sort (matching idx_history_type_updated) already
+        // orders the <= count+1 fetched rows by (last_updated desc, id desc);
+        // only the version_id tie-break stays in Rust, because version_id is
+        // in neither idx_history_type_updated nor idx_history_system_updated
+        // (pushing it server-side would reintroduce a blocking SORT, and it
+        // is stored as a string, so a server-side $lt/sort on it would
+        // misorder "10" ahead of "9" anyway). When a (last_updated, id) tie
+        // group straddles the fetch-limit boundary, the server's limit() may
+        // now pick an arbitrary subset of that group before this sort runs,
+        // so which member lands on the page is no longer guaranteed to be
+        // the highest version_id — but any group member beyond the boundary
+        // was already dropped by the (ts, id)-only cursor predicate above
+        // (shared with SQLite/Postgres), so total loss is unchanged.
         rows.sort_by(|a, b| {
             b.last_updated
                 .cmp(&a.last_updated)
                 .then_with(|| b.id.cmp(&a.id))
                 .then_with(|| parse_version_id(&b.version_id).cmp(&parse_version_id(&a.version_id)))
         });
-
-        if let Some((cursor_timestamp, cursor_id)) = parse_type_history_cursor(params) {
-            rows.retain(|row| {
-                row.last_updated < cursor_timestamp
-                    || (row.last_updated == cursor_timestamp && row.id < cursor_id)
-            });
-        }
 
         let page_len = params.pagination.count as usize;
         let has_more = rows.len() > page_len;
@@ -2534,9 +2607,19 @@ impl SystemHistoryProvider for MongoBackend {
             "tenant_id": tenant_id,
         };
         apply_history_params_filter(&mut filter, params);
+        if let Some(or_branches) = system_history_cursor_or(params) {
+            filter.insert("$or", or_branches);
+        }
+
+        let opts = FindOptions::builder()
+            .sort(system_history_sort())
+            .limit(history_fetch_limit(params.pagination.count))
+            .projection(doc! { "_id": 0, "created_at": 0 })
+            .build();
 
         let cursor = history
             .find(filter)
+            .with_options(opts)
             .await
             .or_query_error("Failed to query system history")?;
 
@@ -2546,6 +2629,12 @@ impl SystemHistoryProvider for MongoBackend {
             .map(|doc| parse_history_row(doc, None, None))
             .collect::<StorageResult<Vec<_>>>()?;
 
+        // See the matching comment in history_type: the server-side sort
+        // (matching idx_history_system_updated) already orders the fetched
+        // page; only the version_id tie-break stays in Rust, and a
+        // (last_updated, resource_type, id) tie group straddling the
+        // fetch-limit boundary can show an arbitrary member without
+        // widening total loss versus today.
         rows.sort_by(|a, b| {
             b.last_updated
                 .cmp(&a.last_updated)
@@ -2553,17 +2642,6 @@ impl SystemHistoryProvider for MongoBackend {
                 .then_with(|| b.id.cmp(&a.id))
                 .then_with(|| parse_version_id(&b.version_id).cmp(&parse_version_id(&a.version_id)))
         });
-
-        if let Some((cursor_timestamp, cursor_type, cursor_id)) =
-            parse_system_history_cursor(params)
-        {
-            rows.retain(|row| {
-                row.last_updated < cursor_timestamp
-                    || (row.last_updated == cursor_timestamp
-                        && (row.resource_type < cursor_type
-                            || (row.resource_type == cursor_type && row.id < cursor_id)))
-            });
-        }
 
         let page_len = params.pagination.count as usize;
         let has_more = rows.len() > page_len;
@@ -4149,5 +4227,177 @@ fn resolve_bundle_references(value: &mut Value, reference_map: &HashMap<String, 
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod history_query_tests {
+    //! Docker-free unit tests for the pure query builders behind #1053's
+    //! fix: the server-side cursor predicate, sort, and fetch-limit that
+    //! `history_type`/`history_system` now push to MongoDB instead of
+    //! draining the whole history corpus into Rust before paging.
+
+    use super::*;
+    use crate::types::Pagination;
+
+    fn cursor_params(sort_values: Vec<CursorValue>, resource_id: &str) -> HistoryParams {
+        let cursor = PageCursor::new(sort_values, resource_id);
+        HistoryParams {
+            pagination: Pagination::with_cursor(10, cursor.encode()),
+            ..HistoryParams::default()
+        }
+    }
+
+    #[test]
+    fn type_history_cursor_or_matches_expected_shape() {
+        let ts = DateTime::parse_from_rfc3339("2024-01-01T00:00:10Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let params = cursor_params(
+            vec![
+                CursorValue::String(ts.to_rfc3339()),
+                CursorValue::String("obs-5".to_string()),
+            ],
+            "Observation",
+        );
+
+        let or_branches = type_history_cursor_or(&params).expect("expected a cursor predicate");
+        let expected_ts = chrono_to_bson(ts);
+        assert_eq!(
+            or_branches,
+            vec![
+                doc! { "last_updated": { "$lt": expected_ts } },
+                doc! { "last_updated": expected_ts, "id": { "$lt": "obs-5" } },
+            ]
+        );
+    }
+
+    #[test]
+    fn system_history_cursor_or_matches_expected_3_branch_shape() {
+        let ts = DateTime::parse_from_rfc3339("2024-01-01T00:00:10Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let params = cursor_params(
+            vec![
+                CursorValue::String(ts.to_rfc3339()),
+                CursorValue::String("Observation".to_string()),
+                CursorValue::String("obs-5".to_string()),
+            ],
+            "system",
+        );
+
+        let or_branches =
+            system_history_cursor_or(&params).expect("expected a cursor predicate");
+        let expected_ts = chrono_to_bson(ts);
+        assert_eq!(
+            or_branches,
+            vec![
+                doc! { "last_updated": { "$lt": expected_ts } },
+                doc! {
+                    "last_updated": expected_ts,
+                    "resource_type": { "$lt": "Observation" },
+                },
+                doc! {
+                    "last_updated": expected_ts,
+                    "resource_type": "Observation",
+                    "id": { "$lt": "obs-5" },
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn cursor_or_is_none_for_absent_cursor() {
+        let params = HistoryParams::default();
+        assert!(type_history_cursor_or(&params).is_none());
+        assert!(system_history_cursor_or(&params).is_none());
+    }
+
+    #[test]
+    fn cursor_or_is_none_for_malformed_cursor() {
+        // Only one sort value: type history needs 2, system needs 3.
+        let ts = Utc::now();
+        let params = cursor_params(vec![CursorValue::String(ts.to_rfc3339())], "Observation");
+        assert!(type_history_cursor_or(&params).is_none());
+        assert!(system_history_cursor_or(&params).is_none());
+
+        // Two sort values: enough for type history, not for system history.
+        let params2 = cursor_params(
+            vec![
+                CursorValue::String(ts.to_rfc3339()),
+                CursorValue::String("obs-5".to_string()),
+            ],
+            "Observation",
+        );
+        assert!(type_history_cursor_or(&params2).is_some());
+        assert!(system_history_cursor_or(&params2).is_none());
+    }
+
+    #[test]
+    fn cursor_or_is_none_for_offset_mode_pagination() {
+        let params = HistoryParams {
+            pagination: Pagination::offset(5),
+            ..HistoryParams::default()
+        };
+        assert!(type_history_cursor_or(&params).is_none());
+        assert!(system_history_cursor_or(&params).is_none());
+    }
+
+    #[test]
+    fn since_before_range_coexists_with_cursor_or_without_key_collision() {
+        let since = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let before = DateTime::parse_from_rfc3339("2024-06-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let cursor_ts = DateTime::parse_from_rfc3339("2024-03-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let mut params = cursor_params(
+            vec![
+                CursorValue::String(cursor_ts.to_rfc3339()),
+                CursorValue::String("obs-5".to_string()),
+            ],
+            "Observation",
+        );
+        params.since = Some(since);
+        params.before = Some(before);
+
+        let mut filter = doc! { "tenant_id": "tenant-1", "resource_type": "Observation" };
+        apply_history_params_filter(&mut filter, &params);
+        let or_branches = type_history_cursor_or(&params).expect("expected a cursor predicate");
+        filter.insert("$or", or_branches);
+
+        // Both the range (under "last_updated") and the cursor predicate
+        // (under the distinct top-level "$or" key) are present — they AND
+        // together implicitly rather than colliding on the same key.
+        let range = filter
+            .get_document("last_updated")
+            .expect("expected the since/before range to remain under last_updated");
+        assert_eq!(range.get("$gte"), Some(&Bson::from(chrono_to_bson(since))));
+        assert_eq!(range.get("$lt"), Some(&Bson::from(chrono_to_bson(before))));
+        assert!(filter.contains_key("$or"));
+        // include_deleted defaults to false, so the filter also carries it.
+        assert_eq!(filter.get_bool("is_deleted").ok(), Some(false));
+    }
+
+    #[test]
+    fn history_fetch_limit_is_count_plus_one_and_never_zero() {
+        assert_eq!(history_fetch_limit(10), 11);
+        assert_eq!(history_fetch_limit(0), 1);
+        assert_eq!(history_fetch_limit(99), 100);
+    }
+
+    #[test]
+    fn sorts_match_the_serving_index_key_order() {
+        // idx_history_type_updated = {tenant_id, resource_type, last_updated: -1, id: -1}
+        assert_eq!(type_history_sort(), doc! { "last_updated": -1_i32, "id": -1_i32 });
+        // idx_history_system_updated = {tenant_id, last_updated: -1, resource_type: -1, id: -1}
+        assert_eq!(
+            system_history_sort(),
+            doc! { "last_updated": -1_i32, "resource_type": -1_i32, "id": -1_i32 }
+        );
     }
 }

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -2087,6 +2087,667 @@ async fn mongodb_integration_history_providers() {
     assert!(system_count >= 4);
 }
 
+// ---------------------------------------------------------------------------
+// #1053: history_type / history_system must page via a server-side sort +
+// limit + cursor predicate rather than draining the whole history corpus into
+// memory before sorting/paging in Rust. See mongodb storage.rs history_type /
+// history_system and the module-level doc comment there.
+// ---------------------------------------------------------------------------
+
+use mongodb::Collection;
+
+/// Seeds `obs_count` Observations with 3 versions each (create + 2 updates)
+/// and returns the (id, version_id) history keys in creation order:
+/// `hist-obs-0` v1, v2, v3, `hist-obs-1` v1, v2, v3, ...
+async fn seed_type_history_corpus(
+    backend: &MongoBackend,
+    tenant: &TenantContext,
+    obs_count: usize,
+) -> Vec<(String, String)> {
+    let mut keys = Vec::new();
+    for i in 0..obs_count {
+        let id = format!("hist-obs-{i}");
+        let v1 = backend
+            .create(
+                tenant,
+                "Observation",
+                json!({"resourceType": "Observation", "id": id, "status": "final"}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        keys.push((id.clone(), "1".to_string()));
+
+        let v2 = backend
+            .update(
+                tenant,
+                &v1,
+                json!({"resourceType": "Observation", "id": id, "status": "amended"}),
+            )
+            .await
+            .unwrap();
+        keys.push((id.clone(), "2".to_string()));
+
+        backend
+            .update(
+                tenant,
+                &v2,
+                json!({"resourceType": "Observation", "id": id, "status": "final"}),
+            )
+            .await
+            .unwrap();
+        keys.push((id.clone(), "3".to_string()));
+    }
+    keys
+}
+
+/// Overwrites `last_updated` on one `resource_history` row directly, so tests
+/// can pin a deterministic, wall-clock-independent ordering instead of
+/// trusting back-to-back millisecond-resolution writes not to tie.
+async fn stamp_history_last_updated(
+    history: &Collection<Document>,
+    tenant: &TenantContext,
+    resource_type: &str,
+    id: &str,
+    version_id: &str,
+    ts: mongodb::bson::DateTime,
+) {
+    let result = history
+        .update_one(
+            doc! {
+                "tenant_id": tenant.tenant_id().as_str(),
+                "resource_type": resource_type,
+                "id": id,
+                "version_id": version_id,
+            },
+            doc! { "$set": { "last_updated": ts } },
+        )
+        .await
+        .expect("failed to stamp resource_history.last_updated");
+    assert_eq!(
+        result.matched_count, 1,
+        "expected exactly one history row for ({resource_type}, {id}, v{version_id})"
+    );
+}
+
+fn history_ts(base_millis: i64, offset_secs: i64) -> mongodb::bson::DateTime {
+    mongodb::bson::DateTime::from_millis(base_millis + offset_secs * 1000)
+}
+
+/// Pin for #1053: `history_type` must not read rows outside the requested
+/// page. A `data`-less sentinel row sits at the *oldest* timestamp (well
+/// outside the first two pages); today's unbounded `find` drains it into
+/// `parse_history_row`, which errors on the missing payload even though the
+/// sentinel is nowhere near the page being requested. After the fix the
+/// server-side `sort + limit` means the sentinel is never fetched for a
+/// small page, and assertion (3) below proves the sentinel is still live
+/// (and still errors) once the requested window actually reaches it — so a
+/// future tolerant parse that swallowed missing-payload rows could not make
+/// this test pass vacuously.
+#[tokio::test]
+async fn mongodb_history_type_does_not_read_rows_outside_the_page() {
+    let Some(backend) = create_backend("history_page_bounds").await else {
+        eprintln!(
+            "Skipping mongodb_history_type_does_not_read_rows_outside_the_page (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let tenant = create_tenant("tenant-history-page-bounds");
+
+    // 10 Observations x 3 versions = 30 good history rows.
+    seed_type_history_corpus(&backend, &tenant, 10).await;
+
+    let client = raw_test_client(&backend.config().connection_string)
+        .await
+        .expect("failed to connect raw MongoDB client");
+    let database = client.database(&backend.config().database_name);
+    let history: Collection<Document> = database.collection("resource_history");
+
+    // Deterministic timestamps: row k (k = i*3 + (v-1)) gets base + k seconds,
+    // so descending last_updated order is exactly descending k, with no ties.
+    let base_millis = chrono::Utc::now().timestamp_millis() - 1_000_000;
+    for i in 0..10usize {
+        for v in 1..=3usize {
+            let k = (i * 3 + (v - 1)) as i64;
+            stamp_history_last_updated(
+                &history,
+                &tenant,
+                "Observation",
+                &format!("hist-obs-{i}"),
+                &v.to_string(),
+                history_ts(base_millis, k),
+            )
+            .await;
+        }
+    }
+
+    // Sentinel: oldest timestamp of all, no `data` field, unique id so the
+    // (tenant_id, resource_type, id, version_id) unique index is satisfied.
+    history
+        .insert_one(doc! {
+            "tenant_id": tenant.tenant_id().as_str(),
+            "resource_type": "Observation",
+            "id": "sentinel-1053",
+            "version_id": "1",
+            "last_updated": history_ts(base_millis, -1000),
+            "is_deleted": false,
+            "fhir_version": "R4",
+        })
+        .await
+        .expect("failed to insert sentinel history row");
+
+    // Expected global order (newest first) is descending k: 29, 28, ..., 0.
+    let expected: Vec<(String, String)> = (0..30i64)
+        .rev()
+        .map(|k| {
+            let i = k / 3;
+            let v = (k % 3) + 1;
+            (format!("hist-obs-{i}"), v.to_string())
+        })
+        .collect();
+
+    // --- Assertion (1): THE PIN ---
+    let params = HistoryParams::new().count(10).include_deleted(true);
+    let page1 = backend
+        .history_type(&tenant, "Observation", &params)
+        .await
+        .expect(
+            "history_type must not read past the requested page \
+             (a data-less sentinel far outside the page must not surface)",
+        );
+    assert_eq!(page1.items.len(), 10);
+    let page1_keys: Vec<(String, String)> = page1
+        .items
+        .iter()
+        .map(|e| (e.resource.id().to_string(), e.resource.version_id().to_string()))
+        .collect();
+    assert_eq!(page1_keys, expected[0..10]);
+    assert!(page1.page_info.has_next);
+    let next_cursor = page1
+        .page_info
+        .next_cursor
+        .clone()
+        .expect("expected a next_cursor for page 1");
+
+    // --- Assertion (2): CURSOR CONSISTENCY ---
+    let mut params2 = HistoryParams::new().count(10).include_deleted(true);
+    params2.pagination = helios_persistence::types::Pagination::with_cursor(10, next_cursor);
+    let page2 = backend
+        .history_type(&tenant, "Observation", &params2)
+        .await
+        .expect("page 2 must succeed (its fetch window does not reach the sentinel)");
+    assert_eq!(page2.items.len(), 10);
+    let page2_keys: Vec<(String, String)> = page2
+        .items
+        .iter()
+        .map(|e| (e.resource.id().to_string(), e.resource.version_id().to_string()))
+        .collect();
+    assert_eq!(page2_keys, expected[10..20]);
+    // Disjoint from page 1, contiguous with it.
+    for key in &page2_keys {
+        assert!(!page1_keys.contains(key), "page 2 repeated a page 1 row: {key:?}");
+    }
+
+    // --- Assertion (3): CANARY PREMISE ---
+    // A window wide enough to actually reach the sentinel must still error,
+    // proving the sentinel is live and matches the filter (i.e. it is only
+    // absent from assertion (1) because the page stopped short of it).
+    let wide_params = HistoryParams::new().count(100).include_deleted(true);
+    let err = backend
+        .history_type(&tenant, "Observation", &wide_params)
+        .await
+        .expect_err("a window reaching the sentinel must surface its missing payload");
+    let message = format!("{err}");
+    assert!(
+        message.contains("Missing history payload"),
+        "expected a missing-payload error, got: {message}"
+    );
+}
+
+/// Companion to the pin test: no sentinel, walks every page via `next_cursor`
+/// and checks the full corpus comes back in the right order with no
+/// duplicates or omissions. Includes one deliberate (last_updated, id) tie
+/// pair placed strictly inside page 1, to pin that the version_id tie-break
+/// (last_updated desc, id desc, version_id desc) survives in Rust once the
+/// sort/limit/cursor predicate move server-side.
+#[tokio::test]
+async fn mongodb_history_type_paging_is_ordered_and_complete() {
+    let Some(backend) = create_backend("history_paging_complete").await else {
+        eprintln!(
+            "Skipping mongodb_history_type_paging_is_ordered_and_complete (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let tenant = create_tenant("tenant-history-paging-complete");
+
+    // 8 Observations x 3 versions = 24 rows, plus 2 extra versions on
+    // "hist-obs-0" (v4, v5) sharing v3's timestamp to create a tie group that
+    // straddles nothing but sits inside page 1 (count=5).
+    seed_type_history_corpus(&backend, &tenant, 8).await;
+    let obs0_v3 = backend
+        .read(&tenant, "Observation", "hist-obs-0")
+        .await
+        .unwrap()
+        .unwrap();
+    let obs0_v4 = backend
+        .update(
+            &tenant,
+            &obs0_v3,
+            json!({"resourceType": "Observation", "id": "hist-obs-0", "status": "final"}),
+        )
+        .await
+        .unwrap();
+    backend
+        .update(
+            &tenant,
+            &obs0_v4,
+            json!({"resourceType": "Observation", "id": "hist-obs-0", "status": "final"}),
+        )
+        .await
+        .unwrap();
+
+    let client = raw_test_client(&backend.config().connection_string)
+        .await
+        .expect("failed to connect raw MongoDB client");
+    let database = client.database(&backend.config().database_name);
+    let history: Collection<Document> = database.collection("resource_history");
+
+    let base_millis = chrono::Utc::now().timestamp_millis() - 1_000_000;
+    // 26 total rows: assign distinct k = 0..25 to every (id, version) except
+    // that hist-obs-0's v4 and v5 both get k = 25 (the newest slot), forming
+    // the deliberate tie: version_id 5 must sort before version_id 4.
+    let mut k = 0i64;
+    let mut expected_by_k: Vec<(i64, String, String)> = Vec::new();
+    for i in 0..8usize {
+        for v in 1..=3usize {
+            expected_by_k.push((k, format!("hist-obs-{i}"), v.to_string()));
+            stamp_history_last_updated(
+                &history,
+                &tenant,
+                "Observation",
+                &format!("hist-obs-{i}"),
+                &v.to_string(),
+                history_ts(base_millis, k),
+            )
+            .await;
+            k += 1;
+        }
+    }
+    // Tie pair: v4 and v5 of hist-obs-0 share the *next* timestamp (k = 25).
+    let tie_k = k;
+    for v in [4usize, 5usize] {
+        stamp_history_last_updated(
+            &history,
+            &tenant,
+            "Observation",
+            "hist-obs-0",
+            &v.to_string(),
+            history_ts(base_millis, tie_k),
+        )
+        .await;
+    }
+    expected_by_k.push((tie_k, "hist-obs-0".to_string(), "5".to_string()));
+    expected_by_k.push((tie_k, "hist-obs-0".to_string(), "4".to_string()));
+
+    // Expected global order: descending k; within a k tie, descending
+    // version_id (the Rust-side tie-break).
+    let mut expected = expected_by_k;
+    expected.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| b.2.parse::<i64>().unwrap().cmp(&a.2.parse::<i64>().unwrap()))
+    });
+    let expected: Vec<(String, String)> = expected.into_iter().map(|(_, id, v)| (id, v)).collect();
+    assert_eq!(expected.len(), 26);
+    // The tie pair (v5, v4) must be strictly inside page 1 (count=5): it's
+    // rank 1-2 of 26, well inside the first 5.
+    assert_eq!(expected[0], ("hist-obs-0".to_string(), "5".to_string()));
+    assert_eq!(expected[1], ("hist-obs-0".to_string(), "4".to_string()));
+
+    let mut all_rows: Vec<(String, String)> = Vec::new();
+    let mut params = HistoryParams::new().count(5).include_deleted(true);
+    loop {
+        let page = backend
+            .history_type(&tenant, "Observation", &params)
+            .await
+            .expect("paging through the full corpus must not error");
+        let keys: Vec<(String, String)> = page
+            .items
+            .iter()
+            .map(|e| (e.resource.id().to_string(), e.resource.version_id().to_string()))
+            .collect();
+        all_rows.extend(keys);
+
+        if page.page_info.has_next {
+            let cursor = page.page_info.next_cursor.expect("has_next implies a cursor");
+            params = HistoryParams::new().count(5).include_deleted(true);
+            params.pagination = helios_persistence::types::Pagination::with_cursor(5, cursor);
+        } else {
+            break;
+        }
+    }
+
+    assert_eq!(all_rows.len(), expected.len(), "row count mismatch");
+    assert_eq!(all_rows, expected, "row order mismatch");
+    let mut dedup_check = all_rows.clone();
+    dedup_check.sort();
+    dedup_check.dedup();
+    assert_eq!(dedup_check.len(), all_rows.len(), "found duplicate rows across pages");
+}
+
+/// Mirror of the pin test for `history_system`: sentinel row of a resource
+/// type that already appears in the corpus, at the oldest timestamp, no
+/// `data` field.
+#[tokio::test]
+async fn mongodb_history_system_does_not_read_rows_outside_the_page() {
+    let Some(backend) = create_backend("history_system_page_bounds").await else {
+        eprintln!(
+            "Skipping mongodb_history_system_does_not_read_rows_outside_the_page (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let tenant = create_tenant("tenant-history-system-page-bounds");
+
+    // 5 Patients + 5 Observations, 3 versions each = 30 rows.
+    for i in 0..5usize {
+        let id = format!("sys-pat-{i}");
+        let v1 = backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({"resourceType": "Patient", "id": id, "name": [{"family": "X"}]}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+        let v2 = backend
+            .update(
+                &tenant,
+                &v1,
+                json!({"resourceType": "Patient", "id": id, "name": [{"family": "Y"}]}),
+            )
+            .await
+            .unwrap();
+        backend
+            .update(
+                &tenant,
+                &v2,
+                json!({"resourceType": "Patient", "id": id, "name": [{"family": "Z"}]}),
+            )
+            .await
+            .unwrap();
+    }
+    seed_type_history_corpus(&backend, &tenant, 5).await;
+
+    let client = raw_test_client(&backend.config().connection_string)
+        .await
+        .expect("failed to connect raw MongoDB client");
+    let database = client.database(&backend.config().database_name);
+    let history: Collection<Document> = database.collection("resource_history");
+
+    // Deterministic, distinct timestamps across all 30 rows: Patients get
+    // k = 0..14, Observations get k = 15..29 (so ordering is unambiguous by
+    // timestamp alone; resource_type/id tie-break is covered by the type
+    // history companion test).
+    let base_millis = chrono::Utc::now().timestamp_millis() - 1_000_000;
+    let mut expected: Vec<(String, String, String)> = Vec::new();
+    let mut k = 0i64;
+    for i in 0..5usize {
+        for v in 1..=3usize {
+            let id = format!("sys-pat-{i}");
+            stamp_history_last_updated(&history, &tenant, "Patient", &id, &v.to_string(), history_ts(base_millis, k))
+                .await;
+            expected.push(("Patient".to_string(), id, v.to_string()));
+            k += 1;
+        }
+    }
+    for i in 0..5usize {
+        for v in 1..=3usize {
+            let id = format!("hist-obs-{i}");
+            stamp_history_last_updated(&history, &tenant, "Observation", &id, &v.to_string(), history_ts(base_millis, k))
+                .await;
+            expected.push(("Observation".to_string(), id, v.to_string()));
+            k += 1;
+        }
+    }
+    expected.reverse(); // newest (highest k) first
+
+    history
+        .insert_one(doc! {
+            "tenant_id": tenant.tenant_id().as_str(),
+            "resource_type": "Patient",
+            "id": "sentinel-1053-system",
+            "version_id": "1",
+            "last_updated": history_ts(base_millis, -1000),
+            "is_deleted": false,
+            "fhir_version": "R4",
+        })
+        .await
+        .expect("failed to insert sentinel history row");
+
+    let params = HistoryParams::new().count(10).include_deleted(true);
+    let page1 = backend
+        .history_system(&tenant, &params)
+        .await
+        .expect("history_system must not read past the requested page");
+    assert_eq!(page1.items.len(), 10);
+    let page1_keys: Vec<(String, String, String)> = page1
+        .items
+        .iter()
+        .map(|e| {
+            (
+                e.resource.resource_type().to_string(),
+                e.resource.id().to_string(),
+                e.resource.version_id().to_string(),
+            )
+        })
+        .collect();
+    assert_eq!(page1_keys, expected[0..10]);
+    assert!(page1.page_info.has_next);
+
+    let wide_params = HistoryParams::new().count(100).include_deleted(true);
+    let err = backend
+        .history_system(&tenant, &wide_params)
+        .await
+        .expect_err("a window reaching the sentinel must surface its missing payload");
+    assert!(
+        format!("{err}").contains("Missing history payload"),
+        "expected a missing-payload error"
+    );
+}
+
+/// Scale-free plan guard: the winning plan for the *first* (no-cursor) page
+/// must be a bounded index walk — sort and limit pushed to MongoDB, no
+/// blocking in-memory SORT stage, and keys/docs examined bounded by
+/// `_count`, not by the size of the corpus. Per code review: on a tiny
+/// corpus the cursor-page query can legitimately choose a residual-filter
+/// plan whose keysExamined scale with the cursor's rank rather than just
+/// `_count` (still O(rank + count), still non-blocking) — so this test only
+/// asserts the hard bound on the first page, where no cursor predicate is
+/// involved and the index alone must satisfy the whole query.
+#[tokio::test]
+async fn mongodb_history_type_plan_is_a_bounded_index_walk() {
+    let Some(backend) = create_backend("history_plan_guard").await else {
+        eprintln!(
+            "Skipping mongodb_history_type_plan_is_a_bounded_index_walk (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+    let tenant = create_tenant("tenant-history-plan-guard");
+
+    seed_type_history_corpus(&backend, &tenant, 10).await; // 30 rows
+
+    let client = raw_test_client(&backend.config().connection_string)
+        .await
+        .expect("failed to connect raw MongoDB client");
+    let db_name = backend.config().database_name.clone();
+    let database = client.database(&db_name);
+
+    if let Err(e) = database.run_command(doc! { "profile": 2_i32 }).await {
+        eprintln!(
+            "Skipping mongodb_history_type_plan_is_a_bounded_index_walk plan assertions: \
+             {{profile: 2}} was refused ({e})"
+        );
+        return;
+    }
+
+    let params = HistoryParams::new().count(10).include_deleted(true);
+    backend
+        .history_type(&tenant, "Observation", &params)
+        .await
+        .expect("history_type must succeed");
+
+    let _ = database.run_command(doc! { "profile": 0_i32 }).await;
+
+    let profile: Collection<Document> = database.collection("system.profile");
+    let opts = mongodb::options::FindOptions::builder()
+        .sort(doc! { "ts": -1_i32 })
+        .limit(20)
+        .build();
+    let mut cursor = profile
+        .find(doc! {
+            "ns": format!("{db_name}.resource_history"),
+            "op": "query",
+            "command.find": "resource_history",
+        })
+        .with_options(opts)
+        .await
+        .expect("failed to query system.profile");
+
+    let mut entry: Option<Document> = None;
+    while cursor.advance().await.expect("failed to advance profile cursor") {
+        let doc = cursor.deserialize_current().expect("failed to deserialize profile entry");
+        entry = Some(doc);
+        break;
+    }
+    let entry = entry.expect("expected a profiled find on resource_history");
+
+    let command = entry
+        .get_document("command")
+        .expect("profile entry missing command");
+    assert_eq!(
+        command.get_document("sort").ok(),
+        Some(&doc! { "last_updated": -1_i32, "id": -1_i32 })
+    );
+    let limit = command
+        .get_i32("limit")
+        .map(i64::from)
+        .or_else(|_| command.get_i64("limit"))
+        .expect("command missing limit");
+    assert_eq!(limit, 11);
+
+    // On MongoDB 5.0 `hasSortStage` is simply absent when there is no sort
+    // stage — must not unwrap a missing field as an error.
+    let has_sort_stage = entry.get_bool("hasSortStage").unwrap_or(false);
+    assert!(!has_sort_stage, "expected no blocking sort stage on the first page");
+
+    let docs_examined = entry.get_i64("docsExamined").or_else(|_| entry.get_i32("docsExamined").map(i64::from));
+    let keys_examined = entry.get_i64("keysExamined").or_else(|_| entry.get_i32("keysExamined").map(i64::from));
+    if let Ok(d) = docs_examined {
+        assert!(d <= 11, "docsExamined {d} exceeds count+1 (11) on the first page");
+    }
+    if let Ok(k) = keys_examined {
+        assert!(k <= 11, "keysExamined {k} exceeds count+1 (11) on the first page");
+    }
+
+    let plan_summary = entry.get_str("planSummary").unwrap_or_default();
+    assert!(plan_summary.contains("IXSCAN"), "expected an IXSCAN plan, got: {plan_summary}");
+
+    // Rebuild the inner find command from exactly what the server recorded
+    // (command also carries $db/lsid/$readPreference, which explain rejects).
+    let mut inner = Document::new();
+    for key in ["find", "filter", "sort", "limit", "projection"] {
+        if let Some(v) = command.get(key) {
+            inner.insert(key, v.clone());
+        }
+    }
+    let explain = database
+        .run_command(doc! { "explain": inner, "verbosity": "executionStats" })
+        .await
+        .expect("explain of the recorded find command failed");
+
+    let stats = explain
+        .get_document("executionStats")
+        .expect("explain missing executionStats");
+    let total_keys = stats.get_i64("totalKeysExamined").or_else(|_| stats.get_i32("totalKeysExamined").map(i64::from)).unwrap();
+    let total_docs = stats.get_i64("totalDocsExamined").or_else(|_| stats.get_i32("totalDocsExamined").map(i64::from)).unwrap();
+    assert!(total_keys <= 11, "explain totalKeysExamined {total_keys} exceeds 11");
+    assert!(total_docs <= 11, "explain totalDocsExamined {total_docs} exceeds 11");
+
+    // Only the *winning* plan matters here. `explain` also carries
+    // `queryPlanner.rejectedPlans` — other candidates the multi-planner
+    // tried and discarded (e.g. via idx_history_identity or
+    // idx_history_resource_updated), several of which legitimately contain
+    // their own SORT stage. Scanning the whole explain document (including
+    // rejected plans) would false-positive on those, so only the winning
+    // plan tree is searched for a blocking SORT.
+    let winning_plan = explain
+        .get_document("queryPlanner")
+        .expect("explain missing queryPlanner")
+        .get_document("winningPlan")
+        .expect("explain missing winningPlan");
+    assert!(
+        !contains_stage_named(winning_plan, "SORT"),
+        "winning plan contains a blocking SORT stage: {winning_plan:?}"
+    );
+    let mut index_names = Vec::new();
+    collect_index_names(winning_plan, &mut index_names);
+    assert!(
+        index_names.iter().any(|n| n == "idx_history_type_updated"),
+        "expected idx_history_type_updated in the winning plan, got: {index_names:?}"
+    );
+}
+
+/// Recursively searches a BSON document for a nested `"stage"` field equal
+/// exactly to `name` (case-sensitive). Used to assert the *absence* of a
+/// blocking `SORT` stage without false-positiving on the non-blocking
+/// `SORT_MERGE`.
+fn contains_stage_named(doc: &Document, name: &str) -> bool {
+    if doc.get_str("stage").map(|s| s == name).unwrap_or(false) {
+        return true;
+    }
+    for (_, v) in doc.iter() {
+        match v {
+            mongodb::bson::Bson::Document(d) => {
+                if contains_stage_named(d, name) {
+                    return true;
+                }
+            }
+            mongodb::bson::Bson::Array(arr) => {
+                for item in arr {
+                    if let mongodb::bson::Bson::Document(d) = item {
+                        if contains_stage_named(d, name) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Recursively collects every `"indexName"` field found anywhere in a BSON
+/// document (explain output nests it under queryPlanner/winningPlan/inputStages).
+fn collect_index_names(doc: &Document, out: &mut Vec<String>) {
+    if let Ok(name) = doc.get_str("indexName") {
+        out.push(name.to_string());
+    }
+    for (_, v) in doc.iter() {
+        match v {
+            mongodb::bson::Bson::Document(d) => collect_index_names(d, out),
+            mongodb::bson::Bson::Array(arr) => {
+                for item in arr {
+                    if let mongodb::bson::Bson::Document(d) = item {
+                        collect_index_names(d, out);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 #[tokio::test]
 async fn mongodb_integration_history_delete_trial_use_not_supported() {
     let Some(backend) = create_backend("history_delete_not_supported").await else {

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -2090,8 +2090,8 @@ async fn mongodb_integration_history_providers() {
 // ---------------------------------------------------------------------------
 // #1053: history_type / history_system must page via a server-side sort +
 // limit + cursor predicate rather than draining the whole history corpus into
-// memory before sorting/paging in Rust. See mongodb storage.rs history_type /
-// history_system and the module-level doc comment there.
+// memory before sorting/paging in Rust. See the inline comments in
+// history_type / history_system in mongodb/storage.rs.
 // ---------------------------------------------------------------------------
 
 use mongodb::Collection;
@@ -2259,7 +2259,12 @@ async fn mongodb_history_type_does_not_read_rows_outside_the_page() {
     let page1_keys: Vec<(String, String)> = page1
         .items
         .iter()
-        .map(|e| (e.resource.id().to_string(), e.resource.version_id().to_string()))
+        .map(|e| {
+            (
+                e.resource.id().to_string(),
+                e.resource.version_id().to_string(),
+            )
+        })
         .collect();
     assert_eq!(page1_keys, expected[0..10]);
     assert!(page1.page_info.has_next);
@@ -2280,12 +2285,20 @@ async fn mongodb_history_type_does_not_read_rows_outside_the_page() {
     let page2_keys: Vec<(String, String)> = page2
         .items
         .iter()
-        .map(|e| (e.resource.id().to_string(), e.resource.version_id().to_string()))
+        .map(|e| {
+            (
+                e.resource.id().to_string(),
+                e.resource.version_id().to_string(),
+            )
+        })
         .collect();
     assert_eq!(page2_keys, expected[10..20]);
     // Disjoint from page 1, contiguous with it.
     for key in &page2_keys {
-        assert!(!page1_keys.contains(key), "page 2 repeated a page 1 row: {key:?}");
+        assert!(
+            !page1_keys.contains(key),
+            "page 2 repeated a page 1 row: {key:?}"
+        );
     }
 
     // --- Assertion (3): CANARY PREMISE ---
@@ -2393,8 +2406,11 @@ async fn mongodb_history_type_paging_is_ordered_and_complete() {
     // version_id (the Rust-side tie-break).
     let mut expected = expected_by_k;
     expected.sort_by(|a, b| {
-        b.0.cmp(&a.0)
-            .then_with(|| b.2.parse::<i64>().unwrap().cmp(&a.2.parse::<i64>().unwrap()))
+        b.0.cmp(&a.0).then_with(|| {
+            b.2.parse::<i64>()
+                .unwrap()
+                .cmp(&a.2.parse::<i64>().unwrap())
+        })
     });
     let expected: Vec<(String, String)> = expected.into_iter().map(|(_, id, v)| (id, v)).collect();
     assert_eq!(expected.len(), 26);
@@ -2413,12 +2429,20 @@ async fn mongodb_history_type_paging_is_ordered_and_complete() {
         let keys: Vec<(String, String)> = page
             .items
             .iter()
-            .map(|e| (e.resource.id().to_string(), e.resource.version_id().to_string()))
+            .map(|e| {
+                (
+                    e.resource.id().to_string(),
+                    e.resource.version_id().to_string(),
+                )
+            })
             .collect();
         all_rows.extend(keys);
 
         if page.page_info.has_next {
-            let cursor = page.page_info.next_cursor.expect("has_next implies a cursor");
+            let cursor = page
+                .page_info
+                .next_cursor
+                .expect("has_next implies a cursor");
             params = HistoryParams::new().count(5).include_deleted(true);
             params.pagination = helios_persistence::types::Pagination::with_cursor(5, cursor);
         } else {
@@ -2431,7 +2455,11 @@ async fn mongodb_history_type_paging_is_ordered_and_complete() {
     let mut dedup_check = all_rows.clone();
     dedup_check.sort();
     dedup_check.dedup();
-    assert_eq!(dedup_check.len(), all_rows.len(), "found duplicate rows across pages");
+    assert_eq!(
+        dedup_check.len(),
+        all_rows.len(),
+        "found duplicate rows across pages"
+    );
 }
 
 /// Mirror of the pin test for `history_system`: sentinel row of a resource
@@ -2494,8 +2522,15 @@ async fn mongodb_history_system_does_not_read_rows_outside_the_page() {
     for i in 0..5usize {
         for v in 1..=3usize {
             let id = format!("sys-pat-{i}");
-            stamp_history_last_updated(&history, &tenant, "Patient", &id, &v.to_string(), history_ts(base_millis, k))
-                .await;
+            stamp_history_last_updated(
+                &history,
+                &tenant,
+                "Patient",
+                &id,
+                &v.to_string(),
+                history_ts(base_millis, k),
+            )
+            .await;
             expected.push(("Patient".to_string(), id, v.to_string()));
             k += 1;
         }
@@ -2503,8 +2538,15 @@ async fn mongodb_history_system_does_not_read_rows_outside_the_page() {
     for i in 0..5usize {
         for v in 1..=3usize {
             let id = format!("hist-obs-{i}");
-            stamp_history_last_updated(&history, &tenant, "Observation", &id, &v.to_string(), history_ts(base_millis, k))
-                .await;
+            stamp_history_last_updated(
+                &history,
+                &tenant,
+                "Observation",
+                &id,
+                &v.to_string(),
+                history_ts(base_millis, k),
+            )
+            .await;
             expected.push(("Observation".to_string(), id, v.to_string()));
             k += 1;
         }
@@ -2613,12 +2655,22 @@ async fn mongodb_history_type_plan_is_a_bounded_index_walk() {
         .await
         .expect("failed to query system.profile");
 
-    let mut entry: Option<Document> = None;
-    while cursor.advance().await.expect("failed to advance profile cursor") {
-        let doc = cursor.deserialize_current().expect("failed to deserialize profile entry");
-        entry = Some(doc);
-        break;
-    }
+    // Only the newest matching entry is of interest, so advance once rather
+    // than looping (a `while` with an unconditional `break` trips
+    // `clippy::never_loop`, which CI denies).
+    let entry: Option<Document> = if cursor
+        .advance()
+        .await
+        .expect("failed to advance profile cursor")
+    {
+        Some(
+            cursor
+                .deserialize_current()
+                .expect("failed to deserialize profile entry"),
+        )
+    } else {
+        None
+    };
     let entry = entry.expect("expected a profiled find on resource_history");
 
     let command = entry
@@ -2638,19 +2690,35 @@ async fn mongodb_history_type_plan_is_a_bounded_index_walk() {
     // On MongoDB 5.0 `hasSortStage` is simply absent when there is no sort
     // stage — must not unwrap a missing field as an error.
     let has_sort_stage = entry.get_bool("hasSortStage").unwrap_or(false);
-    assert!(!has_sort_stage, "expected no blocking sort stage on the first page");
+    assert!(
+        !has_sort_stage,
+        "expected no blocking sort stage on the first page"
+    );
 
-    let docs_examined = entry.get_i64("docsExamined").or_else(|_| entry.get_i32("docsExamined").map(i64::from));
-    let keys_examined = entry.get_i64("keysExamined").or_else(|_| entry.get_i32("keysExamined").map(i64::from));
+    let docs_examined = entry
+        .get_i64("docsExamined")
+        .or_else(|_| entry.get_i32("docsExamined").map(i64::from));
+    let keys_examined = entry
+        .get_i64("keysExamined")
+        .or_else(|_| entry.get_i32("keysExamined").map(i64::from));
     if let Ok(d) = docs_examined {
-        assert!(d <= 11, "docsExamined {d} exceeds count+1 (11) on the first page");
+        assert!(
+            d <= 11,
+            "docsExamined {d} exceeds count+1 (11) on the first page"
+        );
     }
     if let Ok(k) = keys_examined {
-        assert!(k <= 11, "keysExamined {k} exceeds count+1 (11) on the first page");
+        assert!(
+            k <= 11,
+            "keysExamined {k} exceeds count+1 (11) on the first page"
+        );
     }
 
     let plan_summary = entry.get_str("planSummary").unwrap_or_default();
-    assert!(plan_summary.contains("IXSCAN"), "expected an IXSCAN plan, got: {plan_summary}");
+    assert!(
+        plan_summary.contains("IXSCAN"),
+        "expected an IXSCAN plan, got: {plan_summary}"
+    );
 
     // Rebuild the inner find command from exactly what the server recorded
     // (command also carries $db/lsid/$readPreference, which explain rejects).
@@ -2668,10 +2736,22 @@ async fn mongodb_history_type_plan_is_a_bounded_index_walk() {
     let stats = explain
         .get_document("executionStats")
         .expect("explain missing executionStats");
-    let total_keys = stats.get_i64("totalKeysExamined").or_else(|_| stats.get_i32("totalKeysExamined").map(i64::from)).unwrap();
-    let total_docs = stats.get_i64("totalDocsExamined").or_else(|_| stats.get_i32("totalDocsExamined").map(i64::from)).unwrap();
-    assert!(total_keys <= 11, "explain totalKeysExamined {total_keys} exceeds 11");
-    assert!(total_docs <= 11, "explain totalDocsExamined {total_docs} exceeds 11");
+    let total_keys = stats
+        .get_i64("totalKeysExamined")
+        .or_else(|_| stats.get_i32("totalKeysExamined").map(i64::from))
+        .unwrap();
+    let total_docs = stats
+        .get_i64("totalDocsExamined")
+        .or_else(|_| stats.get_i32("totalDocsExamined").map(i64::from))
+        .unwrap();
+    assert!(
+        total_keys <= 11,
+        "explain totalKeysExamined {total_keys} exceeds 11"
+    );
+    assert!(
+        total_docs <= 11,
+        "explain totalDocsExamined {total_docs} exceeds 11"
+    );
 
     // Only the *winning* plan matters here. `explain` also carries
     // `queryPlanner.rejectedPlans` — other candidates the multi-planner


### PR DESCRIPTION
Fixes #1053.

## What was wrong

`history_type` and `history_system` issued `history.find(filter)` with no `.sort()`, no `.limit()` and no `.projection()`, drained the whole cursor via `collect_documents`, deserialized every row's full `data` payload, then sorted in Rust, applied the cursor predicate client-side, and only then truncated to the page size.

`GET /Observation/_history?_count=10` therefore materialized every version of every Observation to return ten rows; `history_system` filters on `tenant_id` alone, so it did it for the whole tenant. That fails by exhausting memory rather than returning an OperationOutcome — it can take the process down rather than the request.

The indexes that answer this as an ordered index walk already existed (`idx_history_type_updated`, `idx_history_system_updated`). With no sort or limit sent, the planner could not use them.

## What changed

`crates/persistence/src/backends/mongodb/storage.rs`:

- The sort is pushed to MongoDB, matching each index's key order — `{last_updated: -1, id: -1}` for type history, `{last_updated: -1, resource_type: -1, id: -1}` for system history.
- The cursor predicate becomes a server-side keyset `$or`, AND-ed as a separate top-level key so it composes with the existing `since`/`before` range rather than colliding with it.
- `.limit(count + 1)` replaces the client-side truncation (never 0).
- An exclusion projection `{_id: 0, created_at: 0}` drops the two fields `parse_history_row` never reads.
- The `rows.retain(...)` client-side cursor filter is deleted; the `rows.sort_by` comparator is kept verbatim.

`history_instance` is untouched — same shape, but bounded by one resource's version count.

**The `version_id` tie-break stays in Rust**, with a comment at both sites explaining why: `version_id` is in neither serving index, so sorting on it server-side would reintroduce a blocking SORT, and it is a string, so `$lt`/sort would misorder `"10"` against `"9"`.

## Tests

Four new tests in `crates/persistence/tests/mongodb_tests.rs`. The paging tests seed a deliberately payload-less sentinel row at the oldest timestamp: `parse_history_row` errors on it, so any code path that reads beyond the requested page fails loudly. A companion assertion (`count=100` must still error) proves the sentinel is live, so a tolerant parser cannot make the test pass vacuously.

`mongodb_history_type_plan_is_a_bounded_index_walk` is the scale-free guard: via MongoDB profiling plus `explain("executionStats")`, it asserts the sort and limit reached the server, no stage named `SORT` appears in the winning plan, the expected index is used, and `totalKeysExamined`/`totalDocsExamined` are bounded by `_count`.

```
cargo test -p helios-persistence --features mongodb --test mongodb_tests history
test result: ok. 6 passed; 0 failed; 0 ignored
```

Zero skips — Docker was running, so these actually executed against MongoDB. `cargo fmt --all -- --check` and clippy with CI's allowlist both pass.

## Behaviour changes a reviewer should weigh

1. **Page-boundary tie groups.** Previously every row was loaded and fully sorted by `(last_updated, id, version_id)` before truncation, so the highest `version_id` of a `(last_updated, id)` tie group deterministically landed on the page. Now the server's `limit(count+1)` picks group members in index order before the Rust `version_id` sort runs. The number of rows dropped by the `(ts, id)`-only cursor is unchanged — that loss predates this change and is shared with the SQL backends — but *which* member of a tie group appears at a boundary is no longer guaranteed to be the highest version. Only reachable when two versions of one resource are written in the same millisecond.

2. **The hard bound is asserted on the first page only.** With the keyset `$or`, the planner may legitimately choose either a `SORT_MERGE` of two index-bounded scans or a single `IXSCAN` with the `$or` as a residual filter. The latter examines O(cursor rank + count) keys. Both are non-blocking and fetch only `count+1` documents, so memory is bounded either way, but deep pages are not proven O(count). The test deliberately does not pin the tiny-corpus plan choice, which is a multi-planner tie-break. Low practical impact today: `crates/rest/src/handlers/history.rs` emits no `next` link, so the cursor branch is reachable only via the storage API.

3. **Rows with no BSON `last_updated`** previously sorted first (the extractor fell back to `Utc::now()`) and now sort last (a missing field is null in a descending server sort). Every write path sets it as a BSON DateTime, so this is theoretical for legacy or hand-inserted rows.

4. **`include_deleted = false`** leaves `is_deleted: false` as a residual filter not present in either serving index, so `keysExamined` is `count+1` plus any deleted rows interleaved in the walk. Still bounded by page position rather than corpus size, and identical in semantics to SQLite and Postgres.

Found while researching #1040 / #999. This was the highest-severity site found in the backend, and it is not in the search path at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECbBsNhgXwBo4dQtFyVBXv
