### PR TITLE
fix(persistence): Elasticsearch cursor paging emits a working previous link (#1015)

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
+++ b/crates/persistence/src/backends/elasticsearch/search/query_builder.rs
@@ -5,8 +5,9 @@
 use serde_json::{Value, json};
 
 use crate::types::{
-    CompartmentMembership, PageCursor, SearchModifier, SearchParamType, SearchParameter,
-    SearchPrefix, SearchQuery, SortDirection, SortDirective, strip_reference_version,
+    CompartmentMembership, CursorDirection, PageCursor, SearchModifier, SearchParamType,
+    SearchParameter, SearchPrefix, SearchQuery, SortDirection, SortDirective,
+    strip_reference_version,
 };
 
 use super::fts;
@@ -33,6 +34,24 @@ fn query_has_relevance(query: &SearchQuery) -> bool {
                 Some(SearchModifier::Text) | Some(SearchModifier::TextAdvanced)
             )
     })
+}
+
+/// Returns the effective Elasticsearch sort order (`"asc"`/`"desc"`) for a
+/// sort directive's `direction`, swapped when `paging` is
+/// `CursorDirection::Previous`. Paging backward means walking the result set
+/// in the opposite order, so every criterion — including `mode` and
+/// `missing`, which are derived from this order — must flip too (#1015).
+fn es_order(direction: SortDirection, paging: CursorDirection) -> &'static str {
+    let ascending = match direction {
+        SortDirection::Ascending => true,
+        SortDirection::Descending => false,
+    };
+    let ascending = if paging == CursorDirection::Previous {
+        !ascending
+    } else {
+        ascending
+    };
+    if ascending { "asc" } else { "desc" }
 }
 
 /// Builds Elasticsearch queries from FHIR search queries.
@@ -110,18 +129,36 @@ impl<'a> EsQueryBuilder<'a> {
             "query": { "bool": bool_query },
         });
 
+        // Decode the cursor once and reuse it for sort direction, size, and
+        // `search_after` — an undecodable cursor is treated as absent
+        // everywhere, matching the pre-existing `search_after` behavior.
+        let cursor = query
+            .cursor
+            .as_deref()
+            .and_then(|c| PageCursor::decode(c).ok());
+        let paging = cursor
+            .as_ref()
+            .map(PageCursor::direction)
+            .unwrap_or_default();
+
         // Add sorting
-        let sort = self.build_sort(&query.sort);
+        let sort = self.build_sort(&query.sort, paging);
         body["sort"] = sort;
 
         // Add pagination
         let count = query.count.unwrap_or(20);
-        body["size"] = json!(count);
+        // `Previous` requests one extra hit so the results layer can tell
+        // whether an earlier page exists beyond the ones returned (#1015).
+        let size = if paging == CursorDirection::Previous {
+            count + 1
+        } else {
+            count
+        };
+        body["size"] = json!(size);
 
-        if let Some(ref cursor_str) = query.cursor {
-            if let Ok(cursor) = PageCursor::decode(cursor_str) {
-                let search_after = self.build_search_after(&cursor);
-                body["search_after"] = search_after;
+        if query.cursor.is_some() {
+            if let Some(cursor) = cursor.as_ref() {
+                body["search_after"] = self.build_search_after(cursor);
             }
         } else if let Some(offset) = query.offset {
             body["from"] = json!(offset);
@@ -304,22 +341,34 @@ impl<'a> EsQueryBuilder<'a> {
     }
 
     /// Builds the sort clause.
-    fn build_sort(&self, directives: &[SortDirective]) -> Value {
+    ///
+    /// A `Previous` cursor walks the result set backward, so `paging`
+    /// reverses every criterion — including the final `resource_id`
+    /// tie-breaker — relative to the `Next` order. `search_after` then seeks
+    /// from the cursor position in that reversed order, and the results
+    /// layer restores the caller-facing order before returning the page
+    /// (#1015).
+    fn build_sort(&self, directives: &[SortDirective], paging: CursorDirection) -> Value {
         if directives.is_empty() {
-            // Default sort: _lastUpdated descending, then _id for tie-breaking
-            return json!([
-                { "last_updated": { "order": "desc" } },
-                { "resource_id": { "order": "asc" } }
-            ]);
+            // Default sort: _lastUpdated descending, then _id for
+            // tie-breaking; reversed when paging backward.
+            return if paging == CursorDirection::Previous {
+                json!([
+                    { "last_updated": { "order": "asc" } },
+                    { "resource_id": { "order": "desc" } }
+                ])
+            } else {
+                json!([
+                    { "last_updated": { "order": "desc" } },
+                    { "resource_id": { "order": "asc" } }
+                ])
+            };
         }
 
         let mut sort_clauses: Vec<Value> = Vec::new();
 
         for directive in directives {
-            let order = match directive.direction {
-                SortDirection::Ascending => "asc",
-                SortDirection::Descending => "desc",
-            };
+            let order = es_order(directive.direction, paging);
 
             match directive.parameter.as_str() {
                 "_id" => {
@@ -376,8 +425,13 @@ impl<'a> EsQueryBuilder<'a> {
             }
         }
 
-        // Always add tie-breaker
-        sort_clauses.push(json!({ "resource_id": { "order": "asc" } }));
+        // Always add tie-breaker, reversed when paging backward.
+        let tie_breaker_order = if paging == CursorDirection::Previous {
+            "desc"
+        } else {
+            "asc"
+        };
+        sort_clauses.push(json!({ "resource_id": { "order": tie_breaker_order } }));
 
         Value::Array(sort_clauses)
     }
@@ -420,7 +474,19 @@ pub fn build_count_query(tenant_id: &str, resource_type: &str, query: &SearchQue
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{SearchValue, SortDirection};
+    use crate::types::{CursorValue, SearchValue, SortDirection};
+
+    /// Encodes a `Previous` cursor at the given resource ID, used to
+    /// exercise the backward-paging path of `build`.
+    fn previous_cursor(id: &str) -> String {
+        PageCursor::previous(vec![CursorValue::Number(1_700_000_000_000)], id).encode()
+    }
+
+    /// Encodes a `Next` cursor at the given resource ID, used as the
+    /// forward-paging regression baseline.
+    fn next_cursor(id: &str) -> String {
+        PageCursor::new(vec![CursorValue::Number(1_700_000_000_000)], id).encode()
+    }
 
     #[test]
     fn test_basic_query_build() {
@@ -664,5 +730,90 @@ mod tests {
             !sort["search_params.string.value.keyword"].is_null(),
             "untyped parameters keep the string-group sort, got {sort}"
         );
+    }
+
+    /// #1015: a `Previous` cursor must reverse the default sort (including
+    /// the tie-breaker) and over-fetch by one hit so the results layer can
+    /// tell whether an earlier page exists.
+    #[test]
+    fn test_previous_cursor_reverses_default_sort_and_overfetches() {
+        let query = SearchQuery::new("Patient")
+            .with_count(5)
+            .with_cursor(previous_cursor("p-5"));
+        let builder = EsQueryBuilder::new("acme", "Patient", "hfs_acme_patient".to_string());
+        let body = builder.build(&query).body;
+
+        assert_eq!(
+            body["sort"],
+            json!([
+                { "last_updated": { "order": "asc" } },
+                { "resource_id": { "order": "desc" } }
+            ])
+        );
+        assert_eq!(body["search_after"], json!([1_700_000_000_000i64, "p-5"]));
+        assert_eq!(body["size"], json!(6));
+        assert!(body.get("from").is_none());
+    }
+
+    /// #1015: a custom sort's `mode`/`missing` are derived from the
+    /// *effective* order, so a `Previous` cursor over an ascending directive
+    /// yields `desc`/`max`/`_first` — the same derivation used for a plain
+    /// descending sort, without a second table for the reversed case.
+    #[test]
+    fn test_previous_cursor_reverses_custom_sort_mode_and_missing() {
+        let query = SearchQuery::new("Patient")
+            .with_sort(SortDirective {
+                parameter: "birthdate".to_string(),
+                direction: SortDirection::Ascending,
+                param_type: Some(SearchParamType::Date),
+            })
+            .with_cursor(previous_cursor("p-5"));
+        let builder = EsQueryBuilder::new("acme", "Patient", "hfs_acme_patient".to_string());
+        let sort = builder.build(&query).body["sort"].clone();
+        let sort = sort.as_array().expect("sort is an array");
+
+        let clause = &sort[0]["search_params.date.value"];
+        assert_eq!(clause["order"], "desc");
+        assert_eq!(clause["mode"], "max");
+        assert_eq!(clause["missing"], "_first");
+
+        let tie_breaker = sort.last().expect("tie-breaker present");
+        assert_eq!(tie_breaker, &json!({ "resource_id": { "order": "desc" } }));
+    }
+
+    /// #1015: `_sort=_score` also flips under a `Previous` cursor.
+    #[test]
+    fn test_previous_cursor_reverses_score_sort() {
+        let query = SearchQuery::new("Patient")
+            .with_sort(SortDirective {
+                parameter: "_score".to_string(),
+                direction: SortDirection::Descending,
+                param_type: None,
+            })
+            .with_cursor(previous_cursor("p-5"));
+        let builder = EsQueryBuilder::new("acme", "Patient", "hfs_acme_patient".to_string());
+        let sort = builder.build(&query).body["sort"].clone();
+
+        assert_eq!(sort[0], json!({ "_score": { "order": "asc" } }));
+    }
+
+    /// #1015 regression: a `Next` cursor leaves sort and size untouched.
+    #[test]
+    fn test_next_cursor_keeps_sort_and_size() {
+        let query = SearchQuery::new("Patient")
+            .with_count(5)
+            .with_cursor(next_cursor("p-5"));
+        let builder = EsQueryBuilder::new("acme", "Patient", "hfs_acme_patient".to_string());
+        let body = builder.build(&query).body;
+
+        assert_eq!(
+            body["sort"],
+            json!([
+                { "last_updated": { "order": "desc" } },
+                { "resource_id": { "order": "asc" } }
+            ])
+        );
+        assert_eq!(body["size"], json!(5));
+        assert_eq!(body["search_after"], json!([1_700_000_000_000i64, "p-5"]));
     }
 }

--- a/crates/persistence/src/backends/elasticsearch/search_impl.rs
+++ b/crates/persistence/src/backends/elasticsearch/search_impl.rs
@@ -16,8 +16,8 @@ use crate::core::search::{
 use crate::error::{BackendError, StorageResult};
 use crate::tenant::TenantContext;
 use crate::types::{
-    CursorValue, IncludeDirective, Page, PageCursor, PageInfo, Pagination, SearchQuery,
-    StoredResource,
+    CursorDirection, CursorValue, IncludeDirective, Page, PageCursor, PageInfo, Pagination,
+    SearchQuery, StoredResource,
 };
 
 use super::backend::ElasticsearchBackend;
@@ -206,6 +206,50 @@ async fn send_search_with_retry(
     )
 }
 
+/// Converts an Elasticsearch hit's `sort` array into cursor values, dropping
+/// the trailing tie-breaker (the resource id the query builder appends to
+/// every sort for deterministic ordering). The remaining values are mapped
+/// to the matching [`CursorValue`] variant so the cursor can be replayed
+/// against a future search without re-deriving them from the stored
+/// resource.
+fn cursor_values_from_sort(sort_values: &[Value]) -> Vec<CursorValue> {
+    sort_values
+        .iter()
+        .take(sort_values.len().saturating_sub(1))
+        .map(|v| {
+            if let Some(s) = v.as_str() {
+                CursorValue::String(s.to_string())
+            } else if let Some(n) = v.as_i64() {
+                CursorValue::Number(n)
+            } else if let Some(b) = v.as_bool() {
+                CursorValue::Boolean(b)
+            } else if v.is_null() {
+                CursorValue::Null
+            } else {
+                CursorValue::String(v.to_string())
+            }
+        })
+        .collect()
+}
+
+/// Builds an opaque page cursor pointing at `resource`, or `None` if the hit
+/// carried no `sort` values (e.g. the query had no explicit or default sort
+/// applied to it). `direction` selects whether the cursor should be replayed
+/// as `Next` (walk forward from this resource) or `Previous` (walk backward
+/// from this resource).
+fn page_cursor_for(
+    resource: &StoredResource,
+    sort_values: Option<&Vec<Value>>,
+    direction: CursorDirection,
+) -> Option<String> {
+    let values = cursor_values_from_sort(sort_values?);
+    let cursor = match direction {
+        CursorDirection::Next => PageCursor::new(values, resource.id()),
+        CursorDirection::Previous => PageCursor::previous(values, resource.id()),
+    };
+    Some(cursor.encode())
+}
+
 #[async_trait]
 impl SearchProvider for ElasticsearchBackend {
     async fn search(
@@ -250,10 +294,8 @@ impl SearchProvider for ElasticsearchBackend {
 
         let count = query.count.unwrap_or(20) as usize;
 
-        let mut resources = Vec::new();
+        let mut hits_with_sort: Vec<(StoredResource, Option<Vec<Value>>)> = Vec::new();
         let mut scores: HashMap<String, f64> = HashMap::new();
-        let mut last_sort: Option<Vec<Value>> = None;
-        let mut last_resource_id = String::new();
 
         for hit in &hits {
             let source = match hit.get("_source") {
@@ -277,52 +319,85 @@ impl SearchProvider for ElasticsearchBackend {
                 if let Some(score) = hit.get("_score").and_then(|s| s.as_f64()) {
                     scores.insert(stored.url(), score);
                 }
-                last_resource_id = stored.id().to_string();
-                resources.push(stored);
-            }
-
-            // Track sort values for cursor
-            if let Some(sort) = hit.get("sort") {
-                last_sort = sort.as_array().cloned();
+                let sort_values = hit.get("sort").and_then(Value::as_array).cloned();
+                hits_with_sort.push((stored, sort_values));
             }
         }
 
-        // Determine pagination
-        let has_next = resources.len() >= count;
-        let next_cursor = if has_next {
-            last_sort.as_ref().map(|sort_values| {
-                let cursor_values: Vec<CursorValue> = sort_values
-                    .iter()
-                    .take(sort_values.len().saturating_sub(1)) // exclude tie-breaker
-                    .map(|v| {
-                        if let Some(s) = v.as_str() {
-                            CursorValue::String(s.to_string())
-                        } else if let Some(n) = v.as_i64() {
-                            CursorValue::Number(n)
-                        } else if let Some(b) = v.as_bool() {
-                            CursorValue::Boolean(b)
-                        } else if v.is_null() {
-                            CursorValue::Null
-                        } else {
-                            CursorValue::String(v.to_string())
-                        }
+        // A `Previous` cursor asks the query builder for the reversed sort order
+        // (T1) plus one extra hit (`count + 1`), so `hits_with_sort` here arrives
+        // in reverse result order and may be one item longer than the requested
+        // page. That extra hit is the farthest one from the cursor — it belongs
+        // to the page *before* the one we return, not to this page — so it must
+        // be dropped with `truncate` before we `reverse()` back into normal
+        // query order. See #1015.
+        let backward = query
+            .cursor
+            .as_deref()
+            .and_then(|c| PageCursor::decode(c).ok())
+            .is_some_and(|c| c.direction() == CursorDirection::Previous);
+
+        let page_info = if backward {
+            let has_previous = hits_with_sort.len() > count;
+            if has_previous {
+                hits_with_sort.truncate(count);
+            }
+            hits_with_sort.reverse();
+
+            if hits_with_sort.is_empty() {
+                PageInfo {
+                    next_cursor: None,
+                    previous_cursor: None,
+                    total,
+                    has_next: false,
+                    has_previous: false,
+                }
+            } else {
+                let next_cursor = hits_with_sort
+                    .last()
+                    .and_then(|(r, s)| page_cursor_for(r, s.as_ref(), CursorDirection::Next));
+                let previous_cursor = if has_previous {
+                    hits_with_sort.first().and_then(|(r, s)| {
+                        page_cursor_for(r, s.as_ref(), CursorDirection::Previous)
                     })
-                    .collect();
-
-                PageCursor::new(cursor_values, &last_resource_id).encode()
-            })
+                } else {
+                    None
+                };
+                PageInfo {
+                    next_cursor,
+                    previous_cursor,
+                    total,
+                    has_next: true,
+                    has_previous,
+                }
+            }
         } else {
-            None
+            let has_next = hits_with_sort.len() >= count;
+            let has_previous = query.cursor.is_some() || query.offset.unwrap_or(0) > 0;
+            let next_cursor = if has_next {
+                hits_with_sort
+                    .last()
+                    .and_then(|(r, s)| page_cursor_for(r, s.as_ref(), CursorDirection::Next))
+            } else {
+                None
+            };
+            let previous_cursor = if has_previous {
+                hits_with_sort
+                    .first()
+                    .and_then(|(r, s)| page_cursor_for(r, s.as_ref(), CursorDirection::Previous))
+            } else {
+                None
+            };
+            PageInfo {
+                next_cursor,
+                previous_cursor,
+                total,
+                has_next,
+                has_previous,
+            }
         };
 
-        let page_info = PageInfo {
-            next_cursor,
-            previous_cursor: None,
-            total,
-            has_next,
-            has_previous: query.cursor.is_some() || query.offset.unwrap_or(0) > 0,
-        };
-
+        let resources: Vec<StoredResource> = hits_with_sort.into_iter().map(|(r, _)| r).collect();
         let page = Page::new(resources, page_info);
         let mut result = SearchResult::new(page);
 
@@ -892,5 +967,24 @@ mod tests {
             r#"{"error":{"type":"illegal_argument_exception"}}"#
         ));
         assert!(!is_transient_es_error(404, "index_not_found_exception"));
+    }
+
+    #[test]
+    fn cursor_values_from_sort_drops_tie_breaker_and_maps_types() {
+        let sort_values = vec![
+            json!(1700),
+            json!("x"),
+            json!(true),
+            Value::Null,
+            json!("p-1"),
+        ];
+
+        let cursor_values = cursor_values_from_sort(&sort_values);
+
+        assert_eq!(cursor_values.len(), 4);
+        assert!(matches!(cursor_values[0], CursorValue::Number(1700)));
+        assert!(matches!(&cursor_values[1], CursorValue::String(s) if s == "x"));
+        assert!(matches!(cursor_values[2], CursorValue::Boolean(true)));
+        assert!(matches!(cursor_values[3], CursorValue::Null));
     }
 }

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -3726,6 +3726,215 @@ mod es_integration {
     }
 
     // ========================================================================
+    // Cursor Pagination Tests (#1015)
+    // ========================================================================
+
+    /// Creates Patients `cp-1..cp-n` (inclusive) in the given tenant.
+    async fn create_cursor_paging_patients(
+        backend: &ElasticsearchBackend,
+        tenant: &TenantContext,
+        n: u32,
+    ) {
+        for i in 1..=n {
+            backend
+                .create(
+                    tenant,
+                    "Patient",
+                    json!({
+                        "resourceType": "Patient",
+                        "id": format!("cp-{i}"),
+                        "name": [{"family": "CursorPaging"}]
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    /// Collects the resource ids of a search result's page, in page order.
+    fn page_ids(result: &helios_persistence::core::SearchResult) -> Vec<String> {
+        result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect()
+    }
+
+    /// Walks forward through 7 Patients 3 at a time (no explicit `_sort`),
+    /// then walks all the way back via `previous_cursor` and confirms every
+    /// page is reproduced exactly, including the page-3-to-page-2 hop that a
+    /// naive truncate-after-reverse implementation gets wrong (#1015).
+    #[tokio::test]
+    async fn es_integration_cursor_paging_round_trip_previous() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::SearchQuery;
+
+        let backend = create_backend_with("1ms", WriteRefreshPolicy::WaitFor).await;
+        let tenant = create_tenant("cursor-prev");
+        create_cursor_paging_patients(&backend, &tenant, 7).await;
+
+        let query = SearchQuery::new("Patient").with_count(3);
+
+        let page1 = backend.search(&tenant, &query).await.unwrap();
+        assert_eq!(page1.resources.items.len(), 3);
+        assert!(!page1.resources.page_info.has_previous);
+        assert!(page1.resources.page_info.previous_cursor.is_none());
+        assert!(page1.resources.page_info.has_next);
+        assert!(page1.resources.page_info.next_cursor.is_some());
+
+        let page2 = backend
+            .search(
+                &tenant,
+                &query
+                    .clone()
+                    .with_cursor(page1.resources.page_info.next_cursor.clone().unwrap()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page2.resources.items.len(), 3);
+        assert!(page2.resources.page_info.has_previous);
+        assert!(page2.resources.page_info.previous_cursor.is_some());
+        assert!(page2.resources.page_info.has_next);
+
+        let page3 = backend
+            .search(
+                &tenant,
+                &query
+                    .clone()
+                    .with_cursor(page2.resources.page_info.next_cursor.clone().unwrap()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page3.resources.items.len(), 1);
+        assert!(!page3.resources.page_info.has_next);
+        assert!(page3.resources.page_info.next_cursor.is_none());
+        assert!(page3.resources.page_info.previous_cursor.is_some());
+
+        let page1_ids = page_ids(&page1);
+        let page2_ids = page_ids(&page2);
+        let page3_ids = page_ids(&page3);
+        let mut all_ids = page1_ids.clone();
+        all_ids.extend(page2_ids.clone());
+        all_ids.extend(page3_ids.clone());
+        let mut unique_ids = all_ids.clone();
+        unique_ids.sort();
+        unique_ids.dedup();
+        assert_eq!(unique_ids.len(), 7, "all 7 ids must be distinct");
+
+        // Walk back: page 3 -> page 2 must be exact, including order. This is
+        // the case a naive truncate-after-reverse gets wrong: it drops the
+        // nearest hit instead of the farthest one.
+        let back2 = backend
+            .search(
+                &tenant,
+                &query
+                    .clone()
+                    .with_cursor(page3.resources.page_info.previous_cursor.clone().unwrap()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page_ids(&back2), page2_ids);
+        assert!(back2.resources.page_info.has_previous);
+        assert!(back2.resources.page_info.has_next);
+        assert!(back2.resources.page_info.next_cursor.is_some());
+
+        let back1 = backend
+            .search(
+                &tenant,
+                &query
+                    .clone()
+                    .with_cursor(back2.resources.page_info.previous_cursor.clone().unwrap()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page_ids(&back1), page1_ids);
+        assert!(!back1.resources.page_info.has_previous);
+        assert!(back1.resources.page_info.previous_cursor.is_none());
+        assert!(back1.resources.page_info.has_next);
+
+        let again2 = backend
+            .search(
+                &tenant,
+                &query
+                    .clone()
+                    .with_cursor(back1.resources.page_info.next_cursor.clone().unwrap()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page_ids(&again2), page2_ids);
+    }
+
+    /// Same round trip, but with an explicit `_sort=_id` ascending so the
+    /// exact page contents (not just their distinctness) can be asserted.
+    #[tokio::test]
+    async fn es_integration_cursor_paging_round_trip_previous_with_sort() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{SearchQuery, SortDirection, SortDirective};
+
+        let backend = create_backend_with("1ms", WriteRefreshPolicy::WaitFor).await;
+        let tenant = create_tenant("cursor-prev-sort");
+        create_cursor_paging_patients(&backend, &tenant, 7).await;
+
+        let query = SearchQuery::new("Patient")
+            .with_count(3)
+            .with_sort(SortDirective {
+                parameter: "_id".to_string(),
+                direction: SortDirection::Ascending,
+                param_type: None,
+            });
+
+        let page1 = backend.search(&tenant, &query).await.unwrap();
+        assert_eq!(page_ids(&page1), vec!["cp-1", "cp-2", "cp-3"]);
+
+        let page2 = backend
+            .search(
+                &tenant,
+                &query
+                    .clone()
+                    .with_cursor(page1.resources.page_info.next_cursor.clone().unwrap()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page_ids(&page2), vec!["cp-4", "cp-5", "cp-6"]);
+
+        let page3 = backend
+            .search(
+                &tenant,
+                &query
+                    .clone()
+                    .with_cursor(page2.resources.page_info.next_cursor.clone().unwrap()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page_ids(&page3), vec!["cp-7"]);
+
+        let back2 = backend
+            .search(
+                &tenant,
+                &query
+                    .clone()
+                    .with_cursor(page3.resources.page_info.previous_cursor.clone().unwrap()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page_ids(&back2), vec!["cp-4", "cp-5", "cp-6"]);
+
+        let back1 = backend
+            .search(
+                &tenant,
+                &query
+                    .clone()
+                    .with_cursor(back2.resources.page_info.previous_cursor.clone().unwrap()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page_ids(&back1), vec!["cp-1", "cp-2", "cp-3"]);
+        assert!(back1.resources.page_info.previous_cursor.is_none());
+    }
+
+    // ========================================================================
     // Backend Info Tests
     // ========================================================================
 


### PR DESCRIPTION
## Summary

Closes #1015.

On Elasticsearch-backed searches (`pg-es`), page 2 of any cursor-paged search carried `self`, `next` and `first` links but never `previous`, so the UI had no way back. `search_impl.rs` built the page with `previous_cursor: None` unconditionally, and the query builder ignored the cursor's direction, so even a hand-built `Previous` cursor paged forward.

The REST bundle (`core/search.rs`) and the UI (`saved-queries.js`) already render a `previous` link/button whenever the page carries a previous cursor; neither needed changes.

## Changes

- `d261b8089` Query builder: a `Previous` cursor flips every sort clause (including the `resource_id` tie-breaker, `mode` and `missing`) so `search_after` walks backward, and requests one extra hit. Forward paging is unchanged.
- `1aac5f0d8` Search page: the previous cursor is built from the first hit of every page that has one. Backward pages use the extra hit to compute `has_previous`, drop the farthest hit before restoring the query order, and keep `next` available.

## Acceptance criteria (#1015)

- [x] Bundles for page > 1 include a working `previous` link (cursor-based).
- [x] The UI renders the Previous control and it returns to the prior page (no UI change needed; verified manually on `/ui/resources`).
- [x] Round-trip test: next → previous reproduces page 1's entries (and page 3 → page 2, the case that distinguishes a correct backward page).

## Test plan

- Unit (`cargo test --workspace --all-features --exclude pysof -- elasticsearch::search::query_builder`): reversed default/custom/`_score` sort and `size` for a `Previous` cursor; forward cursor unchanged.
- Unit (`-- cursor_values_from_sort_drops_tie_breaker_and_maps_types`): sort-value → cursor mapping drops the tie-breaker.
- Integration, testcontainers ES (`-- es_integration_cursor_paging_round_trip`): 1 → 2 → 3 → 2 → 1 → 2 round trip with the default sort and with `_sort=_id`, asserting identical entries and `has_previous`/`has_next` on every hop.
- Manual smoke on `pg-es` with the dev binary (25 Patients, `_count=10`): page 2 carries `previous`; `previous` from page 2 reproduces page 1; `previous` from page 3 reproduces page 2 exactly and offers both links; same round trip with `_sort=_id`; `/ui/resources` shows the Previous button only when a previous page exists and each click returns exactly the previous page (`_count=20` and `_count=10`); `_offset` paging, exact `_count` and empty results unchanged.

## Out of scope

Follow-up #1079 (MongoDB part already tracked in #1057): the same backward hop on SQLite/PostgreSQL/MongoDB drops the wrong row from page 3 onward and the SQL backends hardcode `has_previous = false` after a backward hop; Elasticsearch's phantom `next` link on an exactly-full last page.
