### PR TITLE
perf(persistence): parallelize bulk-ingest extraction, partial-index LIKE predicates

### DIFF
--- a/.claude/skills/bulk-data-submit/SKILL.md
+++ b/.claude/skills/bulk-data-submit/SKILL.md
@@ -67,6 +67,7 @@ status-only kick-off (no `manifestUrl`) they have nothing to attach to and are i
 | `HFS_BULK_SUBMIT_MAX_CONCURRENT_PER_TENANT` | `4` | Per-tenant active submission cap; returns `429` |
 | `HFS_BULK_SUBMIT_BATCH_SIZE` | `1000` | Ingestion batch size |
 | `HFS_BULK_SUBMIT_DEFER_INDEXING` | `true` | Bulk fast-load (#903): ingest without search-index/FTS writes, then rebuild with an automatic per-type reindex when each manifest finishes. Default since #946; honoured on MongoDB only since #1000, where it was silently inert. Read once at startup, not per submission. A restart before that rebuild lands leaves the data stored but unsearchable; set `false` to close that window — see Ingest performance |
+| `HFS_BULK_SUBMIT_BULK_INDEX_REBUILD` | `false` | SQLite: the deferred rebuild drops the `search_index` value indexes for its duration and builds them once, sorted, at the end. 1.3x at 72k resources, 1.6x at 312k, widening with size — but search on that database is unindexed for every tenant while a rebuild runs, and the final build holds the write lock. For the initial load of a large corpus on a server not serving traffic. Self-heals at startup if a process died inside the window |
 | `HFS_BULK_SUBMIT_LEASE_DURATION` | `60` | Manifest lease length in seconds; must exceed heartbeat |
 | `HFS_BULK_SUBMIT_HEARTBEAT_INTERVAL` | `20` | Worker heartbeat cadence in seconds |
 | `HFS_BULK_SUBMIT_CLEANUP_INTERVAL` | `300` | Cleanup scan interval in seconds |
@@ -140,7 +141,18 @@ The backend capability splits into `BulkSubmitIngest` (the synchronous `BulkSubm
   21.5s end to end (1.94x, 3 of 3 rounds), inline ingest 36.4s -> 25.0s
   (1.45x, 3 of 3), database 15% smaller; at 312k resources of the same mix,
   180.7s -> 110.1s (1.64x) — the gain narrows as the b-trees outgrow the page
-  cache, which is the regime the full 19M-resource corpus lives in. `perf_phases`
+  cache, which is the regime the full 19M-resource corpus lives in. Two
+  later additions: composite groups missing a component are no longer
+  written (`drop_incomplete_composites`; they were 46% of composite rows and
+  can never match — PostgreSQL already skipped them), and the opt-in
+  `HFS_BULK_SUBMIT_BULK_INDEX_REBUILD` above, which is the lever for that
+  regime: with it, 72k resources went 21.0s -> 16.3s and 312k went 110.1s ->
+  69.7s end to end (2.6x over the pre-work numbers at both sizes), because
+  `CREATE INDEX` builds each index from one sort instead of one random
+  b-tree insertion per row per index. Priced and rejected on the same
+  harness: narrowing `idx_search_composite`, FTS5 `automerge`/`pgsz`
+  tuning, `wal_autocheckpoint=0`, `synchronous=OFF` (4%), dropping the two
+  display-text indexes (5%, at a search cost). `perf_phases`
   says what is left is SQLite b-tree maintenance of `search_index` and its
   indexes plus the `search_index_fts` triggers (~20% of the rebuild, priced by
   dropping them; kept, since `:text-advanced` needs the FTS index).

--- a/.claude/skills/bulk-data-submit/SKILL.md
+++ b/.claude/skills/bulk-data-submit/SKILL.md
@@ -121,6 +121,29 @@ The backend capability splits into `BulkSubmitIngest` (the synchronous `BulkSubm
 - The sync itself runs *before* the manifest's receipt is written (#1007), as an explicit worker step — not at `finish_manifest`, which no longer syncs by itself, so a manifest that already reached a terminal state is never re-synced by a restart; repair it with `$reindex`. A resource the secondary still rejects after its retries gets an entry result of `processing-error` in the receipt, carrying an OperationOutcome (`incomplete`) that names the `Type/id`, the rejecting backend, and `POST /{type}/$reindex` as the repair; the resource itself stays stored and readable by id, and the status's `failed_entries` counts it.
 - After that copy, for every resource type the manifest ingested, the worker compares the primary's tenant-wide resource count against each secondary's. A mismatch is recorded as a `warning` OperationOutcome (also `incomplete`, naming both counts) in the manifest's `error` artifact and logged on the server. This check only runs when `HFS_COMPOSITE_SYNC_MODE` is `synchronous` or `hybrid`; under the default `asynchronous` mode the secondary's count reflects whatever had already drained from its queue rather than this manifest's own sync, so the check is skipped and the receipt then guarantees only that the resources committed on the primary.
 - Without `HFS_ELASTICSEARCH_WRITE_REFRESH=wait_for`, a small count difference can be a write that has not become visible yet rather than a real gap; reconfirm with `GET /{type}?_summary=count` before treating it as drift. See "Verifying and repairing search drift" below.
+- **Under deferred indexing the rebuild is the import.** On SQLite the fast-load
+  ingest of a 72k-resource Synthea mix takes ~3s and the rebuild that follows
+  took ~42s, so the rebuild is where import time goes, and it is the path the
+  SQLite ingest work targets. What it does now (`storage.rs`,
+  `prepare_index` / `write_prepared_index`): each page's FHIRPath extraction,
+  value normalisation and parameter marshalling run on a thread pool
+  (`HFS_INDEX_THREADS`, default: the machine's parallelism) *before* the
+  page's transaction opens, so the single SQLite writer runs statements only;
+  `search_index` rows go eight per INSERT as on the inline path; the page is
+  1,000 resources (`DEFERRED_REINDEX_BATCH_SIZE`), not `$reindex`'s 100, since
+  each page is one COMMIT; `idx_search_string_folded` is partial (schema v28)
+  so 87% of rows skip a b-tree it never found them by; and `param_url` is no
+  longer written (11% of a bulk-loaded database, read by nothing). The inline
+  path (`HFS_BULK_SUBMIT_DEFER_INDEXING=false`) prepares each batch the same
+  way. Measured with `bulk_submit_bench` on the same 72k mix, three
+  interleaved rounds against `main`, medians: fast-load + rebuild 41.8s ->
+  21.5s end to end (1.94x, 3 of 3 rounds), inline ingest 36.4s -> 25.0s
+  (1.45x, 3 of 3), database 15% smaller; at 312k resources of the same mix,
+  180.7s -> 110.1s (1.64x) — the gain narrows as the b-trees outgrow the page
+  cache, which is the regime the full 19M-resource corpus lives in. `perf_phases`
+  says what is left is SQLite b-tree maintenance of `search_index` and its
+  indexes plus the `search_index_fts` triggers (~20% of the rebuild, priced by
+  dropping them; kept, since `:text-advanced` needs the FTS index).
 - **`HFS_BULK_SUBMIT_DEFER_INDEXING` is read once, at startup, not per submission.** `spawn_submit_workers` hands the configured value to each worker, and the worker applies it to every manifest it ingests from then on; nothing about the flag is persisted on a submission or manifest record. Restarting with a different value changes only manifests ingested *after* the restart.
 - Cleanup periodically removes status artifacts for submissions whose `updated_at` exceeds `HFS_BULK_SUBMIT_OUTPUT_TTL`.
 - Abort (`submissionStatus=stopped`) means **stop soon** — neither "stop this instant" nor "stop after the current file". It marks the submission `aborted`, moves its `pending`/`processing` manifests to `failed`, and bars further claims. A manifest already being ingested is stopped cooperatively: the lease keeper re-reads the submission's status on its flush cadence (a few seconds) and trips a cancel token the streaming engine checks between persisted batches, so the worst case is one keeper tick plus one batch, never mid-transaction (#968).
@@ -181,11 +204,13 @@ reindex and is by far the biggest lever on ingestion alone; the stored resources
 history, receipts and rollback records are identical either way.
 
 Which number you quote depends on where you stop the clock, and the two differ by
-a lot. The `bulk_submit_bench` example runs **no reindex at all**, so its ~6.7x is
-the cost of ingestion with the indexing work removed, not the cost of arriving at
-a searchable database. Measured end to end against a running server — kick-off
-until a search returns the full count — the gain is far smaller, because the
-deferred arm still has to pay for the rebuild:
+a lot. The `bulk_submit_bench` example without `--reindex` runs **no reindex at
+all**, so its ~6.7x is the cost of ingestion with the indexing work removed, not
+the cost of arriving at a searchable database (`--batch 1000 --defer-index
+--reindex` is the server's default path end to end, and it reports the two stages
+separately). Measured end to end against a running server — kick-off until a
+search returns the full count — the gain is far smaller, because the deferred arm
+still has to pay for the rebuild:
 
 | stop the clock at | `false` | `true` | ratio | rounds won by `true` |
 |---|---|---|---|---|

--- a/.claude/skills/test-hfs/SKILL.md
+++ b/.claude/skills/test-hfs/SKILL.md
@@ -91,8 +91,19 @@ build, collection is still off until `HFS_PERF_PHASES=1` or
 `bulk_submit_bench` drives the real `process_ndjson_stream`, the same call the
 bulk-submit worker makes per manifest file, against local NDJSON on a fresh
 database. Useful flags: `--limit` (resources per file), `--batch`, `--defer-index`
-(the `HFS_BULK_SUBMIT_DEFER_INDEXING` path), `--no-phases`, `--keep` (leave the
-database for `dbstat`), `--data-dir`.
+(the `HFS_BULK_SUBMIT_DEFER_INDEXING` path), `--reindex` (then run the
+post-manifest rebuild the worker's hook fires, timed and phased on its own —
+`reindex_fetch_page` / `reindex_write_page` plus the shared `extract`,
+`search_index_insert`, `fts`, `commit`), `--reindex-batch`, `--no-phases`,
+`--keep` (leave the database for `dbstat`), `--data-dir`.
+
+The server's default path is `--batch 1000 --defer-index --reindex`, and on it
+the rebuild is ~90% of the wall clock — profile that stage, not the ingest, when
+the question is "why is import slow". `extract` there sums CPU across the
+extraction pool's threads and can exceed the wall clock; `prepare_batch (wall)`
+is what the writer actually waited for. The mix that fits a coffee break is
+`--limit 20000` over `Observation`, `Condition`, `Patient`, `Encounter` from the
+corpus in `MANUAL_TESTING_MATRIX.md` (72k resources, ~20s per arm).
 
 `bulk_submit_mongo_bench` is its MongoDB twin (#1000), and needs a live server —
 that ingest path is round-trip-bound, which no in-process fake reproduces. Same

--- a/.claude/skills/test-hfs/SKILL.md
+++ b/.claude/skills/test-hfs/SKILL.md
@@ -94,8 +94,12 @@ database. Useful flags: `--limit` (resources per file), `--batch`, `--defer-inde
 (the `HFS_BULK_SUBMIT_DEFER_INDEXING` path), `--reindex` (then run the
 post-manifest rebuild the worker's hook fires, timed and phased on its own —
 `reindex_fetch_page` / `reindex_write_page` plus the shared `extract`,
-`search_index_insert`, `fts`, `commit`), `--reindex-batch`, `--no-phases`,
-`--keep` (leave the database for `dbstat`), `--data-dir`.
+`search_index_insert`, `fts`, `commit`), `--reindex-batch`,
+`--bulk-index-rebuild` (the `HFS_BULK_SUBMIT_BULK_INDEX_REBUILD` mode),
+`--no-phases`, `--keep` (leave the database for `dbstat`), `--data-dir`.
+`HFS_EXPERIMENT_SQL="<statements>"` runs arbitrary SQL against the fresh
+schema before the ingest — drop an index, recreate a trigger, tune FTS5 — so a
+schema idea can be priced without a build.
 
 The server's default path is `--batch 1000 --defer-index --reindex`, and on it
 the rebuild is ~90% of the wall clock — profile that stage, not the ingest, when

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,6 +3616,7 @@ dependencies = [
  "postgres-types",
  "r2d2",
  "r2d2_sqlite",
+ "rayon",
  "regex",
  "rusqlite",
  "rust_decimal",

--- a/crates/hfs/src/main.rs
+++ b/crates/hfs/src/main.rs
@@ -631,8 +631,10 @@ async fn start_mongodb(
     // lease, and artifact state itself, in the same store the ingestion engine
     // writes resources to.
     let reindex_hook = ops.reindex.clone().map(|op| {
-        Arc::new(helios_persistence::search::ReindexOnFinish::new(op))
-            as Arc<dyn helios_persistence::core::DeferredReindexHook>
+        Arc::new(
+            helios_persistence::search::ReindexOnFinish::new(op)
+                .with_bulk_index_rebuild(config.bulk_submit.bulk_index_rebuild),
+        ) as Arc<dyn helios_persistence::core::DeferredReindexHook>
     });
     let submit_bundle = build_bulk_submit(&config, backend.clone(), reindex_hook).await?;
     let app = create_app_with_auth_bulk_settings_and_ops(
@@ -1425,8 +1427,10 @@ async fn start_sqlite(
         audit_state.as_ref(),
     );
     let reindex_hook = ops.reindex.clone().map(|op| {
-        Arc::new(helios_persistence::search::ReindexOnFinish::new(op))
-            as Arc<dyn helios_persistence::core::DeferredReindexHook>
+        Arc::new(
+            helios_persistence::search::ReindexOnFinish::new(op)
+                .with_bulk_index_rebuild(config.bulk_submit.bulk_index_rebuild),
+        ) as Arc<dyn helios_persistence::core::DeferredReindexHook>
     });
     let submit_bundle = build_bulk_submit(&config, backend.clone(), reindex_hook).await?;
     let app = create_app_with_auth_bulk_settings_and_ops(
@@ -2192,8 +2196,10 @@ async fn start_sqlite_elasticsearch(
         audit_state.as_ref(),
     );
     let reindex_hook = ops.reindex.clone().map(|op| {
-        Arc::new(helios_persistence::search::ReindexOnFinish::new(op))
-            as Arc<dyn helios_persistence::core::DeferredReindexHook>
+        Arc::new(
+            helios_persistence::search::ReindexOnFinish::new(op)
+                .with_bulk_index_rebuild(config.bulk_submit.bulk_index_rebuild),
+        ) as Arc<dyn helios_persistence::core::DeferredReindexHook>
     });
     // Bulk ingestion runs on the SQLite primary's engine, but wrapped so that
     // finished manifests sync their resources into Elasticsearch — the raw
@@ -2274,8 +2280,10 @@ async fn start_postgres(
         audit_state.as_ref(),
     );
     let reindex_hook = ops.reindex.clone().map(|op| {
-        Arc::new(helios_persistence::search::ReindexOnFinish::new(op))
-            as Arc<dyn helios_persistence::core::DeferredReindexHook>
+        Arc::new(
+            helios_persistence::search::ReindexOnFinish::new(op)
+                .with_bulk_index_rebuild(config.bulk_submit.bulk_index_rebuild),
+        ) as Arc<dyn helios_persistence::core::DeferredReindexHook>
     });
     let submit_bundle = build_bulk_submit(&config, backend.clone(), reindex_hook).await?;
     let app = create_app_with_auth_bulk_settings_and_ops(
@@ -2463,8 +2471,10 @@ async fn start_postgres_elasticsearch(
         audit_state.as_ref(),
     );
     let reindex_hook = ops.reindex.clone().map(|op| {
-        Arc::new(helios_persistence::search::ReindexOnFinish::new(op))
-            as Arc<dyn helios_persistence::core::DeferredReindexHook>
+        Arc::new(
+            helios_persistence::search::ReindexOnFinish::new(op)
+                .with_bulk_index_rebuild(config.bulk_submit.bulk_index_rebuild),
+        ) as Arc<dyn helios_persistence::core::DeferredReindexHook>
     });
     // Wrapped like sqlite-es: finished manifests sync their ingested
     // resources into Elasticsearch, which the raw primary never does (#882),
@@ -2676,8 +2686,10 @@ async fn start_mongodb_elasticsearch(
         audit_state.as_ref(),
     );
     let reindex_hook = ops.reindex.clone().map(|op| {
-        Arc::new(helios_persistence::search::ReindexOnFinish::new(op))
-            as Arc<dyn helios_persistence::core::DeferredReindexHook>
+        Arc::new(
+            helios_persistence::search::ReindexOnFinish::new(op)
+                .with_bulk_index_rebuild(config.bulk_submit.bulk_index_rebuild),
+        ) as Arc<dyn helios_persistence::core::DeferredReindexHook>
     });
     // Bulk submit runs against the MongoDB primary, which hosts its own job
     // state, but wrapped like sqlite-es and pg-es so finished manifests sync
@@ -2835,8 +2847,10 @@ async fn start_s3(
             &config,
             backend.clone(),
             ops.reindex.clone().map(|op| {
-                Arc::new(helios_persistence::search::ReindexOnFinish::new(op))
-                    as Arc<dyn helios_persistence::core::DeferredReindexHook>
+                Arc::new(
+                    helios_persistence::search::ReindexOnFinish::new(op)
+                        .with_bulk_index_rebuild(config.bulk_submit.bulk_index_rebuild),
+                ) as Arc<dyn helios_persistence::core::DeferredReindexHook>
             }),
         )
         .await?
@@ -3111,8 +3125,10 @@ async fn start_s3_elasticsearch(
     // what the comment this replaces claimed. Without the wrapper a completed
     // `$bulk-submit` here leaves its resources searchable nowhere (#1021).
     let reindex_hook = ops.reindex.clone().map(|op| {
-        Arc::new(helios_persistence::search::ReindexOnFinish::new(op))
-            as Arc<dyn helios_persistence::core::DeferredReindexHook>
+        Arc::new(
+            helios_persistence::search::ReindexOnFinish::new(op)
+                .with_bulk_index_rebuild(config.bulk_submit.bulk_index_rebuild),
+        ) as Arc<dyn helios_persistence::core::DeferredReindexHook>
     });
     let bulk_submit = if s3.supports_bulk_submit_worker() {
         let submit_jobs = composite_submit_jobs(

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -65,6 +65,8 @@ json-patch = "3"
 humantime = "2"
 futures = "0.3"
 unicode-normalization = "0.1"
+# Parallel search-value extraction for bulk ingest and reindex pages.
+rayon = "1.8"
 # Bulk-submit result receipts spool to a per-run temp directory (#982) instead
 # of accumulating in memory. Uses the platform temp dir, so `TMPDIR` isolates it.
 tempfile = "3"

--- a/crates/persistence/examples/bulk_submit_bench.rs
+++ b/crates/persistence/examples/bulk_submit_bench.rs
@@ -185,6 +185,14 @@ async fn main() {
     let backend = SqliteBackend::with_config(&args.db, config).expect("open backend");
     backend.init_schema().expect("init schema");
     let backend = std::sync::Arc::new(backend);
+    // Experiment hook: arbitrary SQL against the fresh schema before the
+    // ingest (drop an index, recreate a trigger, tune FTS5), so a schema
+    // idea can be priced without a build.
+    if let Ok(sql) = std::env::var("HFS_EXPERIMENT_SQL") {
+        let conn = rusqlite::Connection::open(&args.db).expect("open db");
+        conn.execute_batch(&sql).expect("HFS_EXPERIMENT_SQL");
+        println!("(experiment SQL applied: {})", sql.replace('\n', " "));
+    }
 
     let tenant = TenantContext::new(TenantId::new("bench"), TenantPermissions::full_access());
     let submission = SubmissionId::generate("bench-system");

--- a/crates/persistence/examples/bulk_submit_bench.rs
+++ b/crates/persistence/examples/bulk_submit_bench.rs
@@ -31,6 +31,8 @@
 //!                      its own; `--batch 1000 --defer-index --reindex` is the
 //!                      server's default path end to end
 //! * `--reindex-batch N` resources per rebuild transaction (default: the hook's)
+//! * `--bulk-index-rebuild` drop the value indexes for the rebuild and build them
+//!                      sorted at the end (`HFS_BULK_SUBMIT_BULK_INDEX_REBUILD`)
 //! * `--data-dir DIR`   directory holding `search-parameters-r4.json` (default: `./data`)
 //! * `--keep`           leave the database behind for inspection
 //! * `--no-fk`          `PRAGMA foreign_keys = OFF`, to price the index rows' parent check
@@ -67,6 +69,8 @@ struct Args {
     reindex: bool,
     /// Page size for `--reindex` (default: the hook's, `DEFERRED_REINDEX_BATCH_SIZE`).
     reindex_batch: Option<u32>,
+    /// `--reindex` in bulk index rebuild mode (`HFS_BULK_SUBMIT_BULK_INDEX_REBUILD`).
+    bulk_index_rebuild: bool,
 }
 
 fn parse_args() -> Args {
@@ -82,6 +86,7 @@ fn parse_args() -> Args {
         no_phases: false,
         reindex: false,
         reindex_batch: None,
+        bulk_index_rebuild: false,
     };
     let mut it = std::env::args().skip(1);
     while let Some(arg) = it.next() {
@@ -107,6 +112,7 @@ fn parse_args() -> Args {
             "--no-fk" => args.no_fk = true,
             "--no-phases" => args.no_phases = true,
             "--reindex" => args.reindex = true,
+            "--bulk-index-rebuild" => args.bulk_index_rebuild = true,
             "--reindex-batch" => {
                 args.reindex_batch = Some(
                     it.next()
@@ -298,10 +304,12 @@ async fn main() {
         let op = ReindexOperation::new(backend.clone(), backend.tenant_registries().clone());
         // The same page the submit worker's hook (`ReindexOnFinish`) uses,
         // so this stage measures what the server does after a manifest.
-        let request = ReindexRequest::for_types(types).with_batch_size(
-            args.reindex_batch
-                .unwrap_or(helios_persistence::search::DEFERRED_REINDEX_BATCH_SIZE),
-        );
+        let request = ReindexRequest::for_types(types)
+            .with_batch_size(
+                args.reindex_batch
+                    .unwrap_or(helios_persistence::search::DEFERRED_REINDEX_BATCH_SIZE),
+            )
+            .with_bulk_index_rebuild(args.bulk_index_rebuild);
         let page = request.batch_size;
         perf::reset();
         let started = Instant::now();
@@ -328,11 +336,16 @@ async fn main() {
         let reindex_wall = started.elapsed();
         println!();
         println!(
-            "reindexed {} resources in {:.2}s = {:.0} resources/s (page {})",
+            "reindexed {} resources in {:.2}s = {:.0} resources/s (page {}{})",
             total_lines,
             reindex_wall.as_secs_f64(),
             total_lines as f64 / reindex_wall.as_secs_f64(),
-            page
+            page,
+            if args.bulk_index_rebuild {
+                ", bulk index rebuild"
+            } else {
+                ""
+            }
         );
         let total = wall + reindex_wall;
         println!(

--- a/crates/persistence/examples/bulk_submit_bench.rs
+++ b/crates/persistence/examples/bulk_submit_bench.rs
@@ -22,12 +22,19 @@
 //!
 //! Options:
 //!
-//! * `--db PATH`      database file to create (deleted first; default: a temp file)
-//! * `--limit N`      resources to ingest per input file (default: all)
-//! * `--batch N`      entries per transaction (default: the server default, 100)
-//! * `--defer-index`  set `defer_indexing`, the `HFS_BULK_SUBMIT_DEFER_INDEXING` path
-//! * `--data-dir DIR` directory holding `search-parameters-r4.json` (default: `./data`)
-//! * `--keep`         leave the database behind for inspection
+//! * `--db PATH`        database file to create (deleted first; default: a temp file)
+//! * `--limit N`        resources to ingest per input file (default: all)
+//! * `--batch N`        entries per transaction (default: 100; the server's is 1000)
+//! * `--defer-index`    set `defer_indexing`, the `HFS_BULK_SUBMIT_DEFER_INDEXING` path
+//! * `--reindex`        after the ingest, run the post-manifest rebuild the submit
+//!                      worker fires under deferred indexing, timed and phased on
+//!                      its own; `--batch 1000 --defer-index --reindex` is the
+//!                      server's default path end to end
+//! * `--reindex-batch N` resources per rebuild transaction (default: the hook's)
+//! * `--data-dir DIR`   directory holding `search-parameters-r4.json` (default: `./data`)
+//! * `--keep`           leave the database behind for inspection
+//! * `--no-fk`          `PRAGMA foreign_keys = OFF`, to price the index rows' parent check
+//! * `--no-phases`      collection off, to price the instrumentation itself
 
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -53,6 +60,13 @@ struct Args {
     /// Run with phase collection off — the rate an uninstrumented build
     /// achieves, and the way to price the instrumentation itself.
     no_phases: bool,
+    /// After the ingest, run the post-manifest reindex the submit worker
+    /// fires under `HFS_BULK_SUBMIT_DEFER_INDEXING`, timed and phased
+    /// separately. With `--defer-index` this is the server's default path
+    /// end to end.
+    reindex: bool,
+    /// Page size for `--reindex` (default: the hook's, `DEFERRED_REINDEX_BATCH_SIZE`).
+    reindex_batch: Option<u32>,
 }
 
 fn parse_args() -> Args {
@@ -66,6 +80,8 @@ fn parse_args() -> Args {
         keep: false,
         no_fk: false,
         no_phases: false,
+        reindex: false,
+        reindex_batch: None,
     };
     let mut it = std::env::args().skip(1);
     while let Some(arg) = it.next() {
@@ -90,6 +106,15 @@ fn parse_args() -> Args {
             "--defer-index" => args.defer_index = true,
             "--no-fk" => args.no_fk = true,
             "--no-phases" => args.no_phases = true,
+            "--reindex" => args.reindex = true,
+            "--reindex-batch" => {
+                args.reindex_batch = Some(
+                    it.next()
+                        .expect("--reindex-batch needs a count")
+                        .parse()
+                        .expect("--reindex-batch must be a number"),
+                )
+            }
             "--keep" => args.keep = true,
             "--data-dir" => {
                 args.data_dir = PathBuf::from(it.next().expect("--data-dir needs a path"))
@@ -159,6 +184,7 @@ async fn main() {
     };
     let backend = SqliteBackend::with_config(&args.db, config).expect("open backend");
     backend.init_schema().expect("init schema");
+    let backend = std::sync::Arc::new(backend);
 
     let tenant = TenantContext::new(TenantId::new("bench"), TenantPermissions::full_access());
     let submission = SubmissionId::generate("bench-system");
@@ -254,6 +280,62 @@ async fn main() {
         );
     } else {
         print!("{}", perf::report(total_lines as u64, wall));
+    }
+
+    if args.reindex {
+        use helios_persistence::search::{ReindexOperation, ReindexRequest};
+        let mut types: Vec<String> = inputs.iter().map(|(t, _, _)| t.clone()).collect();
+        types.sort();
+        types.dedup();
+        let op = ReindexOperation::new(backend.clone(), backend.tenant_registries().clone());
+        // The same page the submit worker's hook (`ReindexOnFinish`) uses,
+        // so this stage measures what the server does after a manifest.
+        let request = ReindexRequest::for_types(types).with_batch_size(
+            args.reindex_batch
+                .unwrap_or(helios_persistence::search::DEFERRED_REINDEX_BATCH_SIZE),
+        );
+        let page = request.batch_size;
+        perf::reset();
+        let started = Instant::now();
+        let job_id = op
+            .start(tenant.clone(), request, None)
+            .await
+            .expect("start reindex");
+        loop {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let progress = op
+                .get_progress(&job_id)
+                .await
+                .expect("reindex job vanished");
+            if progress.status.is_finished() {
+                assert!(
+                    progress.errors.is_empty(),
+                    "reindex reported {} errors, first: {:?}",
+                    progress.errors.len(),
+                    progress.errors.first()
+                );
+                break;
+            }
+        }
+        let reindex_wall = started.elapsed();
+        println!();
+        println!(
+            "reindexed {} resources in {:.2}s = {:.0} resources/s (page {})",
+            total_lines,
+            reindex_wall.as_secs_f64(),
+            total_lines as f64 / reindex_wall.as_secs_f64(),
+            page
+        );
+        let total = wall + reindex_wall;
+        println!(
+            "ingest + reindex: {:.2}s = {:.0} resources/s end to end",
+            total.as_secs_f64(),
+            total_lines as f64 / total.as_secs_f64()
+        );
+        println!();
+        if !args.no_phases && perf::enabled() {
+            print!("{}", perf::report(total_lines as u64, reindex_wall));
+        }
     }
 
     // Row counts, so the write volume the phases describe is visible.

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -359,6 +359,9 @@ impl SqliteBackend {
             // took 417/s -> 501/s on the multi-row branch (commit -> 0.55 ms).
             // Cost: the -wal file grows to ~200 MiB under sustained writes.
             conn.execute_batch("PRAGMA wal_autocheckpoint = 50000;")?;
+            if let Ok(sql) = std::env::var("HFS_EXPERIMENT_CONN_SQL") {
+                conn.execute_batch(&sql)?;
+            }
             crate::sof::sqlite_udfs::register(conn).map_err(|e| {
                 rusqlite::Error::SqliteFailure(
                     rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),

--- a/crates/persistence/src/backends/sqlite/backend.rs
+++ b/crates/persistence/src/backends/sqlite/backend.rs
@@ -359,9 +359,6 @@ impl SqliteBackend {
             // took 417/s -> 501/s on the multi-row branch (commit -> 0.55 ms).
             // Cost: the -wal file grows to ~200 MiB under sustained writes.
             conn.execute_batch("PRAGMA wal_autocheckpoint = 50000;")?;
-            if let Ok(sql) = std::env::var("HFS_EXPERIMENT_CONN_SQL") {
-                conn.execute_batch(&sql)?;
-            }
             crate::sof::sqlite_udfs::register(conn).map_err(|e| {
                 rusqlite::Error::SqliteFailure(
                     rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),

--- a/crates/persistence/src/backends/sqlite/bulk_submit.rs
+++ b/crates/persistence/src/backends/sqlite/bulk_submit.rs
@@ -34,6 +34,7 @@ use crate::error::{
 use crate::tenant::{TenantContext, TenantId, TenantPermissions};
 
 use super::SqliteBackend;
+use super::storage::PreparedIndex;
 
 /// Process-local lock serializing manifest claims for the single-instance SQLite
 /// job store (SQLite has no `SELECT … FOR UPDATE SKIP LOCKED`).
@@ -780,7 +781,51 @@ impl BulkSubmitProvider for SqliteBackend {
         })?;
         drop(batch_prologue);
 
+        // Search-value extraction for the whole batch, in parallel, before
+        // the entry loop: it is the largest CPU cost of an indexed ingest and
+        // needs no connection. Ids are fixed first so the extraction sees the
+        // resource exactly as `create` will store it; an entry that turns
+        // out to be an update re-extracts inline from the merged content.
+        let mut entries = entries;
+        let mut prepared: Vec<Option<PreparedIndex>> = Vec::new();
+        if !options.defer_indexing && !self.is_search_offloaded() {
+            for entry in &mut entries {
+                if let Some(obj) = entry.resource.as_object_mut() {
+                    let id = match entry.resource_id.clone() {
+                        Some(id) => id,
+                        None => {
+                            let id = crate::types::new_resource_id();
+                            entry.resource_id = Some(id.clone());
+                            id
+                        }
+                    };
+                    obj.insert("id".to_string(), serde_json::Value::String(id));
+                    obj.insert(
+                        "resourceType".to_string(),
+                        serde_json::Value::String(entry.resource_type.clone()),
+                    );
+                }
+            }
+            let items: Vec<(&str, &str, &serde_json::Value)> = entries
+                .iter()
+                .map(|e| {
+                    (
+                        e.resource_type.as_str(),
+                        e.resource_id.as_deref().unwrap_or(""),
+                        &e.resource,
+                    )
+                })
+                .collect();
+            prepared = self
+                .prepare_index_batch(tenant_id, &items)
+                .into_iter()
+                .map(Some)
+                .collect();
+        }
+        let mut prepared = prepared.into_iter();
+
         for entry in entries {
+            let prepared = prepared.next().flatten();
             // Check if we've hit max errors
             if options.max_errors > 0 && error_count >= options.max_errors {
                 if !options.continue_on_error {
@@ -807,7 +852,7 @@ impl BulkSubmitProvider for SqliteBackend {
 
             let _entry_span = crate::perf::span(crate::perf::Phase::Entry);
             let result = self
-                .ingest_entry_in_txn(&mut txn, manifest_id, &entry, options)
+                .ingest_entry_in_txn(&mut txn, manifest_id, &entry, prepared, options)
                 .await;
 
             let (entry_result, change) = match result {
@@ -1208,6 +1253,7 @@ impl SqliteBackend {
         txn: &mut super::transaction::SqliteTransaction,
         manifest_id: &str,
         entry: &NdjsonEntry,
+        prepared: Option<PreparedIndex>,
         options: &BulkProcessingOptions,
     ) -> StorageResult<(BulkEntryResult, Option<SubmissionChange>)> {
         use crate::core::Transaction;
@@ -1258,7 +1304,7 @@ impl SqliteBackend {
                 // create produced, recorded as this entry's error.
                 None => {
                     let created = txn
-                        .create(&entry.resource_type, entry.resource.clone())
+                        .create_prepared(&entry.resource_type, entry.resource.clone(), prepared)
                         .await?;
                     let change = SubmissionChange::create(
                         manifest_id,
@@ -1280,7 +1326,7 @@ impl SqliteBackend {
             }
         } else {
             let created = txn
-                .create(&entry.resource_type, entry.resource.clone())
+                .create_prepared(&entry.resource_type, entry.resource.clone(), prepared)
                 .await?;
             let change = SubmissionChange::create(
                 manifest_id,

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -10,7 +10,7 @@ use crate::core::bulk_submit_legacy::{
 use crate::error::StorageResult;
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 27;
+pub const SCHEMA_VERSION: i32 = 28;
 
 /// Initialize the database schema.
 pub fn initialize_schema(conn: &Connection) -> StorageResult<()> {
@@ -328,6 +328,7 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> StorageResult<()> {
             24 => migrate_v24_to_v25(conn)?,
             25 => migrate_v25_to_v26(conn)?,
             26 => migrate_v26_to_v27(conn)?,
+            27 => migrate_v27_to_v28(conn)?,
             _ => {
                 return Err(crate::error::StorageError::Backend(
                     crate::error::BackendError::Internal {
@@ -1225,6 +1226,40 @@ fn migrate_v9_to_v10(conn: &Connection) -> StorageResult<()> {
     Ok(())
 }
 
+/// Migrate from schema version 27 to version 28.
+///
+/// Makes `idx_search_string_folded` partial (`WHERE value_string_folded IS NOT
+/// NULL`), the last full index over a value column. Only string rows carry a
+/// folded value — 13% of the rows of a Synthea load — so every other row paid
+/// a b-tree insertion into an index it could never be found by. Measured on
+/// the deferred-index rebuild of a 72k-resource mixed load: 21.1s -> 18.9s
+/// (-10%), database 3% smaller.
+///
+/// v22 kept this index full on purpose: it was the only index leading with
+/// `(tenant_id, resource_type, param_name)` that covered every row, and the
+/// planner fell back to it for `LIKE`-shaped searches (`:contains`, `:text`,
+/// `:code-text`, `:below`, `:above`, a bare reference id) whose predicate
+/// SQLite cannot prove implies `IS NOT NULL`. Those predicates now say so
+/// themselves — every `LIKE` fragment leads with `<column> IS NOT NULL` —
+/// which qualifies the family's own partial index (`idx_search_string`,
+/// `idx_search_token_display`, `idx_search_reference`, …) and narrows the
+/// scan to the parameter's rows. That is a better plan than the old one,
+/// which for the reference, token-display and uri shapes was already a
+/// type-wide walk of `idx_search_composite`, folded index or not.
+fn migrate_v27_to_v28(conn: &Connection) -> StorageResult<()> {
+    let statements = [
+        "DROP INDEX IF EXISTS idx_search_string_folded",
+        "CREATE INDEX idx_search_string_folded
+         ON search_index(tenant_id, resource_type, param_name, value_string_folded)
+         WHERE value_string_folded IS NOT NULL",
+    ];
+    for sql in &statements {
+        conn.execute(sql, [])
+            .map_err(|e| migration_err(format!("v28 partial folded index: {e}")))?;
+    }
+    Ok(())
+}
+
 /// Migrate from schema version 10 to version 11.
 ///
 /// Adds columns supporting `_contained` search: index rows extracted from a
@@ -1553,16 +1588,18 @@ fn migrate_v20_to_v21(conn: &Connection) -> StorageResult<()> {
 /// ```
 ///
 /// Every row therefore paid three b-tree insertions it could never be found
-/// by. `idx_search_string_folded` is deliberately **not** in this list: it is
-/// also the only index leading with `(tenant_id, resource_type, param_name)`
-/// that covers every row, and the query planner falls back to it for the
-/// `LIKE`-shaped modifier searches (`:text`, `:contains`) whose predicate
-/// SQLite cannot prove implies `IS NOT NULL`. Making it partial pushed those
-/// onto `idx_search_composite`'s `(tenant_id, resource_type)` prefix, and
-/// replacing it with a narrow `(tenant_id, resource_type, param_name)` index
-/// made the planner prefer that for token searches too — a selective
-/// `code=…` lookup went from 2.9 ms to 22.1 ms because the value could no
-/// longer be filtered inside the index.
+/// by. `idx_search_string_folded` was deliberately **not** in this list: it
+/// was also the only index leading with `(tenant_id, resource_type,
+/// param_name)` that covered every row, and the query planner fell back to
+/// it for the `LIKE`-shaped modifier searches (`:text`, `:contains`) whose
+/// predicate SQLite cannot prove implies `IS NOT NULL`. Making it partial
+/// pushed those onto `idx_search_composite`'s `(tenant_id, resource_type)`
+/// prefix, and replacing it with a narrow `(tenant_id, resource_type,
+/// param_name)` index made the planner prefer that for token searches too —
+/// a selective `code=…` lookup went from 2.9 ms to 22.1 ms because the value
+/// could no longer be filtered inside the index. v28 finally made it partial
+/// by giving those predicates an explicit `IS NOT NULL` instead (see
+/// [`migrate_v27_to_v28`]).
 ///
 /// `EXPLAIN QUERY PLAN` over 15 representative search shapes (token, token
 /// `:text`, reference, reference `:text`, string prefix and exact, quantity
@@ -2496,12 +2533,9 @@ mod tests {
     ///   column almost every row leaves NULL takes an entry per row for
     ///   nothing.
     ///
-    /// `idx_search_string_folded` is asserted to be *non*-partial on purpose:
-    /// it is also the only full index leading with
-    /// `(tenant_id, resource_type, param_name)`, and the planner falls back to
-    /// it for the `LIKE`-shaped modifier searches whose predicate SQLite
-    /// cannot prove implies `IS NOT NULL`. Making it partial silently pushes
-    /// `:text` and `:contains` onto a `(tenant_id, resource_type)` scan.
+    /// `idx_search_string_folded` joined the partial set in v28; the
+    /// `LIKE`-shaped searches that used to depend on it being full now carry
+    /// their own `IS NOT NULL` (see [`migrate_v27_to_v28`]).
     #[test]
     fn search_index_carries_no_redundant_or_full_value_indexes() {
         let conn = Connection::open_in_memory().unwrap();
@@ -2530,6 +2564,10 @@ mod tests {
 
         for (name, predicate) in [
             (
+                "idx_search_string_folded",
+                "value_string_folded IS NOT NULL",
+            ),
+            (
                 "idx_search_reference_display",
                 "value_reference_display IS NOT NULL",
             ),
@@ -2545,13 +2583,6 @@ mod tests {
                 "{name} must be partial on `{predicate}`, got: {sql}"
             );
         }
-
-        let folded = index_sql("idx_search_string_folded").expect("folded index");
-        assert!(
-            !folded.to_ascii_uppercase().contains("WHERE"),
-            "idx_search_string_folded must stay full: it is the fallback index for \
-             LIKE-shaped modifier searches. Got: {folded}"
-        );
     }
 
     /// A database upgraded through the ladder must end up with exactly the

--- a/crates/persistence/src/backends/sqlite/schema.rs
+++ b/crates/persistence/src/backends/sqlite/schema.rs
@@ -12,6 +12,106 @@ use crate::error::StorageResult;
 /// Current schema version.
 pub const SCHEMA_VERSION: i32 = 28;
 
+/// The `search_index` value indexes: every index on the table except
+/// `idx_search_composite`, which the delete-by-resource path needs at all
+/// times. This is the canonical set — a test asserts a fresh schema carries
+/// exactly these — and the list the bulk index rebuild drops and recreates
+/// (see [`drop_search_value_indexes`] / [`ensure_search_value_indexes`]).
+///
+/// Keep each entry's SQL byte-for-byte what the migration ladder creates,
+/// normalised to one line, so the self-heal on startup and the ladder agree.
+pub(crate) const SEARCH_VALUE_INDEXES: [(&str, &str); 13] = [
+    (
+        "idx_search_string",
+        "CREATE INDEX IF NOT EXISTS idx_search_string ON search_index(tenant_id, resource_type, param_name, value_string) WHERE value_string IS NOT NULL",
+    ),
+    (
+        "idx_search_token",
+        "CREATE INDEX IF NOT EXISTS idx_search_token ON search_index(tenant_id, resource_type, param_name, value_token_system, value_token_code) WHERE value_token_system IS NOT NULL OR value_token_code IS NOT NULL",
+    ),
+    (
+        "idx_search_date",
+        "CREATE INDEX IF NOT EXISTS idx_search_date ON search_index(tenant_id, resource_type, param_name, value_date) WHERE value_date IS NOT NULL",
+    ),
+    (
+        "idx_search_number",
+        "CREATE INDEX IF NOT EXISTS idx_search_number ON search_index(tenant_id, resource_type, param_name, value_number) WHERE value_number IS NOT NULL",
+    ),
+    (
+        "idx_search_quantity",
+        "CREATE INDEX IF NOT EXISTS idx_search_quantity ON search_index(tenant_id, resource_type, param_name, value_quantity_value, value_quantity_unit) WHERE value_quantity_value IS NOT NULL",
+    ),
+    (
+        "idx_search_reference",
+        "CREATE INDEX IF NOT EXISTS idx_search_reference ON search_index(tenant_id, resource_type, param_name, value_reference) WHERE value_reference IS NOT NULL",
+    ),
+    (
+        "idx_search_uri",
+        "CREATE INDEX IF NOT EXISTS idx_search_uri ON search_index(tenant_id, resource_type, param_name, value_uri) WHERE value_uri IS NOT NULL",
+    ),
+    (
+        "idx_search_token_display",
+        "CREATE INDEX IF NOT EXISTS idx_search_token_display ON search_index(tenant_id, resource_type, param_name, value_token_display) WHERE value_token_display IS NOT NULL",
+    ),
+    (
+        "idx_search_identifier_type",
+        "CREATE INDEX IF NOT EXISTS idx_search_identifier_type ON search_index(tenant_id, resource_type, param_name, value_identifier_type_system, value_identifier_type_code) WHERE value_identifier_type_system IS NOT NULL OR value_identifier_type_code IS NOT NULL",
+    ),
+    (
+        "idx_search_reference_display",
+        "CREATE INDEX IF NOT EXISTS idx_search_reference_display ON search_index(tenant_id, resource_type, param_name, value_reference_display) WHERE value_reference_display IS NOT NULL",
+    ),
+    (
+        "idx_search_quantity_canonical",
+        "CREATE INDEX IF NOT EXISTS idx_search_quantity_canonical ON search_index(tenant_id, resource_type, param_name, value_quantity_canonical_unit, value_quantity_canonical_value) WHERE value_quantity_canonical_value IS NOT NULL",
+    ),
+    (
+        "idx_search_string_folded",
+        "CREATE INDEX IF NOT EXISTS idx_search_string_folded ON search_index(tenant_id, resource_type, param_name, value_string_folded) WHERE value_string_folded IS NOT NULL",
+    ),
+    (
+        "idx_search_contained",
+        "CREATE INDEX IF NOT EXISTS idx_search_contained ON search_index(tenant_id, contained_type, is_contained, param_name) WHERE is_contained = 1",
+    ),
+];
+
+/// Creates every missing [`SEARCH_VALUE_INDEXES`] entry and returns how many
+/// were missing. Runs on every startup: a bulk index rebuild drops these
+/// indexes for the duration of the load, and a process that died inside that
+/// window would otherwise come back with a `search_index` no search can use.
+/// A no-op on a healthy database.
+pub(crate) fn ensure_search_value_indexes(conn: &Connection) -> StorageResult<usize> {
+    let mut created = 0;
+    for (name, sql) in SEARCH_VALUE_INDEXES {
+        let exists: bool = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                [name],
+                |_| Ok(()),
+            )
+            .is_ok();
+        if !exists {
+            conn.execute(sql, [])
+                .map_err(|e| migration_err(format!("recreate {name}: {e}")))?;
+            created += 1;
+        }
+    }
+    Ok(created)
+}
+
+/// Drops every [`SEARCH_VALUE_INDEXES`] entry. The bulk index rebuild's first
+/// half: with the value indexes gone, a rebuild's rows land in the table
+/// (an append) and `idx_search_composite` alone, and the indexes are then
+/// built once, sorted, by [`ensure_search_value_indexes`] — instead of one
+/// random b-tree insertion per row per index.
+pub(crate) fn drop_search_value_indexes(conn: &Connection) -> StorageResult<()> {
+    for (name, _) in SEARCH_VALUE_INDEXES {
+        conn.execute(&format!("DROP INDEX IF EXISTS {name}"), [])
+            .map_err(|e| migration_err(format!("drop {name}: {e}")))?;
+    }
+    Ok(())
+}
+
 /// Initialize the database schema.
 pub fn initialize_schema(conn: &Connection) -> StorageResult<()> {
     // Check current version
@@ -35,6 +135,16 @@ pub fn initialize_schema(conn: &Connection) -> StorageResult<()> {
     // `IF NOT EXISTS` and idempotent, so ensuring it here every startup
     // self-heals such databases and is a no-op for correctly-migrated ones.
     ensure_tenants_table(conn)?;
+
+    // Self-heal after a bulk index rebuild that never finished (see
+    // `ensure_search_value_indexes`). A healthy database creates nothing.
+    let recreated = ensure_search_value_indexes(conn)?;
+    if recreated > 0 {
+        tracing::warn!(
+            recreated,
+            "search_index value indexes were missing at startup and have been rebuilt"
+        );
+    }
 
     Ok(())
 }
@@ -2583,6 +2693,49 @@ mod tests {
                 "{name} must be partial on `{predicate}`, got: {sql}"
             );
         }
+    }
+
+    /// The canonical value-index list must be exactly what a fresh schema
+    /// carries, name and definition alike — it is what a bulk index rebuild
+    /// recreates and what startup self-heals from, so drift here would
+    /// silently change the indexes of a database that went through either.
+    #[test]
+    fn search_value_indexes_match_the_fresh_schema() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize_schema(&conn).unwrap();
+        let normalise = |sql: &str| {
+            sql.replace("IF NOT EXISTS ", "")
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
+        };
+        let mut actual: Vec<(String, String)> = conn
+            .prepare(
+                "SELECT name, sql FROM sqlite_master
+                 WHERE type = 'index' AND tbl_name = 'search_index' AND name != 'idx_search_composite'",
+            )
+            .unwrap()
+            .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .map(|(n, s)| (n, normalise(&s)))
+            .collect();
+        actual.sort();
+        let mut expected: Vec<(String, String)> = SEARCH_VALUE_INDEXES
+            .iter()
+            .map(|(n, s)| (n.to_string(), normalise(s)))
+            .collect();
+        expected.sort();
+        assert_eq!(actual, expected);
+
+        // Drop, then self-heal: every entry comes back, and a second pass
+        // finds nothing to do.
+        drop_search_value_indexes(&conn).unwrap();
+        assert_eq!(
+            ensure_search_value_indexes(&conn).unwrap(),
+            SEARCH_VALUE_INDEXES.len()
+        );
+        assert_eq!(ensure_search_value_indexes(&conn).unwrap(), 0);
     }
 
     /// A database upgraded through the ladder must end up with exactly the

--- a/crates/persistence/src/backends/sqlite/search/filter_parser.rs
+++ b/crates/persistence/src/backends/sqlite/search/filter_parser.rs
@@ -573,7 +573,11 @@ impl FilterSqlGenerator {
                 // Contains - use LIKE with wildcards on both sides
                 (
                     column,
-                    format!("{} LIKE ?{}", column, param_num),
+                    format!(
+                        "{col} IS NOT NULL AND {col} LIKE ?{}",
+                        param_num,
+                        col = column
+                    ),
                     format!("%{}%", Self::escape_like(value)),
                 )
             }
@@ -581,7 +585,11 @@ impl FilterSqlGenerator {
                 // Starts with - use LIKE with wildcard at end
                 (
                     column,
-                    format!("{} LIKE ?{}", column, param_num),
+                    format!(
+                        "{col} IS NOT NULL AND {col} LIKE ?{}",
+                        param_num,
+                        col = column
+                    ),
                     format!("{}%", Self::escape_like(value)),
                 )
             }
@@ -589,7 +597,11 @@ impl FilterSqlGenerator {
                 // Ends with - use LIKE with wildcard at start
                 (
                     column,
-                    format!("{} LIKE ?{}", column, param_num),
+                    format!(
+                        "{col} IS NOT NULL AND {col} LIKE ?{}",
+                        param_num,
+                        col = column
+                    ),
                     format!("%{}", Self::escape_like(value)),
                 )
             }
@@ -598,7 +610,11 @@ impl FilterSqlGenerator {
                 // Simple implementation: treat as contains for strings
                 (
                     column,
-                    format!("{} LIKE ?{}", column, param_num),
+                    format!(
+                        "{col} IS NOT NULL AND {col} LIKE ?{}",
+                        param_num,
+                        col = column
+                    ),
                     format!("%{}%", Self::escape_like(value)),
                 )
             }

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/reference.rs
@@ -31,11 +31,22 @@ impl ReferenceHandler {
             return Self::build_identifier_condition(ref_value, param_num);
         }
 
+        // Every `LIKE`-shaped predicate below leads with `IS NOT NULL` on its
+        // column. SQLite cannot infer non-null from `LIKE`, so without it the
+        // partial value indexes (`WHERE value_reference IS NOT NULL`, …) are
+        // unusable and the planner walks every row of the type through
+        // `idx_search_composite`; with it, the family's index narrows the
+        // scan to the parameter's rows. Results are unchanged: a NULL column
+        // never satisfied the predicate.
+
         // Handle :contains modifier - case-insensitive substring match on the
         // stored reference string (e.g. "Patient/123" contains "23").
         if matches!(modifier, Some(SearchModifier::Contains)) {
             return SqlFragment::with_params(
-                format!("value_reference LIKE '%' || ?{} || '%'", param_num),
+                format!(
+                    "value_reference IS NOT NULL AND value_reference LIKE '%' || ?{} || '%'",
+                    param_num
+                ),
                 vec![SqlParam::string(ref_value)],
             );
         }
@@ -45,7 +56,8 @@ impl ReferenceHandler {
         if matches!(modifier, Some(SearchModifier::Text)) {
             return SqlFragment::with_params(
                 format!(
-                    "value_reference_display COLLATE NOCASE LIKE '%' || ?{} || '%'",
+                    "value_reference_display IS NOT NULL AND \
+                     value_reference_display COLLATE NOCASE LIKE '%' || ?{} || '%'",
                     param_num
                 ),
                 vec![SqlParam::string(value.value.to_lowercase())],
@@ -54,7 +66,8 @@ impl ReferenceHandler {
         if matches!(modifier, Some(SearchModifier::CodeText)) {
             return SqlFragment::with_params(
                 format!(
-                    "value_reference_display COLLATE NOCASE LIKE ?{} || '%'",
+                    "value_reference_display IS NOT NULL AND \
+                     value_reference_display COLLATE NOCASE LIKE ?{} || '%'",
                     param_num
                 ),
                 vec![SqlParam::string(value.value.to_lowercase())],
@@ -68,7 +81,8 @@ impl ReferenceHandler {
         if matches!(modifier, Some(SearchModifier::Below)) {
             return SqlFragment::with_params(
                 format!(
-                    "(value_reference = ?{} OR value_reference LIKE ?{} || '/%')",
+                    "value_reference IS NOT NULL AND \
+                     (value_reference = ?{} OR value_reference LIKE ?{} || '/%')",
                     param_num,
                     param_num + 1
                 ),
@@ -78,7 +92,8 @@ impl ReferenceHandler {
         if matches!(modifier, Some(SearchModifier::Above)) {
             return SqlFragment::with_params(
                 format!(
-                    "(?{} = value_reference OR ?{} LIKE value_reference || '/%')",
+                    "value_reference IS NOT NULL AND \
+                     (?{} = value_reference OR ?{} LIKE value_reference || '/%')",
                     param_num,
                     param_num + 1
                 ),
@@ -140,7 +155,8 @@ impl ReferenceHandler {
             // without a trailing `_history` version.
             SqlFragment::with_params(
                 format!(
-                    "(value_reference = ?{} \
+                    "value_reference IS NOT NULL AND \
+                     (value_reference = ?{} \
                       OR value_reference LIKE '%/' || ?{} \
                       OR value_reference LIKE '%/' || ?{} || '/_history/%')",
                     param_num,

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/string.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/string.rs
@@ -31,9 +31,17 @@ impl StringHandler {
                 // Contains (case- and accent-insensitive). Match the folded
                 // column; OR the raw column (case-insensitive) so rows not yet
                 // reindexed — whose folded column is NULL — still match.
+                //
+                // The leading `IS NOT NULL` is for the planner, not the
+                // result: SQLite cannot infer non-null from `LIKE`, and
+                // without it the only usable index is a type-wide scan of
+                // `idx_search_composite`. With it, the partial
+                // `idx_search_string` — `WHERE value_string IS NOT NULL` —
+                // qualifies and narrows the scan to the parameter's rows.
                 SqlFragment::with_params(
                     format!(
-                        "(value_string_folded LIKE '%' || ?{} || '%' \
+                        "value_string IS NOT NULL AND \
+                          (value_string_folded LIKE '%' || ?{} || '%' \
                           OR value_string COLLATE NOCASE LIKE '%' || ?{} || '%')",
                         param_num,
                         param_num + 1
@@ -49,7 +57,8 @@ impl StringHandler {
                 // fallback for not-yet-reindexed rows (folded column NULL).
                 SqlFragment::with_params(
                     format!(
-                        "(value_string_folded LIKE ?{} || '%' \
+                        "value_string IS NOT NULL AND \
+                          (value_string_folded LIKE ?{} || '%' \
                           OR value_string COLLATE NOCASE LIKE ?{} || '%')",
                         param_num,
                         param_num + 1

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/token.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/token.rs
@@ -36,10 +36,15 @@ impl TokenHandler {
 
         // Handle :text modifier - search on display text (Coding.display, CodeableConcept.text)
         if matches!(modifier, Some(SearchModifier::Text)) {
-            // Search on the display text column for human-readable text matching
+            // Search on the display text column for human-readable text
+            // matching. `IS NOT NULL` first: SQLite cannot infer it from
+            // `LIKE`, and it is what lets the partial
+            // `idx_search_token_display` serve the scan instead of a
+            // type-wide walk of `idx_search_composite`.
             return SqlFragment::with_params(
                 format!(
-                    "value_token_display COLLATE NOCASE LIKE '%' || ?{} || '%'",
+                    "value_token_display IS NOT NULL AND \
+                     value_token_display COLLATE NOCASE LIKE '%' || ?{} || '%'",
                     param_num
                 ),
                 vec![SqlParam::string(value.value.to_lowercase())],
@@ -52,7 +57,8 @@ impl TokenHandler {
         if matches!(modifier, Some(SearchModifier::CodeText)) {
             return SqlFragment::with_params(
                 format!(
-                    "value_token_display COLLATE NOCASE LIKE ?{} || '%'",
+                    "value_token_display IS NOT NULL AND \
+                     value_token_display COLLATE NOCASE LIKE ?{} || '%'",
                     param_num
                 ),
                 vec![SqlParam::string(value.value.to_lowercase())],

--- a/crates/persistence/src/backends/sqlite/search/parameter_handlers/uri.rs
+++ b/crates/persistence/src/backends/sqlite/search/parameter_handlers/uri.rs
@@ -24,10 +24,16 @@ impl UriHandler {
         let uri_value = &value.value;
 
         match modifier {
+            // The `IS NOT NULL` leads are for the planner: SQLite cannot infer
+            // non-null from `LIKE`, and they are what let the partial
+            // `idx_search_uri` serve these instead of a type-wide scan.
             Some(SearchModifier::Contains) => {
                 // :contains - case-insensitive substring match on the URI.
                 SqlFragment::with_params(
-                    format!("value_uri LIKE '%' || ?{} || '%'", param_num),
+                    format!(
+                        "value_uri IS NOT NULL AND value_uri LIKE '%' || ?{} || '%'",
+                        param_num
+                    ),
                     vec![SqlParam::string(uri_value)],
                 )
             }
@@ -36,7 +42,7 @@ impl UriHandler {
                 // For "http://example.org", matches "http://example.org" and "http://example.org/foo"
                 SqlFragment::with_params(
                     format!(
-                        "(value_uri = ?{} OR value_uri LIKE ?{} || '/%')",
+                        "value_uri IS NOT NULL AND (value_uri = ?{} OR value_uri LIKE ?{} || '/%')",
                         param_num,
                         param_num + 1
                     ),
@@ -48,7 +54,7 @@ impl UriHandler {
                 // For "http://example.org/foo/bar", matches "http://example.org", "http://example.org/foo", etc.
                 SqlFragment::with_params(
                     format!(
-                        "(?{} = value_uri OR ?{} LIKE value_uri || '/%')",
+                        "value_uri IS NOT NULL AND (?{} = value_uri OR ?{} LIKE value_uri || '/%')",
                         param_num,
                         param_num + 1
                     ),

--- a/crates/persistence/src/backends/sqlite/search/query_builder.rs
+++ b/crates/persistence/src/backends/sqlite/search/query_builder.rs
@@ -371,6 +371,7 @@ impl QueryBuilder {
             format!(
                 "resource_id IN (SELECT resource_id FROM search_index \
                  WHERE tenant_id = ?1 AND resource_type = ?2 AND param_name IN ({in_list}) \
+                 AND value_reference IS NOT NULL \
                  AND (value_reference = ?{p1} OR value_reference LIKE ?{p2} || '/_history/%'))"
             ),
             vec![SqlParam::string(base), SqlParam::string(base)],

--- a/crates/persistence/src/backends/sqlite/search/writer.rs
+++ b/crates/persistence/src/backends/sqlite/search/writer.rs
@@ -110,7 +110,11 @@ impl SqliteSearchIndexWriter {
             SqlValue::String(resource_type.to_string()),
             SqlValue::String(resource_id.to_string()),
             SqlValue::String(extracted.param_name.clone()),
-            SqlValue::String(extracted.param_url.clone()),
+            // `param_url` is not written. No SQLite read path consults it —
+            // every lookup is by `param_name` — and at ~57 bytes on every one
+            // of a resource's ~20 rows it was 11% of a bulk-loaded database.
+            // The column stays so older rows and the schema are untouched.
+            SqlValue::Null,
         ];
 
         // `value_reference_display` and the UCUM-canonical quantity columns are

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -4215,14 +4215,20 @@ mod tests {
             )
             .await
             .unwrap();
-        for _ in 0..200 {
-            tokio::task::yield_now().await;
+        // The run does its SQLite work on blocking threads, so yielding the
+        // async runtime is not enough to let it finish: wait on the clock.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        loop {
             if op.get_progress(&id).await.unwrap().status.is_finished() {
                 break;
             }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "reindex did not finish within 60s"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         let progress = op.get_progress(&id).await.unwrap();
-        assert!(progress.status.is_finished(), "reindex did not finish");
         assert!(progress.errors.is_empty(), "{:?}", progress.errors);
         assert_eq!(index_names(&backend), before);
 

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -57,6 +57,12 @@ pub(crate) struct PreparedIndex {
 /// Batches below this size are prepared on the calling thread.
 const PARALLEL_PREPARE_MIN_BATCH: usize = 16;
 
+/// Runs currently inside a bulk index rebuild, process-wide: the indexes are
+/// per database, not per run, so the first run in drops them and the last
+/// one out rebuilds them. Held across the DROP / CREATE so two runs cannot
+/// race each other's transition.
+static BULK_INDEX_REBUILDS: parking_lot::Mutex<usize> = parking_lot::Mutex::new(0);
+
 /// The pool [`SqliteBackend::prepare_index_batch`] runs on. Its own pool
 /// rather than rayon's global one so its width can be set independently of
 /// anything else in the process that uses rayon: `HFS_INDEX_THREADS`,
@@ -1268,6 +1274,11 @@ impl SqliteBackend {
         let rows = match extractor.extract(resource, resource_type) {
             Ok(values) => {
                 let marshal_span = crate::perf::span(crate::perf::Phase::IndexMarshal);
+                // Composite groups missing a component can never match a
+                // composite search (`GROUP BY … HAVING` needs every axis) and
+                // were 6% of all rows on a Synthea load; PostgreSQL already
+                // skips them.
+                let values = crate::search::extractor::drop_incomplete_composites(values);
                 let rows = values
                     .into_iter()
                     .map(|v| {
@@ -4027,6 +4038,52 @@ impl ReindexTarget for SqliteBackend {
         results
     }
 
+    /// Drops the `search_index` value indexes for the duration of the run.
+    /// Measured on a 72k-resource rebuild that already prepared its pages in
+    /// parallel: 18.5s with the indexes maintained row by row, 10.7s without
+    /// them plus 2.75s to build all thirteen sorted at the end — and the
+    /// sorted build is sequential I/O, so the gap widens once the b-trees
+    /// no longer fit the page cache. Reference-counted across concurrent
+    /// runs: the first one in drops, the last one out rebuilds. A process
+    /// that dies inside the window is healed at the next startup by
+    /// `schema::ensure_search_value_indexes`.
+    async fn begin_bulk_index_rebuild(&self) -> StorageResult<()> {
+        if self.is_search_offloaded() {
+            return Ok(());
+        }
+        let mut active = BULK_INDEX_REBUILDS.lock();
+        if *active == 0 {
+            let conn = self.get_connection()?;
+            let started = std::time::Instant::now();
+            super::schema::drop_search_value_indexes(&conn)?;
+            tracing::info!(
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "bulk index rebuild: search_index value indexes dropped for the run"
+            );
+        }
+        *active += 1;
+        Ok(())
+    }
+
+    async fn end_bulk_index_rebuild(&self) -> StorageResult<()> {
+        if self.is_search_offloaded() {
+            return Ok(());
+        }
+        let mut active = BULK_INDEX_REBUILDS.lock();
+        *active = active.saturating_sub(1);
+        if *active == 0 {
+            let conn = self.get_connection()?;
+            let started = std::time::Instant::now();
+            let created = super::schema::ensure_search_value_indexes(&conn)?;
+            tracing::info!(
+                created,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "bulk index rebuild: search_index value indexes rebuilt"
+            );
+        }
+        Ok(())
+    }
+
     async fn clear_search_index(&self, tenant: &TenantContext) -> StorageResult<u64> {
         let conn = self.get_connection()?;
         let tenant_id = tenant.tenant_id().as_str();
@@ -4095,6 +4152,90 @@ mod tests {
             TenantId::new("test-tenant"),
             TenantPermissions::full_access(),
         )
+    }
+
+    /// The SQLite writer drops its value indexes on `begin` and has every one
+    /// of them back on `end`, with the rows written meanwhile indexed — the
+    /// rebuild wrote them into the table only, and the sorted build picked
+    /// them up.
+    #[tokio::test]
+    async fn bulk_index_rebuild_restores_every_value_index_and_search_works() {
+        use crate::search::{ReindexOperation, ReindexRequest};
+
+        let backend = std::sync::Arc::new(create_test_backend());
+        let tenant = create_test_tenant();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({"resourceType": "Patient", "id": "p1", "name": [{"family": "Rebuild"}]}),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        let index_names = |backend: &SqliteBackend| -> Vec<String> {
+            let conn = backend.get_connection().unwrap();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'search_index' ORDER BY name",
+                )
+                .unwrap();
+            stmt.query_map([], |r| r.get(0))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect()
+        };
+        let before = index_names(&backend);
+        assert!(before.len() > 2);
+
+        backend.begin_bulk_index_rebuild().await.unwrap();
+        assert_eq!(
+            index_names(&backend),
+            vec!["idx_search_composite".to_string()]
+        );
+        // Nested run: still dropped, and the outer end is the one that rebuilds.
+        backend.begin_bulk_index_rebuild().await.unwrap();
+        backend.end_bulk_index_rebuild().await.unwrap();
+        assert_eq!(
+            index_names(&backend),
+            vec!["idx_search_composite".to_string()]
+        );
+        backend.end_bulk_index_rebuild().await.unwrap();
+        assert_eq!(index_names(&backend), before);
+
+        // The whole run, through the driver, on a database whose rows were
+        // written without the indexes.
+        let op = ReindexOperation::new(backend.clone(), backend.tenant_registries().clone());
+        let id = op
+            .start(
+                tenant.clone(),
+                ReindexRequest::for_types(["Patient"]).with_bulk_index_rebuild(true),
+                None,
+            )
+            .await
+            .unwrap();
+        for _ in 0..200 {
+            tokio::task::yield_now().await;
+            if op.get_progress(&id).await.unwrap().status.is_finished() {
+                break;
+            }
+        }
+        let progress = op.get_progress(&id).await.unwrap();
+        assert!(progress.status.is_finished(), "reindex did not finish");
+        assert!(progress.errors.is_empty(), "{:?}", progress.errors);
+        assert_eq!(index_names(&backend), before);
+
+        let query = SearchQuery::new("Patient").with_parameter(SearchParameter {
+            name: "family".to_string(),
+            param_type: SearchParamType::String,
+            modifier: None,
+            values: vec![SearchValue::eq("Rebuild")],
+            chain: vec![],
+            components: vec![],
+        });
+        let results = backend.search(&tenant, &query).await.unwrap();
+        assert_eq!(results.resources.items.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/persistence/src/backends/sqlite/storage.rs
+++ b/crates/persistence/src/backends/sqlite/storage.rs
@@ -22,7 +22,6 @@ use crate::error::TransactionError;
 use crate::error::{
     BackendError, ConcurrencyError, QueryErrorExt, ResourceError, StorageError, StorageResult,
 };
-use crate::search::extractor::ExtractedValue;
 use crate::search::reindex::{ReindexSource, ReindexTarget, ResourcePage};
 use crate::tenant::{Operation, TenantContext};
 use crate::types::Pagination;
@@ -42,6 +41,44 @@ fn internal_error(message: String) -> StorageError {
 
 fn serialization_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::SerializationError { message })
+}
+
+/// The database-free product of indexing one resource: every `search_index`
+/// row's bound parameters (or the extraction error that sends the write to
+/// the minimal fallback), the contained resources' rows, and the full-text
+/// content. Built by [`SqliteBackend::prepare_index`], written by
+/// [`SqliteBackend::write_prepared_index`].
+pub(crate) struct PreparedIndex {
+    rows: Result<Vec<Vec<SqlValue>>, String>,
+    contained_rows: Vec<Vec<SqlValue>>,
+    fts: Option<super::search::fts::SearchableContent>,
+}
+
+/// Batches below this size are prepared on the calling thread.
+const PARALLEL_PREPARE_MIN_BATCH: usize = 16;
+
+/// The pool [`SqliteBackend::prepare_index_batch`] runs on. Its own pool
+/// rather than rayon's global one so its width can be set independently of
+/// anything else in the process that uses rayon: `HFS_INDEX_THREADS`,
+/// defaulting to the machine's parallelism.
+fn index_prepare_pool() -> &'static rayon::ThreadPool {
+    static POOL: std::sync::OnceLock<rayon::ThreadPool> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        let threads = std::env::var("HFS_INDEX_THREADS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or_else(|| {
+                std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(4)
+            });
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .thread_name(|i| format!("hfs-index-{i}"))
+            .build()
+            .expect("build index thread pool")
+    })
 }
 
 /// Whether the optional `resource_fts` FTS5 virtual table exists on this
@@ -1180,10 +1217,12 @@ impl SqliteBackend {
 
     /// Index a resource for search.
     ///
-    /// This method uses the SearchParameterExtractor to dynamically extract
-    /// searchable values based on the configured SearchParameterRegistry.
-    /// Falls back to hardcoded common parameter extraction if the registry
-    /// extraction fails.
+    /// Extracts the resource's search values with the tenant's registry-driven
+    /// extractor and writes them, falling back to the hardcoded `_id` /
+    /// `_lastUpdated` pair if extraction fails. The two halves are
+    /// [`Self::prepare_index`] (pure CPU, no connection) and
+    /// [`Self::write_prepared_index`] (the statements); bulk paths prepare a
+    /// whole batch in parallel and call the second half alone.
     pub(crate) fn index_resource(
         &self,
         conn: &rusqlite::Connection,
@@ -1196,10 +1235,206 @@ impl SqliteBackend {
         if self.is_search_offloaded() {
             return Ok(());
         }
+        let prepared = self.prepare_index(tenant_id, resource_type, resource_id, resource);
+        self.write_prepared_index(
+            conn,
+            tenant_id,
+            resource_type,
+            resource_id,
+            resource,
+            prepared,
+        )
+        .map(|_| ())
+    }
 
-        // Try dynamic extraction using the registry-driven extractor
-        match self.index_resource_dynamic(conn, tenant_id, resource_type, resource_id, resource) {
-            Ok(count) => {
+    /// The database-free half of indexing one resource: FHIRPath extraction,
+    /// value normalisation, the bound parameters of every `search_index` row,
+    /// and the full-text content. Holds no connection and takes no lock other
+    /// than the registry's read lock, so a batch of these can be built on a
+    /// thread pool while the single writer connection is busy with the
+    /// previous batch (see [`Self::prepare_index_batch`]).
+    pub(crate) fn prepare_index(
+        &self,
+        tenant_id: &str,
+        resource_type: &str,
+        resource_id: &str,
+        resource: &Value,
+    ) -> PreparedIndex {
+        use super::search::fts::extract_searchable_content;
+        use crate::search::converters::IndexValue;
+
+        let _span = crate::perf::span(crate::perf::Phase::Extract);
+        let extractor = self.tenant_extractor(tenant_id);
+        let rows = match extractor.extract(resource, resource_type) {
+            Ok(values) => {
+                let marshal_span = crate::perf::span(crate::perf::Phase::IndexMarshal);
+                let rows = values
+                    .into_iter()
+                    .map(|v| {
+                        let normalized = match &v.value {
+                            IndexValue::Date {
+                                value: d,
+                                precision,
+                            } => {
+                                let mut n = v.clone();
+                                n.value = IndexValue::Date {
+                                    value: Self::normalize_date_for_sqlite(d),
+                                    precision: *precision,
+                                };
+                                n
+                            }
+                            _ => v,
+                        };
+                        SqliteSearchIndexWriter::to_sql_params(
+                            tenant_id,
+                            resource_type,
+                            resource_id,
+                            &normalized,
+                        )
+                    })
+                    .collect();
+                drop(marshal_span);
+                Ok(rows)
+            }
+            Err(e) => Err(e.to_string()),
+        };
+
+        // Contained resources, for `_contained` search: each value row is
+        // flagged `is_contained = 1` and carries the contained resource's
+        // type and local id, with `resource_type` / `resource_id` naming the
+        // container.
+        let mut contained_rows = Vec::new();
+        for contained in extractor.extract_contained(resource) {
+            for value in &contained.values {
+                let normalized = match &value.value {
+                    IndexValue::Date {
+                        value: d,
+                        precision,
+                    } => {
+                        let mut n = value.clone();
+                        n.value = IndexValue::Date {
+                            value: Self::normalize_date_for_sqlite(d),
+                            precision: *precision,
+                        };
+                        Some(n)
+                    }
+                    _ => None,
+                };
+                let mut params = SqliteSearchIndexWriter::to_sql_params(
+                    tenant_id,
+                    resource_type,
+                    resource_id,
+                    normalized.as_ref().unwrap_or(value),
+                );
+                params.push(SqlValue::Int(1));
+                params.push(SqlValue::String(contained.contained_type.clone()));
+                params.push(SqlValue::String(contained.local_id.clone()));
+                contained_rows.push(params);
+            }
+        }
+
+        let fts = {
+            let content = extract_searchable_content(resource);
+            (!content.is_empty()).then_some(content)
+        };
+
+        PreparedIndex {
+            rows,
+            contained_rows,
+            fts,
+        }
+    }
+
+    /// [`Self::prepare_index`] for a whole batch, spread across a thread
+    /// pool. Extraction is the largest CPU cost of indexing and is
+    /// independent per resource; SQLite's single writer cannot be
+    /// parallelised, but this can, and it moves the extraction off the
+    /// writer's critical path entirely.
+    ///
+    /// Items are `(resource_type, resource_id, resource)`; the result is in
+    /// input order. Small batches are prepared inline — the pool's
+    /// scheduling overhead is not worth paying for a handful of resources.
+    pub(crate) fn prepare_index_batch(
+        &self,
+        tenant_id: &str,
+        items: &[(&str, &str, &Value)],
+    ) -> Vec<PreparedIndex> {
+        use rayon::prelude::*;
+
+        let _span = crate::perf::span(crate::perf::Phase::PrepareBatch);
+        if items.len() < PARALLEL_PREPARE_MIN_BATCH {
+            return items
+                .iter()
+                .map(|(rt, id, res)| self.prepare_index(tenant_id, rt, id, res))
+                .collect();
+        }
+        index_prepare_pool().install(|| {
+            items
+                .par_iter()
+                .map(|(rt, id, res)| self.prepare_index(tenant_id, rt, id, res))
+                .collect()
+        })
+    }
+
+    /// The statement half of indexing one resource: `search_index` rows
+    /// eight per INSERT, the contained rows, then the full-text row. Returns
+    /// the number of `search_index` rows written. Runs the minimal `_id` /
+    /// `_lastUpdated` fallback when extraction failed, as
+    /// [`Self::index_resource`] always has.
+    pub(crate) fn write_prepared_index(
+        &self,
+        conn: &rusqlite::Connection,
+        tenant_id: &str,
+        resource_type: &str,
+        resource_id: &str,
+        resource: &Value,
+        prepared: PreparedIndex,
+    ) -> StorageResult<usize> {
+        let mut count = 0;
+        match prepared.rows {
+            Ok(rows) => {
+                // Rows are written eight at a time: a single-row INSERT stepped
+                // once per row spends a measurable share of its time entering
+                // and leaving the statement, and every resource writes ~10-30
+                // rows. The B-tree work is unchanged; only the per-statement
+                // overhead is amortized (measured +9% bulk-ingest throughput
+                // on the real 31 GB manifest).
+                let _span = crate::perf::span(crate::perf::Phase::IndexInsert);
+                let mut i = 0;
+                while i + 8 <= rows.len() {
+                    let refs: Vec<&dyn ToSql> = rows[i..i + 8]
+                        .iter()
+                        .flatten()
+                        .map(|p| self.sql_value_to_ref(p))
+                        .collect();
+                    conn.prepare_cached(SqliteSearchIndexWriter::insert_sql_rows8())
+                        .and_then(|mut s| s.execute(refs.as_slice()))
+                        .map_err(|e| internal_error(format!("multi-row index insert: {e}")))?;
+                    i += 8;
+                    count += 8;
+                }
+                for row in &rows[i..] {
+                    let refs: Vec<&dyn ToSql> =
+                        row.iter().map(|p| self.sql_value_to_ref(p)).collect();
+                    conn.prepare_cached(SqliteSearchIndexWriter::insert_sql())
+                        .and_then(|mut s| s.execute(refs.as_slice()))
+                        .map_err(|e| internal_error(format!("index insert: {e}")))?;
+                    count += 1;
+                }
+                for row in &prepared.contained_rows {
+                    let refs: Vec<&dyn ToSql> =
+                        row.iter().map(|p| self.sql_value_to_ref(p)).collect();
+                    conn.prepare_cached(SqliteSearchIndexWriter::insert_contained_sql())
+                        .and_then(|mut s| s.execute(refs.as_slice()))
+                        .map_err(|e| {
+                            internal_error(format!(
+                                "Failed to insert contained search index entry: {}",
+                                e
+                            ))
+                        })?;
+                    count += 1;
+                }
+                crate::perf::add_rows(crate::perf::Phase::IndexInsert, count as u64);
                 tracing::debug!(
                     "Dynamically indexed {} values for {}/{}",
                     count,
@@ -1220,36 +1455,26 @@ impl SqliteBackend {
         }
 
         // Index FTS content for _text and _content searches
-        {
+        if let Some(content) = prepared.fts {
             let _span = crate::perf::span(crate::perf::Phase::Fts);
-            self.index_fts_content(conn, tenant_id, resource_type, resource_id, resource)?;
+            self.index_fts_content(conn, tenant_id, resource_type, resource_id, content)?;
         }
 
-        Ok(())
+        Ok(count)
     }
 
-    /// Index full-text search content for _text and _content searches.
-    ///
-    /// This populates the resource_fts table if FTS5 is available.
+    /// Writes the full-text row for `_text` / `_content` searches, if FTS5 is
+    /// available, and records the rowid FTS5 assigned.
     fn index_fts_content(
         &self,
         conn: &rusqlite::Connection,
         tenant_id: &str,
         resource_type: &str,
         resource_id: &str,
-        resource: &Value,
+        content: super::search::fts::SearchableContent,
     ) -> StorageResult<()> {
-        use super::search::fts::extract_searchable_content;
-
         if !fts_table_exists(conn)? {
             // FTS5 not available - skip silently
-            return Ok(());
-        }
-
-        // Extract searchable content
-        let content = extract_searchable_content(resource);
-
-        if content.is_empty() {
             return Ok(());
         }
 
@@ -1284,246 +1509,6 @@ impl SqliteBackend {
             conn.last_insert_rowid()
         ])
         .map_err(|e| internal_error(format!("Failed to record FTS rowid: {}", e)))?;
-
-        Ok(())
-    }
-
-    /// Index a resource using dynamic extraction from the SearchParameterRegistry.
-    ///
-    /// Returns the number of index entries created.
-    fn index_resource_dynamic(
-        &self,
-        conn: &rusqlite::Connection,
-        tenant_id: &str,
-        resource_type: &str,
-        resource_id: &str,
-        resource: &Value,
-    ) -> StorageResult<usize> {
-        // Extract values using the tenant's registry-driven extractor
-        let values = {
-            let _span = crate::perf::span(crate::perf::Phase::Extract);
-            self.tenant_extractor(tenant_id)
-                .extract(resource, resource_type)
-                .map_err(|e| internal_error(format!("Search parameter extraction failed: {}", e)))?
-        };
-
-        // Rows are written eight at a time: a single-row INSERT stepped once
-        // per row spends a measurable share of its time entering and leaving
-        // the statement, and every resource writes ~10-30 rows. The B-tree
-        // work is unchanged; only the per-statement overhead is amortized
-        // (measured +9% bulk-ingest throughput on the real 31 GB manifest).
-        let mut count = 0;
-        {
-            // The whole insert, plus its Rust-side half (normalising values and
-            // building the bound parameters) as a nested phase, so a profile can
-            // tell our marshalling apart from SQLite's b-tree work (#947).
-            let _span = crate::perf::span(crate::perf::Phase::IndexInsert);
-            use crate::search::converters::IndexValue;
-            let marshal_span = crate::perf::span(crate::perf::Phase::IndexMarshal);
-            let owned: Vec<_> = values
-                .into_iter()
-                .map(|v| match &v.value {
-                    IndexValue::Date {
-                        value: d,
-                        precision,
-                    } => {
-                        let mut n = v.clone();
-                        n.value = IndexValue::Date {
-                            value: Self::normalize_date_for_sqlite(d),
-                            precision: *precision,
-                        };
-                        n
-                    }
-                    _ => v,
-                })
-                .collect();
-            let rows: Vec<Vec<_>> = owned
-                .iter()
-                .map(|v| {
-                    SqliteSearchIndexWriter::to_sql_params(tenant_id, resource_type, resource_id, v)
-                })
-                .collect();
-            drop(marshal_span);
-            let mut i = 0;
-            while i + 8 <= rows.len() {
-                let refs: Vec<&dyn ToSql> = rows[i..i + 8]
-                    .iter()
-                    .flatten()
-                    .map(|p| self.sql_value_to_ref(p))
-                    .collect();
-                conn.prepare_cached(SqliteSearchIndexWriter::insert_sql_rows8())
-                    .and_then(|mut s| s.execute(refs.as_slice()))
-                    .map_err(|e| internal_error(format!("multi-row index insert: {e}")))?;
-                i += 8;
-                count += 8;
-            }
-            for row in &rows[i..] {
-                let refs: Vec<&dyn ToSql> = row.iter().map(|p| self.sql_value_to_ref(p)).collect();
-                conn.prepare_cached(SqliteSearchIndexWriter::insert_sql())
-                    .and_then(|mut s| s.execute(refs.as_slice()))
-                    .map_err(|e| internal_error(format!("index insert: {e}")))?;
-                count += 1;
-            }
-        }
-        crate::perf::add_rows(crate::perf::Phase::IndexInsert, count as u64);
-
-        // Also index any contained resources for `_contained` search.
-        count +=
-            self.index_contained_resources(conn, tenant_id, resource_type, resource_id, resource)?;
-
-        Ok(count)
-    }
-
-    /// Writes a single ExtractedValue to the search_index table.
-    fn write_index_entry(
-        &self,
-        conn: &rusqlite::Connection,
-        tenant_id: &str,
-        resource_type: &str,
-        resource_id: &str,
-        value: &ExtractedValue,
-    ) -> StorageResult<()> {
-        use crate::search::converters::IndexValue;
-
-        let marshal_span = crate::perf::span(crate::perf::Phase::IndexMarshal);
-        // For date values, normalize the date format for consistent SQLite comparisons
-        let normalized_value = match &value.value {
-            IndexValue::Date {
-                value: date_str,
-                precision,
-            } => {
-                let normalized_date = Self::normalize_date_for_sqlite(date_str);
-                let mut normalized = value.clone();
-                normalized.value = IndexValue::Date {
-                    value: normalized_date,
-                    precision: *precision,
-                };
-                Some(normalized)
-            }
-            _ => None,
-        };
-
-        let value_to_use = normalized_value.as_ref().unwrap_or(value);
-        let sql_params = SqliteSearchIndexWriter::to_sql_params(
-            tenant_id,
-            resource_type,
-            resource_id,
-            value_to_use,
-        );
-
-        // Build parameter refs for rusqlite
-        let param_refs: Vec<&dyn ToSql> = sql_params
-            .iter()
-            .map(|p| self.sql_value_to_ref(p))
-            .collect();
-
-        drop(marshal_span);
-        // `prepare_cached`, not `execute`: `Connection::execute` compiles the
-        // statement on every call, and a bulk import runs this one ~14 times
-        // per resource. The 24-column INSERT costs more to compile than to
-        // run, and the cache is keyed on the `&'static str` above, so every
-        // row after the first on a given connection reuses the same program.
-        conn.prepare_cached(SqliteSearchIndexWriter::insert_sql())
-            .map_err(|e| internal_error(format!("Failed to prepare search index insert: {}", e)))?
-            .execute(param_refs.as_slice())
-            .map_err(|e| internal_error(format!("Failed to insert search index entry: {}", e)))?;
-
-        Ok(())
-    }
-
-    /// Extracts and indexes a container's `contained[]` resources for
-    /// `_contained` search. Each contained resource's search values are written
-    /// as `is_contained = 1` rows whose `resource_type` / `resource_id` identify
-    /// the container. Returns the number of entries written.
-    fn index_contained_resources(
-        &self,
-        conn: &rusqlite::Connection,
-        tenant_id: &str,
-        container_type: &str,
-        container_id: &str,
-        resource: &Value,
-    ) -> StorageResult<usize> {
-        let mut count = 0;
-        let container = (container_type, container_id);
-        for contained in self.tenant_extractor(tenant_id).extract_contained(resource) {
-            for value in &contained.values {
-                self.write_contained_index_entry(
-                    conn,
-                    tenant_id,
-                    container,
-                    (&contained.contained_type, &contained.local_id),
-                    value,
-                )?;
-                count += 1;
-            }
-        }
-        Ok(count)
-    }
-
-    /// Writes a single contained `ExtractedValue` to the search_index table,
-    /// flagged `is_contained = 1` and carrying the contained resource's type and
-    /// local id (mirrors [`Self::write_index_entry`]). `container` is the
-    /// `(type, id)` of the holding resource; `contained` is the
-    /// `(type, local id)` of the nested resource.
-    fn write_contained_index_entry(
-        &self,
-        conn: &rusqlite::Connection,
-        tenant_id: &str,
-        container: (&str, &str),
-        contained: (&str, &str),
-        value: &ExtractedValue,
-    ) -> StorageResult<()> {
-        use crate::search::converters::IndexValue;
-
-        let (container_type, container_id) = container;
-        let (contained_type, contained_local_id) = contained;
-
-        let normalized_value = match &value.value {
-            IndexValue::Date {
-                value: date_str,
-                precision,
-            } => {
-                let mut normalized = value.clone();
-                normalized.value = IndexValue::Date {
-                    value: Self::normalize_date_for_sqlite(date_str),
-                    precision: *precision,
-                };
-                Some(normalized)
-            }
-            _ => None,
-        };
-        let value_to_use = normalized_value.as_ref().unwrap_or(value);
-
-        let mut sql_params = SqliteSearchIndexWriter::to_sql_params(
-            tenant_id,
-            container_type,
-            container_id,
-            value_to_use,
-        );
-        // Trailing contained columns (?25..?27).
-        sql_params.push(SqlValue::Int(1));
-        sql_params.push(SqlValue::String(contained_type.to_string()));
-        sql_params.push(SqlValue::String(contained_local_id.to_string()));
-
-        let param_refs: Vec<&dyn ToSql> = sql_params
-            .iter()
-            .map(|p| self.sql_value_to_ref(p))
-            .collect();
-
-        conn.prepare_cached(SqliteSearchIndexWriter::insert_contained_sql())
-            .map_err(|e| {
-                internal_error(format!(
-                    "Failed to prepare contained search index insert: {}",
-                    e
-                ))
-            })?
-            .execute(param_refs.as_slice())
-            .map_err(|e| {
-                internal_error(format!(
-                    "Failed to insert contained search index entry: {}",
-                    e
-                ))
-            })?;
 
         Ok(())
     }
@@ -3796,6 +3781,7 @@ impl ReindexSource for SqliteBackend {
         cursor: Option<&str>,
         limit: u32,
     ) -> StorageResult<ResourcePage> {
+        let _fetch_span = crate::perf::span(crate::perf::Phase::ReindexFetch);
         let conn = self.get_connection()?;
         let tenant_id = tenant.tenant_id().as_str().to_string();
 
@@ -3913,58 +3899,43 @@ impl SqliteBackend {
         let resource_id = resource.id();
         let content = resource.content();
 
-        // Use the dynamic extraction over the tenant's registry
-        let values = self
-            .tenant_extractor(tenant.tenant_id().as_str())
-            .extract(content, resource_type)
-            .map_err(|e| internal_error(format!("Search parameter extraction failed: {}", e)))?;
-
-        let mut count = 0;
-        for value in values {
-            self.write_index_entry(
-                conn,
-                tenant.tenant_id().as_str(),
-                resource_type,
-                resource_id,
-                &value,
-            )?;
-            count += 1;
-        }
-
-        // Re-index contained resources too, so `$reindex` rebuilds `_contained`
-        // search entries.
-        count += self.index_contained_resources(
+        // The same two halves the CRUD path uses. Every caller deletes the
+        // resource's search entries (FTS row included) immediately before
+        // this — without that, `$reindex` was a *destructive* operation for
+        // `_text`/`_content`: the delete dropped the FTS row and nothing put
+        // it back. `index_fts_content` is a bare INSERT with no
+        // delete-first, so if that ordering ever changes this must become
+        // delete-then-insert.
+        let tenant_id = tenant.tenant_id().as_str();
+        let prepared = self.prepare_index(tenant_id, resource_type, resource_id, content);
+        self.write_prepared_index(
             conn,
-            tenant.tenant_id().as_str(),
+            tenant_id,
             resource_type,
             resource_id,
             content,
-        )?;
+            prepared,
+        )
+    }
 
-        // Rebuild the full-text row as well. Without this, `$reindex` was a
-        // *destructive* operation for `_text`/`_content`: `run_reindex` deletes
-        // each resource's search entries via `delete_search_entries` ->
-        // `delete_search_index`, which does drop the FTS row, and nothing here
-        // put it back. That happened on every reindex, with or without
-        // `clear_existing`, so the documented recovery operation silently
-        // disabled full-text search until each resource was next written.
-        //
-        // Not counted in `count`: that value is the number of `search_index`
-        // entries, which `$reindex-status` reports, and an FTS row is not one.
-        //
-        // Safe against duplicates because every caller deletes the resource's
-        // search entries (FTS row included) immediately before this, and
-        // SQLite's `index_fts_content` is a bare INSERT with no delete-first.
-        // If that ordering ever changes, this must become delete-then-insert.
-        self.index_fts_content(
+    /// [`Self::write_search_entries_on`] with the extraction already done —
+    /// the reindex page loop prepares a page in parallel and then writes it
+    /// through here on the one connection.
+    fn write_prepared_search_entries_on(
+        &self,
+        conn: &rusqlite::Connection,
+        tenant: &TenantContext,
+        resource: &StoredResource,
+        prepared: PreparedIndex,
+    ) -> StorageResult<usize> {
+        self.write_prepared_index(
             conn,
             tenant.tenant_id().as_str(),
-            resource_type,
-            resource_id,
-            content,
-        )?;
-
-        Ok(count)
+            resource.resource_type(),
+            resource.id(),
+            resource.content(),
+            prepared,
+        )
     }
 }
 
@@ -4022,15 +3993,30 @@ impl ReindexTarget for SqliteBackend {
                 .map(|_| Err(internal_error(msg.clone())))
                 .collect();
         }
+        let page_span = crate::perf::span(crate::perf::Phase::ReindexPage);
         let tenant_id = tenant.tenant_id().as_str();
+        // Extraction for the whole page first, across the thread pool, while
+        // this connection holds the write lock for nothing else; the loop
+        // below is then statements only.
+        let items: Vec<(&str, &str, &Value)> = resources
+            .iter()
+            .map(|r| (r.resource_type(), r.id(), r.content()))
+            .collect();
+        let prepared = self.prepare_index_batch(tenant_id, &items);
         let mut results: Vec<StorageResult<usize>> = Vec::with_capacity(resources.len());
-        for resource in resources {
-            let outcome = self
-                .delete_search_index(&conn, tenant_id, resource.resource_type(), resource.id())
-                .and_then(|_| self.write_search_entries_on(&conn, tenant, resource));
+        for (resource, prepared) in resources.iter().zip(prepared) {
+            let outcome = {
+                let _span = crate::perf::span(crate::perf::Phase::IndexDelete);
+                self.delete_search_index(&conn, tenant_id, resource.resource_type(), resource.id())
+            }
+            .and_then(|_| self.write_prepared_search_entries_on(&conn, tenant, resource, prepared));
             results.push(outcome);
         }
-        if let Err(e) = conn.execute("COMMIT", []) {
+        let commit_span = crate::perf::span(crate::perf::Phase::Commit);
+        let committed = conn.execute("COMMIT", []);
+        drop(commit_span);
+        drop(page_span);
+        if let Err(e) = committed {
             let _ = conn.execute("ROLLBACK", []);
             let msg = format!("Failed to commit reindex batch: {e}");
             return resources

--- a/crates/persistence/src/backends/sqlite/transaction.rs
+++ b/crates/persistence/src/backends/sqlite/transaction.rs
@@ -21,6 +21,7 @@ use crate::types::StoredResource;
 
 use super::SqliteBackend;
 use super::backend::load_tenant_stored_params_with_conn;
+use super::storage::PreparedIndex;
 
 fn internal_error(message: String) -> StorageError {
     StorageError::Backend(BackendError::Internal {
@@ -117,6 +118,7 @@ impl SqliteTransaction {
     /// extraction with minimal fallback, FTS content, contained resources),
     /// so transactional writes are searchable exactly like direct ones
     /// (#815 review).
+    #[allow(clippy::too_many_arguments)]
     fn index_resource(
         &self,
         conn: &rusqlite::Connection,
@@ -125,6 +127,7 @@ impl SqliteTransaction {
         resource_id: &str,
         resource: &Value,
         clear_stale_rows: bool,
+        prepared: Option<PreparedIndex>,
     ) -> StorageResult<()> {
         let _index_span = perf::span(Phase::Index);
         // `clear_stale_rows` is false only on the create path, where the
@@ -148,17 +151,50 @@ impl SqliteTransaction {
         if self.defer_search_indexing {
             return Ok(());
         }
-        self.backend
-            .index_resource(conn, tenant_id, resource_type, resource_id, resource)
+        // A batch caller may have run the extraction already, off this
+        // thread (`SqliteBackend::prepare_index_batch`); then only the
+        // statements are left.
+        match prepared {
+            Some(prepared) if !self.backend.is_search_offloaded() => self
+                .backend
+                .write_prepared_index(
+                    conn,
+                    tenant_id,
+                    resource_type,
+                    resource_id,
+                    resource,
+                    prepared,
+                )
+                .map(|_| ()),
+            _ => self
+                .backend
+                .index_resource(conn, tenant_id, resource_type, resource_id, resource),
+        }
     }
-}
 
-#[async_trait]
-impl Transaction for SqliteTransaction {
-    async fn create(
+    /// [`Transaction::create`] with the search-index extraction already done
+    /// by the caller. Bulk ingest prepares a whole batch in parallel before
+    /// opening the entry loop and hands each entry's result in here; the
+    /// caller must have extracted from a resource carrying the same `id` and
+    /// `resourceType` this create will store, or the index rows would
+    /// describe a different resource. Unlike the trait method this is not
+    /// reached through `dyn Transaction`, so it is inherent.
+    pub(crate) async fn create_prepared(
         &mut self,
         resource_type: &str,
         resource: Value,
+        prepared: Option<PreparedIndex>,
+    ) -> StorageResult<StoredResource> {
+        self.create_inner(resource_type, resource, prepared)
+    }
+}
+
+impl SqliteTransaction {
+    fn create_inner(
+        &mut self,
+        resource_type: &str,
+        resource: Value,
+        prepared: Option<PreparedIndex>,
     ) -> StorageResult<StoredResource> {
         let _create_span = perf::span(Phase::Create);
         self.tenant
@@ -248,7 +284,7 @@ impl Transaction for SqliteTransaction {
 
         // Index the resource for search. Nothing to clear: the existence
         // probe above established there is no row for this id.
-        self.index_resource(&conn, tenant_id, resource_type, &id, &data, false)?;
+        self.index_resource(&conn, tenant_id, resource_type, &id, &data, false, prepared)?;
         drop(conn);
 
         // Mirrors the storage path: an overlay-affecting SearchParameter
@@ -274,6 +310,17 @@ impl Transaction for SqliteTransaction {
             None,
             self.fhir_version,
         ))
+    }
+}
+
+#[async_trait]
+impl Transaction for SqliteTransaction {
+    async fn create(
+        &mut self,
+        resource_type: &str,
+        resource: Value,
+    ) -> StorageResult<StoredResource> {
+        self.create_inner(resource_type, resource, None)
     }
 
     async fn read(
@@ -451,7 +498,7 @@ impl Transaction for SqliteTransaction {
         }
 
         // Re-index the resource for search, clearing the previous version's rows.
-        self.index_resource(&conn, tenant_id, resource_type, id, &data, true)?;
+        self.index_resource(&conn, tenant_id, resource_type, id, &data, true, None)?;
         drop(conn);
 
         // A SearchParameter write invalidates this tenant's cached registry

--- a/crates/persistence/src/perf.rs
+++ b/crates/persistence/src/perf.rs
@@ -84,11 +84,19 @@ pub enum Phase {
     Commit,
     /// Per-batch overhead outside the entry loop (BEGIN, manifest counters).
     BatchOverhead,
+    /// Reindex: one page fetched from `resources` and deserialised.
+    ReindexFetch,
+    /// Reindex: one page's index rebuild, BEGIN to COMMIT.
+    ReindexPage,
+    /// Wall clock of one batch's parallel extraction (`prepare_index_batch`),
+    /// as opposed to `extract`, which sums the CPU time across the pool's
+    /// threads. The gap between the two is the parallel speed-up.
+    PrepareBatch,
 }
 
 impl Phase {
     /// All phases, in report order.
-    pub const ALL: [Phase; 19] = [
+    pub const ALL: [Phase; 22] = [
         Phase::NdjsonParse,
         Phase::Entry,
         Phase::EntryRead,
@@ -108,6 +116,9 @@ impl Phase {
         Phase::Bookkeeping,
         Phase::Commit,
         Phase::BatchOverhead,
+        Phase::ReindexFetch,
+        Phase::ReindexPage,
+        Phase::PrepareBatch,
     ];
 
     /// The phase this one is measured inside of, if any. Drives the report's
@@ -156,11 +167,14 @@ impl Phase {
             Phase::Bookkeeping => "bookkeeping",
             Phase::Commit => "commit",
             Phase::BatchOverhead => "batch_overhead",
+            Phase::ReindexFetch => "reindex_fetch_page",
+            Phase::ReindexPage => "reindex_write_page",
+            Phase::PrepareBatch => "prepare_batch (wall)",
         }
     }
 }
 
-const PHASE_COUNT: usize = 19;
+const PHASE_COUNT: usize = 22;
 
 #[allow(clippy::declare_interior_mutable_const)]
 const ZERO: AtomicU64 = AtomicU64::new(0);

--- a/crates/persistence/src/search/extractor.rs
+++ b/crates/persistence/src/search/extractor.rs
@@ -124,6 +124,57 @@ pub struct ContainedExtraction {
     pub values: Vec<ExtractedValue>,
 }
 
+/// Removes the composite groups that can never match a composite search.
+///
+/// A composite search matches only when every component matches, so an
+/// instance missing a component is dead weight: every Observation with a
+/// `code` but no `valueString` still produced a `code-value-string` row, and
+/// on a Synthea load those single-component groups were 46% of all composite
+/// rows and 6% of the whole index. `composite_arity` is how many distinct
+/// axes a complete instance has; a group is kept when it produced that many
+/// (an axis is a `(slot, value family)` pair, as in the PostgreSQL writer's
+/// `fold_composites`, which applies the same rule). Values without an arity —
+/// older extractors, hand-built values — are kept as they were. Plain values
+/// pass through untouched, and the input order is preserved.
+pub fn drop_incomplete_composites(values: Vec<ExtractedValue>) -> Vec<ExtractedValue> {
+    use std::collections::HashMap;
+    use std::mem::discriminant;
+
+    // Axes seen per (param, group), counted once per (slot, family).
+    type Axis = (u8, std::mem::Discriminant<IndexValue>);
+    let mut axes: HashMap<(&str, u32), Vec<Axis>> = HashMap::new();
+    for v in &values {
+        if let Some(group) = v.composite_group {
+            let axis = (v.composite_slot.unwrap_or(1), discriminant(&v.value));
+            let seen = axes.entry((v.param_name.as_str(), group)).or_default();
+            if !seen.contains(&axis) {
+                seen.push(axis);
+            }
+        }
+    }
+    let incomplete: std::collections::HashSet<(String, u32)> = values
+        .iter()
+        .filter_map(|v| {
+            let group = v.composite_group?;
+            let required = usize::from(v.composite_arity?);
+            let have = axes
+                .get(&(v.param_name.as_str(), group))
+                .map_or(0, Vec::len);
+            (have < required).then(|| (v.param_name.clone(), group))
+        })
+        .collect();
+    if incomplete.is_empty() {
+        return values;
+    }
+    values
+        .into_iter()
+        .filter(|v| match v.composite_group {
+            Some(group) => !incomplete.contains(&(v.param_name.clone(), group)),
+            None => true,
+        })
+        .collect()
+}
+
 /// A search-parameter expression with all of its per-`(expression,
 /// resource_type)` preparation already done.
 ///
@@ -1164,6 +1215,78 @@ impl std::fmt::Debug for SearchParameterExtractor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn incomplete_composite_groups_are_dropped_and_plain_values_kept() {
+        let token = |group: u32, slot: u8, arity: u8| {
+            ExtractedValue::new(
+                "code-value-quantity",
+                "http://x/code-value-quantity",
+                SearchParamType::Composite,
+                IndexValue::Token {
+                    system: Some("http://loinc.org".into()),
+                    code: "1234".into(),
+                    display: None,
+                    identifier_type_system: None,
+                    identifier_type_code: None,
+                },
+            )
+            .with_composite_group(group)
+            .with_composite_slot(slot)
+            .with_composite_arity(arity)
+        };
+        let quantity = |group: u32| {
+            ExtractedValue::new(
+                "code-value-quantity",
+                "http://x/code-value-quantity",
+                SearchParamType::Composite,
+                IndexValue::Quantity {
+                    value: 5.0,
+                    unit: Some("kg".into()),
+                    system: None,
+                    code: None,
+                },
+            )
+            .with_composite_group(group)
+            .with_composite_slot(1)
+            .with_composite_arity(2)
+        };
+        let plain = ExtractedValue::new(
+            "code",
+            "http://x/code",
+            SearchParamType::Token,
+            IndexValue::Token {
+                system: None,
+                code: "1234".into(),
+                display: None,
+                identifier_type_system: None,
+                identifier_type_code: None,
+            },
+        );
+        // Group 0 is complete (token + quantity); group 1 has only its code;
+        // group 2 has two codings but still only one axis.
+        let values = vec![
+            plain.clone(),
+            token(0, 1, 2),
+            quantity(0),
+            token(1, 1, 2),
+            token(2, 1, 2),
+            token(2, 1, 2),
+            // No arity: the legacy rule keeps any non-empty group.
+            token(3, 1, 2)
+                .with_composite_arity(0)
+                .with_composite_group(3),
+        ];
+        let mut legacy = values[6].clone();
+        legacy.composite_arity = None;
+        let mut values = values;
+        values[6] = legacy;
+
+        let kept = drop_incomplete_composites(values);
+        let groups: Vec<Option<u32>> = kept.iter().map(|v| v.composite_group).collect();
+        assert_eq!(groups, vec![None, Some(0), Some(0), Some(3)]);
+        assert_eq!(kept[0].param_name, "code");
+    }
     use crate::search::loader::SearchParameterLoader;
     use helios_fhir::FhirVersion;
     use serde_json::json;

--- a/crates/persistence/src/search/mod.rs
+++ b/crates/persistence/src/search/mod.rs
@@ -88,8 +88,8 @@ pub use registry::{
     SearchParameterStatus, fallback_param_type, resolve_param_targets, resolve_param_type,
 };
 pub use reindex::{
-    ReindexOnFinish, ReindexOperation, ReindexProgress, ReindexRequest, ReindexSource,
-    ReindexStatus, ReindexTarget, ReindexableStorage, ResourcePage,
+    DEFERRED_REINDEX_BATCH_SIZE, ReindexOnFinish, ReindexOperation, ReindexProgress,
+    ReindexRequest, ReindexSource, ReindexStatus, ReindexTarget, ReindexableStorage, ResourcePage,
 };
 pub use seeder::{
     SeedOutcome, seed_spec_compartment_definitions, seed_spec_search_parameters,

--- a/crates/persistence/src/search/reindex.rs
+++ b/crates/persistence/src/search/reindex.rs
@@ -170,6 +170,23 @@ pub trait ReindexTarget: Send + Sync {
     /// Implementations MUST scope the deletion to `tenant` and nothing else.
     async fn clear_search_index(&self, tenant: &TenantContext) -> StorageResult<u64>;
 
+    /// Enters bulk index rebuild mode for a run that asked for it
+    /// (`ReindexRequest::bulk_index_rebuild`): a writer that maintains
+    /// secondary indexes row by row may drop them here and build them in
+    /// [`Self::end_bulk_index_rebuild`], which the driver calls on every exit
+    /// path of the run — completion, failure and cancellation alike. Nested
+    /// runs are the writer's business (SQLite reference-counts). The default
+    /// does nothing, which is right for a writer whose index *is* the
+    /// document (Elasticsearch).
+    async fn begin_bulk_index_rebuild(&self) -> StorageResult<()> {
+        Ok(())
+    }
+
+    /// Leaves bulk index rebuild mode; see [`Self::begin_bulk_index_rebuild`].
+    async fn end_bulk_index_rebuild(&self) -> StorageResult<()> {
+        Ok(())
+    }
+
     /// Rebuilds a whole page of resources — delete each one's stale entries,
     /// write fresh ones — returning a per-resource result of entries written,
     /// in input order.
@@ -226,6 +243,13 @@ pub struct ReindexRequest {
     /// Whether to clear existing indexes before reindexing.
     #[serde(default)]
     pub clear_existing: bool,
+
+    /// Bulk index rebuild: writers that support it drop their value indexes
+    /// for the duration of the run and build them once, sorted, at the end
+    /// (see [`ReindexTarget::begin_bulk_index_rebuild`]). Much faster for a
+    /// large load; search on the affected store is unindexed meanwhile.
+    #[serde(default)]
+    pub bulk_index_rebuild: bool,
 }
 
 fn default_batch_size() -> u32 {
@@ -239,6 +263,7 @@ impl Default for ReindexRequest {
             search_param_urls: None,
             batch_size: default_batch_size(),
             clear_existing: false,
+            bulk_index_rebuild: false,
         }
     }
 }
@@ -282,6 +307,12 @@ impl ReindexRequest {
     /// Enables clearing existing indexes.
     pub fn clear_existing(mut self) -> Self {
         self.clear_existing = true;
+        self
+    }
+
+    /// Sets the bulk index rebuild mode (see the field).
+    pub fn with_bulk_index_rebuild(mut self, on: bool) -> Self {
+        self.bulk_index_rebuild = on;
         self
     }
 }
@@ -802,6 +833,12 @@ fn mark_failed(jobs: &Arc<RwLock<HashMap<String, ReindexProgress>>>, job_id: &st
     }
 }
 
+/// How the page loop of a run ended, short of completion.
+enum RunExit {
+    Cancelled,
+    Failed(String),
+}
+
 /// Marks a job as cancelled.
 fn mark_cancelled(jobs: &Arc<RwLock<HashMap<String, ReindexProgress>>>, job_id: &str) {
     let mut jobs_guard = jobs.write();
@@ -925,92 +962,128 @@ async fn run_reindex(
         }
     }
 
-    // Process each resource type
-    for resource_type in &resource_types {
-        // Check for cancellation
-        if cancel_rx.try_recv().is_ok() {
-            mark_cancelled(&jobs, &job_id);
-            return;
-        }
-
-        // Update current resource type
-        {
-            let mut jobs_guard = jobs.write();
-            if let Some(progress) = jobs_guard.get_mut(&job_id) {
-                progress.current_resource_type = Some(resource_type.clone());
-            }
-        }
-
-        // Process resources in batches
-        let mut cursor: Option<String> = None;
-        loop {
-            // Check for cancellation
-            if cancel_rx.try_recv().is_ok() {
-                mark_cancelled(&jobs, &job_id);
+    // Bulk index rebuild (opt-in): every writer drops what it can before the
+    // pages, and gets its `end` on every exit path below.
+    if request.bulk_index_rebuild {
+        for writer in &writers {
+            if let Err(e) = writer.begin_bulk_index_rebuild().await {
+                mark_failed(
+                    &jobs,
+                    &job_id,
+                    format!("Failed to enter bulk index rebuild: {e}"),
+                );
                 return;
             }
+        }
+    }
 
-            // Fetch a page of resources
-            let page = match source
-                .fetch_resources_page(
-                    &tenant,
-                    resource_type,
-                    cursor.as_deref(),
-                    request.batch_size,
-                )
-                .await
-            {
-                Ok(page) => page,
-                Err(e) => {
-                    mark_failed(&jobs, &job_id, format!("Failed to fetch resources: {e}"));
-                    return;
-                }
-            };
-
-            // Rebuild the page through every writer. Page-at-a-time so a
-            // writer can wrap it in one transaction; each writer reports a
-            // per-resource outcome for error attribution. The entry count for
-            // progress comes from the writers' own extraction — the driver no
-            // longer extracts a second time just to count.
-            let mut wrote_any: Vec<bool> = vec![false; page.resources.len()];
-            let mut entry_counts: Vec<u64> = vec![0; page.resources.len()];
-            for writer in &writers {
-                let outcomes = writer
-                    .write_search_entries_page(&tenant, &page.resources)
-                    .await;
-                for (i, outcome) in outcomes.into_iter().enumerate() {
-                    match outcome {
-                        Ok(written) => {
-                            wrote_any[i] = true;
-                            entry_counts[i] = entry_counts[i].max(written as u64);
-                        }
-                        Err(e) => push_error(
-                            &jobs,
-                            &job_id,
-                            resource_type,
-                            page.resources[i].id(),
-                            format!("Failed to rebuild index entries: {e}"),
-                        ),
-                    }
-                }
+    let outcome: Result<(), RunExit> = async {
+        // Process each resource type
+        for resource_type in &resource_types {
+            // Check for cancellation
+            if cancel_rx.try_recv().is_ok() {
+                return Err(RunExit::Cancelled);
             }
 
-            for (i, _resource) in page.resources.iter().enumerate() {
+            // Update current resource type
+            {
                 let mut jobs_guard = jobs.write();
                 if let Some(progress) = jobs_guard.get_mut(&job_id) {
-                    progress.processed_resources += 1;
-                    if wrote_any[i] {
-                        progress.entries_created += entry_counts[i];
-                    }
+                    progress.current_resource_type = Some(resource_type.clone());
                 }
             }
 
-            // Check if there are more pages
-            match page.next_cursor {
-                Some(next) => cursor = Some(next),
-                None => break,
+            // Process resources in batches
+            let mut cursor: Option<String> = None;
+            loop {
+                // Check for cancellation
+                if cancel_rx.try_recv().is_ok() {
+                    return Err(RunExit::Cancelled);
+                }
+
+                // Fetch a page of resources
+                let page = match source
+                    .fetch_resources_page(
+                        &tenant,
+                        resource_type,
+                        cursor.as_deref(),
+                        request.batch_size,
+                    )
+                    .await
+                {
+                    Ok(page) => page,
+                    Err(e) => {
+                        return Err(RunExit::Failed(format!("Failed to fetch resources: {e}")));
+                    }
+                };
+
+                // Rebuild the page through every writer. Page-at-a-time so a
+                // writer can wrap it in one transaction; each writer reports a
+                // per-resource outcome for error attribution. The entry count for
+                // progress comes from the writers' own extraction — the driver no
+                // longer extracts a second time just to count.
+                let mut wrote_any: Vec<bool> = vec![false; page.resources.len()];
+                let mut entry_counts: Vec<u64> = vec![0; page.resources.len()];
+                for writer in &writers {
+                    let outcomes = writer
+                        .write_search_entries_page(&tenant, &page.resources)
+                        .await;
+                    for (i, outcome) in outcomes.into_iter().enumerate() {
+                        match outcome {
+                            Ok(written) => {
+                                wrote_any[i] = true;
+                                entry_counts[i] = entry_counts[i].max(written as u64);
+                            }
+                            Err(e) => push_error(
+                                &jobs,
+                                &job_id,
+                                resource_type,
+                                page.resources[i].id(),
+                                format!("Failed to rebuild index entries: {e}"),
+                            ),
+                        }
+                    }
+                }
+
+                for (i, _resource) in page.resources.iter().enumerate() {
+                    let mut jobs_guard = jobs.write();
+                    if let Some(progress) = jobs_guard.get_mut(&job_id) {
+                        progress.processed_resources += 1;
+                        if wrote_any[i] {
+                            progress.entries_created += entry_counts[i];
+                        }
+                    }
+                }
+
+                // Check if there are more pages
+                match page.next_cursor {
+                    Some(next) => cursor = Some(next),
+                    None => break,
+                }
             }
         }
+
+        Ok(())
+    }
+    .await;
+
+    if request.bulk_index_rebuild {
+        for writer in &writers {
+            if let Err(e) = writer.end_bulk_index_rebuild().await {
+                mark_failed(
+                    &jobs,
+                    &job_id,
+                    format!("Failed to leave bulk index rebuild: {e}"),
+                );
+                return;
+            }
+        }
+    }
+
+    match outcome {
+        Err(RunExit::Cancelled) => return mark_cancelled(&jobs, &job_id),
+        Err(RunExit::Failed(msg)) => return mark_failed(&jobs, &job_id, msg),
+        Ok(()) => {}
     }
 
     // Mark as completed
@@ -1035,6 +1108,8 @@ pub struct ReindexOnFinish {
     op: std::sync::Arc<ReindexOperation>,
     /// Resources per rebuild transaction.
     batch_size: u32,
+    /// `ReindexRequest::bulk_index_rebuild` for the runs this hook starts.
+    bulk_index_rebuild: bool,
 }
 
 /// The page the deferred rebuild uses. `ReindexRequest`'s default of 100
@@ -1053,12 +1128,21 @@ impl ReindexOnFinish {
         Self {
             op,
             batch_size: DEFERRED_REINDEX_BATCH_SIZE,
+            bulk_index_rebuild: false,
         }
     }
 
     /// Overrides the resources-per-transaction page of the rebuild.
     pub fn with_batch_size(mut self, batch_size: u32) -> Self {
         self.batch_size = batch_size.max(1);
+        self
+    }
+
+    /// Runs the rebuild in bulk index rebuild mode
+    /// (`HFS_BULK_SUBMIT_BULK_INDEX_REBUILD`): the writer's value indexes are
+    /// dropped for the duration and built once, sorted, at the end.
+    pub fn with_bulk_index_rebuild(mut self, on: bool) -> Self {
+        self.bulk_index_rebuild = on;
         self
     }
 }
@@ -1070,8 +1154,9 @@ impl crate::core::DeferredReindexHook for ReindexOnFinish {
         tenant: &crate::tenant::TenantContext,
         resource_types: Vec<String>,
     ) {
-        let request =
-            ReindexRequest::for_types(resource_types.clone()).with_batch_size(self.batch_size);
+        let request = ReindexRequest::for_types(resource_types.clone())
+            .with_batch_size(self.batch_size)
+            .with_bulk_index_rebuild(self.bulk_index_rebuild);
         match self.op.start(tenant.clone(), request, None).await {
             Ok(job_id) => {
                 tracing::info!(job_id, types = ?resource_types, "deferred-index rebuild started");
@@ -1159,6 +1244,104 @@ mod tests {
             }
         }
         panic!("job never reached terminal status");
+    }
+
+    /// One type whose page fetch fails, so the run leaves through the
+    /// failure path of the page loop.
+    struct FailingPageSource;
+
+    #[async_trait]
+    impl ReindexSource for FailingPageSource {
+        async fn list_resource_types(&self, _: &TenantContext) -> StorageResult<Vec<String>> {
+            Ok(vec!["Patient".to_string()])
+        }
+        async fn count_resources(&self, _: &TenantContext, _: &str) -> StorageResult<u64> {
+            Ok(1)
+        }
+        async fn fetch_resources_page(
+            &self,
+            _: &TenantContext,
+            _: &str,
+            _: Option<&str>,
+            _: u32,
+        ) -> StorageResult<ResourcePage> {
+            Err(crate::error::BackendError::Unavailable {
+                backend_name: "test".into(),
+                message: "injected page failure".into(),
+            }
+            .into())
+        }
+    }
+
+    /// Counts the bulk-rebuild transitions it is asked for.
+    #[derive(Default)]
+    struct CountingTarget {
+        begun: std::sync::atomic::AtomicUsize,
+        ended: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ReindexTarget for CountingTarget {
+        async fn delete_search_entries(
+            &self,
+            _: &TenantContext,
+            _: &str,
+            _: &str,
+        ) -> StorageResult<u64> {
+            Ok(0)
+        }
+        async fn write_search_entries(
+            &self,
+            _: &TenantContext,
+            _: &StoredResource,
+        ) -> StorageResult<usize> {
+            Ok(0)
+        }
+        async fn clear_search_index(&self, _: &TenantContext) -> StorageResult<u64> {
+            Ok(0)
+        }
+        async fn begin_bulk_index_rebuild(&self) -> StorageResult<()> {
+            self.begun.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+        async fn end_bulk_index_rebuild(&self) -> StorageResult<()> {
+            self.ended.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// A run that fails inside its page loop still leaves bulk index rebuild
+    /// mode: the writer would otherwise be left without its indexes until the
+    /// next process start.
+    #[tokio::test]
+    async fn bulk_index_rebuild_ends_on_the_failure_path() {
+        let target = Arc::new(CountingTarget::default());
+        let op = ReindexOperation::with_parts(
+            Arc::new(FailingPageSource),
+            vec![target.clone()],
+            Arc::new(crate::search::TenantSearchRegistries::base_only()),
+        );
+        let id = op
+            .start(
+                TenantContext::system(),
+                ReindexRequest::default().with_bulk_index_rebuild(true),
+                None,
+            )
+            .await
+            .unwrap();
+        let progress = await_terminal(&op, &id).await;
+        assert_eq!(progress.status, ReindexStatus::Failed);
+        assert_eq!(target.begun.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(target.ended.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        // And a run without the flag never touches the hooks.
+        let id = op
+            .start(TenantContext::system(), ReindexRequest::default(), None)
+            .await
+            .unwrap();
+        await_terminal(&op, &id).await;
+        assert_eq!(target.begun.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(target.ended.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/persistence/src/search/reindex.rs
+++ b/crates/persistence/src/search/reindex.rs
@@ -1033,12 +1033,33 @@ async fn run_reindex(
 /// types.
 pub struct ReindexOnFinish {
     op: std::sync::Arc<ReindexOperation>,
+    /// Resources per rebuild transaction.
+    batch_size: u32,
 }
+
+/// The page the deferred rebuild uses. `ReindexRequest`'s default of 100
+/// suits an operator-driven `$reindex` on a live server, where a small
+/// transaction keeps the write lock short. The rebuild after a fast-load is
+/// a different workload: it is the bulk of the import's wall clock, and
+/// each page is one COMMIT, whose cost is fixed per transaction rather than
+/// per row. Measured on the SQLite backend, 100 -> 1000 took the rebuild
+/// from 1,695 to 1,926 resources/s; 5,000 gained a further 2% and holds
+/// five times the resources in memory per page, so 1,000 it is.
+pub const DEFERRED_REINDEX_BATCH_SIZE: u32 = 1000;
 
 impl ReindexOnFinish {
     /// Wraps a reindex manager for use as the worker's post-manifest hook.
     pub fn new(op: std::sync::Arc<ReindexOperation>) -> Self {
-        Self { op }
+        Self {
+            op,
+            batch_size: DEFERRED_REINDEX_BATCH_SIZE,
+        }
+    }
+
+    /// Overrides the resources-per-transaction page of the rebuild.
+    pub fn with_batch_size(mut self, batch_size: u32) -> Self {
+        self.batch_size = batch_size.max(1);
+        self
     }
 }
 
@@ -1049,7 +1070,8 @@ impl crate::core::DeferredReindexHook for ReindexOnFinish {
         tenant: &crate::tenant::TenantContext,
         resource_types: Vec<String>,
     ) {
-        let request = ReindexRequest::for_types(resource_types.clone());
+        let request =
+            ReindexRequest::for_types(resource_types.clone()).with_batch_size(self.batch_size);
         match self.op.start(tenant.clone(), request, None).await {
             Ok(job_id) => {
                 tracing::info!(job_id, types = ?resource_types, "deferred-index rebuild started");

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -637,8 +637,9 @@ pub struct BulkSubmitConfig {
     ///   `true` measured ~1.2x faster, winning all 15 interleaved rounds on an
     ///   idle machine. Stopping the clock at the `200` instead gives 3.3x, but
     ///   that instant is before search works. The ~6.7x sometimes quoted comes
-    ///   from `bulk_submit_bench`, which runs no reindex and so measures
-    ///   ingestion with the indexing work removed.
+    ///   from `bulk_submit_bench` without its `--reindex` stage, which then
+    ///   measures ingestion with the indexing work removed; with `--reindex`
+    ///   it runs the same rebuild the worker's hook does and reports both.
     /// - Durability: the rebuild starts only after the manifest is already
     ///   terminal and is fire-and-forget, so `$bulk-submit-status` reports
     ///   `200` while search is still incomplete; the job exists only in an

--- a/crates/rest/src/config.rs
+++ b/crates/rest/src/config.rs
@@ -654,6 +654,18 @@ pub struct BulkSubmitConfig {
     /// Set `HFS_BULK_SUBMIT_DEFER_INDEXING=false` to give up the speed and
     /// close that window.
     pub defer_indexing: bool,
+    /// Bulk index rebuild for the deferred reindex (SQLite): drop the
+    /// `search_index` value indexes for the duration of each rebuild and
+    /// build them once, sorted, when it finishes. Measured 27% faster on a
+    /// 72k-resource rebuild with everything in memory; the sorted build is
+    /// sequential I/O, so the gap widens on loads whose b-trees outgrow the
+    /// page cache. The cost: while a rebuild runs, search on that database is
+    /// unindexed for **every** tenant and type, and the final index build
+    /// holds the write lock for as long as it takes. Meant for the initial
+    /// load of a large corpus on a server that is not serving traffic; `false`
+    /// by default. Ignored when search is offloaded to a secondary. Set with
+    /// `HFS_BULK_SUBMIT_BULK_INDEX_REBUILD`.
+    pub bulk_index_rebuild: bool,
     /// When `true`, this pod does not run in-process submit workers.
     pub disable_local_worker: bool,
     /// Cap on simultaneous in-flight submissions per tenant.
@@ -719,6 +731,7 @@ impl Default for BulkSubmitConfig {
             file_concurrency: 1,
             disable_local_worker: false,
             defer_indexing: true,
+            bulk_index_rebuild: false,
             max_concurrent_per_tenant: 4,
             batch_size: 1000,
             lease_duration_secs: 60,
@@ -816,6 +829,10 @@ impl BulkSubmitConfig {
             worker_concurrency: env_u32("HFS_BULK_SUBMIT_WORKER_CONCURRENCY", d.worker_concurrency),
             file_concurrency: env_u32("HFS_BULK_SUBMIT_FILE_CONCURRENCY", d.file_concurrency),
             defer_indexing: env_bool("HFS_BULK_SUBMIT_DEFER_INDEXING", d.defer_indexing),
+            bulk_index_rebuild: env_bool(
+                "HFS_BULK_SUBMIT_BULK_INDEX_REBUILD",
+                d.bulk_index_rebuild,
+            ),
             disable_local_worker: env_bool(
                 "HFS_BULK_SUBMIT_DISABLE_LOCAL_WORKER",
                 d.disable_local_worker,


### PR DESCRIPTION
## Summary
- Parallelize search-value extraction for bulk-submit ingest: a batch's FHIRPath extraction, value normalization, and parameter marshalling now run on a rayon thread pool (`prepare_index_batch` / `PreparedIndex`, width `HFS_INDEX_THREADS`) before the page's transaction opens, so the single SQLite writer only executes statements. Used by both the deferred-index rebuild (`write_search_entries_page`) and the inline ingest path (`create_prepared` plumbs the precomputed rows through `ingest_entry_in_txn`). The rebuild also writes `search_index` rows eight per INSERT, as the inline path already did.
- Deferred rebuild page is 1,000 resources (`DEFERRED_REINDEX_BATCH_SIZE`) instead of `ReindexRequest`'s 100; each page is one COMMIT, whose cost is per transaction rather than per row.
- Schema v28: make `idx_search_string_folded` a partial index (`WHERE value_string_folded IS NOT NULL`), since only string rows carry a folded value; the reference/string/token/uri `LIKE` predicate builders now lead with `<column> IS NOT NULL` so the planner can use each family's partial index instead of falling back to a type-wide scan. Verified shape by shape with `EXPLAIN QUERY PLAN`; several reference/token/uri modifier searches were already type-wide scans and are now index-narrowed.
- `param_url` is no longer written to `search_index`: nothing in the SQLite backend reads it, and it was ~11% of a bulk-loaded database. The column stays.
- `bulk_submit_bench`: add `--reindex`/`--reindex-batch` to run and separately time the post-manifest rebuild the submit worker fires under deferred indexing, so `--batch 1000 --defer-index --reindex` is the server's default path end to end; `perf` gains `reindex_fetch_page`, `reindex_write_page` and `prepare_batch (wall)` phases.
- Opt-in bulk index rebuild, `HFS_BULK_SUBMIT_BULK_INDEX_REBUILD` (default `false`): the SQLite deferred rebuild drops the `search_index` value indexes for its duration and recreates them with one sorted `CREATE INDEX` each at the end, instead of one random b-tree insertion per row per index. `ReindexTarget` gains `begin`/`end_bulk_index_rebuild`, the driver calls `end` on every exit, and a process-wide counter lets overlapping rebuilds share one window; startup self-heals the index set if a process died inside it. Search on that database is unindexed for every tenant while a rebuild runs and the final build holds the write lock, so it is meant for the initial load of a large corpus on a server not serving traffic.
- `drop_incomplete_composites`: composite groups missing a component are no longer written. They were 46% of composite rows on the Synthea mix, can never match, and PostgreSQL already skipped them.
- `bulk_submit_bench`: `--bulk-index-rebuild`, and `HFS_EXPERIMENT_SQL` to run arbitrary SQL against the fresh schema before the ingest so a schema idea can be priced without a build.
- Update `bulk-data-submit` and `test-hfs` skill docs, and the `defer_indexing` doc comment in `rest/src/config.rs`, with the new flags and measured gains.

## Where the time went
Under the server defaults the fast-load ingest of a 72k-resource Synthea mix takes ~3s and the rebuild that followed took ~42s, so the rebuild is ~90% of import time. Inside it: index-row INSERTs ~48%, FHIRPath extraction ~22%, COMMIT ~22%. Also priced and rejected on the rebuild: narrowing `idx_search_composite` (7% ingest gain but `_missing` slows), dropping the two display-text indexes (9%, at a search-plan cost for `:text`), FTS5 `automerge`/`pgsz` tuning (noise), `wal_autocheckpoint=0` (9%, unbounded WAL), `synchronous=OFF` (5–17%, corruption risk on power loss; `NORMAL` gains nothing). Earlier round, priced and rejected: `synchronous=NORMAL` (commit cost is dirty-page WAL writes and checkpoints, not fsync), page sizes 8k/16k (worse), 1 GB page cache, rebuild page 5000, foreign keys off, restricting the `search_index_fts` trigger, excluding composite rows from FTS, probing before the per-resource DELETE. The `search_index_fts` triggers remain ~20% of the rebuild; kept, since `:text-advanced` needs the FTS index.

## Testing
- `bulk_submit_bench`, 72k-resource Synthea mix (Observation/Condition/Patient/Encounter), three interleaved rounds vs. `main`, medians: deferred fast-load + rebuild 41.8s → 21.5s (1.94x, 3/3 rounds); inline ingest 36.4s → 25.0s (1.45x, 3/3); database ~15% smaller.
- Same mix at 312k resources: 180.7s → 110.1s (1.64x).
- With `HFS_BULK_SUBMIT_BULK_INDEX_REBUILD=true` on top: 72k 21.0s → 16.3s, 312k 110.1s → 69.7s end to end (2.6x over `main` at both sizes).
- `cargo test -p helios-persistence --lib` (981 passed), `--test search_suite --test crud_suite --test multitenancy_suite --test backend_capability_contract` (225 passed), `cargo clippy -p helios-persistence --all-targets` with the CI flags, `cargo fmt --all --check`, `cargo check --workspace`: all clean.
