### PR TITLE
fix(search): _include returns only the targets of the requested parameter on Elasticsearch-backed searches (#1013)

### DIFF
--- a/crates/persistence/src/backends/elasticsearch/search_impl.rs
+++ b/crates/persistence/src/backends/elasticsearch/search_impl.rs
@@ -334,22 +334,6 @@ impl SearchProvider for ElasticsearchBackend {
             result = result.with_total(t);
         }
 
-        // Resolve includes if requested
-        if !query.includes.is_empty() {
-            let include_directives: Vec<IncludeDirective> = query
-                .includes
-                .iter()
-                .filter(|i| i.include_type == crate::types::IncludeType::Include)
-                .cloned()
-                .collect();
-            if !include_directives.is_empty() {
-                let included = self
-                    .resolve_includes(tenant, &result.resources.items, &include_directives)
-                    .await?;
-                result = result.with_included(included);
-            }
-        }
-
         Ok(result)
     }
 
@@ -657,45 +641,17 @@ async fn execute_text_search(
 
 #[async_trait]
 impl IncludeProvider for ElasticsearchBackend {
+    /// Delegates to the shared, registry-driven resolver so `_include` (and
+    /// `:iterate`) follows the same search-parameter definitions (with FHIRPath
+    /// expression evaluation) used to build the index, instead of a
+    /// backend-specific reference extractor that could disagree with it.
     async fn resolve_includes(
         &self,
         tenant: &TenantContext,
         resources: &[StoredResource],
         includes: &[IncludeDirective],
     ) -> StorageResult<Vec<StoredResource>> {
-        let mut included = Vec::new();
-
-        for directive in includes {
-            for resource in resources {
-                // Extract references from the resource's content
-                let content = resource.content();
-                let search_param = &directive.search_param;
-
-                // Walk the content looking for reference values
-                let references = extract_references(content, search_param);
-
-                for (ref_type, ref_id) in references {
-                    // Check target type filter
-                    if let Some(ref target_type) = directive.target_type {
-                        if ref_type != *target_type {
-                            continue;
-                        }
-                    }
-
-                    // Read the referenced resource from ES
-                    if let Some(stored) = self.read(tenant, &ref_type, &ref_id).await? {
-                        // Avoid duplicates
-                        if !included.iter().any(|r: &StoredResource| {
-                            r.resource_type() == stored.resource_type() && r.id() == stored.id()
-                        }) {
-                            included.push(stored);
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(included)
+        crate::core::resolve_includes_iterative(self, tenant, resources, includes).await
     }
 }
 
@@ -792,79 +748,6 @@ fn parse_hit_to_stored_resource(
         None,
         fhir_version,
     )))
-}
-
-/// Extracts reference values from a FHIR resource for a given search parameter.
-///
-/// Returns a list of (resource_type, resource_id) tuples.
-fn extract_references(content: &Value, param_name: &str) -> Vec<(String, String)> {
-    let mut refs = Vec::new();
-
-    // Common reference fields in FHIR resources
-    // The param name maps to a path in the resource
-    if let Some(obj) = content.as_object() {
-        // Direct field match (e.g., "subject" -> content.subject)
-        if let Some(ref_value) = obj.get(param_name) {
-            extract_reference_from_value(ref_value, &mut refs);
-        }
-
-        // Also check common FHIR reference patterns
-        for (_key, value) in obj {
-            if let Some(ref_obj) = value.as_object() {
-                if let Some(reference) = ref_obj.get("reference").and_then(|r| r.as_str()) {
-                    if let Some((rt, id)) = parse_reference_string(reference) {
-                        refs.push((rt, id));
-                    }
-                }
-            }
-            if let Some(arr) = value.as_array() {
-                for item in arr {
-                    if let Some(ref_obj) = item.as_object() {
-                        if let Some(reference) = ref_obj.get("reference").and_then(|r| r.as_str()) {
-                            if let Some((rt, id)) = parse_reference_string(reference) {
-                                refs.push((rt, id));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    refs
-}
-
-/// Extracts a reference from a JSON value (object with "reference" field or array).
-fn extract_reference_from_value(value: &Value, refs: &mut Vec<(String, String)>) {
-    if let Some(obj) = value.as_object() {
-        if let Some(reference) = obj.get("reference").and_then(|r| r.as_str()) {
-            if let Some((rt, id)) = parse_reference_string(reference) {
-                refs.push((rt, id));
-            }
-        }
-    } else if let Some(arr) = value.as_array() {
-        for item in arr {
-            extract_reference_from_value(item, refs);
-        }
-    }
-}
-
-/// Parses a FHIR reference string "Type/id" into (type, id).
-fn parse_reference_string(reference: &str) -> Option<(String, String)> {
-    // Handle relative references: "Patient/123"
-    if let Some((type_part, id_part)) = reference.rsplit_once('/') {
-        // Avoid URL paths - just take the last two segments
-        let resource_type = type_part.rsplit('/').next().unwrap_or(type_part);
-        if resource_type
-            .chars()
-            .next()
-            .map(|c| c.is_uppercase())
-            .unwrap_or(false)
-        {
-            return Some((resource_type.to_string(), id_part.to_string()));
-        }
-    }
-    None
 }
 
 #[cfg(test)]

--- a/crates/persistence/src/core/search.rs
+++ b/crates/persistence/src/core/search.rs
@@ -463,7 +463,11 @@ const INCLUDE_FETCH_LIMIT: u32 = 10_000;
 /// (SQLite, Postgres). References are extracted via the search-parameter
 /// registry's FHIRPath expression — so parameters whose name differs from the
 /// JSON field (e.g. Patient `organization` → `managingOrganization`) resolve
-/// correctly — and the referenced resources are fetched with `search()`.
+/// correctly — and the referenced resources are fetched with `search()`. Only
+/// references the extractor has already resolved to a `resource_type` +
+/// `resource_id` pair are followed; conditional references
+/// (`Type?param=value`), `urn:` references, and contained (`#`) references
+/// have no resolvable id and therefore never produce an included resource.
 pub async fn resolve_includes_iterative<S>(
     provider: &S,
     tenant: &TenantContext,
@@ -514,15 +518,18 @@ where
                         let Some(def) = def else { continue };
                         if let Ok(values) = extractor.extract_for_param(res.content(), &def) {
                             for v in values {
-                                if let IndexValue::Reference { reference, .. } = v.value {
-                                    if let Some((t, i)) = reference.split_once('/') {
-                                        if let Some(target) = &directive.target_type {
-                                            if t != target {
-                                                continue;
-                                            }
+                                if let IndexValue::Reference {
+                                    resource_type: Some(t),
+                                    resource_id: Some(i),
+                                    ..
+                                } = v.value
+                                {
+                                    if let Some(target) = &directive.target_type {
+                                        if &t != target {
+                                            continue;
                                         }
-                                        wanted.push((t.to_string(), i.to_string()));
                                     }
+                                    wanted.push((t, i));
                                 }
                             }
                         }

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -3726,6 +3726,254 @@ mod es_integration {
     }
 
     // ========================================================================
+    // Include Resolution Tests (#1013)
+    // ========================================================================
+
+    /// Sorted `(resource_type, id)` pairs, for exact-set assertions regardless
+    /// of the order resources were fetched in.
+    fn include_type_ids(
+        resources: &[helios_persistence::types::StoredResource],
+    ) -> Vec<(String, String)> {
+        let mut pairs: Vec<(String, String)> = resources
+            .iter()
+            .map(|r| (r.resource_type().to_string(), r.id().to_string()))
+            .collect();
+        pairs.sort();
+        pairs
+    }
+
+    /// Seeds the fixture shared by the `_include` delegation tests: `pat-1`
+    /// (managed by `org-1`), `org-1`, an Encounter with a real `serviceProvider`
+    /// reference (`enc-org`) and one with a conditional reference (`enc-cond`),
+    /// both referencing `pat-1` via `subject`.
+    async fn seed_include_fixture(backend: &ElasticsearchBackend, tenant: &TenantContext) {
+        backend
+            .create(
+                tenant,
+                "Organization",
+                json!({
+                    "resourceType": "Organization",
+                    "id": "org-1",
+                    "name": "Include Org"
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        backend
+            .create(
+                tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "pat-1",
+                    "name": [{"family": "Include"}],
+                    "managingOrganization": {"reference": "Organization/org-1"}
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        backend
+            .create(
+                tenant,
+                "Encounter",
+                json!({
+                    "resourceType": "Encounter",
+                    "id": "enc-cond",
+                    "status": "finished",
+                    "class": {"code": "AMB"},
+                    "subject": {"reference": "Patient/pat-1"},
+                    "serviceProvider": {
+                        "reference": "Organization?identifier=http://example.org/org|dept-9"
+                    }
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        backend
+            .create(
+                tenant,
+                "Encounter",
+                json!({
+                    "resourceType": "Encounter",
+                    "id": "enc-org",
+                    "status": "finished",
+                    "class": {"code": "AMB"},
+                    "subject": {"reference": "Patient/pat-1"},
+                    "serviceProvider": {"reference": "Organization/org-1"}
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        // Wait for index refresh so the fixture is visible to search()/read().
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    }
+
+    /// `search()` leaves `included` empty, like SQLite and Postgres, so the
+    /// REST layer resolves `_include` for Elasticsearch through the shared
+    /// `resolve_includes_iterative` path instead of an inline extractor.
+    #[tokio::test]
+    async fn es_integration_search_does_not_resolve_includes_inline() {
+        use helios_persistence::core::SearchProvider;
+        use helios_persistence::types::{IncludeDirective, IncludeType, SearchQuery};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("include-1013-1");
+        seed_include_fixture(&backend, &tenant).await;
+
+        let query = SearchQuery::new("Encounter").with_include(IncludeDirective {
+            include_type: IncludeType::Include,
+            source_type: "Encounter".to_string(),
+            search_param: "service-provider".to_string(),
+            target_type: None,
+            iterate: false,
+        });
+
+        let result = backend.search(&tenant, &query).await.unwrap();
+
+        let mut ids: Vec<String> = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["enc-cond".to_string(), "enc-org".to_string()]);
+        assert!(result.included.is_empty());
+    }
+
+    /// `IncludeProvider::resolve_includes` delegates to the shared,
+    /// registry-driven resolver: a conditional `serviceProvider` reference
+    /// never resolves to an included resource, a real one resolves to exactly
+    /// its target, and resolving the same target from two source resources
+    /// dedupes it.
+    #[tokio::test]
+    async fn es_integration_include_service_provider_returns_only_targets() {
+        use helios_persistence::core::IncludeProvider;
+        use helios_persistence::types::{IncludeDirective, IncludeType};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("include-1013-2");
+        seed_include_fixture(&backend, &tenant).await;
+
+        let enc_cond = backend
+            .read(&tenant, "Encounter", "enc-cond")
+            .await
+            .unwrap()
+            .expect("enc-cond must exist");
+        let enc_org = backend
+            .read(&tenant, "Encounter", "enc-org")
+            .await
+            .unwrap()
+            .expect("enc-org must exist");
+
+        let service_provider = IncludeDirective {
+            include_type: IncludeType::Include,
+            source_type: "Encounter".to_string(),
+            search_param: "service-provider".to_string(),
+            target_type: None,
+            iterate: false,
+        };
+
+        let both = backend
+            .resolve_includes(
+                &tenant,
+                &[enc_cond.clone(), enc_org.clone()],
+                std::slice::from_ref(&service_provider),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            include_type_ids(&both),
+            vec![("Organization".to_string(), "org-1".to_string())]
+        );
+
+        let cond_only = backend
+            .resolve_includes(
+                &tenant,
+                std::slice::from_ref(&enc_cond),
+                std::slice::from_ref(&service_provider),
+            )
+            .await
+            .unwrap();
+        assert!(cond_only.is_empty());
+
+        let subject = IncludeDirective {
+            include_type: IncludeType::Include,
+            source_type: "Encounter".to_string(),
+            search_param: "subject".to_string(),
+            target_type: None,
+            iterate: false,
+        };
+
+        let subjects = backend
+            .resolve_includes(&tenant, &[enc_cond, enc_org], &[subject])
+            .await
+            .unwrap();
+        assert_eq!(
+            include_type_ids(&subjects),
+            vec![("Patient".to_string(), "pat-1".to_string())]
+        );
+    }
+
+    /// `:iterate` follows references transitively through the same shared
+    /// resolver: `Encounter:subject` finds the Patient on the first hop, and
+    /// `Patient:organization` (marked `iterate`) then follows that Patient to
+    /// its managing Organization.
+    #[tokio::test]
+    async fn es_integration_include_iterate_follows_included_resources() {
+        use helios_persistence::core::IncludeProvider;
+        use helios_persistence::types::{IncludeDirective, IncludeType};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("include-1013-3");
+        seed_include_fixture(&backend, &tenant).await;
+
+        let enc_org = backend
+            .read(&tenant, "Encounter", "enc-org")
+            .await
+            .unwrap()
+            .expect("enc-org must exist");
+
+        let includes = vec![
+            IncludeDirective {
+                include_type: IncludeType::Include,
+                source_type: "Encounter".to_string(),
+                search_param: "subject".to_string(),
+                target_type: None,
+                iterate: false,
+            },
+            IncludeDirective {
+                include_type: IncludeType::Include,
+                source_type: "Patient".to_string(),
+                search_param: "organization".to_string(),
+                target_type: None,
+                iterate: true,
+            },
+        ];
+
+        let included = backend
+            .resolve_includes(&tenant, &[enc_org], &includes)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            include_type_ids(&included),
+            vec![
+                ("Organization".to_string(), "org-1".to_string()),
+                ("Patient".to_string(), "pat-1".to_string()),
+            ]
+        );
+    }
+
+    // ========================================================================
     // Backend Info Tests
     // ========================================================================
 

--- a/crates/persistence/tests/search/include_tests.rs
+++ b/crates/persistence/tests/search/include_tests.rs
@@ -659,3 +659,265 @@ async fn test_include_no_references() {
     assert!(!result.resources.is_empty());
     assert!(result.included.is_empty());
 }
+
+// ============================================================================
+// Parsed Type/id Only (#1013)
+// ============================================================================
+
+/// Sorted `(resource_type, id)` pairs for a set of included resources, to
+/// allow exact-set assertions regardless of fetch order.
+#[cfg(feature = "sqlite")]
+fn included_type_ids(
+    resources: &[helios_persistence::types::StoredResource],
+) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = resources
+        .iter()
+        .map(|r| (r.resource_type().to_string(), r.id().to_string()))
+        .collect();
+    pairs.sort();
+    pairs
+}
+
+/// A conditional reference (`Type?param=value`) has no resolvable
+/// `resource_type`/`resource_id`, so `_include` must skip it entirely rather
+/// than searching against a bogus type derived from the raw string.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_include_skips_conditional_reference() {
+    let backend = create_sqlite_backend();
+    let tenant = create_tenant();
+
+    let patient = json!({
+        "resourceType": "Patient",
+        "id": "patient-1",
+        "name": [{"family": "Smith"}]
+    });
+    backend
+        .create_or_update(
+            &tenant,
+            "Patient",
+            "patient-1",
+            patient,
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let encounter = json!({
+        "resourceType": "Encounter",
+        "id": "enc-cond",
+        "status": "finished",
+        "class": {"code": "AMB"},
+        "subject": {"reference": "Patient/patient-1"},
+        "serviceProvider": {
+            "reference": "Organization?identifier=http://example.org/org|dept-9"
+        }
+    });
+    backend
+        .create_or_update(
+            &tenant,
+            "Encounter",
+            "enc-cond",
+            encounter,
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let query = SearchQuery::new("Encounter")
+        .with_parameter(helios_persistence::types::SearchParameter {
+            name: "_id".to_string(),
+            param_type: helios_persistence::types::SearchParamType::Token,
+            modifier: None,
+            values: vec![helios_persistence::types::SearchValue::eq("enc-cond")],
+            chain: vec![],
+            components: vec![],
+        })
+        .with_include(IncludeDirective {
+            include_type: IncludeType::Include,
+            source_type: "Encounter".to_string(),
+            search_param: "service-provider".to_string(),
+            target_type: None,
+            iterate: false,
+        });
+
+    let result = search_with_includes(&backend, &tenant, &query.with_count(100))
+        .await
+        .unwrap();
+
+    assert_eq!(result.resources.len(), 1);
+    assert_eq!(result.resources.items[0].resource_type(), "Encounter");
+    assert!(result.included.is_empty());
+}
+
+/// A hyphenated search parameter name (`service-provider`) resolves via the
+/// registry to the referenced `Organization`, both with and without an
+/// explicit `:target_type` filter.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_include_hyphenated_param_resolves_via_registry() {
+    let backend = create_sqlite_backend();
+    let tenant = create_tenant();
+
+    let patient = json!({
+        "resourceType": "Patient",
+        "id": "patient-1",
+        "name": [{"family": "Smith"}]
+    });
+    backend
+        .create_or_update(
+            &tenant,
+            "Patient",
+            "patient-1",
+            patient,
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let org = json!({
+        "resourceType": "Organization",
+        "id": "org-sp",
+        "name": "Service Provider Org"
+    });
+    backend
+        .create_or_update(
+            &tenant,
+            "Organization",
+            "org-sp",
+            org,
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let encounter = json!({
+        "resourceType": "Encounter",
+        "id": "enc-sp",
+        "status": "finished",
+        "class": {"code": "AMB"},
+        "subject": {"reference": "Patient/patient-1"},
+        "serviceProvider": {"reference": "Organization/org-sp"}
+    });
+    backend
+        .create_or_update(
+            &tenant,
+            "Encounter",
+            "enc-sp",
+            encounter,
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let expected = vec![("Organization".to_string(), "org-sp".to_string())];
+
+    for target_type in [None, Some("Organization".to_string())] {
+        let query = SearchQuery::new("Encounter")
+            .with_parameter(helios_persistence::types::SearchParameter {
+                name: "_id".to_string(),
+                param_type: helios_persistence::types::SearchParamType::Token,
+                modifier: None,
+                values: vec![helios_persistence::types::SearchValue::eq("enc-sp")],
+                chain: vec![],
+                components: vec![],
+            })
+            .with_include(IncludeDirective {
+                include_type: IncludeType::Include,
+                source_type: "Encounter".to_string(),
+                search_param: "service-provider".to_string(),
+                target_type,
+                iterate: false,
+            });
+
+        let result = search_with_includes(&backend, &tenant, &query.with_count(100))
+            .await
+            .unwrap();
+
+        assert_eq!(included_type_ids(&result.included), expected);
+    }
+}
+
+/// `_include=Encounter:subject` on the same `Encounter` returns exactly the
+/// referenced `Patient`, never the `Organization` from `serviceProvider`.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_include_subject_returns_only_patient() {
+    let backend = create_sqlite_backend();
+    let tenant = create_tenant();
+
+    let patient = json!({
+        "resourceType": "Patient",
+        "id": "patient-1",
+        "name": [{"family": "Smith"}]
+    });
+    backend
+        .create_or_update(
+            &tenant,
+            "Patient",
+            "patient-1",
+            patient,
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let org = json!({
+        "resourceType": "Organization",
+        "id": "org-sp",
+        "name": "Service Provider Org"
+    });
+    backend
+        .create_or_update(
+            &tenant,
+            "Organization",
+            "org-sp",
+            org,
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let encounter = json!({
+        "resourceType": "Encounter",
+        "id": "enc-sp",
+        "status": "finished",
+        "class": {"code": "AMB"},
+        "subject": {"reference": "Patient/patient-1"},
+        "serviceProvider": {"reference": "Organization/org-sp"}
+    });
+    backend
+        .create_or_update(
+            &tenant,
+            "Encounter",
+            "enc-sp",
+            encounter,
+            FhirVersion::default(),
+        )
+        .await
+        .unwrap();
+
+    let query = SearchQuery::new("Encounter")
+        .with_parameter(helios_persistence::types::SearchParameter {
+            name: "_id".to_string(),
+            param_type: helios_persistence::types::SearchParamType::Token,
+            modifier: None,
+            values: vec![helios_persistence::types::SearchValue::eq("enc-sp")],
+            chain: vec![],
+            components: vec![],
+        })
+        .with_include(IncludeDirective {
+            include_type: IncludeType::Include,
+            source_type: "Encounter".to_string(),
+            search_param: "subject".to_string(),
+            target_type: None,
+            iterate: false,
+        });
+
+    let result = search_with_includes(&backend, &tenant, &query.with_count(100))
+        .await
+        .unwrap();
+
+    let expected = vec![("Patient".to_string(), "patient-1".to_string())];
+    assert_eq!(included_type_ids(&result.included), expected);
+}

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -411,9 +411,9 @@ where
         })?;
 
     // Resolve _include/_revinclude (with :iterate) for backends whose search()
-    // does not populate includes inline (SQLite, Postgres). Backends that
-    // resolve inline (Elasticsearch, MongoDB) return a non-empty `included` and
-    // are left as-is.
+    // does not populate includes inline (SQLite, Postgres, Elasticsearch).
+    // MongoDB is the only backend that resolves inline, returning a non-empty
+    // `included` that is left as-is.
     if !query.includes.is_empty() && result.included.is_empty() {
         let included = resolve_includes_iterative(
             state.storage(),

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -2097,6 +2097,27 @@ mod chaining {
 mod includes {
     use super::*;
 
+    /// Sorted `(resourceType, id)` pairs for bundle entries tagged
+    /// `search.mode == "include"`, for exact-set assertions independent of
+    /// fetch order.
+    fn include_entries(body: &Value) -> Vec<(String, String)> {
+        let mut pairs: Vec<(String, String)> = get_bundle_entries(body)
+            .iter()
+            .filter(|e| e["search"]["mode"] == "include")
+            .map(|e| {
+                (
+                    e["resource"]["resourceType"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_string(),
+                    e["resource"]["id"].as_str().unwrap_or_default().to_string(),
+                )
+            })
+            .collect();
+        pairs.sort();
+        pairs
+    }
+
     #[tokio::test]
     async fn test_include_subject() {
         let (server, backend) = create_test_server().await;
@@ -2336,6 +2357,121 @@ mod includes {
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_include_service_provider_conditional_reference_yields_no_includes() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let tenant = test_tenant();
+        let encounter = json!({
+            "resourceType": "Encounter",
+            "id": "enc-cond",
+            "status": "finished",
+            "class": {"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode", "code": "AMB"},
+            "subject": {"reference": "Patient/patient-1"},
+            "serviceProvider": {
+                "reference": "Organization?identifier=http://example.org/org|dept-9"
+            }
+        });
+        backend
+            .create(&tenant, "Encounter", encounter, FhirVersion::R4)
+            .await
+            .unwrap();
+
+        let response = server
+            .get("/Encounter?_id=enc-cond&_include=Encounter:service-provider")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let entries = get_bundle_entries(&body);
+
+        let match_entries: Vec<&&Value> = entries
+            .iter()
+            .filter(|e| e["search"]["mode"] == "match")
+            .collect();
+        assert_eq!(match_entries.len(), 1);
+        assert_eq!(match_entries[0]["resource"]["resourceType"], "Encounter");
+
+        assert!(
+            include_entries(&body).is_empty(),
+            "a conditional serviceProvider reference must not produce an include"
+        );
+        assert!(
+            !entries
+                .iter()
+                .any(|e| e["resource"]["resourceType"] == "Patient"),
+            "the conditional serviceProvider reference must not pull in the subject Patient either"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_include_service_provider_returns_only_the_organization() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let tenant = test_tenant();
+        let encounter = json!({
+            "resourceType": "Encounter",
+            "id": "enc-sp",
+            "status": "finished",
+            "class": {"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode", "code": "AMB"},
+            "subject": {"reference": "Patient/patient-1"},
+            "serviceProvider": {"reference": "Organization/org-2"}
+        });
+        backend
+            .create(&tenant, "Encounter", encounter, FhirVersion::R4)
+            .await
+            .unwrap();
+
+        let expected = vec![("Organization".to_string(), "org-2".to_string())];
+
+        for query in [
+            "/Encounter?_id=enc-sp&_include=Encounter:service-provider",
+            "/Encounter?_id=enc-sp&_include=Encounter:service-provider:Organization",
+        ] {
+            let response = server
+                .get(query)
+                .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+                .await;
+
+            response.assert_status_ok();
+            let body: Value = response.json();
+            assert_eq!(include_entries(&body), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_include_subject_returns_only_the_patient() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let tenant = test_tenant();
+        let encounter = json!({
+            "resourceType": "Encounter",
+            "id": "enc-sp",
+            "status": "finished",
+            "class": {"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode", "code": "AMB"},
+            "subject": {"reference": "Patient/patient-1"},
+            "serviceProvider": {"reference": "Organization/org-2"}
+        });
+        backend
+            .create(&tenant, "Encounter", encounter, FhirVersion::R4)
+            .await
+            .unwrap();
+
+        let response = server
+            .get("/Encounter?_id=enc-sp&_include=Encounter:subject")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let expected = vec![("Patient".to_string(), "patient-1".to_string())];
+        assert_eq!(include_entries(&body), expected);
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #1013.

On `pg-es`, `GET /Encounter?patient=…&_include=Encounter:service-provider` returned the subject Patient as an included resource, while the Organizations behind `serviceProvider` were never found and `_include:iterate` was ignored. The Elasticsearch backend resolved `_include` inline with its own reference extractor: it looked the search parameter up as a literal JSON field (`service-provider`, which does not exist; the field is `serviceProvider`) and then swept every reference in the resource. Because the composite router sends searches to Elasticsearch and the result already carried a non-empty `included`, the REST layer's registry-driven resolver never ran. SQLite and Postgres were unaffected because their `search()` leaves `included` empty.

## Changes

- `fix(persistence)`: `resolve_includes_iterative` follows only references the extractor parsed to `Type/id`; conditional references (`Organization?identifier=…`), `urn:` and contained references produce no includes even without a `:Type` filter (previously the raw string was split on `/`). Adds REST and shared-suite tests asserting the exact include set for `Encounter:service-provider` and `Encounter:subject`.
- `fix(elasticsearch)`: `ElasticsearchBackend::search()` no longer resolves includes inline; like SQLite and Postgres it returns an empty `included`, and the REST handler runs the shared `resolve_includes_iterative` (SearchParameter registry + FHIRPath expression, target-type filter, `:iterate`). `IncludeProvider for ElasticsearchBackend` delegates to that same resolver; the hand-rolled `extract_references` / `parse_reference_string` helpers are removed. Adds Elasticsearch integration tests (testcontainers) for the inline contract, the exact include set and `:iterate`.

## Acceptance criteria (#1013)

- [x] Only targets of the requested include parameter are returned as includes.
- [x] The subject Patient appears only when `_include=Encounter:subject` (or `:patient`) is requested.
- [x] Conformance tests assert the include set contents, not just the count (REST on SQLite, shared include suite, Elasticsearch integration via testcontainers).

## Testing

- `cargo test --workspace --all-features --exclude pysof -- include_tests` (shared include suite, 12 passed) and `-- includes::` (REST, 11 passed).
- `cargo test --workspace --all-features --exclude pysof -- es_integration_include es_integration_search_does_not_resolve_includes_inline` (Docker, 3 passed).
- Manual smoke on `pg-es` (PostgreSQL 16 + Elasticsearch 8.15.0, dev binary): conditional `serviceProvider` → 0 includes and no Patient; real Organization → exactly that Organization, with and without `:Organization`; `subject` → exactly the Patient, once; `_include:iterate=Patient:organization` → Patient + Organization; `_revinclude=Encounter:patient` unchanged (both Encounters).

## Follow-ups

- #1075: MongoDB resolves `_include` inline with the same literal-field heuristic, so renamed parameters such as `Encounter:service-provider` return nothing (`:iterate` on that backend is #1063).
- #1076: SQLite/Postgres/Composite `IncludeProvider` impls are dead in the REST path and still use the literal-field heuristic.
