### PR TITLE
fix(persistence): MongoDB comma-separated date/number values now OR per spec

### DIFF
--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -1107,13 +1107,24 @@ impl MongoBackend {
             return Ok(filter);
         }
 
-        let combine_with_and = matches!(
-            param.param_type,
-            SearchParamType::Date | SearchParamType::Number
-        );
-        let operator = if combine_with_and { "$and" } else { "$or" };
+        // #1062: FHIR comma-separated values are OR for every parameter type
+        // (https://build.fhir.org/search.html#combining) — Date and Number
+        // used to get `$and` here, which was not merely stricter but wrong
+        // in a way that emptied the whole result. This filter is evaluated
+        // against a single `search_index` document (one value of one
+        // parameter, for one resource), so a disjoint AND can never be
+        // satisfied by any row: `distinct_resource_ids` then returns
+        // nothing, and `matching_resource_ids`'s empty-set short circuit
+        // empties the *entire* search result, not just this parameter. The
+        // AND semantics callers actually want is the *repeated*-parameter
+        // form (`?date=ge2020&date=le2021`), which arrives as separate
+        // `SearchParameter`s and is intersected in `matching_resource_ids` —
+        // unaffected by this change. Behavior change: a range-shaped comma
+        // list (`?date=ge2020,le2021`) widens from "in 2020-2021" to "any
+        // date >= 2020 OR any date <= 2021"; use the repeated form above for
+        // a closed range.
         filter.insert(
-            operator,
+            "$or",
             Bson::Array(value_filters.into_iter().map(Bson::Document).collect()),
         );
 
@@ -1509,11 +1520,25 @@ impl MongoBackend {
         &self,
         param: &SearchParameter,
     ) -> StorageResult<Vec<Document>> {
-        param
+        let mut conditions = param
             .values
             .iter()
             .map(|value| self.build_date_filter(value, "last_updated"))
-            .collect()
+            .collect::<StorageResult<Vec<_>>>()?;
+
+        // #1062: comma-separated `_lastUpdated` values are OR, the same
+        // defect and fix as `build_search_index_filter` above (see the
+        // comment there). Returning a single combined document — instead of
+        // one document per value — keeps `build_resource_filter` unchanged:
+        // it still `extend`s whatever comes back into the top-level `$and`,
+        // so two *separate* `_lastUpdated` parameters (the repeated form)
+        // still AND.
+        if conditions.len() <= 1 {
+            return Ok(conditions);
+        }
+        Ok(vec![doc! {
+            "$or": Bson::Array(conditions.drain(..).map(Bson::Document).collect()),
+        }])
     }
 
     fn build_cursor_condition(&self, cursor: &PageCursor) -> StorageResult<Document> {
@@ -2098,5 +2123,200 @@ mod query_support_tests {
                 ..
             }) if modifier == "below"
         ));
+    }
+}
+
+/// #1062: comma-separated search values are OR per FHIR
+/// (https://build.fhir.org/search.html#combining), for every parameter
+/// type. These pins target the exact filter document `build_search_index_filter`
+/// sends to `distinct_resource_ids` (:832), because *where* the predicate is
+/// evaluated is what made the old `$and` catastrophic rather than merely
+/// strict: a `search_index` document holds one value of one parameter for
+/// one resource, so a disjoint `$and` can never be satisfied by any single
+/// row. `distinct` then returns empty, `matching_resource_ids`'s empty-set
+/// short circuit fires, and the *entire* search result is emptied — not
+/// just the one parameter.
+///
+/// This is unrelated to the repeated-parameter form
+/// (`?birthdate=ge1980-01-01&birthdate=lt1990-01-01`), which arrives as two
+/// separate `SearchParameter` entries and is intersected across parameters
+/// in `matching_resource_ids`; that AND is correct per spec and is guarded
+/// here too, so a change that widens the comma-list join cannot silently
+/// widen the repeated form as well.
+#[cfg(test)]
+mod value_list_tests {
+    use super::*;
+    use crate::backends::mongodb::MongoBackendConfig;
+
+    fn backend() -> MongoBackend {
+        MongoBackend::new(MongoBackendConfig::default()).unwrap()
+    }
+
+    #[test]
+    fn comma_separated_date_values_are_ored() {
+        let backend = backend();
+        let param = SearchParameter {
+            name: "birthdate".to_string(),
+            param_type: SearchParamType::Date,
+            modifier: None,
+            values: vec![SearchValue::parse("2019"), SearchValue::parse("2021")],
+            chain: vec![],
+            components: vec![],
+        };
+
+        let filter = backend
+            .build_search_index_filter("t1", "Patient", &param)
+            .expect("valid filter");
+
+        assert!(
+            filter.get("$and").is_none(),
+            "date value list must not be ANDed: {filter:?}"
+        );
+        let arms = filter.get_array("$or").expect("$or array");
+        assert_eq!(arms.len(), 2);
+        for arm in arms {
+            let doc = arm.as_document().expect("$or arm is a document");
+            assert!(
+                doc.contains_key("value_date"),
+                "each $or arm constrains value_date: {doc:?}"
+            );
+        }
+    }
+
+    /// A regression a partial fix could pass: dropping only `Date` from the
+    /// old `matches!` would leave `Number` ANDed and this test red.
+    #[test]
+    fn comma_separated_number_values_are_ored() {
+        let backend = backend();
+        let param = SearchParameter {
+            name: "factor-override".to_string(),
+            param_type: SearchParamType::Number,
+            modifier: None,
+            values: vec![SearchValue::parse("0.25"), SearchValue::parse("1.5")],
+            chain: vec![],
+            components: vec![],
+        };
+
+        let filter = backend
+            .build_search_index_filter("t1", "ChargeItem", &param)
+            .expect("valid filter");
+
+        assert!(
+            filter.get("$and").is_none(),
+            "number value list must not be ANDed: {filter:?}"
+        );
+        let arms = filter.get_array("$or").expect("$or array");
+        assert_eq!(arms.len(), 2);
+        for arm in arms {
+            let doc = arm.as_document().expect("$or arm is a document");
+            assert!(
+                doc.contains_key("value_number"),
+                "each $or arm constrains value_number: {doc:?}"
+            );
+        }
+    }
+
+    /// Quantity was never in the AND list. Confirmed here rather than
+    /// assumed, so this module pins the join for every parameter type in
+    /// one place.
+    #[test]
+    fn comma_separated_quantity_values_stay_ored() {
+        let backend = backend();
+        let param = SearchParameter {
+            name: "value-quantity".to_string(),
+            param_type: SearchParamType::Quantity,
+            modifier: None,
+            values: vec![SearchValue::parse("5"), SearchValue::parse("10")],
+            chain: vec![],
+            components: vec![],
+        };
+
+        let filter = backend
+            .build_search_index_filter("t1", "Observation", &param)
+            .expect("valid filter");
+
+        assert!(filter.get("$and").is_none());
+        assert_eq!(filter.get_array("$or").expect("$or array").len(), 2);
+    }
+
+    /// Second site, same defect, one function away:
+    /// `build_resource_last_updated_conditions` (:1508) is the `_lastUpdated`
+    /// equivalent of `build_search_index_filter`, resolved against the
+    /// resource document instead of `search_index`. A disjoint comma list
+    /// must OR into a single combined condition.
+    #[test]
+    fn comma_separated_last_updated_values_are_ored() {
+        let backend = backend();
+        let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "_lastUpdated".to_string(),
+            param_type: SearchParamType::Date,
+            modifier: None,
+            values: vec![SearchValue::parse("2019"), SearchValue::parse("2021")],
+            chain: vec![],
+            components: vec![],
+        });
+
+        let filter = backend
+            .build_resource_filter("t1", "Patient", &query, None, None)
+            .expect("valid filter");
+
+        let and_arms = filter.get_array("$and").expect("$and array");
+        assert_eq!(
+            and_arms.len(),
+            2,
+            "base document plus one combined last_updated condition: {filter:?}"
+        );
+        let combined = and_arms[1].as_document().expect("condition is a document");
+        let or_arms = combined.get_array("$or").expect("$or array");
+        assert_eq!(or_arms.len(), 2);
+        for arm in or_arms {
+            let doc = arm.as_document().expect("$or arm is a document");
+            assert!(doc.contains_key("last_updated"));
+        }
+    }
+
+    /// Guard: the repeated-parameter form is a different mechanism (two
+    /// separate `SearchParameter` entries, not one with two values) and
+    /// must keep ANDing exactly as before — MANUAL_TESTING_MATRIX row 4.3
+    /// depends on it. Must stay green before and after the fix.
+    #[test]
+    fn repeated_last_updated_parameters_still_and() {
+        let backend = backend();
+        let query = SearchQuery::new("Patient")
+            .with_parameter(SearchParameter {
+                name: "_lastUpdated".to_string(),
+                param_type: SearchParamType::Date,
+                modifier: None,
+                values: vec![SearchValue::parse("ge2019")],
+                chain: vec![],
+                components: vec![],
+            })
+            .with_parameter(SearchParameter {
+                name: "_lastUpdated".to_string(),
+                param_type: SearchParamType::Date,
+                modifier: None,
+                values: vec![SearchValue::parse("le2021")],
+                chain: vec![],
+                components: vec![],
+            });
+
+        let filter = backend
+            .build_resource_filter("t1", "Patient", &query, None, None)
+            .expect("valid filter");
+
+        let and_arms = filter.get_array("$and").expect("$and array");
+        assert_eq!(
+            and_arms.len(),
+            3,
+            "base document plus one condition per repeated parameter: {filter:?}"
+        );
+        for arm in &and_arms[1..] {
+            let doc = arm.as_document().expect("condition is a document");
+            assert!(doc.contains_key("last_updated"));
+            assert!(
+                doc.get("$or").is_none(),
+                "a single-value condition stays flat, not wrapped in $or"
+            );
+        }
     }
 }

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -349,7 +349,7 @@ async fn mongodb_comma_separated_date_values_are_ored() {
             .expect("seed patient");
     }
 
-    // One `birthdate` SearchParameter, `values.len() == values.len()`
+    // One `birthdate` SearchParameter carrying all the values
     // (a comma list), as opposed to `repeated_birthdate_query` below which
     // builds one SearchParameter per value.
     fn comma_birthdate_query(values: &[&str]) -> SearchQuery {

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -317,6 +317,241 @@ async fn mongodb_day_precision_date_boundaries() {
     date_boundary_suite::day_precision_boundaries(&backend, "date-boundary-519").await;
 }
 
+/// #1062: a comma-separated value list on one `SearchParameter` is OR per
+/// FHIR (https://build.fhir.org/search.html#combining) — for date same as
+/// every other type. Drives the real `SearchProvider::search` /
+/// `search_count` path so the assertion is on behavior, not just the filter
+/// document shape (see `value_list_tests` in `search_impl.rs` for that
+/// Docker-free half of the pin).
+///
+/// This is deliberately distinct from the *repeated*-parameter form
+/// (`?birthdate=ge...&birthdate=le...`), which is two separate
+/// `SearchParameter` entries and is intersected, not OR-ed — case (d) below
+/// guards that it is untouched (MANUAL_TESTING_MATRIX row 4.3 relies on it).
+#[tokio::test]
+async fn mongodb_comma_separated_date_values_are_ored() {
+    let Some(backend) = create_backend_with_full_registry("comma_or_date").await else {
+        eprintln!("skipping: no MongoDB container available");
+        return;
+    };
+    let tenant = create_tenant("tenant-comma-or-date");
+
+    const BIRTHDATES: [&str; 3] = ["1985-05-05", "1995-10-02", "2005-01-01"];
+    for (i, birth) in BIRTHDATES.iter().enumerate() {
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({"id": format!("cod-{i}"), "birthDate": birth}),
+                FhirVersion::default(),
+            )
+            .await
+            .expect("seed patient");
+    }
+
+    // One `birthdate` SearchParameter, `values.len() == values.len()`
+    // (a comma list), as opposed to `repeated_birthdate_query` below which
+    // builds one SearchParameter per value.
+    fn comma_birthdate_query(values: &[&str]) -> SearchQuery {
+        SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "birthdate".to_string(),
+            param_type: SearchParamType::Date,
+            values: values.iter().map(|v| SearchValue::parse(v)).collect(),
+            ..Default::default()
+        })
+    }
+
+    fn repeated_birthdate_query(values: &[&str]) -> SearchQuery {
+        let mut query = SearchQuery::new("Patient");
+        for v in values {
+            query = query.with_parameter(SearchParameter {
+                name: "birthdate".to_string(),
+                param_type: SearchParamType::Date,
+                values: vec![SearchValue::parse(v)],
+                ..Default::default()
+            });
+        }
+        query
+    }
+
+    // Eventually-consistent search backends need the seed to land in the
+    // index first; poll on the broadest query until all 3 are visible (same
+    // idiom as `date_boundary_suite::day_precision_boundaries`).
+    let visibility_probe = comma_birthdate_query(&["ge1900-01-01"]);
+    for attempt in 0..60 {
+        let visible = backend
+            .search(&tenant, &visibility_probe)
+            .await
+            .expect("visibility probe")
+            .resources
+            .items
+            .len();
+        if visible == BIRTHDATES.len() {
+            break;
+        }
+        assert!(
+            attempt < 59,
+            "cohort never became searchable: {visible}/{} visible",
+            BIRTHDATES.len()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
+    // (a) Precondition: extraction really produced 3 rows, so a failure
+    // below is never blamed on extraction instead of the fix under test.
+    let precondition = backend
+        .search(&tenant, &comma_birthdate_query(&["ge1900-01-01"]))
+        .await
+        .expect("precondition search");
+    assert_eq!(
+        precondition.resources.items.len(),
+        3,
+        "precondition: birthdate=ge1900-01-01 must see all 3 patients"
+    );
+
+    // (b) Disjoint comma list -> the union, not the empty set. Before the
+    // fix the $and over one search_index row can never be satisfied by a
+    // disjoint pair, `matching_resource_ids` short-circuits to an empty
+    // set, and the whole search returns 0.
+    let disjoint = comma_birthdate_query(&["1985-05-05", "2005-01-01"]);
+    let disjoint_result = backend
+        .search(&tenant, &disjoint)
+        .await
+        .expect("disjoint comma search");
+    assert_eq!(
+        disjoint_result.resources.items.len(),
+        2,
+        "birthdate=1985-05-05,2005-01-01 must return the union (FHIR comma = OR)"
+    );
+    let disjoint_count = backend
+        .search_count(&tenant, &disjoint)
+        .await
+        .expect("disjoint comma count");
+    assert_eq!(
+        disjoint_count, 2,
+        "search_count must agree with search() on the same query"
+    );
+
+    // (c) Range-shaped comma list -> the deliberate widening. Before the
+    // fix this behaved as a closed range (1: only the 1995-10-02 patient).
+    // After, it is "any date >= 1995-01-01 OR any date <= 1995-12-31" (in
+    // FHIR terms, ge OR le), which every patient in this cohort satisfies —
+    // the widening this fix pins on purpose (see PR description / issue
+    // #1062 for the migration to the repeated form).
+    let range_shaped = comma_birthdate_query(&["ge1995-01-01", "le1995-12-31"]);
+    let range_result = backend
+        .search(&tenant, &range_shaped)
+        .await
+        .expect("range-shaped comma search");
+    assert_eq!(
+        range_result.resources.items.len(),
+        3,
+        "birthdate=ge1995-01-01,le1995-12-31 widens to OR across all 3 patients"
+    );
+
+    // (d) Guard: the repeated-parameter form is a different mechanism (two
+    // `SearchParameter` entries, intersected in `matching_resource_ids`)
+    // and must be unaffected — it stays a closed range.
+    let repeated = repeated_birthdate_query(&["ge1995-01-01", "le1995-12-31"]);
+    let repeated_result = backend
+        .search(&tenant, &repeated)
+        .await
+        .expect("repeated-parameter search");
+    assert_eq!(
+        repeated_result.resources.items.len(),
+        1,
+        "repeated birthdate parameters (ge&le) must still AND to a closed range"
+    );
+}
+
+/// #1062, Number: same defect class as the date case above. `ChargeItem`
+/// is chosen deliberately over `RiskAssessment.probability`: the latter is
+/// an uncast choice element (`RiskAssessment.prediction.probability`) that
+/// the schema-less extractor does not resolve, so a failure there would be
+/// ambiguous between "extraction didn't run" and "the fix is wrong".
+/// `ChargeItem.factorOverride` is a plain decimal path.
+#[tokio::test]
+async fn mongodb_comma_separated_number_values_are_ored() {
+    let Some(backend) = create_backend_with_full_registry("comma_or_number").await else {
+        eprintln!("skipping: no MongoDB container available");
+        return;
+    };
+    let tenant = create_tenant("tenant-comma-or-number");
+
+    const FACTORS: [f64; 3] = [0.25, 0.75, 1.5];
+    for (i, factor) in FACTORS.iter().enumerate() {
+        backend
+            .create(
+                &tenant,
+                "ChargeItem",
+                json!({
+                    "id": format!("con-{i}"),
+                    "status": "billable",
+                    "factorOverride": factor,
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .expect("seed chargeitem");
+    }
+
+    fn factor_query(values: &[&str]) -> SearchQuery {
+        SearchQuery::new("ChargeItem").with_parameter(SearchParameter {
+            name: "factor-override".to_string(),
+            param_type: SearchParamType::Number,
+            values: values.iter().map(|v| SearchValue::parse(v)).collect(),
+            ..Default::default()
+        })
+    }
+
+    let visibility_probe = factor_query(&["ge0"]);
+    for attempt in 0..60 {
+        let visible = backend
+            .search(&tenant, &visibility_probe)
+            .await
+            .expect("visibility probe")
+            .resources
+            .items
+            .len();
+        if visible == FACTORS.len() {
+            break;
+        }
+        assert!(
+            attempt < 59,
+            "cohort never became searchable: {visible}/{} visible",
+            FACTORS.len()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
+    // (a) Precondition: proves ChargeItem.factorOverride actually extracts
+    // into a `value_number` row, isolating that risk from the fix itself.
+    let precondition = backend
+        .search(&tenant, &visibility_probe)
+        .await
+        .expect("precondition search");
+    assert_eq!(
+        precondition.resources.items.len(),
+        3,
+        "precondition: factor-override=ge0 must see all 3 ChargeItems \
+         (a failure here means ChargeItem.factorOverride did not extract, \
+         which is unrelated to #1062 — see comma_separated_number_values_are_ored \
+         in search_impl.rs for the extraction-free pin of the same fix)"
+    );
+
+    // (b) Disjoint comma list -> the union, not the empty set.
+    let disjoint = factor_query(&["0.25", "1.5"]);
+    let disjoint_result = backend
+        .search(&tenant, &disjoint)
+        .await
+        .expect("disjoint comma search");
+    assert_eq!(
+        disjoint_result.resources.items.len(),
+        2,
+        "factor-override=0.25,1.5 must return the union (FHIR comma = OR)"
+    );
+}
+
 fn create_tenant(tenant_id: &str) -> TenantContext {
     TenantContext::new(TenantId::new(tenant_id), TenantPermissions::full_access())
 }

--- a/docs/search-conformance-plan.md
+++ b/docs/search-conformance-plan.md
@@ -106,8 +106,48 @@ Each item notes the spec basis, the fix, the files touched, and backend coverage
   `state.storage().search_param_registry()`). Files:
   `crates/rest/src/handlers/capabilities.rs`.
 
+## A7 — Combining values (comma-lists)
+- **A7a — MongoDB: comma-separated date/number values were ANDed, not
+  ORed (#1062).** Spec (build.fhir.org/search.html#combining): a
+  comma-separated value list on one parameter is OR; only *repeated*
+  parameters (`?p=a&p=b`) AND. `build_search_index_filter` singled out
+  `Date`/`Number` for `$and` instead of `$or`. Because the predicate is
+  evaluated against a single `search_index` document (one value of one
+  parameter per resource), a disjoint list (`?date=2019,2021`) could never
+  match any row — `distinct` returned empty, and `matching_resource_ids`'
+  empty-set short circuit then emptied the *entire* result, including any
+  other parameter in the query. A range-shaped list
+  (`?date=ge2020,le2021`) accidentally read as a closed range, since one
+  row's value can satisfy both bounds. The sibling `_lastUpdated` path
+  (`build_resource_last_updated_conditions`, resolved against the resource
+  document rather than `search_index`) had the same defect. Fix: always
+  join with `$or`; `_lastUpdated`'s multiple values now wrap into one `$or`
+  document instead of one `$and`-ed document per value, so the repeated
+  form (two separate `_lastUpdated` parameters) still ANDs unchanged.
+  **Behavior change:** `?date=ge2020,le2021` no longer means "in
+  2020-2021" — it now widens to "any date >= 2020 OR any date <= 2021".
+  The closed-range query is the repeated form,
+  `?date=ge2020&date=le2021`, which is unaffected. Quantity was already
+  correct (never in the AND list) and is unchanged; SQLite and
+  Elasticsearch were already correct (OR for every type) and are
+  unchanged. PostgreSQL has the same class of defect, more broadly
+  (quantity included) — tracked as a follow-up below, not fixed here.
+  Files: `crates/persistence/src/backends/mongodb/search_impl.rs`.
+
 ## Out of first cut (tracked follow-ups)
 - A5a for Postgres / Elasticsearch / MongoDB query builders.
 - A5b all-types compartment search.
 - A1b full `|` / `$` escaping inside token & composite value parsing.
 - Per-param `modifier` arrays in the CapabilityStatement.
+- **A7b — PostgreSQL: comma-separated date/number/quantity/`_lastUpdated`
+  values are ANDed across per-value subqueries** (`build_date_condition`,
+  `build_number_condition`, `build_quantity_condition`,
+  `build_last_updated_condition` in
+  `crates/persistence/src/backends/postgres/search/query_builder.rs`), the
+  same class of defect as A7a and wider (quantity is affected there, unlike
+  MongoDB). The failure mode differs from MongoDB's: each condition is its
+  own `id IN (SELECT ...)` subquery, so the AND is applied *across rows*
+  rather than within one row — `date=2019,2021` reads as "has a 2019 date
+  **and** a 2021 date" (not automatically empty) rather than MongoDB's
+  whole-result-emptying failure, which makes it easy to misread Postgres as
+  unaffected. Not fixed here; reuse A7a's test shape when it is.

--- a/docs/search-conformance-plan.md
+++ b/docs/search-conformance-plan.md
@@ -132,6 +132,15 @@ Each item notes the spec basis, the fix, the files touched, and backend coverage
   Elasticsearch were already correct (OR for every type) and are
   unchanged. PostgreSQL has the same class of defect, more broadly
   (quantity included) — tracked as a follow-up below, not fixed here.
+  MongoDB was the outlier here, not an exception to a settled convention:
+  the REST extractor, SQLite, Elasticsearch, and the UI's own query
+  builder already narrate a comma-separated date range as OR (e.g.
+  `crates/ui/e2e/tests/queries.spec.ts:1186` —
+  `"birthdate is on or before “1979-12-31” or birthdate is on or
+  after “1980-01-02”"`, exercised by the `mongodb`
+  backend lane of `.github/workflows/ui-tests-matrix.yml`); those e2e
+  assertions narrate builder hydration only, not result counts, so they
+  are unaffected by this fix either way.
   Files: `crates/persistence/src/backends/mongodb/search_impl.rs`.
 
 ## Out of first cut (tracked follow-ups)


### PR DESCRIPTION
Fixes #1062.

## What was wrong

`build_search_index_filter` singled out `Date` and `Number` for `$and` while OR-ing every other type:

```rust
let combine_with_and = matches!(
    param.param_type,
    SearchParamType::Date | SearchParamType::Number
);
let operator = if combine_with_and { "$and" } else { "$or" };
```

FHIR specifies a comma-separated value list on one parameter as **OR**; only *repeated* parameters AND. Because the predicate is evaluated against a single `search_index` document — one value of one parameter per row — a disjoint list could never match anything:

- `?date=2019,2021` returned **zero** results. Worse, `matching_resource_ids`' empty-set short circuit then emptied the *entire* search, discarding any other parameter in the query.
- `?date=ge2020,le2021` accidentally read as a **closed range**, since one row's value can satisfy both bounds.

`build_resource_last_updated_conditions` had the same defect on the `_lastUpdated` path, which resolves against the resource document rather than `search_index`.

## What changed

Two call sites now `$or` comma-lists for every type. `_lastUpdated`'s multiple values wrap into one `$or` document instead of one `$and`-ed document per value, so the repeated form still ANDs unchanged.

Verified that all four callers — `matching_resource_ids`, the `:not` complement, `matching_contained`, and `ifNoneExist` in `storage.rs` — already wrap the returned document in an outer `$and`/`$match`, so the `$or` shape is safe at every site. `tenant_id` / `resource_type` scoping is untouched at both sites.

## ⚠️ Behaviour change — read before merging

**Range-shaped comma lists widen.** Under the old `$and`, `?date=ge2020,le2021` meant "has a date in 2020–2021". Under the correct `$or` it means "has any date at or after 2020, **or** any date at or before 2021" — in practice nearly every resource with that date element populated.

**Callers using the comma form to express a range must switch to the repeated-parameter form**, `?date=ge2020&date=le2021`, which ANDs per spec and is unaffected by this change.

Disjoint lists change from returning nothing to returning the union — that's the bug being fixed. Only MongoDB is affected; SQLite, Postgres and Elasticsearch already OR. Quantity was already correct (never in the AND list).

The release note is recorded as **A7a** in `docs/search-conformance-plan.md`, in a new "Combining values (comma-lists)" section. Since the repo has no `CHANGELOG.md`, that doc plus this PR body are the record.

## Also found, not fixed here

**PostgreSQL has the same class of defect, more broadly** — quantity included, where MongoDB's quantity was already correct. Tracked as **A7b** in the same doc rather than fixed in this branch.

## Tests

Filter-shape unit tests (no Docker needed):

- `comma_separated_date_values_are_ored` / `comma_separated_number_values_are_ored` — no `$and` key, a 2-arm `$or`
- `comma_separated_last_updated_values_are_ored` — 2 `$and` arms (base + one combined `$or`) where the old code produced 3
- `quantity_values_stay_ored` and `repeated_last_updated_parameters_still_and` — guards, green before and after, labelled as such

Live-MongoDB integration test `mongodb_comma_separated_date_values_are_ored` pins all four cases on one seeded cohort of 3 Patients:

| assertion | old | new |
|---|---|---|
| (a) precondition `birthdate=ge1900-01-01` | 3 | 3 |
| (b) disjoint `birthdate=1985-05-05,2005-01-01` | **0** | **2** |
| (c) range-shaped `birthdate=ge1995-01-01,le1995-12-31` | **1** | **3** |
| (d) repeated form `birthdate=ge1995-01-01&birthdate=le1995-12-31` | 1 | 1 |

(c) is the widening, pinned deliberately so it can't be discovered later by a caller; (d) guards the migration path in the same test. (a) exists so a red test can never be blamed on extraction rather than the fix.

```
cargo test -p helios-persistence --features mongodb --test mongodb_tests
test result: ok. 105 passed; 0 failed; 0 ignored
```

Zero skips — Docker was live. `cargo fmt --all -- --check` and clippy with CI's allowlist both pass.

## Landing note

A dry `git merge-tree` against the in-flight #999 work conflicts only at the end-of-file test-module append — both add a test module at the same spot. Both production hunks auto-merge and #999 leaves the `combine_with_and` line intact. Resolution is keep-both.

---

Found while researching #1040 / #999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECbBsNhgXwBo4dQtFyVBXv
