### PR TITLE
fix: ci(ui-matrix): nightly red on all 7 legs — bulk-submit-ingest fixture unreachable from HFS, sql-export padding leak on sqlite-es, name:contains ignored on s3-es

### DIFF
--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -1304,6 +1304,88 @@ fn spawn_s3_search_param_refresh(
     });
 }
 
+/// Registers the shared base SearchParameters — embedded fallback, the FHIR
+/// spec file, and every custom file in `data_dir` (e.g. the SQL-on-FHIR
+/// `ViewDefinition` params in `sql-on-fhir-search-parameters.json`) — into
+/// `registry`.
+///
+/// This is the same three-tier load the SQLite, PostgreSQL, and MongoDB
+/// backends perform when they build their own registries. A primary with no
+/// `data_dir` of its own (S3) needs a starter to do it instead; skipping the
+/// custom tier left Elasticsearch unaware of params such as `ViewDefinition`
+/// `name`, so `name:contains` was silently dropped from searches (#1070).
+#[cfg(all(feature = "s3", feature = "elasticsearch"))]
+fn populate_base_search_registry(
+    registry: &mut helios_persistence::search::SearchParameterRegistry,
+    fhir_version: helios_fhir::FhirVersion,
+    data_dir: &std::path::Path,
+) {
+    use helios_persistence::search::SearchParameterLoader;
+
+    let loader = SearchParameterLoader::new(fhir_version);
+    let mut fallback_count = 0;
+    let mut spec_count = 0;
+    let mut custom_count = 0;
+    let mut custom_files: Vec<String> = Vec::new();
+
+    match loader.load_embedded() {
+        Ok(params) => {
+            for p in params {
+                if registry.register(p).is_ok() {
+                    fallback_count += 1;
+                }
+            }
+        }
+        Err(e) => warn!("Failed to load embedded SearchParameters: {e}"),
+    }
+
+    let spec_path = data_dir.join(loader.spec_filename());
+    match loader.load_from_spec_file(data_dir) {
+        Ok(params) => {
+            for p in params {
+                if registry.register(p).is_ok() {
+                    spec_count += 1;
+                }
+            }
+        }
+        Err(e) => warn!(
+            "Could not load spec SearchParameters from {}: {e}. Using minimal fallback.",
+            spec_path.display()
+        ),
+    }
+
+    match loader.load_custom_from_directory_with_files(data_dir) {
+        Ok((params, files)) => {
+            for p in params {
+                if registry.register(p).is_ok() {
+                    custom_count += 1;
+                }
+            }
+            custom_files = files;
+        }
+        Err(e) => warn!(
+            "Error loading custom SearchParameters from {}: {e}",
+            data_dir.display()
+        ),
+    }
+
+    let custom_info = if custom_files.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", custom_files.join(", "))
+    };
+    info!(
+        "SearchParameter registry initialized: {} total ({} spec from {}, {} fallback, {} custom{}) covering {} resource types",
+        registry.len(),
+        spec_count,
+        spec_path.display(),
+        fallback_count,
+        custom_count,
+        custom_info,
+        registry.resource_types().len()
+    );
+}
+
 /// Starts the server with SQLite-only backend.
 #[cfg(feature = "sqlite")]
 async fn start_sqlite(
@@ -2894,32 +2976,26 @@ async fn start_s3_elasticsearch(
     );
 
     // Populate S3's own per-tenant registry container with the shared base
-    // (embedded + spec) — S3 has no `data_dir`/FHIR version of its own to load
-    // these from, so a composite starter does it once here, the same params
-    // `build_search_registry` used to load into a standalone container. Unlike
+    // (embedded + spec + custom, e.g. the SQL-on-FHIR `ViewDefinition` params) —
+    // S3 has no `data_dir`/FHIR version of its own to load these from, so a
+    // composite starter does it once here, the same three tiers the SQLite,
+    // PostgreSQL, and MongoDB primaries load into theirs. Omitting the custom
+    // tier left ES blind to `ViewDefinition?name:contains=…` (#1070). Unlike
     // before, this container is *S3's real registries* (`s3.tenant_registries()`),
     // not a throwaway one: S3's own create/update/delete hooks now keep each
     // tenant's stored SearchParameter overlay on it current (#787), so sharing
     // it with Elasticsearch below gives ES the same live overlay every other
     // composite's search backend already gets from its primary.
     {
-        use helios_persistence::search::SearchParameterLoader;
-        let loader = SearchParameterLoader::new(config.default_fhir_version);
-        let mut base = s3.tenant_registries().base().write();
-        if let Ok(params) = loader.load_embedded() {
-            for p in params {
-                let _ = base.register(p);
-            }
-        }
         let data_dir = config
             .data_dir
             .clone()
             .unwrap_or_else(|| std::path::PathBuf::from("./data"));
-        if let Ok(params) = loader.load_from_spec_file(&data_dir) {
-            for p in params {
-                let _ = base.register(p);
-            }
-        }
+        populate_base_search_registry(
+            &mut s3.tenant_registries().base().write(),
+            config.default_fhir_version,
+            &data_dir,
+        );
     }
     let es = Arc::new(ElasticsearchBackend::with_shared_registry(
         es_config,

--- a/crates/persistence/tests/s3_es_tests.rs
+++ b/crates/persistence/tests/s3_es_tests.rs
@@ -29,7 +29,9 @@ use helios_persistence::core::{Backend, BackendKind, ResourceStorage};
 use helios_persistence::error::{ResourceError, StorageError};
 use helios_persistence::search::{SearchParameterLoader, TenantSearchRegistries};
 use helios_persistence::tenant::{TenantContext, TenantId, TenantPermissions};
-use helios_persistence::types::{SearchParamType, SearchParameter, SearchQuery, SearchValue};
+use helios_persistence::types::{
+    SearchModifier, SearchParamType, SearchParameter, SearchQuery, SearchValue, SortDirective,
+};
 
 use aws_config::{BehaviorVersion, Region};
 use aws_sdk_s3::Client;
@@ -269,6 +271,14 @@ fn build_search_registry() -> Arc<TenantSearchRegistries> {
                 let _ = registry.register(p);
             }
         }
+        // Custom files (e.g. the SQL-on-FHIR `ViewDefinition` params), the
+        // third tier `start_s3_elasticsearch` loads too — without it ES never
+        // indexes `ViewDefinition.name` (#1070).
+        if let Ok((params, _files)) = loader.load_custom_from_directory_with_files(&data_dir) {
+            for p in params {
+                let _ = registry.register(p);
+            }
+        }
     }
     registries
 }
@@ -393,6 +403,75 @@ where
 // ============================================================================
 // Tests
 // ============================================================================
+
+/// `ViewDefinition?_sort=name&name:contains=view` — the web UI's SQL-views rail
+/// and Add-table combobox query — returns only the case-insensitive substring
+/// matches, in name order (#1070). The `name` param comes from the custom
+/// `sql-on-fhir-search-parameters.json` file, so this fails if the search
+/// registry skips the custom tier: ES never indexes `ViewDefinition.name`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn s3_es_test_view_definition_name_contains_sorted() {
+    if skip_if_disabled("s3_es_test_view_definition_name_contains_sorted") {
+        return;
+    }
+
+    let harness = make_harness("vd-name-contains").await;
+    let tenant = tenant("s3-es-tenant");
+
+    // Created out of name order so the sort is observable. Names start
+    // lowercase so the expected order is the same whether the backend's
+    // string sort is case-sensitive or not.
+    let mut ids_by_name = HashMap::new();
+    for name in ["beta_VIEW_x", "gamma", "alpha_view"] {
+        let created = harness
+            .composite
+            .create(
+                &tenant,
+                "ViewDefinition",
+                json!({
+                    "resourceType": "ViewDefinition",
+                    "url": format!("http://example.org/ViewDefinition/{name}"),
+                    "name": name,
+                    "status": "active",
+                    "resource": "Patient",
+                    "select": [{"column": [{"path": "id", "name": "id"}]}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .expect("create ViewDefinition should succeed");
+        ids_by_name.insert(name, created.id().to_string());
+    }
+
+    let query = SearchQuery::new("ViewDefinition")
+        .with_parameter(SearchParameter {
+            name: "name".to_string(),
+            param_type: SearchParamType::String,
+            modifier: Some(SearchModifier::Contains),
+            values: vec![SearchValue::eq("view")],
+            chain: vec![],
+            components: vec![],
+        })
+        .with_sort(SortDirective::parse("name").with_param_type(Some(SearchParamType::String)));
+
+    let expected = vec![
+        ids_by_name["alpha_view"].clone(),
+        ids_by_name["beta_VIEW_x"].clone(),
+    ];
+    let ids = |r: &SearchResult| -> Vec<String> {
+        r.resources
+            .items
+            .iter()
+            .map(|res| res.id().to_string())
+            .collect()
+    };
+    let results = search_until(&harness, &tenant, &query, |r| ids(r) == expected).await;
+    assert_eq!(
+        ids(&results),
+        expected,
+        "name:contains=view must return only alpha_view and beta_VIEW_x, sorted by name"
+    );
+}
 
 /// Write a Patient to S3, then verify it appears in ES search by name.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/rest/tests/view_definition_search_params.rs
+++ b/crates/rest/tests/view_definition_search_params.rs
@@ -189,6 +189,54 @@ mod search_by_name {
         let body: Value = response.json();
         assert_eq!(entry_ids(&body), vec!["vd-draft".to_string()]);
     }
+
+    /// The web UI's SQL-views rail and Add-table combobox query:
+    /// `_sort=name&name:contains=<q>` returns exactly the case-insensitive
+    /// substring matches, sorted by name — never the unfiltered list (#1070).
+    #[tokio::test]
+    async fn contains_modifier_filters_case_insensitively_and_sorts_by_name() {
+        let (server, backend) = create_test_server().await;
+        seed_view_definitions(&backend).await;
+
+        // Created out of name order so the sort is observable; lowercase
+        // leading letters keep the expected order independent of whether the
+        // string sort is case-sensitive. `gamma` and the seeded `Patient*`
+        // views must be filtered out.
+        let tenant = test_tenant();
+        for (id, name) in [
+            ("vd-beta", "beta_VIEW_x"),
+            ("vd-gamma", "gamma"),
+            ("vd-alpha", "alpha_view"),
+        ] {
+            backend
+                .create(
+                    &tenant,
+                    "ViewDefinition",
+                    view_definition(
+                        id,
+                        &format!("http://example.org/ViewDefinition/{id}"),
+                        name,
+                        "active",
+                        "2024-02-01",
+                    ),
+                    FhirVersion::R4,
+                )
+                .await
+                .expect("seed ViewDefinition");
+        }
+
+        let response = server
+            .get("/ViewDefinition?_sort=name&name:contains=View")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        assert_eq!(
+            entry_ids(&body),
+            vec!["vd-alpha".to_string(), "vd-beta".to_string()]
+        );
+    }
 }
 
 mod search_by_status {

--- a/crates/ui/e2e/pages/api.ts
+++ b/crates/ui/e2e/pages/api.ts
@@ -30,18 +30,57 @@ export async function createResource(
 export type BatchEntry = { type: string; body: Record<string, unknown> };
 
 /**
- * Create several resources in a single batch Bundle round trip, returning
- * their server-assigned ids in submission order. For tests that need many
- * resources (e.g. enough `$sql-export` subjects to keep a job genuinely
- * `in-progress` for a moment — a single tiny job finishes before the page
- * even finishes rendering), calling `createResource` in a loop is one HTTP
- * round trip per resource; this is one round trip total.
+ * Create several resources in batch Bundle round trips of `CREATE_BATCH`
+ * entries apiece, returning their server-assigned ids in submission order.
+ * For tests that need many resources (e.g. enough `$sql-export` subjects to
+ * keep a job genuinely `in-progress` for a moment — a single tiny job
+ * finishes before the page even finishes rendering), calling
+ * `createResource` in a loop is one HTTP round trip per resource; this is
+ * one round trip per chunk.
+ *
+ * `onChunk` receives the ids each chunk created as soon as that chunk lands
+ * — including the entries that did succeed in a chunk that then throws — so
+ * a spec can register them for cleanup incrementally: a failure in chunk N
+ * still leaves chunks 0..N-1 known and deletable. A chunk whose whole
+ * request fails (e.g. a `408`) reports nothing, and the server may still be
+ * committing it; pair this with [`deleteByNamePrefix`] for those.
  */
 export async function createResources(
   request: APIRequestContext,
   entries: BatchEntry[],
   tenant?: string,
+  onChunk?: (ids: string[]) => void,
 ): Promise<string[]> {
+  // One request per CREATE_BATCH entries, for the same reason as
+  // `deleteResources`: a batch runs its entries at the backend's write
+  // concurrency inside the server's 30s request timeout, and on the ES
+  // composites (synchronous sync, `wait_for` refreshed writes) a 200-entry
+  // padding batch ran past it — a 408 while the server kept committing,
+  // leaking every entry the caller never learned the id of (#1070).
+  const ids: string[] = [];
+  for (let start = 0; start < entries.length; start += CREATE_BATCH) {
+    const chunkIds = await createBatch(
+      request,
+      entries.slice(start, start + CREATE_BATCH),
+      start,
+      tenant,
+      onChunk,
+    );
+    ids.push(...chunkIds);
+  }
+  return ids;
+}
+
+const CREATE_BATCH = 25;
+
+async function createBatch(
+  request: APIRequestContext,
+  entries: BatchEntry[],
+  offset: number,
+  tenant?: string,
+  onChunk?: (ids: string[]) => void,
+): Promise<string[]> {
+  if (entries.length === 0) return [];
   const bundle = {
     resourceType: "Bundle",
     type: "batch",
@@ -61,19 +100,27 @@ export async function createResources(
   if (!res.ok()) throw new Error(`batch create -> ${res.status()}: ${await res.text()}`);
   type BatchResponseEntry = { response?: { status?: string; location?: string } };
   const responseEntries = ((await res.json()).entry ?? []) as BatchResponseEntry[];
-  return responseEntries.map((entry, index) => {
+  const ids: string[] = [];
+  const failures: string[] = [];
+  for (const [i, entry] of responseEntries.entries()) {
+    const index = offset + i;
     const status = entry.response?.status ?? "";
     if (!status.startsWith("201")) {
-      throw new Error(`batch entry ${index} (${entries[index]?.type}) failed: ${status}`);
+      failures.push(`batch entry ${index} (${entries[i]?.type}) failed: ${status}`);
+      continue;
     }
     // `Location: {Type}/{id}/_history/{version}`.
     const location = entry.response?.location ?? "";
     const id = location.split("/")[1];
     if (!id) {
-      throw new Error(`batch entry ${index} had no usable Location: ${location}`);
+      failures.push(`batch entry ${index} had no usable Location: ${location}`);
+      continue;
     }
-    return id;
-  });
+    ids.push(id);
+  }
+  onChunk?.(ids);
+  if (failures.length > 0) throw new Error(failures[0]);
+  return ids;
 }
 
 /**
@@ -137,6 +184,60 @@ async function deleteBatch(
       throw new Error(`batch delete entry ${index} (${type}/${ids[index]}) failed: ${status}`);
     }
   });
+}
+
+/**
+ * Delete every `type` resource whose `name` starts with `prefix`. The
+ * backstop for [`createResources`] padding: a batch whose request failed
+ * outright (e.g. a `408` past the server's request timeout) never told the
+ * spec its ids, yet the server may have committed its entries anyway, so a
+ * spec that names its padding under a per-run prefix sweeps that prefix
+ * here too.
+ *
+ * Searches `name=<prefix>` (FHIR's default string search: a case- and
+ * accent-insensitive starts-with) and re-checks `name.startsWith(prefix)`
+ * on each hit, since that match is looser than an exact prefix. Every page
+ * is collected (following `link[relation=next]`, path and query only, so a
+ * server-advertised base URL never matters) before anything is deleted: an
+ * offset-paged search would skip rows if the set shrank under it.
+ */
+export async function deleteByNamePrefix(
+  request: APIRequestContext,
+  type: string,
+  prefix: string,
+  tenant?: string,
+): Promise<void> {
+  const headers = { Accept: FHIR_JSON, ...(tenant ? { "X-Tenant-ID": tenant } : {}) };
+  const ids = new Set<string>();
+  const seen = new Set<string>();
+  let url: string | undefined =
+    `/${type}?name=${encodeURIComponent(prefix)}&_count=${SWEEP_PAGE}`;
+  while (url && !seen.has(url)) {
+    seen.add(url);
+    const res = await request.get(url, { headers });
+    if (!res.ok()) throw new Error(`search ${url} -> ${res.status()}: ${await res.text()}`);
+    type SearchBundle = {
+      entry?: { resource?: { id?: string; name?: string } }[];
+      link?: { relation?: string; url?: string }[];
+    };
+    const bundle = (await res.json()) as SearchBundle;
+    for (const { resource } of bundle.entry ?? []) {
+      if (resource?.id && resource.name?.startsWith(prefix)) ids.add(resource.id);
+    }
+    const next = bundle.link?.find((link) => link.relation === "next")?.url;
+    url = next ? pathAndQuery(next) : undefined;
+  }
+  await deleteResources(request, type, [...ids], tenant);
+}
+
+const SWEEP_PAGE = 100;
+
+/** `https://host/a/b?c` -> `/a/b?c`; an already-relative link passes through. */
+function pathAndQuery(link: string): string {
+  const scheme = link.indexOf("://");
+  if (scheme < 0) return link.startsWith("/") ? link : `/${link}`;
+  const slash = link.indexOf("/", scheme + 3);
+  return slash < 0 ? "/" : link.slice(slash);
 }
 
 /** PUT a resource, minting a new version. */

--- a/crates/ui/e2e/tests/bulk-submit-ingest.spec.ts
+++ b/crates/ui/e2e/tests/bulk-submit-ingest.spec.ts
@@ -61,6 +61,18 @@ function progressReports(lines: string[]): { pct: number; written: number }[] {
     .map((match) => ({ pct: Number(match[1]), written: Number(match[2].replace(/,/g, "")) }));
 }
 
+// The source listens on loopback, so it is only reachable by an hfs running on
+// this host. A remote HFS_E2E_BASE_URL (the backend matrix) cannot fetch it;
+// the per-PR ui-tests.yml run, where hfs and the browser share a host, keeps
+// the coverage. Skipped here, before the test body starts the source at all.
+test.beforeEach(({ baseURL }) => {
+  const host = new URL(baseURL!).hostname;
+  test.skip(
+    host !== "127.0.0.1" && host !== "localhost" && host !== "::1",
+    "the bulk-submit source is served on loopback; a remote server cannot fetch it",
+  );
+});
+
 test("a manifest submitted from the Import page ingests, and its counters only ever climb", async ({
   page,
   chrome,

--- a/crates/ui/e2e/tests/nojs/sql-export.spec.ts
+++ b/crates/ui/e2e/tests/nojs/sql-export.spec.ts
@@ -3,6 +3,7 @@ import {
   createResource,
   createResources,
   createSqlQueryLibrary,
+  deleteByNamePrefix,
   deleteResources,
   waitSearchable,
 } from "../../pages/api";
@@ -37,6 +38,12 @@ const PADDING_SUBJECTS = 200;
 // the full mechanism).
 let seededViewDefinitionIds: string[] = [];
 
+// The per-run name prefix of every padding batch, swept by name in this
+// file's own `afterEach` on top of the ids above: a `createResources` chunk
+// whose request fails outright (a 408 on the ES composites) never reports its
+// ids while the server may still commit it (#1070).
+let seededViewDefinitionPrefixes: string[] = [];
+
 // Same reasoning as `seededViewDefinitionIds` above, for the `Library`
 // sql-query subject the failed-job detail test below seeds.
 let seededLibraryIds: string[] = [];
@@ -45,6 +52,12 @@ test.afterEach(async ({ request }) => {
   const ids = seededViewDefinitionIds;
   seededViewDefinitionIds = [];
   await deleteResources(request, "ViewDefinition", ids);
+
+  const prefixes = seededViewDefinitionPrefixes;
+  seededViewDefinitionPrefixes = [];
+  for (const prefix of prefixes) {
+    await deleteByNamePrefix(request, "ViewDefinition", prefix);
+  }
 
   const libraryIds = seededLibraryIds;
   seededLibraryIds = [];
@@ -71,6 +84,10 @@ test("SQL Export lifecycle works without JavaScript", async ({ page, request, sq
   test.setTimeout(120_000);
 
   async function startPaddedExport(name: string): Promise<void> {
+    // `name` already carries a per-run `Date.now()` stamp. Registered before
+    // the batch starts and per chunk as it lands, so a failure partway
+    // through still leaves `afterEach` able to clean up every padding row.
+    seededViewDefinitionPrefixes.push(`${name}_`);
     const ids = await createResources(
       request,
       Array.from({ length: PADDING_SUBJECTS }, (_, i) => ({
@@ -82,8 +99,9 @@ test("SQL Export lifecycle works without JavaScript", async ({ page, request, sq
           select: [{ column: [{ name: "id", path: "getResourceKey()" }] }],
         },
       })),
+      undefined,
+      (chunkIds) => seededViewDefinitionIds.push(...chunkIds),
     );
-    seededViewDefinitionIds.push(...ids);
 
     await sqlExport.gotoNew();
     const checkboxes = ids

--- a/crates/ui/e2e/tests/sql-export.spec.ts
+++ b/crates/ui/e2e/tests/sql-export.spec.ts
@@ -10,6 +10,7 @@ import {
   createResource,
   createResources,
   createSqlQueryLibrary,
+  deleteByNamePrefix,
   deleteResources,
   waitSearchable,
 } from "../pages/api";
@@ -27,6 +28,13 @@ const POLL_TIMEOUT = 30_000;
 // happens to follow this one against the same shared server.
 let seededViewDefinitionIds: string[] = [];
 
+// The per-run name prefix of every padding `ViewDefinition` batch a test
+// below seeds, swept by name in this file's own `afterEach` (below) on top of
+// the ids above: `createResources` reports each chunk's ids as it lands, but a
+// chunk whose request fails outright (a 408 on the ES composites) never
+// reports its ids while the server may still commit it (#1070).
+let seededViewDefinitionPrefixes: string[] = [];
+
 // Same reasoning as `seededViewDefinitionIds` above, for the `Library`
 // sql-query/sql-view subjects the builder-enhancement tests below seed: left
 // behind, a `Library` becomes `/ui/sql/queries`' or `/ui/sql/views`' default
@@ -37,6 +45,12 @@ test.afterEach(async ({ request }) => {
   const ids = seededViewDefinitionIds;
   seededViewDefinitionIds = [];
   await deleteResources(request, "ViewDefinition", ids);
+
+  const prefixes = seededViewDefinitionPrefixes;
+  seededViewDefinitionPrefixes = [];
+  for (const prefix of prefixes) {
+    await deleteByNamePrefix(request, "ViewDefinition", prefix);
+  }
 
   const libraryIds = seededLibraryIds;
   seededLibraryIds = [];
@@ -93,6 +107,10 @@ test.describe.serial("Active SQL Exports", () => {
     await waitSearchable(request, "Patient", patientId);
 
     const prefix = `e2e_sql_export_slow_${Date.now()}`;
+    // Registered before the batch starts and per chunk as it lands, so a
+    // failure partway through still leaves `afterEach` able to clean up
+    // every padding row that did (or may yet) commit.
+    seededViewDefinitionPrefixes.push(`${prefix}_`);
     const ids = await createResources(
       request,
       Array.from({ length: PADDING_SUBJECTS }, (_, i) => ({
@@ -104,8 +122,9 @@ test.describe.serial("Active SQL Exports", () => {
           select: [{ column: [{ name: "id", path: "getResourceKey()" }] }],
         },
       })),
+      undefined,
+      (chunkIds) => seededViewDefinitionIds.push(...chunkIds),
     );
-    seededViewDefinitionIds.push(...ids);
 
     await sqlExport.gotoNew();
     const checkboxes = ids


### PR DESCRIPTION
Closes #1070

The nightly UI matrix is red for three independent reasons. bulk-submit-ingest now skips, with a stated reason, when HFS cannot reach the Playwright-hosted loopback fixture. The sql-export padding is created in batches of 25 and cleaned up by a per-run name prefix, so a timed-out batch no longer leaks ViewDefinitions. The s3-elasticsearch starter now loads the custom SQL-on-FHIR search parameters (e.g. ViewDefinition `name`) like the other primaries do, so `name:contains` is honored instead of silently dropped.

_PR auto-generated by claude-agent; fix implemented with Claude Code and validated with the Playwright e2e suite._