### PR TITLE
fix(persistence): remove shared ES/MinIO testcontainers at process exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3599,6 +3599,7 @@ dependencies = [
  "cdrs-tokio-helpers-derive",
  "chrono",
  "criterion",
+ "ctor",
  "deadpool-postgres",
  "elasticsearch",
  "futures",

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -134,6 +134,9 @@ tokio-test = "0.4"
 criterion = { version = "0.5", features = ["async_tokio"] }
 testcontainers-modules = { version = "0.15", features = ["postgres", "elastic_search", "minio", "mongo"] }
 paste = "1.0"
+# `#[ctor::dtor]` exit hook that removes testcontainers held in `static`s
+# (tests/common/container_cleanup.rs).
+ctor = "0.2"
 
 # `watchdog` pulls in `signal_hook::iterator`/`SIGQUIT`, which only compile on Unix.
 # Windows test runs don't need SIGTERM cleanup, so drop the feature there.

--- a/crates/persistence/tests/common/container_cleanup.rs
+++ b/crates/persistence/tests/common/container_cleanup.rs
@@ -1,0 +1,64 @@
+//! Process-exit cleanup for testcontainers held in `static`s.
+//!
+//! Shared containers live in a `static OnceCell` so every test in a binary
+//! reuses one instance. `static` values are never dropped, so
+//! `ContainerAsync`'s `Drop` cleanup never runs and the container outlives the
+//! test process (testcontainers-rs has no Ryuk reaper; the `watchdog` feature
+//! only covers SIGINT/SIGTERM). Label every shared container with
+//! [`with_cleanup_label`] and the `#[ctor::dtor]` hook below force-removes
+//! them via the `docker` CLI when the process exits.
+//!
+//! The label value is unique per process, so the hook never removes containers
+//! owned by another test binary running concurrently on the same Docker host.
+//!
+//! `#[path]`-include this file from a test binary; it is not part of
+//! `common/mod.rs`.
+
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use testcontainers::{ContainerRequest, Image, ImageExt};
+
+const OWNER_LABEL_KEY: &str = "io.helios.persistence.test-owner";
+
+static OWNER_LABEL_VALUE: LazyLock<String> = LazyLock::new(|| {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    format!("{}-{nanos}", std::process::id())
+});
+
+/// Set once a labeled container may exist, so binaries that never start one
+/// (e.g. filtered or skipped runs) do not shell out to `docker` at exit.
+static CONTAINER_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Labels a container request so it is force-removed when this process exits.
+pub fn with_cleanup_label<I: Image>(request: impl ImageExt<I>) -> ContainerRequest<I> {
+    CONTAINER_REQUESTED.store(true, Ordering::SeqCst);
+    request.with_label(OWNER_LABEL_KEY, OWNER_LABEL_VALUE.as_str())
+}
+
+#[ctor::dtor]
+fn remove_labeled_containers() {
+    if !CONTAINER_REQUESTED.load(Ordering::SeqCst) {
+        return;
+    }
+    let filter = format!("label={OWNER_LABEL_KEY}={}", *OWNER_LABEL_VALUE);
+    let Ok(listing) = std::process::Command::new("docker")
+        .args(["ps", "-aq", "--filter", &filter])
+        .output()
+    else {
+        return;
+    };
+    let listing = String::from_utf8_lossy(&listing.stdout);
+    let ids: Vec<&str> = listing.split_whitespace().collect();
+    if ids.is_empty() {
+        return;
+    }
+    let _ = std::process::Command::new("docker")
+        .args(["rm", "-f"])
+        .args(&ids)
+        .output();
+}

--- a/crates/persistence/tests/elasticsearch_tests.rs
+++ b/crates/persistence/tests/elasticsearch_tests.rs
@@ -646,6 +646,9 @@ mod parameter_handler_tests {
 #[path = "search/date_boundary_suite.rs"]
 mod date_boundary_suite;
 
+#[path = "common/container_cleanup.rs"]
+mod container_cleanup;
+
 #[cfg(test)]
 mod es_integration {
     use std::path::PathBuf;
@@ -706,13 +709,17 @@ mod es_integration {
         let run_id = std::env::var("GITHUB_RUN_ID").unwrap_or_default();
         let mut last_err = None;
         for attempt in 1..=ES_START_ATTEMPTS {
-            match ElasticSearch::default()
-                .with_tag(ES_IMAGE_TAG)
-                .with_env_var("ES_JAVA_OPTS", "-Xms256m -Xmx256m")
-                .with_label("github.run_id", &run_id)
-                .with_startup_timeout(ES_STARTUP_TIMEOUT)
-                .start()
-                .await
+            // `SHARED_ES` is a static and never dropped; the cleanup label
+            // lets the exit hook remove the container.
+            match super::container_cleanup::with_cleanup_label(
+                ElasticSearch::default()
+                    .with_tag(ES_IMAGE_TAG)
+                    .with_env_var("ES_JAVA_OPTS", "-Xms256m -Xmx256m")
+                    .with_label("github.run_id", &run_id)
+                    .with_startup_timeout(ES_STARTUP_TIMEOUT),
+            )
+            .start()
+            .await
             {
                 Ok(container) => return container,
                 Err(err) => {

--- a/crates/persistence/tests/s3_es_tests.rs
+++ b/crates/persistence/tests/s3_es_tests.rs
@@ -45,6 +45,12 @@ use testcontainers_modules::elastic_search::ElasticSearch;
 use tokio::sync::OnceCell;
 use uuid::Uuid;
 
+// `SHARED_MINIO` / `SHARED_ES` are statics and never dropped; containers
+// labeled via `with_cleanup_label` are removed by an exit hook instead.
+#[path = "common/container_cleanup.rs"]
+mod container_cleanup;
+use container_cleanup::with_cleanup_label;
+
 // ============================================================================
 // Container setup
 // ============================================================================
@@ -94,15 +100,17 @@ async fn shared_minio() -> &'static SharedMinio {
             let root_password = std::env::var("MINIO_ROOT_PASSWORD")
                 .unwrap_or_else(|_| DEFAULT_MINIO_ROOT_PASSWORD.to_string());
 
-            let container = GenericImage::new(image, tag)
-                .with_wait_for(WaitFor::message_on_stderr("API:"))
-                .with_exposed_port(9000.tcp())
-                .with_env_var("MINIO_ROOT_USER", root_user.clone())
-                .with_env_var("MINIO_ROOT_PASSWORD", root_password.clone())
-                .with_cmd(["server", "/data", "--console-address", ":9001"])
-                .start()
-                .await
-                .expect("failed to start MinIO container");
+            let container = with_cleanup_label(
+                GenericImage::new(image, tag)
+                    .with_wait_for(WaitFor::message_on_stderr("API:"))
+                    .with_exposed_port(9000.tcp())
+                    .with_env_var("MINIO_ROOT_USER", root_user.clone())
+                    .with_env_var("MINIO_ROOT_PASSWORD", root_password.clone())
+                    .with_cmd(["server", "/data", "--console-address", ":9001"]),
+            )
+            .start()
+            .await
+            .expect("failed to start MinIO container");
 
             let host = container
                 .get_host()
@@ -159,13 +167,15 @@ async fn start_es_container() -> testcontainers::ContainerAsync<ElasticSearch> {
     let run_id = std::env::var("GITHUB_RUN_ID").unwrap_or_default();
     let mut last_err = None;
     for attempt in 1..=ES_START_ATTEMPTS {
-        match ElasticSearch::default()
-            .with_tag(ES_IMAGE_TAG)
-            .with_env_var("ES_JAVA_OPTS", "-Xms256m -Xmx256m")
-            .with_label("github.run_id", &run_id)
-            .with_startup_timeout(ES_STARTUP_TIMEOUT)
-            .start()
-            .await
+        match with_cleanup_label(
+            ElasticSearch::default()
+                .with_tag(ES_IMAGE_TAG)
+                .with_env_var("ES_JAVA_OPTS", "-Xms256m -Xmx256m")
+                .with_label("github.run_id", &run_id)
+                .with_startup_timeout(ES_STARTUP_TIMEOUT),
+        )
+        .start()
+        .await
         {
             Ok(container) => return container,
             Err(err) => {


### PR DESCRIPTION
## Problem

`elasticsearch_tests` and `s3_es_tests` keep their shared Elasticsearch / MinIO testcontainers in `static OnceCell`s. Statics are never dropped, so `ContainerAsync`'s `Drop` cleanup never runs and every local run leaves a container behind. One was found still running ~32h after a `cargo test --test elasticsearch_tests` run. testcontainers 0.27 has no Ryuk reaper, and the `watchdog` feature only handles SIGINT/SIGTERM, not a normal exit.

## Fix

- New `crates/persistence/tests/common/container_cleanup.rs` (`#[path]`-included by both binaries):
  - `with_cleanup_label(request)` tags a container request with `io.helios.persistence.test-owner=<pid>-<nanos>`.
  - A `#[ctor::dtor]` hook runs `docker rm -f` on containers carrying that label when the process exits. It is skipped if the process never requested a container.
- This is the same exit-hook approach as `crates/hts/tests`, but the label value is unique per process, so concurrent test binaries on one Docker host don't remove each other's containers.
- Wrapped the ES container in `elasticsearch_tests.rs`, and both the MinIO and ES containers in `s3_es_tests.rs`.
- Added `ctor = "0.2"` to `helios-persistence` dev-dependencies (already in `Cargo.lock` via `helios-hts`).

## Testing

- `cargo clippy -p helios-persistence --features elasticsearch,s3 --test elasticsearch_tests --test s3_es_tests` with the CI flags: clean. `rustfmt --check`: clean.
- `elasticsearch_tests -- es_integration_cursor_paging`: 2 passed. Docker events show the labeled container created, then destroyed at process exit. No leftover containers.
- `RUN_MINIO_S3_ES_TESTS=1 MINIO_TAG=latest s3_es_tests`: 11 passed. No leftover ES or MinIO containers.

## Notes

- **Default MinIO tag no longer pulls:** `minio/minio:RELEASE.2025-02-28T09-55-16Z` currently fails with `pull access denied`, so `s3_es_tests` fails at container start unless `MINIO_TAG` is overridden. This predates this PR and is not changed here.
- **Other suites still leak the same way:** `postgres_tests`, `mongodb_tests`, `minio_s3_tests`, `sof_pg_runner`, and the PG/Mongo tests in `crates/rest`. They can adopt `with_cleanup_label` in a follow-up.

https://claude.ai/code/session_015mXkHsUPVvBRqgJ7QEuH3c
