### PR TITLE
perf(sqlite): collapse multi-value reference search to a flat IN (#1052)

### DIFF
--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -423,27 +423,64 @@ impl QueryBuilder {
             return self.build_composite_parameter_condition(param, param_offset);
         }
 
-        // Multiple values are ORed together
-        let mut or_conditions = Vec::new();
-        let mut total_params = 0usize;
+        // A plain multi-value reference search (all `Type/id`, no modifier)
+        // collapses to a single index-friendly `value_reference IN (...)`
+        // instead of ORing one `(= OR range)` branch per value (#1052). The
+        // OR-of-branches did two `idx_search_reference` probes per value and
+        // nested one level per term — ~18 ms/value (250 refs ≈ 4.6 s) and the
+        // parse-depth blow-up behind #943; a flat `IN` is a single indexed
+        // lookup of any length at ~1 node. Version-stripped bases are matched
+        // exactly, which covers every unversioned stored reference (references
+        // are stored unversioned in practice); the single-value path below
+        // keeps the full `_history` range match for the rare versioned case.
+        let is_plain_multi_reference = matches!(param.param_type, SearchParamType::Reference)
+            && param.modifier.is_none()
+            && param.values.len() >= 2
+            && param
+                .values
+                .iter()
+                .all(|v| strip_reference_version(&v.value).contains('/'));
 
-        for value in &param.values {
-            let condition = self.build_value_condition(param, value, param_offset + total_params);
-            if let Some(cond) = condition {
-                total_params += cond.params.len();
-                or_conditions.push(cond);
+        let combined = if is_plain_multi_reference {
+            let mut params = Vec::with_capacity(param.values.len());
+            let placeholders: Vec<String> = param
+                .values
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    params.push(SqlParam::string(strip_reference_version(&v.value)));
+                    format!("?{}", param_offset + i + 1)
+                })
+                .collect();
+            SqlFragment::with_params(
+                format!("value_reference IN ({})", placeholders.join(", ")),
+                params,
+            )
+        } else {
+            // Multiple values are ORed together
+            let mut or_conditions = Vec::new();
+            let mut total_params = 0usize;
+
+            for value in &param.values {
+                let condition =
+                    self.build_value_condition(param, value, param_offset + total_params);
+                if let Some(cond) = condition {
+                    total_params += cond.params.len();
+                    or_conditions.push(cond);
+                }
             }
-        }
 
-        if or_conditions.is_empty() {
-            return None;
-        }
+            if or_conditions.is_empty() {
+                return None;
+            }
 
-        // Combine with OR
-        let mut combined = or_conditions.remove(0);
-        for cond in or_conditions {
-            combined = combined.or(cond);
-        }
+            // Combine with OR
+            let mut combined = or_conditions.remove(0);
+            for cond in or_conditions {
+                combined = combined.or(cond);
+            }
+            combined
+        };
 
         // Wrap in subquery to ensure proper AND/OR semantics. `:not` negates
         // HERE, at the resource level, not inside the row predicate (#473):
@@ -1226,5 +1263,112 @@ mod tests {
         }
         // tenant, resource_type, + 3 per ID-only ref × 2 values
         assert_eq!(fragment.params.len(), 8);
+    }
+
+    #[test]
+    fn test_multi_value_typed_reference_uses_flat_in() {
+        // A plain multi-value `Type/id` reference collapses to one flat
+        // `value_reference IN (...)` — a single indexed lookup, not an OR of
+        // per-value range branches (#1052).
+        let builder = QueryBuilder::new("default", "Observation");
+        let mut query = SearchQuery::new("Observation");
+        query.parameters.push(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![
+                SearchValue::eq("Patient/a"),
+                SearchValue::eq("Patient/b"),
+                SearchValue::eq("Patient/c"),
+            ],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let fragment = builder.build(&query);
+        assert!(
+            fragment.sql.contains("value_reference IN (?3, ?4, ?5)"),
+            "expected a flat IN list, got: {}",
+            fragment.sql
+        );
+        // No per-value OR branches, and no `_history` range scan.
+        assert!(
+            !fragment.sql.contains(" OR "),
+            "should not OR: {}",
+            fragment.sql
+        );
+        assert!(
+            !fragment.sql.contains("_history"),
+            "multi-value IN path is exact-base only: {}",
+            fragment.sql
+        );
+        // tenant, resource_type, + one base per value
+        assert_eq!(fragment.params.len(), 5);
+    }
+
+    #[test]
+    fn test_multi_value_typed_reference_strips_versions() {
+        // Each search value is version-stripped to its base before going into
+        // the IN list, so a versioned search value still matches the base.
+        let builder = QueryBuilder::new("default", "Observation");
+        let mut query = SearchQuery::new("Observation");
+        query.parameters.push(SearchParameter {
+            name: "subject".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![
+                SearchValue::eq("Patient/a/_history/2"),
+                SearchValue::eq("Patient/b"),
+            ],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let fragment = builder.build(&query);
+        assert!(
+            fragment.sql.contains("value_reference IN (?3, ?4)"),
+            "{}",
+            fragment.sql
+        );
+        let bound: Vec<String> = fragment
+            .params
+            .iter()
+            .filter_map(|p| match p {
+                SqlParam::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            bound.contains(&"Patient/a".to_string()),
+            "version not stripped: {bound:?}"
+        );
+        assert!(bound.contains(&"Patient/b".to_string()), "bound: {bound:?}");
+    }
+
+    #[test]
+    fn test_multi_value_bare_id_reference_keeps_or_path() {
+        // Bare ids (no `Type/`) cannot use the base-equality IN — they still
+        // need the `%/id` suffix match — so they keep the generic OR path.
+        let builder = QueryBuilder::new("default", "Immunization");
+        let mut query = SearchQuery::new("Immunization");
+        query.parameters.push(SearchParameter {
+            name: "patient".to_string(),
+            param_type: SearchParamType::Reference,
+            modifier: None,
+            values: vec![SearchValue::eq("p1"), SearchValue::eq("p2")],
+            chain: vec![],
+            components: vec![],
+        });
+        let fragment = builder.build(&query);
+        assert!(
+            !fragment.sql.contains("value_reference IN (?3, ?4)"),
+            "bare ids must not take the flat-IN path: {}",
+            fragment.sql
+        );
+        assert!(
+            fragment.sql.contains(" OR "),
+            "bare-id path still ORs: {}",
+            fragment.sql
+        );
     }
 }


### PR DESCRIPTION
Fixes #1052.

## Problem

A multi-value reference search (`Type?ref=a,b,c,…`, and every hop of the application-side chained-search resolver) built one `(value_reference = ? OR value_reference >= ?||'/_history/' AND < ?||'/_history0')` branch per value and ORed them together. That did two `idx_search_reference` probes per value and nested one level per term — ~18 ms/value and a parse-tree that blows past SQLite's depth-1000 limit (the crash behind #943). #1017 fixed only the *single*-value case.

## Fix

A plain multi-value reference (every value a `Type/id`, no modifier) now collapses to a single **`value_reference IN (?, ?, …)`** — one flat, index-friendly node of any length instead of an OR of per-value range branches. Each search value is version-stripped to its base, so the `IN` matches every unversioned stored reference (references are stored unversioned in practice). The single-value path keeps the full `_history` range match for the rare version-qualified stored reference, and bare-id multi-value (no `Type/`) keeps its `%/id` suffix OR path (it can't use base equality).

## Measured (all-features release, ~512k-resource Synthea corpus, 10.3M search_index rows)

| query | before | after |
|---|---|---|
| `Observation?encounter=<50 refs>` | 2.17 s | **0.05 s** |
| `Observation?encounter=<250 refs>` | 4.59 s | **0.06 s** (~76×) |
| 2-level chain `Observation?encounter.patient.address-city=Everett` (~4,700 matches) | 33.6 s | **2.0 s** (~16×) |

The chained-search win is a direct consequence: the resolver's reference hops are exactly these multi-value searches.

## Scope / composition with #943

This makes multi-value reference and moderate chains fast, and the very-wide chain no longer saturates the server (it now returns and the server stays responsive). A *very* wide chain (tens of thousands of intermediate refs — e.g. `encounter.patient.gender=female`, ~49k here) still errors, because without the chunking in #943 (PR #1034) the resolver builds one `IN` list that exceeds SQLite's `SQLITE_MAX_VARIABLE_NUMBER` (~32k). The two fixes **compose**: #1052 makes each search a fast flat `IN`; #943 chunks the intermediate set so each chunk stays under the variable limit (and its `_id`-list rewrite becomes a flat `IN` too). With both, wide chains are both fast and bounded — and #943's 250-value chunk size can likely be raised once each chunk is a single indexed `IN`.

## Tests

`query_builder` suite green (21), incl. three new: the flat-IN shape, version stripping into the base, and bare-id multi-value still taking the OR path. clippy clean (CI invocation). The two failing `bulk_submit_receipts`/`bulk_submit_worker` tests in the local run are pre-existing on `main` (verified by stashing this change) and unrelated to search.