### PR TITLE
fix(search): _text/_content on composite storage return results and a total (#1012)

### DIFF
--- a/crates/persistence/src/composite/storage.rs
+++ b/crates/persistence/src/composite/storage.rs
@@ -489,12 +489,26 @@ impl CompositeStorage {
     }
 
     /// Routes and executes a search query.
+    ///
+    /// With a dedicated Search backend the whole query goes there; otherwise
+    /// the query is routed, split by feature across backends, and merged.
     #[instrument(skip(self, tenant, query), fields(resource_type = %query.resource_type))]
     async fn execute_routed_search(
         &self,
         tenant: &TenantContext,
         query: &SearchQuery,
     ) -> StorageResult<SearchResult> {
+        // When a dedicated Search backend is configured, the primary has its
+        // search index offloaded (`search_offloaded = true`) and thus empty.
+        // Splitting the query and intersecting with the primary's (empty)
+        // results would always return nothing and drop the `total`. The
+        // Search backend supports every query feature, including full-text,
+        // so send it the whole query instead, exactly like the no-auxiliary
+        // path below already does. See #1012.
+        if self.has_dedicated_search_backend() {
+            return self.execute_primary_search(tenant, query).await;
+        }
+
         // Route the query
         let decision = self
             .router
@@ -2623,11 +2637,13 @@ mod tests {
     use crate::error::{BackendError, StorageError, StorageResult};
     use crate::tenant::{TenantContext, TenantId, TenantPermissions};
     use crate::types::{
-        SearchParamType, SearchParameter, SearchQuery, SearchValue, StoredResource,
+        Page, PageInfo, SearchParamType, SearchParameter, SearchQuery, SearchValue, StoredResource,
+        StoredResourceBuilder,
     };
     use async_trait::async_trait;
     use helios_fhir::FhirVersion;
     use serde_json::{Value, json};
+    use std::sync::Mutex;
 
     #[derive(Debug)]
     struct FailingSearchBackend {
@@ -3363,6 +3379,340 @@ mod tests {
             .await
             .expect("composite search_count should succeed");
         assert_eq!(count, 1);
+    }
+
+    /// A fake resource storage that also acts as a search provider. It
+    /// records every `search` query it receives (so tests can assert which
+    /// backend answered, and with which parameters) and returns a fixed set
+    /// of results with the total set to the number of results.
+    struct RecordingSearchProvider {
+        name: &'static str,
+        calls: Mutex<Vec<SearchQuery>>,
+        results: Vec<StoredResource>,
+    }
+
+    impl RecordingSearchProvider {
+        fn new(name: &'static str, results: Vec<StoredResource>) -> Self {
+            Self {
+                name,
+                calls: Mutex::new(Vec::new()),
+                results,
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.lock().expect("calls mutex poisoned").len()
+        }
+    }
+
+    #[async_trait]
+    impl ResourceStorage for RecordingSearchProvider {
+        fn backend_name(&self) -> &'static str {
+            self.name
+        }
+
+        async fn create(
+            &self,
+            _tenant: &TenantContext,
+            _resource_type: &str,
+            _resource: Value,
+            _fhir_version: FhirVersion,
+        ) -> StorageResult<StoredResource> {
+            Err(StorageError::Backend(BackendError::UnsupportedCapability {
+                backend_name: self.name.to_string(),
+                capability: "create".to_string(),
+            }))
+        }
+
+        async fn create_or_update(
+            &self,
+            _tenant: &TenantContext,
+            _resource_type: &str,
+            _id: &str,
+            _resource: Value,
+            _fhir_version: FhirVersion,
+        ) -> StorageResult<(StoredResource, bool)> {
+            Err(StorageError::Backend(BackendError::UnsupportedCapability {
+                backend_name: self.name.to_string(),
+                capability: "create_or_update".to_string(),
+            }))
+        }
+
+        async fn read(
+            &self,
+            _tenant: &TenantContext,
+            _resource_type: &str,
+            _id: &str,
+        ) -> StorageResult<Option<StoredResource>> {
+            Ok(None)
+        }
+
+        async fn update(
+            &self,
+            _tenant: &TenantContext,
+            _current: &StoredResource,
+            _resource: Value,
+        ) -> StorageResult<StoredResource> {
+            Err(StorageError::Backend(BackendError::UnsupportedCapability {
+                backend_name: self.name.to_string(),
+                capability: "update".to_string(),
+            }))
+        }
+
+        async fn delete(
+            &self,
+            _tenant: &TenantContext,
+            _resource_type: &str,
+            _id: &str,
+        ) -> StorageResult<()> {
+            Err(StorageError::Backend(BackendError::UnsupportedCapability {
+                backend_name: self.name.to_string(),
+                capability: "delete".to_string(),
+            }))
+        }
+
+        async fn count(
+            &self,
+            _tenant: &TenantContext,
+            _resource_type: Option<&str>,
+        ) -> StorageResult<u64> {
+            Ok(self.results.len() as u64)
+        }
+    }
+
+    #[async_trait]
+    impl SearchProvider for RecordingSearchProvider {
+        async fn search(
+            &self,
+            _tenant: &TenantContext,
+            query: &SearchQuery,
+        ) -> StorageResult<SearchResult> {
+            self.calls
+                .lock()
+                .expect("calls mutex poisoned")
+                .push(query.clone());
+            Ok(
+                SearchResult::new(Page::new(self.results.clone(), PageInfo::end()))
+                    .with_total(self.results.len() as u64),
+            )
+        }
+
+        async fn search_count(
+            &self,
+            _tenant: &TenantContext,
+            _query: &SearchQuery,
+        ) -> StorageResult<u64> {
+            Ok(self.results.len() as u64)
+        }
+
+        fn search_param_registry(
+            &self,
+            _tenant: &TenantContext,
+        ) -> std::sync::Arc<parking_lot::RwLock<crate::search::SearchParameterRegistry>> {
+            std::sync::Arc::new(parking_lot::RwLock::new(
+                crate::search::SearchParameterRegistry::new(),
+            ))
+        }
+    }
+
+    /// Builds a fake `Patient` resource with the given id, for use as a
+    /// dedicated-search-backend fixture.
+    fn fake_patient(id: &str) -> StoredResource {
+        StoredResourceBuilder::new()
+            .resource_type("Patient")
+            .id(id)
+            .tenant_id(TenantId::new("composite-test"))
+            .content(json!({
+                "resourceType": "Patient",
+                "id": id,
+            }))
+            .build()
+    }
+
+    /// Builds a composite whose config has a primary and a dedicated
+    /// Search-role backend, backed by [`RecordingSearchProvider`] fakes so
+    /// tests can assert which backend answered a query.
+    fn make_composite_with_dedicated_search(
+        primary_results: Vec<StoredResource>,
+        search_results: Vec<StoredResource>,
+    ) -> (
+        CompositeStorage,
+        Arc<RecordingSearchProvider>,
+        Arc<RecordingSearchProvider>,
+    ) {
+        let primary = Arc::new(RecordingSearchProvider::new("primary", primary_results));
+        let search = Arc::new(RecordingSearchProvider::new("search", search_results));
+
+        let composite_config = CompositeConfig::builder()
+            .primary("primary", BackendKind::Sqlite)
+            .search_backend("search", BackendKind::Sqlite)
+            .build()
+            .expect("build composite config");
+
+        let mut backends: HashMap<String, DynStorage> = HashMap::new();
+        backends.insert("primary".to_string(), primary.clone() as DynStorage);
+        backends.insert("search".to_string(), search.clone() as DynStorage);
+
+        let mut search_providers: HashMap<String, DynSearchProvider> = HashMap::new();
+        search_providers.insert("primary".to_string(), primary.clone() as DynSearchProvider);
+        search_providers.insert("search".to_string(), search.clone() as DynSearchProvider);
+
+        let composite = CompositeStorage::new(composite_config, backends)
+            .expect("create composite storage")
+            .with_search_providers(search_providers);
+
+        (composite, primary, search)
+    }
+
+    /// Builds a composite whose config has only a primary backend (no
+    /// dedicated Search role), backed by a single [`RecordingSearchProvider`]
+    /// fake.
+    fn make_composite_no_search_backend(
+        primary_results: Vec<StoredResource>,
+    ) -> (CompositeStorage, Arc<RecordingSearchProvider>) {
+        let primary = Arc::new(RecordingSearchProvider::new("primary", primary_results));
+
+        let composite_config = CompositeConfig::builder()
+            .primary("primary", BackendKind::Sqlite)
+            .build()
+            .expect("build composite config");
+
+        let mut backends: HashMap<String, DynStorage> = HashMap::new();
+        backends.insert("primary".to_string(), primary.clone() as DynStorage);
+
+        let mut search_providers: HashMap<String, DynSearchProvider> = HashMap::new();
+        search_providers.insert("primary".to_string(), primary.clone() as DynSearchProvider);
+
+        let composite = CompositeStorage::new(composite_config, backends)
+            .expect("create composite storage")
+            .with_search_providers(search_providers);
+
+        (composite, primary)
+    }
+
+    #[tokio::test]
+    async fn test_full_text_query_is_answered_whole_by_dedicated_search_backend() {
+        let tenant = TenantContext::new(
+            TenantId::new("composite-test"),
+            TenantPermissions::full_access(),
+        );
+
+        let search_results = vec![
+            fake_patient("patient-1"),
+            fake_patient("patient-2"),
+            fake_patient("patient-3"),
+        ];
+        let (composite, primary, search) =
+            make_composite_with_dedicated_search(vec![], search_results);
+
+        let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "_content".to_string(),
+            param_type: SearchParamType::String,
+            modifier: None,
+            values: vec![SearchValue::string("everett")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = composite
+            .search(&tenant, &query)
+            .await
+            .expect("composite search should succeed");
+
+        assert_eq!(result.resources.len(), 3);
+        assert_eq!(result.total, Some(3));
+        assert_eq!(search.call_count(), 1);
+        assert_eq!(primary.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_mixed_query_reaches_dedicated_search_backend_intact() {
+        let tenant = TenantContext::new(
+            TenantId::new("composite-test"),
+            TenantPermissions::full_access(),
+        );
+
+        let search_results = vec![
+            fake_patient("patient-1"),
+            fake_patient("patient-2"),
+            fake_patient("patient-3"),
+        ];
+        let (composite, primary, search) =
+            make_composite_with_dedicated_search(vec![], search_results);
+
+        let query = SearchQuery::new("Patient")
+            .with_parameter(SearchParameter {
+                name: "_content".to_string(),
+                param_type: SearchParamType::String,
+                modifier: None,
+                values: vec![SearchValue::string("everett")],
+                chain: vec![],
+                components: vec![],
+            })
+            .with_parameter(SearchParameter {
+                name: "gender".to_string(),
+                param_type: SearchParamType::Token,
+                modifier: None,
+                values: vec![SearchValue::eq("female")],
+                chain: vec![],
+                components: vec![],
+            });
+
+        let result = composite
+            .search(&tenant, &query)
+            .await
+            .expect("composite search should succeed");
+
+        assert_eq!(result.total, Some(3));
+        assert_eq!(primary.call_count(), 0);
+        assert_eq!(search.call_count(), 1);
+
+        let recorded = search.calls.lock().expect("calls mutex poisoned");
+        let recorded_query = recorded.first().expect("search should have been called");
+        let names: Vec<&str> = recorded_query
+            .parameters
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert!(
+            names.contains(&"_content"),
+            "recorded query should keep the _content parameter"
+        );
+        assert!(
+            names.contains(&"gender"),
+            "recorded query should keep the gender parameter"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_full_text_query_without_dedicated_search_backend_is_unchanged() {
+        // No Search-role backend is configured, so the guard added for #1012
+        // never triggers here: this exercises the pre-existing routing path
+        // (single backend, no auxiliary targets), unchanged by this fix.
+        let tenant = TenantContext::new(
+            TenantId::new("composite-test"),
+            TenantPermissions::full_access(),
+        );
+
+        let primary_results = vec![fake_patient("patient-1"), fake_patient("patient-2")];
+        let (composite, primary) = make_composite_no_search_backend(primary_results);
+
+        let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "_text".to_string(),
+            param_type: SearchParamType::String,
+            modifier: None,
+            values: vec![SearchValue::string("everett")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let result = composite
+            .search(&tenant, &query)
+            .await
+            .expect("composite search should succeed from the primary backend");
+
+        assert_eq!(result.resources.len(), 2);
+        assert_eq!(primary.call_count(), 1);
     }
 
     #[cfg(feature = "sqlite")]

--- a/crates/rest/src/handlers/search.rs
+++ b/crates/rest/src/handlers/search.rs
@@ -17,7 +17,7 @@ use helios_persistence::core::{
     IncludeProvider, MultiTypeSearchProvider, ResourceStorage, RevincludeProvider, SearchProvider,
     resolve_includes_iterative,
 };
-use helios_persistence::types::{SearchBundle, SearchParamType};
+use helios_persistence::types::{SearchBundle, SearchParamType, TotalMode};
 use tracing::{debug, warn};
 
 use helios_fhir::FhirVersion;
@@ -466,8 +466,20 @@ where
     // Get FHIR version from config for subsetting
     let fhir_version = state.config().default_fhir_version;
 
-    let mut bundle_json =
-        bundle_to_json_with_subsetting(bundle, summary_mode, elements.as_deref(), fhir_version);
+    // Whether the resolved query actually requires an accurate total: either
+    // requested explicitly via `_total=accurate` or implied by
+    // `_summary=count` with no conflicting explicit `_total` (see
+    // `build_search_query`). A missing total only fails closed when this
+    // holds — an explicit `_total=none`/`_total=estimate` opts out (#254).
+    let total_required = query.total == Some(TotalMode::Accurate);
+
+    let mut bundle_json = bundle_to_json_with_subsetting(
+        bundle,
+        summary_mode,
+        total_required,
+        elements.as_deref(),
+        fhir_version,
+    )?;
 
     // Report the parameters that were ignored under lenient handling. Added
     // after subsetting so `_elements`/`_summary` don't strip the outcome.
@@ -601,8 +613,17 @@ where
     // Get FHIR version from config for subsetting
     let fhir_version = state.config().default_fhir_version;
 
-    let bundle_json =
-        bundle_to_json_with_subsetting(bundle, summary_mode, elements.as_deref(), fhir_version);
+    // See the type-level search handler above for why this check matters
+    // (#254, #1012).
+    let total_required = query.total == Some(TotalMode::Accurate);
+
+    let bundle_json = bundle_to_json_with_subsetting(
+        bundle,
+        summary_mode,
+        total_required,
+        elements.as_deref(),
+        fhir_version,
+    )?;
 
     format_resource_response(StatusCode::OK, HeaderMap::new(), &bundle_json, format).map_err(|_| {
         RestError::InternalError {
@@ -637,24 +658,51 @@ fn encode_query(params: &SearchParams) -> String {
 }
 
 /// Converts a SearchBundle to a serde_json::Value for response with optional subsetting.
+///
+/// With `_summary=count`, the response carries only `Bundle.total`. When the
+/// query required an accurate total (either implied by `_summary=count` or
+/// requested explicitly via `_total=accurate`) and the backend did not
+/// compute one, this returns `Err(RestError::InternalError)` instead of
+/// silently emitting `"total": null`. If the client explicitly opted out of
+/// an accurate total (e.g. `_total=none`), a missing total still serializes
+/// as `null`, since that is the behavior the client asked for.
 fn bundle_to_json_with_subsetting(
     bundle: SearchBundle,
     summary_mode: Option<SummaryMode>,
+    total_required: bool,
     elements: Option<&[&str]>,
     fhir_version: FhirVersion,
-) -> serde_json::Value {
-    // Handle _summary=count specially - only return count, no entries
+) -> Result<serde_json::Value, RestError> {
+    // Handle _summary=count specially - only return count, no entries.
     if summary_mode == Some(SummaryMode::Count) {
-        return serde_json::json!({
+        if total_required {
+            // `_summary=count` implies an accurate total; a missing one is a
+            // server fault and must surface as an error, never as
+            // `"total": null` (#1012).
+            let total = bundle.total.ok_or_else(|| RestError::InternalError {
+                message: "search backend returned no total for _summary=count".to_string(),
+            })?;
+            return Ok(serde_json::json!({
+                "resourceType": "Bundle",
+                "type": bundle.bundle_type,
+                "total": total
+            }));
+        }
+        // An explicit `_total` other than `accurate` (e.g. `_total=none`) wins
+        // over the `_summary=count` implication (#254); a missing total here
+        // reflects that explicit choice, not a server fault, so it passes
+        // through unchanged.
+        return Ok(serde_json::json!({
             "resourceType": "Bundle",
             "type": bundle.bundle_type,
             "total": bundle.total
-        });
+        }));
     }
 
-    crate::responses::bundle::searchset_to_json(bundle, |resource| {
-        apply_subsetting(resource, summary_mode, elements, fhir_version)
-    })
+    Ok(crate::responses::bundle::searchset_to_json(
+        bundle,
+        |resource| apply_subsetting(resource, summary_mode, elements, fhir_version),
+    ))
 }
 
 /// Applies subsetting to a resource based on _summary and _elements parameters.
@@ -1127,7 +1175,8 @@ mod tests {
             .with_score(Some(0.42)),
         );
 
-        let json = bundle_to_json_with_subsetting(bundle, None, None, FhirVersion::R4);
+        let json = bundle_to_json_with_subsetting(bundle, None, false, None, FhirVersion::R4)
+            .expect("bundle without _summary=count always serializes");
         let search = &json["entry"][0]["search"];
         assert_eq!(search["mode"], "match");
         assert_eq!(search["score"], serde_json::json!(0.42));
@@ -1142,7 +1191,106 @@ mod tests {
             serde_json::json!({"resourceType": "Patient", "id": "1"}),
         ));
 
-        let json = bundle_to_json_with_subsetting(bundle, None, None, FhirVersion::R4);
+        let json = bundle_to_json_with_subsetting(bundle, None, false, None, FhirVersion::R4)
+            .expect("bundle without _summary=count always serializes");
         assert!(json["entry"][0]["search"].get("score").is_none());
+    }
+
+    /// `_summary=count` with a backend-supplied total returns only the count:
+    /// `Bundle.total` as a number and no `entry` key at all.
+    #[test]
+    fn test_count_summary_emits_total_and_no_entries() {
+        use helios_persistence::types::{BundleEntry, SearchBundle};
+
+        let bundle = SearchBundle::new()
+            .with_entry(BundleEntry::match_entry(
+                "http://example.com/fhir/Patient/1",
+                serde_json::json!({"resourceType": "Patient", "id": "1"}),
+            ))
+            .with_total(83);
+
+        let json = bundle_to_json_with_subsetting(
+            bundle,
+            Some(SummaryMode::Count),
+            true,
+            None,
+            FhirVersion::R4,
+        )
+        .expect("total is present, so _summary=count serializes");
+
+        assert_eq!(json["resourceType"], "Bundle");
+        assert_eq!(json["total"], serde_json::json!(83));
+        assert!(json.get("entry").is_none());
+    }
+
+    /// `_summary=count` implies an accurate total (#1012); a backend that
+    /// returns no total despite an accurate total being required is a server
+    /// fault, not a silent `"total": null`.
+    #[test]
+    fn test_count_summary_without_total_is_internal_error() {
+        use helios_persistence::types::SearchBundle;
+
+        let bundle = SearchBundle::new();
+
+        let result = bundle_to_json_with_subsetting(
+            bundle,
+            Some(SummaryMode::Count),
+            true,
+            None,
+            FhirVersion::R4,
+        );
+
+        match result {
+            Err(RestError::InternalError { message }) => {
+                assert!(
+                    message.contains("_summary=count"),
+                    "message should mention _summary=count, got: {message}"
+                );
+            }
+            other => panic!("expected RestError::InternalError, got: {other:?}"),
+        }
+    }
+
+    /// The fail-closed behavior is exclusive to `_summary=count`: a normal
+    /// FHIR search is allowed to omit `total`, so it still serializes today
+    /// as `"total": null` via `searchset_to_json`.
+    #[test]
+    fn test_non_count_summary_without_total_still_serializes() {
+        use helios_persistence::types::{BundleEntry, SearchBundle};
+
+        let bundle = SearchBundle::new().with_entry(BundleEntry::match_entry(
+            "http://example.com/fhir/Patient/1",
+            serde_json::json!({"resourceType": "Patient", "id": "1"}),
+        ));
+
+        let json = bundle_to_json_with_subsetting(bundle, None, false, None, FhirVersion::R4)
+            .expect("a missing total is not an error outside of _summary=count");
+
+        assert!(json["total"].is_null());
+        assert_eq!(json["entry"][0]["resource"]["id"], "1");
+    }
+
+    /// An explicit `_total` other than `accurate` (e.g. `_total=none`) wins
+    /// over the `_summary=count` implication (#254): the caller signals this
+    /// by passing `total_required = false`, and a missing total then
+    /// serializes as `null` instead of failing closed.
+    #[test]
+    fn test_count_summary_with_total_not_required_serializes_null_without_error() {
+        use helios_persistence::types::SearchBundle;
+
+        let bundle = SearchBundle::new();
+
+        let json = bundle_to_json_with_subsetting(
+            bundle,
+            Some(SummaryMode::Count),
+            false,
+            None,
+            FhirVersion::R4,
+        )
+        .expect("total_required = false opts out of the fail-closed check");
+
+        assert_eq!(json["resourceType"], "Bundle");
+        assert!(json["total"].is_null());
+        assert!(json.get("entry").is_none());
     }
 }

--- a/crates/rest/tests/search_integration.rs
+++ b/crates/rest/tests/search_integration.rs
@@ -2346,6 +2346,19 @@ mod includes {
 mod fulltext_search {
     use super::*;
 
+    /// Extracts the `id` of every `entry[].resource` in a search Bundle.
+    ///
+    /// Used instead of raw `get_bundle_entries` closures so every full-text
+    /// test can assert both presence and absence of specific ids without
+    /// repeating the extraction logic.
+    fn entry_ids(body: &Value) -> Vec<String> {
+        get_bundle_entries(body)
+            .iter()
+            .filter_map(|e| e["resource"]["id"].as_str())
+            .map(|s| s.to_string())
+            .collect()
+    }
+
     #[tokio::test]
     async fn test_text_search() {
         let (server, backend) = create_test_server().await;
@@ -2357,28 +2370,22 @@ mod fulltext_search {
             .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
             .await;
 
-        // Full-text search may or may not be implemented
-        let status = response.status_code();
-        if status == StatusCode::OK {
-            let body: Value = response.json();
-            let entries = get_bundle_entries(&body);
+        assert_eq!(response.status_code(), StatusCode::OK);
+        let body: Value = response.json();
+        let ids = entry_ids(&body);
 
-            // If implemented, should find patient-1 (has "diabetes" in text)
-            if !entries.is_empty() {
-                // At least one result should mention diabetes in narrative
-                let has_diabetes_patient =
-                    entries.iter().any(|e| e["resource"]["id"] == "patient-1");
-                assert!(
-                    has_diabetes_patient,
-                    "Should find patient with diabetes in text"
-                );
-            }
-        } else {
-            // Not implemented - that's okay
-            assert_eq!(
-                status,
-                StatusCode::BAD_REQUEST,
-                "Should return 400 if not supported"
+        // patient-1's narrative mentions diabetes; the others don't.
+        assert!(
+            ids.contains(&"patient-1".to_string()),
+            "expected patient-1 in results, got {:?}",
+            ids
+        );
+        for excluded in ["patient-2", "patient-3", "patient-4"] {
+            assert!(
+                !ids.contains(&excluded.to_string()),
+                "did not expect {} in results, got {:?}",
+                excluded,
+                ids
             );
         }
     }
@@ -2394,29 +2401,21 @@ mod fulltext_search {
             .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
             .await;
 
-        let status = response.status_code();
-        if status == StatusCode::OK {
-            let body: Value = response.json();
-            let entries = get_bundle_entries(&body);
+        assert_eq!(response.status_code(), StatusCode::OK);
+        let body: Value = response.json();
+        let ids = entry_ids(&body);
 
-            // If implemented, should find condition-2 (hypertension)
-            if !entries.is_empty() {
-                let has_hypertension = entries.iter().any(|e| {
-                    e["resource"]["id"] == "condition-2"
-                        || e["resource"]["code"]["coding"]
-                            .as_array()
-                            .map(|arr| arr.iter().any(|c| c["display"] == "Hypertension"))
-                            .unwrap_or(false)
-                });
-                if has_hypertension {
-                    // Good, found the expected result
-                }
-            }
-        }
-        // Either OK or BAD_REQUEST is acceptable
+        // condition-2's display ("Hypertension") and narrative both mention
+        // it; condition-1 is about diabetes and mentions neither.
         assert!(
-            status == StatusCode::OK || status == StatusCode::BAD_REQUEST,
-            "Should return OK or 400"
+            ids.contains(&"condition-2".to_string()),
+            "expected condition-2 in results, got {:?}",
+            ids
+        );
+        assert!(
+            !ids.contains(&"condition-1".to_string()),
+            "did not expect condition-1 in results, got {:?}",
+            ids
         );
     }
 
@@ -2425,22 +2424,32 @@ mod fulltext_search {
         let (server, backend) = create_test_server().await;
         seed_search_test_data(&backend).await;
 
-        // Search for multiple words
+        // Search for multiple words; FTS5's default bareword syntax is an
+        // implicit AND across terms, so this must behave like Elasticsearch's
+        // `operator: "and"` rather than matching on either word alone.
         let response = server
             .get("/Observation?_text=heart%20rate")
             .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
             .await;
 
-        let status = response.status_code();
-        if status == StatusCode::OK {
-            let body: Value = response.json();
-            // Should find observations with "heart rate" in text
-            assert_eq!(body["resourceType"], "Bundle");
+        assert_eq!(response.status_code(), StatusCode::OK);
+        let body: Value = response.json();
+        let ids = entry_ids(&body);
+
+        // obs-1, obs-3, obs-4 mention both "heart" and "rate"; obs-2 mentions
+        // neither (its narrative is about temperature).
+        for expected in ["obs-1", "obs-3", "obs-4"] {
+            assert!(
+                ids.contains(&expected.to_string()),
+                "expected {} in results, got {:?}",
+                expected,
+                ids
+            );
         }
-        // Either OK or BAD_REQUEST is acceptable
         assert!(
-            status == StatusCode::OK || status == StatusCode::BAD_REQUEST,
-            "Should return OK or 400"
+            !ids.contains(&"obs-2".to_string()),
+            "did not expect obs-2 in results, got {:?}",
+            ids
         );
     }
 
@@ -2454,17 +2463,72 @@ mod fulltext_search {
             .get("/Patient?_text=smith")
             .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
             .await;
-
         let response_upper = server
             .get("/Patient?_text=SMITH")
             .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
             .await;
 
-        // Both should succeed or both should fail (unsupported)
+        assert_eq!(response_lower.status_code(), StatusCode::OK);
+        assert_eq!(response_upper.status_code(), StatusCode::OK);
+
+        let mut ids_lower = entry_ids(&response_lower.json::<Value>());
+        let mut ids_upper = entry_ids(&response_upper.json::<Value>());
+        ids_lower.sort();
+        ids_upper.sort();
+
+        // patient-1 and patient-2 are both named Smith; case must not change
+        // which resources are found.
+        assert!(!ids_lower.is_empty(), "expected some matches for 'smith'");
         assert_eq!(
-            response_lower.status_code(),
-            response_upper.status_code(),
-            "Case should not affect search availability"
+            ids_lower, ids_upper,
+            "case should not affect which resources are found"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_text_search_count_summary_carries_total() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_text=smith&_summary=count")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+        let body: Value = response.json();
+
+        // patient-1 and patient-2 both match "smith"; _summary=count must
+        // carry the numeric total instead of an empty/absent Bundle field.
+        assert_eq!(body["total"].as_i64(), Some(2));
+        assert!(
+            body.get("entry").is_none(),
+            "_summary=count must not return entries, got {:?}",
+            body.get("entry")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_text_search_without_match_is_empty_200() {
+        let (server, backend) = create_test_server().await;
+        seed_search_test_data(&backend).await;
+
+        let response = server
+            .get("/Patient?_text=zzzznomatchzzzz")
+            .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
+            .await;
+
+        // No matches is a well-formed empty result, not "unsupported".
+        assert_eq!(response.status_code(), StatusCode::OK);
+        let body: Value = response.json();
+        assert!(get_bundle_entries(&body).is_empty());
+        // `total` may be omitted or reported as zero, but never a non-zero
+        // number: that would mean the filter was silently dropped.
+        let total = body.get("total").and_then(|t| t.as_i64());
+        assert!(
+            total.is_none() || total == Some(0),
+            "expected no total or a total of 0, got {:?}",
+            total
         );
     }
 
@@ -2480,7 +2544,7 @@ mod fulltext_search {
             .await;
 
         let status = response.status_code();
-        // This is an advanced feature, may not be supported
+        // :text-advanced is out of scope for #1012; still accepts OK or 400.
         assert!(
             status == StatusCode::OK || status == StatusCode::BAD_REQUEST,
             "Should return OK or 400"
@@ -2498,20 +2562,28 @@ mod fulltext_search {
             .add_header(X_TENANT_ID, HeaderValue::from_static("test-tenant"))
             .await;
 
-        let status = response.status_code();
-        if status == StatusCode::OK {
-            let body: Value = response.json();
-            let entries = get_bundle_entries(&body);
+        assert_eq!(response.status_code(), StatusCode::OK);
+        let body: Value = response.json();
+        let ids = entry_ids(&body);
 
-            // obs-1 has "normal sinus rhythm", obs-2 has "normal range"
-            if !entries.is_empty() {
-                // Results should include observations with "normal" in content
-            }
+        // obs-1 has "normal sinus rhythm", obs-2 has "normal range"; obs-3
+        // and obs-4 don't mention "normal" anywhere.
+        for expected in ["obs-1", "obs-2"] {
+            assert!(
+                ids.contains(&expected.to_string()),
+                "expected {} in results, got {:?}",
+                expected,
+                ids
+            );
         }
-        assert!(
-            status == StatusCode::OK || status == StatusCode::BAD_REQUEST,
-            "Should return OK or 400"
-        );
+        for excluded in ["obs-3", "obs-4"] {
+            assert!(
+                !ids.contains(&excluded.to_string()),
+                "did not expect {} in results, got {:?}",
+                excluded,
+                ids
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

On composite deployments with a dedicated search backend (pg-es, sqlite-es, mongo-es), `_text` / `_content` searches returned an empty Bundle silently, and `_summary=count` carried no `total`.

Root cause: the composite router classified `_text`/`_content` as full-text and split the query between the primary (Postgres) and the search backend (Elasticsearch), then intersected the two result sets. The primary has its search index offloaded and therefore empty, so the intersection was always empty and the merge dropped the total. Elasticsearch itself was already indexing `content_text` / `narrative_text` and building the right query.

## Changes

- **persistence/composite** (`55269a7cf`): when a Search-role backend is configured, the whole query goes to it, the same rule the non-split path already applied. No router/merger changes. Unit tests with fake providers cover it.
- **rest/search** (`7c8c8cd6d`): `_summary=count` now fails closed. When the resolved query requires an accurate total (implied by `_summary=count`, or `_total=accurate`), the response carries a numeric `total` or returns 500 + OperationOutcome, never `"total": null`. An explicit `_total=none` / `_total=estimate` still wins over the `_summary=count` implication (#254), so that case keeps serializing `null`.
- **rest/tests** (`8363de668`): the `_text`/`_content` conformance tests pin the contract (200 + expected resources present, others absent, case-insensitive, numeric total on count, empty 200 on no match) instead of accepting "200 or 400".

## Verification

- Unit tests with fake providers: primary not consulted, N results, `total = N`, full query (both `_content` and `gender`) reaches the search backend; a config without a Search-role backend is unchanged.
- REST unit tests: count with total → number; count without total and total required → `InternalError`; `_total=none` → `null` without error; non-count bundles unchanged.
- `cargo test --workspace --all-features --exclude pysof --test search_integration`: 117 passed.
- Manual smoke on pg-es (PostgreSQL 16 + Elasticsearch 8.15, `HFS_COMPOSITE_SYNC_MODE=synchronous`, `HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for`), 8 patients (5 mention Everett, 3 of them in the narrative):
  - Before the fix (binary without these commits, same data): `GET /Patient?_content=Everett` → 200, 0 entries, `"total": null`; `_summary=count` → `"total": null`; log shows the split (`Routing query … auxiliary_count=1`). Reproduced.
  - After the fix: `_content=Everett` → 5 entries, `total: 5`; `_text=Everett` → 3, `total: 3`; `_summary=count` → `total: 5` / `3`, no `entry`; `_content=Everett&gender=female` → 3; no match → 200, `total: 0`; `everett`/`EVERETT` → same 5; `name=Adams`, `_id=ev-2` → 1 each; 0 split lines, 0 `ERROR` in the log.

## Out of scope

- The parallel split/merge path for graph/terminology auxiliaries (unused by `hfs` deployments).
- A dedicated `search_count` path for `_summary=count`.
- `_text:text-advanced`.

Closes #1012
