### PR TITLE
bulk-submit(postgres): batch post-import reindex pages

### DIFF
--- a/MANUAL_TESTING_MATRIX.md
+++ b/MANUAL_TESTING_MATRIX.md
@@ -343,6 +343,10 @@ references; 6.4 gives the exact messages. On `s3`/`s3-es` run 6.2 and 6.4 only.
 
 ## 7. T3 — Import the Synthea corpus from the Import page
 
+For issue #1086 development measurements, use the bounded 2,000-resource
+[PostgreSQL reindex benchmark](docs/postgres-reindex-benchmark.md). That protocol
+does not replace this full-corpus release-matrix test or change its pass criteria.
+
 The corpus is a Bulk Data export of 11,704 Synthea patients (18,955,865 resources in
 24 NDJSON files) plus a `manifest.json` that references those files at
 `http://localhost:8000/…`. HFS ingests it with the Bulk Data `$bulk-submit`

--- a/crates/hfs/tests/bulk_submit/measure_memory.py
+++ b/crates/hfs/tests/bulk_submit/measure_memory.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Bulk-submit memory benchmark controller for issue #995 (current HEAD).
+"""Bulk-submit benchmark controller for issues #995 and #1086.
 
 Drives the release ``hfs`` binary natively on macOS against a dedicated
 PostgreSQL container the caller owns, and records **external** observations
 only: HFS RSS from ``ps`` every 0.5 s, host memory pressure/swap/compressor
 vitals every 5 s, PostgreSQL state through ``docker exec <container> psql``,
-and HTTP phase markers with the raw responses behind them.  The server is
-never instrumented and no internal phase is claimed; see
-``MEMORY_MEASUREMENT.md`` next to this file for the protocol.
+and HTTP phase markers with the raw responses behind them. The optional
+``--postgres-reindex-evidence`` profile also captures the opt-in HFS phase
+summary, PostgreSQL activity deltas, and representative cursor plans required
+by the bounded #1086 protocol. See ``MEMORY_MEASUREMENT.md`` beside this file
+for #995 and ``docs/postgres-reindex-benchmark.md`` for #1086.
 
 A successful attempt requires the deferred reindex to be positively verified:
 the ``deferred-index rebuild started job_id=...`` log line, ``$reindex-status``
@@ -47,7 +49,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+ISSUE_1086_DEFAULT_RESOURCES = 2000
+ISSUE_1086_MAX_RESOURCES = 10_000
 TENANT = "default"
 FAMILY = "Pilot995"
 MRN_SYSTEM = "http://helios.example/mrn"
@@ -78,6 +82,32 @@ HFS_ENV_BASE = {
 }
 
 
+def effective_hfs_env(
+    args: argparse.Namespace, base_url: str, output_dir: Path
+) -> dict[str, str]:
+    """Build the measured HFS environment, with caller overrides applied last."""
+    env = dict(HFS_ENV_BASE)
+    env["HFS_BASE_URL"] = base_url
+    env["HFS_SERVER_HOST"] = args.host
+    env["HFS_SERVER_PORT"] = str(args.hfs_port)
+    env["HFS_LOG_LEVEL"] = args.hfs_log_level
+    env["HFS_BULK_SUBMIT_FILE_CONCURRENCY"] = str(args.file_concurrency)
+    env["HFS_BULK_SUBMIT_DEFER_INDEXING"] = (
+        "true" if args.defer_indexing else "false"
+    )
+    env["HFS_BULK_SUBMIT_OUTPUT_BACKEND"] = "local-fs"
+    env["HFS_BULK_SUBMIT_OUTPUT_DIR"] = str(output_dir / "artifacts")
+    if args.postgres_reindex_evidence:
+        env["HFS_PERF_PHASES"] = "1"
+        # EnvFilter target directives match prefixes. Without the more-specific
+        # override, `hfs=warn` also suppresses the `hfs_perf` INFO summary.
+        env["RUST_LOG"] = "info,hfs=warn,hfs_perf=info"
+    for item in args.hfs_env:
+        key, _, value = item.partition("=")
+        env[key.strip()] = value
+    return env
+
+
 # --------------------------------------------------------------------------
 # utilities
 # --------------------------------------------------------------------------
@@ -85,6 +115,19 @@ HFS_ENV_BASE = {
 
 def iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def parse_reindex_start_log_timestamp(line: str) -> Optional[datetime]:
+    """Parse the RFC3339 prefix from a deferred-reindex start log line."""
+    if "deferred-index rebuild started" not in line:
+        return None
+    match = re.match(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s", line)
+    if not match:
+        return None
+    try:
+        return datetime.fromisoformat(match.group(1)[:-1] + "+00:00")
+    except ValueError:
+        return None
 
 
 def mono() -> float:
@@ -123,8 +166,62 @@ def db_url_parts(url: str) -> dict[str, Optional[str]]:
     }
 
 
-def run_capture(cmd: Iterable[str], timeout: float = 60.0) -> subprocess.CompletedProcess:
-    return subprocess.run(list(cmd), capture_output=True, text=True, timeout=timeout, check=False)
+def run_capture(
+    cmd: Iterable[str], timeout: float = 60.0, cwd: Optional[Path] = None
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        list(cmd), capture_output=True, text=True, timeout=timeout, check=False, cwd=cwd
+    )
+
+
+def source_fingerprint(repo_root: Path) -> dict[str, Any]:
+    """Hash HEAD, every tracked change, and every untracked file."""
+
+    def git(*args: str) -> str:
+        result = run_capture(["git", *args], timeout=60, cwd=repo_root)
+        if result.returncode != 0:
+            raise ConfigError(
+                f"git {' '.join(args)} failed in {repo_root}: {result.stderr.strip()[:300]}"
+            )
+        return result.stdout
+
+    head = git("rev-parse", "HEAD").strip()
+    branch = git("rev-parse", "--abbrev-ref", "HEAD").strip()
+    tracked_diff = git("diff", "--binary", "HEAD", "--", ".").encode("utf-8")
+    untracked_paths = sorted(
+        path for path in git("ls-files", "--others", "--exclude-standard", "-z").split("\0") if path
+    )
+    untracked: list[dict[str, Any]] = []
+    digest = hashlib.sha256()
+    digest.update(b"hfs-source-fingerprint-v1\0")
+    digest.update(head.encode("ascii"))
+    digest.update(b"\0tracked-diff\0")
+    digest.update(tracked_diff)
+    for relative in untracked_paths:
+        path = repo_root / relative
+        content = os.readlink(path).encode("utf-8") if path.is_symlink() else path.read_bytes()
+        encoded_path = relative.encode("utf-8")
+        digest.update(b"\0untracked\0")
+        digest.update(len(encoded_path).to_bytes(8, "big"))
+        digest.update(encoded_path)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+        untracked.append(
+            {
+                "path": relative,
+                "bytes": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+        )
+    return {
+        "head": head,
+        "branch": branch,
+        "dirty": bool(tracked_diff or untracked),
+        "tracked_diff_bytes": len(tracked_diff),
+        "tracked_diff_sha256": hashlib.sha256(tracked_diff).hexdigest(),
+        "untracked": untracked,
+        "fingerprint_sha256": digest.hexdigest(),
+    }
 
 
 def pgrep_count(name: str) -> int:
@@ -286,6 +383,120 @@ def _json_array_length(path: Path) -> Optional[int]:
     if isinstance(payload, dict) and isinstance(payload.get("entry"), list):
         return len(payload["entry"])
     return None
+
+
+def numeric_delta(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    """Subtract numeric PostgreSQL counters while retaining unsupported fields."""
+    delta: dict[str, Any] = {}
+    for key in sorted(set(before) | set(after)):
+        old, new = before.get(key), after.get(key)
+        if isinstance(old, (int, float)) and isinstance(new, (int, float)):
+            delta[key] = new - old
+        else:
+            delta[key] = None
+    return delta
+
+
+def postgres_activity_intervals(
+    before_kickoff: dict[str, Any],
+    polling_observed_terminal: dict[str, Any],
+    verified_search_ready: dict[str, Any],
+) -> dict[str, Any]:
+    """Build honestly labelled deltas around the observable reindex boundaries."""
+    whole_delta = numeric_delta(before_kickoff, verified_search_ready)
+    return {
+        # Keep the original before/after/delta fields for existing consumers.
+        "before": before_kickoff,
+        "polling_observed_terminal": polling_observed_terminal,
+        "after": verified_search_ready,
+        "delta": whole_delta,
+        "interval_deltas": {
+            "kickoff_to_terminal": numeric_delta(
+                before_kickoff, polling_observed_terminal
+            ),
+            "observed_terminal_to_search_ready": numeric_delta(
+                polling_observed_terminal, verified_search_ready
+            ),
+            "kickoff_to_search_ready": whole_delta,
+        },
+        "attribution": {
+            "terminal_boundary": (
+                "Observed after terminal-manifest polling and validation; it may include a small "
+                "amount of reindex work that started before the snapshot."
+            ),
+            "search_ready_boundary": (
+                "Observed after status and SQL readiness probes; interval deltas include those "
+                "measurement queries and are not exact DB-only reindex attribution."
+            ),
+            "counter_scope": (
+                "Database and WAL counters can include other sessions; use a dedicated PostgreSQL "
+                "container with one benchmark job at a time."
+            ),
+        },
+    }
+
+
+def postgres_reindex_comparability_reasons(
+    attempt: dict[str, Any],
+    preflight: dict[str, Any],
+    fixture: dict[str, Any],
+    hfs_samples: int,
+    postgres_samples: int,
+    require_phase_summary: bool,
+) -> list[str]:
+    """Return missing #1086 evidence without changing functional validation."""
+    reasons: list[str] = []
+    git = preflight.get("git") or {}
+    postgres = preflight.get("postgres") or {}
+    reindex = attempt.get("reindex") or {}
+    work = attempt.get("postgres_work") or {}
+    plans = attempt.get("cursor_plans") or []
+    intervals = work.get("interval_deltas") or {}
+    if not (preflight.get("binary") or {}).get("sha256"):
+        reasons.append("missing binary fingerprint")
+    if not (preflight.get("controller") or {}).get("sha256"):
+        reasons.append("missing controller fingerprint")
+    if not preflight.get("host"):
+        reasons.append("missing host metadata")
+    if not git.get("fingerprint_sha256"):
+        reasons.append("missing full source fingerprint")
+    if not git.get("fingerprint_verified"):
+        reasons.append("source fingerprint was not bound to the expected value")
+    if not postgres.get("image_id"):
+        reasons.append("missing immutable PostgreSQL image ID")
+    if not (postgres.get("server") or {}).get("version"):
+        reasons.append("missing PostgreSQL server version")
+    if not fixture.get("corpus_sha256"):
+        reasons.append("missing corpus fingerprint")
+    if not all(
+        isinstance(work.get(key), dict)
+        for key in ("before", "polling_observed_terminal", "after", "delta")
+    ):
+        reasons.append("missing PostgreSQL activity boundary snapshots")
+    if not all(
+        key in intervals
+        for key in (
+            "kickoff_to_terminal",
+            "observed_terminal_to_search_ready",
+            "kickoff_to_search_ready",
+        )
+    ):
+        reasons.append("missing PostgreSQL activity interval deltas")
+    if reindex.get("start_log_to_completion_observed_interval_s") is None:
+        reasons.append("missing reindex start-log to completion-observation interval")
+    if len(plans) != 3 or {plan.get("label") for plan in plans} != {
+        "early",
+        "middle",
+        "late",
+    } or not all(plan.get("ok") and plan.get("plan") is not None for plan in plans):
+        reasons.append("expected three parsed cursor plans")
+    if require_phase_summary and not reindex.get("phase_summary_available"):
+        reasons.append("required correlated phase summary is missing")
+    if hfs_samples < 1:
+        reasons.append("missing HFS memory sample between kickoff and search readiness")
+    if postgres_samples < 1:
+        reasons.append("missing PostgreSQL memory sample between kickoff and search readiness")
+    return reasons
 
 
 # --------------------------------------------------------------------------
@@ -553,6 +764,89 @@ class PgClient:
             else:
                 flat[key] = number
         return {"counts": flat, "version_spread": version_spread, "history_spread": history_spread}
+
+    def server_info(self) -> dict[str, Any]:
+        rows = self.require(
+            "SELECT current_setting('server_version'), current_setting('server_version_num'), "
+            "pg_size_pretty(pg_database_size(current_database()));"
+        )
+        return {
+            "version": rows[0][0],
+            "version_num": rows[0][1],
+            "database_size": rows[0][2],
+        }
+
+    def activity_snapshot(self) -> dict[str, Any]:
+        names = [
+            "xact_commit", "xact_rollback", "blks_read", "blks_hit",
+            "tup_returned", "tup_fetched", "tup_inserted", "tup_updated",
+            "tup_deleted", "temp_files", "temp_bytes", "wal_bytes",
+        ]
+        rows = self.require(
+            "SELECT xact_commit::text, xact_rollback::text, blks_read::text, blks_hit::text, "
+            "tup_returned::text, tup_fetched::text, tup_inserted::text, tup_updated::text, "
+            "tup_deleted::text, temp_files::text, temp_bytes::text, "
+            "pg_wal_lsn_diff(pg_current_wal_lsn(), '0/0')::text "
+            "FROM pg_stat_database WHERE datname = current_database();"
+        )
+        if not rows:
+            raise PgError("pg_stat_database returned no row for current database")
+        values: dict[str, Any] = {}
+        for name, raw in zip(names, rows[0]):
+            try:
+                values[name] = int(raw)
+            except ValueError:
+                values[name] = float(raw)
+        return values
+
+    def reindex_cursor_plans(self, total: int, analyze: bool = False) -> list[dict[str, Any]]:
+        offsets = [("early", None), ("middle", max(0, total // 2 - 1)), ("late", max(0, total - 101))]
+        plans: list[dict[str, Any]] = []
+        prefix = (
+            "EXPLAIN (ANALYZE, BUFFERS, WAL, SETTINGS, FORMAT JSON)"
+            if analyze
+            else "EXPLAIN (SETTINGS, FORMAT JSON)"
+        )
+        for label, offset in offsets:
+            cursor = None
+            predicate = ""
+            if offset is not None:
+                rows = self.require(
+                    "SELECT last_updated::text, id FROM resources "
+                    f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient' "
+                    f"AND is_deleted = FALSE ORDER BY last_updated, id OFFSET {offset} LIMIT 1;"
+                )
+                if not rows:
+                    plans.append({"label": label, "error": "cursor row not found"})
+                    continue
+                cursor = {"last_updated": rows[0][0], "id": rows[0][1]}
+                timestamp = cursor["last_updated"].replace("'", "''")
+                resource_id = cursor["id"].replace("'", "''")
+                predicate = (
+                    f" AND (last_updated > '{timestamp}'::timestamptz OR "
+                    f"(last_updated = '{timestamp}'::timestamptz AND id > '{resource_id}'))"
+                )
+            sql = (
+                f"{prefix} SELECT id, version_id, data, last_updated, fhir_version FROM resources "
+                f"WHERE tenant_id = '{TENANT}' AND resource_type = 'Patient' "
+                f"AND is_deleted = FALSE{predicate} ORDER BY last_updated ASC, id ASC LIMIT 100;"
+            )
+            result = self.psql(sql, timeout=300)
+            raw = "\n".join(row[0] for row in result["rows"] if row)
+            try:
+                plan = json.loads(raw) if result["ok"] else None
+            except json.JSONDecodeError:
+                plan = None
+            plans.append({
+                "label": label,
+                "cursor": cursor,
+                "analyze": analyze,
+                "ok": result["ok"] and plan is not None,
+                "plan": plan,
+                "raw": None if plan is not None else raw,
+                "error": result["error"],
+            })
+        return plans
 
     def detail(self, resource_ids: list[str], submission_id: str) -> dict[str, Any]:
         """Versions, history and receipt bookkeeping.  Never SELECT * on changes."""
@@ -878,6 +1172,7 @@ class Controller:
         self.checks: list[dict[str, Any]] = []
         self.attempts: list[dict[str, Any]] = []
         self.rss_rows: list[dict[str, Any]] = []
+        self.docker_rows: list[dict[str, Any]] = []
         self.preflight_info: dict[str, Any] = {}
         self.fixture_info: dict[str, Any] = {}
         self.current_attempt: Optional[dict[str, Any]] = None
@@ -984,6 +1279,9 @@ class Controller:
                 "files": files,
                 "total": sum(entry["count"] for entry in files),
                 "total_bytes": sum(entry["bytes"] for entry in files),
+                "corpus_sha256": hashlib.sha256(
+                    "".join(entry["sha256"] for entry in files).encode("ascii")
+                ).hexdigest(),
                 "scheme": "identical resources re-submitted with stable ids (reimports)",
             }
         manifest_path = self.fixtures_dir / f"manifest-{job:02d}.json"
@@ -1217,6 +1515,7 @@ class Controller:
             )
         if self.csv_docker:
             self.csv_docker.write(row)
+        self.docker_rows.append(row)
 
     def check_deadline(self) -> None:
         if self.args.deadline > 0 and mono() > self.deadline_mono:
@@ -1299,18 +1598,13 @@ class Controller:
                 "cargo": pgrep_count("cargo"),
             },
         }
-        for key, cmd in (
-            ("head", ["git", "rev-parse", "HEAD"]),
-            ("branch", ["git", "rev-parse", "--abbrev-ref", "HEAD"]),
-        ):
-            try:
-                info["git"][key] = run_capture(cmd, timeout=20).stdout.strip()
-            except Exception as exc:
-                info["git"][key] = f"error: {exc}"
-        try:
-            info["git"]["dirty"] = bool(run_capture(["git", "status", "--porcelain"], timeout=30).stdout.strip())
-        except Exception:
-            info["git"]["dirty"] = None
+        info["git"] = source_fingerprint(self.repo_root)
+        info["git"]["expected_fingerprint"] = self.args.expected_source_fingerprint
+        info["git"]["fingerprint_verified"] = bool(
+            self.args.expected_source_fingerprint
+            and info["git"]["fingerprint_sha256"]
+            == self.args.expected_source_fingerprint
+        )
         try:
             info["host"] = {
                 "macos": run_capture(["sw_vers", "-productVersion"], timeout=20).stdout.strip(),
@@ -1328,6 +1622,7 @@ class Controller:
                 f"psql is not usable inside container {self.args.pg_container!r}; "
                 "the deferred-reindex verdict requires SQL coverage probes"
             )
+        info["postgres"]["server"] = self.pg.server_info()
         info["db_before"] = self.pg.counts()
 
         samples = []
@@ -1353,6 +1648,15 @@ class Controller:
         }
 
         blocked: list[str] = []
+        expected_fingerprint = self.args.expected_source_fingerprint
+        if (
+            expected_fingerprint
+            and info["git"]["fingerprint_sha256"] != expected_fingerprint
+        ):
+            blocked.append(
+                "source fingerprint mismatch: "
+                f"expected {expected_fingerprint}, got {info['git']['fingerprint_sha256']}"
+            )
         counts = info["db_before"]["counts"]
         stale = {
             key: counts[key]
@@ -1365,6 +1669,8 @@ class Controller:
             blocked.append(f"another hfs process is running ({info['foreign_processes']['hfs']})")
         if info["foreign_processes"]["rustc"]:
             blocked.append(f"a rustc build is active ({info['foreign_processes']['rustc']} processes)")
+        if info["foreign_processes"]["cargo"]:
+            blocked.append(f"a cargo build is active ({info['foreign_processes']['cargo']} processes)")
         recent = [s["pressure_level"] for s in samples[-3:]]
         if recent and all(level is not None and level != 1 for level in recent):
             blocked.append(f"memory pressure is not normal: {recent}")
@@ -1397,6 +1703,7 @@ class Controller:
             "container": self.args.pg_container,
             "id": payload.get("Id"),
             "image": (payload.get("Config") or {}).get("Image"),
+            "image_id": payload.get("Image"),
             "running": state.get("Running"),
             "started_at": state.get("StartedAt"),
             "memory_limit_mib": _mib(host_config.get("Memory")),
@@ -1409,19 +1716,7 @@ class Controller:
     # -- HFS lifecycle ----------------------------------------------------
 
     def effective_env(self) -> dict[str, str]:
-        env = dict(HFS_ENV_BASE)
-        env["HFS_BASE_URL"] = self.base_url
-        env["HFS_SERVER_HOST"] = self.args.host
-        env["HFS_SERVER_PORT"] = str(self.args.hfs_port)
-        env["HFS_LOG_LEVEL"] = self.args.hfs_log_level
-        env["HFS_BULK_SUBMIT_FILE_CONCURRENCY"] = str(self.args.file_concurrency)
-        env["HFS_BULK_SUBMIT_DEFER_INDEXING"] = "true" if self.args.defer_indexing else "false"
-        env["HFS_BULK_SUBMIT_OUTPUT_BACKEND"] = "local-fs"
-        env["HFS_BULK_SUBMIT_OUTPUT_DIR"] = str(self.out / "artifacts")
-        for item in self.args.hfs_env:
-            key, _, value = item.partition("=")
-            env[key.strip()] = value
-        return env
+        return effective_hfs_env(self.args, self.base_url, self.out)
 
     def start_hfs(self, job: int) -> None:
         # An unrelated shell's HFS settings must not change this experiment.
@@ -1703,6 +1998,7 @@ class Controller:
         if self.args.defer_indexing:
             deadline = mono() + self.args.reindex_timeout
             job_id = None
+            start_log_timestamp = None
             lines: list[str] = []
             while job_id is None:
                 self.raise_if_aborted()
@@ -1736,9 +2032,21 @@ class Controller:
                             {"job_ids": sorted(ids), "hook_lines": hooks[-3:]},
                         )
                     job_id = ids.pop()
+                    correlated_start_lines = [
+                        line for line in started if job_id in line
+                    ]
+                    start_log_timestamp = parse_reindex_start_log_timestamp(
+                        correlated_start_lines[-1]
+                    )
                 time.sleep(min(1.0, self.args.endpoint_poll_interval))
             evidence["job_id"] = job_id
             evidence["job_id_source"] = "hfs log line 'deferred-index rebuild started' after kickoff"
+            evidence["start_log_timestamp"] = (
+                start_log_timestamp.isoformat().replace("+00:00", "Z")
+                if start_log_timestamp
+                else None
+            )
+            evidence["status_poll_resolution_s"] = self.args.endpoint_poll_interval
             status_deadline = mono() + self.args.reindex_timeout
             status_polls: list[dict[str, Any]] = []
             while True:
@@ -1746,22 +2054,36 @@ class Controller:
                 result = http_json("GET", f"{self.base_url}/$reindex-status/{job_id}", timeout=60)
                 params = parameters_map(result["json"]) if result["status"] == 200 else {}
                 status_polls.append(
-                    {"status": result["status"], "reindex": params.get("status"), "at_s": round(mono() - kickoff_mono, 1)}
+                    {"status": result["status"], "reindex": params.get("status"), "at_s": round(mono() - kickoff_mono, 3)}
                 )
                 if params.get("status") in ("completed", "failed", "cancelled"):
+                    completion_observed_wall = datetime.now(timezone.utc)
                     break
                 if mono() > status_deadline:
                     raise Aborted(
                         "reindex_timeout",
                         {"polls": status_polls[-10:], "evidence": evidence},
                     )
-                time.sleep(max(0.5, self.args.endpoint_poll_interval))
+                time.sleep(max(0.05, self.args.endpoint_poll_interval))
             evidence["status_polls"] = status_polls[-10:]
             evidence["status"] = params.get("status")
             evidence["total"] = params.get("total")
             evidence["processed"] = params.get("processed")
             evidence["entries_created"] = params.get("entriesCreated")
             evidence["error_count"] = params.get("errorCount")
+            evidence["completion_observed_wall"] = completion_observed_wall.isoformat(
+                timespec="milliseconds"
+            ).replace("+00:00", "Z")
+            upper_bound = (
+                (completion_observed_wall - start_log_timestamp).total_seconds()
+                if start_log_timestamp
+                else None
+            )
+            evidence["start_log_to_completion_observed_interval_s"] = (
+                round(upper_bound, 3)
+                if upper_bound is not None and upper_bound >= 0
+                else None
+            )
             if (
                 params.get("status") != "completed"
                 or params.get("errorCount") != 0
@@ -1778,11 +2100,42 @@ class Controller:
         indexed_total = self.search_count(f"family={FAMILY}")
         evidence["search_total_family"] = indexed_total
         evidence["unindexed_patients"] = unindexed
-        evidence["reindex_s"] = round(mono() - kickoff_mono, 3)
         if unindexed != 0:
             raise Aborted("reindex_coverage_incomplete", {"evidence": evidence})
         if indexed_total != total:
             raise Aborted("search_index_count_mismatch", {"evidence": evidence})
+        ready_mono = mono()
+        evidence["reindex_s"] = round(ready_mono - kickoff_mono, 3)
+        evidence["search_ready_observed_mono"] = ready_mono
+        if self.args.postgres_reindex_evidence:
+            try:
+                evidence["postgres_activity_at_search_ready"] = self.pg.activity_snapshot()
+            except Exception as error:
+                evidence["postgres_activity_at_search_ready"] = None
+                evidence["postgres_activity_at_search_ready_error"] = str(error)
+        if self.args.defer_indexing:
+            # Search readiness and its database snapshot are already fixed.
+            # Waiting for buffered log output must not inflate either metric.
+            summary_wait_started = mono()
+            summary_deadline = summary_wait_started + 5.0
+            summary_lines: list[str] = []
+            while mono() <= summary_deadline:
+                lines.extend(self.follower.read_new())
+                summary_lines = [
+                    line
+                    for line in lines
+                    if "reindex phase summary" in line and job_id in line
+                ][-3:]
+                if summary_lines:
+                    break
+                time.sleep(0.05)
+            evidence["phase_summary_wait_limit_s"] = 5.0
+            evidence["phase_summary_wait_elapsed_s"] = round(
+                mono() - summary_wait_started, 3
+            )
+            evidence["phase_summary_required"] = bool(self.args.require_phase_summary)
+            evidence["phase_summary_lines"] = summary_lines
+            evidence["phase_summary_available"] = bool(evidence["phase_summary_lines"])
         evidence["verified"] = True
         self.jsonl_pg.write({"phase": "reindex_verified", "job": job, **evidence})
         return evidence
@@ -2015,6 +2368,8 @@ class Controller:
             "status": "running",
             "timings": {"label": "incomplete", "comparable": False},
             "throughput_resources_per_s": None,
+            "throughput_to_publication_resources_per_s": None,
+            "throughput_to_verified_search_ready_resources_per_s": None,
         }
         self.current_attempt = attempt
         self.attempts.append(attempt)
@@ -2030,6 +2385,17 @@ class Controller:
                 "manifest": str(Path(manifest_url).name),
             },
         )
+        if self.args.postgres_reindex_evidence:
+            attempt["postgres_work"] = {
+                "before_kickoff": None,
+                "measurement_errors": [],
+            }
+            try:
+                attempt["postgres_work"]["before_kickoff"] = self.pg.activity_snapshot()
+            except Exception as error:
+                attempt["postgres_work"]["measurement_errors"].append(
+                    {"boundary": "before_kickoff", "error": str(error)}
+                )
         log_offset = self.follower.seek_end()
         self.phase("kickoff", job, {"submission_id": submission_id})
         kickoff_mono = mono()
@@ -2085,6 +2451,18 @@ class Controller:
             "transaction_time": (terminal["manifest"] or {}).get("transactionTime"),
             "requires_access_token": (terminal["manifest"] or {}).get("requiresAccessToken"),
         }
+        if self.args.postgres_reindex_evidence:
+            # This is the earliest safe boundary after the polled terminal
+            # manifest and its hard invariants have been validated.
+            try:
+                attempt["postgres_work"]["polling_observed_terminal"] = (
+                    self.pg.activity_snapshot()
+                )
+            except Exception as error:
+                attempt["postgres_work"]["polling_observed_terminal"] = None
+                attempt["postgres_work"]["measurement_errors"].append(
+                    {"boundary": "polling_observed_terminal", "error": str(error)}
+                )
         reindex = self.verify_reindex(job, submission_id, log_offset, kickoff_mono)
         self.phase("reindex_terminal", job, {
             "job_id": reindex.get("job_id"), "verified": reindex["verified"],
@@ -2092,6 +2470,67 @@ class Controller:
         })
         attempt["reindex"] = reindex
         attempt["timings"]["kickoff_to_reindex_s"] = reindex["reindex_s"]
+        attempt["timings"]["terminal_to_reindex_s"] = round(
+            reindex["reindex_s"] - terminal["terminal_s"], 3
+        )
+        attempt["timings"]["observed_terminal_to_search_ready_s"] = attempt[
+            "timings"
+        ]["terminal_to_reindex_s"]
+        attempt["timings"]["kickoff_to_verified_search_ready_s"] = reindex[
+            "reindex_s"
+        ]
+        if self.args.postgres_reindex_evidence:
+            work = attempt["postgres_work"]
+            ready_snapshot = reindex.get("postgres_activity_at_search_ready")
+            if ready_snapshot is None:
+                work["measurement_errors"].append(
+                    {
+                        "boundary": "verified_search_ready",
+                        "error": reindex.get("postgres_activity_at_search_ready_error")
+                        or "snapshot unavailable",
+                    }
+                )
+            if all(
+                isinstance(snapshot, dict)
+                for snapshot in (
+                    work.get("before_kickoff"),
+                    work.get("polling_observed_terminal"),
+                    ready_snapshot,
+                )
+            ):
+                completed_work = postgres_activity_intervals(
+                    work["before_kickoff"],
+                    work["polling_observed_terminal"],
+                    ready_snapshot,
+                )
+                completed_work["measurement_errors"] = work["measurement_errors"]
+                attempt["postgres_work"] = completed_work
+            else:
+                attempt["postgres_work"] = {
+                    "before": work.get("before_kickoff"),
+                    "polling_observed_terminal": work.get(
+                        "polling_observed_terminal"
+                    ),
+                    "after": ready_snapshot,
+                    "delta": None,
+                    "interval_deltas": {},
+                    "measurement_errors": work["measurement_errors"],
+                }
+            try:
+                attempt["cursor_plans"] = self.pg.reindex_cursor_plans(
+                    total, analyze=self.args.explain_analyze
+                )
+            except Exception as error:
+                attempt["cursor_plans"] = []
+                attempt["cursor_plan_error"] = str(error)
+            self.write_json(
+                f"jobs/job{job:02d}/postgres-reindex-evidence.json",
+                {
+                    "postgres_work": attempt["postgres_work"],
+                    "cursor_plans": attempt["cursor_plans"],
+                    "phase_summary_lines": reindex.get("phase_summary_lines", []),
+                },
+            )
         self.write_json(f"jobs/job{job:02d}/reindex.json", reindex)
         idle_end = self.idle(job)
         validation = self.validate_job(job, submission_id, terminal["output"])
@@ -2111,18 +2550,91 @@ class Controller:
         attempt["rss"] = self.rss_stats(job, kickoff_mono, idle_end, baseline["rss_mib"])
         if self.args.mode == "restart":
             self.stop_hfs(job, "job_complete")
-        self.write_summary()
         # A failed validation stops the run: the next job would build on an
         # unverified database state.
         if attempt["validation"]["failed_hard"]:
             attempt["status"] = "failed"
+            self.write_summary()
             raise Aborted(
                 "hard_validation_failed",
                 {"job": job, "checks": attempt["validation"]["failed_hard"]},
             )
-        attempt["timings"].update({"label": "complete", "comparable": True, "verified": True})
+        ready_mono = reindex["search_ready_observed_mono"]
+        hfs_memory_values = [
+            row["rss_mib"]
+            for row in self.rss_rows
+            if row.get("job") == job
+            and kickoff_mono <= row["mono_s"] <= ready_mono
+            and row.get("rss_mib") is not None
+        ]
+        postgres_memory_values = [
+            row["mem_usage_mib"]
+            for row in self.docker_rows
+            if row.get("job") == job
+            and kickoff_mono <= row["mono_s"] <= ready_mono
+            and row.get("mem_usage_mib") is not None
+        ]
+        hfs_samples = len(hfs_memory_values)
+        postgres_samples = len(postgres_memory_values)
+        attempt["evidence_sample_counts"] = {
+            "hfs_memory_kickoff_to_search_ready": hfs_samples,
+            "postgres_memory_kickoff_to_search_ready": postgres_samples,
+        }
+        attempt["hfs_memory_kickoff_to_search_ready"] = {
+            "samples": hfs_samples,
+            "peak_mib": max(hfs_memory_values) if hfs_memory_values else None,
+        }
+        attempt["postgres_memory_kickoff_to_search_ready"] = {
+            "samples": postgres_samples,
+            "peak_mib": max(postgres_memory_values) if postgres_memory_values else None,
+        }
+        comparison_reasons = (
+            postgres_reindex_comparability_reasons(
+                attempt,
+                self.preflight_info,
+                self.fixture_info,
+                hfs_samples,
+                postgres_samples,
+                self.args.require_phase_summary,
+            )
+            if self.args.postgres_reindex_evidence
+            else []
+        )
+        attempt["timings"].update(
+            {
+                "label": "complete",
+                "comparable": not comparison_reasons,
+                "comparison_reasons": comparison_reasons,
+                "verified": True,
+            }
+        )
         attempt["status"] = "verified"
-        attempt["throughput_resources_per_s"] = round(total / max(terminal["terminal_s"], 0.001), 3)
+        publication_throughput = round(total / max(terminal["terminal_s"], 0.001), 3)
+        readiness_throughput = round(total / max(reindex["reindex_s"], 0.001), 3)
+        attempt["throughput_to_publication_resources_per_s"] = publication_throughput
+        attempt["throughput_to_verified_search_ready_resources_per_s"] = readiness_throughput
+        # Compatibility alias: this historically meant terminal publication.
+        attempt["throughput_resources_per_s"] = publication_throughput
+        if self.args.postgres_reindex_evidence:
+            self.write_json(
+                f"jobs/job{job:02d}/postgres-reindex-evidence.json",
+                {
+                    "postgres_work": attempt["postgres_work"],
+                    "cursor_plans": attempt["cursor_plans"],
+                    "phase_summary_lines": reindex.get("phase_summary_lines", []),
+                    "memory": {
+                        "hfs": attempt["hfs_memory_kickoff_to_search_ready"],
+                        "postgres": attempt[
+                            "postgres_memory_kickoff_to_search_ready"
+                        ],
+                    },
+                    "comparability": {
+                        "comparable": not comparison_reasons,
+                        "reasons": comparison_reasons,
+                    },
+                },
+            )
+        self.write_summary()
 
     def rss_stats(self, job: int, start: float, end: float, baseline: Optional[float]) -> dict[str, Any]:
         """Measured window is kickoff..idle_end; startup and validation are separate."""
@@ -2158,6 +2670,8 @@ class Controller:
         attempt["failure_reason"] = reason
         attempt["timings"].update({"label": "incomplete", "comparable": False, "verified": False})
         attempt["throughput_resources_per_s"] = None
+        attempt["throughput_to_publication_resources_per_s"] = None
+        attempt["throughput_to_verified_search_ready_resources_per_s"] = None
         attempt["rss"] = self.rss_stats(attempt["ordinal"], 0.0, float("inf"), None)
 
     def hard_failures(self) -> list[dict[str, Any]]:
@@ -2213,6 +2727,10 @@ class Controller:
                 "jobs": self.args.jobs,
                 "mode": self.args.mode,
                 "defer_indexing": bool(self.args.defer_indexing),
+                "postgres_reindex_evidence": bool(self.args.postgres_reindex_evidence),
+                "explain_analyze": bool(self.args.explain_analyze),
+                "require_phase_summary": bool(self.args.require_phase_summary),
+                "expected_source_fingerprint": self.args.expected_source_fingerprint,
                 "idle_seconds": self.args.idle_seconds,
                 "file_concurrency": self.args.file_concurrency,
                 "pg_container": self.args.pg_container,
@@ -2383,7 +2901,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--binary", required=True, help="release hfs binary (R4+postgres)")
     parser.add_argument("--output-dir", required=True, help="new, nonexistent output directory")
-    parser.add_argument("--resources", type=int, default=1000, help="Patients per submission")
+    parser.add_argument(
+        "--resources",
+        type=int,
+        help="Patients per submission (1000 normally, 2000 with --postgres-reindex-evidence)",
+    )
     parser.add_argument("--jobs", type=int, default=1, help="submissions in this run")
     parser.add_argument("--mode", choices=("consecutive", "restart"), default="consecutive")
     parser.add_argument(
@@ -2402,8 +2924,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--hfs-log-level", default="info")
     parser.add_argument("--sample-interval", type=float, default=0.5, help="HFS RSS cadence, seconds")
     parser.add_argument("--host-interval", type=float, default=5.0, help="host vitals cadence, seconds")
-    parser.add_argument("--docker-stats-interval", type=float, default=60.0, help="0 disables")
-    parser.add_argument("--endpoint-poll-interval", type=float, default=1.0)
+    parser.add_argument(
+        "--docker-stats-interval",
+        type=float,
+        help="0 disables; defaults to 1s for #1086 evidence and 60s otherwise",
+    )
+    parser.add_argument(
+        "--endpoint-poll-interval",
+        type=float,
+        help="defaults to 0.25s for #1086 evidence and 1s otherwise",
+    )
     parser.add_argument("--request-timeout", type=float, default=60.0)
     parser.add_argument("--startup-timeout", type=float, default=180.0)
     parser.add_argument("--terminal-timeout", type=float, default=3600.0)
@@ -2419,7 +2949,26 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--strict-validation", dest="strict_validation", action="store_true", default=True)
     parser.add_argument("--no-strict-validation", dest="strict_validation", action="store_false")
     parser.add_argument("--repo-root", help="checkout root containing data/ (default: derived)")
+    parser.add_argument(
+        "--expected-source-fingerprint",
+        help="reject a run if repo-root no longer matches this full source fingerprint",
+    )
     parser.add_argument("--hfs-env", action="append", default=[], metavar="KEY=VALUE")
+    parser.add_argument(
+        "--postgres-reindex-evidence",
+        action="store_true",
+        help="capture the bounded #1086 phase, PostgreSQL delta, and cursor-plan evidence",
+    )
+    parser.add_argument(
+        "--explain-analyze",
+        action="store_true",
+        help="execute the bounded SELECT cursor probes while collecting EXPLAIN plans",
+    )
+    parser.add_argument(
+        "--require-phase-summary",
+        action="store_true",
+        help="make missing correlated phase output a #1086 comparability failure",
+    )
     parser.add_argument("--dry-run", action="store_true", help="print the plan and exit")
     parser.add_argument("--quiet", action="store_true", help="do not echo controller events to stdout")
     return parser
@@ -2435,12 +2984,16 @@ def dry_run_plan(args: argparse.Namespace) -> dict[str, Any]:
     layout = [per_file] * FIXTURE_FILE_COUNT
     for _ in range(per_file * FIXTURE_FILE_COUNT, args.resources):
         layout[-1] += 1
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    base_url = f"http://{args.host}:{args.hfs_port}"
     return {
         "schema_version": SCHEMA_VERSION,
         "dry_run": True,
         "binary": str(Path(args.binary).expanduser().resolve()),
-        "output_dir": str(Path(args.output_dir).expanduser().resolve()),
+        "output_dir": str(output_dir),
         "repo_root": str(repo_root),
+        "source": source_fingerprint(repo_root),
+        "expected_source_fingerprint": args.expected_source_fingerprint,
         "search_parameters_file": str(repo_root / "data" / "search-parameters-r4.json"),
         "fixture": {
             "files": [
@@ -2454,8 +3007,16 @@ def dry_run_plan(args: argparse.Namespace) -> dict[str, Any]:
         "jobs": args.jobs,
         "mode": args.mode,
         "defer_indexing": bool(args.defer_indexing),
+        "postgres_reindex_evidence": bool(args.postgres_reindex_evidence),
+        "explain_analyze": bool(args.explain_analyze),
+        "require_phase_summary": bool(args.require_phase_summary),
+        "hfs_env": effective_hfs_env(args, base_url, output_dir),
         "database": redact_db_url(args.database_url),
         "pg_container": args.pg_container,
+        "sampling": {
+            "docker_stats_interval_s": args.docker_stats_interval,
+            "endpoint_poll_interval_s": args.endpoint_poll_interval,
+        },
         "watchdog": {
             "operational_max_rss_mib": args.operational_max_rss_mib,
             "pressure_samples": args.pressure_samples,
@@ -2469,6 +3030,7 @@ def dry_run_plan(args: argparse.Namespace) -> dict[str, Any]:
             "deferred reindex job id from the hfs log line, $reindex-status completed with errorCount=0 and processed=total",
             "SQL coverage: zero unindexed Patients, parameterised family search equals the expected total",
             "post-idle: version/history spread, content, entry_results receipts, submission changes",
+            "#1086 profile: PostgreSQL work interval deltas, early/middle/late cursor plans, opt-in phase summary",
         ],
     }
 
@@ -2476,8 +3038,29 @@ def dry_run_plan(args: argparse.Namespace) -> dict[str, Any]:
 def main(argv: Optional[list[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.resources is None:
+        args.resources = (
+            ISSUE_1086_DEFAULT_RESOURCES if args.postgres_reindex_evidence else 1000
+        )
+    if args.docker_stats_interval is None:
+        args.docker_stats_interval = 1.0 if args.postgres_reindex_evidence else 60.0
+    if args.endpoint_poll_interval is None:
+        args.endpoint_poll_interval = 0.25 if args.postgres_reindex_evidence else 1.0
     if args.resources < FIXTURE_FILE_COUNT:
         parser.error(f"--resources must be >= {FIXTURE_FILE_COUNT}")
+    if args.postgres_reindex_evidence and args.resources > ISSUE_1086_MAX_RESOURCES:
+        parser.error(
+            f"--resources must be <= {ISSUE_1086_MAX_RESOURCES} "
+            "with --postgres-reindex-evidence"
+        )
+    if args.postgres_reindex_evidence and not args.defer_indexing:
+        parser.error("--postgres-reindex-evidence requires --defer-indexing=true")
+    if args.require_phase_summary and not args.postgres_reindex_evidence:
+        parser.error("--require-phase-summary requires --postgres-reindex-evidence")
+    if args.expected_source_fingerprint and not re.fullmatch(
+        r"[0-9a-f]{64}", args.expected_source_fingerprint
+    ):
+        parser.error("--expected-source-fingerprint must be 64 lowercase hexadecimal characters")
     if args.jobs < 1:
         parser.error("--jobs must be >= 1")
     if args.file_concurrency < 1:
@@ -2487,7 +3070,16 @@ def main(argv: Optional[list[str]] = None) -> int:
     if args.pressure_samples < 1 or args.swap_growth_samples < 1:
         parser.error("--pressure-samples and --swap-growth-samples must be >= 1")
     if args.dry_run:
-        print(json.dumps(dry_run_plan(args), indent=2))
+        plan = dry_run_plan(args)
+        if (
+            args.expected_source_fingerprint
+            and plan["source"]["fingerprint_sha256"]
+            != args.expected_source_fingerprint
+        ):
+            parser.error(
+                "current source does not match --expected-source-fingerprint"
+            )
+        print(json.dumps(plan, indent=2))
         return EXIT_OK
     try:
         args.hfs_port = args.hfs_port or pick_free_port(18810, args.host)

--- a/crates/persistence/src/backends/postgres/cached.rs
+++ b/crates/persistence/src/backends/postgres/cached.rs
@@ -110,16 +110,19 @@
 //! made sargable-under-generic (the same treatment v34 gave the string
 //! predicate) before `auto` is safe to switch on.
 
-use deadpool_postgres::Client;
+use deadpool_postgres::{Client, GenericClient};
 use tokio_postgres::types::ToSql;
 use tokio_postgres::{Error, Row, Statement};
 
 /// `Client::execute` against the connection's cached prepared statement.
-pub(crate) async fn execute_cached(
-    client: &Client,
+pub(crate) async fn execute_cached<C>(
+    client: &C,
     sql: &str,
     params: &[&(dyn ToSql + Sync)],
-) -> Result<u64, Error> {
+) -> Result<u64, Error>
+where
+    C: GenericClient + ?Sized,
+{
     let statement = client.prepare_cached(sql).await?;
     client.execute(&statement, params).await
 }

--- a/crates/persistence/src/backends/postgres/search/writer.rs
+++ b/crates/persistence/src/backends/postgres/search/writer.rs
@@ -168,6 +168,13 @@ fn internal_error(message: String) -> crate::error::StorageError {
     })
 }
 
+fn postgres_error_message(error: &tokio_postgres::Error) -> String {
+    error.as_db_error().map_or_else(
+        || error.to_string(),
+        |db_error| db_error.message().to_string(),
+    )
+}
+
 /// Parses an extracted date value into the UTC timestamp stored in `value_date`.
 ///
 /// Returns `None` when the value cannot be parsed, so the caller can skip the
@@ -1200,7 +1207,10 @@ impl PostgresSearchIndexWriter {
             execute_cached(client, sql, &param_refs)
                 .await
                 .map_err(|e| {
-                    internal_error(format!("Failed to insert search index rows: {}", e))
+                    internal_error(format!(
+                        "Failed to insert search index rows: {}",
+                        postgres_error_message(&e)
+                    ))
                 })?;
         }
 
@@ -1220,11 +1230,14 @@ impl PostgresSearchIndexWriter {
     /// Chunked at [`MULTI_BATCH_ROWS`] so one caller's flush is normally one
     /// statement, and a single pathological resource (`Provenance.target` writes
     /// 1,626 rows) cannot make the arrays unbounded.
-    pub(crate) async fn insert_rows_multi(
-        client: &deadpool_postgres::Client,
+    pub(crate) async fn insert_rows_multi<C>(
+        client: &C,
         tenant_id: &str,
         batches: &[(&str, &str, &[IndexRow])],
-    ) -> StorageResult<()> {
+    ) -> StorageResult<()>
+    where
+        C: deadpool_postgres::GenericClient + ?Sized,
+    {
         let total: usize = batches.iter().map(|(_, _, rows)| rows.len()).sum();
         if total == 0 {
             return Ok(());
@@ -1263,7 +1276,10 @@ impl PostgresSearchIndexWriter {
             execute_cached(client, INSERT_SQL_MULTI.as_str(), &param_refs)
                 .await
                 .map_err(|e| {
-                    internal_error(format!("Failed to insert search index rows: {}", e))
+                    internal_error(format!(
+                        "Failed to insert search index rows: {}",
+                        postgres_error_message(&e)
+                    ))
                 })?;
         }
 

--- a/crates/persistence/src/backends/postgres/storage.rs
+++ b/crates/persistence/src/backends/postgres/storage.rs
@@ -1348,7 +1348,10 @@ impl PostgresBackend {
     /// instance is serving: the table is created by `initialize_schema` and
     /// only migrations touch it, both of which run at startup under an advisory
     /// lock before any request is accepted.
-    async fn fts_table_exists(&self, client: &deadpool_postgres::Client) -> StorageResult<bool> {
+    async fn fts_table_exists<C>(&self, client: &C) -> StorageResult<bool>
+    where
+        C: deadpool_postgres::GenericClient + ?Sized,
+    {
         if let Some(known) = self.fts_table_exists.get() {
             return Ok(*known);
         }
@@ -1430,14 +1433,17 @@ impl PostgresBackend {
     /// deliberately: the fix adds a `to_tsvector` per bundle entry, which is
     /// cost on the import path, and it belongs with a decision about the
     /// paragraph above rather than inside a performance change.
-    async fn index_fts_content(
+    async fn index_fts_content<C>(
         &self,
-        client: &deadpool_postgres::Client,
+        client: &C,
         tenant_id: &str,
         resource_type: &str,
         resource_id: &str,
         resource: &Value,
-    ) -> StorageResult<()> {
+    ) -> StorageResult<()>
+    where
+        C: deadpool_postgres::GenericClient + ?Sized,
+    {
         if !self.fts_table_exists(client).await? {
             return Ok(());
         }
@@ -1450,12 +1456,13 @@ impl PostgresBackend {
             // `resourceType`, so this is unreachable in practice, but if a
             // rewrite ever did empty a resource out, the previous row has to go
             // rather than survive as a stale match.
-            let _ = execute_cached(
-                    client,
-                    "DELETE FROM resource_fts WHERE tenant_id = $1 AND resource_type = $2 AND resource_id = $3",
-                    &[&tenant_id, &resource_type, &resource_id],
-                )
-                .await;
+            execute_cached(
+                client,
+                "DELETE FROM resource_fts WHERE tenant_id = $1 AND resource_type = $2 AND resource_id = $3",
+                &[&tenant_id, &resource_type, &resource_id],
+            )
+            .await
+            .map_err(|e| internal_error(format!("Failed to delete empty FTS index: {}", e)))?;
             return Ok(());
         }
 
@@ -1494,10 +1501,13 @@ impl PostgresBackend {
         // error surfaced as a 500 and the whole `POST` failed, so an entirely
         // valid resource could not be created at all.
         //
-        // Retry once against a truncated input instead. Nothing here runs
-        // inside an explicit transaction — the bundle path
-        // (`PostgresTransaction`) does not write `resource_fts` at all — so the
-        // failed statement leaves the session usable.
+        // Retry once against a truncated input instead. Ordinary resource
+        // writes run without an explicit transaction, so their session remains
+        // usable. A batched reindex calls this inside its managed page
+        // transaction; PostgreSQL aborts that transaction after this error, so
+        // the retry fails and the page writer rolls back and repeats each
+        // resource through the ordinary path. The bundle path
+        // (`PostgresTransaction`) does not write `resource_fts` at all.
         if err.code() != Some(&tokio_postgres::error::SqlState::PROGRAM_LIMIT_EXCEEDED) {
             return Err(internal_error(format!(
                 "Failed to insert FTS content: {}",
@@ -1577,14 +1587,34 @@ impl PostgresBackend {
             .map_err(|e| internal_error(format!("Failed to delete search index: {}", e)))?;
 
         // The full-text row goes with them.
-        let _ = execute_cached(
-                client,
-                "DELETE FROM resource_fts WHERE tenant_id = $1 AND resource_type = $2 AND resource_id = $3",
-                &[&tenant_id, &resource_type, &resource_id],
-            )
-            .await;
+        execute_cached(
+            client,
+            "DELETE FROM resource_fts WHERE tenant_id = $1 AND resource_type = $2 AND resource_id = $3",
+            &[&tenant_id, &resource_type, &resource_id],
+        )
+        .await
+        .map_err(|e| internal_error(format!("Failed to delete FTS index: {}", e)))?;
 
         Ok(deleted)
+    }
+
+    async fn write_reindex_page_individually(
+        &self,
+        tenant: &TenantContext,
+        resources: &[StoredResource],
+    ) -> Vec<StorageResult<usize>> {
+        let _fallback_span = crate::perf::span(crate::perf::Phase::ReindexFallback);
+        let mut results = Vec::with_capacity(resources.len());
+        for resource in resources {
+            match self
+                .delete_search_entries(tenant, resource.resource_type(), resource.id())
+                .await
+            {
+                Ok(_) => results.push(self.write_search_entries(tenant, resource).await),
+                Err(error) => results.push(Err(error)),
+            }
+        }
+        results
     }
 }
 
@@ -3687,26 +3717,246 @@ impl ReindexTarget for PostgresBackend {
         Ok(count)
     }
 
-    async fn clear_search_index(&self, tenant: &TenantContext) -> StorageResult<u64> {
-        let client = self.get_client().await?;
-        let tenant_id = tenant.tenant_id().as_str();
+    async fn write_search_entries_page(
+        &self,
+        tenant: &TenantContext,
+        resources: &[StoredResource],
+    ) -> Vec<StorageResult<usize>> {
+        if resources.is_empty() {
+            return Vec::new();
+        }
+        let _page_span = crate::perf::span(crate::perf::Phase::ReindexPage);
 
-        let deleted = client
+        // Composite deployments historically run the PostgreSQL per-resource
+        // writer even when reads are offloaded. Keep that behavior outside the
+        // new batched path so this optimization does not change pg-es.
+        if self.is_search_offloaded() {
+            return self
+                .write_reindex_page_individually(tenant, resources)
+                .await;
+        }
+
+        let tenant_id = tenant.tenant_id().as_str();
+        let mut rows_by_resource = Vec::with_capacity(resources.len());
+        let mut extraction_errors = Vec::with_capacity(resources.len());
+
+        let extraction_span = crate::perf::span(crate::perf::Phase::ReindexExtract);
+        for resource in resources {
+            let resource_type = resource.resource_type();
+            let resource_id = resource.id();
+            let content = resource.content();
+            match self
+                .tenant_extractor(tenant_id)
+                .extract(content, resource_type)
+            {
+                Ok(values) => {
+                    let mut rows = PostgresSearchIndexWriter::build_rows(
+                        resource_type,
+                        resource_id,
+                        resource.last_modified(),
+                        self.index_layout(),
+                        values,
+                    );
+                    rows.extend(self.contained_index_rows(
+                        tenant_id,
+                        resource_type,
+                        resource_id,
+                        content,
+                    ));
+                    rows_by_resource.push(rows);
+                    extraction_errors.push(None);
+                }
+                Err(error) => {
+                    rows_by_resource.push(Vec::new());
+                    extraction_errors.push(Some(internal_error(format!(
+                        "Search parameter extraction failed: {}",
+                        error
+                    ))));
+                }
+            }
+        }
+        drop(extraction_span);
+
+        let resource_types: Vec<&str> = resources
+            .iter()
+            .map(StoredResource::resource_type)
+            .collect();
+        let resource_ids: Vec<&str> = resources.iter().map(StoredResource::id).collect();
+
+        let connection_span = crate::perf::span(crate::perf::Phase::ReindexConnection);
+        let connection = self.get_client().await;
+        drop(connection_span);
+        let mut client = match connection {
+            Ok(client) => client,
+            Err(error) => {
+                tracing::warn!(
+                    "Failed to acquire a connection for batched PostgreSQL reindex; retrying the page per resource: {error}"
+                );
+                return self
+                    .write_reindex_page_individually(tenant, resources)
+                    .await;
+            }
+        };
+
+        let transaction_result = client.transaction().await;
+        if let Err(error) = &transaction_result {
+            let error = error.to_string();
+            drop(transaction_result);
+            drop(client);
+            tracing::warn!(
+                "Failed to begin batched PostgreSQL reindex; retrying the page per resource: {error}"
+            );
+            return self
+                .write_reindex_page_individually(tenant, resources)
+                .await;
+        }
+        let transaction = transaction_result.expect("transaction error handled above");
+
+        let batch_result: StorageResult<()> = async {
+            let search_delete_span = crate::perf::span(crate::perf::Phase::ReindexSearchDelete);
+            let deleted = execute_cached(
+                &transaction,
+                "DELETE FROM search_index
+                 WHERE tenant_id = $1
+                   AND (resource_type, resource_id) IN (
+                       SELECT * FROM unnest($2::text[], $3::text[])
+                   )",
+                &[&tenant_id, &resource_types, &resource_ids],
+            )
+            .await;
+            drop(search_delete_span);
+            deleted.map_err(|e| {
+                internal_error(format!("Failed to delete search index page: {}", e))
+            })?;
+
+            let fts_delete_span = crate::perf::span(crate::perf::Phase::ReindexFtsDelete);
+            let deleted = execute_cached(
+                &transaction,
+                "DELETE FROM resource_fts
+                 WHERE tenant_id = $1
+                   AND (resource_type, resource_id) IN (
+                       SELECT * FROM unnest($2::text[], $3::text[])
+                   )",
+                &[&tenant_id, &resource_types, &resource_ids],
+            )
+            .await;
+            drop(fts_delete_span);
+            deleted
+                .map_err(|e| internal_error(format!("Failed to delete FTS index page: {}", e)))?;
+
+            let valid_batches: Vec<(&str, &str, &[IndexRow])> = resources
+                .iter()
+                .zip(&rows_by_resource)
+                .zip(&extraction_errors)
+                .filter_map(|((resource, rows), error)| {
+                    error.is_none().then_some((
+                        resource.resource_type(),
+                        resource.id(),
+                        rows.as_slice(),
+                    ))
+                })
+                .collect();
+            let search_insert_span = crate::perf::span(crate::perf::Phase::ReindexSearchInsert);
+            let inserted = PostgresSearchIndexWriter::insert_rows_multi(
+                &transaction,
+                tenant_id,
+                &valid_batches,
+            )
+            .await;
+            drop(search_insert_span);
+            inserted?;
+            crate::perf::add_rows(
+                crate::perf::Phase::ReindexSearchInsert,
+                valid_batches
+                    .iter()
+                    .map(|(_, _, rows)| rows.len() as u64)
+                    .sum(),
+            );
+
+            let fts_span = crate::perf::span(crate::perf::Phase::ReindexFts);
+            for (resource, error) in resources.iter().zip(&extraction_errors) {
+                if error.is_none() {
+                    self.index_fts_content(
+                        &transaction,
+                        tenant_id,
+                        resource.resource_type(),
+                        resource.id(),
+                        resource.content(),
+                    )
+                    .await?;
+                }
+            }
+            drop(fts_span);
+            Ok(())
+        }
+        .await;
+
+        if let Err(error) = batch_result {
+            // Dropping the managed transaction schedules a rollback. Drop the
+            // pooled client too, so a one-connection pool can service the
+            // per-resource fallback. Protocol ordering makes the rollback run
+            // before the next borrower can issue a query.
+            tracing::warn!(
+                "Batched PostgreSQL reindex failed; retrying the page per resource: {error}"
+            );
+            drop(transaction);
+            drop(client);
+            return self
+                .write_reindex_page_individually(tenant, resources)
+                .await;
+        }
+
+        let commit_span = crate::perf::span(crate::perf::Phase::ReindexCommit);
+        let committed = transaction.commit().await;
+        drop(commit_span);
+        drop(client);
+        if let Err(error) = committed {
+            // Commit consumes the transaction, so its result can be uncertain.
+            // The fallback remains idempotent because it deletes every
+            // resource's rows before writing them again.
+            tracing::warn!(
+                "Failed to commit batched PostgreSQL reindex; retrying the page per resource: {error}"
+            );
+            return self
+                .write_reindex_page_individually(tenant, resources)
+                .await;
+        }
+
+        rows_by_resource
+            .into_iter()
+            .zip(extraction_errors)
+            .map(|(rows, error)| match error {
+                Some(error) => Err(error),
+                None => Ok(rows.len()),
+            })
+            .collect()
+    }
+
+    async fn clear_search_index(&self, tenant: &TenantContext) -> StorageResult<u64> {
+        let mut client = self.get_client().await?;
+        let tenant_id = tenant.tenant_id().as_str();
+        let transaction = client
+            .transaction()
+            .await
+            .or_query_error("Failed to begin clearing search index")?;
+        let deleted = transaction
             .execute(
                 "DELETE FROM search_index WHERE tenant_id = $1",
                 &[&tenant_id],
             )
             .await
             .or_query_error("Failed to clear search index")?;
-
-        // Also clear FTS entries
-        let _ = client
+        transaction
             .execute(
                 "DELETE FROM resource_fts WHERE tenant_id = $1",
                 &[&tenant_id],
             )
-            .await;
-
+            .await
+            .or_query_error("Failed to clear FTS index")?;
+        transaction
+            .commit()
+            .await
+            .or_query_error("Failed to commit clearing search index")?;
         Ok(deleted)
     }
 }

--- a/crates/persistence/src/perf.rs
+++ b/crates/persistence/src/perf.rs
@@ -84,11 +84,31 @@ pub enum Phase {
     Commit,
     /// Per-batch overhead outside the entry loop (BEGIN, manifest counters).
     BatchOverhead,
+    /// Fetch one page of stored resources for a reindex job.
+    ReindexFetch,
+    /// One writer rebuilding one reindex page in full.
+    ReindexPage,
+    /// Acquire the PostgreSQL connection used by a reindex page.
+    ReindexConnection,
+    /// Extract and marshal every resource in a PostgreSQL reindex page.
+    ReindexExtract,
+    /// Grouped delete from `search_index` for a PostgreSQL reindex page.
+    ReindexSearchDelete,
+    /// Grouped delete from `resource_fts` for a PostgreSQL reindex page.
+    ReindexFtsDelete,
+    /// Batched insert into `search_index` for a PostgreSQL reindex page.
+    ReindexSearchInsert,
+    /// Rebuild full-text rows for a PostgreSQL reindex page.
+    ReindexFts,
+    /// Commit a PostgreSQL reindex page.
+    ReindexCommit,
+    /// Retry a failed PostgreSQL reindex page through the individual path.
+    ReindexFallback,
 }
 
 impl Phase {
     /// All phases, in report order.
-    pub const ALL: [Phase; 19] = [
+    pub const ALL: [Phase; 29] = [
         Phase::NdjsonParse,
         Phase::Entry,
         Phase::EntryRead,
@@ -108,6 +128,16 @@ impl Phase {
         Phase::Bookkeeping,
         Phase::Commit,
         Phase::BatchOverhead,
+        Phase::ReindexFetch,
+        Phase::ReindexPage,
+        Phase::ReindexConnection,
+        Phase::ReindexExtract,
+        Phase::ReindexSearchDelete,
+        Phase::ReindexFtsDelete,
+        Phase::ReindexSearchInsert,
+        Phase::ReindexFts,
+        Phase::ReindexCommit,
+        Phase::ReindexFallback,
     ];
 
     /// The phase this one is measured inside of, if any. Drives the report's
@@ -130,6 +160,14 @@ impl Phase {
                 Some(Phase::Index)
             }
             Phase::IndexMarshal => Some(Phase::IndexInsert),
+            Phase::ReindexConnection
+            | Phase::ReindexExtract
+            | Phase::ReindexSearchDelete
+            | Phase::ReindexFtsDelete
+            | Phase::ReindexSearchInsert
+            | Phase::ReindexFts
+            | Phase::ReindexCommit
+            | Phase::ReindexFallback => Some(Phase::ReindexPage),
             _ => None,
         }
     }
@@ -156,11 +194,21 @@ impl Phase {
             Phase::Bookkeeping => "bookkeeping",
             Phase::Commit => "commit",
             Phase::BatchOverhead => "batch_overhead",
+            Phase::ReindexFetch => "reindex_fetch",
+            Phase::ReindexPage => "reindex_page (total)",
+            Phase::ReindexConnection => "reindex_connection",
+            Phase::ReindexExtract => "reindex_extract",
+            Phase::ReindexSearchDelete => "reindex_search_delete",
+            Phase::ReindexFtsDelete => "reindex_fts_delete",
+            Phase::ReindexSearchInsert => "reindex_search_insert",
+            Phase::ReindexFts => "reindex_fts",
+            Phase::ReindexCommit => "reindex_commit",
+            Phase::ReindexFallback => "reindex_fallback",
         }
     }
 }
 
-const PHASE_COUNT: usize = 19;
+const PHASE_COUNT: usize = 29;
 
 #[allow(clippy::declare_interior_mutable_const)]
 const ZERO: AtomicU64 = AtomicU64::new(0);
@@ -310,6 +358,38 @@ pub fn reset() {
 /// Renders the snapshot as a table: per-resource cost and share of `wall` for
 /// each phase, children indented under the phase that encloses them.
 pub fn report(resources: u64, wall: Duration) -> String {
+    report_totals(&snapshot(), resources, wall)
+}
+
+/// Renders only work recorded after `before`.
+///
+/// Counters are process-global. This subtraction is useful for a benchmark
+/// that runs one reindex job at a time, but concurrent jobs contribute to the
+/// same delta and cannot be separated by job id.
+pub fn report_since(before: &[PhaseTotals], resources: u64, wall: Duration) -> String {
+    let after = snapshot();
+    let delta: Vec<PhaseTotals> = after
+        .iter()
+        .enumerate()
+        .map(|(index, totals)| {
+            let old = before.get(index).copied().unwrap_or(PhaseTotals {
+                phase: totals.phase,
+                elapsed: Duration::ZERO,
+                hits: 0,
+                rows: 0,
+            });
+            PhaseTotals {
+                phase: totals.phase,
+                elapsed: totals.elapsed.saturating_sub(old.elapsed),
+                hits: totals.hits.saturating_sub(old.hits),
+                rows: totals.rows.saturating_sub(old.rows),
+            }
+        })
+        .collect();
+    report_totals(&delta, resources, wall)
+}
+
+fn report_totals(totals_by_phase: &[PhaseTotals], resources: u64, wall: Duration) -> String {
     let mut out = String::new();
     out.push_str(&format!(
         "{:<28} {:>12} {:>12} {:>10} {:>10}\n",
@@ -323,7 +403,7 @@ pub fn report(resources: u64, wall: Duration) -> String {
         100.0,
         resources
     ));
-    for totals in snapshot() {
+    for totals in totals_by_phase {
         if totals.hits == 0 {
             continue;
         }
@@ -479,5 +559,27 @@ mod tests {
         for (i, phase) in Phase::ALL.iter().enumerate() {
             assert_eq!(*phase as usize, i, "{} out of order", phase.label());
         }
+    }
+
+    #[cfg(perf_phases)]
+    #[test]
+    fn report_since_contains_only_the_counter_delta() {
+        let _guard = SWITCH.lock();
+        set_enabled(true);
+        reset();
+        add_rows(Phase::ReindexSearchInsert, 7);
+        let before = snapshot();
+        {
+            let _span = span(Phase::ReindexSearchInsert);
+            add_rows(Phase::ReindexSearchInsert, 11);
+        }
+        {
+            let _span = span(Phase::ReindexCommit);
+        }
+        let report = report_since(&before, 2, Duration::from_secs(1));
+        set_enabled(false);
+        assert!(report.contains("reindex_search_insert"));
+        assert!(report.contains("rows=11 (5.50/resource)"));
+        assert!(report.contains("reindex_commit"));
     }
 }

--- a/crates/persistence/src/search/reindex.rs
+++ b/crates/persistence/src/search/reindex.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use parking_lot::RwLock;
@@ -848,6 +848,7 @@ async fn run_reindex(
     jobs: Arc<RwLock<HashMap<String, ReindexProgress>>>,
     mut cancel_rx: mpsc::Receiver<()>,
 ) {
+    let perf_run = crate::perf::enabled().then(|| (Instant::now(), crate::perf::snapshot()));
     // The writers extract with their own tenant registries; the driver no
     // longer runs a second extraction just to count entries — the per-page
     // outcomes report what was actually written.
@@ -951,15 +952,17 @@ async fn run_reindex(
             }
 
             // Fetch a page of resources
-            let page = match source
+            let fetch_span = crate::perf::span(crate::perf::Phase::ReindexFetch);
+            let fetched = source
                 .fetch_resources_page(
                     &tenant,
                     resource_type,
                     cursor.as_deref(),
                     request.batch_size,
                 )
-                .await
-            {
+                .await;
+            drop(fetch_span);
+            let page = match fetched {
                 Ok(page) => page,
                 Err(e) => {
                     mark_failed(&jobs, &job_id, format!("Failed to fetch resources: {e}"));
@@ -1011,6 +1014,25 @@ async fn run_reindex(
                 None => break,
             }
         }
+    }
+
+    if let Some((started, before)) = perf_run {
+        let processed = jobs
+            .read()
+            .get(&job_id)
+            .map(|progress| progress.processed_resources)
+            .unwrap_or(0);
+        let report =
+            crate::perf::report_since(&before, processed, started.elapsed()).replace('\n', " | ");
+        tracing::info!(
+            target: "hfs_perf",
+            job_id = %job_id,
+            resources = processed,
+            process_global = true,
+            single_job_required = true,
+            phases = %report,
+            "reindex phase summary"
+        );
     }
 
     // Mark as completed

--- a/crates/persistence/tests/postgres_tests.rs
+++ b/crates/persistence/tests/postgres_tests.rs
@@ -1980,6 +1980,10 @@ mod postgres_integration {
     /// Schema is initialized once when the shared container starts; `init_schema()` is
     /// idempotent (uses CREATE TABLE IF NOT EXISTS).
     async fn create_backend() -> PostgresBackend {
+        create_backend_with_max_connections(5).await
+    }
+
+    async fn create_backend_with_max_connections(max_connections: usize) -> PostgresBackend {
         let pg = shared_pg().await;
 
         let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -1994,7 +1998,7 @@ mod postgres_integration {
             dbname: "postgres".to_string(),
             user: "postgres".to_string(),
             password: Some("postgres".to_string()),
-            max_connections: 5,
+            max_connections,
             data_dir: Some(data_dir),
             ..Default::default()
         };
@@ -5922,6 +5926,764 @@ mod postgres_integration {
     // Reindex Tests
     // ========================================================================
 
+    async fn reindex_test_client() -> tokio_postgres::Client {
+        let pg = shared_pg().await;
+        let conn_str = format!(
+            "host={} port={} user=postgres password=postgres dbname=postgres",
+            pg.host, pg.port,
+        );
+        let (client, connection) = tokio_postgres::connect(&conn_str, tokio_postgres::NoTls)
+            .await
+            .expect("connect to shared pg for reindex assertions");
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        client
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_reindex_page_batches_and_scopes_writes() {
+        use helios_persistence::search::{ReindexSource, ReindexTarget};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("reindex-page-batch");
+        let other_tenant = create_tenant("reindex-page-bystander");
+        let tenant_id = tenant.tenant_id().as_str();
+        let other_tenant_id = other_tenant.tenant_id().as_str();
+
+        for (id, family) in [
+            ("page-a", "Able"),
+            ("page-b", "Baker"),
+            ("outside", "Clark"),
+        ] {
+            backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({
+                        "resourceType": "Patient",
+                        "id": id,
+                        "name": [{"family": family}],
+                        "contained": [{
+                            "resourceType": "Practitioner",
+                            "id": format!("contained-{id}"),
+                            "name": [{"family": format!("Contained {family}")}]
+                        }]
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+        backend
+            .create(
+                &other_tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "page-a",
+                    "name": [{"family": "Bystander"}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        let client = reindex_test_client().await;
+        for (scoped_tenant, id) in [
+            (tenant_id, "page-a"),
+            (tenant_id, "page-b"),
+            (tenant_id, "outside"),
+            (other_tenant_id, "page-a"),
+        ] {
+            client
+                .execute(
+                    "INSERT INTO search_index
+                     (tenant_id, resource_type, resource_id, param_name, value_string)
+                     VALUES ($1, 'Patient', $2, 'obsolete-batch-probe', 'stale')",
+                    &[&scoped_tenant, &id],
+                )
+                .await
+                .unwrap();
+        }
+
+        let page = backend
+            .fetch_resources_page(&tenant, "Patient", None, 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            page.resources.iter().map(|r| r.id()).collect::<Vec<_>>(),
+            vec!["page-a", "page-b"]
+        );
+
+        let before: Vec<(String, serde_json::Value)> = client
+            .query(
+                "SELECT version_id, data FROM resources
+                 WHERE tenant_id = $1 AND resource_type = 'Patient'
+                   AND id = ANY($2::text[]) ORDER BY id",
+                &[&tenant_id, &vec!["page-a", "page-b"]],
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| (row.get(0), row.get(1)))
+            .collect();
+        let history_before: i64 = client
+            .query_one(
+                "SELECT COUNT(*) FROM resource_history
+                 WHERE tenant_id = $1 AND resource_type = 'Patient'
+                   AND id = ANY($2::text[])",
+                &[&tenant_id, &vec!["page-a", "page-b"]],
+            )
+            .await
+            .unwrap()
+            .get(0);
+
+        let results = backend
+            .write_search_entries_page(&tenant, &page.resources)
+            .await;
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(Result::is_ok));
+        assert!(results.iter().all(|result| *result.as_ref().unwrap() > 0));
+
+        let remaining_stale: Vec<(String, String)> = client
+            .query(
+                "SELECT tenant_id, resource_id FROM search_index
+                 WHERE param_name = 'obsolete-batch-probe'
+                   AND ((tenant_id = $1 AND resource_id = ANY($2::text[]))
+                     OR (tenant_id = $3 AND resource_id = 'page-a'))
+                 ORDER BY tenant_id, resource_id",
+                &[
+                    &tenant_id,
+                    &vec!["page-a", "page-b", "outside"],
+                    &other_tenant_id,
+                ],
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| (row.get(0), row.get(1)))
+            .collect();
+        assert_eq!(remaining_stale.len(), 2);
+        assert!(remaining_stale.contains(&(tenant_id.to_string(), "outside".to_string())));
+        assert!(remaining_stale.contains(&(other_tenant_id.to_string(), "page-a".to_string())));
+
+        for resource in &page.resources {
+            let contained_count: i64 = client
+                .query_one(
+                    "SELECT COUNT(*) FROM search_index
+                     WHERE tenant_id = $1 AND resource_type = 'Patient'
+                       AND resource_id = $2 AND is_contained = TRUE",
+                    &[&tenant_id, &resource.id()],
+                )
+                .await
+                .unwrap()
+                .get(0);
+            assert!(contained_count > 0);
+        }
+
+        let after: Vec<(String, serde_json::Value)> = client
+            .query(
+                "SELECT version_id, data FROM resources
+                 WHERE tenant_id = $1 AND resource_type = 'Patient'
+                   AND id = ANY($2::text[]) ORDER BY id",
+                &[&tenant_id, &vec!["page-a", "page-b"]],
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| (row.get(0), row.get(1)))
+            .collect();
+        let history_after: i64 = client
+            .query_one(
+                "SELECT COUNT(*) FROM resource_history
+                 WHERE tenant_id = $1 AND resource_type = 'Patient'
+                   AND id = ANY($2::text[])",
+                &[&tenant_id, &vec!["page-a", "page-b"]],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(after, before);
+        assert_eq!(history_after, history_before);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_reindex_page_uses_one_transaction_for_all_index_writes() {
+        use helios_persistence::search::{ReindexSource, ReindexTarget};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("reindex-page-single-transaction");
+        let tenant_id = tenant.tenant_id().as_str();
+        for id in ["tx-a", "tx-b"] {
+            backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({
+                        "resourceType": "Patient",
+                        "id": id,
+                        "name": [{"family": id}]
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+        let page = backend
+            .fetch_resources_page(&tenant, "Patient", None, 10)
+            .await
+            .unwrap();
+
+        let client = reindex_test_client().await;
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let table_name = format!("reindex_tx_probe_{suffix}");
+        let function_name = format!("record_reindex_tx_{suffix}");
+        let search_trigger = format!("record_search_tx_{suffix}");
+        let fts_trigger = format!("record_fts_tx_{suffix}");
+        client
+            .batch_execute(&format!(
+                "CREATE TABLE {table_name} (operation text NOT NULL, transaction_id bigint NOT NULL);
+                 CREATE FUNCTION {function_name}() RETURNS trigger LANGUAGE plpgsql AS $$
+                 BEGIN
+                   IF TG_OP = 'DELETE' THEN
+                     IF OLD.tenant_id = '{tenant_id}' THEN
+                       INSERT INTO {table_name} VALUES (TG_TABLE_NAME || '_delete', txid_current());
+                     END IF;
+                     RETURN OLD;
+                   END IF;
+                   IF NEW.tenant_id = '{tenant_id}' THEN
+                     INSERT INTO {table_name} VALUES (TG_TABLE_NAME || '_insert', txid_current());
+                   END IF;
+                   RETURN NEW;
+                 END $$;
+                 CREATE TRIGGER {search_trigger} AFTER INSERT OR DELETE ON search_index
+                 FOR EACH ROW EXECUTE FUNCTION {function_name}();
+                 CREATE TRIGGER {fts_trigger} AFTER INSERT OR DELETE ON resource_fts
+                 FOR EACH ROW EXECUTE FUNCTION {function_name}();"
+            ))
+            .await
+            .unwrap();
+
+        let results = backend
+            .write_search_entries_page(&tenant, &page.resources)
+            .await;
+        let probe_rows: Vec<(String, i64)> = client
+            .query(
+                &format!(
+                    "SELECT DISTINCT operation, transaction_id FROM {table_name} ORDER BY operation"
+                ),
+                &[],
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| (row.get(0), row.get(1)))
+            .collect();
+
+        client
+            .batch_execute(&format!(
+                "DROP TRIGGER {search_trigger} ON search_index;
+                 DROP TRIGGER {fts_trigger} ON resource_fts;
+                 DROP FUNCTION {function_name}();
+                 DROP TABLE {table_name};"
+            ))
+            .await
+            .unwrap();
+
+        assert!(results.iter().all(Result::is_ok));
+        assert_eq!(
+            probe_rows
+                .iter()
+                .map(|(operation, _)| operation.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "resource_fts_delete",
+                "resource_fts_insert",
+                "search_index_delete",
+                "search_index_insert",
+            ]
+        );
+        assert_eq!(
+            probe_rows
+                .iter()
+                .map(|(_, transaction_id)| *transaction_id)
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            1,
+            "all page index writes must share one PostgreSQL transaction"
+        );
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_reindex_page_failure_releases_single_connection_pool() {
+        use helios_persistence::search::{ReindexSource, ReindexTarget};
+
+        let backend = create_backend_with_max_connections(1).await;
+        let tenant = create_tenant("reindex-page-one-connection");
+        let tenant_id = tenant.tenant_id().as_str();
+        for id in ["one-a", "one-fail", "one-c"] {
+            backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({
+                        "resourceType": "Patient",
+                        "id": id,
+                        "name": [{"family": id}]
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+        let page = backend
+            .fetch_resources_page(&tenant, "Patient", None, 10)
+            .await
+            .unwrap();
+        let client = reindex_test_client().await;
+        client
+            .execute(
+                "INSERT INTO search_index
+                 (tenant_id, resource_type, resource_id, param_name, value_string)
+                 VALUES ($1, 'Patient', 'one-fail', 'obsolete-one-connection', 'stale')",
+                &[&tenant_id],
+            )
+            .await
+            .unwrap();
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let function_name = format!("reject_one_connection_{suffix}");
+        let trigger_name = format!("reject_one_connection_{suffix}");
+        client
+            .batch_execute(&format!(
+                "CREATE FUNCTION {function_name}() RETURNS trigger LANGUAGE plpgsql AS $$
+                 BEGIN
+                   IF NEW.tenant_id = '{tenant_id}' AND NEW.resource_id = 'one-fail' THEN
+                     RAISE EXCEPTION 'deliberate one-connection reindex failure';
+                   END IF;
+                   RETURN NEW;
+                 END $$;
+                 CREATE TRIGGER {trigger_name} BEFORE INSERT ON search_index
+                 FOR EACH ROW EXECUTE FUNCTION {function_name}();"
+            ))
+            .await
+            .unwrap();
+
+        let results = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            backend.write_search_entries_page(&tenant, &page.resources),
+        )
+        .await
+        .expect("fallback must not deadlock a one-connection pool");
+
+        client
+            .batch_execute(&format!(
+                "DROP TRIGGER {trigger_name} ON search_index;
+                 DROP FUNCTION {function_name}();"
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        for (resource, result) in page.resources.iter().zip(&results) {
+            if resource.id() == "one-fail" {
+                let error = result.as_ref().expect_err("trigger target must fail");
+                assert!(
+                    error
+                        .to_string()
+                        .contains("deliberate one-connection reindex failure"),
+                    "deliberate database cause was lost: {error}"
+                );
+            } else {
+                assert!(result.is_ok(), "{} should be reindexed", resource.id());
+            }
+        }
+        for table in ["search_index", "resource_fts"] {
+            let stale: i64 = client
+                .query_one(
+                    &format!(
+                        "SELECT COUNT(*) FROM {table}
+                         WHERE tenant_id = $1 AND resource_type = 'Patient'
+                           AND resource_id = 'one-fail'"
+                    ),
+                    &[&tenant_id],
+                )
+                .await
+                .unwrap()
+                .get(0);
+            assert_eq!(stale, 0, "failed resource retained stale rows in {table}");
+        }
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_reindex_status_attributes_page_resource_error() {
+        use helios_persistence::search::{ReindexOperation, ReindexRequest, ReindexStatus};
+        use std::sync::Arc;
+
+        let backend = Arc::new(create_backend().await);
+        let tenant = create_tenant("reindex-page-status-error");
+        let tenant_id = tenant.tenant_id().as_str();
+        for id in ["status-a", "status-fail", "status-c"] {
+            backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({
+                        "resourceType": "Patient",
+                        "id": id,
+                        "name": [{"family": id}]
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+        let client = reindex_test_client().await;
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let function_name = format!("reject_status_reindex_{suffix}");
+        let trigger_name = format!("reject_status_reindex_{suffix}");
+        client
+            .batch_execute(&format!(
+                "CREATE FUNCTION {function_name}() RETURNS trigger LANGUAGE plpgsql AS $$
+                 BEGIN
+                   IF NEW.tenant_id = '{tenant_id}' AND NEW.resource_id = 'status-fail' THEN
+                     RAISE EXCEPTION 'deliberate status reindex failure';
+                   END IF;
+                   RETURN NEW;
+                 END $$;
+                 CREATE TRIGGER {trigger_name} BEFORE INSERT ON search_index
+                 FOR EACH ROW EXECUTE FUNCTION {function_name}();"
+            ))
+            .await
+            .unwrap();
+
+        let operation = ReindexOperation::new(backend.clone(), backend.tenant_registries().clone());
+        let job_id = operation
+            .start(
+                tenant.clone(),
+                ReindexRequest::for_types(["Patient"]).with_batch_size(10),
+                None,
+            )
+            .await
+            .unwrap();
+        let progress = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                let progress = operation.get_progress(&job_id).await.unwrap();
+                if progress.status.is_finished() {
+                    break progress;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("reindex status should become terminal");
+
+        client
+            .batch_execute(&format!(
+                "DROP TRIGGER {trigger_name} ON search_index;
+                 DROP FUNCTION {function_name}();"
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(progress.status, ReindexStatus::Completed);
+        assert_eq!(progress.total_resources, 3);
+        assert_eq!(progress.processed_resources, 3);
+        assert_eq!(progress.errors.len(), 1);
+        assert_eq!(progress.errors[0].resource_type, "Patient");
+        assert_eq!(progress.errors[0].resource_id, "status-fail");
+        assert!(
+            progress.errors[0]
+                .error
+                .contains("deliberate status reindex failure")
+        );
+        let parameters = progress.to_parameters();
+        let error_count = parameters["parameter"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|parameter| parameter["name"] == "errorCount")
+            .unwrap();
+        assert_eq!(error_count["valueInteger"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_reindex_page_handles_empty_and_extraction_failure() {
+        use helios_persistence::search::ReindexTarget;
+        use helios_persistence::types::StoredResource;
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("reindex-page-extraction");
+        let tenant_id = tenant.tenant_id().as_str();
+        assert!(
+            backend
+                .write_search_entries_page(&tenant, &[])
+                .await
+                .is_empty()
+        );
+
+        let invalid = StoredResource::new(
+            "Patient",
+            "invalid-extraction",
+            tenant.tenant_id().clone(),
+            json!({"resourceType": "Observation", "id": "invalid-extraction"}),
+            FhirVersion::default(),
+        );
+        let empty_fts = StoredResource::new(
+            "Patient",
+            "empty-fts",
+            tenant.tenant_id().clone(),
+            json!({}),
+            FhirVersion::default(),
+        );
+        let client = reindex_test_client().await;
+        client
+            .execute(
+                "INSERT INTO search_index
+                 (tenant_id, resource_type, resource_id, param_name, value_string)
+                 VALUES ($1, 'Patient', 'invalid-extraction', 'obsolete-batch-probe', 'stale')",
+                &[&tenant_id],
+            )
+            .await
+            .unwrap();
+        client
+            .execute(
+                "INSERT INTO resource_fts
+                 (tenant_id, resource_type, resource_id, narrative_tsvector, content_tsvector)
+                 VALUES ($1, 'Patient', 'empty-fts', to_tsvector('english', 'stale'), to_tsvector('english', 'stale'))",
+                &[&tenant_id],
+            )
+            .await
+            .unwrap();
+
+        let results = backend
+            .write_search_entries_page(&tenant, &[invalid, empty_fts])
+            .await;
+        assert_eq!(results.len(), 2);
+        assert!(results[0].is_err());
+        assert!(results[1].is_ok());
+
+        let stale_count: i64 = client
+            .query_one(
+                "SELECT COUNT(*) FROM search_index
+                 WHERE tenant_id = $1 AND resource_id = 'invalid-extraction'",
+                &[&tenant_id],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        let empty_fts_count: i64 = client
+            .query_one(
+                "SELECT COUNT(*) FROM resource_fts
+                 WHERE tenant_id = $1 AND resource_id = 'empty-fts'",
+                &[&tenant_id],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(stale_count, 0);
+        assert_eq!(empty_fts_count, 0);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_reindex_page_rolls_back_and_falls_back_per_resource() {
+        use helios_persistence::search::{ReindexSource, ReindexTarget};
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("reindex-page-fallback");
+        let tenant_id = tenant.tenant_id().as_str();
+        for id in ["fallback-a", "fallback-fail", "fallback-c"] {
+            backend
+                .create(
+                    &tenant,
+                    "Patient",
+                    json!({
+                        "resourceType": "Patient",
+                        "id": id,
+                        "name": [{"family": id}]
+                    }),
+                    FhirVersion::default(),
+                )
+                .await
+                .unwrap();
+        }
+        let page = backend
+            .fetch_resources_page(&tenant, "Patient", None, 10)
+            .await
+            .unwrap();
+        let client = reindex_test_client().await;
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let function_name = format!("reject_reindex_{suffix}");
+        let trigger_name = format!("reject_reindex_{suffix}");
+        client
+            .batch_execute(&format!(
+                "CREATE FUNCTION {function_name}() RETURNS trigger LANGUAGE plpgsql AS $$
+                 BEGIN
+                   IF NEW.tenant_id = '{tenant_id}' AND NEW.resource_id = 'fallback-fail' THEN
+                     RAISE EXCEPTION 'deliberate reindex failure';
+                   END IF;
+                   RETURN NEW;
+                 END $$;
+                 CREATE TRIGGER {trigger_name} BEFORE INSERT ON search_index
+                 FOR EACH ROW EXECUTE FUNCTION {function_name}();"
+            ))
+            .await
+            .unwrap();
+
+        let results = backend
+            .write_search_entries_page(&tenant, &page.resources)
+            .await;
+
+        client
+            .batch_execute(&format!(
+                "DROP TRIGGER {trigger_name} ON search_index;
+                 DROP FUNCTION {function_name}();"
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        for (resource, result) in page.resources.iter().zip(results) {
+            if resource.id() == "fallback-fail" {
+                assert!(result.is_err());
+            } else {
+                assert!(result.is_ok(), "{} should be reindexed", resource.id());
+                let rows: i64 = client
+                    .query_one(
+                        "SELECT COUNT(*) FROM search_index
+                         WHERE tenant_id = $1 AND resource_type = 'Patient'
+                           AND resource_id = $2",
+                        &[&tenant_id, &resource.id()],
+                    )
+                    .await
+                    .unwrap()
+                    .get(0);
+                assert!(rows > 0);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_reindex_page_retries_oversized_fts_individually() {
+        use helios_persistence::search::ReindexTarget;
+        use helios_persistence::types::StoredResource;
+
+        let backend = create_backend().await;
+        let tenant = create_tenant("reindex-page-oversized-fts");
+        let tenant_id = tenant.tenant_id().as_str();
+        let text = (0..100_000)
+            .map(|index| format!("lexeme{index:08x}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let resource = StoredResource::new(
+            "Patient",
+            "oversized-fts",
+            tenant.tenant_id().clone(),
+            json!({
+                "resourceType": "Patient",
+                "id": "oversized-fts",
+                "text": {"status": "generated", "div": format!("<div>{text}</div>")}
+            }),
+            FhirVersion::default(),
+        );
+
+        let results = backend
+            .write_search_entries_page(&tenant, &[resource])
+            .await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+
+        let client = reindex_test_client().await;
+        let fts_rows: i64 = client
+            .query_one(
+                "SELECT COUNT(*) FROM resource_fts
+                 WHERE tenant_id = $1 AND resource_type = 'Patient'
+                   AND resource_id = 'oversized-fts'",
+                &[&tenant_id],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(fts_rows, 1);
+    }
+
+    #[tokio::test]
+    async fn postgres_integration_reindex_clear_rolls_back_when_fts_delete_fails() {
+        use helios_persistence::search::ReindexTarget;
+
+        let backend = create_backend_with_max_connections(1).await;
+        let tenant = create_tenant("reindex-clear-atomic");
+        let tenant_id = tenant.tenant_id().as_str();
+        backend
+            .create(
+                &tenant,
+                "Patient",
+                json!({
+                    "resourceType": "Patient",
+                    "id": "clear-atomic",
+                    "name": [{"family": "Atomic"}]
+                }),
+                FhirVersion::default(),
+            )
+            .await
+            .unwrap();
+
+        let client = reindex_test_client().await;
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let function_name = format!("reject_fts_clear_{suffix}");
+        let trigger_name = format!("reject_fts_clear_{suffix}");
+        client
+            .batch_execute(&format!(
+                "CREATE FUNCTION {function_name}() RETURNS trigger LANGUAGE plpgsql AS $$
+                 BEGIN
+                   IF OLD.tenant_id = '{tenant_id}' THEN
+                     RAISE EXCEPTION 'deliberate FTS clear failure';
+                   END IF;
+                   RETURN OLD;
+                 END $$;
+                 CREATE TRIGGER {trigger_name} BEFORE DELETE ON resource_fts
+                 FOR EACH ROW EXECUTE FUNCTION {function_name}();"
+            ))
+            .await
+            .unwrap();
+
+        let failed_clear = backend.clear_search_index(&tenant).await;
+
+        client
+            .batch_execute(&format!(
+                "DROP TRIGGER {trigger_name} ON resource_fts;
+                 DROP FUNCTION {function_name}();"
+            ))
+            .await
+            .unwrap();
+
+        assert!(failed_clear.is_err());
+        for table in ["search_index", "resource_fts"] {
+            let rows: i64 = client
+                .query_one(
+                    &format!("SELECT COUNT(*) FROM {table} WHERE tenant_id = $1"),
+                    &[&tenant_id],
+                )
+                .await
+                .unwrap()
+                .get(0);
+            assert!(rows > 0, "{table} deletion should have rolled back");
+        }
+
+        assert!(backend.clear_search_index(&tenant).await.unwrap() > 0);
+        for table in ["search_index", "resource_fts"] {
+            let rows: i64 = client
+                .query_one(
+                    &format!("SELECT COUNT(*) FROM {table} WHERE tenant_id = $1"),
+                    &[&tenant_id],
+                )
+                .await
+                .unwrap()
+                .get(0);
+            assert_eq!(rows, 0);
+        }
+    }
+
     #[tokio::test]
     async fn postgres_integration_reindex_list_types() {
         use helios_persistence::search::ReindexSource;
@@ -6019,6 +6781,18 @@ mod postgres_integration {
                 .unwrap();
         }
 
+        // Force every resource onto the same timestamp so the cursor's id
+        // tiebreaker, rather than incidental clock ordering, carries the page.
+        reindex_test_client()
+            .await
+            .execute(
+                "UPDATE resources SET last_updated = '2026-01-01T00:00:00Z'
+                 WHERE tenant_id = $1 AND resource_type = 'Patient'",
+                &[&tenant.tenant_id().as_str()],
+            )
+            .await
+            .unwrap();
+
         // Fetch first page (5 resources)
         let page1 = backend
             .fetch_resources_page(&tenant, "Patient", None, 5)
@@ -6037,6 +6811,26 @@ mod postgres_integration {
         // Ensure no duplicates between pages
         let page1_ids: Vec<&str> = page1.resources.iter().map(|r| r.id()).collect();
         let page2_ids: Vec<&str> = page2.resources.iter().map(|r| r.id()).collect();
+        assert_eq!(
+            page1_ids,
+            vec![
+                "patient-01",
+                "patient-02",
+                "patient-03",
+                "patient-04",
+                "patient-05"
+            ]
+        );
+        assert_eq!(
+            page2_ids,
+            vec![
+                "patient-06",
+                "patient-07",
+                "patient-08",
+                "patient-09",
+                "patient-10"
+            ]
+        );
         for id in &page1_ids {
             assert!(!page2_ids.contains(id), "Duplicate ID found: {}", id);
         }

--- a/docs/postgres-reindex-benchmark.md
+++ b/docs/postgres-reindex-benchmark.md
@@ -1,0 +1,294 @@
+# PostgreSQL reindex benchmark for issue #1086
+
+This protocol measures the deferred PostgreSQL reindex after `$bulk-submit` without importing the full manual-testing corpus. It is an issue-specific performance check, not a replacement for the release matrix.
+
+## Fixed scope
+
+- Build only the `hfs` R4 PostgreSQL binary from the source revision under test.
+- Use `2,000` deterministic Patient resources per trial. The controller rejects more than `10,000` resources when the #1086 evidence profile is selected.
+- Run one import and one deferred reindex at a time. The Rust phase counters are process-global and cannot separate concurrent jobs.
+- Run three fresh, equivalent trials for the baseline and three for the candidate. Restore the same empty PostgreSQL image or dump before every trial.
+- Keep the PostgreSQL image, container limits, HFS settings, host load policy, fixture generation, and sampling intervals identical across both arms.
+
+The 18,955,865-resource corpus in `MANUAL_TESTING_MATRIX.md` is intentionally excluded. Downloading, unpacking, importing, and reindexing it takes hours and measures many unrelated costs. The workspace all-features release build is also excluded because this change affects the R4 PostgreSQL path. The full corpus and all-features build remain release checks.
+
+## Build each arm
+
+From the exact baseline or candidate checkout:
+
+```bash
+CARGO_BUILD_JOBS=4 \
+RUSTFLAGS='--cfg perf_phases' \
+cargo build --locked --release -p helios-hfs --bin hfs \
+  --no-default-features --features R4,postgres
+```
+
+Record the source SHA and binary SHA256 before moving or copying the binary. Keep both binaries so the trials do not rebuild between arms.
+
+Use the candidate checkout's controller for both arms so the measurement code is identical. Set `ARM_REPO` to the exact baseline or candidate source checkout that produced the binary. After the build, compute that checkout's full source fingerprint. It includes `HEAD`, the binary form of every tracked change, and the path and content of every untracked file:
+
+```bash
+CONTROLLER=/absolute/path/to/candidate-checkout/crates/hfs/tests/bulk_submit/measure_memory.py
+ARM_REPO=/absolute/path/to/baseline-or-candidate-source-checkout
+
+python3 "$CONTROLLER" \
+  --dry-run \
+  --binary /absolute/path/to/hfs-baseline-or-candidate \
+  --output-dir /tmp/hfs-1086/fingerprint-placeholder \
+  --repo-root "$ARM_REPO" \
+  --pg-container hfs-1086-postgres-reindex-pg \
+  --database-url "$HFS_1086_DATABASE_URL" \
+  --postgres-reindex-evidence \
+  > /tmp/hfs-1086/source-plan.json
+
+SOURCE_FINGERPRINT=$(python3 -c \
+  'import json; print(json.load(open("/tmp/hfs-1086/source-plan.json"))["source"]["fingerprint_sha256"])')
+shasum -a 256 /absolute/path/to/hfs-baseline-or-candidate
+```
+
+Do not edit the checkout or rebuild after this point. Every timed invocation verifies `SOURCE_FINGERPRINT`. The run records that fingerprint and the binary SHA256 together. This binds a trial to both files, although an external build system could still supply an unrelated binary under that path.
+
+## Run one trial
+
+Use a new output directory and a freshly restored database for every invocation:
+
+```bash
+python3 "$CONTROLLER" \
+  --binary /absolute/path/to/hfs-baseline-or-candidate \
+  --output-dir /tmp/hfs-1086/<arm>-trial-01 \
+  --repo-root "$ARM_REPO" \
+  --resources 2000 \
+  --jobs 1 \
+  --postgres-reindex-evidence \
+  --expected-source-fingerprint "$SOURCE_FINGERPRINT" \
+  --pg-container hfs-1086-postgres-reindex-pg \
+  --database-url "$HFS_1086_DATABASE_URL" \
+  --idle-seconds 0
+```
+
+Set `HFS_1086_DATABASE_URL` in the invoking shell; do not put the real password in notes or committed files. Use `--explain-analyze` only when the database is disposable and no competing measurement is running. It executes three bounded `SELECT ... LIMIT 100` cursor probes. Plain `EXPLAIN` is the default.
+
+Add `--require-phase-summary` to every candidate trial. A pre-instrumentation baseline may omit it. The controller still completes functional validation when required measurement evidence is absent, but it sets `timings.comparable=false` and records each reason. Do not accept that trial for the six-row comparison.
+
+For the #1086 profile, the controller enables `HFS_PERF_PHASES=1` and uses
+`RUST_LOG=info,hfs=warn,hfs_perf=info`. The explicit `hfs_perf` directive is
+required because tracing target filters match prefixes: `hfs=warn` alone also
+matches `hfs_perf` and would suppress its INFO summary. A caller-provided
+`--hfs-env RUST_LOG=...` is applied last and intentionally overrides this
+default; if it filters out `hfs_perf`, a candidate run requiring the summary is
+non-comparable.
+
+The #1086 profile defaults PostgreSQL container sampling to 1 second and endpoint polling to 0.25 seconds. Keep those defaults in both arms. The controller parses the RFC3339 timestamp embedded in the correlated `deferred-index rebuild started` log line and pairs it with the wall-clock time when polling first observes completed status. It reports `start_log_to_completion_observed_interval_s` plus the endpoint polling resolution. This observational interval has no guaranteed error direction. Task spawning precedes the start log and can shorten the reported interval, while completion polling can lengthen it. It is not an exact database rebuild duration. A missing or invalid start timestamp makes the trial non-comparable.
+
+Preflight blocks an existing `hfs`, `rustc`, or `cargo` process. It cannot detect a competing process that starts after preflight. Review the run's host load and memory evidence before accepting it, and reject the trial if a competing build or server appeared during the measured window.
+
+The controller records:
+
+- source revision, full source fingerprint, binary hash, controller hash, corpus hash, settings, host details, immutable PostgreSQL image ID, image name, and server version;
+- kickoff to polling-observed terminal manifest publication, observed terminal to verified search readiness, and kickoff to verified readiness as separate durations;
+- the start-log to completion-observation interval, with its polling resolution and stated uncertainty;
+- throughput to terminal publication and throughput to verified search readiness as separate values;
+- HFS RSS, PostgreSQL container memory, host memory pressure, swap, and load samples;
+- `pg_stat_database` transaction, block, tuple, temporary-file, and WAL counter deltas for kickoff to polling-observed terminal, observed terminal to verified search readiness, and the whole kickoff-to-readiness window;
+- early, middle, and late cursor plans for the reindex page query;
+- the opt-in process-global reindex phase summary extracted from the HFS log;
+- exact receipt, current-resource, history, version, indexed-search, and zero-unindexed-resource checks.
+
+`pg_stat_statements` is not required. If an operator collects it separately, record whether the extension was already enabled and its reset point. Do not mix its numbers into trials that lack the same setup.
+
+The terminal database snapshot is taken immediately after the controller has polled and validated the terminal manifest. It is an observed boundary, not the exact instant of publication, so its first interval may contain a small amount of reindex work that had already started. The readiness snapshot follows the status and SQL probes. Those probes contribute a little database work too. Therefore, none of the three deltas is exact DB-only reindex attribution. WAL and database counters can also include other sessions, which is why a dedicated PostgreSQL container and one job at a time are required.
+
+## Candidate correctness and stable-ID reimport check
+
+Run this small candidate-only check once, separately from the six fresh timed trials. Set `CANDIDATE_REPO` to the source checkout used for the candidate binary and set `SOURCE_FINGERPRINT` from that checkout as described above. The command submits the same 12 stable Patient IDs twice and leaves strict validation enabled:
+
+```bash
+python3 "$CONTROLLER" \
+  --binary /absolute/path/to/hfs-candidate \
+  --output-dir /tmp/hfs-1086/candidate-reimport-correctness \
+  --repo-root "$CANDIDATE_REPO" \
+  --resources 12 \
+  --jobs 2 \
+  --mode consecutive \
+  --strict-validation \
+  --postgres-reindex-evidence \
+  --require-phase-summary \
+  --expected-source-fingerprint "$SOURCE_FINGERPRINT" \
+  --pg-container hfs-1086-postgres-reindex-pg \
+  --database-url "$HFS_1086_DATABASE_URL" \
+  --idle-seconds 0
+```
+
+Start from an empty database. Job 1 covers fresh import; job 2 reimports the same IDs. The controller's hard checks cover terminal manifests, receipts, current resources, incremented versions, history, zero unindexed resources, indexed family search, and verified reindex readiness after each job. Do not include its timings in the baseline/candidate performance comparison.
+
+## Trial acceptance
+
+A trial is comparable only when all of these are true:
+
+- the database began from the agreed empty state;
+- the manifest reached terminal status with no outcome or deleted entries;
+- the correlated reindex job completed with `errorCount=0` and `processed=total`;
+- SQL reports zero unindexed Patients;
+- indexed family search returns all 2,000 resources;
+- the run contains the source, binary, corpus, host, PostgreSQL, memory, database delta, and cursor-plan evidence;
+- all three cursor plans parse, and both HFS and PostgreSQL have at least one memory sample inside the kickoff-to-readiness window;
+- the run records whether a phase summary was available. A saved baseline binary built before the #1086 phase instrumentation may lack it. Record that limitation and do not compare internal phase totals across arms.
+
+Reject and rerun a trial if another HFS, Cargo, or rustc process competed for the host, memory pressure became non-normal, the watchdog fired, or any hard validation failed.
+
+## Results from the bounded local run
+
+The six fresh trials run on 2026-09-12 passed every hard and soft validation and
+met the comparability gates. These results apply only to the 2,000-Patient
+workload described above; they do not establish behavior for the 10,000-resource
+protocol cap or the 18.9-million-resource manual corpus.
+
+| Arm | Trial | Source SHA | Source fingerprint | Binary SHA256 | Corpus SHA256 | Publish s | Search-ready s | Observed terminal-to-ready s | Start-log to completion-observed interval s | Resources/s to publish | Resources/s to ready | HFS peak MiB | PostgreSQL peak MiB | WAL bytes K-to-Tobs / Tobs-to-ready / K-to-ready | Commits K-to-Tobs / Tobs-to-ready / K-to-ready | Blocks read/hit K-to-Tobs / Tobs-to-ready / K-to-ready | Phase summary present | Cursor plans parsed | Comparable | Accepted |
+|---|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|---|---|---|
+| baseline | 1 | `2fa9dfaee722d1dad76acfb89c7b3d7e83c64bb9` | `a1c0ff03f553cc86ff1de017b9fd1370032162610109f91d2273ebeace0f3e36` | `3cc3dce622e8affb995208f70bb9297528d2feef3f90662c8d72315e90d21d70` | `73c86175d59c02915736be5074447e7789736771bea1e5f9c784f0119d2ce964` | 5.292 | 12.439 | 7.147 | 3.856 | 377.929 | 160.785 | 58.172 | 262.2 | 8,743,856 / 32,001,224 / 40,745,080 | 4,242 / 7,778 / 12,020 | 14/310,289 / 0/3,095,559 / 14/3,405,848 | no | 3/3 | yes | yes |
+| baseline | 2 | `2fa9dfaee722d1dad76acfb89c7b3d7e83c64bb9` | `a1c0ff03f553cc86ff1de017b9fd1370032162610109f91d2273ebeace0f3e36` | `3cc3dce622e8affb995208f70bb9297528d2feef3f90662c8d72315e90d21d70` | `73c86175d59c02915736be5074447e7789736771bea1e5f9c784f0119d2ce964` | 5.300 | 12.139 | 6.839 | 3.565 | 377.358 | 164.758 | 57.922 | 265.1 | 8,365,720 / 32,322,024 / 40,687,744 | 4,290 / 7,692 / 11,982 | 14/320,212 / 0/3,104,623 / 14/3,424,835 | no | 3/3 | yes | yes |
+| baseline | 3 | `2fa9dfaee722d1dad76acfb89c7b3d7e83c64bb9` | `a1c0ff03f553cc86ff1de017b9fd1370032162610109f91d2273ebeace0f3e36` | `3cc3dce622e8affb995208f70bb9297528d2feef3f90662c8d72315e90d21d70` | `73c86175d59c02915736be5074447e7789736771bea1e5f9c784f0119d2ce964` | 5.274 | 9.265 | 3.991 | 3.884 | 379.219 | 215.866 | 57.797 | 269.6 | 8,755,656 / 31,943,256 / 40,698,912 | 4,175 / 7,643 / 11,818 | 14/294,133 / 1/980,159 / 15/1,274,292 | no | 3/3 | yes | yes |
+| candidate | 1 | `2fa9dfaee722d1dad76acfb89c7b3d7e83c64bb9` | `9b20d270862f3cf930fb2ffcbd9a74305c8af8ae7133a5df15ea9aa1c8cbd9ed` | `0a73991cacf645367d546cabbc6188ba6486a5348d4246dec4a74fb428c1ce78` | `73c86175d59c02915736be5074447e7789736771bea1e5f9c784f0119d2ce964` | 5.294 | 6.942 | 1.648 | 1.593 | 377.786 | 288.101 | 65.375 | 272.2 | 12,294,256 / 28,242,440 / 40,536,696 | 3,914 / 66 / 3,980 | 11/368,073 / 0/330,438 / 11/698,511 | yes | 3/3 | yes | yes |
+| candidate | 2 | `2fa9dfaee722d1dad76acfb89c7b3d7e83c64bb9` | `9b20d270862f3cf930fb2ffcbd9a74305c8af8ae7133a5df15ea9aa1c8cbd9ed` | `0a73991cacf645367d546cabbc6188ba6486a5348d4246dec4a74fb428c1ce78` | `73c86175d59c02915736be5074447e7789736771bea1e5f9c784f0119d2ce964` | 5.265 | 6.879 | 1.614 | 1.519 | 379.867 | 290.740 | 64.797 | 298.3 | 14,977,872 / 28,349,832 / 43,327,704 | 3,897 / 78 / 3,975 | 11/309,773 / 0/411,906 / 11/721,679 | yes | 3/3 | yes | yes |
+| candidate | 3 | `2fa9dfaee722d1dad76acfb89c7b3d7e83c64bb9` | `9b20d270862f3cf930fb2ffcbd9a74305c8af8ae7133a5df15ea9aa1c8cbd9ed` | `0a73991cacf645367d546cabbc6188ba6486a5348d4246dec4a74fb428c1ce78` | `73c86175d59c02915736be5074447e7789736771bea1e5f9c784f0119d2ce964` | 5.031 | 9.958 | 4.927 | 1.610 | 397.535 | 200.844 | 65.266 | 295.3 | 10,351,800 / 32,591,672 / 42,943,472 | 3,799 / 179 / 3,978 | 14/284,482 / 1/1,531,850 / 15/1,816,332 | yes | 3/3 | yes | yes |
+
+### Aggregate comparison
+
+Each aggregate cell is `median / minimum / maximum / absolute spread` across
+the three fresh trials. The change is candidate median relative to baseline
+median.
+
+| Metric | Baseline | Candidate | Median change |
+|---|---:|---:|---:|
+| Publication (s) | 5.292 / 5.274 / 5.300 / 0.026 | 5.265 / 5.031 / 5.294 / 0.263 | -0.51% |
+| Verified readiness (s) | 12.139 / 9.265 / 12.439 / 3.174 | 6.942 / 6.879 / 9.958 / 3.079 | -42.81% |
+| Observed terminal to ready (s) | 6.839 / 3.991 / 7.147 / 3.156 | 1.648 / 1.614 / 4.927 / 3.313 | -75.90% |
+| Start-log to completion-observed interval (s) | 3.856 / 3.565 / 3.884 / 0.319 | 1.593 / 1.519 / 1.610 / 0.091 | -58.69% |
+| Throughput to publication (resources/s) | 377.929 / 377.358 / 379.219 / 1.861 | 379.867 / 377.786 / 397.535 / 19.749 | +0.51% |
+| Throughput to readiness (resources/s) | 164.758 / 160.785 / 215.866 / 55.081 | 288.101 / 200.844 / 290.740 / 89.896 | +74.86% |
+| HFS peak (MiB) | 57.922 / 57.797 / 58.172 / 0.375 | 65.266 / 64.797 / 65.375 / 0.578 | +12.68% |
+| PostgreSQL peak (MiB) | 265.100 / 262.200 / 269.600 / 7.400 | 295.300 / 272.200 / 298.300 / 26.100 | +11.39% |
+| Post-terminal WAL (bytes) | 32,001,224 / 31,943,256 / 32,322,024 / 378,768 | 28,349,832 / 28,242,440 / 32,591,672 / 4,349,232 | -11.41% |
+| Post-terminal commits | 7,692 / 7,643 / 7,778 / 135 | 78 / 66 / 179 / 113 | -98.99% |
+| Post-terminal block hits | 3,095,559 / 980,159 / 3,104,623 / 2,124,464 | 411,906 / 330,438 / 1,531,850 / 1,201,412 | -86.69% |
+
+Publication was effectively unchanged, as expected for work performed after
+deferred ingestion. Median verified readiness fell by 42.81%, median observed
+post-terminal time fell by 75.90%, and median throughput to verified readiness
+rose by 74.86%. The clearest database effect was transaction reduction: median
+post-terminal commits fell from 7,692 to 78. Post-terminal block hits fell
+86.69% and WAL fell 11.41%.
+
+The tradeoff in this bounded run was higher measured peak memory: HFS increased
+by 7.344 MiB at the median (+12.68%) and PostgreSQL by 30.2 MiB (+11.39%). These
+are sampled process/container peaks, not allocation attribution. The candidate
+also had wider PostgreSQL memory and post-terminal WAL variation.
+
+Trial 3 was the readiness outlier in both directions: baseline trial 3 was
+faster than its first two trials, while candidate trial 3 took 9.958 seconds to
+verified readiness rather than about 6.9 seconds. Candidate internal phase WALL
+remained stable at 1.48 seconds and its start-log-to-completion-observed interval
+remained 1.610 seconds. The extra candidate trial-3 time coincided with the
+readiness probes and 1,531,850 post-terminal block hits, versus 330,438 and
+411,906 in trials 1 and 2. Baseline block-hit variation was also large. This
+supports treating the readiness spread as observed end-to-end variation rather
+than a change in the candidate's page algorithm.
+
+The start-log interval is observational, not an exact rebuild duration. Task
+spawn precedes the start log, completion is polled at 0.25-second resolution,
+and the subsequent search/SQL readiness probes are outside that interval.
+
+### Candidate phase attribution and cursor plans
+
+Only the candidate can be compared internally. The saved baseline binary
+predates the phase instrumentation, so setting `HFS_PERF_PHASES=1` could not
+produce a baseline phase summary and no cross-arm internal-phase comparison is
+made.
+
+Across candidate trials, the page WALL was 1.43-1.45 seconds for 2,000 resources
+over 20 pages. FTS accounted for 41.7-43.1% of WALL (42.0% median), grouped
+search insertion for 29.5-30.2% (29.6% median), extraction for 12.8-13.9%
+(13.6% median), search deletion for 7.1-7.2%, fetch for 2.6-2.7% (2.7%
+median), commit for 2.4-2.5% (2.5% median), and grouped FTS deletion for
+1.2-1.3%. Connection acquisition rounded to 0.0%. Each summary reported 46,000
+search rows, or 23 per resource. These process-global counters are valid here
+because only one job ran at a time.
+
+All 18 representative cursor plans parsed. In both arms, early, middle, and
+late probes used `idx_resources_search` with a backward index scan followed by
+incremental sort. Total cost was 8.35 for early and 8.36 for middle/late. With
+fetch contributing only about 2.7% of candidate WALL, this workload provides no
+measured reason to change the cursor index order.
+
+### Correctness reimport
+
+The separate candidate run at
+`/tmp/hfs-1086-postgres-reindex/final-candidate-reimport-12x2` submitted the same
+12 stable IDs twice. Both jobs were verified: each reindex processed 12/12
+resources with `errorCount=0` and created 276 entries. Validation observed
+version distribution `{1: 12}` after the fresh import and `{2: 12}` after the
+reimport, with 12 history IDs in both checks. All 32 checks passed with zero
+hard and zero soft failures; receipt, content, indexed search, and zero-unindexed
+checks also passed. This correctness run is not included in the timing
+comparison.
+
+### Recorded environment and provenance
+
+- Baseline source fingerprint:
+  `a1c0ff03f553cc86ff1de017b9fd1370032162610109f91d2273ebeace0f3e36`;
+  candidate source fingerprint:
+  `9b20d270862f3cf930fb2ffcbd9a74305c8af8ae7133a5df15ea9aa1c8cbd9ed`.
+  Both report HEAD `2fa9dfaee722d1dad76acfb89c7b3d7e83c64bb9`. The
+  candidate fingerprint was captured before this results writeback; the final
+  source differs only by this evidence documentation, not executable code.
+- Baseline binary SHA256:
+  `3cc3dce622e8affb995208f70bb9297528d2feef3f90662c8d72315e90d21d70`;
+  candidate binary SHA256:
+  `0a73991cacf645367d546cabbc6188ba6486a5348d4246dec4a74fb428c1ce78`.
+  The shared controller SHA256 was
+  `369282c1a32271f1e724f3489549f6a8756f24268e79bdfa6ebcf6d23e64629f`.
+- The six timed trials used 2,000 resources with corpus SHA256
+  `73c86175d59c02915736be5074447e7789736771bea1e5f9c784f0119d2ce964`.
+  The 12-resource reimport corpus was
+  `a7143714f95ffe141e77fefd866eec539b161dbf42dbeee97d9a7e26a225b8c5`.
+- Host: macOS 26.6.2 build 25G83, Apple M3 Max, 14 logical CPUs, 36 GiB
+  (`38,654,705,664` bytes). PostgreSQL: 16.15 in `postgres:16-alpine`, image
+  ID `sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685`,
+  container ID
+  `fa8c6b5701bf1753a905db735d04f7c1bbe69d159ffcb33080f9eb1e6c6485d0`.
+- Effective HFS settings were `HFS_STORAGE_BACKEND=postgres`,
+  `HFS_DEFAULT_TENANT=default`, `HFS_DEFAULT_FHIR_VERSION=R4`,
+  `HFS_BULK_SUBMIT_ENABLED=true`, worker concurrency `1`, maximum concurrent
+  jobs per tenant `1`, file concurrency `1`, deferred indexing `true`, poll
+  rate limit `1000000`, local-filesystem output, `HFS_PG_MAX_CONNECTIONS=4`,
+  `HFS_MAX_PAGE_SIZE=1000`, auth disabled, audit backend `none`, server host
+  `127.0.0.1` on port `18810`, log level `info`, `HFS_PERF_PHASES=1`, and
+  `RUST_LOG=info,hfs=warn,hfs_perf=info`. Trials used fresh databases, one job,
+  strict validation, plain `EXPLAIN`, no idle period, and no container CPU or
+  memory limit.
+- Timers were 180-second startup, 3,600-second manifest terminal, 900-second
+  reindex, and 10,800-second whole-run deadline. Sampling was 0.5 seconds for
+  HFS RSS, 1 second for Docker stats, 5 seconds for host vitals, and 0.25
+  seconds for endpoint polling. The watchdog limit was 1,536 MiB HFS RSS, six
+  pressure samples, and 256 MiB swap growth over three samples.
+
+Raw evidence for this local run remains under these exact paths:
+
+- `/tmp/hfs-1086-postgres-reindex/final-baseline-trial-01` through `03`;
+- `/tmp/hfs-1086-postgres-reindex/final-candidate-trial-01` through `03`;
+- `/tmp/hfs-1086-postgres-reindex/final-candidate-reimport-12x2`.
+
+Those temporary directories are local and may be removed; this section is the
+compact committed record of the accepted evidence.
+
+### PostgreSQL and Elasticsearch composite smoke check
+
+A separate bounded smoke check used an R4 development build with both the
+PostgreSQL and Elasticsearch features, a dedicated PostgreSQL database, and
+Elasticsearch 8.15.0. After loading eight Patient resources, a
+`POST /Patient/$reindex` request with `batchSize=4` reached `Completed` and
+reported `processed=8` of `total=8`, `entriesCreated=48`, and `errorCount=0`.
+HFS family search through the Elasticsearch secondary returned a count of 8 and the Elasticsearch
+document count was 8. This validates preservation of composite pg-es behavior;
+it is not a performance measurement. Both services were stopped after the
+check.


### PR DESCRIPTION
Closes #1086.

## Visual explanation

[PostgreSQL post-import reindex page batching](https://vanish.gordex.dev/s/happy-orbit-oc/) visualizes the transaction boundary, fallback path, correctness coverage, and bounded benchmark results. The temporary link expires on October 12, 2026 at 22:19 UTC.

## Problem

Deferred PostgreSQL indexing after `$bulk-submit` rewrote search data one
resource at a time. At import scale, that multiplied connection acquisition,
transactions, deletes, inserts, and commits. Publishing the terminal manifest
was reasonably quick, but verified search readiness lagged behind it.

## Solution

This change adds a PostgreSQL page writer for deferred reindexing. It prepares
normal and contained search rows in page order, acquires one connection, and
uses one managed PostgreSQL transaction per page to:

1. delete stale `search_index` and `resource_fts` rows for the page, grouped by
   tenant and resource identity;
2. insert all valid search rows with the existing multi-row writer;
3. write FTS rows on the same connection; and
4. commit once.

Extraction failures still delete that resource's stale rows and return an error
at the corresponding page position. If connection, transaction, delete,
insert, FTS, or commit handling fails, the managed transaction is released
before falling back to the existing per-resource path. That preserves precise
resource attribution and the existing `PROGRAM_LIMIT_EXCEEDED` oversized-FTS
retry. The fallback is idempotent if a commit result was uncertain. Clearing the
PostgreSQL index now deletes both search tables in one managed transaction.

The existing PostgreSQL-plus-Elasticsearch path remains outside the grouped
PostgreSQL-only writer, so composite search behavior is preserved.

## Observability and bounded protocol

The opt-in `perf_phases` build cfg plus `HFS_PERF_PHASES=1` attributes reindex
work to fetch, connection acquisition, extraction, grouped search/FTS deletes,
search insertion, FTS, commit, and fallback. It emits one correlated summary at
job completion. Counters are process-global, so the documented protocol
requires a single reindex job. Normal builds retain the existing behavior and
do not enable collection.

The existing bulk-submit measurement controller now records reproducible #1086
evidence: full source fingerprint and binary hash, immutable PostgreSQL image
ID, deterministic corpus hash, host/settings, HFS and PostgreSQL memory,
polling-observed publication and verified readiness, database counter deltas,
three cursor plans, and the correlated phase summary. The issue-specific
protocol uses 2,000 resources by default, rejects more than 10,000, and requires
three fresh trials per arm.

## Measured result

Three fresh 2,000-Patient trials were accepted for both the saved baseline and
candidate. Candidate median versus baseline median:

- verified search readiness: 12.139 s to 6.942 s (-42.81%);
- observed terminal-to-ready: 6.839 s to 1.648 s (-75.90%);
- throughput to verified readiness: 164.758 to 288.101 resources/s (+74.86%);
- post-terminal commits: 7,692 to 78 (-98.99%);
- post-terminal block hits: 3,095,559 to 411,906 (-86.69%);
- post-terminal WAL: 32,001,224 to 28,349,832 bytes (-11.41%);
- publication time: 5.292 s to 5.265 s (-0.51%, effectively unchanged).

The measured tradeoff was higher peak memory in this bounded run: HFS median
rose from 57.922 to 65.266 MiB (+12.68%), and PostgreSQL container median rose
from 265.1 to 295.3 MiB (+11.39%). These are sampled peaks, not allocation
attribution, and no claim is made beyond the 2,000-resource workload.

Candidate phase summaries were stable across the three trials: page WALL was
1.43-1.45 s for 2,000 resources, with FTS about 42%, grouped search insertion
about 30%, extraction about 13%, fetch about 2.7%, and commit about 2.5%. The
saved baseline predates this phase instrumentation, so internal phases are not
compared across arms.

All early, middle, and late cursor probes in both arms used
`idx_resources_search` with a backward index scan and incremental sort, at total
cost 8.35-8.36. Since fetch represented only about 2.7% of candidate WALL at
this cardinality, the evidence does not justify changing index order.

## Correctness evidence

- A separate candidate check submitted the same 12 stable Patient IDs twice.
  Both reindexes completed 12/12 with zero errors. Validation observed versions
  `{1: 12}` after the fresh import and `{2: 12}` after reimport, with 12 history
  IDs and zero hard or soft failures.
- An R4 PostgreSQL-plus-Elasticsearch smoke check loaded eight Patients and ran
  `POST /Patient/$reindex` with `batchSize=4`. It reached `Completed` with
  `processed=8` of `total=8`, `entriesCreated=48`, and `errorCount=0`; family
  search and the Elasticsearch document count both returned 8. The dedicated
  PostgreSQL and Elasticsearch 8.15.0 services were stopped afterwards.

## Focused validation

- `CARGO_BUILD_JOBS=4 cargo test -p helios-persistence --test postgres_tests --no-default-features --features R4,postgres postgres_integration_reindex -- --test-threads=1` — 13 passed.
- `RUSTFLAGS='--cfg perf_phases' cargo test -p helios-persistence perf::tests --lib` — 5 passed. The narrower R4/PostgreSQL lib-test build is blocked by pre-existing SQLite imports under `cfg(test)`; the PostgreSQL integration target above does compile with only R4/PostgreSQL.
- R4/PostgreSQL `cargo check` for `helios-hfs` passed both with and without
  `RUSTFLAGS='--cfg perf_phases'`.
- `python3 -m py_compile crates/hfs/tests/bulk_submit/measure_memory.py`, direct
  evidence-helper assertions, and legacy/#1086/override dry runs passed.
- Managed-transaction regressions cover one-connection fallback without pool
  deadlock, same-transaction search/FTS writes, stale-row cleanup, precise error
  attribution, oversized FTS retry, clear rollback, tenant/page isolation,
  contained rows, empty pages, cursor ties, and history/content/version
  invariants.
- The changed-line lint review, `cargo fmt --all -- --check`, relevant Cargo
  checks, and `git diff --check` passed.

A strict Clippy run with `-D warnings` remains blocked only by pre-existing
warnings in `crates/serde-support/src/lib.rs` and `crates/fhir/build.rs`; the
changed lines and focused checks pass.

## Scope

The full `MANUAL_TESTING_MATRIX.md` corpus and an all-features build were not
run. This was the deliberately approved resource limit for #1086: the manual
corpus contains about 18.9 million resources and the full import/build would
measure unrelated work while taking substantially longer. The existing release
matrix expectations are unchanged; the matrix now points to the bounded
issue-specific protocol and evidence.
