### PR TITLE
fix: ui: aborting a bulk import shows Stopped, then flips to Completed on the next status poll

### DIFF
--- a/crates/persistence/src/core/bulk_submit_receipts.rs
+++ b/crates/persistence/src/core/bulk_submit_receipts.rs
@@ -348,11 +348,16 @@ mod tests {
         names
     }
 
+    /// Bytes on disk across the spool directory. Sizes come from
+    /// `fs::metadata` on each path, not `DirEntry::metadata`: on Windows the
+    /// latter is the directory listing's copy, which NTFS may leave stale while
+    /// a writer still holds the file open, so a spool with bytes on disk can
+    /// read 0.
     fn spool_bytes(path: &std::path::Path) -> u64 {
         std::fs::read_dir(path)
             .map(|entries| {
                 entries
-                    .map(|entry| entry.unwrap().metadata().unwrap().len())
+                    .map(|entry| std::fs::metadata(entry.unwrap().path()).unwrap().len())
                     .sum()
             })
             .unwrap_or(0)

--- a/crates/persistence/src/core/bulk_submit_worker.rs
+++ b/crates/persistence/src/core/bulk_submit_worker.rs
@@ -2244,9 +2244,12 @@ mod tests {
                 // A continuation means a previous page was consumed, and its
                 // receipts have to be on disk by now.
                 Some(_) => {
+                    // `fs::metadata` on the path, not `DirEntry::metadata`: on
+                    // Windows the listing's size can lag a file still open for
+                    // writing and read 0 despite the bytes being on disk.
                     let spooled: u64 = std::fs::read_dir(&directory)
                         .expect("the spool directory exists while receipts are building")
-                        .map(|entry| entry.unwrap().metadata().unwrap().len())
+                        .map(|entry| std::fs::metadata(entry.unwrap().path()).unwrap().len())
                         .sum();
                     if spooled < expected_on_disk {
                         Err(internal_error(format!(

--- a/crates/ui/src/bulk_import.rs
+++ b/crates/ui/src/bulk_import.rs
@@ -971,6 +971,15 @@ fn poll_due(submission: &Submission) -> bool {
             .unwrap_or(true)
 }
 
+/// Whether the Data Provider has closed the submission out (Abort / Mark
+/// completed). Recipient polls no longer decide its status: HFS answers an
+/// aborted submission's status poll with a clean `200`, which would otherwise
+/// read as a finished import (#1069). `failed` is not terminal — it can still
+/// be resubmitted, aborted, or completed.
+fn is_terminal(status: &str) -> bool {
+    matches!(status, "stopped" | "completed")
+}
+
 /// Materializes a `Retry-After` delta (seconds) into `next_poll_at`.
 fn hold_polls_for(submission: &mut Submission, seconds: u64) {
     submission.next_poll_at = (Utc::now() + chrono::Duration::seconds(seconds as i64))
@@ -987,9 +996,10 @@ fn retry_after_seconds(response: &reqwest::Response) -> Option<u64> {
 
 /// One poll of the recipient's status URL: `202` records `X-Progress`, `200`
 /// records the status manifest as the submission's result, anything else is
-/// logged and polling stops (the poll URL is cleared). `202` and `429` carry
-/// `Retry-After`; both push `next_poll_at` out so the card's refresh cadence
-/// never turns into a poll the recipient would reject (#790).
+/// logged and polling stops (the poll URL is cleared). Neither `200` nor a
+/// failure changes a closed-out submission's status (#1069). `202` and `429`
+/// carry `Retry-After`; both push `next_poll_at` out so the card's refresh
+/// cadence never turns into a poll the recipient would reject (#790).
 async fn poll_status(submission: &mut Submission, tenant: &str) {
     let poll_url = submission.poll_url.clone();
     let response = match with_tenant(
@@ -1061,8 +1071,13 @@ async fn poll_status(submission: &mut Submission, tenant: &str) {
                 })
                 .unwrap_or(0);
             let errors = manifest["error"].as_array().map(Vec::len).unwrap_or(0) + outcome_errors;
+            // A closed-out submission keeps the instant it was closed out.
+            let completed_at = match submission.result["completedAt"].as_str() {
+                Some(at) if is_terminal(&submission.status) && !at.is_empty() => at.to_string(),
+                _ => now_stamp(),
+            };
             submission.result = json!({
-                "completedAt": now_stamp(),
+                "completedAt": completed_at,
                 "outputs": outputs,
                 "errors": errors,
             });
@@ -1073,8 +1088,17 @@ async fn poll_status(submission: &mut Submission, tenant: &str) {
             // verdict is the submission's (#764, #765): errors mark it
             // failed; a clean completion completes it. Complete remains
             // available for closing out early by hand, and a later submit
-            // returns a failed submission to in-progress.
-            if errors > 0 {
+            // returns a failed submission to in-progress. A submission the
+            // provider already closed out keeps its status (#1069).
+            if is_terminal(&submission.status) {
+                let status = submission.status.clone();
+                push_log(
+                    submission,
+                    format!(
+                        "Status: got 200 OK ({outputs} outputs, {errors} error file(s)); submission stays {status}."
+                    ),
+                );
+            } else if errors > 0 {
                 submission.status = "failed".to_string();
                 push_log(
                     submission,
@@ -1101,16 +1125,28 @@ async fn poll_status(submission: &mut Submission, tenant: &str) {
         other => {
             // Polling can never resume (the URL is dropped), so the submission
             // must not keep reading In Progress (#764). completedAt keeps the
-            // status card rendered; the log carries the diagnosis.
+            // status card rendered; the log carries the diagnosis. A
+            // closed-out submission is not reopened as failed, and keeps the
+            // result it was closed out with (#1069).
+            submission.progress = String::new();
+            submission.poll_url = String::new();
+            submission.next_poll_at = String::new();
+            if is_terminal(&submission.status) {
+                let status = submission.status.clone();
+                push_log(
+                    submission,
+                    format!(
+                        "Status poll answered {other}; polling stopped; submission stays {status}."
+                    ),
+                );
+                return;
+            }
             submission.status = "failed".to_string();
             submission.result = json!({
                 "completedAt": now_stamp(),
                 "outputs": 0,
                 "errors": 0,
             });
-            submission.progress = String::new();
-            submission.poll_url = String::new();
-            submission.next_poll_at = String::new();
             push_log(
                 submission,
                 format!(
@@ -1233,6 +1269,21 @@ async fn set_status(
             // The change landed, so any banner from an earlier attempt is
             // stale (#968).
             s.status_error = String::new();
+            // A closed-out submission stops polling the recipient, which
+            // answers an aborted submission's status poll with a clean `200`
+            // that would otherwise flip Stopped to Completed (#1069). The
+            // result stamps the close-out so the card shows its Result form,
+            // keeping any counts an earlier `200` manifest recorded.
+            if is_terminal(status) {
+                s.poll_url = String::new();
+                s.next_poll_at = String::new();
+                s.progress = String::new();
+                s.result = json!({
+                    "completedAt": now_stamp(),
+                    "outputs": s.result["outputs"].as_u64().unwrap_or(0),
+                    "errors": s.result["errors"].as_u64().unwrap_or(0),
+                });
+            }
         }
         Ok((code, content_type, body)) => {
             let detail = format!("{code}: {}", summarize_error_body(&content_type, &body));
@@ -1257,8 +1308,9 @@ async fn set_status(
 }
 
 /// The recipient-status card fragment, polled by htmx while a poll URL is
-/// live. Each fetch performs at most one poll against the recipient, so the
-/// cadence is the page's `every 5s` trigger — no background tasks.
+/// live and the submission is not closed out (#1069). Each fetch performs at
+/// most one poll against the recipient, so the cadence is the page's
+/// `every 5s` trigger — no background tasks.
 #[derive(Template)]
 #[template(path = "partials/bulk_import_status.html")]
 struct StatusCard {
@@ -1302,7 +1354,9 @@ pub async fn status_fragment(
     let Some((mut s, sv)) = load_one(&state, &rt, &id).await else {
         return StatusCode::NOT_FOUND.into_response();
     };
-    if !s.poll_url.is_empty() && poll_due(&s) {
+    // A closed-out submission is never polled, even if it was stored with a
+    // poll URL before #1069 — the recipient's answer no longer decides it.
+    if !s.poll_url.is_empty() && !is_terminal(&s.status) && poll_due(&s) {
         poll_status(&mut s, &rt.id).await;
         save_or_warn(&state, &rt, &id, &s, Some(sv)).await;
     }
@@ -1310,7 +1364,7 @@ pub async fn status_fragment(
     let status_error = status_error_message(&i18n, &s);
     render(StatusCard {
         id,
-        polling: !s.poll_url.is_empty(),
+        polling: !s.poll_url.is_empty() && !is_terminal(&s.status),
         can_abort: matches!(s.status.as_str(), "in-progress" | "failed"),
         percent: progress_percent(&s.progress),
         progress: s.progress.clone(),
@@ -1427,6 +1481,17 @@ mod tests {
         // Non-matching recipients keep the indeterminate sweep.
         assert_eq!(progress_percent("halfway there"), None);
         assert_eq!(progress_percent("processing lots"), None);
+    }
+
+    /// #1069: only a provider close-out is terminal; `failed` can still be
+    /// resubmitted, aborted, or completed.
+    #[test]
+    fn only_stopped_and_completed_are_terminal() {
+        assert!(is_terminal("stopped"));
+        assert!(is_terminal("completed"));
+        for status in ["not-started", "in-progress", "failed", ""] {
+            assert!(!is_terminal(status), "status: {status}");
+        }
     }
 
     #[test]

--- a/crates/ui/tests/bulk_import_http.rs
+++ b/crates/ui/tests/bulk_import_http.rs
@@ -883,8 +883,15 @@ async fn abort_sends_a_status_only_kickoff() {
     let abort_path = create_submission(&ctx).await;
     post_form(&ctx, &format!("{abort_path}/abort"), "").await;
     let (_, html) = get(&ctx, &abort_path).await;
-    assert!(html.contains("Stopped"));
+    assert!(
+        html.contains(r#"<div id="submission-status">Stopped</div>"#),
+        "{html}"
+    );
     assert!(html.contains("Recipient acknowledged (200)"));
+    // The landed Abort closes the submission out: its card is the settled
+    // result, not a progress card that keeps polling (#1069).
+    let (_, fragment) = get(&ctx, &format!("{abort_path}/status")).await;
+    assert_closed_out_card(&fragment, &abort_path, "Stopped");
 
     // The abort kick-off is status-only: no manifestUrl rides along.
     let bodies = received.lock().unwrap().clone();
@@ -910,8 +917,13 @@ async fn complete_sends_a_status_only_kickoff() {
     set_submission_status(&ctx, &detail_path, "in-progress").await;
     post_form(&ctx, &format!("{detail_path}/complete"), "").await;
     let (_, html) = get(&ctx, &detail_path).await;
-    assert!(html.contains("Completed"), "{html}");
+    assert!(
+        html.contains(r#"<div id="submission-status">Completed</div>"#),
+        "{html}"
+    );
     assert!(html.contains("Recipient acknowledged (200)"), "{html}");
+    let (_, fragment) = get(&ctx, &format!("{detail_path}/status")).await;
+    assert_closed_out_card(&fragment, &detail_path, "Completed");
 
     let bodies = received.lock().unwrap().clone();
     let params = bodies.last().unwrap()["parameter"].as_array().unwrap();
@@ -1007,8 +1019,9 @@ async fn a_successful_abort_clears_the_error_banner_and_the_buttons() {
     // The recipient base URL is captured on the submission at create time, so
     // the retry must reach the same origin — this mock changes its mind
     // instead.
-    let (recipient_url, answer) = mock_recipient_with_switchable_status(StatusCode::OK).await;
-    let ctx = ctx(&recipient_url);
+    let recipient = mock_recipient_with_switchable_status(StatusCode::OK, 3600).await;
+    let answer = &recipient.answer;
+    let ctx = ctx(&recipient.url);
     let detail_path = create_submission(&ctx).await;
 
     // First Abort: the recipient is saturated and rejects it.
@@ -1061,35 +1074,226 @@ async fn a_successful_abort_clears_the_error_banner_and_the_buttons() {
         !fragment.contains(&format!(r#"action="{detail_path}/complete""#)),
         "{fragment}"
     );
+    // A landed Abort closes the submission out, so the card stops polling and
+    // settles on the result (#1069).
+    assert!(!fragment.contains("every 5s"), "{fragment}");
+    assert!(fragment.contains(RESULT_CARD), "{fragment}");
+}
+
+/// The opening of the settled, non-polling status card — the one a finished
+/// or closed-out submission renders.
+const RESULT_CARD: &str = r#"<div id="bulk-status" class="card panel bulk-import-section">"#;
+
+/// Asserts the status fragment shows a closed-out submission: the result card
+/// (its "Result" label and closing instant), no htmx refresh, no Abort or
+/// Mark completed, and the out-of-band STATUS cell reading `label`.
+fn assert_closed_out_card(fragment: &str, detail_path: &str, label: &str) {
+    assert!(
+        !fragment.contains("every 5s"),
+        "polling stopped: {fragment}"
+    );
+    assert!(fragment.contains(RESULT_CARD), "{fragment}");
+    assert!(fragment.contains("<span>Result</span>"), "{fragment}");
+    assert!(
+        fragment.contains("Processing finished at <code>"),
+        "{fragment}"
+    );
+    assert!(
+        fragment.contains(&format!(
+            r#"<div id="submission-status" hx-swap-oob="true">{label}</div>"#
+        )),
+        "{fragment}"
+    );
+    assert!(
+        !fragment.contains(&format!(r#"action="{detail_path}/abort""#)),
+        "{fragment}"
+    );
+    assert!(
+        !fragment.contains(&format!(r#"action="{detail_path}/complete""#)),
+        "{fragment}"
+    );
+}
+
+/// #1069: Abort showed Stopped, then the next 5s refresh flipped it to
+/// Completed. The landed Abort left the poll URL on the submission, so the
+/// card kept polling — and HFS answers an aborted submission's status poll
+/// with a terminal `200` whose `outcome` is empty, which read as a clean
+/// finish. Here the recipient does exactly that, with no `Retry-After` hold
+/// in the way, so the only thing keeping the submission Stopped is the UI
+/// refusing to poll (or believe) the recipient once it is closed out.
+#[tokio::test]
+async fn an_aborted_submission_stays_stopped_when_the_recipient_later_answers_200() {
+    let recipient = mock_recipient_with_switchable_status(StatusCode::OK, 0).await;
+    let ctx = ctx(&recipient.url);
+    let detail_path = create_submission(&ctx).await;
+    let status_path = format!("{detail_path}/status");
+
+    // Before the abort the card polls the recipient, which is still running.
+    let (_, fragment) = get(&ctx, &status_path).await;
+    assert!(fragment.contains("every 5s"), "{fragment}");
+    assert!(
+        fragment.contains(&format!(r#"action="{detail_path}/abort""#)),
+        "{fragment}"
+    );
+    let polls_before_abort = recipient.polls.load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(polls_before_abort, 1, "the card polled the recipient");
+
+    let (status, _, _) = post_form(&ctx, &format!("{detail_path}/abort"), "").await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    // The recipient now answers the poll the way HFS does once aborted.
+    *recipient.poll_manifest.lock().unwrap() = Some(aborted_status_manifest());
+
+    // The card's refresh keeps firing on an open page; every one of them must
+    // still read Stopped.
+    for refresh in 1..=2 {
+        let (status, fragment) = get(&ctx, &status_path).await;
+        assert_eq!(status, StatusCode::OK, "refresh {refresh}");
+        assert_closed_out_card(&fragment, &detail_path, "Stopped");
+    }
+    assert_eq!(
+        recipient.polls.load(std::sync::atomic::Ordering::SeqCst),
+        polls_before_abort,
+        "a stopped submission is never polled again"
+    );
+
+    let (_, detail) = get(&ctx, &detail_path).await;
+    assert!(
+        detail.contains(r#"<div id="submission-status">Stopped</div>"#),
+        "{detail}"
+    );
+    assert!(
+        !detail.contains(r#"<div id="submission-status">Completed</div>"#),
+        "{detail}"
+    );
+    assert!(!detail.contains("finished cleanly"), "{detail}");
+    assert!(!detail.contains("submission completed"), "{detail}");
+}
+
+/// #1069's companion for Mark completed: a closed-out submission keeps the
+/// provider's verdict, so a recipient poll that would report error files does
+/// not reopen it as Failed.
+#[tokio::test]
+async fn a_completed_submission_is_not_failed_by_a_later_poll_with_errors() {
+    let recipient = mock_recipient_with_switchable_status(StatusCode::OK, 0).await;
+    let ctx = ctx(&recipient.url);
+    let detail_path = create_submission(&ctx).await;
+    let status_path = format!("{detail_path}/status");
+
+    let (_, fragment) = get(&ctx, &status_path).await;
+    assert!(fragment.contains("every 5s"), "{fragment}");
+    let polls_before = recipient.polls.load(std::sync::atomic::Ordering::SeqCst);
+
+    let (status, _, _) = post_form(&ctx, &format!("{detail_path}/complete"), "").await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    *recipient.poll_manifest.lock().unwrap() = Some(serde_json::json!({
+        "output": [{"type": "Patient", "url": "http://example/out.ndjson"}],
+        "outcome": [{
+            "type": "OperationOutcome",
+            "url": "http://example/errors.ndjson",
+            "countSeverity": {"error": 2}
+        }]
+    }));
+
+    for _ in 1..=2 {
+        let (_, fragment) = get(&ctx, &status_path).await;
+        assert_closed_out_card(&fragment, &detail_path, "Completed");
+    }
+    assert_eq!(
+        recipient.polls.load(std::sync::atomic::Ordering::SeqCst),
+        polls_before
+    );
+    let (_, detail) = get(&ctx, &detail_path).await;
+    assert!(
+        detail.contains(r#"<div id="submission-status">Completed</div>"#),
+        "{detail}"
+    );
+    assert!(!detail.contains("marked failed"), "{detail}");
+}
+
+/// #1069: submissions the old UI already stopped still carry a live poll URL
+/// in storage. The card must not poll the recipient for them either — nor let
+/// its terminal `200` rewrite the status.
+#[tokio::test]
+async fn a_stored_stopped_submission_with_a_poll_url_is_not_polled() {
+    let recipient = mock_recipient_with_switchable_status(StatusCode::OK, 0).await;
+    let ctx = ctx(&recipient.url);
+    let detail_path = create_submission(&ctx).await;
+    // Stopped the old way: the status changed, the poll URL stayed.
+    set_submission_status(&ctx, &detail_path, "stopped").await;
+    *recipient.poll_manifest.lock().unwrap() = Some(aborted_status_manifest());
+
+    for _ in 1..=2 {
+        let (_, fragment) = get(&ctx, &format!("{detail_path}/status")).await;
+        assert!(!fragment.contains("every 5s"), "{fragment}");
+        assert!(
+            fragment.contains(r#"<div id="submission-status" hx-swap-oob="true">Stopped</div>"#),
+            "{fragment}"
+        );
+    }
+    assert_eq!(recipient.polls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    let (_, detail) = get(&ctx, &detail_path).await;
+    assert!(
+        detail.contains(r#"<div id="submission-status">Stopped</div>"#),
+        "{detail}"
+    );
+    assert!(!detail.contains("submission completed"), "{detail}");
+}
+
+/// The handles of [`mock_recipient_with_switchable_status`].
+struct SwitchableRecipient {
+    url: String,
+    /// The status code the *next* `$bulk-submit` kick-off gets.
+    answer: Arc<std::sync::atomic::AtomicU16>,
+    /// What the *next* `/poll` gets: `None` is `202` with `X-Progress`, while
+    /// `Some(manifest)` is `200` with that status manifest — the recipient
+    /// saying the submission is over.
+    poll_manifest: Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+    /// How many `/poll` requests actually arrived.
+    polls: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 /// A recipient that accepts the submission, hands out a status poll URL, and
-/// whose `$bulk-submit` answer the test can change between requests — the
-/// returned handle holds the status code the *next* kick-off gets.
+/// whose answers the test can change between requests: the `$bulk-submit`
+/// status code, and whether `/poll` is still running (`202`) or has finished
+/// (`200` with a manifest).
 ///
 /// Two reasons for the shape: a submission stores one recipient base URL for
 /// its whole life, so a retry cannot simply be pointed at a second mock; and
 /// only a submission with a poll URL renders the status card that carries
 /// Abort and Mark completed, which is the state #968 was reported from.
-/// `/poll` answers `202` with a long `Retry-After`, so reading the card never
-/// moves the submission on its own.
+///
+/// A running `/poll` answers `202` with the given `Retry-After`. A long one
+/// (`3600`) means reading the card never moves the submission on its own; `0`
+/// leaves the next poll due at once, which is what #1069 needs — HFS answers
+/// an aborted submission's poll with a terminal `200`, and only a poll that
+/// actually goes out after the abort can show whether the UI trusts it.
 async fn mock_recipient_with_switchable_status(
     initial: StatusCode,
-) -> (String, Arc<std::sync::atomic::AtomicU16>) {
+    retry_after: u64,
+) -> SwitchableRecipient {
     use axum::extract::State as AxState;
     #[derive(Clone)]
     struct S {
         answer: Arc<std::sync::atomic::AtomicU16>,
+        poll_manifest: Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+        polls: Arc<std::sync::atomic::AtomicUsize>,
         base: Arc<std::sync::Mutex<String>>,
     }
     let state = S {
         answer: Arc::new(std::sync::atomic::AtomicU16::new(initial.as_u16())),
+        poll_manifest: Arc::new(std::sync::Mutex::new(None)),
+        polls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         base: Arc::new(std::sync::Mutex::new(String::new())),
     };
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     *state.base.lock().unwrap() = format!("http://{addr}");
-    let answer = Arc::clone(&state.answer);
+    let handles = SwitchableRecipient {
+        url: format!("http://{addr}"),
+        answer: Arc::clone(&state.answer),
+        poll_manifest: Arc::clone(&state.poll_manifest),
+        polls: Arc::clone(&state.polls),
+    };
     let recipient = Router::new()
         .route(
             "/$bulk-submit",
@@ -1116,17 +1320,39 @@ async fn mock_recipient_with_switchable_status(
         )
         .route(
             "/poll",
-            axum::routing::get(|| async {
-                (
-                    StatusCode::ACCEPTED,
-                    [("x-progress", "50%"), ("retry-after", "3600")],
-                    "",
-                )
+            axum::routing::get(move |AxState(s): AxState<S>| async move {
+                s.polls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let manifest = s.poll_manifest.lock().unwrap().clone();
+                match manifest {
+                    Some(manifest) => axum::Json(manifest).into_response(),
+                    None => (
+                        StatusCode::ACCEPTED,
+                        [
+                            ("x-progress", "50%".to_string()),
+                            ("retry-after", retry_after.to_string()),
+                        ],
+                        "",
+                    )
+                        .into_response(),
+                }
             }),
         )
         .with_state(state);
     tokio::spawn(async move { axum::serve(listener, recipient).await.unwrap() });
-    (format!("http://{addr}"), answer)
+    handles
+}
+
+/// The status manifest HFS answers an aborted submission's poll with: a
+/// terminal `200` listing what was ingested before the abort, with an empty
+/// `outcome` — indistinguishable, on its own, from a clean finish (#1069).
+fn aborted_status_manifest() -> serde_json::Value {
+    serde_json::json!({
+        "transactionTime": "2026-09-11T10:00:00Z",
+        "request": "http://recipient.example/$bulk-submit-status",
+        "requiresAccessToken": false,
+        "output": [{"type": "Patient", "url": "http://example/out.ndjson", "count": 3}],
+        "outcome": []
+    })
 }
 
 #[tokio::test]
@@ -1163,7 +1389,10 @@ async fn terminal_submissions_reject_status_changes_without_side_effects() {
     assert_eq!(stored_after, stored_before);
 
     let (_, html) = get(&ctx, &detail_path).await;
-    assert!(html.contains("Completed"));
+    assert!(
+        html.contains(r#"<div id="submission-status">Completed</div>"#),
+        "{html}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1069

Aborting a bulk import left the submission's poll URL in place, so the status card kept polling the recipient and overwrote `stopped` with `completed` when the aborted submission's status endpoint answered 200. The fix clears polling state and records a completion time when the recipient accepts the stop, and guards `status_fragment`/`poll_status` so a terminal status is never overwritten. A new HTTP test uses a recipient that answers the status poll with a clean 200 after the abort and checks that the page stays Stopped and stops polling.

_PR auto-generated by claude-agent; fix implemented with Claude Code and validated with the Playwright e2e suite._