### PR TITLE
fix(persistence): honour :not/:missing on _id and _lastUpdated (mongodb) — _id:not returned the excluded resource

### DIFF
--- a/crates/persistence/src/backends/mongodb/backend.rs
+++ b/crates/persistence/src/backends/mongodb/backend.rs
@@ -738,13 +738,22 @@ impl MongoBackend {
     /// value, so `:missing` there would answer from an empty index rather
     /// than a real absence check.
     ///
-    /// One known-imprecise case, not fixed here: `matching_resource_ids`
-    /// skips `_id`/`_lastUpdated` by name and never evaluates their modifiers
-    /// at all, but this function is keyed on parameter type only, so the
-    /// common-param loop in `resource_search_capabilities` will still
-    /// advertise `:missing` on `_lastUpdated` (and `:not`/`:missing` on
-    /// `_id`, via its Token fallback type) even though the Mongo index path
-    /// silently ignores those modifiers there.
+    /// `_id` and `_lastUpdated` take a different route and are no longer
+    /// imprecise here (#1055). `matching_resource_ids` skips them by name and
+    /// hands them to `build_resource_id_condition` /
+    /// `build_resource_last_updated_conditions`, which now honour the
+    /// modifiers this function advertises for them: `:not` and `:missing` on
+    /// `_id`, `:missing` on `_lastUpdated`. Anything else on those two names
+    /// is rejected with `UnsupportedModifier` rather than silently degrading
+    /// to a positive match — which is what `_id:not` used to do, returning
+    /// exactly the resource the caller asked to exclude.
+    ///
+    /// One residual imprecision: this function is keyed on parameter *type*,
+    /// so the Token arm advertises `text`/`code-text` for every token param
+    /// including `_id` (via its Token fallback), while
+    /// `validate_query_support` now rejects `_id:text`. Advertised-but-
+    /// rejected is a visible 400 rather than the old silent wrong answer;
+    /// narrowing it would need a name-aware capability path.
     ///
     /// Still unimplemented and therefore still unadvertised: `:above`/
     /// `:below`/`:in`/`:not-in` (rejected outright by `validate_query_support`

--- a/crates/persistence/src/backends/mongodb/search_impl.rs
+++ b/crates/persistence/src/backends/mongodb/search_impl.rs
@@ -711,6 +711,34 @@ impl MongoBackend {
                     param_type: param.param_type.to_string(),
                 }));
             }
+
+            // `_id`/`_lastUpdated` are lowered outside the generic modifier
+            // dispatch (see `build_resource_id_condition` /
+            // `build_resource_last_updated_conditions`), which only knows
+            // how to honour a narrow set of modifiers on them. Reject
+            // anything else explicitly here rather than letting it fall
+            // through to a builder that would silently misinterpret it
+            // (#1055).
+            let metadata_param_honoured = match param.name.as_str() {
+                "_id" => matches!(
+                    param.modifier,
+                    None | Some(SearchModifier::Not) | Some(SearchModifier::Missing)
+                ),
+                "_lastUpdated" => {
+                    matches!(param.modifier, None | Some(SearchModifier::Missing))
+                }
+                _ => true,
+            };
+            if !metadata_param_honoured {
+                return Err(StorageError::Search(SearchError::UnsupportedModifier {
+                    modifier: param
+                        .modifier
+                        .as_ref()
+                        .map(ToString::to_string)
+                        .unwrap_or_default(),
+                    param_type: param.param_type.to_string(),
+                }));
+            }
         }
 
         Ok(())
@@ -1496,8 +1524,34 @@ impl MongoBackend {
     }
 
     fn build_resource_id_condition(&self, param: &SearchParameter) -> StorageResult<Document> {
-        let mut ids = Vec::new();
+        // `:missing` is a presence test on `id`, not a value to compare
+        // against it — resolved before the values loop so the boolean
+        // literal ("true"/"false") is never consumed as an id (#1055).
+        if matches!(param.modifier, Some(SearchModifier::Missing)) {
+            let wants_missing = param
+                .values
+                .first()
+                .map(|v| v.value == "true")
+                .unwrap_or(false);
+            return Ok(if wants_missing {
+                doc! { "id": Bson::Null }
+            } else {
+                doc! { "id": { "$ne": Bson::Null } }
+            });
+        }
 
+        let negated = match &param.modifier {
+            None => false,
+            Some(SearchModifier::Not) => true,
+            Some(other) => {
+                return Err(StorageError::Search(SearchError::UnsupportedModifier {
+                    modifier: other.to_string(),
+                    param_type: param.param_type.to_string(),
+                }));
+            }
+        };
+
+        let mut ids = Vec::new();
         for value in &param.values {
             if value.prefix != SearchPrefix::Eq {
                 return Err(StorageError::Search(SearchError::QueryParseError {
@@ -1507,12 +1561,15 @@ impl MongoBackend {
             ids.push(value.value.clone());
         }
 
-        if ids.len() == 1 {
-            return Ok(doc! { "id": ids.remove(0) });
-        }
-
-        Ok(doc! {
-            "id": { "$in": Bson::Array(ids.into_iter().map(Bson::String).collect()) }
+        Ok(match (ids.len(), negated) {
+            (1, false) => doc! { "id": ids.remove(0) },
+            (1, true) => doc! { "id": { "$ne": ids.remove(0) } },
+            (_, false) => doc! {
+                "id": { "$in": Bson::Array(ids.into_iter().map(Bson::String).collect()) }
+            },
+            (_, true) => doc! {
+                "id": { "$nin": Bson::Array(ids.into_iter().map(Bson::String).collect()) }
+            },
         })
     }
 
@@ -1520,25 +1577,51 @@ impl MongoBackend {
         &self,
         param: &SearchParameter,
     ) -> StorageResult<Vec<Document>> {
-        let mut conditions = param
-            .values
-            .iter()
-            .map(|value| self.build_date_filter(value, "last_updated"))
-            .collect::<StorageResult<Vec<_>>>()?;
+        match &param.modifier {
+            None => {
+                let mut conditions = param
+                    .values
+                    .iter()
+                    .map(|value| self.build_date_filter(value, "last_updated"))
+                    .collect::<StorageResult<Vec<_>>>()?;
 
-        // #1062: comma-separated `_lastUpdated` values are OR, the same
-        // defect and fix as `build_search_index_filter` above (see the
-        // comment there). Returning a single combined document — instead of
-        // one document per value — keeps `build_resource_filter` unchanged:
-        // it still `extend`s whatever comes back into the top-level `$and`,
-        // so two *separate* `_lastUpdated` parameters (the repeated form)
-        // still AND.
-        if conditions.len() <= 1 {
-            return Ok(conditions);
+                // #1062: comma-separated `_lastUpdated` values are OR, the
+                // same defect and fix as `build_search_index_filter` above
+                // (see the comment there). Returning a single combined
+                // document - instead of one document per value - keeps
+                // `build_resource_filter` unchanged: it still `extend`s
+                // whatever comes back into the top-level `$and`, so two
+                // *separate* `_lastUpdated` parameters (the repeated form)
+                // still AND.
+                if conditions.len() <= 1 {
+                    return Ok(conditions);
+                }
+                Ok(vec![doc! {
+                    "$or": Bson::Array(conditions.drain(..).map(Bson::Document).collect()),
+                }])
+            }
+            // Presence test on `last_updated`, mirroring `_id:missing` above.
+            // Every live resource carries a `last_updated`, so `:missing=true`
+            // is trivially empty and `:missing=false` trivially everything -
+            // but the boolean literal must never reach `build_date_filter`
+            // (#1055: it previously 400'd there as an unparseable date).
+            Some(SearchModifier::Missing) => {
+                let wants_missing = param
+                    .values
+                    .first()
+                    .map(|v| v.value == "true")
+                    .unwrap_or(false);
+                Ok(vec![if wants_missing {
+                    doc! { "last_updated": Bson::Null }
+                } else {
+                    doc! { "last_updated": { "$ne": Bson::Null } }
+                }])
+            }
+            Some(other) => Err(StorageError::Search(SearchError::UnsupportedModifier {
+                modifier: other.to_string(),
+                param_type: param.param_type.to_string(),
+            })),
         }
-        Ok(vec![doc! {
-            "$or": Bson::Array(conditions.drain(..).map(Bson::Document).collect()),
-        }])
     }
 
     fn build_cursor_condition(&self, cursor: &PageCursor) -> StorageResult<Document> {
@@ -2436,5 +2519,188 @@ mod value_list_tests {
                 "a single-value condition stays flat, not wrapped in $or"
             );
         }
+    }
+}
+
+/// #1055: `_id`/`_lastUpdated` are lowered outside the generic modifier
+/// dispatch (`matching_resource_ids` skips them and hands them to
+/// `build_resource_id_condition` / `build_resource_last_updated_conditions`
+/// instead), so these two builders must honour `param.modifier` themselves.
+/// Pinned at the filter-shape level, without a live MongoDB, because the
+/// integration test cannot fully discriminate `_id:missing=true` (an
+/// accidental pass either way — see the sibling integration test).
+#[cfg(test)]
+mod metadata_param_modifier_tests {
+    use super::*;
+    use crate::backends::mongodb::MongoBackendConfig;
+
+    fn backend() -> MongoBackend {
+        MongoBackend::new(MongoBackendConfig::default()).unwrap()
+    }
+
+    fn id_param(modifier: Option<SearchModifier>, values: &[&str]) -> SearchParameter {
+        SearchParameter {
+            name: "_id".to_string(),
+            param_type: SearchParamType::Token,
+            modifier,
+            values: values.iter().map(|v| SearchValue::eq(*v)).collect(),
+            chain: vec![],
+            components: vec![],
+        }
+    }
+
+    fn last_updated_param(modifier: Option<SearchModifier>, value: &str) -> SearchParameter {
+        SearchParameter {
+            name: "_lastUpdated".to_string(),
+            param_type: SearchParamType::Date,
+            modifier,
+            values: vec![SearchValue::eq(value)],
+            chain: vec![],
+            components: vec![],
+        }
+    }
+
+    /// The metadata-param condition alone: `build_resource_filter`'s first
+    /// `$and` arm is always the tenant/resource_type/is_deleted seed, so with
+    /// a single parameter and no matched-id set the second arm is the
+    /// condition under test.
+    fn condition(backend: &MongoBackend, param: SearchParameter) -> Document {
+        let query = SearchQuery::new("Patient").with_parameter(param);
+        let filter = backend
+            .build_resource_filter("t", "Patient", &query, None, None)
+            .expect("filter should build");
+        filter.get_array("$and").expect("$and array")[1]
+            .as_document()
+            .expect("condition document")
+            .clone()
+    }
+
+    #[test]
+    fn plain_id_match_is_unchanged() {
+        let backend = backend();
+        let cond = condition(&backend, id_param(None, &["pat-a"]));
+        assert_eq!(cond.get_str("id").unwrap(), "pat-a");
+    }
+
+    #[test]
+    fn id_not_negates_instead_of_matching() {
+        let backend = backend();
+
+        let single = condition(&backend, id_param(Some(SearchModifier::Not), &["pat-a"]));
+        assert_eq!(
+            single.get_document("id").unwrap().get_str("$ne").unwrap(),
+            "pat-a"
+        );
+
+        let multi = condition(
+            &backend,
+            id_param(Some(SearchModifier::Not), &["pat-a", "pat-b"]),
+        );
+        let nin = multi.get_document("id").unwrap().get_array("$nin").unwrap();
+        let values: Vec<&str> = nin.iter().map(|b| b.as_str().unwrap()).collect();
+        assert_eq!(values, vec!["pat-a", "pat-b"]);
+    }
+
+    #[test]
+    fn id_missing_is_a_presence_test_on_the_id_field() {
+        let backend = backend();
+
+        let missing_true = condition(&backend, id_param(Some(SearchModifier::Missing), &["true"]));
+        assert!(matches!(missing_true.get("id"), Some(Bson::Null)));
+
+        let missing_false = condition(
+            &backend,
+            id_param(Some(SearchModifier::Missing), &["false"]),
+        );
+        assert!(matches!(
+            missing_false.get_document("id").unwrap().get("$ne"),
+            Some(Bson::Null)
+        ));
+    }
+
+    /// Control for #519: the refactor of `build_resource_last_updated_conditions`
+    /// into a modifier match must leave the no-modifier (period-comparison) arm
+    /// byte-identical.
+    #[test]
+    fn last_updated_no_modifier_control_still_builds_a_date_range() {
+        let backend = backend();
+        let cond = condition(&backend, last_updated_param(None, "2024"));
+        let bounds = cond.get_document("last_updated").expect("field doc");
+        assert!(bounds.get_datetime("$gte").is_ok());
+        assert!(bounds.get_datetime("$lt").is_ok());
+    }
+
+    #[test]
+    fn last_updated_missing_does_not_parse_the_boolean_as_a_date() {
+        let backend = backend();
+
+        let missing_true = condition(
+            &backend,
+            last_updated_param(Some(SearchModifier::Missing), "true"),
+        );
+        assert!(matches!(missing_true.get("last_updated"), Some(Bson::Null)));
+
+        let missing_false = condition(
+            &backend,
+            last_updated_param(Some(SearchModifier::Missing), "false"),
+        );
+        assert!(matches!(
+            missing_false
+                .get_document("last_updated")
+                .unwrap()
+                .get("$ne"),
+            Some(Bson::Null)
+        ));
+    }
+
+    #[test]
+    fn unhonoured_modifiers_on_metadata_params_are_rejected() {
+        let backend = backend();
+
+        let id_text = SearchQuery::new("Patient")
+            .with_parameter(id_param(Some(SearchModifier::Text), &["abc"]));
+        let err = backend.validate_query_support(&id_text).unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::Search(SearchError::UnsupportedModifier { ref modifier, .. })
+                if modifier == "text"
+        ));
+
+        let last_updated_not = SearchQuery::new("Patient")
+            .with_parameter(last_updated_param(Some(SearchModifier::Not), "2024"));
+        let err = backend
+            .validate_query_support(&last_updated_not)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::Search(SearchError::UnsupportedModifier { ref modifier, .. })
+                if modifier == "not"
+        ));
+
+        // The three honoured combinations must not be rejected.
+        assert!(
+            backend
+                .validate_query_support(
+                    &SearchQuery::new("Patient")
+                        .with_parameter(id_param(Some(SearchModifier::Not), &["pat-a"]))
+                )
+                .is_ok()
+        );
+        assert!(
+            backend
+                .validate_query_support(
+                    &SearchQuery::new("Patient")
+                        .with_parameter(id_param(Some(SearchModifier::Missing), &["true"]))
+                )
+                .is_ok()
+        );
+        assert!(
+            backend
+                .validate_query_support(
+                    &SearchQuery::new("Patient")
+                        .with_parameter(last_updated_param(Some(SearchModifier::Missing), "true"))
+                )
+                .is_ok()
+        );
     }
 }

--- a/crates/persistence/tests/mongodb_tests.rs
+++ b/crates/persistence/tests/mongodb_tests.rs
@@ -3664,6 +3664,151 @@ async fn mongodb_integration_search_missing_not_and_param_sort() {
     assert!(page2.resources.page_info.has_previous);
 }
 
+/// #1055: `_id`/`_lastUpdated` used to bypass the generic modifier dispatch
+/// entirely, so `:not` returned the exact inverse of the request and
+/// `:missing` compared the boolean literal against the id/date fields
+/// (`_lastUpdated:missing` even 400'd, since "true"/"false" is not a date).
+#[tokio::test]
+async fn mongodb_integration_search_id_and_last_updated_modifiers() {
+    let Some(backend) = create_backend_with_full_registry("id_last_updated_modifiers").await else {
+        eprintln!(
+            "Skipping mongodb_integration_search_id_and_last_updated_modifiers (requires Docker or HFS_TEST_MONGODB_URL)"
+        );
+        return;
+    };
+
+    let tenant = create_tenant("tenant-id-modifiers");
+
+    for id in ["patient-idm-1", "patient-idm-2", "patient-idm-3"] {
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": id,
+                    "name": [{"family": format!("Idm-{}", id)}],
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+    }
+
+    let ids = |result: &helios_persistence::core::SearchResult| {
+        let mut got = result
+            .resources
+            .items
+            .iter()
+            .map(|r| r.id().to_string())
+            .collect::<Vec<_>>();
+        got.sort();
+        got
+    };
+
+    // Control: plain `_id=patient-idm-1` is unaffected by this change.
+    let plain = SearchQuery::new("Patient").with_parameter(SearchParameter {
+        name: "_id".to_string(),
+        param_type: SearchParamType::Token,
+        modifier: None,
+        values: vec![SearchValue::eq("patient-idm-1")],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = backend.search(&tenant, &plain).await.unwrap();
+    assert_eq!(ids(&result), vec!["patient-idm-1"]);
+    assert_eq!(backend.search_count(&tenant, &plain).await.unwrap(), 1);
+
+    // `_id:not=patient-idm-1` -> everyone EXCEPT patient-idm-1. Before the
+    // fix this returned ONLY patient-idm-1 (the exact inverse) with count 1.
+    let not_one = SearchQuery::new("Patient").with_parameter(SearchParameter {
+        name: "_id".to_string(),
+        param_type: SearchParamType::Token,
+        modifier: Some(SearchModifier::Not),
+        values: vec![SearchValue::eq("patient-idm-1")],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = backend.search(&tenant, &not_one).await.unwrap();
+    assert_eq!(ids(&result), vec!["patient-idm-2", "patient-idm-3"]);
+    assert_eq!(backend.search_count(&tenant, &not_one).await.unwrap(), 2);
+
+    // `_id:not=patient-idm-1,patient-idm-2` -> only patient-idm-3.
+    let not_two = SearchQuery::new("Patient").with_parameter(SearchParameter {
+        name: "_id".to_string(),
+        param_type: SearchParamType::Token,
+        modifier: Some(SearchModifier::Not),
+        values: vec![
+            SearchValue::eq("patient-idm-1"),
+            SearchValue::eq("patient-idm-2"),
+        ],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = backend.search(&tenant, &not_two).await.unwrap();
+    assert_eq!(ids(&result), vec!["patient-idm-3"]);
+
+    // `_id:missing=false` -> every live resource of the type. Before the fix
+    // this returned nothing (the filter compared ids against the string
+    // "false").
+    let id_missing_false = SearchQuery::new("Patient").with_parameter(SearchParameter {
+        name: "_id".to_string(),
+        param_type: SearchParamType::Token,
+        modifier: Some(SearchModifier::Missing),
+        values: vec![SearchValue::eq("false")],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = backend.search(&tenant, &id_missing_false).await.unwrap();
+    assert_eq!(
+        ids(&result),
+        vec!["patient-idm-1", "patient-idm-2", "patient-idm-3"]
+    );
+
+    // `_id:missing=true` -> empty. NOT a discriminator on its own: `{id:
+    // "true"}` matched nothing before the fix too, so this passes either way
+    // — the filter-shape unit tests above are what actually pin this case.
+    let id_missing_true = SearchQuery::new("Patient").with_parameter(SearchParameter {
+        name: "_id".to_string(),
+        param_type: SearchParamType::Token,
+        modifier: Some(SearchModifier::Missing),
+        values: vec![SearchValue::eq("true")],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = backend.search(&tenant, &id_missing_true).await.unwrap();
+    assert!(ids(&result).is_empty());
+
+    // `_lastUpdated:missing=false` -> every live resource. Before the fix
+    // this was a hard 400 (`Invalid date value 'false'`).
+    let lu_missing_false = SearchQuery::new("Patient").with_parameter(SearchParameter {
+        name: "_lastUpdated".to_string(),
+        param_type: SearchParamType::Date,
+        modifier: Some(SearchModifier::Missing),
+        values: vec![SearchValue::eq("false")],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = backend.search(&tenant, &lu_missing_false).await.unwrap();
+    assert_eq!(
+        ids(&result),
+        vec!["patient-idm-1", "patient-idm-2", "patient-idm-3"]
+    );
+
+    // `_lastUpdated:missing=true` -> empty. Before the fix this was a hard
+    // 400 (`Invalid date value 'true'`), not an empty bundle.
+    let lu_missing_true = SearchQuery::new("Patient").with_parameter(SearchParameter {
+        name: "_lastUpdated".to_string(),
+        param_type: SearchParamType::Date,
+        modifier: Some(SearchModifier::Missing),
+        values: vec![SearchValue::eq("true")],
+        chain: vec![],
+        components: vec![],
+    });
+    let result = backend.search(&tenant, &lu_missing_true).await.unwrap();
+    assert!(ids(&result).is_empty());
+}
+
 /// The in-DB runner compiles no compartment predicate, so a run carrying
 /// `patient`/`group` filters is handed to the in-process engine over a scan
 /// of the same collection instead of failing as uncompilable — and answers


### PR DESCRIPTION
Fixes #1055.

## What was wrong

`matching_resource_ids` skips `_id` and `_lastUpdated` by name **before** the modifier dispatch (`search_impl.rs:947`):

```rust
for param in &query.parameters {
    if matches!(param.name.as_str(), "_id" | "_lastUpdated") {
        continue;                       // <-- before any modifier handling
    }
```

They are lowered instead by `build_resource_id_condition` and `build_resource_last_updated_conditions`, neither of which ever read `param.modifier`. So the modifier was silently dropped and the value consumed as a plain match:

| query | filter produced | result |
|---|---|---|
| `_id:not=abc` | `{id: "abc"}` | returns **only** `abc` — the exact inverse of the request |
| `_id:not=a,b` | `{id: {$in: ["a","b"]}}` | returns exactly `a` and `b` |
| `_id:missing=false` | `{id: "false"}` | matches nothing; should match everything |
| `_lastUpdated:missing=true` | — | 400 `Invalid date value 'true'` |

The REST layer does not stop these: `_id` resolves to `SearchParamType::Token`, and both `Not` and `Missing` are valid for Token, so the generic `is_valid_for` gate passes.

## What changed

**Honour the modifiers that have a defensible lowering; reject the rest explicitly.**

- `_id:not=abc` → `{id: {$ne: "abc"}}`; `_id:not=a,b` → `{id: {$nin: […]}}`
- `_id:missing=true` → `{id: null}` (matches nothing, since every live resource has an id); `:missing=false` → `{id: {$ne: null}}`
- `_lastUpdated:missing` → the same presence test on `last_updated`, so the boolean literal never reaches `build_date_filter`
- Every other modifier on those two names → 400 `UnsupportedModifier`

The rejection is applied in **two** places: `validate_query_support`, and defensively in each builder. The second is not redundant — the `ifNoneExist` path (`storage.rs:3465`) reaches the builders without going through `validate_query_support`, so a conditional create carrying a bad modifier would otherwise still degrade silently.

Every condition stays AND-ed under the existing `tenant_id` / `resource_type` / `is_deleted` seed arm; tenant scoping is untouched.

## Behaviour changes

- `_id:not=abc` now returns every live resource of the type **except** `abc`, where it previously returned exactly `abc`. Any client built against the old output was reading the precise inverse of what it asked for. `_total` / `search_count` move in lockstep, since both share `build_resource_filter`.
- `_id:missing=false` now returns everything instead of an empty Bundle.
- `_lastUpdated:missing=true|false` now answers instead of returning 400, aligning MongoDB with SQLite (pinned at `tests/search/modifier_tests.rs:288`), Postgres and Elasticsearch.
- `_id:text`, `_id:code-text`, `_id:of-type`, `_id:text-advanced` and `_lastUpdated:<anything but :missing>` now return 400 `unsupported modifier` instead of silently degrading. No in-tree test, fixture or doc uses any of these.
- Unchanged: plain `_id=x`, `_id=a,b`, and all `_lastUpdated` prefix/period behaviour.

## Tests

Six filter-shape unit tests needing no Docker — they assert the exact document `build_resource_filter` produces, including a no-modifier control for each parameter so the refactor cannot silently change the plain path:

`id_not_negates_instead_of_matching`, `id_missing_is_a_presence_test_on_the_id_field`, `last_updated_missing_does_not_parse_the_boolean_as_a_date`, `last_updated_no_modifier_control_still_builds_a_date_range`, `plain_id_match_is_unchanged`, `unhonoured_modifiers_on_metadata_params_are_rejected`

Plus a live-MongoDB integration test asserting both the page and `search_count` for each corrected case.

```
cargo fmt --all -- --check                                        PASS
cargo clippy -p helios-persistence -p helios-rest \
  --features mongodb --all-targets -- -D warnings <CI allow-list>  PASS
cargo test -p helios-persistence --features mongodb \
  --test mongodb_tests            113 passed; 0 failed; 0 skipped
```

Docker was live, so nothing skipped.

## Rebase note for reviewers

This branch was written before #1088 (comma-OR) merged, and both rewrote `build_resource_last_updated_conditions`. The rebase conflict was resolved by keeping **both**: #1088's `$or` combining lives in the `None` arm, #1055's modifier handling wraps it.

Because that resolution was manual, both test modules were run separately to prove neither behaviour was lost — `comma_separated_last_updated_values_are_ored` (#1062) and `last_updated_missing_does_not_parse_the_boolean_as_a_date` (#1055) both pass. A conflict resolution that dropped the `$or` would still have shown a green suite total.

## Scope — the other three backends have the same bug

**Confirmed and deliberately not fixed here.** `sqlite/search/query_builder.rs:525`, `postgres/search/query_builder.rs:676` and `elasticsearch/search/query_builder.rs:262` all read only `param.values` and never `param.modifier`, so **`_id:not=abc` returns only `abc` on every backend**, not just MongoDB. `:missing` is handled correctly on all three, because it resolves before the special-param dispatch.

Filed separately rather than widened into this PR: a four-backend change is materially slower to review, and each of the other three needs its own testcontainer suite.

## Known residual

`modifiers_for_type` is keyed on parameter *type*, so the Token arm advertises `text`/`code-text` for every token param including `_id` (via its Token fallback) — which `validate_query_support` now rejects with a 400. Advertised-but-rejected is a visible error rather than the previous silent wrong answer, and narrowing it would need a name-aware capability path. Documented in the doc comment rather than fixed.

---

Found while researching #1040 / #999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECbBsNhgXwBo4dQtFyVBXv
